### PR TITLE
fix(permission): clear permission prompt when session is aborted

### DIFF
--- a/.changeset/fix-escape-clears-permission.md
+++ b/.changeset/fix-escape-clears-permission.md
@@ -1,5 +1,5 @@
 ---
-"@kilocode/opencode": patch
+"@kilocode/cli": patch
 ---
 
 fix(permission): clear permission prompt when session is aborted

--- a/.changeset/fix-escape-clears-permission.md
+++ b/.changeset/fix-escape-clears-permission.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/opencode": patch
+---
+
+fix(permission): clear permission prompt when session is aborted
+
+When a user presses Escape to abort a session while a permission prompt is pending, the prompt now correctly disappears. Previously, the server-side cleanup removed the pending request but never published the `permission.replied` event, leaving the TUI prompt stuck.

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -230,11 +230,23 @@ export namespace Permission {
         const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()
         pending.set(id, { info, ruleset, deferred }) // kilocode_change
         yield* bus.publish(Event.Asked, info)
-        return yield* Effect.ensuring(
-          Deferred.await(deferred),
-          Effect.sync(() => {
-            s.pending.delete(id)
-          }),
+        return yield* Deferred.await(deferred).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              s.pending.delete(id)
+            }),
+          ),
+          Effect.onInterrupt(() =>
+            // When the session is aborted, the deferred is interrupted but
+            // Permission.Event.Replied is never published, leaving the TUI
+            // permission prompt stuck.  Publish the event so the client
+            // clears the prompt.
+            bus.publish(Event.Replied, {
+              sessionID: info.sessionID,
+              requestID: id,
+              reply: "reject" as const,
+            }),
+          ),
         )
       })
 

--- a/packages/opencode/test/permission/abort-clears-prompt.test.ts
+++ b/packages/opencode/test/permission/abort-clears-prompt.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
+import { Bus } from "../../src/bus"
+import { Permission } from "../../src/permission"
+import { SessionID } from "../../src/session/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const bus = Bus.layer
+const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(bus)), bus, CrossSpawnSpawner.defaultLayer)
+const { effect: it, live } = testEffect(env)
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask(input)
+  })
+
+const reply = (input: Parameters<Permission.Interface["reply"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.reply(input)
+  })
+
+const list = () =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.list()
+  })
+
+describe("Permission abort", () => {
+  live("publishes Replied event when ask fiber is interrupted", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessionID = SessionID.make("session_test")
+        const b = yield* Bus.Service
+
+        const replied: string[] = []
+        yield* b.subscribeCallback(Permission.Event.Replied, (evt: any) => {
+          replied.push(evt.properties.requestID as string)
+        })
+
+        const fiber = yield* ask({
+          sessionID,
+          permission: "bash",
+          patterns: ["*"],
+          ruleset: [],
+          metadata: {},
+          always: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* Effect.gen(function* () {
+          let pending = yield* list()
+          while (pending.length === 0) {
+            yield* Effect.sleep("10 millis")
+            pending = yield* list()
+          }
+          expect(pending).toHaveLength(1)
+        })
+
+        // Interrupt the fiber (simulating session abort)
+        yield* Fiber.interrupt(fiber)
+        yield* Effect.sleep("100 millis")
+
+        // Permission should be cleared from pending
+        const remaining = yield* list()
+        expect(remaining).toHaveLength(0)
+
+        // Replied event should have been published so the TUI clears the prompt
+        expect(replied).toHaveLength(1)
+      }),
+    ),
+  )
+
+  live("does not double-publish Replied event on normal reply", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessionID = SessionID.make("session_test")
+        const b = yield* Bus.Service
+
+        const replied: string[] = []
+        yield* b.subscribeCallback(Permission.Event.Replied, (evt: any) => {
+          replied.push(evt.properties.requestID as string)
+        })
+
+        const fiber = yield* ask({
+          sessionID,
+          permission: "bash",
+          patterns: ["*"],
+          ruleset: [],
+          metadata: {},
+          always: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* Effect.gen(function* () {
+          let pending = yield* list()
+          while (pending.length === 0) {
+            yield* Effect.sleep("10 millis")
+            pending = yield* list()
+          }
+          const requestID = pending[0].id
+
+          // Reply normally
+          yield* reply({ requestID, reply: "once" })
+        })
+
+        yield* Fiber.join(fiber)
+        yield* Effect.sleep("50 millis")
+
+        // Only one Replied event from the explicit reply, none from interrupt
+        expect(replied).toHaveLength(1)
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
## Summary

Fixes #9271

When a user presses Escape to abort a session while a permission prompt is pending, the prompt stays visible because the server-side cleanup removes the pending request but never publishes `permission.replied`. The TUI client only removes permissions from its store when it receives this event, so the prompt gets stuck.

## Changes

- **`packages/opencode/src/permission/index.ts`**: Add `Effect.onInterrupt` to `Permission.ask` so that when the deferred is interrupted (session abort), a `Permission.Event.Replied` event is published with `reply: "reject"`, causing the TUI to clear the prompt. The existing `Effect.ensuring` cleanup still handles deleting from the pending map.

- **`packages/opencode/test/permission/abort-clears-prompt.test.ts`**: Two new tests:
  - Verifies that interrupting an `ask` fiber publishes the Replied event
  - Verifies that normal reply flow does not double-publish

## How to test

1. Start a session, trigger a tool that requires permission (e.g., bash command)
2. While the permission prompt is showing, press Escape to abort
3. The permission prompt should disappear (previously it stayed stuck)