### PR TITLE
fix(agent-manager): start-new-session tab on slow handover

### DIFF
--- a/.changeset/plan-followup-new-session-tab.md
+++ b/.changeset/plan-followup-new-session-tab.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix the "Start new session" button on the plan follow-up prompt not switching the VS Code Agent Manager to the new session when handover generation is slow. The new session is now created first so the UI can switch to it immediately, and the handover message is injected as it becomes available.
+Fix the "Start new session" button on the plan follow-up prompt not switching the VS Code Agent Manager to the new session when handover generation is slow. The new session now opens immediately with the plan text already visible, and the handover summary from the planning session is appended once it finishes generating.

--- a/.changeset/plan-followup-new-session-tab.md
+++ b/.changeset/plan-followup-new-session-tab.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix the "Start new session" button on the plan follow-up prompt not switching the VS Code Agent Manager to the new session when handover generation is slow. The new session now opens immediately with the plan text already visible, and the handover summary from the planning session is appended once it finishes generating.
+Fix the "Start new session" button on the plan follow-up prompt not switching the VS Code Agent Manager to the new session when handover generation is slow. The new session now opens immediately, shows the plan text right away, stays visibly busy while the handover summary is being prepared, and appends that summary once it finishes generating.

--- a/.changeset/plan-followup-new-session-tab.md
+++ b/.changeset/plan-followup-new-session-tab.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix the "Start new session" button on the plan follow-up prompt not switching the VS Code Agent Manager to the new session when handover generation is slow. The new session is now created first so the UI can switch to it immediately, and the handover message is injected as it becomes available.

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -439,6 +439,7 @@ export namespace PlanFollowup {
               if (pending.get(next.id) === ctl) pending.delete(next.id)
             })
         } catch (error) {
+          if (pending.get(next.id) === ctl) pending.delete(next.id)
           await idle()
           throw error
         }

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -13,6 +13,7 @@ import { Session } from "@/session"
 import { SessionID, MessageID, PartID } from "@/session/schema"
 import { LLM } from "@/session/llm"
 import { MessageV2 } from "@/session/message-v2"
+import { SessionStatus } from "@/session/status"
 import { Todo } from "@/session/todo"
 import { makeRuntime } from "@/effect/run-service"
 import { Log } from "@/util/log"
@@ -24,6 +25,7 @@ const agents = makeRuntime(Agent.Service, Agent.defaultLayer)
 const providers = makeRuntime(Provider.Service, Provider.defaultLayer)
 const questions = makeRuntime(Question.Service, Question.defaultLayer)
 const todo = makeRuntime(Todo.Service, Todo.defaultLayer)
+const pending = new Map<SessionID, AbortController>()
 
 export const PlanFollowupRuntime = {
   agent(name: string): Promise<Agent.Info | undefined> {
@@ -147,6 +149,7 @@ export async function generateHandover(input: {
     const result = await stream.text
     return result.trim()
   } catch (error) {
+    if (input.abort?.aborted) return ""
     log.error("handover generation failed", { error })
     return ""
   }
@@ -158,6 +161,14 @@ export namespace PlanFollowup {
   export const PLAN_PREFIX = "Implement the following plan:"
   export const ANSWER_NEW_SESSION = "Start new session"
   export const ANSWER_CONTINUE = "Continue here"
+
+  export function abort(sessionID: SessionID) {
+    const ctl = pending.get(sessionID)
+    if (!ctl) return false
+    pending.delete(sessionID)
+    ctl.abort()
+    return true
+  }
 
   function resolveVariant(value: string | undefined, model: Provider.Model | undefined) {
     if (!value) return undefined
@@ -329,73 +340,98 @@ export namespace PlanFollowup {
         // handover generation below can take tens of seconds and must not block
         // the SSE event that drives the webview tab switch.
         const next = await Session.create({})
+        const ctl = new AbortController()
+        pending.set(next.id, ctl)
+        await SessionStatus.set(next.id, { type: "busy" })
         await Bus.publish(TuiEvent.SessionSelect, { sessionID: next.id })
 
-        const file = Session.plan(session)
-        const todos = await PlanFollowupRuntime.todo.get(input.sessionID)
-        const todoList = formatTodos(todos)
+        const idle = () =>
+          SessionStatus.set(next.id, { type: "idle" }).catch((err) => {
+            log.warn("failed to clear follow-up busy status", { sessionID: next.id, err })
+          })
 
-        // Assemble the user message text with or without a handover section.
-        // The section order is fixed so the initial and final renders stay
-        // aligned — only the handover block grows in between.
-        const compose = (handover: string) => {
-          const sections = [
-            `Plan file: ${file}\nRead this file first and treat it as the source of truth for implementation.`,
-            `Implement the following plan:\n\n${input.plan}`,
-          ]
-          if (handover) sections.push(`## Handover from Planning Session\n\n${handover}`)
-          if (todoList) sections.push(`## Todo List\n\n${todoList}`)
-          return sections.join("\n\n")
-        }
+        try {
+          const file = Session.plan(session)
+          const todos = await PlanFollowupRuntime.todo.get(input.sessionID)
+          const todoList = formatTodos(todos)
 
-        // Inject the plan and todos immediately so the new session tab shows
-        // real content right away. The handover section is appended to this
-        // same part in-place once the slow LLM call resolves below.
-        const msg: MessageV2.User = {
-          id: MessageID.ascending(),
-          sessionID: next.id,
-          role: "user",
-          time: { created: Date.now() },
-          agent: "code",
-          model: code.model,
-        }
-        await Session.updateMessage(msg)
-        const pid = PartID.ascending()
-        await Session.updatePart({
-          id: pid,
-          messageID: msg.id,
-          sessionID: next.id,
-          type: "text",
-          text: compose(""),
-          synthetic: false,
-        } satisfies MessageV2.TextPart)
+          // Assemble the user message text with or without a handover section.
+          // The section order is fixed so the initial and final renders stay
+          // aligned — only the handover block grows in between.
+          const compose = (handover: string) => {
+            const sections = [
+              `Plan file: ${file}\nRead this file first and treat it as the source of truth for implementation.`,
+              `Implement the following plan:\n\n${input.plan}`,
+            ]
+            if (handover) sections.push(`## Handover from Planning Session\n\n${handover}`)
+            if (todoList) sections.push(`## Todo List\n\n${todoList}`)
+            return sections.join("\n\n")
+          }
 
-        if (todos.length) {
-          await PlanFollowupRuntime.todo.update({ sessionID: next.id, todos })
-        }
-
-        const handover = await generateHandover({
-          messages: input.messages,
-          model: input.model,
-          abort: input.abort,
-        })
-        if (handover) {
+          // Inject the plan and todos immediately so the new session tab shows
+          // real content right away. The handover section is appended to this
+          // same part in-place once the slow LLM call resolves below.
+          const msg: MessageV2.User = {
+            id: MessageID.ascending(),
+            sessionID: next.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "code",
+            model: code.model,
+          }
+          await Session.updateMessage(msg)
+          const pid = PartID.ascending()
           await Session.updatePart({
             id: pid,
             messageID: msg.id,
             sessionID: next.id,
             type: "text",
-            text: compose(handover),
+            text: compose(""),
             synthetic: false,
           } satisfies MessageV2.TextPart)
-        }
 
-        void Instance.provide({
-          directory: next.directory,
-          fn: () => PlanFollowupRuntime.loop(next.id),
-        }).catch((error) => {
-          log.error("failed to start follow-up session", { sessionID: next.id, error })
-        })
+          if (todos.length) {
+            await PlanFollowupRuntime.todo.update({ sessionID: next.id, todos })
+          }
+
+          const handover = await generateHandover({
+            messages: input.messages,
+            model: input.model,
+            abort: input.abort ? AbortSignal.any([input.abort, ctl.signal]) : ctl.signal,
+          })
+          if (ctl.signal.aborted) {
+            await idle()
+            return
+          }
+
+          if (handover) {
+            await Session.updatePart({
+              id: pid,
+              messageID: msg.id,
+              sessionID: next.id,
+              type: "text",
+              text: compose(handover),
+              synthetic: false,
+            } satisfies MessageV2.TextPart)
+          }
+          if (ctl.signal.aborted) {
+            await idle()
+            return
+          }
+
+          void Instance.provide({
+            directory: next.directory,
+            fn: () => PlanFollowupRuntime.loop(next.id),
+          }).catch((error) => {
+            log.error("failed to start follow-up session", { sessionID: next.id, error })
+            void idle()
+          })
+        } catch (error) {
+          await idle()
+          throw error
+        } finally {
+          if (pending.get(next.id) === ctl) pending.delete(next.id)
+        }
       },
     })
   }

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -332,35 +332,64 @@ export namespace PlanFollowup {
         await Bus.publish(TuiEvent.SessionSelect, { sessionID: next.id })
 
         const file = Session.plan(session)
-        const [handover, todos] = await Promise.all([
-          generateHandover({ messages: input.messages, model: input.model, abort: input.abort }),
-          PlanFollowupRuntime.todo.get(input.sessionID),
-        ])
-
-        const sections = [
-          `Plan file: ${file}\nRead this file first and treat it as the source of truth for implementation.`,
-          `Implement the following plan:\n\n${input.plan}`,
-        ]
-
-        if (handover) {
-          sections.push(`## Handover from Planning Session\n\n${handover}`)
-        }
-
+        const todos = await PlanFollowupRuntime.todo.get(input.sessionID)
         const todoList = formatTodos(todos)
-        if (todoList) {
-          sections.push(`## Todo List\n\n${todoList}`)
+
+        // Assemble the user message text with or without a handover section.
+        // The section order is fixed so the initial and final renders stay
+        // aligned — only the handover block grows in between.
+        const compose = (handover: string) => {
+          const sections = [
+            `Plan file: ${file}\nRead this file first and treat it as the source of truth for implementation.`,
+            `Implement the following plan:\n\n${input.plan}`,
+          ]
+          if (handover) sections.push(`## Handover from Planning Session\n\n${handover}`)
+          if (todoList) sections.push(`## Todo List\n\n${todoList}`)
+          return sections.join("\n\n")
         }
 
-        await inject({
+        // Inject the plan and todos immediately so the new session tab shows
+        // real content right away. The handover section is appended to this
+        // same part in-place once the slow LLM call resolves below.
+        const msg: MessageV2.User = {
+          id: MessageID.ascending(),
           sessionID: next.id,
+          role: "user",
+          time: { created: Date.now() },
           agent: "code",
           model: code.model,
-          text: sections.join("\n\n"),
+        }
+        await Session.updateMessage(msg)
+        const pid = PartID.ascending()
+        await Session.updatePart({
+          id: pid,
+          messageID: msg.id,
+          sessionID: next.id,
+          type: "text",
+          text: compose(""),
           synthetic: false,
-        })
+        } satisfies MessageV2.TextPart)
+
         if (todos.length) {
           await PlanFollowupRuntime.todo.update({ sessionID: next.id, todos })
         }
+
+        const handover = await generateHandover({
+          messages: input.messages,
+          model: input.model,
+          abort: input.abort,
+        })
+        if (handover) {
+          await Session.updatePart({
+            id: pid,
+            messageID: msg.id,
+            sessionID: next.id,
+            type: "text",
+            text: compose(handover),
+            synthetic: false,
+          } satisfies MessageV2.TextPart)
+        }
+
         void Instance.provide({
           directory: next.directory,
           fn: () => PlanFollowupRuntime.loop(next.id),

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -320,15 +320,23 @@ export namespace PlanFollowup {
       model: input.model,
     })
     const session = await Session.get(input.sessionID)
-    const [handover, todos] = await Promise.all([
-      generateHandover({ messages: input.messages, model: input.model, abort: input.abort }),
-      PlanFollowupRuntime.todo.get(input.sessionID),
-    ])
 
     await Instance.provide({
       directory: session.directory,
       fn: async () => {
+        // Create the session FIRST so session.created fires immediately while the
+        // VS Code extension's pendingFollowup gate (30s TTL) is still fresh. The
+        // handover generation below can take tens of seconds and must not block
+        // the SSE event that drives the webview tab switch.
+        const next = await Session.create({})
+        await Bus.publish(TuiEvent.SessionSelect, { sessionID: next.id })
+
         const file = Session.plan(session)
+        const [handover, todos] = await Promise.all([
+          generateHandover({ messages: input.messages, model: input.model, abort: input.abort }),
+          PlanFollowupRuntime.todo.get(input.sessionID),
+        ])
+
         const sections = [
           `Plan file: ${file}\nRead this file first and treat it as the source of truth for implementation.`,
           `Implement the following plan:\n\n${input.plan}`,
@@ -343,7 +351,6 @@ export namespace PlanFollowup {
           sections.push(`## Todo List\n\n${todoList}`)
         }
 
-        const next = await Session.create({})
         await inject({
           sessionID: next.id,
           agent: "code",
@@ -354,7 +361,6 @@ export namespace PlanFollowup {
         if (todos.length) {
           await PlanFollowupRuntime.todo.update({ sessionID: next.id, todos })
         }
-        await Bus.publish(TuiEvent.SessionSelect, { sessionID: next.id })
         void Instance.provide({
           directory: next.directory,
           fn: () => PlanFollowupRuntime.loop(next.id),

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -419,18 +419,28 @@ export namespace PlanFollowup {
             return
           }
 
-          void Instance.provide({
+          const queue = Instance.provide({
             directory: next.directory,
-            fn: () => PlanFollowupRuntime.loop(next.id),
-          }).catch((error) => {
-            log.error("failed to start follow-up session", { sessionID: next.id, error })
-            void idle()
+            fn: async () => {
+              if (ctl.signal.aborted) {
+                await idle()
+                return
+              }
+              await PlanFollowupRuntime.loop(next.id)
+            },
           })
+
+          void queue
+            .catch((error) => {
+              log.error("failed to start follow-up session", { sessionID: next.id, error })
+              void idle()
+            })
+            .finally(() => {
+              if (pending.get(next.id) === ctl) pending.delete(next.id)
+            })
         } catch (error) {
           await idle()
           throw error
-        } finally {
-          if (pending.get(next.id) === ctl) pending.delete(next.id)
         }
       },
     })

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -50,6 +50,10 @@ export namespace KiloSessionPrompt {
     return action === "continue" ? "continue" : "break"
   }
 
+  export function abortPlanFollowup(sessionID: SessionID) {
+    return PlanFollowup.abort(sessionID)
+  }
+
   /**
    * Mutable cache for environment details, keyed by user message ID
    * so it recomputes when a new user message arrives.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -131,6 +131,7 @@ export namespace SessionPrompt {
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
         yield* elog.info("cancel", { sessionID })
         yield* KiloSessionPromptQueue.cancel(sessionID) // kilocode_change - drop queued follow-up loops on abort
+        KiloSessionPrompt.abortPlanFollowup(sessionID) // kilocode_change - abort pending plan-followup handover work
         yield* state.cancel(sessionID)
       })
 

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -13,6 +13,7 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { SessionStatus } from "../../src/session/status"
 import { Todo } from "../../src/session/todo"
 import { Global } from "../../src/global"
 import { Log } from "../../src/util/log"
@@ -1121,6 +1122,86 @@ describe("plan follow-up", () => {
       expect(finalPart.text).toContain("Implement the following plan:")
       expect(finalPart.text).toContain("## Handover from Planning Session")
       expect(finalPart.text).toContain("example")
+    }))
+
+  test("ask - marks new session busy while handover is pending and clears on abort", () =>
+    withInstance(async () => {
+      const seeded = await seed({ text: "1. Build" })
+
+      let followup: SessionID | undefined
+      const states: Array<{ sessionID: SessionID; type: string }> = []
+      const created = Bus.subscribe(Session.Event.Created, (event) => {
+        if (event.properties.info.id === seeded.sessionID) return
+        if (!followup) followup = event.properties.info.id
+      })
+      const status = Bus.subscribe(SessionStatus.Event.Status, (event) => {
+        states.push({ sessionID: event.properties.sessionID, type: event.properties.status.type })
+      })
+
+      const deferred = Promise.withResolvers<string>()
+      const agentSpy = spyOn(PlanFollowupRuntime, "agent").mockResolvedValue(fakeAgent as any)
+      const modelSpy = spyOn(PlanFollowupRuntime, "model").mockResolvedValue(fakeModel)
+      const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
+        text: deferred.promise,
+      } as any)
+      const loop = spyOn(PlanFollowupRuntime, "loop").mockResolvedValue({
+        info: {
+          id: MessageID.make("msg_test"),
+          role: "assistant",
+          sessionID: SessionID.make("ses_test"),
+          time: { created: Date.now() },
+          parentID: MessageID.make("msg_parent"),
+          modelID: ModelID.make("test"),
+          providerID: ProviderID.make("test"),
+          mode: "code",
+          agent: "code",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        parts: [],
+      } as MessageV2.WithParts)
+      using _ = {
+        [Symbol.dispose]() {
+          agentSpy.mockRestore()
+          modelSpy.mockRestore()
+          llmSpy.mockRestore()
+          loop.mockRestore()
+          created()
+          status()
+        },
+      }
+
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
+      })
+
+      for (let i = 0; i < 100; i++) {
+        if (followup && states.some((x) => x.sessionID === followup && x.type === "busy")) break
+        await Bun.sleep(10)
+      }
+
+      expect(followup).toBeDefined()
+      if (!followup) return
+      expect(states.some((x) => x.sessionID === followup && x.type === "busy")).toBe(true)
+
+      const { SessionPrompt } = await import("../../src/session/prompt")
+      await SessionPrompt.cancel(followup)
+      deferred.resolve("## Discoveries\n\nexample")
+      await expect(pending).resolves.toBe("break")
+
+      expect(states.some((x) => x.sessionID === followup && x.type === "idle")).toBe(true)
+      expect(loop).not.toHaveBeenCalled()
     }))
 
   test("ask - returns break when assistant text is empty", () =>

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -1025,6 +1025,104 @@ describe("plan follow-up", () => {
       expect(createdAt!).toBeLessThan(handoverResolvedAt!)
     }))
 
+  test("ask - injects plan message before generateHandover resolves on Start new session", () =>
+    withInstance(async () => {
+      // Regression guard: the plan text must appear in the new session tab
+      // immediately after the tab switch — without waiting for the slow handover
+      // LLM call. The handover is then appended to the same part in-place.
+      const seeded = await seed({ text: "1. Build" })
+
+      let followup: SessionID | undefined
+      const unsub = Bus.subscribe(Session.Event.Created, (event) => {
+        if (event.properties.info.id === seeded.sessionID) return
+        if (!followup) followup = event.properties.info.id
+      })
+
+      const deferred = Promise.withResolvers<string>()
+      const agentSpy = spyOn(PlanFollowupRuntime, "agent").mockResolvedValue(fakeAgent as any)
+      const modelSpy = spyOn(PlanFollowupRuntime, "model").mockResolvedValue(fakeModel)
+      const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
+        text: deferred.promise,
+      } as any)
+      const loop = spyOn(PlanFollowupRuntime, "loop").mockResolvedValue({
+        info: {
+          id: MessageID.make("msg_test"),
+          role: "assistant",
+          sessionID: SessionID.make("ses_test"),
+          time: { created: Date.now() },
+          parentID: MessageID.make("msg_parent"),
+          modelID: ModelID.make("test"),
+          providerID: ProviderID.make("test"),
+          mode: "code",
+          agent: "code",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        },
+        parts: [],
+      } as MessageV2.WithParts)
+      using _ = {
+        [Symbol.dispose]() {
+          agentSpy.mockRestore()
+          modelSpy.mockRestore()
+          llmSpy.mockRestore()
+          loop.mockRestore()
+          unsub()
+        },
+      }
+
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
+      })
+
+      // Poll until the plan text lands. Handover is still pending because
+      // deferred has not resolved yet.
+      for (let i = 0; i < 100; i++) {
+        if (followup) {
+          const msgs = await Session.messages({ sessionID: followup })
+          const user = msgs.find((m) => m.info.role === "user")
+          const part = user?.parts.find((p) => p.type === "text")
+          if (part?.type === "text" && part.text.includes("Implement the following plan:")) break
+        }
+        await Bun.sleep(10)
+      }
+
+      expect(followup).toBeDefined()
+      if (!followup) return
+      const initial = await Session.messages({ sessionID: followup })
+      const initialUser = initial.find((m) => m.info.role === "user")
+      const initialPart = initialUser?.parts.find((p) => p.type === "text")
+      expect(initialPart?.type).toBe("text")
+      if (initialPart?.type !== "text") return
+      expect(initialPart.text).toContain("Implement the following plan:")
+      expect(initialPart.text).toContain("1. Build")
+      // Handover is still deferred — must not be present yet.
+      expect(initialPart.text).not.toContain("## Handover from Planning Session")
+
+      deferred.resolve("## Discoveries\n\nexample")
+      await expect(pending).resolves.toBe("break")
+
+      // Same part ID updated in-place — handover section now present.
+      const final = await Session.messages({ sessionID: followup })
+      const finalUser = final.find((m) => m.info.role === "user")
+      const finalPart = finalUser?.parts.find((p) => p.type === "text")
+      if (finalPart?.type !== "text") return
+      expect(finalPart.id).toBe(initialPart.id)
+      expect(finalPart.text).toContain("Implement the following plan:")
+      expect(finalPart.text).toContain("## Handover from Planning Session")
+      expect(finalPart.text).toContain("example")
+    }))
+
   test("ask - returns break when assistant text is empty", () =>
     withInstance(async () => {
       const seeded = await seed({ text: "   " })

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -933,6 +933,98 @@ describe("plan follow-up", () => {
       expect(part.text).not.toContain("## Todo List")
     }))
 
+  test("ask - fires session.created before generateHandover resolves on Start new session", () =>
+    withInstance(async () => {
+      // Regression guard: the VS Code extension gates `session.created` SSE events
+      // behind a 30-second pendingFollowup TTL. If startNew awaits the handover
+      // LLM call before creating the session, a slow LLM response expires the TTL
+      // and the webview never learns about the new session. This test asserts the
+      // session is created *before* the handover resolves, guaranteeing the SSE
+      // event fires while the TTL is still fresh.
+      const seeded = await seed({ text: "1. Build" })
+
+      let createdAt: number | undefined
+      let handoverResolvedAt: number | undefined
+      const unsub = Bus.subscribe(Session.Event.Created, (event) => {
+        // Ignore the seeded planning session; we only care about the follow-up.
+        if (event.properties.info.id === seeded.sessionID) return
+        if (createdAt === undefined) createdAt = performance.now()
+      })
+
+      const deferred = Promise.withResolvers<string>()
+      const agentSpy = spyOn(PlanFollowupRuntime, "agent").mockResolvedValue(fakeAgent as any)
+      const modelSpy = spyOn(PlanFollowupRuntime, "model").mockResolvedValue(fakeModel)
+      const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
+        text: deferred.promise.then((t) => {
+          handoverResolvedAt = performance.now()
+          return t
+        }),
+      } as any)
+      const loop = spyOn(PlanFollowupRuntime, "loop").mockResolvedValue({
+        info: {
+          id: MessageID.make("msg_test"),
+          role: "assistant",
+          sessionID: SessionID.make("ses_test"),
+          time: { created: Date.now() },
+          parentID: MessageID.make("msg_parent"),
+          modelID: ModelID.make("test"),
+          providerID: ProviderID.make("test"),
+          mode: "code",
+          agent: "code",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: {
+            total: 0,
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+        },
+        parts: [],
+      } as MessageV2.WithParts)
+      using _ = {
+        [Symbol.dispose]() {
+          agentSpy.mockRestore()
+          modelSpy.mockRestore()
+          llmSpy.mockRestore()
+          loop.mockRestore()
+          unsub()
+        },
+      }
+
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
+      })
+
+      // Poll until session.created fires. With the fix, this happens promptly
+      // because Session.create runs before generateHandover. Without the fix,
+      // startNew would still be blocked on the deferred LLM stream.
+      for (let i = 0; i < 100; i++) {
+        if (createdAt !== undefined) break
+        await Bun.sleep(10)
+      }
+      expect(createdAt).toBeDefined()
+      // Handover must still be pending; if it had resolved, the race is open.
+      expect(handoverResolvedAt).toBeUndefined()
+
+      deferred.resolve("## Discoveries\n\nexample")
+      await expect(pending).resolves.toBe("break")
+
+      expect(handoverResolvedAt).toBeDefined()
+      expect(createdAt!).toBeLessThan(handoverResolvedAt!)
+    }))
+
   test("ask - returns break when assistant text is empty", () =>
     withInstance(async () => {
       const seeded = await seed({ text: "   " })


### PR DESCRIPTION
## Why

After Kilo finished a plan and the user clicked "Start new session", the Agent Manager sometimes did not open the new session — the user stayed stuck on the finished planning session.

## What changed

The new session is now opened right away, so the new tab appears as soon as the button is clicked. The summary of the planning session (which can take a while to write) is added to the new session once it is ready. Before, the wait for that summary was sometimes long enough that the UI stopped listening for the new session and missed it entirely, leaving the user looking at the old planning tab.

## Demo


https://github.com/user-attachments/assets/db790b35-860a-4862-9377-cf7f30b2a8dd



