### PR TITLE
fix(cli): restore model descriptions in expanded model picker

### DIFF
--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -54,6 +54,7 @@ export function patchModelsDevModel(providerID: string, source: any) {
     prompt: source.prompt,
     isFree: source.isFree,
     ai_sdk_provider: source.ai_sdk_provider,
+    options: source.options ?? {},
   }
 }
 


### PR DESCRIPTION
## Summary

Model descriptions stopped showing in the expanded model picker panel. The Kilo Gateway API returns a `description` field inside each model's `options` object, but `patchModelsDevModel` was not forwarding `options` in its return value — so `Object.assign` in `fromModelsDevModel` left `options` as `{}` and silently discarded the description before it ever reached the server response or the webview.

**Fix:** add `options: source.options ?? {}` to `patchModelsDevModel`'s return value (one line in `packages/opencode/src/kilocode/provider/provider.ts`).

## Before

**Before:** expanded model picker shows pricing + capability badges for Claude Haiku 4.5, but the description area is empty.

<img width="573" height="792" alt="Screen Shot 2026-04-20 at 5 46 43 PM" src="https://github.com/user-attachments/assets/36976b1f-a478-483f-9a7c-f9635afc9f2d" />


## After

**After:** description text appears below the badges — *"Claude Haiku 4.5 is Anthropic's fastest and most efficient model, delivering near-frontier intelligence at a fraction of the cost and latency of larger Claude models…"*

<img width="582" height="690" alt="Screen Shot 2026-04-20 at 5 45 09 PM" src="https://github.com/user-attachments/assets/ce708eda-3046-4ebf-808d-079617ce9297" />




