### PR TITLE
fix: clamp output token count to prevent negative values

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -318,7 +318,7 @@ export const getUsage = (input: {
   const tokens = {
     total,
     input: adjustedInputTokens,
-    output: safe(outputTokens - reasoningTokens),
+    output: Math.max(0, safe(outputTokens - reasoningTokens)),
     reasoning: reasoningTokens,
     cache: {
       write: cacheWriteInputTokens,


### PR DESCRIPTION
## Summary

- Clamp `output` token count in `getUsage` to `Math.max(0, ...)` to prevent negative values when a provider reports `reasoningTokens > outputTokens`

Fixes #9168

## Root cause

`packages/opencode/src/session/index.ts:319` subtracts `reasoningTokens` from `outputTokens` to derive the 'visible output' count. When the Kilo gateway reports an inconsistent usage breakdown (`reasoningTokens > outputTokens`), the result goes negative.

Observed with: `moonshotai/kimi-k2.5` (thinking variant) via Kilo gateway.

## Impact of fix

- **Display**: no more negative token counts in TUI, VS Code extension, or session exports
- **Stats**: `stats.ts` aggregation no longer skewed by negative output values
- **Cost**: unchanged (Kilo gateway cost is reported separately)

## Changes

`packages/opencode/src/session/index.ts` (line 319):

\\\diff
- output: safe(outputTokens - reasoningTokens),
+ output: Math.max(0, safe(outputTokens - reasoningTokens)),
\\\

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] With a model that has `reasoningTokens > outputTokens`, output shows 0 instead of negative
- [ ] Normal sessions (reasoningTokens < outputTokens) are unaffected