### PR TITLE
docs: document CLI custom modes paths and legacy file lookup order

### DIFF
--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -458,14 +458,14 @@ Default legacy mode slugs (`code`, `build`, `architect`, `ask`, `debug`, `orches
 
 ### Legacy File Lookup Paths
 
-The CLI reads legacy `custom_modes.yaml` from the following locations (in order):
+The CLI reads legacy mode files from the following locations (in load order). When the same slug appears in multiple sources, the **last loaded source wins**:
 
-| Priority | Path | Scope |
-|----------|------|-------|
-| 1 | VSCode extension global storage `/settings/custom_modes.yaml` | Global |
-| 2 | `~/.kilocode/cli/global/settings/custom_modes.yaml` | Global |
-| 3 | `~/.kilocodemodes` | Global |
-| 4 | `<project>/.kilocodemodes` | Project |
+| Load Order | Path | Format | Scope |
+|------------|------|--------|-------|
+| 1 | VSCode extension global storage `/settings/custom_modes.yaml` | YAML | Global |
+| 2 | `~/.kilocode/cli/global/settings/custom_modes.yaml` | YAML | Global |
+| 3 | `~/.kilocodemodes` | YAML | Global |
+| 4 | `<project>/.kilocodemodes` | YAML | Project (wins on conflict) |
 
 {% callout type="info" %}
 `~/.config/kilo/` is the XDG config directory for the new agent format — legacy `custom_modes.yaml` placed there will **not** be loaded. Use `~/.config/kilo/agent/*.md` or `~/.config/kilo/kilo.jsonc` for new agent definitions instead.

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -232,6 +232,18 @@ If you have existing `.kilocodemodes` or `custom_modes.yaml` files from the VSCo
 
 Default legacy mode slugs (`code`, `build`, `architect`, `ask`, `debug`, `orchestrator`) are skipped during migration since they map to built-in agents (`build` → `code`, `architect` → `plan`).
 
+### Legacy File Locations
+
+The current VSCode extension reads the legacy `custom_modes.yaml` file from its own global storage directory. Helpful for inspecting or fixing the file before the one-time migration runs:
+
+| OS      | Path                                                                                                  |
+| ------- | ----------------------------------------------------------------------------------------------------- |
+| macOS   | `~/Library/Application Support/Code/User/globalStorage/kilocode.kilo-code/settings/custom_modes.yaml` |
+| Linux   | `~/.config/Code/User/globalStorage/kilocode.kilo-code/settings/custom_modes.yaml`                     |
+| Windows | `%APPDATA%\Code\User\globalStorage\kilocode.kilo-code\settings\custom_modes.yaml`                     |
+
+Project-level `.kilocodemodes` and workspace-scoped files are handled by the CLI backend that the extension delegates to — see the [CLI tab](#cli) for the full load-order table. After the extension migrates on startup, the legacy file is no longer consulted; remove new modes through the extension UI instead of editing `custom_modes.yaml` directly.
+
 {% /tab %}
 {% tab label="CLI" %}
 

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -237,6 +237,10 @@ Default legacy mode slugs (`code`, `build`, `architect`, `ask`, `debug`, `orches
 
 In the CLI, custom behavioral profiles are called **agents** instead of modes. Agents are defined as Markdown files with YAML frontmatter or as entries in the `agent` key of your config file.
 
+{% callout type="warning" %}
+**Legacy `custom_modes.yaml` is not loaded from `~/.config/kilo/`.** If you're migrating from the legacy VSCode extension, global custom modes are read from `~/.kilocode/cli/global/settings/custom_modes.yaml` (not from the CLI's XDG config directory). The recommended approach is to convert legacy modes to agent `.md` files and place them in `~/.config/kilo/agent/` instead — see [Markdown files](#3-markdown-files-with-yaml-frontmatter) and [Migration](#migration-from-vscode-extension-modes) below.
+{% /callout %}
+
 ## What's Included in a Custom Agent?
 
 | Property                    | Description                                                                                                           |
@@ -451,6 +455,21 @@ If you have existing `.kilocodemodes` or `custom_modes.yaml` files from the VSCo
 - Mode is set to `primary`
 
 Default legacy mode slugs (`code`, `build`, `architect`, `ask`, `debug`, `orchestrator`) are skipped during migration since they map to built-in agents (`build` → `code`, `architect` → `plan`).
+
+### Legacy File Lookup Paths
+
+The CLI reads legacy `custom_modes.yaml` from the following locations (in order):
+
+| Priority | Path | Scope |
+|----------|------|-------|
+| 1 | VSCode extension global storage `/settings/custom_modes.yaml` | Global |
+| 2 | `~/.kilocode/cli/global/settings/custom_modes.yaml` | Global |
+| 3 | `~/.kilocodemodes` | Global |
+| 4 | `<project>/.kilocodemodes` | Project |
+
+{% callout type="info" %}
+`~/.config/kilo/` is the XDG config directory for the new agent format — legacy `custom_modes.yaml` placed there will **not** be loaded. Use `~/.config/kilo/agent/*.md` or `~/.config/kilo/kilo.jsonc` for new agent definitions instead.
+{% /callout %}
 
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}


### PR DESCRIPTION
Fixes #6471

## Summary

- Added a warning callout in the CLI tab of the Custom Modes docs explaining that legacy `custom_modes.yaml` is **not** loaded from `~/.config/kilo/` (the XDG config directory). Users migrating from the legacy VSCode extension were placing the file there and it was silently ignored.
- Added a **Legacy File Lookup Paths** table documenting the 4 locations the CLI actually reads `custom_modes.yaml` from, in priority order:
  1. VSCode extension global storage
  2. `~/.kilocode/cli/global/settings/custom_modes.yaml`
  3. `~/.kilocodemodes`
  4. `<project>/.kilocodemodes`
- Added an info callout clarifying that `~/.config/kilo/` is exclusively for the new agent `.md` format and `kilo.jsonc` config.

## Why

Issue #6471 reports that placing `custom_modes.yaml` in `~/.config/kilo/` (where the new CLI stores configs) has no effect. The paths were undocumented, leading to user confusion. This change makes the distinction explicit.

## Test plan

- [x] Verified paths against `packages/opencode/src/kilocode/modes-migrator.ts` source code
- [ ] Visual check on docs site preview (Vercel)

Made with [Cursor](https://cursor.com)