### PR TITLE
fix(log): use relative history path to prevent double-concatenation (fixes #9321)

### DIFF
--- a/.changeset/fix-log-history-path.md
+++ b/.changeset/fix-log-history-path.md
@@ -1,5 +1,5 @@
 ---
-"opencode": patch
+"@kilocode/cli": patch
 ---
 
 fix(log): use relative path for rotating-file-stream history option to prevent double-concatenated absolute paths

--- a/.changeset/fix-log-history-path.md
+++ b/.changeset/fix-log-history-path.md
@@ -1,0 +1,5 @@
+---
+"opencode": patch
+---
+
+fix(log): use relative path for rotating-file-stream history option to prevent double-concatenated absolute paths

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -72,7 +72,7 @@ export namespace Log {
     const stream = createStream(path.basename(logpath), {
       size: "50M",
       maxFiles: 10,
-      history: path.join(dir, ".log-history"),
+      history: ".log-history",
       path: dir,
     })
     stream.on("error", (err: Error) => {


### PR DESCRIPTION
## Summary

Fixes #9321 — Log stream fails with ENOENT because the log file history path is double-concatenated.

## Root Cause

`rotating-file-stream` internally concatenates its `path` option with the `history` option via string concatenation ([source](https://github.com/iccicci/rotating-file-stream/blob/master/index.ts#L162)):

```ts
options.history = path + (history ? history : ...)
```

When `history` is set to an absolute path (`path.join(dir, ".log-history")`), this produces:

```
/Users/username/.local/share/kilo/log//Users/username/.local/share/kilo/log/.log-history
```

## Fix

Use a relative path (`".log-history"`) for the `history` option since the `path` option already provides the directory prefix.

## Changes

- `packages/opencode/src/util/log.ts`: Changed `history: path.join(dir, ".log-history")` → `history: ".log-history"`