### PR TITLE
Add config to disable review suggestions

### DIFF
--- a/.changeset/review-auto-suggest.md
+++ b/.changeset/review-auto-suggest.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support disabling automatic local review suggestions with `review.auto_suggest: false` in Kilo config.

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -72,6 +72,16 @@ Two slash commands are available for local code reviews:
 - **`/local-review`** — Review all changes on your current branch vs the base branch
 - **`/local-review-uncommitted`** — Review uncommitted changes (staged + unstaged)
 
+The CLI may also offer a local review after completing implementation work. To turn off that prompt, set `review.auto_suggest` to `false` in `kilo.json` or `kilo.jsonc`:
+
+```json
+{
+  "review": {
+    "auto_suggest": false
+  }
+}
+```
+
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}
 

--- a/packages/kilo-vscode/tests/unit/settings-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/settings-io.test.ts
@@ -75,6 +75,7 @@ describe("buildExport", () => {
       permission: { read: "allow" },
       instructions: ["rule1.md"],
       snapshot: true,
+      review: { auto_suggest: false },
       share: "manual",
     }
     const result = buildExport(cfg)
@@ -85,6 +86,7 @@ describe("buildExport", () => {
     expect(result.permission).toEqual({ read: "allow" })
     expect(result.instructions).toEqual(["rule1.md"])
     expect(result.snapshot).toBe(true)
+    expect(result.review).toEqual({ auto_suggest: false })
     expect(result.share).toBe("manual")
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -23,6 +23,7 @@ export const KNOWN_KEYS: ReadonlyArray<string> = [
   "skills",
   "snapshot",
   "remote_control",
+  "review",
   "share",
   "username",
   "watcher",

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -452,6 +452,10 @@ export interface CommitMessageConfig {
   prompt?: string
 }
 
+export interface ReviewConfig {
+  auto_suggest?: boolean
+}
+
 export interface Config {
   permission?: PermissionConfig
   model?: string | null
@@ -467,6 +471,7 @@ export interface Config {
   skills?: SkillsConfig
   snapshot?: boolean
   remote_control?: boolean
+  review?: ReviewConfig
   share?: "manual" | "auto" | "disabled"
   username?: string
   watcher?: WatcherConfig

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -982,6 +982,15 @@ export namespace Config {
         .boolean()
         .optional()
         .describe("Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup."),
+      review: z
+        .object({
+          auto_suggest: z
+            .boolean()
+            .optional()
+            .describe("Offer a local code review suggestion after completing implementation work (default: true)."),
+        })
+        .optional()
+        .describe("Code review configuration"),
       // kilocode_change end
       autoupdate: z
         .union([z.boolean(), z.literal("notify")])

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -207,19 +207,20 @@ Skills are markdown files at `skills/<name>/SKILL.md` (or `skill/<name>/SKILL.md
 
 ## Other Top-Level Fields
 
-| Field              | Type                           | Description                                         |
-| ------------------ | ------------------------------ | --------------------------------------------------- |
-| `model`            | `"provider/model"`             | Default model                                       |
-| `small_model`      | `"provider/model"`             | Model for titles/summaries                          |
-| `default_agent`    | `string`                       | Default primary agent (fallback: `code`)            |
-| `instructions`     | `string[]`                     | Glob patterns for additional instruction files      |
-| `plugin`           | `string[]`                     | Plugin specifiers (npm packages or `file://` paths) |
-| `snapshot`         | `boolean`                      | Enable git snapshots                                |
-| `share`            | `"manual"\|"auto"\|"disabled"` | Session sharing mode                                |
-| `autoupdate`       | `boolean\|"notify"`            | Auto-update behavior                                |
-| `username`         | `string`                       | Display name override                               |
-| `compaction.auto`  | `boolean`                      | Auto-compact when context full (default: true)      |
-| `compaction.prune` | `boolean`                      | Prune old tool outputs (default: true)              |
+| Field                 | Type                           | Description                                         |
+| --------------------- | ------------------------------ | --------------------------------------------------- |
+| `model`               | `"provider/model"`             | Default model                                       |
+| `small_model`         | `"provider/model"`             | Model for titles/summaries                          |
+| `default_agent`       | `string`                       | Default primary agent (fallback: `code`)            |
+| `instructions`        | `string[]`                     | Glob patterns for additional instruction files      |
+| `plugin`              | `string[]`                     | Plugin specifiers (npm packages or `file://` paths) |
+| `snapshot`            | `boolean`                      | Enable git snapshots                                |
+| `share`               | `"manual"\|"auto"\|"disabled"` | Session sharing mode                                |
+| `autoupdate`          | `boolean\|"notify"`            | Auto-update behavior                                |
+| `username`            | `string`                       | Display name override                               |
+| `review.auto_suggest` | `boolean`                      | Offer local review suggestions (default: true)      |
+| `compaction.auto`     | `boolean`                      | Auto-compact when context full (default: true)      |
+| `compaction.prune`    | `boolean`                      | Prune old tool outputs (default: true)              |
 
 ## TUI Settings (Ctrl+P Command Palette)
 

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -38,7 +38,8 @@ export namespace KiloToolRegistry {
   }
 
   /** Suggest tool is only registered for cli and vscode clients */
-  export function suggest(tool: Tool.Def): Tool.Def[] {
+  export function suggest(tool: Tool.Def, cfg: { review?: { auto_suggest?: boolean } }): Tool.Def[] {
+    if (cfg.review?.auto_suggest === false) return []
     return ["cli", "vscode"].includes(Flag.KILO_CLIENT) ? [tool] : []
   }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -103,7 +103,7 @@ export namespace LLM {
           system.push(
             [
               // kilocode_change start - soul defines core identity and personality
-              ...(isOpenaiOauth ? [] : [SystemPrompt.soul()]),
+              ...(isOpenaiOauth ? [] : [SystemPrompt.soul(cfg)]),
               // kilocode_change end
               // use agent prompt otherwise provider prompt
               ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
@@ -148,7 +148,7 @@ export namespace LLM {
           )
           if (isOpenaiOauth) {
             // kilocode_change start - prepend soul to instructions
-            options.instructions = SystemPrompt.soul() + "\n" + system.join("\n")
+            options.instructions = SystemPrompt.soul(cfg) + "\n" + system.join("\n")
             // kilocode_change end
           }
 

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -28,8 +28,10 @@ export namespace SystemPrompt {
     return PROMPT_CODEX.trim()
   }
 
-  export function soul() {
-    return SOUL.trim()
+  export function soul(cfg?: { review?: { auto_suggest?: boolean } }) {
+    const prompt = SOUL.trim()
+    if (cfg?.review?.auto_suggest === false) return prompt.replace(/\n## Suggestions[\s\S]*$/, "")
+    return prompt
   }
   // kilocode_change end
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -226,7 +226,7 @@ export namespace ToolRegistry {
               tool.skill,
               tool.patch,
               ...(KiloToolRegistry.plan() ? [tool.plan] : []), // kilocode_change
-              ...KiloToolRegistry.suggest(tool.suggest), // kilocode_change
+              ...KiloToolRegistry.suggest(tool.suggest, cfg), // kilocode_change
               ...KiloToolRegistry.extra(kilo, cfg), // kilocode_change
               ...(Flag.KILO_EXPERIMENTAL_LSP_TOOL ? [tool.lsp] : []),
             ],

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -11,6 +11,17 @@ function load<A>(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<A>) {
 }
 
 describe("session.system", () => {
+  // kilocode_change start
+  test("soul omits review suggestion guidance when disabled", () => {
+    const enabled = SystemPrompt.soul()
+    const disabled = SystemPrompt.soul({ review: { auto_suggest: false } })
+
+    expect(enabled).toContain("## Suggestions")
+    expect(disabled).not.toContain("## Suggestions")
+    expect(disabled).not.toContain("local code review")
+  })
+  // kilocode_change end
+
   test("skills output is sorted by name and stable across calls", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -71,6 +71,33 @@ describe("tool.registry", () => {
       else process.env["KILO_CONFIG_DIR"] = originalConfig
     }
   })
+
+  test("suggest is skipped when review auto suggestions are disabled", async () => {
+    const original = process.env["KILO_CLIENT"]
+    const originalConfig = process.env["KILO_CONFIG_DIR"]
+    try {
+      process.env["KILO_CLIENT"] = "cli"
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "kilo.json"), JSON.stringify({ review: { auto_suggest: false } }))
+        },
+      })
+      process.env["KILO_CONFIG_DIR"] = tmp.path
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).not.toContain("suggest")
+        },
+      })
+    } finally {
+      if (original === undefined) delete process.env["KILO_CLIENT"]
+      else process.env["KILO_CLIENT"] = original
+      if (originalConfig === undefined) delete process.env["KILO_CONFIG_DIR"]
+      else process.env["KILO_CONFIG_DIR"] = originalConfig
+    }
+  })
   // kilocode_change end
 
   it.live("loads tools from .opencode/tool (singular)", () =>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1553,9 +1553,9 @@ export type ProviderConfig = {
            */
           disabled?: boolean
           [key: string]: unknown | boolean | undefined
-        }
+        } | null
       }
-    }
+    } | null
   }
 }
 
@@ -1697,6 +1697,15 @@ export type Config = {
    * Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.
    */
   remote_control?: boolean
+  /**
+   * Code review configuration
+   */
+  review?: {
+    /**
+     * Offer a local code review suggestion after completing implementation work (default: true).
+     */
+    auto_suggest?: boolean
+  }
   /**
    * Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14598,67 +14598,54 @@
               "type": "string"
             },
             "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "family": {
-                  "type": "string"
-                },
-                "release_date": {
-                  "type": "string"
-                },
-                "attachment": {
-                  "type": "boolean"
-                },
-                "reasoning": {
-                  "type": "boolean"
-                },
-                "temperature": {
-                  "type": "boolean"
-                },
-                "tool_call": {
-                  "type": "boolean"
-                },
-                "interleaved": {
-                  "anyOf": [
-                    {
-                      "type": "boolean",
-                      "const": true
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "type": "string",
-                          "enum": ["reasoning_content", "reasoning_details"]
-                        }
-                      },
-                      "required": ["field"],
-                      "additionalProperties": false
-                    }
-                  ]
-                },
-                "cost": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
-                    "input": {
-                      "type": "number"
+                    "id": {
+                      "type": "string"
                     },
-                    "output": {
-                      "type": "number"
+                    "name": {
+                      "type": "string"
                     },
-                    "cache_read": {
-                      "type": "number"
+                    "family": {
+                      "type": "string"
                     },
-                    "cache_write": {
-                      "type": "number"
+                    "release_date": {
+                      "type": "string"
                     },
-                    "context_over_200k": {
+                    "attachment": {
+                      "type": "boolean"
+                    },
+                    "reasoning": {
+                      "type": "boolean"
+                    },
+                    "temperature": {
+                      "type": "boolean"
+                    },
+                    "tool_call": {
+                      "type": "boolean"
+                    },
+                    "interleaved": {
+                      "anyOf": [
+                        {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string",
+                              "enum": ["reasoning_content", "reasoning_details"]
+                            }
+                          },
+                          "required": ["field"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "cost": {
                       "type": "object",
                       "properties": {
                         "input": {
@@ -14672,100 +14659,127 @@
                         },
                         "cache_write": {
                           "type": "number"
+                        },
+                        "context_over_200k": {
+                          "type": "object",
+                          "properties": {
+                            "input": {
+                              "type": "number"
+                            },
+                            "output": {
+                              "type": "number"
+                            },
+                            "cache_read": {
+                              "type": "number"
+                            },
+                            "cache_write": {
+                              "type": "number"
+                            }
+                          },
+                          "required": ["input", "output"]
                         }
                       },
                       "required": ["input", "output"]
-                    }
-                  },
-                  "required": ["input", "output"]
-                },
-                "limit": {
-                  "type": "object",
-                  "properties": {
-                    "context": {
-                      "type": "number"
                     },
-                    "input": {
-                      "type": "number"
+                    "limit": {
+                      "type": "object",
+                      "properties": {
+                        "context": {
+                          "type": "number"
+                        },
+                        "input": {
+                          "type": "number"
+                        },
+                        "output": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["context", "output"]
                     },
-                    "output": {
-                      "type": "number"
-                    }
-                  },
-                  "required": ["context", "output"]
-                },
-                "modalities": {
-                  "type": "object",
-                  "properties": {
-                    "input": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
+                    "modalities": {
+                      "type": "object",
+                      "properties": {
+                        "input": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": ["text", "audio", "image", "video", "pdf"]
+                          }
+                        },
+                        "output": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "enum": ["text", "audio", "image", "video", "pdf"]
+                          }
+                        }
+                      },
+                      "required": ["input", "output"]
+                    },
+                    "experimental": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": ["alpha", "beta", "deprecated"]
+                    },
+                    "provider": {
+                      "type": "object",
+                      "properties": {
+                        "npm": {
+                          "type": "string"
+                        },
+                        "api": {
+                          "type": "string"
+                        }
                       }
                     },
-                    "output": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
-                      }
-                    }
-                  },
-                  "required": ["input", "output"]
-                },
-                "experimental": {
-                  "type": "boolean"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": ["alpha", "beta", "deprecated"]
-                },
-                "provider": {
-                  "type": "object",
-                  "properties": {
-                    "npm": {
-                      "type": "string"
+                    "options": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {}
                     },
-                    "api": {
-                      "type": "string"
+                    "headers": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "variants": {
+                      "description": "Variant-specific configuration",
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "disabled": {
+                                "description": "Disable this variant for the model",
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": {}
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
                     }
                   }
                 },
-                "options": {
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {}
-                },
-                "headers": {
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
-                    "type": "string"
-                  }
-                },
-                "variants": {
-                  "description": "Variant-specific configuration",
-                  "type": "object",
-                  "propertyNames": {
-                    "type": "string"
-                  },
-                  "additionalProperties": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "description": "Disable this variant for the model",
-                        "type": "boolean"
-                      }
-                    },
-                    "additionalProperties": {}
-                  }
+                {
+                  "type": "null"
                 }
-              }
+              ]
             }
           }
         },
@@ -14998,6 +15012,16 @@
           "remote_control": {
             "description": "Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup.",
             "type": "boolean"
+          },
+          "review": {
+            "description": "Code review configuration",
+            "type": "object",
+            "properties": {
+              "auto_suggest": {
+                "description": "Offer a local code review suggestion after completing implementation work (default: true).",
+                "type": "boolean"
+              }
+            }
           },
           "autoupdate": {
             "description": "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",


### PR DESCRIPTION
Adds `review.auto_suggest` so CLI and VS Code users can disable automatic local review suggestions after implementation work.
When disabled, Kilo omits the suggestion guidance from the system prompt and does not register the suggest tool, while manual `/local-review` commands remain available.
