### PR TITLE
docs: fix ZenMux provider page format and add to sidebar nav

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -1,85 +1,86 @@
 import { NavSection } from "../types"
 
 export const AiProvidersNav: NavSection[] = [
-  {
-    title: "AI Providers",
-    links: [
-      { href: "/ai-providers", children: "Overview" },
-      { href: "/ai-providers/kilocode", children: "Kilo Code (Default)" },
-    ],
-  },
-  {
-    title: "AI Labs",
-    links: [
-      { href: "/ai-providers/anthropic", children: "Anthropic" },
-      { href: "/ai-providers/claude-code", children: "Claude Code" },
-      { href: "/ai-providers/openai", children: "OpenAI" },
-      {
-        href: "/ai-providers/openai-chatgpt-plus-pro",
-        children: "ChatGPT Plus/Pro",
-      },
-      { href: "/ai-providers/gemini", children: "Google Gemini" },
-      { href: "/ai-providers/mistral", children: "Mistral AI" },
-      { href: "/ai-providers/deepseek", children: "DeepSeek" },
-      { href: "/ai-providers/xai", children: "xAI (Grok)" },
-    ],
-  },
-  {
-    title: "AI Gateways",
-    links: [
-      { href: "/ai-providers/openrouter", children: "OpenRouter" },
-      { href: "/ai-providers/glama", children: "Glama" },
-      { href: "/ai-providers/requesty", children: "Requesty" },
-      { href: "/ai-providers/unbound", children: "Unbound" },
-      {
-        href: "/ai-providers/vercel-ai-gateway",
-        children: "Vercel AI Gateway",
-      },
-    ],
-  },
-  {
-    title: "Cloud Providers",
-    links: [
-      { href: "/ai-providers/vertex", children: "Google Vertex AI" },
-      { href: "/ai-providers/bedrock", children: "AWS Bedrock" },
-      { href: "/ai-providers/groq", children: "Groq" },
-      { href: "/ai-providers/cerebras", children: "Cerebras" },
-      { href: "/ai-providers/fireworks", children: "Fireworks AI" },
-    ],
-  },
-  {
-    title: "Local & Self-Hosted",
-    links: [
-      { href: "/ai-providers/ollama", children: "Ollama" },
-      { href: "/ai-providers/lmstudio", children: "LM Studio" },
-      { href: "/ai-providers/vscode-lm", children: "VS Code LM API" },
-      {
-        href: "/ai-providers/openai-compatible",
-        children: "OpenAI Compatible",
-      },
-    ],
-  },
-  {
-    title: "Other Providers",
-    links: [
-      { href: "/ai-providers/chutes-ai", children: "Chutes AI" },
-      { href: "/ai-providers/inception", children: "Inception" },
-      { href: "/ai-providers/minimax", children: "MiniMax" },
-      { href: "/ai-providers/moonshot", children: "Moonshot" },
-      { href: "/ai-providers/ovhcloud", children: "OVHcloud" },
-      { href: "/ai-providers/sap-ai-core", children: "SAP AI Core" },
-    ],
-  },
-  {
-    title: "Special Modes",
-    links: [
-      { href: "/ai-providers/v0", children: "v0" },
-      { href: "/ai-providers/human-relay", children: "Human Relay" },
-      { href: "/ai-providers/synthetic", children: "Synthetic Provider" },
-      {
-        href: "/ai-providers/virtual-quota-fallback",
-        children: "Virtual Quota Fallback",
-      },
-    ],
-  },
+	{
+		title: "AI Providers",
+		links: [
+			{ href: "/ai-providers", children: "Overview" },
+			{ href: "/ai-providers/kilocode", children: "Kilo Code (Default)" },
+		],
+	},
+	{
+		title: "AI Labs",
+		links: [
+			{ href: "/ai-providers/anthropic", children: "Anthropic" },
+			{ href: "/ai-providers/claude-code", children: "Claude Code" },
+			{ href: "/ai-providers/openai", children: "OpenAI" },
+			{
+				href: "/ai-providers/openai-chatgpt-plus-pro",
+				children: "ChatGPT Plus/Pro",
+			},
+			{ href: "/ai-providers/gemini", children: "Google Gemini" },
+			{ href: "/ai-providers/mistral", children: "Mistral AI" },
+			{ href: "/ai-providers/deepseek", children: "DeepSeek" },
+			{ href: "/ai-providers/xai", children: "xAI (Grok)" },
+		],
+	},
+	{
+		title: "AI Gateways",
+		links: [
+			{ href: "/ai-providers/openrouter", children: "OpenRouter" },
+			{ href: "/ai-providers/glama", children: "Glama" },
+			{ href: "/ai-providers/requesty", children: "Requesty" },
+			{ href: "/ai-providers/unbound", children: "Unbound" },
+			{
+				href: "/ai-providers/vercel-ai-gateway",
+				children: "Vercel AI Gateway",
+			},
+			{ href: "/ai-providers/zenmux", children: "ZenMux" },
+		],
+	},
+	{
+		title: "Cloud Providers",
+		links: [
+			{ href: "/ai-providers/vertex", children: "Google Vertex AI" },
+			{ href: "/ai-providers/bedrock", children: "AWS Bedrock" },
+			{ href: "/ai-providers/groq", children: "Groq" },
+			{ href: "/ai-providers/cerebras", children: "Cerebras" },
+			{ href: "/ai-providers/fireworks", children: "Fireworks AI" },
+		],
+	},
+	{
+		title: "Local & Self-Hosted",
+		links: [
+			{ href: "/ai-providers/ollama", children: "Ollama" },
+			{ href: "/ai-providers/lmstudio", children: "LM Studio" },
+			{ href: "/ai-providers/vscode-lm", children: "VS Code LM API" },
+			{
+				href: "/ai-providers/openai-compatible",
+				children: "OpenAI Compatible",
+			},
+		],
+	},
+	{
+		title: "Other Providers",
+		links: [
+			{ href: "/ai-providers/chutes-ai", children: "Chutes AI" },
+			{ href: "/ai-providers/inception", children: "Inception" },
+			{ href: "/ai-providers/minimax", children: "MiniMax" },
+			{ href: "/ai-providers/moonshot", children: "Moonshot" },
+			{ href: "/ai-providers/ovhcloud", children: "OVHcloud" },
+			{ href: "/ai-providers/sap-ai-core", children: "SAP AI Core" },
+		],
+	},
+	{
+		title: "Special Modes",
+		links: [
+			{ href: "/ai-providers/v0", children: "v0" },
+			{ href: "/ai-providers/human-relay", children: "Human Relay" },
+			{ href: "/ai-providers/synthetic", children: "Synthetic Provider" },
+			{
+				href: "/ai-providers/virtual-quota-fallback",
+				children: "Virtual Quota Fallback",
+			},
+		],
+	},
 ]

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -31,7 +31,7 @@ ZenMux provides a unified API gateway to access multiple AI models from differen
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly u{2014} see the **CLI** tab for the file format.
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
 
 {% /tab %}
 {% tab label="CLI" %}

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -31,7 +31,7 @@ ZenMux provides a unified API gateway to access multiple AI models from differen
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly â€” see the **CLI** tab for the file format.
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly u{2014} see the **CLI** tab for the file format.
 
 {% /tab %}
 {% tab label="CLI" %}

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -1,25 +1,26 @@
 ---
-title: ZenMux
+sidebar_label: ZenMux
 ---
-
-import Codicon from "@site/src/components/Codicon";
 
 # Using ZenMux With Kilo Code
 
-[ZenMux](https://zenmux.ai) provides a unified API gateway to access multiple AI models from different providers through a single endpoint. It supports OpenAI, Anthropic, Google, and other major AI providers, automatically handling routing, fallbacks, and cost optimization.
+ZenMux provides a unified API gateway to access multiple AI models from different providers through a single endpoint, with automatic routing, fallbacks, and cost optimization.
 
-## Getting Started
+**Website:** [https://zenmux.ai](https://zenmux.ai)
 
-1. **Sign up for ZenMux:** Visit [zenmux.ai](https://zenmux.ai) to create an account.
-2. **Get your API key:** After signing up, navigate to your dashboard to generate an API key.
-3. **Configure in Kilo Code:** Add your API key to Kilo Code settings.
+## Getting an API Key
+
+1. **Sign Up:** Visit [zenmux.ai](https://zenmux.ai) to create an account.
+2. **Navigate to Dashboard:** After signing up, go to your dashboard.
+3. **Generate API Key:** Create a new API key for use with Kilo Code.
+4. **Copy the Key:** Copy and store your API key securely.
 
 ## Configuration in Kilo Code
 
 {% tabs %}
 {% tab label="VSCode (Legacy)" %}
 
-1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
@@ -30,7 +31,7 @@ import Codicon from "@site/src/components/Codicon";
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly â€” see the **CLI** tab for the file format.
 
 {% /tab %}
 {% tab label="CLI" %}
@@ -68,174 +69,10 @@ Then set your default model:
 
 ## Supported Models
 
-ZenMux supports a wide range of models from various providers:
+ZenMux supports models from OpenAI, Anthropic, Google, Meta, Mistral, and other providers. Visit [zenmux.ai/models](https://zenmux.ai/models) for the complete list of available models.
 
-Visi [zenmux.ai/models](https://zenmux.ai/models) to see the complete list of available models.
+## Tips and Notes
 
-### Other Providers
-
-ZenMux also supports models from Meta, Mistral, and many other providers. Check your ZenMux dashboard for the complete list of available models.
-
-## API Compatibility
-
-ZenMux provides multiple API endpoints for different protocols:
-
-### OpenAI Compatible API
-
-Use the standard OpenAI SDK with ZenMux's base URL:
-
-```javascript
-import OpenAI from "openai"
-
-const openai = new OpenAI({
-  baseURL: "https://zenmux.ai/api/v1",
-  apiKey: "<ZENMUX_API_KEY>",
-})
-
-async function main() {
-  const completion = await openai.chat.completions.create({
-    model: "openai/gpt-5",
-    messages: [
-      {
-        role: "user",
-        content: "What is the meaning of life?",
-      },
-    ],
-  })
-
-  console.log(completion.choices[0].message)
-}
-
-main()
-```
-
-### Anthropic API
-
-For Anthropic models, use the dedicated endpoint:
-
-```typescript
-import Anthropic from "@anthropic-ai/sdk"
-
-// 1. Initialize the Anthropic client
-const anthropic = new Anthropic({
-  // 2. Replace with the API key from your ZenMux console
-  apiKey: "<YOUR ZENMUX_API_KEY>",
-  // 3. Point the base URL to the ZenMux endpoint
-  baseURL: "https://zenmux.ai/api/anthropic",
-})
-
-async function main() {
-  const msg = await anthropic.messages.create({
-    model: "anthropic/claude-sonnet-4.5",
-    max_tokens: 1024,
-    messages: [{ role: "user", content: "Hello, Claude" }],
-  })
-  console.log(msg)
-}
-
-main()
-```
-
-### Platform API
-
-The Get generation interface is used to query generation information, such as usage and costs.
-
-```bash
-curl https://zenmux.ai/api/v1/generation?id=<generation_id> \
-  -H "Authorization: Bearer $ZENMUX_API_KEY"
-```
-
-### Google Vertex AI API
-
-For Google models:
-
-```typescript
-const genai = require("@google/genai")
-
-const client = new genai.GoogleGenAI({
-  apiKey: "$ZENMUX_API_KEY",
-  vertexai: true,
-  httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
-    apiVersion: "v1",
-  },
-})
-
-const response = await client.models.generateContent({
-  model: "google/gemini-2.5-pro",
-  contents: "How does AI work?",
-})
-console.log(response)
-```
-
-## Features
-
-### Automatic Routing
-
-ZenMux automatically routes your requests to the best available provider based on:
-
-- Model availability
-- Response time
-- Cost optimization
-- Provider health status
-
-### Fallback Support
-
-If a provider is unavailable, ZenMux automatically falls back to alternative providers that support the same model capabilities.
-
-### Cost Optimization
-
-ZenMux can be configured to optimize for cost, routing requests to the most cost-effective provider while maintaining quality.
-
-### Zero Data Retention (ZDR)
-
-Enable ZDR mode to ensure that no request or response data is stored by ZenMux, providing maximum privacy for sensitive applications.
-
-## Advanced Configuration
-
-### Provider Routing
-
-You can specify routing preferences:
-
-- **Price**: Route to the lowest cost provider
-- **Throughput**: Route to the provider with highest tokens/second
-- **Latency**: Route to the provider with fastest response time
-
-### Data Collection Settings
-
-Control how ZenMux handles your data:
-
-- **Allow**: Allow data collection for service improvement
-- **Deny**: Disable all data collection
-
-### Middle-Out Transform
-
-Enable the middle-out transform feature to optimize prompts that exceed model context limits.
-
-## Troubleshooting
-
-### API Key Issues
-
-- Ensure your API key is correctly copied without any extra spaces
-- Check that your ZenMux account is active and has available credits
-- Verify the API key has the necessary permissions
-
-### Model Availability
-
-- Some models may have regional restrictions
-- Check the ZenMux dashboard for current model availability
-- Ensure your account tier has access to the desired models
-
-### Connection Issues
-
-- Verify your internet connection
-- Check if you're behind a firewall that might block API requests
-- Try using a custom base URL if the default endpoint is blocked
-
-## Support
-
-For additional support:
-
-- Visit the [ZenMux documentation](https://zenmux.ai/docs)
-- Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues
+- **Pricing:** Check the [ZenMux dashboard](https://zenmux.ai) for current pricing and usage details.
+- **Zero Data Retention:** ZenMux offers a ZDR mode for maximum privacy. See the [ZenMux documentation](https://zenmux.ai/docs) for configuration details.
+- **Routing Options:** ZenMux can route requests by price, throughput, or latency. Refer to the [ZenMux documentation](https://zenmux.ai/docs) for advanced routing configuration.


### PR DESCRIPTION
## Summary

Fixes #6141

The ZenMux provider documentation page was inconsistent with other provider docs and was missing from the sidebar navigation.

### Changes

**packages/kilo-docs/pages/ai-providers/zenmux.md:**
- Replaced `title` frontmatter with `sidebar_label: ZenMux` to match all other provider pages
- Added **Website** link matching the standard format used by other providers (e.g. OpenAI, Anthropic)
- Restructured **Getting an API Key** section with numbered steps matching the standard format
- Removed excessive ZenMux-specific API usage examples (OpenAI SDK, Anthropic SDK, Vertex AI, Platform API) that belong in ZenMux's own docs, not a Kilo Code integration guide
- Consolidated Features/Advanced Configuration/Troubleshooting into a concise **Tips and Notes** section

**packages/kilo-docs/lib/nav/ai-providers.ts:**
- Added ZenMux entry to the **AI Gateways** section (as it is a multi-provider API gateway)

## Test plan

- [ ] Verify ZenMux appears in the sidebar under AI Gateways
- [ ] Verify the ZenMux page renders correctly with proper tabs
- [ ] Compare formatting with other provider pages (e.g. OpenAI) for consistency