### PR TITLE
Cli - Add dev:local script for isolated local development

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -14,6 +14,7 @@
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
+    "dev:local": "XDG_DATA_HOME=/tmp/kilo-local/data XDG_CONFIG_HOME=/tmp/kilo-local/config XDG_STATE_HOME=/tmp/kilo-local/state XDG_CACHE_HOME=/tmp/kilo-local/cache KILO_API_URL=http://localhost:3000 KILO_SESSION_INGEST_URL=http://localhost:8800 bun run --conditions=browser ./src/index.ts",
     "db": "bun drizzle-kit"
   },
   "bin": {


### PR DESCRIPTION
## Summary

Adds a `dev:local` script to `@kilocode/cli` that runs the CLI with isolated XDG directories under `/tmp/kilo-local` and points `KILO_API_URL`/`KILO_SESSION_INGEST_URL` at locally running services. Lets you develop against a local backend without polluting or being affected by the shared user config, cache, and session data.