### PR TITLE
fix(jetbrains): cancel app state collectors

### DIFF
--- a/.changeset/jetbrains-state-collector.md
+++ b/.changeset/jetbrains-state-collector.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent duplicate JetBrains app state listeners after restarting or reinstalling Kilo.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloAppService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloAppService.kt
@@ -12,6 +12,7 @@ import fleet.rpc.client.durable
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +38,7 @@ class KiloAppService internal constructor(
     }
 
     private val started = AtomicBoolean(false)
+    private var collector: Job? = null
 
     /** CLI version string from the last successful health check, or null if unknown. */
     @Volatile
@@ -57,8 +59,9 @@ class KiloAppService internal constructor(
 
     fun connect() {
         if (!started.compareAndSet(false, true)) return
+        collector?.cancel()
         cs.launch { call { connect() } }
-        cs.launch {
+        collector = cs.launch {
             val api = rpc
             if (api != null) api.state().collect { _state.value = it }
             else durable { KiloAppRpcApi.getInstance().state().collect { _state.value = it } }
@@ -77,6 +80,8 @@ class KiloAppService internal constructor(
     suspend fun restart() {
         LOG.info("restart: resetting state and sending RPC")
         started.set(false)
+        collector?.cancelAndJoin()
+        collector = null
         version = null
         call { restart() }
         LOG.info("restart: RPC returned — backend restart complete")
@@ -86,6 +91,8 @@ class KiloAppService internal constructor(
     suspend fun reinstall() {
         LOG.info("reinstall: resetting state and sending RPC")
         started.set(false)
+        collector?.cancelAndJoin()
+        collector = null
         version = null
         call { reinstall() }
         LOG.info("reinstall: RPC returned — backend reinstall complete")

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/model/AppWatchingTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/model/AppWatchingTest.kt
@@ -2,6 +2,7 @@ package ai.kilocode.client.session.model
 
 import ai.kilocode.rpc.dto.KiloAppStateDto
 import ai.kilocode.rpc.dto.KiloAppStatusDto
+import kotlinx.coroutines.runBlocking
 
 class AppWatchingTest : SessionModelTestBase() {
 
@@ -15,5 +16,29 @@ class AppWatchingTest : SessionModelTestBase() {
 
         assertTrue(events.any { it is SessionEvent.AppChanged })
         assertEquals(KiloAppStatusDto.READY, m.chat.app.status)
+    }
+
+    fun `test restart reconnect keeps single app state collector`() = runBlocking {
+        app.connect()
+        flush()
+        assertEquals(1, appRpc.collectors.get())
+
+        app.restart()
+        app.connect()
+        flush()
+
+        assertEquals(1, appRpc.collectors.get())
+    }
+
+    fun `test reinstall reconnect keeps single app state collector`() = runBlocking {
+        app.connect()
+        flush()
+        assertEquals(1, appRpc.collectors.get())
+
+        app.reinstall()
+        app.connect()
+        flush()
+
+        assertEquals(1, appRpc.collectors.get())
     }
 }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeAppRpcApi.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeAppRpcApi.kt
@@ -4,8 +4,11 @@ import ai.kilocode.rpc.KiloAppRpcApi
 import ai.kilocode.rpc.dto.HealthDto
 import ai.kilocode.rpc.dto.KiloAppStateDto
 import ai.kilocode.rpc.dto.KiloAppStatusDto
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Fake [KiloAppRpcApi] for testing.
@@ -17,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class FakeAppRpcApi : KiloAppRpcApi {
 
     val state = MutableStateFlow(KiloAppStateDto(KiloAppStatusDto.DISCONNECTED))
+    val collectors = AtomicInteger(0)
     var health = HealthDto(healthy = true, version = "1.0.0")
 
     var connected = false
@@ -30,6 +34,8 @@ class FakeAppRpcApi : KiloAppRpcApi {
     override suspend fun state(): Flow<KiloAppStateDto> {
         assertNotEdt("state")
         return state
+            .onStart { collectors.incrementAndGet() }
+            .onCompletion { collectors.decrementAndGet() }
     }
 
     override suspend fun health(): HealthDto {


### PR DESCRIPTION
Fix duplicate JetBrains app state collectors by tracking the collector job and cancelling it across restart/reinstall reconnect cycles.
Adds coverage that reconnecting after restart or reinstall leaves only one active app state collector.

Fixes #9219

Tests:
- `git diff --check`
- `./gradlew :frontend:test --tests ai.kilocode.client.session.model.AppWatchingTest` (blocked: JAVA_HOME is not set and no `java` command is available in PATH)