### PR TITLE
fix(ignore): match unrooted .kilocodeignore patterns at any tree depth

### DIFF
--- a/.changeset/fix-kilocodeignore-single-files.md
+++ b/.changeset/fix-kilocodeignore-single-files.md
@@ -1,0 +1,14 @@
+---
+"@kilocode/cli": patch
+---
+
+fix(ignore): match unrooted .kilocodeignore patterns at any tree depth
+
+Patterns like `secret.txt` or `secrets/` (without a path separator at the
+beginning or middle) should match at any depth per gitignore spec. Previously
+they only matched at the workspace root, so `.kilocodeignore` entries for
+single files or bare directory names had no effect in subdirectories.
+
+For each unrooted pattern, we now emit both the root-level rule and a
+`*/`-prefixed variant so `Wildcard.all` can deny access inside nested
+directories as well.

--- a/packages/opencode/src/kilocode/ignore-migrator.ts
+++ b/packages/opencode/src/kilocode/ignore-migrator.ts
@@ -114,31 +114,59 @@ export namespace IgnoreMigrator {
   }
 
   /**
+   * Check if a gitignore pattern is "unrooted" (should match at any tree depth).
+   *
+   * Per gitignore spec: "If there is a separator at the beginning or middle
+   * (or both) of the pattern, then the pattern is relative to the directory
+   * level of the particular .gitignore file itself. Otherwise the pattern may
+   * also match at any level below the .gitignore level."
+   *
+   * A trailing "/" only means "directories only" and does not count as a
+   * separator for this rule.
+   */
+  export function isUnrooted(pattern: string): boolean {
+    const withoutTrailingSlash = pattern.replace(/\/$/, "")
+    return !withoutTrailingSlash.includes("/")
+  }
+
+  /**
    * Build permission rules from ignore patterns.
    *
    * Order matters! Patterns are evaluated in order:
    * 1. Start with "*": "allow" (default allow)
    * 2. Add deny patterns
    * 3. Add negated patterns (allow) last to override denies
+   *
+   * For unrooted patterns (no path separator at beginning or middle),
+   * gitignore matches them at any depth in the tree. We emit both the
+   * root-level pattern and a wildcard-prefixed variant so Wildcard.all
+   * can match them in subdirectories too.
    */
   export function buildPermissionRules(patterns: IgnorePattern[]): Record<string, Config.PermissionAction> {
     const rules: Record<string, Config.PermissionAction> = {
       "*": "allow", // Default: allow all
     }
 
+    function addRule(pattern: IgnorePattern, action: Config.PermissionAction) {
+      const glob = convertToGlob(pattern.pattern)
+      rules[glob] = action
+      // Unrooted patterns must also match inside subdirectories
+      if (isUnrooted(pattern.pattern)) {
+        rules["*/" + glob] = action
+      }
+    }
+
     // First pass: add deny rules
     for (const p of patterns) {
       if (!p.negated) {
-        const glob = convertToGlob(p.pattern)
-        rules[glob] = "deny"
+        addRule(p, "deny")
       }
     }
 
     // Second pass: add negated (allow) rules - these override denies
     for (const p of patterns) {
       if (p.negated) {
-        const glob = convertToGlob(p.pattern)
-        rules[glob] = "allow"
+        addRule(p, "allow")
       }
     }
 

--- a/packages/opencode/test/kilocode/ignore-migrator.test.ts
+++ b/packages/opencode/test/kilocode/ignore-migrator.test.ts
@@ -103,6 +103,32 @@ pattern2
     })
   })
 
+  describe("isUnrooted", () => {
+    test("simple filename is unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("secret.txt")).toBe(true)
+    })
+
+    test("glob pattern is unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("*.env")).toBe(true)
+    })
+
+    test("directory pattern (trailing slash only) is unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("secrets/")).toBe(true)
+    })
+
+    test("rooted pattern is not unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("/root-only")).toBe(false)
+    })
+
+    test("nested path pattern is not unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("config/secrets.json")).toBe(false)
+    })
+
+    test("pattern with separator in middle is not unrooted", () => {
+      expect(IgnoreMigrator.isUnrooted("src/secrets/")).toBe(false)
+    })
+  })
+
   describe("buildPermissionRules", () => {
     test("creates default allow rule", () => {
       const rules = IgnoreMigrator.buildPermissionRules([])
@@ -115,6 +141,8 @@ pattern2
 
       expect(rules["*"]).toBe("allow")
       expect(rules["secrets/*"]).toBe("deny")
+      // Unrooted: also denies in subdirectories
+      expect(rules["*/secrets/*"]).toBe("deny")
     })
 
     test("creates allow rules for negated patterns", () => {
@@ -126,6 +154,9 @@ pattern2
 
       expect(rules["*.env"]).toBe("deny")
       expect(rules[".env.example"]).toBe("allow")
+      // Unrooted variants
+      expect(rules["*/*.env"]).toBe("deny")
+      expect(rules["*/.env.example"]).toBe("allow")
     })
 
     test("handles multiple deny patterns", () => {
@@ -150,6 +181,25 @@ pattern2
 
       expect(rules["config/*"]).toBe("deny")
       expect(rules["config/public.json"]).toBe("allow")
+    })
+
+    test("single filename gets subdirectory variant for any-depth matching", () => {
+      const patterns = [{ pattern: "secret.txt", negated: false, source: "project" as const }]
+      const rules = IgnoreMigrator.buildPermissionRules(patterns)
+
+      // Root match
+      expect(rules["secret.txt"]).toBe("deny")
+      // Subdirectory match
+      expect(rules["*/secret.txt"]).toBe("deny")
+    })
+
+    test("rooted pattern does not get subdirectory variant", () => {
+      const patterns = [{ pattern: "/config/private/", negated: false, source: "project" as const }]
+      const rules = IgnoreMigrator.buildPermissionRules(patterns)
+
+      expect(rules["config/private/*"]).toBe("deny")
+      // Rooted: no subdirectory variant
+      expect(rules["*/config/private/*"]).toBeUndefined()
     })
   })
 
@@ -199,7 +249,9 @@ pattern2
       const editRules = result.permission.edit as Record<string, string>
 
       expect(readRules["secrets/*"]).toBe("deny")
+      expect(readRules["*/secrets/*"]).toBe("deny")
       expect(editRules["secrets/*"]).toBe("deny")
+      expect(editRules["*/secrets/*"]).toBe("deny")
     })
 
     test("handles negation patterns correctly", async () => {


### PR DESCRIPTION
## Summary

Fixes #9228

`.kilocodeignore` patterns like `secret.txt`, `Dockerfile`, or `secrets/` (without a path separator at the beginning or middle) should match at **any depth** in the file tree per gitignore spec. Previously, the `IgnoreMigrator` only emitted a root-level permission rule, so these patterns had no effect in subdirectories.

## Root cause

`buildPermissionRules()` converts each ignore pattern into a single Wildcard rule. For example, `secret.txt` becomes the rule `{"secret.txt": "deny"}`. But `Wildcard.match("subdir/secret.txt", "secret.txt")` produces regex `^secret\.txt$` which doesn't match paths containing subdirectories.

Per the [gitignore spec](https://git-scm.com/docs/gitignore#_pattern_format):
> *If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.*

A trailing `/` only means "directories only" and does **not** count as a separator for this rule.

## Fix

- Add `isUnrooted()` helper that checks whether a pattern has a path separator at the beginning or middle (excluding trailing `/`)
- In `buildPermissionRules()`, for each unrooted pattern, emit **both** the root-level rule (`secret.txt → deny`) and a `*/`-prefixed variant (`*/secret.txt → deny`) so `Wildcard.all` can match at any depth
- Rooted patterns (e.g. `/config/private/`) and patterns with path separators in the middle (e.g. `config/secrets.json`) are unaffected

## Testing

- 8 new tests covering `isUnrooted()` classification and `buildPermissionRules()` subdirectory variant emission
- Updated existing tests to verify the new `*/` variants
- All 36 tests pass

## Changeset

Included — `@kilocode/cli` patch