### PR TITLE
fix(vscode): register .kilo artifacts in git exclude on first state write

### DIFF
--- a/.changeset/agent-manager-exclude-on-first-save.md
+++ b/.changeset/agent-manager-exclude-on-first-save.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Stop Agent Manager's `.kilo/agent-manager.json` from showing up in `git status` on projects that use local sessions without ever creating a worktree.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -26,6 +26,7 @@ import {
   type PRInfo,
   type BranchListItem,
 } from "./git-import"
+import { ensureKiloGitExclude } from "./git-exclude"
 
 const TEMP_PREFIX = ".kilo-delete-"
 const RM_OPTS: fs.RmOptions = { recursive: true, force: true, maxRetries: 3, retryDelay: 200 }
@@ -500,28 +501,7 @@ export class WorktreeManager {
   // ---------------------------------------------------------------------------
 
   async ensureGitExclude(): Promise<void> {
-    const gitDir = await this.resolveGitDir()
-    const excludePath = path.join(gitDir, "info", "exclude")
-    const items = [
-      [".kilo/worktrees/", "Kilo Code agent worktrees"],
-      [".kilo/agent-manager.json", "Kilo Agent Manager state"],
-      [".kilo/setup-script", "Kilo Code worktree setup script"],
-      [".kilo/setup-script.sh", "Kilo Code worktree setup script"],
-      [".kilo/setup-script.ps1", "Kilo Code worktree setup script"],
-      [".kilo/setup-script.cmd", "Kilo Code worktree setup script"],
-      [".kilo/setup-script.bat", "Kilo Code worktree setup script"],
-      [".kilocode/worktrees/", "Kilo Code legacy agent worktrees"],
-      [".kilocode/agent-manager.json", "Kilo Agent Manager legacy state"],
-      [".kilocode/setup-script", "Kilo Code legacy worktree setup script"],
-      [".kilocode/setup-script.sh", "Kilo Code legacy worktree setup script"],
-      [".kilocode/setup-script.ps1", "Kilo Code legacy worktree setup script"],
-      [".kilocode/setup-script.cmd", "Kilo Code legacy worktree setup script"],
-      [".kilocode/setup-script.bat", "Kilo Code legacy worktree setup script"],
-    ] as const
-
-    for (const [entry, comment] of items) {
-      await this.addExcludeEntry(excludePath, entry, comment)
-    }
+    await ensureKiloGitExclude(this.root, this.log)
   }
 
   private async ensureWorktreeExclude(worktreePath: string): Promise<void> {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -76,6 +76,7 @@ interface StateFile {
 }
 
 import { KILO_DIR, migrateAgentManagerData, type MigrationResult } from "./constants"
+import { ensureKiloGitExclude } from "./git-exclude"
 
 const STATE_FILE = "agent-manager.json"
 
@@ -101,6 +102,7 @@ export class WorktreeStateManager {
 
   private readonly root: string
   private migrated = false
+  private excludeEnsured = false
 
   constructor(root: string, log: (msg: string) => void) {
     this.root = root
@@ -666,6 +668,14 @@ export class WorktreeStateManager {
     try {
       const dir = path.dirname(this.file)
       if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true })
+      // Register .kilo/ artifacts in .git/info/exclude on the first write per
+      // instance. Gating on a flag (vs. file existence) ensures users who
+      // already have agent-manager.json from before this fix still get the
+      // exclude entries on their next extension reload.
+      if (!this.excludeEnsured) {
+        this.excludeEnsured = true
+        await ensureKiloGitExclude(this.root, this.log)
+      }
       await fs.promises.writeFile(this.file, JSON.stringify(data, null, 2), "utf-8")
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -668,13 +668,14 @@ export class WorktreeStateManager {
     try {
       const dir = path.dirname(this.file)
       if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true })
-      // Register .kilo/ artifacts in .git/info/exclude on the first write per
-      // instance. Gating on a flag (vs. file existence) ensures users who
-      // already have agent-manager.json from before this fix still get the
-      // exclude entries on their next extension reload.
+      // Register .kilo/ artifacts in .git/info/exclude on the first successful
+      // write per instance. Gating on a flag (vs. file existence) ensures users
+      // who already have agent-manager.json from before this fix still get the
+      // exclude entries on their next extension reload. Only flip the flag when
+      // the helper actually found a git repo so a folder that becomes a git
+      // repo mid-session is retried on the next save.
       if (!this.excludeEnsured) {
-        this.excludeEnsured = true
-        await ensureKiloGitExclude(this.root, this.log)
+        this.excludeEnsured = await ensureKiloGitExclude(this.root, this.log)
       }
       await fs.promises.writeFile(this.file, JSON.stringify(data, null, 2), "utf-8")
     } catch (error) {

--- a/packages/kilo-vscode/src/agent-manager/git-exclude.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-exclude.ts
@@ -1,0 +1,89 @@
+/**
+ * Ensures Agent Manager artifacts (worktrees, state file, setup scripts) are
+ * listed in .git/info/exclude so they do not pollute `git status` in users'
+ * repos.
+ *
+ * Uses .git/info/exclude rather than the project .gitignore because these are
+ * per-clone, local-only concerns — they should not be committed to the repo.
+ *
+ * Safe to call in any non-git context (returns silently) and safe to call
+ * repeatedly (individual entries are skipped when already present).
+ */
+
+import * as fs from "fs"
+import * as path from "path"
+
+/** Entries written to .git/info/exclude, with human-readable section comments. */
+const ENTRIES: readonly (readonly [string, string])[] = [
+  [".kilo/worktrees/", "Kilo Code agent worktrees"],
+  [".kilo/agent-manager.json", "Kilo Agent Manager state"],
+  [".kilo/setup-script", "Kilo Code worktree setup script"],
+  [".kilo/setup-script.sh", "Kilo Code worktree setup script"],
+  [".kilo/setup-script.ps1", "Kilo Code worktree setup script"],
+  [".kilo/setup-script.cmd", "Kilo Code worktree setup script"],
+  [".kilo/setup-script.bat", "Kilo Code worktree setup script"],
+  [".kilocode/worktrees/", "Kilo Code legacy agent worktrees"],
+  [".kilocode/agent-manager.json", "Kilo Agent Manager legacy state"],
+  [".kilocode/setup-script", "Kilo Code legacy worktree setup script"],
+  [".kilocode/setup-script.sh", "Kilo Code legacy worktree setup script"],
+  [".kilocode/setup-script.ps1", "Kilo Code legacy worktree setup script"],
+  [".kilocode/setup-script.cmd", "Kilo Code legacy worktree setup script"],
+  [".kilocode/setup-script.bat", "Kilo Code legacy worktree setup script"],
+] as const
+
+type Log = (msg: string) => void
+
+/**
+ * Resolve the shared git directory for a working tree root.
+ *
+ * When root/.git is a directory, returns it directly.
+ * When root/.git is a file (the repo itself is a worktree), follows the
+ * `gitdir:` pointer up two levels to reach the shared .git directory.
+ * Returns undefined when the path is not a git repo.
+ */
+async function resolveGitDir(root: string): Promise<string | undefined> {
+  const gitPath = path.join(root, ".git")
+  const stat = await fs.promises.stat(gitPath).catch(() => undefined)
+  if (!stat) return undefined
+  if (stat.isDirectory()) return gitPath
+
+  const content = await fs.promises.readFile(gitPath, "utf-8").catch(() => undefined)
+  if (!content) return undefined
+  const match = content.match(/^gitdir:\s*(.+)$/m)
+  if (!match?.[1]) return undefined
+  return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
+}
+
+async function addEntry(excludePath: string, entry: string, comment: string, log?: Log): Promise<void> {
+  const dir = path.dirname(excludePath)
+  if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true })
+
+  let content = ""
+  if (fs.existsSync(excludePath)) {
+    content = await fs.promises.readFile(excludePath, "utf-8")
+    if (content.includes(entry)) return
+  }
+
+  const pad = content.endsWith("\n") || content === "" ? "" : "\n"
+  await fs.promises.appendFile(excludePath, `${pad}\n# ${comment}\n${entry}\n`)
+  log?.(`Added ${entry} to ${excludePath}`)
+}
+
+/**
+ * Append Agent Manager entries to .git/info/exclude for the given repo root.
+ *
+ * No-ops when the path is not a git repo. Errors writing individual entries
+ * are surfaced via the optional `log` callback but never thrown — callers
+ * should not have to wrap this in try/catch.
+ */
+export async function ensureKiloGitExclude(root: string, log?: Log): Promise<void> {
+  const gitDir = await resolveGitDir(root)
+  if (!gitDir) return
+
+  const excludePath = path.join(gitDir, "info", "exclude")
+  for (const [entry, comment] of ENTRIES) {
+    await addEntry(excludePath, entry, comment, log).catch((err) => {
+      log?.(`Failed to add ${entry} to ${excludePath}: ${err}`)
+    })
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/git-exclude.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-exclude.ts
@@ -6,7 +6,7 @@
  * Uses .git/info/exclude rather than the project .gitignore because these are
  * per-clone, local-only concerns — they should not be committed to the repo.
  *
- * Safe to call in any non-git context (returns silently) and safe to call
+ * Safe to call in any non-git context (returns false) and safe to call
  * repeatedly (individual entries are skipped when already present).
  */
 
@@ -34,11 +34,16 @@ const ENTRIES: readonly (readonly [string, string])[] = [
 type Log = (msg: string) => void
 
 /**
- * Resolve the shared git directory for a working tree root.
+ * Resolve the git directory that owns `info/exclude` for a working tree root.
  *
- * When root/.git is a directory, returns it directly.
- * When root/.git is a file (the repo itself is a worktree), follows the
- * `gitdir:` pointer up two levels to reach the shared .git directory.
+ * - `root/.git` is a directory → the repo's own git dir.
+ * - `root/.git` is a file (linked worktree, submodule, or --separate-git-dir):
+ *   follow the `gitdir:` pointer to the individual git dir, then honor the
+ *   `commondir` file when present. `commondir` only exists for linked
+ *   worktrees and points at the shared git dir that actually owns
+ *   `info/exclude`. Submodules and --separate-git-dir have no `commondir`,
+ *   so the pointer path is itself the correct git dir.
+ *
  * Returns undefined when the path is not a git repo.
  */
 async function resolveGitDir(root: string): Promise<string | undefined> {
@@ -51,7 +56,11 @@ async function resolveGitDir(root: string): Promise<string | undefined> {
   if (!content) return undefined
   const match = content.match(/^gitdir:\s*(.+)$/m)
   if (!match?.[1]) return undefined
-  return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
+
+  const gitDir = path.resolve(path.dirname(gitPath), match[1].trim())
+  const commondir = await fs.promises.readFile(path.join(gitDir, "commondir"), "utf-8").catch(() => undefined)
+  if (!commondir) return gitDir
+  return path.resolve(gitDir, commondir.trim())
 }
 
 async function addEntry(excludePath: string, entry: string, comment: string, log?: Log): Promise<void> {
@@ -72,13 +81,14 @@ async function addEntry(excludePath: string, entry: string, comment: string, log
 /**
  * Append Agent Manager entries to .git/info/exclude for the given repo root.
  *
- * No-ops when the path is not a git repo. Errors writing individual entries
- * are surfaced via the optional `log` callback but never thrown — callers
- * should not have to wrap this in try/catch.
+ * Returns true when a git dir was resolved and entries were processed
+ * (callers can use this to cache success and skip retries). Returns false
+ * when the path is not a git repo. Per-entry errors are surfaced via the
+ * optional `log` callback but never thrown.
  */
-export async function ensureKiloGitExclude(root: string, log?: Log): Promise<void> {
+export async function ensureKiloGitExclude(root: string, log?: Log): Promise<boolean> {
   const gitDir = await resolveGitDir(root)
-  if (!gitDir) return
+  if (!gitDir) return false
 
   const excludePath = path.join(gitDir, "info", "exclude")
   for (const [entry, comment] of ENTRIES) {
@@ -86,4 +96,5 @@ export async function ensureKiloGitExclude(root: string, log?: Log): Promise<voi
       log?.(`Failed to add ${entry} to ${excludePath}: ${err}`)
     })
   }
+  return true
 }

--- a/packages/kilo-vscode/tests/unit/git-exclude.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-exclude.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import os from "node:os"
+import path from "node:path"
+import fs from "node:fs/promises"
+import simpleGit from "simple-git"
+import { ensureKiloGitExclude } from "../../src/agent-manager/git-exclude"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+async function createRepo(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-exclude-"))
+  tempDirs.push(dir)
+  const git = simpleGit(dir)
+  await git.init()
+  await git.addConfig("user.email", "test@test.com")
+  await git.addConfig("user.name", "Test")
+  return dir
+}
+
+async function createNonRepo(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-exclude-plain-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe("ensureKiloGitExclude", () => {
+  it("adds .kilo/agent-manager.json to .git/info/exclude", async () => {
+    const root = await createRepo()
+    await ensureKiloGitExclude(root)
+    const content = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
+    expect(content).toContain(".kilo/agent-manager.json")
+  })
+
+  it("adds all Kilo artifacts including legacy .kilocode entries", async () => {
+    const root = await createRepo()
+    await ensureKiloGitExclude(root)
+    const content = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
+    expect(content).toContain(".kilo/worktrees/")
+    expect(content).toContain(".kilo/agent-manager.json")
+    expect(content).toContain(".kilo/setup-script")
+    expect(content).toContain(".kilocode/agent-manager.json")
+    expect(content).toContain(".kilocode/worktrees/")
+  })
+
+  it("is idempotent — repeated calls do not duplicate entries", async () => {
+    const root = await createRepo()
+    await ensureKiloGitExclude(root)
+    await ensureKiloGitExclude(root)
+    await ensureKiloGitExclude(root)
+    const content = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
+    const count = content.split(".kilo/agent-manager.json").length - 1
+    expect(count).toBe(1)
+  })
+
+  it("silently no-ops when path is not a git repository", async () => {
+    const root = await createNonRepo()
+    // Should not throw
+    await ensureKiloGitExclude(root)
+    // No .git directory should have been created
+    const gitExists = await fs
+      .stat(path.join(root, ".git"))
+      .then(() => true)
+      .catch(() => false)
+    expect(gitExists).toBe(false)
+  })
+
+  it("creates .git/info/ directory when missing", async () => {
+    const root = await createRepo()
+    await fs.rm(path.join(root, ".git", "info"), { recursive: true, force: true })
+    await ensureKiloGitExclude(root)
+    const stat = await fs.stat(path.join(root, ".git", "info", "exclude"))
+    expect(stat.isFile()).toBe(true)
+  })
+
+  it("preserves existing exclude content", async () => {
+    const root = await createRepo()
+    const excludePath = path.join(root, ".git", "info", "exclude")
+    await fs.writeFile(excludePath, "existing-entry\n")
+    await ensureKiloGitExclude(root)
+    const content = await fs.readFile(excludePath, "utf-8")
+    expect(content).toContain("existing-entry")
+    expect(content).toContain(".kilo/agent-manager.json")
+  })
+
+  it("surfaces progress via the log callback", async () => {
+    const root = await createRepo()
+    const logs: string[] = []
+    await ensureKiloGitExclude(root, (msg) => logs.push(msg))
+    expect(logs.some((m) => m.includes(".kilo/agent-manager.json"))).toBe(true)
+  })
+
+  it("resolves the shared git dir when invoked from inside a linked worktree", async () => {
+    const root = await createRepo()
+    // Seed commit so we can create a worktree
+    const git = simpleGit(root)
+    await fs.writeFile(path.join(root, "README.md"), "x")
+    await git.add(".")
+    await git.commit("init")
+
+    const wtDir = path.join(root, "wt")
+    await git.raw(["worktree", "add", "-b", "feature", wtDir])
+
+    // Running inside the worktree should still write to the main repo's exclude
+    await ensureKiloGitExclude(wtDir)
+    const mainExclude = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
+    expect(mainExclude).toContain(".kilo/agent-manager.json")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/git-exclude.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-exclude.test.ts
@@ -109,4 +109,55 @@ describe("ensureKiloGitExclude", () => {
     const mainExclude = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
     expect(mainExclude).toContain(".kilo/agent-manager.json")
   })
+
+  it("writes to the submodule's own git dir (no `commondir`)", async () => {
+    // Simulate a submodule layout: root/.git is a file pointing at a directory
+    // that is itself the git dir (no `commondir` file).
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-exclude-sub-"))
+    tempDirs.push(parent)
+
+    const subGitDir = path.join(parent, ".git", "modules", "sub")
+    await fs.mkdir(subGitDir, { recursive: true })
+
+    const subRoot = path.join(parent, "sub")
+    await fs.mkdir(subRoot, { recursive: true })
+    await fs.writeFile(path.join(subRoot, ".git"), `gitdir: ${subGitDir}\n`)
+
+    const ran = await ensureKiloGitExclude(subRoot)
+    expect(ran).toBe(true)
+
+    const subExclude = await fs.readFile(path.join(subGitDir, "info", "exclude"), "utf-8")
+    expect(subExclude).toContain(".kilo/agent-manager.json")
+    // Must NOT have written to the parent's .git — that would be the bug.
+    const parentExists = await fs
+      .stat(path.join(parent, ".git", "info", "exclude"))
+      .then(() => true)
+      .catch(() => false)
+    expect(parentExists).toBe(false)
+  })
+
+  it("writes to the external git dir for --separate-git-dir layouts", async () => {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-exclude-sep-"))
+    tempDirs.push(base)
+
+    const workdir = path.join(base, "workdir")
+    const realGitDir = path.join(base, "elsewhere", "real-git")
+    await fs.mkdir(workdir, { recursive: true })
+    await fs.mkdir(realGitDir, { recursive: true })
+    await fs.writeFile(path.join(workdir, ".git"), `gitdir: ${realGitDir}\n`)
+
+    const ran = await ensureKiloGitExclude(workdir)
+    expect(ran).toBe(true)
+
+    const content = await fs.readFile(path.join(realGitDir, "info", "exclude"), "utf-8")
+    expect(content).toContain(".kilo/agent-manager.json")
+  })
+
+  it("returns true on success and false outside a git repo", async () => {
+    const repo = await createRepo()
+    const plain = await createNonRepo()
+
+    expect(await ensureKiloGitExclude(repo)).toBe(true)
+    expect(await ensureKiloGitExclude(plain)).toBe(false)
+  })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -669,4 +669,29 @@ describe("WorktreeStateManager git-exclude integration", () => {
     const content = fs.readFileSync(excludePath, "utf-8")
     expect(content).toContain(".kilo/agent-manager.json")
   })
+
+  it("retries exclude registration when a folder becomes a git repo mid-session", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "wtsm-late-git-"))
+    roots.push(root)
+
+    // First save happens before `git init` — nothing to register yet.
+    const mgr = new WorktreeStateManager(root, () => {})
+    mgr.addSession("s1", null)
+    await mgr.flush()
+    expect(fs.existsSync(path.join(root, ".git"))).toBe(false)
+
+    // User initializes a repo later in the same session.
+    const git = simpleGit(root)
+    await git.init()
+    await git.addConfig("user.email", "test@test.com")
+    await git.addConfig("user.name", "Test")
+
+    // The next save should backfill the exclude entries.
+    mgr.addSession("s2", null)
+    await mgr.flush()
+
+    const excludePath = path.join(root, ".git", "info", "exclude")
+    expect(fs.existsSync(excludePath)).toBe(true)
+    expect(fs.readFileSync(excludePath, "utf-8")).toContain(".kilo/agent-manager.json")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import * as fs from "fs"
 import * as path from "path"
 import * as os from "os"
+import simpleGit from "simple-git"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 
 describe("WorktreeStateManager", () => {
@@ -580,5 +581,92 @@ describe("WorktreeStateManager", () => {
       // Separator style from the stored path is preserved (backslashes stay as backslashes)
       expect(manager.getWorktrees()[0].path).toBe("C:\\.kilo\\worktrees\\fix")
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Git exclude registration on first write
+// ---------------------------------------------------------------------------
+
+describe("WorktreeStateManager git-exclude integration", () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    while (roots.length) fs.rmSync(roots.pop()!, { recursive: true, force: true })
+  })
+
+  async function createRepo(): Promise<string> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wtsm-exclude-"))
+    roots.push(dir)
+    const git = simpleGit(dir)
+    await git.init()
+    await git.addConfig("user.email", "test@test.com")
+    await git.addConfig("user.name", "Test")
+    return dir
+  }
+
+  it("adds .kilo/agent-manager.json to .git/info/exclude on first save", async () => {
+    const root = await createRepo()
+    const mgr = new WorktreeStateManager(root, () => {})
+    mgr.addSession("local-1", null)
+    await mgr.flush()
+
+    const content = fs.readFileSync(path.join(root, ".git", "info", "exclude"), "utf-8")
+    expect(content).toContain(".kilo/agent-manager.json")
+  })
+
+  it("runs exactly once per instance — subsequent saves skip the exclude work", async () => {
+    const root = await createRepo()
+    const excludePath = path.join(root, ".git", "info", "exclude")
+    const mgr = new WorktreeStateManager(root, () => {})
+
+    mgr.addSession("s1", null)
+    await mgr.flush()
+    const first = fs.readFileSync(excludePath, "utf-8")
+
+    mgr.addSession("s2", null)
+    await mgr.flush()
+    mgr.addSession("s3", null)
+    await mgr.flush()
+    const later = fs.readFileSync(excludePath, "utf-8")
+
+    expect(later).toBe(first)
+    expect(later.split(".kilo/agent-manager.json").length - 1).toBe(1)
+  })
+
+  it("still writes state file when the path is not a git repo", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "wtsm-no-git-"))
+    roots.push(root)
+    const mgr = new WorktreeStateManager(root, () => {})
+    mgr.addSession("local-1", null)
+    await mgr.flush()
+
+    expect(fs.existsSync(path.join(root, ".kilo", "agent-manager.json"))).toBe(true)
+  })
+
+  it("backfills exclude entries on a new instance when existing state file lacks them", async () => {
+    const root = await createRepo()
+    // Pre-seed an agent-manager.json as if a prior extension version had written it
+    fs.mkdirSync(path.join(root, ".kilo"), { recursive: true })
+    fs.writeFileSync(
+      path.join(root, ".kilo", "agent-manager.json"),
+      JSON.stringify({ worktrees: {}, sessions: {} }),
+      "utf-8",
+    )
+
+    // The exclude file does not yet list .kilo/agent-manager.json
+    const excludePath = path.join(root, ".git", "info", "exclude")
+    expect(
+      fs.existsSync(excludePath) && fs.readFileSync(excludePath, "utf-8").includes(".kilo/agent-manager.json"),
+    ).toBe(false)
+
+    // A fresh instance triggering any save (even a no-op change) backfills the exclude
+    const mgr = new WorktreeStateManager(root, () => {})
+    await mgr.load()
+    mgr.addSession("s1", null)
+    await mgr.flush()
+
+    const content = fs.readFileSync(excludePath, "utf-8")
+    expect(content).toContain(".kilo/agent-manager.json")
   })
 })


### PR DESCRIPTION
## Summary

Agent Manager writes `.kilo/agent-manager.json` as soon as a session is created, but `.git/info/exclude` was only populated inside `WorktreeManager.createWorktreeImpl`. Projects that only used local (non-worktree) sessions ended up with the state file showing up in `git status`.

The exclude logic is now extracted into a shared `ensureKiloGitExclude` helper and invoked from `WorktreeStateManager.writeToDisk` on the first save per instance. This covers both fresh projects and existing installs missing the entry (backfills on next extension reload).