### PR TITLE
fix: memory accumulation in webview on session switch

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1325,6 +1325,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   ): Promise<void> {
     const mode = options.mode ?? "replace"
     if (mode !== "prepend") {
+      // Prune previous session from tracked set on session switch to prevent
+      // unbounded growth. Keep child/synced sessions as they may still be active.
+      if (mode === "replace") {
+        const prevId = this.contextSessionID
+        if (prevId && prevId !== sessionID && !this.syncedChildSessions.has(prevId)) {
+          this.trackedSessionIds.delete(prevId)
+        }
+      }
       this.trackedSessionIds.add(sessionID)
       this.focusSession(sessionID)
       this.contextSessionID = sessionID

--- a/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
+++ b/packages/kilo-vscode/src/kilo-provider/slim-metadata.ts
@@ -172,6 +172,10 @@ const slimmers: Record<string, (state: Record<string, unknown>) => Record<string
   multiedit: slimMultiedit,
   write: slimWrite,
   bash: slimBash,
+  webfetch: slimOutput,
+  websearch: slimOutput,
+  codesearch: slimOutput,
+  task: slimOutput,
 }
 
 /** Strip heavy metadata from a single tool part; pass-through for non-tool parts. */
@@ -185,9 +189,15 @@ export function slimPart<T>(part: T): T {
   if (typeof tool !== "string") return part
 
   const fn = slimmers[tool]
-  if (!fn) return part
-
   const state = obj.state
+  if (!fn) {
+    // Fallback for MCP and other unknown tools: slim large output fields
+    if (isObj(state) && typeof state.output === "string" && state.output.length > OUTPUT_CAP) {
+      return { ...obj, state: slimOutput(state) } as T
+    }
+    return part
+  }
+
   if (!isObj(state)) return part
 
   return { ...obj, state: fn(state) } as T

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -932,6 +932,29 @@ export const SessionProvider: ParentComponent = (props) => {
     }
 
     batch(() => {
+      // Evict previous session's messages and parts when switching sessions
+      // to prevent unbounded memory growth across session switches.
+      if (mode === "replace") {
+        const prevId = currentSessionID()
+        if (prevId && prevId !== sessionID) {
+          const oldMsgs = store.messages[prevId] ?? []
+          const oldMsgIds = oldMsgs.map((m) => m.id)
+          for (const id of oldMsgIds) stash.remove(id)
+          setStore(
+            "parts",
+            produce((parts) => {
+              for (const id of oldMsgIds) delete parts[id]
+            }),
+          )
+          setStore(
+            "messages",
+            produce((messages) => {
+              delete messages[prevId]
+            }),
+          )
+        }
+      }
+
       setLoaded((prev) => {
         if (prev.has(sessionID)) return prev
         const next = new Set(prev)
@@ -1370,16 +1393,39 @@ export const SessionProvider: ParentComponent = (props) => {
       // Sessions whose worktree directories failed to list are preserved —
       // their absence is transient, not a real deletion.
       const ids = new Set(loaded.map((s) => s.id))
+      // Collect removed session IDs to clean up their messages and parts
+      const removedIds: string[] = []
       setStore(
         "sessions",
         produce((sessions) => {
           for (const id of Object.keys(sessions)) {
             if (id.startsWith("cloud:")) continue
             if (kept?.has(id)) continue
-            if (!ids.has(id)) delete sessions[id]
+            if (!ids.has(id)) {
+              removedIds.push(id)
+              delete sessions[id]
+            }
           }
         }),
       )
+      // Clean up messages and parts for removed sessions
+      for (const removedId of removedIds) {
+        const oldMsgs = store.messages[removedId] ?? []
+        const oldMsgIds = oldMsgs.map((m) => m.id)
+        for (const id of oldMsgIds) stash.remove(id)
+        setStore(
+          "parts",
+          produce((parts) => {
+            for (const id of oldMsgIds) delete parts[id]
+          }),
+        )
+        setStore(
+          "messages",
+          produce((messages) => {
+            delete messages[removedId]
+          }),
+        )
+      }
       for (const s of loaded) {
         setStore("sessions", s.id, s)
       }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -952,6 +952,14 @@ export const SessionProvider: ParentComponent = (props) => {
               delete messages[prevId]
             }),
           )
+          // Clear loaded flag so switching back triggers a full reload
+          // instead of showing an empty thread.
+          setLoaded((prev) => {
+            if (!prev.has(prevId)) return prev
+            const next = new Set(prev)
+            next.delete(prevId)
+            return next
+          })
         }
       }
 
@@ -1425,6 +1433,47 @@ export const SessionProvider: ParentComponent = (props) => {
             delete messages[removedId]
           }),
         )
+      }
+      // Clean ancillary state for removed sessions
+      if (removedIds.length > 0) {
+        const removedSet = new Set(removedIds)
+        setStore(
+          "todos",
+          produce((todos) => {
+            for (const id of removedIds) delete todos[id]
+          }),
+        )
+        setPages(
+          produce((map) => {
+            for (const id of removedIds) delete map[id]
+          }),
+        )
+        setStore(
+          "agentSelections",
+          produce((selections) => {
+            for (const id of removedIds) delete selections[id]
+          }),
+        )
+        setStatusMap(
+          produce((map) => {
+            for (const id of removedIds) delete map[id]
+          }),
+        )
+        setBusySinceMap(
+          produce((map) => {
+            for (const id of removedIds) delete map[id]
+          }),
+        )
+        setLoaded((prev) => {
+          let changed = false
+          for (const id of removedIds) {
+            if (prev.has(id)) { changed = true; break }
+          }
+          if (!changed) return prev
+          const next = new Set(prev)
+          for (const id of removedIds) next.delete(id)
+          return next
+        })
       }
       for (const s of loaded) {
         setStore("sessions", s.id, s)


### PR DESCRIPTION
## Summary
Fixes #8607 — webview memory accumulates unboundedly during normal usage.

- Evict previous session's messages/parts from SolidJS store on session switch
- Clean orphaned messages/parts when sessions are reconciled in `handleSessionsLoaded`
- Add missing tool types (`webfetch`, `websearch`, `codesearch`, `task`) to `slim-metadata.ts` slimmers, plus a fallback for MCP tools with large output
- Prune `trackedSessionIds` on session switch to prevent unbounded growth

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test tests/unit/slim-metadata.test.ts` passes (19/19)
- [ ] Manual: open extension, switch between multiple sessions, verify no grey screen / reduced memory growth via DevTools heap snapshot