### PR TITLE
fix(cli): remove dead upstream proxy code and prefer top-level await

### DIFF
--- a/.changeset/remove-opencode-proxy.md
+++ b/.changeset/remove-opencode-proxy.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Remove dead upstream proxy code and prefer top-level await in UI routes

--- a/packages/opencode/src/server/ui/index.ts
+++ b/packages/opencode/src/server/ui/index.ts
@@ -1,30 +1,28 @@
 import { Flag } from "@/flag/flag"
 import { Hono } from "hono"
-// import { proxy } from "hono/proxy" // kilocode_change - proxy import removed
 import { getMimeType } from "hono/utils/mime"
-// import { createHash } from "node:crypto" // kilocode_change
 import fs from "node:fs/promises"
-
-const embeddedUIPromise = Flag.KILO_DISABLE_EMBEDDED_WEB_UI
-  ? Promise.resolve(null)
-  : // @ts-expect-error - generated file at build time
-    import("opencode-web-ui.gen.ts").then((module) => module.default as Record<string, string>).catch(() => null)
 
 const DEFAULT_CSP =
   "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
 
-// kilocode_change start - csp function removed, used by proxy fallback to app.opencode.ai
-// const csp = (hash = "") =>
-//   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
-// kilocode_change end
+const embeddedUI = await (async () => {
+  if (Flag.KILO_DISABLE_EMBEDDED_WEB_UI) return null
+  try {
+    // @ts-expect-error - generated file at build time
+    const module = await import("opencode-web-ui.gen.ts")
+    return module.default as Record<string, string>
+  } catch {
+    return null
+  }
+})()
 
 export const UIRoutes = (): Hono =>
   new Hono().all("/*", async (c) => {
-    const embeddedWebUI = await embeddedUIPromise
     const path = c.req.path
 
-    if (embeddedWebUI) {
-      const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
+    if (embeddedUI) {
+      const match = embeddedUI[path.replace(/^\//, "")] ?? embeddedUI["index.html"] ?? null
       if (!match) return c.json({ error: "Not Found" }, 404)
 
       if (await fs.exists(match)) {
@@ -38,8 +36,6 @@ export const UIRoutes = (): Hono =>
         return c.json({ error: "Not Found" }, 404)
       }
     } else {
-      // kilocode_change start - return 404 instead of proxying to app.opencode.ai
       return c.json({ error: "Not Found" }, 404)
-      // kilocode_change end
     }
   })

--- a/packages/opencode/src/server/ui/index.ts
+++ b/packages/opencode/src/server/ui/index.ts
@@ -36,6 +36,7 @@ export const UIRoutes = (): Hono =>
         return c.json({ error: "Not Found" }, 404)
       }
     } else {
+      // kilocode_change - return 404 instead of proxying to app.opencode.ai
       return c.json({ error: "Not Found" }, 404)
     }
   })


### PR DESCRIPTION
Closes #7140

## Summary

The catch-all proxy to `app.opencode.ai` was already disabled in earlier PRs, but dead commented-out code and `kilocode_change` markers were left behind in `packages/opencode/src/server/ui/index.ts`. This PR cleans up that residual code and modernizes the module initialization.

## Blame History

The proxy was disabled in **two phases**:

1. **First fix** — PR #7161 (`3dc6010dc`, 2026-03-17): `kiloconnect[bot]` disabled the catch-all proxy in `server.ts`, replacing the `proxy()` call with `c.notFound()`.

2. **Regression** — Upstream OpenCode v1.4.4 refactored the server and moved the UI catch-all into a new sub-router (`ui/index.ts`). During the Kilo compat merge (`beb9b3b07`, 2026-04-15), the proxy code came back in the new file — the fix from PR #7161 was lost because the route had moved.

3. **Second fix** — Commit `8bff3718a` (2026-04-17, Johnny Amancio): Re-applied the proxy removal in the new `ui/index.ts` location, replacing the proxy fallback with a `404`.

## What Changed

- **Removed dead commented-out upstream code:**
  - Commented `import { proxy } from "hono/proxy"`
  - Commented `import { createHash } from "node:crypto"`
  - Commented `csp` helper and its `kilocode_change` block
  - `kilocode_change` markers around the `404` fallback

- **Modernized module initialization:**
  - Replaced the `Promise.resolve(...).then(...).catch(...)` chain with a top-level await IIFE, resolving SonarQube rule `typescript:S7785` ("Prefer top-level await over using a promise chain").

## Verification

- `bun turbo typecheck` passed with no errors.
- No functional change — the route still returns `404` when the embedded web UI is unavailable.