### PR TITLE
fix(vscode): settle canceled autocomplete debounce

### DIFF
--- a/.changeset/autocomplete-debounce-promise.md
+++ b/.changeset/autocomplete-debounce-promise.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent canceled autocomplete debounce requests from staying pending indefinitely.

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -299,7 +299,7 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
-    this.debouncedPendingRequest = null
+    this.settleDebouncedPendingRequest()
     this.pendingRequests.length = 0
     this.fimAbortController?.abort()
     this.fimAbortController = null
@@ -484,6 +484,15 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     }
   }
 
+  private settleDebouncedPendingRequest(): void {
+    const pending = this.debouncedPendingRequest
+    if (!pending) return
+
+    this.removePendingRequest(pending)
+    pending.resolve?.()
+    this.debouncedPendingRequest = null
+  }
+
   /**
    * Debounced fetch with leading edge execution and pending request reuse.
    * - First call executes immediately (leading edge)
@@ -519,10 +528,8 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     // otherwise linger with a never-resolving promise.
     if (this.debounceTimer !== null) {
       clearTimeout(this.debounceTimer)
-      if (this.debouncedPendingRequest) {
-        this.removePendingRequest(this.debouncedPendingRequest)
-        this.debouncedPendingRequest = null
-      }
+      this.debounceTimer = null
+      this.settleDebouncedPendingRequest()
     }
 
     // Create the pending request object first so we can reference it in the cleanup
@@ -533,14 +540,17 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
     }
 
     const requestPromise = new Promise<void>((resolve) => {
+      pendingRequest.resolve = resolve
       this.debounceTimer = setTimeout(async () => {
         this.debounceTimer = null
         this.debouncedPendingRequest = null
         this.isFirstCall = true // Reset for next sequence
-        await this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId)
-        // Remove this request from pending when done
-        this.removePendingRequest(pendingRequest)
-        resolve()
+        try {
+          await this.fetchAndCacheSuggestion(prompt, prefix, suffix, languageId)
+        } finally {
+          this.removePendingRequest(pendingRequest)
+          resolve()
+        }
       }, this.debounceDelayMs)
     })
 

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/__tests__/AutocompleteInlineCompletionProvider.test.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/__tests__/AutocompleteInlineCompletionProvider.test.ts
@@ -1369,7 +1369,7 @@ describe("AutocompleteInlineCompletionProvider", () => {
         await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
 
         // Second call should set a debounce timer
-        provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
+        const promise = provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
 
         // Verify timer is set for trailing edge
         const timerCountBeforeDispose = vi.getTimerCount()
@@ -1378,9 +1378,10 @@ describe("AutocompleteInlineCompletionProvider", () => {
         // Dispose the provider before timer fires
         provider.dispose()
 
-        // Verify timer is cleared
+        // Verify timer is cleared and the pending request settles
         const timerCountAfterDispose = vi.getTimerCount()
         expect(timerCountAfterDispose).toBeLessThan(timerCountBeforeDispose)
+        await expect(promise).resolves.toEqual([])
       })
     })
   })
@@ -2069,6 +2070,23 @@ describe("AutocompleteInlineCompletionProvider", () => {
       // The key point is that the second request was NOT reused from the first
       // because the suffix changed - it started a new debounce cycle
       expect(callCount).toBe(2)
+    })
+
+    it("should settle canceled debounced requests when the timer is reset", async () => {
+      await provider.provideInlineCompletionItems(mockDocument, mockPosition, mockContext, mockToken)
+
+      const doc2 = new MockTextDocument(vscode.Uri.file("/test.ts"), "const x = 1\nconst z = 3")
+      const promise2 = provider.provideInlineCompletionItems(doc2, mockPosition, mockContext, mockToken)
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      const doc3 = new MockTextDocument(vscode.Uri.file("/test.ts"), "const x = 1\nconst q = 4")
+      const promise3 = provider.provideInlineCompletionItems(doc3, mockPosition, mockContext, mockToken)
+
+      await expect(promise2).resolves.toEqual([])
+
+      await vi.advanceTimersByTimeAsync(500)
+      await promise3
     })
 
     it("should NOT reuse pending request when user backspaces (prefix shrinks)", async () => {

--- a/packages/kilo-vscode/src/services/autocomplete/types.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/types.ts
@@ -110,6 +110,7 @@ export interface PendingRequest {
   prefix: string
   suffix: string
   promise: Promise<void>
+  resolve?: () => void
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Resolve debounced inline autocomplete requests when their timer is reset or the provider is disposed.
- Add coverage for canceled debounce requests so stale VS Code completion calls cannot remain pending indefinitely.

## Testing
- `bun run check-types:extension` from `packages/kilo-vscode`
- `bun test src/services/autocomplete/classic-auto-complete/__tests__/AutocompleteInlineCompletionProvider.test.ts` from `packages/kilo-vscode` (fails before running tests: missing `../../../mocking/MockTextDocument` import in this existing test setup)