### PR TITLE
fix(vscode): revalidate sidebar fork status

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -311,6 +311,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       register: (session: Session) => this.registerSession(session),
       forked: (session: Session) => this.postMessage({ type: "sessionForked", sessionID: session.id }),
       status: (sessionID: string) => this.sessionStatusMap.get(sessionID),
+      directory: (sessionID: string) => this.getWorkspaceDirectory(sessionID),
     }
   }
 

--- a/packages/kilo-vscode/src/kilo-provider/fork-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/fork-session.ts
@@ -14,9 +14,10 @@ export interface ForkContext {
 export async function handleForkSession(ctx: ForkContext, sessionId: string, messageId?: string): Promise<void> {
   const status =
     ctx.status(sessionId) ??
-    (await ctx.connection
-      .getClient()
-      .session.status({ directory: ctx.directory(sessionId) }, { throwOnError: true })
+    (await Promise.resolve()
+      .then(() =>
+        ctx.connection.getClient().session.status({ directory: ctx.directory(sessionId) }, { throwOnError: true }),
+      )
       .then((result) => result.data?.[sessionId]?.type ?? "idle")
       .catch((e) => {
         console.error("[Kilo New] refreshForkStatus failed:", e)

--- a/packages/kilo-vscode/src/kilo-provider/fork-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/fork-session.ts
@@ -8,11 +8,21 @@ export interface ForkContext {
   register: (session: Session) => void
   forked: (session: Session) => void
   status: (sessionID: string) => SessionStatus["type"] | undefined
+  directory: (sessionID: string) => string
 }
 
 export async function handleForkSession(ctx: ForkContext, sessionId: string, messageId?: string): Promise<void> {
-  const status = ctx.status(sessionId)
-  if (status && status !== "idle") {
+  const status =
+    ctx.status(sessionId) ??
+    (await ctx.connection
+      .getClient()
+      .session.status({ directory: ctx.directory(sessionId) }, { throwOnError: true })
+      .then((result) => result.data?.[sessionId]?.type ?? "idle")
+      .catch((e) => {
+        console.error("[Kilo New] refreshForkStatus failed:", e)
+        return "busy" as SessionStatus["type"]
+      }))
+  if (status !== "idle") {
     ctx.post({ type: "error", message: "Wait for the session to finish before forking it." })
     return
   }


### PR DESCRIPTION
## Summary
- Revalidate sidebar fork status from the backend when the local status cache is empty.
- Prevent a freshly reloaded sidebar from forking a still-running session before status sync completes.

Follow-up to #9244 / #9207.