### PR TITLE
docs: fix agentskills.io link to avoid 308 redirect

### DIFF
--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -5,7 +5,7 @@ description: "Extend Kilo Code capabilities with skills"
 
 # Skills
 
-Kilo Code implements [Agent Skills](https://agentskills.io/), a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
+Kilo Code implements [Agent Skills](https://agentskills.io/home), a lightweight, open format for extending AI agent capabilities with specialized knowledge and workflows.
 
 ## What Are Agent Skills?
 


### PR DESCRIPTION
The linkcheck CI job flagged `https://agentskills.io/` as returning a 308 redirect. Updated the link to `https://agentskills.io/home` (the redirect target) so the check passes.