### PR TITLE
fix(vscode): restore explicit submit for question dock

### DIFF
--- a/.changeset/question-dock-explicit-submit.md
+++ b/.changeset/question-dock-explicit-submit.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore explicit Submit behavior for single-choice question prompts in the VS Code extension so option clicks stay visible for review instead of immediately sending the answer.

--- a/packages/kilo-vscode/tests/unit/question-dock-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-contract.test.ts
@@ -43,6 +43,18 @@ describe("QuestionDock explicit submit contract", () => {
     expect(pick).toContain("syncAgent(answers, kinds)")
   })
 
+  it("restores the optimistic agent before dismissing a question", () => {
+    const reject = extractBody(source, "reject")
+    expect(reject).toContain("if (prevAgent !== undefined)")
+    expect(reject).toContain("session.selectAgent(prevAgent)")
+    expect(reject).toContain("prevAgent = undefined")
+    const reset = reject.indexOf("prevAgent = undefined")
+    const sending = reject.indexOf('setStore("sending", true)')
+    expect(reset).toBeGreaterThan(-1)
+    expect(sending).toBeGreaterThan(-1)
+    expect(reset, "reject should restore the agent before sending the dismissal").toBeLessThan(sending)
+  })
+
   it("keeps the footer Submit button wired to submit()", () => {
     expect(source).toContain('<Button variant="primary" size="small" onClick={submit} disabled={store.sending}>')
   })

--- a/packages/kilo-vscode/tests/unit/question-dock-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-contract.test.ts
@@ -1,0 +1,49 @@
+/**
+ * QuestionDock submission contract tests.
+ *
+ * Static analysis — reads QuestionDock source and locks the explicit-submit
+ * behavior for single-question option picks.
+ */
+
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+const FILE = path.join(ROOT, "webview-ui/src/components/chat/QuestionDock.tsx")
+
+function readFile(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8")
+}
+
+function extractBody(source: string, name: string): string {
+  const marker = `const ${name} = `
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+  const rest = source.slice(start + marker.length)
+  const next = rest.search(/\n  const /)
+  return next === -1 ? rest : rest.slice(0, next)
+}
+
+describe("QuestionDock explicit submit contract", () => {
+  const source = readFile(FILE)
+  const pick = extractBody(source, "pick")
+
+  it("keeps option clicks local instead of replying immediately", () => {
+    expect(pick.length).toBeGreaterThan(0)
+    expect(pick).not.toContain("reply([[answer]])")
+  })
+
+  it("still advances multi-question single-select flows", () => {
+    expect(pick).toContain('if (outcome.kind === "advance")')
+    expect(pick).toContain('setStore("tab", store.tab + 1)')
+  })
+
+  it("still syncs the optimistic agent selection on pick", () => {
+    expect(pick).toContain("syncAgent(answers, kinds)")
+  })
+
+  it("keeps the footer Submit button wired to submit()", () => {
+    expect(source).toContain('<Button variant="primary" size="small" onClick={submit} disabled={store.sending}>')
+  })
+})

--- a/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-utils.test.ts
@@ -132,8 +132,8 @@ describe("resolveOptimisticQuestionAgent", () => {
 })
 
 describe("pickOutcome", () => {
-  it("submits immediately on a single-question single-select option pick", () => {
-    expect(pickOutcome({ single: true, multi: false, custom: false })).toEqual({ kind: "submit" })
+  it("keeps a single-question single-select option pick pending until explicit submit", () => {
+    expect(pickOutcome({ single: true, multi: false, custom: false })).toEqual({ kind: "stay" })
   })
 
   it("advances to the next tab on a multi-question single-select option pick", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -102,6 +102,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
 
   const reject = () => {
     if (store.sending) return
+    if (prevAgent !== undefined) {
+      session.selectAgent(prevAgent)
+      prevAgent = undefined
+    }
     setStore("sending", true)
     session.rejectQuestion(props.request.id)
     focusPrompt()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -145,17 +145,6 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     syncAgent(answers, kinds)
 
     const outcome = pickOutcome({ single: single(), multi: multi(), custom })
-    if (outcome.kind === "submit") {
-      // Mirror TUI behaviour: a single-question single-select option pick submits immediately.
-      // handleCustomSubmit covers the custom-input path via its own submit() call.
-      //
-      // NOTE: This auto-submit applies to every single-question single-select prompt, not only
-      // the plan follow-up. If a future caller needs the user to review before submitting, set
-      // `multiple: true` on the question (that path stays on the current tab and waits for the
-      // footer Submit button).
-      reply([[answer]])
-      return
-    }
     if (outcome.kind === "advance") {
       setStore("tab", store.tab + 1)
     }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
@@ -26,14 +26,13 @@ export type PickOutcome = { kind: "submit" } | { kind: "advance" } | { kind: "st
  * Decide what should happen after a user picks an option in the question dock.
  *
  * - Multi-select prompts: the pick only toggles local state; no tab change, no submit.
- * - Single-question single-select, option pick: submit immediately (matches the TUI).
+ * - Single-question single-select prompts: keep the pick local and wait for explicit Submit.
  * - Multi-question single-select, option pick: advance to the next tab.
  * - Custom-input path for a single-select is handled separately in handleCustomSubmit.
  */
 export function pickOutcome(input: { single: boolean; multi: boolean; custom: boolean }): PickOutcome {
   if (input.multi) return { kind: "stay" }
-  if (input.single && input.custom) return { kind: "stay" }
-  if (input.single) return { kind: "submit" }
+  if (input.single) return { kind: "stay" }
   return { kind: "advance" }
 }
 

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -167,7 +167,7 @@ export const ChatViewWithPendingQuestionEmptyInput: Story = {
 // ---------------------------------------------------------------------------
 
 export const QuestionDockSingle: Story = {
-  name: "QuestionDock — single question",
+  name: "QuestionDock — single question (explicit submit)",
   render: () => (
     <StoryProviders sessionID={SESSION_ID} questions={[singleQuestion]}>
       <div style={{ width: "100%" }}>


### PR DESCRIPTION
This restores explicit submission for single-choice QuestionDock prompts in the VS Code extension without touching the plan follow-up backend fixes from #9245.

The auto-submit path was misleading because the footer Submit button stayed visible even though clicking an option had already sent the answer, giving users no chance to review what they clicked. If we want auto-submit later, the UI needs to make that behavior explicit and preserve visible confirmation of the selected option.