### PR TITLE
fix(cli): prevent vite module-resolution race between sdk and app/cli builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,10 @@
       "dependsOn": ["@kilocode/sdk#build"],
       "outputs": ["dist/**"]
     },
+    "@kilocode/plugin#build": {
+      "dependsOn": ["@kilocode/sdk#build"],
+      "outputs": ["dist/**"]
+    },
     "@kilocode/cli#test": {
       "dependsOn": ["^build"],
       "outputs": [],

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,14 @@
       "dependsOn": [],
       "outputs": ["dist/**"]
     },
+    "@kilocode/cli#build": {
+      "dependsOn": ["@kilocode/sdk#build"],
+      "outputs": ["dist/**"]
+    },
+    "@opencode-ai/app#build": {
+      "dependsOn": ["@kilocode/sdk#build"],
+      "outputs": ["dist/**"]
+    },
     "@kilocode/cli#test": {
       "dependsOn": ["^build"],
       "outputs": [],


### PR DESCRIPTION
## Summary

`@kilocode/sdk#build` regenerates `src/v2/gen/` with `clean: true`. Without an explicit ordering edge in `turbo.json`, `@kilocode/cli#build` and `@opencode-ai/app#build` can start concurrently and observe the SDK generated tree mid-deletion, causing Vite/Rollup to fail with `Could not resolve "./client.gen.js"`.

Adds package-specific Turbo tasks so `@kilocode/cli#build` and `@opencode-ai/app#build` wait for `@kilocode/sdk#build` to complete before running.