### PR TITLE
fix(cli): remove suggestion tool from kilo run

### DIFF
--- a/.changeset/suggest-tool-stuck-session.md
+++ b/.changeset/suggest-tool-stuck-session.md
@@ -1,5 +1,6 @@
 ---
 "kilo-code": patch
+"@kilocode/cli": patch
 ---
 
 Fix a stuck session state when the suggest tool was left open. If the suggestion was never accepted or dismissed (for example, because VS Code was closed while it was showing), the session stayed marked as busy and any follow-up messages appeared queued forever. The session is now marked idle while waiting for a response to a suggestion. The suggest tool is also no longer offered to the model during `kilo run`, where there is no UI to respond to it.

--- a/.changeset/suggest-tool-stuck-session.md
+++ b/.changeset/suggest-tool-stuck-session.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix a stuck session state when the suggest tool was left open. If the suggestion was never accepted or dismissed (for example, because VS Code was closed while it was showing), the session stayed marked as busy and any follow-up messages appeared queued forever. The session is now marked idle while waiting for a response to a suggestion.
+Fix a stuck session state when the suggest tool was left open. If the suggestion was never accepted or dismissed (for example, because VS Code was closed while it was showing), the session stayed marked as busy and any follow-up messages appeared queued forever. The session is now marked idle while waiting for a response to a suggestion. The suggest tool is also no longer offered to the model during `kilo run`, where there is no UI to respond to it.

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -394,6 +394,13 @@ export const RunCommand = cmd({
         action: "deny",
         pattern: "*",
       },
+      // kilocode_change start - `suggest` has no UI in `kilo run`, so deny it up-front
+      {
+        permission: "suggest",
+        action: "deny",
+        pattern: "*",
+      },
+      // kilocode_change end
     ]
 
     function title() {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -31,6 +31,33 @@ import { Locale } from "../../util/locale"
 import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 import { AppRuntime } from "@/effect/app-runtime"
 
+// Permission ruleset applied when `kilo run` creates a new session. Exported so tests can verify
+// the exact set of tools denied without having to duplicate (and potentially drift from) the literal.
+export const RUN_RULES: Permission.Ruleset = [
+  {
+    permission: "question",
+    action: "deny",
+    pattern: "*",
+  },
+  {
+    permission: "plan_enter",
+    action: "deny",
+    pattern: "*",
+  },
+  {
+    permission: "plan_exit",
+    action: "deny",
+    pattern: "*",
+  },
+  // kilocode_change start - `suggest` has no UI in `kilo run`, so deny it up-front
+  {
+    permission: "suggest",
+    action: "deny",
+    pattern: "*",
+  },
+  // kilocode_change end
+]
+
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
   metadata: Tool.InferMetadata<T>
@@ -378,30 +405,7 @@ export const RunCommand = cmd({
     }
     // kilocode_change end
 
-    const rules: Permission.Ruleset = [
-      {
-        permission: "question",
-        action: "deny",
-        pattern: "*",
-      },
-      {
-        permission: "plan_enter",
-        action: "deny",
-        pattern: "*",
-      },
-      {
-        permission: "plan_exit",
-        action: "deny",
-        pattern: "*",
-      },
-      // kilocode_change start - `suggest` has no UI in `kilo run`, so deny it up-front
-      {
-        permission: "suggest",
-        action: "deny",
-        pattern: "*",
-      },
-      // kilocode_change end
-    ]
+    const rules = RUN_RULES
 
     function title() {
       if (args.title === undefined) return

--- a/packages/opencode/test/permission/run-ruleset.test.ts
+++ b/packages/opencode/test/permission/run-ruleset.test.ts
@@ -1,18 +1,10 @@
 // kilocode_change - new file
 import { test, expect } from "bun:test"
 import { Permission } from "../../src/permission"
-
-// Mirror of the ruleset in packages/opencode/src/cli/cmd/run.ts (around line 381).
-// Kept in lockstep by intention so this test documents the contract.
-const rules: Permission.Ruleset = [
-  { permission: "question", action: "deny", pattern: "*" },
-  { permission: "plan_enter", action: "deny", pattern: "*" },
-  { permission: "plan_exit", action: "deny", pattern: "*" },
-  { permission: "suggest", action: "deny", pattern: "*" },
-]
+import { RUN_RULES } from "../../src/cli/cmd/run"
 
 test("kilo run ruleset disables interactive tools including suggest", () => {
-  const disabled = Permission.disabled(["suggest", "question", "plan_enter", "plan_exit", "bash", "read"], rules)
+  const disabled = Permission.disabled(["suggest", "question", "plan_enter", "plan_exit", "bash", "read"], RUN_RULES)
   expect(disabled.has("suggest")).toBe(true)
   expect(disabled.has("question")).toBe(true)
   expect(disabled.has("plan_enter")).toBe(true)
@@ -20,7 +12,7 @@ test("kilo run ruleset disables interactive tools including suggest", () => {
 })
 
 test("kilo run ruleset does not over-match allowed tools", () => {
-  const disabled = Permission.disabled(["bash", "read", "edit", "write"], rules)
+  const disabled = Permission.disabled(["bash", "read", "edit", "write"], RUN_RULES)
   expect(disabled.has("bash")).toBe(false)
   expect(disabled.has("read")).toBe(false)
   expect(disabled.has("edit")).toBe(false)

--- a/packages/opencode/test/permission/run-ruleset.test.ts
+++ b/packages/opencode/test/permission/run-ruleset.test.ts
@@ -1,0 +1,28 @@
+// kilocode_change - new file
+import { test, expect } from "bun:test"
+import { Permission } from "../../src/permission"
+
+// Mirror of the ruleset in packages/opencode/src/cli/cmd/run.ts (around line 381).
+// Kept in lockstep by intention so this test documents the contract.
+const rules: Permission.Ruleset = [
+  { permission: "question", action: "deny", pattern: "*" },
+  { permission: "plan_enter", action: "deny", pattern: "*" },
+  { permission: "plan_exit", action: "deny", pattern: "*" },
+  { permission: "suggest", action: "deny", pattern: "*" },
+]
+
+test("kilo run ruleset disables interactive tools including suggest", () => {
+  const disabled = Permission.disabled(["suggest", "question", "plan_enter", "plan_exit", "bash", "read"], rules)
+  expect(disabled.has("suggest")).toBe(true)
+  expect(disabled.has("question")).toBe(true)
+  expect(disabled.has("plan_enter")).toBe(true)
+  expect(disabled.has("plan_exit")).toBe(true)
+})
+
+test("kilo run ruleset does not over-match allowed tools", () => {
+  const disabled = Permission.disabled(["bash", "read", "edit", "write"], rules)
+  expect(disabled.has("bash")).toBe(false)
+  expect(disabled.has("read")).toBe(false)
+  expect(disabled.has("edit")).toBe(false)
+  expect(disabled.has("write")).toBe(false)
+})


### PR DESCRIPTION
## Why

Followup for https://github.com/Kilo-Org/kilocode/pull/9018

If Kilo showed a suggestion and the user never clicked accept or dismiss (for example, because VS Code was closed while the suggestion was on screen), the chat would sit there forever with new messages appearing queued, and `kilo run` would hang or exit early instead of finishing the task.

## What changed

While Kilo is waiting for the user to respond to a suggestion, the session is now marked idle instead of busy, so follow-up messages flow through normally and clients know the assistant is not working. Accepting a suggestion puts the session back into the busy state while the assistant continues, and dismissing it ends the turn cleanly. In one-shot `kilo run` — where there is no UI to click a suggestion — the suggest tool is no longer offered to the model at all, so those runs can't get stuck waiting for a click that will never happen.

Caveat: `kilo run --continue`, `--session`, `--fork`, and `--cloudFork` reuse an existing session's stored permissions, so if that session was originally created by the TUI or the VS Code extension, the suggest tool is still available there. This matches the pre-existing behavior for the other interactive tools (`question`, `plan_enter`, `plan_exit`) and is intentionally out of scope for this PR.

## How to test

1. In VS Code, send a prompt that produces a suggestion, then close the chat/window before clicking. Reopen, send a new message — it should be processed instead of stuck behind the open suggestion.
2. Send a prompt that produces a suggestion, click **Accept** — the assistant should continue its turn normally.
3. Send a prompt that produces a suggestion, click **Dismiss** — the turn should end cleanly.
4. Run `kilo run "<any prompt that would normally offer a suggestion>"` — the command should complete without hanging or exiting early, and no suggest tool call should appear in the output.
5. Run `kilo tui` — suggestions should still render and accept/dismiss as before.