### PR TITLE
fix(cli): release session busy state while suggest tool waits

### DIFF
--- a/.changeset/suggest-tool-stuck-session.md
+++ b/.changeset/suggest-tool-stuck-session.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix a stuck session state when the suggest tool was left open. If the suggestion was never accepted or dismissed (for example, because VS Code was closed while it was showing), the session stayed marked as busy and any follow-up messages appeared queued forever. The session is now marked idle while waiting for a response to a suggestion.

--- a/packages/opencode/src/kilocode/suggestion/tool.ts
+++ b/packages/opencode/src/kilocode/suggestion/tool.ts
@@ -89,6 +89,15 @@ export const SuggestTool = Tool.define<typeof Params, Meta, never, "suggest">(
             ctx.abort.removeEventListener("abort", listener)
           })
 
+        // Restore busy immediately on accept so the session doesn't flash idle
+        // while the follow-up response is being generated. The next runLoop
+        // iteration sets busy too, but not until after the stream finalizes.
+        if (action) {
+          await SessionStatus.set(SessionID.make(ctx.sessionID), { type: "busy" }).catch((err) => {
+            log.warn("failed to restore busy status", { err })
+          })
+        }
+
         if (!action) {
           const metadata: Meta = {
             accepted: undefined,

--- a/packages/opencode/src/kilocode/suggestion/tool.ts
+++ b/packages/opencode/src/kilocode/suggestion/tool.ts
@@ -5,6 +5,8 @@ import { Effect } from "effect"
 import DESCRIPTION from "./tool.txt"
 import { Tool } from "../../tool/tool"
 import { Suggestion } from "./index"
+import { SessionStatus } from "../../session/status"
+import { SessionID } from "../../session/schema"
 
 const log = Log.create({ service: "tool.suggest" })
 
@@ -70,6 +72,13 @@ export const SuggestTool = Tool.define<typeof Params, Meta, never, "suggest">(
             if (match) return Suggestion.dismiss(match.id)
           })
         ctx.abort.addEventListener("abort", listener, { once: true })
+
+        // Mark the session as idle while waiting for user interaction so the
+        // session doesn't appear stuck/busy. The loop will set it back to busy
+        // when the suggestion resolves and processing continues.
+        await SessionStatus.set(SessionID.make(ctx.sessionID), { type: "idle" }).catch((err) => {
+          log.warn("failed to set idle status", { err })
+        })
 
         const action = await promise
           .catch((error) => {

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -99,5 +99,6 @@ export namespace SessionStatus {
 
   export const list = () => runPromise((svc) => svc.list())
   export const get = (sessionID: SessionID) => runPromise((svc) => svc.get(sessionID))
+  export const set = (sessionID: SessionID, status: Info) => runPromise((svc) => svc.set(sessionID, status))
   // kilocode_change end
 }

--- a/packages/opencode/test/kilocode/suggestion/tool.test.ts
+++ b/packages/opencode/test/kilocode/suggestion/tool.test.ts
@@ -6,6 +6,7 @@ import { SuggestTool } from "../../../src/kilocode/suggestion/tool"
 import { Tool } from "../../../src/tool/tool"
 import { Truncate } from "../../../src/tool/truncate"
 import { Agent } from "../../../src/agent/agent"
+import { SessionStatus } from "../../../src/session/status"
 
 const toolRuntime = ManagedRuntime.make(Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer))
 
@@ -44,15 +45,18 @@ const ctx = {
 describe("tool.suggest", () => {
   let show: ReturnType<typeof spyOn>
   let cmdGet: ReturnType<typeof spyOn>
+  let statusSet: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     show = spyOn(Suggestion, "show")
     cmdGet = spyOn(Command, "get")
+    statusSet = spyOn(SessionStatus, "set").mockResolvedValue(undefined as any)
   })
 
   afterEach(() => {
     show.mockRestore()
     cmdGet.mockRestore()
+    statusSet.mockRestore()
   })
 
   test("returns dismissal result when suggestion is dismissed", async () => {
@@ -183,5 +187,87 @@ describe("tool.suggest", () => {
     expect(result.title).toBe("User accepted: Start review")
     expect(result.output).toContain("/local-review-uncommitted")
     expect(result.metadata.dismissed).toBe(false)
+  })
+
+  // Regression for https://github.com/Kilo-Org/kilocode/pull/9199: while the
+  // suggest tool is blocked on user input the session status must be flipped
+  // to idle so a session left with an open suggestion (e.g. VS Code closed
+  // mid-prompt) does not appear stuck as busy.
+  test("marks session idle while waiting for user response", async () => {
+    const tool = await initTool()
+    let resolveShow: (action: Suggestion.Action) => void = () => {}
+    show.mockReturnValueOnce(
+      new Promise<Suggestion.Action>((resolve) => {
+        resolveShow = resolve
+      }),
+    )
+
+    const pending = toolRuntime.runPromise(
+      tool.execute(
+        {
+          suggest: "Run review?",
+          actions: [{ label: "Start", prompt: "do it" }],
+        },
+        ctx as any,
+      ),
+    )
+
+    // Wait for the tool to reach the await on the suggestion promise so the
+    // idle status call has been issued.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(statusSet).toHaveBeenCalledWith(ctx.sessionID, { type: "idle" })
+    expect(statusSet).not.toHaveBeenCalledWith(ctx.sessionID, { type: "busy" })
+
+    resolveShow({ label: "Start", prompt: "do it" })
+    await pending
+  })
+
+  // Regression for https://github.com/Kilo-Org/kilocode/pull/9199: once the
+  // user accepts a suggestion the session must be flipped back to busy
+  // immediately so there is no idle flash while the follow-up response is
+  // generated.
+  test("restores busy status after accept, in order (idle then busy)", async () => {
+    const tool = await initTool()
+    show.mockResolvedValueOnce({ label: "Go", prompt: "go" })
+
+    await toolRuntime.runPromise(
+      tool.execute(
+        {
+          suggest: "Go?",
+          actions: [{ label: "Go", prompt: "go" }],
+        },
+        ctx as any,
+      ),
+    )
+
+    const statuses = statusSet.mock.calls
+      .filter((call: unknown[]) => call[0] === ctx.sessionID)
+      .map((call: unknown[]) => (call[1] as { type: string }).type)
+    expect(statuses).toEqual(["idle", "busy"])
+  })
+
+  // Regression for https://github.com/Kilo-Org/kilocode/pull/9199: a dismissed
+  // suggestion leaves the session idle — the runLoop will restore busy on the
+  // next iteration, so the tool must not flip busy itself when the user
+  // walked away.
+  test("leaves session idle when suggestion is dismissed", async () => {
+    const tool = await initTool()
+    show.mockRejectedValueOnce(new Suggestion.DismissedError())
+
+    await toolRuntime.runPromise(
+      tool.execute(
+        {
+          suggest: "Go?",
+          actions: [{ label: "Go", prompt: "go" }],
+        },
+        ctx as any,
+      ),
+    )
+
+    const statuses = statusSet.mock.calls
+      .filter((call: unknown[]) => call[0] === ctx.sessionID)
+      .map((call: unknown[]) => (call[1] as { type: string }).type)
+    expect(statuses).toEqual(["idle"])
   })
 })


### PR DESCRIPTION
## Why

When the assistant offered a suggestion and the user never answered it (for example, they closed VS Code while it was showing), the session would get stuck thinking it was still busy. Any new messages the user typed would sit as queued forever and the worktree tab would show the session as still running, even though nothing was actually happening.

## What changed

While the suggest tool is waiting for the user to pick an option or dismiss it, the session is now marked as idle. That matches what the user actually sees — the assistant isn't really doing any work, it's just waiting. The moment the user responds (or a new prompt comes in and clears the pending suggestion), the session picks up where it left off and is marked busy again. If the suggestion is abandoned, the session just stays idle the way it should.

## How to test

1. Start a chat and get the assistant to offer a suggestion (any flow that ends with a suggest prompt).
2. Without accepting or dismissing it, close VS Code and reopen it, or switch to the worktree tab.
3. Confirm the session is shown as idle, not busy/running.
4. Send a new message — it should be handled right away instead of being queued behind the old suggestion.

Fixes #9150