### PR TITLE
feat: Add workflow to watch for new Opencode Releases to notify Slack and Community Contributions Dashboard

### DIFF
--- a/.github/workflows/watch-opencode-releases.yml
+++ b/.github/workflows/watch-opencode-releases.yml
@@ -1,0 +1,69 @@
+on:
+  schedule:
+    - cron: "7,37 * * * *"   # every 30 min at :07 and :37
+  workflow_dispatch:
+
+concurrency:
+  group: opencode-release-watch
+  cancel-in-progress: false
+
+permissions:                                                                                           
+  contents: read
+
+jobs:
+  check-release:
+    if: vars.OPENCODE_WATCH_ENABLED != 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          data=$(gh release view --repo anomalyco/opencode --json tagName,name,url 2>/dev/null || echo '{}')
+          tag=$(echo "$data" | jq -r '.tagName // empty')
+          [ -z "$tag" ] && { echo "tag=" >> "$GITHUB_OUTPUT"; exit 0; }
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "name=$(echo "$data" | jq -r '.name // .tagName')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$data" | jq -r '.url')" >> "$GITHUB_OUTPUT"
+
+      - if: steps.fetch.outputs.tag != ''
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/last-seen
+          key: last-seen-${{ steps.fetch.outputs.tag }}
+          restore-keys: last-seen-
+
+      - if: steps.fetch.outputs.tag != '' && steps.cache.outputs.cache-hit != 'true'
+        name: Trigger opencode sync
+        env:
+          URL: ${{ secrets.OPENCODE_WATCH_SYNC_URL }}
+          SECRET: ${{ secrets.OPENCODE_WATCH_SYNC_SECRET }}
+        run: |
+          if [ -n "$URL" ] && [ -n "$SECRET" ]; then
+            curl -sf -X POST "$URL" -H "x-sync-secret: $SECRET" -H "Content-Type: application/json" -d '{}' || true
+          fi
+
+      - if: steps.fetch.outputs.tag != '' && steps.cache.outputs.cache-hit != 'true'
+        name: Notify Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.OPENCODE_WATCH_SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            name: "${{ steps.fetch.outputs.name }}"
+            tag: "${{ steps.fetch.outputs.tag }}"
+            url: "${{ steps.fetch.outputs.url }}"
+
+      - if: steps.fetch.outputs.tag != '' && steps.cache.outputs.cache-hit != 'true'
+        name: Mark tag as seen
+        run: mkdir -p .cache/last-seen && echo "${{ steps.fetch.outputs.tag }}" > .cache/last-seen/tag.txt
+
+      - if: success() && steps.fetch.outputs.tag != '' && steps.cache.outputs.cache-hit != 'true'
+        name: Save seen-tag cache
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/last-seen
+          key: last-seen-${{ steps.fetch.outputs.tag }}
+


### PR DESCRIPTION
## Context

Introducing a new workflow in Github actions with a cron to watch for OpenCode new releases and trigger notifications in our Slack channel #opencode-merge and our community contributions dashboard.

## Implementation

- Cron running every 30 min
- Fetch latest OpenCode release
- Persist latest in Actions cache
- If not in cache:
  - Trigger slack webhook
  - Trigger sync API in community contributions dashboard
- Added a variable `OPENCODE_WATCH_ENABLED` to be able to stop the cron at anytime if it misbehaves. 

## Screenshots

#### Slack workflow
<img width="952" height="513" alt="image" src="https://github.com/user-attachments/assets/42c3558d-95fb-460e-8775-ca2d6c5eca11" />

#### Notification
Latest notification format:
<img width="618" height="161" alt="image" src="https://github.com/user-attachments/assets/1e6e7a02-badc-4e6e-9831-cc0b7d2c15a9" />

Triggered in the channel (old format)
<img width="484" height="118" alt="image" src="https://github.com/user-attachments/assets/88fcba8e-12fd-42d8-a087-4b99e8e20eca" />


## How to Test
- Tested by modifying workflow temporarily to run on branch push
- Tested sending messages to myself
- Tested cache mechanism
- Cron will only start executing on main
  - Added a variable `OPENCODE_WATCH_ENABLED` to be able to stop the cron at anytime if it misbehaves. 

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
