### PR TITLE
fix(cli): guard cyclic session fork remaps

### DIFF
--- a/.changeset/guard-session-fork-cycles.md
+++ b/.changeset/guard-session-fork-cycles.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent session forks with cyclic task metadata from hanging.

--- a/packages/opencode/src/kilocode/session/fork.ts
+++ b/packages/opencode/src/kilocode/session/fork.ts
@@ -1,3 +1,4 @@
+import { makeRuntime } from "@/effect/run-service"
 import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionID, PartID } from "@/session/schema"
@@ -22,7 +23,7 @@ function childID(part: MessageV2.Part): string | undefined {
  * child session references, causing SSE events and permission prompts to bleed
  * across sessions.
  */
-export async function remapChildren(sid: SessionID): Promise<void> {
+export async function remapChildren(sid: SessionID, remapped = new Map<string, SessionID>()): Promise<void> {
   const msgs = await Session.messages({ sessionID: sid })
   const refs: { part: MessageV2.ToolPart; child: string }[] = []
   for (const msg of msgs) {
@@ -33,15 +34,14 @@ export async function remapChildren(sid: SessionID): Promise<void> {
   }
   if (refs.length === 0) return
 
-  const remapped = new Map<string, SessionID>()
+  const { runPromise } = makeRuntime(Session.Service, Session.defaultLayer)
   for (const ref of refs) {
     if (remapped.has(ref.child)) continue
     const exists = await Session.get(SessionID.make(ref.child)).catch(() => undefined)
     if (!exists) continue
-    // Session.fork() already calls remapChildren on the forked child,
-    // so nested subagents are handled recursively without an explicit call here.
-    const forked = await Session.fork({ sessionID: SessionID.make(ref.child) })
+    const forked = await runPromise((svc) => svc.fork({ sessionID: SessionID.make(ref.child) }))
     remapped.set(ref.child, forked.id)
+    await remapChildren(forked.id, remapped)
   }
 
   if (remapped.size === 0) return

--- a/packages/opencode/src/kilocode/session/index.ts
+++ b/packages/opencode/src/kilocode/session/index.ts
@@ -304,7 +304,8 @@ export const kiloSessionFork = fn(
   async (input) => {
     const { runPromise } = makeRuntime(Session.Service, Session.defaultLayer)
     const session = await runPromise((svc) => svc.fork(input))
-    await KiloSession.remapChildren(session.id)
+    const remapped = new Map<string, SessionID>([[input.sessionID, session.id]])
+    await KiloSession.remapChildren(session.id, remapped)
     return session
   },
 )

--- a/packages/opencode/test/kilocode/session-fork-remap.test.ts
+++ b/packages/opencode/test/kilocode/session-fork-remap.test.ts
@@ -222,6 +222,114 @@ describe("Session.fork child session remapping", () => {
   )
 
   test(
+    "self-referential task metadata remaps to the forked session",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const parent = await Session.create({ title: "parent" })
+          const msg = await userMsg(parent.id)
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: msg,
+            sessionID: parent.id,
+            type: "text",
+            text: "self task",
+          } as MessageV2.TextPart)
+          const asst = await asstMsg(parent.id, msg)
+          await Session.updatePart(
+            taskPart({
+              messageID: asst,
+              sessionID: parent.id,
+              childSessionID: parent.id,
+            }),
+          )
+
+          const forked = await Session.fork({ sessionID: parent.id })
+          const msgs = await Session.messages({ sessionID: forked.id })
+          const tools = msgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+
+          expect(tools).toHaveLength(1)
+          const meta = (tools[0].state as unknown as { metadata: { sessionId: string } }).metadata
+          expect(meta.sessionId).toBe(forked.id)
+        },
+      })
+    },
+    { timeout: 30000 },
+  )
+
+  test(
+    "cyclic task metadata remaps each session once",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const parent = await Session.create({ title: "parent" })
+          const child = await Session.create({ parentID: parent.id, title: "child" })
+
+          const parentMsg = await userMsg(parent.id)
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: parentMsg,
+            sessionID: parent.id,
+            type: "text",
+            text: "call child",
+          } as MessageV2.TextPart)
+          const parentAsst = await asstMsg(parent.id, parentMsg)
+          await Session.updatePart(
+            taskPart({
+              messageID: parentAsst,
+              sessionID: parent.id,
+              childSessionID: child.id,
+            }),
+          )
+
+          const childMsg = await userMsg(child.id)
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: childMsg,
+            sessionID: child.id,
+            type: "text",
+            text: "call parent",
+          } as MessageV2.TextPart)
+          const childAsst = await asstMsg(child.id, childMsg)
+          await Session.updatePart(
+            taskPart({
+              messageID: childAsst,
+              sessionID: child.id,
+              childSessionID: parent.id,
+            }),
+          )
+
+          const forked = await Session.fork({ sessionID: parent.id })
+          const msgs = await Session.messages({ sessionID: forked.id })
+          const tools = msgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+          const id = (tools[0].state as unknown as { metadata: { sessionId: string } }).metadata.sessionId
+
+          expect(id).not.toBe(child.id)
+          const copy = await Session.get(SessionID.make(id))
+          expect(copy.id).toBe(id)
+
+          const childMsgs = await Session.messages({ sessionID: copy.id })
+          const childTools = childMsgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+          const back = (childTools[0].state as unknown as { metadata: { sessionId: string } }).metadata.sessionId
+
+          expect(back).toBe(forked.id)
+        },
+      })
+    },
+    { timeout: 30000 },
+  )
+
+  test(
     "non-task tool parts are not affected",
     async () => {
       await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
Prevent session fork child remapping from re-entering the public fork path for already-seen task sessions, so self-referential and cyclic task metadata terminate safely.
Seed the root session remap and reuse it recursively so cycles point at the copied session graph instead of forking indefinitely.

Fixes #9216

Tests: bun test test/kilocode/session-fork-remap.test.ts