### PR TITLE
fix(vscode): preserve older messages when paginating virtualized chat

### DIFF
--- a/.changeset/restore-virtual-history.md
+++ b/.changeset/restore-virtual-history.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore earlier chat history when scrolling through virtualized message lists.

--- a/packages/kilo-vscode/src/kilo-provider/message-page.ts
+++ b/packages/kilo-vscode/src/kilo-provider/message-page.ts
@@ -46,17 +46,11 @@ export async function fetchMessagePage(
     return { items, cursor }
   }
 
-  const suffix = (items: Awaited<ReturnType<typeof read>>["items"]) => {
-    const index = [...items].reverse().findIndex((item) => item.info.role === "user")
-    if (index === -1) return items
-    return items.slice(items.length - index - 1)
-  }
-
   const fill = async (page: Awaited<ReturnType<typeof read>>): Promise<Awaited<ReturnType<typeof read>>> => {
     if (page.items[0]?.info.role !== "assistant") return page
     if (!page.cursor || input.signal?.aborted) return page
     const next = await read(page.cursor)
-    const items = [...suffix(next.items), ...page.items]
+    const items = [...next.items, ...page.items]
     return fill({ items, cursor: next.cursor })
   }
 

--- a/packages/kilo-vscode/tests/unit/message-page.test.ts
+++ b/packages/kilo-vscode/tests/unit/message-page.test.ts
@@ -90,7 +90,7 @@ describe("fetchMessagePage / cursor fallback", () => {
   })
 
   it("synthesized cursor round-trips through the server's before parameter", async () => {
-    // First page: server strips header, items fill limit → cursor synthesized.
+    // First page: server strips header, items fill limit -> cursor synthesized.
     // Next page request uses that cursor and returns more items.
     const { client, calls } = mockClient([
       {
@@ -114,5 +114,54 @@ describe("fetchMessagePage / cursor fallback", () => {
       before: first.cursor,
     })
     expect(calls[1]?.before).toBe(first.cursor)
+  })
+
+  it("keeps all fetched older messages when filling a partial assistant turn", async () => {
+    const { client, calls } = mockClient([
+      {
+        items: [message("m4", "assistant", 40), message("m5", "user", 50)],
+        cursor: "c1",
+      },
+      {
+        items: [message("m1", "user", 10), message("m2", "assistant", 20), message("m3", "user", 30)],
+        cursor: "c2",
+      },
+    ])
+
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 3,
+    })
+
+    expect(calls.map((call) => call.before)).toEqual([undefined, "c1"])
+    expect(page.items.map((item) => item.info.id)).toEqual(["m1", "m2", "m3", "m4", "m5"])
+    expect(page.cursor).toBe("c2")
+  })
+
+  it("continues fetching until a partial assistant turn reaches the first user message", async () => {
+    const { client, calls } = mockClient([
+      {
+        items: [message("m4", "assistant", 40), message("m5", "user", 50)],
+        cursor: "c1",
+      },
+      {
+        items: [message("m2", "assistant", 20), message("m3", "user", 30)],
+        cursor: "c2",
+      },
+      {
+        items: [message("m1", "user", 10)],
+      },
+    ])
+
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 2,
+    })
+
+    expect(calls.map((call) => call.before)).toEqual([undefined, "c1", "c2"])
+    expect(page.items.map((item) => item.info.id)).toEqual(["m1", "m2", "m3", "m4", "m5"])
+    expect(page.cursor).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Scrolling to the top of a long session could leave the conversation truncated — the topmost rendered turn was not the real start of the history. The root cause is in the paginated loader that feeds the virtualizer, not in the virtualizer itself.

`fetchMessagePage` calls `fill()` when a returned page begins with an assistant message so the user/assistant pair renders together. The old implementation kept only the last user-turn suffix from each older page via `suffix()`, which discarded the earlier messages from that page while still advancing the pagination cursor past them. Those earlier messages then became unreachable from subsequent "load earlier" requests, cutting off the conversation.

`fill()` now preserves the full older page on each stitch, terminating naturally once a user message reaches the top or the server reports no more history. A new unit test reproduces the multi-page stitching case and asserts no messages are dropped.