### PR TITLE
fix(cli): reject network waits on instance disposal

### DIFF
--- a/.changeset/reject-network-waits.md
+++ b/.changeset/reject-network-waits.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reject pending network waits when the CLI instance is disposed.

--- a/packages/opencode/src/session/network.ts
+++ b/packages/opencode/src/session/network.ts
@@ -205,9 +205,14 @@ export namespace SessionNetwork {
     }
 
     const promise = new Promise<void>((resolve, reject) => {
+      const abort = new AbortController()
+      const dispose = () => {
+        input.abort.removeEventListener("abort", onAbort)
+        abort.abort()
+      }
       const onAbort = () => {
         if (!s.pending[id]) return
-        cleanup()
+        dispose()
         delete s.pending[id]
         Bus.publish(Event.Rejected, {
           sessionID: input.sessionID,
@@ -215,18 +220,17 @@ export namespace SessionNetwork {
         })
         reject(new DOMException("Aborted", "AbortError"))
       }
-      const cleanup = () => input.abort.removeEventListener("abort", onAbort)
       s.pending[id] = {
         info,
         resolve: () => {
-          cleanup()
+          dispose()
           resolve()
         },
         reject: (err) => {
-          cleanup()
+          dispose()
           reject(err)
         },
-        dispose: cleanup,
+        dispose,
       }
       input.abort.addEventListener("abort", onAbort, { once: true })
       if (input.abort.aborted) {
@@ -235,7 +239,7 @@ export namespace SessionNetwork {
       }
       log.warn("waiting for network", { sessionID: input.sessionID, requestID: id, message: input.message })
       Bus.publish(Event.Asked, info)
-      void watch({ requestID: id, abort: input.abort }).catch((err) => {
+      void watch({ requestID: id, abort: abort.signal }).catch((err) => {
         log.error("restore watch failed", { err, requestID: id })
       })
     })

--- a/packages/opencode/src/session/network.ts
+++ b/packages/opencode/src/session/network.ts
@@ -86,6 +86,7 @@ export namespace SessionNetwork {
         info: Wait
         resolve: () => void
         reject: (e: unknown) => void
+        dispose: () => void
       }
     >
   }
@@ -99,7 +100,22 @@ export namespace SessionNetwork {
     Effect.gen(function* () {
       const is = yield* InstanceState.make(
         Effect.fn("SessionNetwork.state")(function* () {
-          return { pending: {} } as StateShape
+          const s: StateShape = { pending: {} }
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              const pending = Object.entries(s.pending)
+              for (const [id, req] of pending) {
+                delete s.pending[id]
+                req.dispose()
+                Bus.publish(Event.Rejected, {
+                  sessionID: req.info.sessionID,
+                  requestID: req.info.id,
+                })
+                req.reject(new DisposedError())
+              }
+            }),
+          )
+          return s
         }),
       )
       return StateService.of({
@@ -191,7 +207,7 @@ export namespace SessionNetwork {
     const promise = new Promise<void>((resolve, reject) => {
       const onAbort = () => {
         if (!s.pending[id]) return
-        input.abort.removeEventListener("abort", onAbort)
+        cleanup()
         delete s.pending[id]
         Bus.publish(Event.Rejected, {
           sessionID: input.sessionID,
@@ -199,16 +215,18 @@ export namespace SessionNetwork {
         })
         reject(new DOMException("Aborted", "AbortError"))
       }
+      const cleanup = () => input.abort.removeEventListener("abort", onAbort)
       s.pending[id] = {
         info,
         resolve: () => {
-          input.abort.removeEventListener("abort", onAbort)
+          cleanup()
           resolve()
         },
         reject: (err) => {
-          input.abort.removeEventListener("abort", onAbort)
+          cleanup()
           reject(err)
         },
+        dispose: cleanup,
       }
       input.abort.addEventListener("abort", onAbort, { once: true })
       if (input.abort.aborted) {
@@ -303,6 +321,12 @@ export namespace SessionNetwork {
   export class RejectedError extends Error {
     constructor() {
       super("Network reconnect was rejected")
+    }
+  }
+
+  export class DisposedError extends Error {
+    constructor() {
+      super("Network reconnect was cancelled by instance disposal")
     }
   }
 }

--- a/packages/opencode/test/session/network.test.ts
+++ b/packages/opencode/test/session/network.test.ts
@@ -134,4 +134,25 @@ describe("session.network", () => {
       },
     })
   })
+
+  test("instance disposal rejects pending ask and clears wait", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { promise } = await SessionNetwork.ask({
+          sessionID: "ses_test",
+          message: "Connection refused",
+          abort: new AbortController().signal,
+        })
+        const err = promise.catch((e: unknown) => e)
+        expect(await SessionNetwork.list()).toHaveLength(1)
+
+        await Instance.disposeAll()
+
+        expect(await err).toBeInstanceOf(SessionNetwork.DisposedError)
+        expect(await SessionNetwork.list()).toHaveLength(0)
+      },
+    })
+  })
 })


### PR DESCRIPTION
Reject pending session network waits when an instance is disposed so auth/org changes cannot orphan wait promises or abort listeners.
Add a targeted regression test covering Instance.disposeAll() rejection and list cleanup.

Fixes #9218