### PR TITLE
docs: standardize platform tabs to VSCode, CLI, VSCode (Legacy) & JetBrains

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/anthropic.md
+++ b/packages/kilo-docs/pages/ai-providers/anthropic.md
@@ -18,15 +18,6 @@ Anthropic is an AI safety and research company that builds reliable, interpretab
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Anthropic" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Anthropic API key into the "Anthropic API Key" field.
-4.  **Select Model:** Choose your desired Claude model from the "Model" dropdown.
-5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the Anthropic API, check "Use custom base URL" and enter the URL. Most people won't need to adjust this.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Anthropic and enter your API key.
@@ -63,6 +54,15 @@ Then set your default model:
   "model": "anthropic/claude-sonnet-4-20250514",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Anthropic" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Anthropic API key into the "Anthropic API Key" field.
+4.  **Select Model:** Choose your desired Claude model from the "Model" dropdown.
+5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the Anthropic API, check "Use custom base URL" and enter the URL. Most people won't need to adjust this.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/bedrock.md
+++ b/packages/kilo-docs/pages/ai-providers/bedrock.md
@@ -35,23 +35,6 @@ You have three options for configuring AWS credentials:
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Bedrock" from the "API Provider" dropdown.
-3.  **Select Authentication Method:**
-    - **Bedrock API Key:**
-      - Enter your Bedrock API key directly. This is the simplest setup option.
-    - **AWS Credentials:**
-      - Enter your "AWS Access Key" and "AWS Secret Key."
-      - (Optional) Enter your "AWS Session Token" if you're using temporary credentials.
-    - **AWS Profile:**
-      - Enter your "AWS Profile" name (e.g., "default").
-4.  **Select Region:** Choose the AWS region where your Bedrock service is available (e.g., "us-east-1").
-5.  **(Optional) Cross-Region Inference:** Check "Use cross-region inference" if you want to access models in a region different from your configured AWS region.
-6.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add AWS Bedrock. The extension uses the AWS credentials chain for authentication — configure your AWS credentials using the AWS CLI or environment variables before adding the provider.
@@ -94,6 +77,23 @@ Then set your default model:
   "model": "amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Bedrock" from the "API Provider" dropdown.
+3.  **Select Authentication Method:**
+    - **Bedrock API Key:**
+      - Enter your Bedrock API key directly. This is the simplest setup option.
+    - **AWS Credentials:**
+      - Enter your "AWS Access Key" and "AWS Secret Key."
+      - (Optional) Enter your "AWS Session Token" if you're using temporary credentials.
+    - **AWS Profile:**
+      - Enter your "AWS Profile" name (e.g., "default").
+4.  **Select Region:** Choose the AWS region where your Bedrock service is available (e.g., "us-east-1").
+5.  **(Optional) Cross-Region Inference:** Check "Use cross-region inference" if you want to access models in a region different from your configured AWS region.
+6.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/cerebras.md
+++ b/packages/kilo-docs/pages/ai-providers/cerebras.md
@@ -18,14 +18,6 @@ Cerebras is known for their ultra-fast AI inference powered by the Cerebras CS-3
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Cerebras" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your Cerebras API key into the "Cerebras API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Cerebras and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "cerebras/llama-4-scout-17b-16e-instruct",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "Cerebras" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your Cerebras API key into the "Cerebras API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/chutes-ai.md
+++ b/packages/kilo-docs/pages/ai-providers/chutes-ai.md
@@ -21,14 +21,6 @@ Always refer to the official Chutes AI documentation or your dashboard for the m
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Chutes AI" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Chutes AI API key into the "Chutes AI API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Chutes AI and enter your API key.
@@ -65,6 +57,14 @@ Then set your default model:
   "model": "chutes/model-name",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Chutes AI" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Chutes AI API key into the "Chutes AI API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/claude-code.md
+++ b/packages/kilo-docs/pages/ai-providers/claude-code.md
@@ -35,14 +35,6 @@ The specific models available depend on your Claude subscription and plan. See [
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Claude Code" from the "API Provider" dropdown.
-3. **Select Model:** Choose your desired Claude model from the "Model" dropdown.
-4. **(Optional) Custom CLI Path:** If you installed Claude Code to a location other than the default `claude` command, enter the full path to your Claude executable in the "Claude Code Path" field. Most users won't need to change this.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 {% callout type="warning" %}
@@ -84,6 +76,14 @@ Then set your default model:
   "model": "anthropic/claude-sonnet-4-20250514",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "Claude Code" from the "API Provider" dropdown.
+3. **Select Model:** Choose your desired Claude model from the "Model" dropdown.
+4. **(Optional) Custom CLI Path:** If you installed Claude Code to a location other than the default `claude` command, enter the full path to your Claude executable in the "Claude Code Path" field. Most users won't need to change this.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/deepseek.md
+++ b/packages/kilo-docs/pages/ai-providers/deepseek.md
@@ -18,14 +18,6 @@ Kilo Code supports accessing models through the DeepSeek API, including `deepsee
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "DeepSeek" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your DeepSeek API key into the "DeepSeek API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add DeepSeek and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "deepseek/deepseek-chat",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "DeepSeek" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your DeepSeek API key into the "DeepSeek API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/fireworks.md
+++ b/packages/kilo-docs/pages/ai-providers/fireworks.md
@@ -18,14 +18,6 @@ Fireworks AI is a high-performance platform for running AI models that offers fa
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Fireworks AI" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your Fireworks AI API key into the "Fireworks AI API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Fireworks AI and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "fireworks-ai/accounts/fireworks/models/llama4-scout-instruct-basic",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "Fireworks AI" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your Fireworks AI API key into the "Fireworks AI API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/gemini.md
+++ b/packages/kilo-docs/pages/ai-providers/gemini.md
@@ -18,14 +18,6 @@ Kilo Code supports Google's Gemini family of models through the Google AI Gemini
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Google Gemini" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Gemini API key into the "Gemini API Key" field.
-4.  **Select Model:** Choose your desired Gemini model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Google Gemini and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "google/gemini-2.5-pro",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Google Gemini" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Gemini API key into the "Gemini API Key" field.
+4.  **Select Model:** Choose your desired Gemini model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/glama.md
+++ b/packages/kilo-docs/pages/ai-providers/glama.md
@@ -27,14 +27,6 @@ Refer to the [Glama documentation](https://glama.ai/models) for the most up-to-d
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Glama" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Glama API key into the "Glama API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Glama and enter your API key.
@@ -47,6 +39,14 @@ The extension stores this in your `kilo.json` config file. You can also edit the
 {% callout type="warning" %}
 Glama is not yet available as a CLI provider. Check the [Kilo Code releases](https://github.com/Kilo-Org/kilocode/releases) for updates on provider support.
 {% /callout %}
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Glama" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Glama API key into the "Glama API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/groq.md
+++ b/packages/kilo-docs/pages/ai-providers/groq.md
@@ -21,14 +21,6 @@ Kilo Code will attempt to fetch the list of available models from the Groq API.
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Groq" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Groq API key into the "Groq API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Groq and enter your API key.
@@ -65,6 +57,14 @@ Then set your default model:
   "model": "groq/llama-3.3-70b-versatile",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Groq" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Groq API key into the "Groq API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/inception.md
+++ b/packages/kilo-docs/pages/ai-providers/inception.md
@@ -24,14 +24,6 @@ Refer to Inception's current website and developer documentation for the most up
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Inception" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your Inception API key into the "Inception API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Inception and enter your API key.
@@ -68,6 +60,14 @@ Then set your default model:
   "model": "inception/mercury-coder-small-beta",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "Inception" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your Inception API key into the "Inception API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/lmstudio.md
+++ b/packages/kilo-docs/pages/ai-providers/lmstudio.md
@@ -28,15 +28,6 @@ Kilo Code supports running models locally using LM Studio. LM Studio provides a 
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "LM Studio" from the "API Provider" dropdown.
-3.  **Enter Model ID:** Enter the _file name_ of the model you loaded in LM Studio (e.g., `codellama-7b.Q4_0.gguf`). You can find this in the LM Studio "Local Server" tab.
-4.  **(Optional) Base URL:** By default, Kilo Code will connect to LM Studio at `http://localhost:1234`. If you've configured LM Studio to use a different address or port, enter the full URL here.
-5.  **(Optional) Timeout:** By default, API requests time out after 10 minutes. Local models can be slow, if you hit this timeout you can consider increasing it here: VS Code Extensions panel > Kilo Code gear menu > Settings > API Request Timeout.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add LM Studio. No API key is needed since LM Studio runs locally. You can configure the base URL if LM Studio is running on a different host or port.
@@ -69,6 +60,15 @@ Then set your default model:
   "model": "lmstudio/codellama-7b",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "LM Studio" from the "API Provider" dropdown.
+3.  **Enter Model ID:** Enter the _file name_ of the model you loaded in LM Studio (e.g., `codellama-7b.Q4_0.gguf`). You can find this in the LM Studio "Local Server" tab.
+4.  **(Optional) Base URL:** By default, Kilo Code will connect to LM Studio at `http://localhost:1234`. If you've configured LM Studio to use a different address or port, enter the full URL here.
+5.  **(Optional) Timeout:** By default, API requests time out after 10 minutes. Local models can be slow, if you hit this timeout you can consider increasing it here: VS Code Extensions panel > Kilo Code gear menu > Settings > API Request Timeout.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/minimax.md
+++ b/packages/kilo-docs/pages/ai-providers/minimax.md
@@ -18,14 +18,6 @@ MiniMax is a global AI foundation model company focused on fast, cost-efficient 
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Navigate to **Providers**. Choose **MiniMax** from the API Provider dropdown.
-3. **Enter API Key:** Paste your MiniMax API key into the MiniMax API Key field.
-4. **Select Model:** Choose your desired MiniMax model from the Model dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add MiniMax and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "minimax/MiniMax-M1",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Navigate to **Providers**. Choose **MiniMax** from the API Provider dropdown.
+3. **Enter API Key:** Paste your MiniMax API key into the MiniMax API Key field.
+4. **Select Model:** Choose your desired MiniMax model from the Model dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/mistral.md
+++ b/packages/kilo-docs/pages/ai-providers/mistral.md
@@ -18,14 +18,6 @@ Kilo Code supports accessing models through the Mistral AI API, including both s
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Mistral" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Mistral API key into the "Mistral API Key" field if you're using a `mistral` model. If you intend to use `codestral-latest`, see the "Codestral" section below.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Mistral and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "mistral/mistral-large-latest",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Mistral" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Mistral API key into the "Mistral API Key" field if you're using a `mistral` model. If you intend to use `codestral-latest`, see the "Codestral" section below.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/moonshot.md
+++ b/packages/kilo-docs/pages/ai-providers/moonshot.md
@@ -18,14 +18,6 @@ Moonshot.ai is a Chinese AI company known for their **Kimi** models featuring ul
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "Moonshot.ai" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your Moonshot.ai API key into the "Moonshot.ai API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Moonshot.ai and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "moonshotai/moonshot-v1-auto",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "Moonshot.ai" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your Moonshot.ai API key into the "Moonshot.ai API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/ollama.md
+++ b/packages/kilo-docs/pages/ai-providers/ollama.md
@@ -73,15 +73,6 @@ By default, API requests time out after 10 minutes. Local models can be slow, if
 ### Configure Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-- Open the Kilo Code panel ({% kiloCodeIcon size="1em" /%}).
-- Click the Settings gear icon ({% codicon name="gear" /%}).
-- Select "Ollama" as the API Provider.
-- Select the model configured in the previous step.
-- (Optional) You can configure the base URL if you're running Ollama on a different machine. The default is `http://localhost:11434`.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Ollama. No API key is needed since Ollama runs locally. You can configure the base URL if Ollama is running on a different host.
@@ -112,6 +103,15 @@ Then set your default model:
   "model": "ollama/qwen3-coder:30b",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+- Open the Kilo Code panel ({% kiloCodeIcon size="1em" /%}).
+- Click the Settings gear icon ({% codicon name="gear" /%}).
+- Select "Ollama" as the API Provider.
+- Select the model configured in the previous step.
+- (Optional) You can configure the base URL if you're running Ollama on a different machine. The default is `http://localhost:11434`.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
@@ -5,16 +5,6 @@ sidebar_label: ChatGPT Plus/Pro
 # Using ChatGPT Subscriptions With Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. Open Kilo Code settings (click the gear icon {% codicon name="gear" /%} in the Kilo Code panel).
-2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.
-3. Click **Sign in to OpenAI Codex**.
-4. Finish the sign-in flow in your browser.
-5. Back in Kilo Code settings, pick a model from the dropdown.
-6. Save.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab. ChatGPT Plus/Pro uses OAuth authentication — follow the sign-in flow to connect your ChatGPT subscription.
@@ -47,6 +37,16 @@ Then set your default model:
   "model": "openai/gpt-4.1",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. Open Kilo Code settings (click the gear icon {% codicon name="gear" /%} in the Kilo Code panel).
+2. In **API Provider**, select **OpenAI – ChatGPT Plus/Pro**.
+3. Click **Sign in to OpenAI Codex**.
+4. Finish the sign-in flow in your browser.
+5. Back in Kilo Code settings, pick a model from the dropdown.
+6. Save.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/openai-compatible.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-compatible.md
@@ -15,29 +15,6 @@ This document focuses on setting up providers _other than_ the official OpenAI A
 ## General Configuration
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-The key to using an OpenAI-compatible provider is to configure two main settings:
-
-1.  **Base URL:** This is the API endpoint for the provider. It will _not_ be `https://api.openai.com/v1` (that's for the official OpenAI API).
-2.  **API Key:** This is the secret key you obtain from the provider.
-3.  **Model ID:** This is the model name of the specific model.
-
-You'll find these settings in the Kilo Code settings panel (click the {% codicon name="gear" /%} icon):
-
-- **API Provider:** Select "OpenAI Compatible".
-- **Base URL:** Enter the base URL provided by your chosen provider. **This is crucial.**
-- **API Key:** Enter your API key.
-- **Model:** Choose a model.
-- **Model Configuration:** This lets you customize advanced configuration for the model
-  - Max Output Tokens
-  - Context Window
-  - Image Support
-  - Computer Use
-  - Input Price
-  - Output Price
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 1. Open **Settings** (gear icon) and go to the **Providers** tab.
@@ -123,6 +100,29 @@ You can also set the API key via an environment variable instead of putting it i
   },
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+The key to using an OpenAI-compatible provider is to configure two main settings:
+
+1.  **Base URL:** This is the API endpoint for the provider. It will _not_ be `https://api.openai.com/v1` (that's for the official OpenAI API).
+2.  **API Key:** This is the secret key you obtain from the provider.
+3.  **Model ID:** This is the model name of the specific model.
+
+You'll find these settings in the Kilo Code settings panel (click the {% codicon name="gear" /%} icon):
+
+- **API Provider:** Select "OpenAI Compatible".
+- **Base URL:** Enter the base URL provided by your chosen provider. **This is crucial.**
+- **API Key:** Enter your API key.
+- **Model:** Choose a model.
+- **Model Configuration:** This lets you customize advanced configuration for the model
+  - Max Output Tokens
+  - Context Window
+  - Image Support
+  - Computer Use
+  - Input Price
+  - Output Price
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/openai.md
+++ b/packages/kilo-docs/pages/ai-providers/openai.md
@@ -18,14 +18,6 @@ Kilo Code supports accessing models directly through the official OpenAI API.
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "OpenAI" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your OpenAI API key into the "OpenAI API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add OpenAI and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "openai/gpt-4.1",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "OpenAI" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your OpenAI API key into the "OpenAI API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/openrouter.md
+++ b/packages/kilo-docs/pages/ai-providers/openrouter.md
@@ -17,15 +17,6 @@ OpenRouter is an AI platform that provides access to a wide variety of language 
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "OpenRouter" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your OpenRouter API key into the "OpenRouter API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the OpenRouter API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add OpenRouter and enter your API key.
@@ -62,6 +53,15 @@ Then set your default model:
   "model": "openrouter/anthropic/claude-sonnet-4-20250514",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "OpenRouter" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your OpenRouter API key into the "OpenRouter API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
+5.  **(Optional) Custom Base URL:** If you need to use a custom base URL for the OpenRouter API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/ovhcloud.md
+++ b/packages/kilo-docs/pages/ai-providers/ovhcloud.md
@@ -25,14 +25,6 @@ You can report any bugs or feedbacks by chatting with us in our [Discord server]
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "OVHcloud AI Endpoints" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your AI Endpoints API key into the "OVHcloud AI Endpoints API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add OVHcloud AI Endpoints and enter your API key.
@@ -69,6 +61,14 @@ Then set your default model:
   "model": "ovhcloud/model-name",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "OVHcloud AI Endpoints" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your AI Endpoints API key into the "OVHcloud AI Endpoints API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/requesty.md
+++ b/packages/kilo-docs/pages/ai-providers/requesty.md
@@ -16,14 +16,6 @@ Kilo Code supports accessing models through the [Requesty](https://www.requesty.
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Requesty" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Requesty API key into the "Requesty API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Requesty and enter your API key.
@@ -60,6 +52,14 @@ Then set your default model:
   "model": "requesty/anthropic/claude-sonnet-4-20250514",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Requesty" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Requesty API key into the "Requesty API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/sap-ai-core.md
+++ b/packages/kilo-docs/pages/ai-providers/sap-ai-core.md
@@ -78,23 +78,6 @@ The exact list of available models depends on your SAP AI Core configuration and
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2. **Select Provider:** Choose "SAP AI Core" from the "API Provider" dropdown.
-3. **Enter Credentials:**
-   - **Client ID:** Enter your SAP AI Core OAuth2 client ID
-   - **Client Secret:** Enter your SAP AI Core OAuth2 client secret
-   - **Base URL:** Enter your SAP AI Core API base URL (e.g., `https://api.ai.ml.hana.ondemand.com`)
-   - **Auth URL:** Enter your SAP AI Core OAuth2 auth URL (e.g., `https://your-subdomain.authentication.sap.hana.ondemand.com`)
-   - **Resource Group:** (Optional) Enter your resource group name, defaults to "default"
-4. **Choose Operating Mode:**
-   - **Orchestration Mode:** Check the "Use Orchestration" checkbox for broader model access
-   - **Foundation Models Mode:** Leave unchecked to use foundation models with deployments
-5. **Select Model:** Choose your desired model from the dropdown
-6. **Select Deployment:** (Foundation Models Mode only) Choose an active deployment for your selected model
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add SAP AI Core. Enter your OAuth2 client credentials (Client ID, Client Secret, Base URL, and Auth URL) in the provider settings.
@@ -131,6 +114,23 @@ Then set your default model:
   "model": "sap-ai-core/model-name",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2. **Select Provider:** Choose "SAP AI Core" from the "API Provider" dropdown.
+3. **Enter Credentials:**
+   - **Client ID:** Enter your SAP AI Core OAuth2 client ID
+   - **Client Secret:** Enter your SAP AI Core OAuth2 client secret
+   - **Base URL:** Enter your SAP AI Core API base URL (e.g., `https://api.ai.ml.hana.ondemand.com`)
+   - **Auth URL:** Enter your SAP AI Core OAuth2 auth URL (e.g., `https://your-subdomain.authentication.sap.hana.ondemand.com`)
+   - **Resource Group:** (Optional) Enter your resource group name, defaults to "default"
+4. **Choose Operating Mode:**
+   - **Orchestration Mode:** Check the "Use Orchestration" checkbox for broader model access
+   - **Foundation Models Mode:** Leave unchecked to use foundation models with deployments
+5. **Select Model:** Choose your desired model from the dropdown
+6. **Select Deployment:** (Foundation Models Mode only) Choose an active deployment for your selected model
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/unbound.md
+++ b/packages/kilo-docs/pages/ai-providers/unbound.md
@@ -21,14 +21,6 @@ Unbound allows you configure a list of supported models in your application, and
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Unbound" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Unbound API key into the "Unbound API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Unbound and enter your API key.
@@ -41,6 +33,14 @@ The extension stores this in your `kilo.json` config file. You can also edit the
 {% callout type="warning" %}
 Unbound is not yet available as a CLI provider. Check the [Kilo Code releases](https://github.com/Kilo-Org/kilocode/releases) for updates on provider support.
 {% /callout %}
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Unbound" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Unbound API key into the "Unbound API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/v0.md
+++ b/packages/kilo-docs/pages/ai-providers/v0.md
@@ -16,20 +16,6 @@ To use v0 with Kilo Code, you'll need:
 ## Configuration
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-Setting up v0 in Kilo Code is straightforward:
-
-1. In Kilo Code settings (click the {% codicon name="gear" /%} icon):
-   - Under **API Provider**, select: **OpenAI Compatible**
-   - Set the **Base URL**: `https://api.v0.dev/v1`
-   - Paste in your v0 API key
-   - Set the **Model ID**: `v0-1.0-md`
-   - Click **Verify** to confirm the connection
-
-<!-- <img src="/docs/img/providers/v0-setup.png" alt="v0 configuration in Kilo Code settings" width="600" /> -->
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add an OpenAI Compatible provider. Set the base URL to `https://api.v0.dev/v1` and enter your v0 API key.
@@ -67,6 +53,20 @@ Then set your default model:
   "model": "openai-compatible/v0-1.0-md",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+Setting up v0 in Kilo Code is straightforward:
+
+1. In Kilo Code settings (click the {% codicon name="gear" /%} icon):
+   - Under **API Provider**, select: **OpenAI Compatible**
+   - Set the **Base URL**: `https://api.v0.dev/v1`
+   - Paste in your v0 API key
+   - Set the **Model ID**: `v0-1.0-md`
+   - Click **Verify** to confirm the connection
+
+<!-- <img src="/docs/img/providers/v0-setup.png" alt="v0 configuration in Kilo Code settings" width="600" /> -->
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
+++ b/packages/kilo-docs/pages/ai-providers/vercel-ai-gateway.md
@@ -55,14 +55,6 @@ Check the model description in the dropdown for specific capabilities.
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "Vercel AI Gateway" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your Vercel AI Gateway API key into the "Vercel AI Gateway API Key" field.
-4.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add Vercel AI Gateway and enter your API key.
@@ -99,6 +91,14 @@ Then set your default model:
   "model": "vercel/anthropic/claude-sonnet-4",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "Vercel AI Gateway" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your Vercel AI Gateway API key into the "Vercel AI Gateway API Key" field.
+4.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/vertex.md
+++ b/packages/kilo-docs/pages/ai-providers/vertex.md
@@ -21,20 +21,6 @@ Kilo Code supports accessing models through Google Cloud Platform's Vertex AI, a
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "GCP Vertex AI" from the "API Provider" dropdown.
-3.  **Configure Authentication:**
-    - **If using Application Default Credentials (ADC):** No further action is needed here. ADC will be used automatically if configured correctly (see Prerequisites).
-    - **If _not_ using ADC (Service Account Key):**
-      - **Option A: Paste JSON Content:** Paste the entire content of your Service Account JSON key file into the **Google Cloud Credentials** field.
-      - **Option B: Provide File Path:** Enter the absolute path to your downloaded Service Account JSON key file in the **Google Cloud Key File Path** field.
-4.  **Enter Project ID:** Enter your Google Cloud Project ID.
-5.  **Select Region:** Choose the region where your Vertex AI resources are located (e.g., `us-east5`).
-6.  **Select Model:** Choose your desired model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add GCP Vertex AI. The extension uses Google Application Default Credentials (ADC) for authentication — run `gcloud auth application-default login` before adding the provider. Set your project ID and region in the provider settings.
@@ -74,6 +60,20 @@ Then set your default model:
   "model": "google-vertex/claude-sonnet-4@20250514",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "GCP Vertex AI" from the "API Provider" dropdown.
+3.  **Configure Authentication:**
+    - **If using Application Default Credentials (ADC):** No further action is needed here. ADC will be used automatically if configured correctly (see Prerequisites).
+    - **If _not_ using ADC (Service Account Key):**
+      - **Option A: Paste JSON Content:** Paste the entire content of your Service Account JSON key file into the **Google Cloud Credentials** field.
+      - **Option B: Provide File Path:** Enter the absolute path to your downloaded Service Account JSON key file in the **Google Cloud Key File Path** field.
+4.  **Enter Project ID:** Enter your Google Cloud Project ID.
+5.  **Select Region:** Choose the region where your Vertex AI resources are located (e.g., `us-east5`).
+6.  **Select Model:** Choose your desired model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/xai.md
+++ b/packages/kilo-docs/pages/ai-providers/xai.md
@@ -18,14 +18,6 @@ xAI is the company behind Grok, a large language model known for its conversatio
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
-2.  **Select Provider:** Choose "xAI" from the "API Provider" dropdown.
-3.  **Enter API Key:** Paste your xAI API key into the "xAI API Key" field.
-4.  **Select Model:** Choose your desired Grok model from the "Model" dropdown.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add xAI and enter your API key.
@@ -62,6 +54,14 @@ Then set your default model:
   "model": "xai/grok-3",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1.  **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
+2.  **Select Provider:** Choose "xAI" from the "API Provider" dropdown.
+3.  **Enter API Key:** Paste your xAI API key into the "xAI API Key" field.
+4.  **Select Model:** Choose your desired Grok model from the "Model" dropdown.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -17,15 +17,6 @@ import Codicon from "@site/src/components/Codicon";
 ## Configuration in Kilo Code
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
-
-1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
-2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
-3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
-4. **Select Model:** Choose your desired model from the "Model" dropdown.
-5. **(Optional) Custom Base URL:** If you need to use a custom base URL for the ZenMux API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
-
-{% /tab %}
 {% tab label="VSCode" %}
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
@@ -62,6 +53,15 @@ Then set your default model:
   "model": "zenmux/openai/gpt-5",
 }
 ```
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
+2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
+3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
+4. **Select Model:** Choose your desired model from the "Model" dropdown.
+5. **(Optional) Custom Base URL:** If you need to use a custom base URL for the ZenMux API, check "Use custom base URL" and enter the URL. Leave this blank for most users.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -249,7 +249,7 @@ Agent Manager state is persisted in `.kilo/agent-manager.json`. Sessions, worktr
 - **Worktree creation fails** — ensure Git is installed and the workspace is a valid git repository. Open the main repository (where `.git` is a directory), not an existing worktree checkout.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 The Agent Manager is a dedicated control panel for running and supervising Kilo Code agents as interactive CLI processes. It supports:
 

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -73,7 +73,7 @@ Two slash commands are available for local code reviews:
 - **`/local-review-uncommitted`** — Review uncommitted changes (staged + unstaged)
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Select 'Review' from the mode dropdown after making local changes, and click 'Send' for AI-powered feedback and suggestions.
 

--- a/packages/kilo-docs/pages/automate/extending/shell-integration.md
+++ b/packages/kilo-docs/pages/automate/extending/shell-integration.md
@@ -8,7 +8,124 @@ description: "Integrate Kilo Code with your shell environment"
 Terminal Shell Integration is a key feature that enables Kilo Code to execute commands in your terminal and intelligently process their output. This bidirectional communication between the AI and your development environment unlocks powerful automation capabilities.
 
 {% tabs %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode" %}
+
+## How Shell Execution Works
+
+The current VS Code extension is built on the [Kilo CLI](https://github.com/Kilo-Org/kilocode) and takes a fundamentally different approach to shell execution than the legacy extension. Instead of relying on VS Code's terminal shell integration, it spawns and manages shell processes directly using the `bash` tool.
+
+This means:
+
+- **No VS Code shell integration required** — the extension handles shell execution independently
+- **No shell integration setup or troubleshooting** — it works out of the box
+- **Consistent behavior** across environments — the same shell execution logic runs whether you use the CLI directly or through the VS Code extension
+
+## The `bash` Tool
+
+The `bash` tool is the primary way the agent executes shell commands. It spawns a persistent shell session and runs commands within it.
+
+### Key Features
+
+- **Working directory control**: Use the `workdir` parameter to run commands in a specific directory, instead of `cd <dir> && <command>` patterns
+- **Configurable timeout**: Set a per-command timeout in milliseconds (defaults to 2 minutes)
+- **Real-time output streaming**: Command output is streamed back as it's produced
+- **Process tree management**: The tool manages the full process tree, ensuring child processes are properly cleaned up
+
+### Security Analysis
+
+Commands are parsed using **Tree-sitter** before execution, enabling:
+
+- Path resolution to detect file access patterns
+- External directory detection to flag commands that reach outside the project
+- Structured analysis of command intent for safer auto-approval decisions
+
+### Shell Detection
+
+The extension automatically detects the appropriate shell for your platform using `Shell.acceptable()`. This selects a compatible shell (bash, zsh, etc.) without requiring manual configuration.
+
+## Agent Manager Terminals
+
+When using the Kilo Code VS Code extension with the Agent Manager, each agent session gets its own dedicated VS Code terminal.
+
+### Per-Session Terminals
+
+- Each session creates a terminal named **`Agent: {branch}`**, where `{branch}` is the git branch or worktree the session is working in
+- The terminal's working directory is automatically set to the session's worktree directory
+- Terminals are standard VS Code integrated terminals — you can interact with them directly
+
+### Keyboard Shortcuts
+
+| Shortcut                    | Action                       |
+| --------------------------- | ---------------------------- |
+| <kbd>Cmd</kbd>+<kbd>/</kbd> | Focus the session's terminal |
+| <kbd>Cmd</kbd>+<kbd>.</kbd> | Cycle agent mode             |
+
+### Terminal Context Menu Actions
+
+Right-click in an Agent Manager terminal to access these actions:
+
+- **Add Terminal Content to Context** — sends the terminal's visible output to the agent as context
+- **Fix This Command** — asks the agent to diagnose and fix the last failed command
+- **Explain This Command** — asks the agent to explain what a command does
+
+## Troubleshooting
+
+Shell execution in the current extension is significantly simpler than the legacy version's terminal integration. Most issues are resolved by ensuring:
+
+1. **A supported shell is installed**: bash or zsh on macOS/Linux, PowerShell on Windows
+2. **The shell is on your PATH**: the extension needs to find the shell binary
+3. **File permissions are correct**: the extension needs execute permission on the shell binary
+
+If commands fail to execute, check the log output for error details. The extension logs the shell it detected and any errors during command execution.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+## How Shell Execution Works
+
+The Kilo CLI takes a fundamentally different approach to shell execution than the legacy VS Code extension. Instead of relying on VS Code's terminal shell integration, the CLI spawns and manages shell processes directly using the `bash` tool.
+
+This means:
+
+- **No VS Code shell integration required** — the CLI handles shell execution independently
+- **No shell integration setup or troubleshooting** — it works out of the box
+- **Consistent behavior** across environments — the same shell execution logic runs whether you use the CLI directly or through the VS Code extension
+
+## The `bash` Tool
+
+The `bash` tool is the primary way the agent executes shell commands. It spawns a persistent shell session and runs commands within it.
+
+### Key Features
+
+- **Working directory control**: Use the `workdir` parameter to run commands in a specific directory, instead of `cd <dir> && <command>` patterns
+- **Configurable timeout**: Set a per-command timeout in milliseconds (defaults to 2 minutes)
+- **Real-time output streaming**: Command output is streamed back as it's produced
+- **Process tree management**: The tool manages the full process tree, ensuring child processes are properly cleaned up
+
+### Security Analysis
+
+Commands are parsed using **Tree-sitter** before execution, enabling:
+
+- Path resolution to detect file access patterns
+- External directory detection to flag commands that reach outside the project
+- Structured analysis of command intent for safer auto-approval decisions
+
+### Shell Detection
+
+The CLI automatically detects the appropriate shell for your platform using `Shell.acceptable()`. This selects a compatible shell (bash, zsh, etc.) without requiring manual configuration.
+
+## Troubleshooting
+
+Shell execution in the CLI is significantly simpler than the legacy VS Code extension's terminal integration. Most issues are resolved by ensuring:
+
+1. **A supported shell is installed**: bash or zsh on macOS/Linux, PowerShell on Windows
+2. **The shell is on your PATH**: the CLI needs to find the shell binary
+3. **File permissions are correct**: the CLI needs execute permission on the shell binary
+
+If commands fail to execute, check the CLI's log output for error details. The CLI logs the shell it detected and any errors during command execution.
+
+{% /tab %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## What is Shell Integration?
 
@@ -342,77 +459,6 @@ The [VS Code Terminal Integration Test Extension](https://github.com/KJ7LNW/vsce
    - Document the exact settings combination
    - Note your environment (OS, VS Code version, shell, and any shell prompt customization)
    - Open an issue with these details to help improve shell integration
-
-{% /tab %}
-{% tab label="VSCode & CLI" %}
-
-## How Shell Execution Works
-
-The new CLI and extension take a fundamentally different approach to shell execution. Instead of relying on VS Code's terminal shell integration, the CLI spawns and manages shell processes directly using the `bash` tool.
-
-This means:
-
-- **No VS Code shell integration required** — the CLI handles shell execution independently
-- **No shell integration setup or troubleshooting** — it works out of the box
-- **Consistent behavior** across environments — the same shell execution logic runs whether you use the CLI directly or through the VS Code extension
-
-## The `bash` Tool
-
-The `bash` tool is the primary way the agent executes shell commands. It spawns a persistent shell session and runs commands within it.
-
-### Key Features
-
-- **Working directory control**: Use the `workdir` parameter to run commands in a specific directory, instead of `cd <dir> && <command>` patterns
-- **Configurable timeout**: Set a per-command timeout in milliseconds (defaults to 2 minutes)
-- **Real-time output streaming**: Command output is streamed back as it's produced
-- **Process tree management**: The tool manages the full process tree, ensuring child processes are properly cleaned up
-
-### Security Analysis
-
-Commands are parsed using **Tree-sitter** before execution, enabling:
-
-- Path resolution to detect file access patterns
-- External directory detection to flag commands that reach outside the project
-- Structured analysis of command intent for safer auto-approval decisions
-
-### Shell Detection
-
-The CLI automatically detects the appropriate shell for your platform using `Shell.acceptable()`. This selects a compatible shell (bash, zsh, etc.) without requiring manual configuration.
-
-## Agent Manager Terminals (VS Code Extension)
-
-When using the Kilo Code VS Code extension with the Agent Manager, each agent session gets its own dedicated VS Code terminal.
-
-### Per-Session Terminals
-
-- Each session creates a terminal named **`Agent: {branch}`**, where `{branch}` is the git branch or worktree the session is working in
-- The terminal's working directory is automatically set to the session's worktree directory
-- Terminals are standard VS Code integrated terminals — you can interact with them directly
-
-### Keyboard Shortcuts
-
-| Shortcut                    | Action                       |
-| --------------------------- | ---------------------------- |
-| <kbd>Cmd</kbd>+<kbd>/</kbd> | Focus the session's terminal |
-| <kbd>Cmd</kbd>+<kbd>.</kbd> | Cycle agent mode             |
-
-### Terminal Context Menu Actions
-
-Right-click in an Agent Manager terminal to access these actions:
-
-- **Add Terminal Content to Context** — sends the terminal's visible output to the agent as context
-- **Fix This Command** — asks the agent to diagnose and fix the last failed command
-- **Explain This Command** — asks the agent to explain what a command does
-
-## Troubleshooting
-
-Shell execution in the new CLI is significantly simpler than the **VSCode** version's terminal integration. Most issues are resolved by ensuring:
-
-1. **A supported shell is installed**: bash or zsh on macOS/Linux, PowerShell on Windows
-2. **The shell is on your PATH**: The CLI needs to find the shell binary
-3. **File permissions are correct**: The CLI needs execute permission on the shell binary
-
-If commands fail to execute, check the CLI's log output for error details. The CLI logs the shell it detected and any errors during command execution.
 
 {% /tab %}
 {% /tabs %}

--- a/packages/kilo-docs/pages/automate/how-tools-work.md
+++ b/packages/kilo-docs/pages/automate/how-tools-work.md
@@ -30,7 +30,7 @@ Describe what you want to accomplish in natural language, and Kilo Code will:
 | Workflow | Manage task flow and sub-agents            | `question`, `task`, `todowrite`, `todoread`, `plan`, `skill` |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 | Category | Purpose                                    | Tool Names                                                               |
 | :------- | :----------------------------------------- | :----------------------------------------------------------------------- |
@@ -61,7 +61,7 @@ When a tool is proposed, you'll see an approval prompt in the **Permission Dock*
 The extension shows the file path and proposed content for review. Click **Approve** to execute or **Deny** to cancel.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% callout type="info" title="Tool Approval UI" %}
 When a tool is proposed, you'll see Save and Reject buttons along with an optional Auto-approve checkbox for trusted operations.
@@ -136,7 +136,7 @@ To pre-configure permissions in your config file:
 This safety mechanism ensures you maintain control over which files are modified, what commands are executed, and how your codebase is changed.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Every tool use requires your explicit approval. When Kilo proposes a tool, you'll see:
 
@@ -175,7 +175,7 @@ This safety mechanism ensures you maintain control over which files are modified
 | `skill`       | Invokes a reusable skill (Markdown instruction module) | Workflow |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 | Tool Name                    | Description                                         | Category |
 | :--------------------------- | :-------------------------------------------------- | :------- |

--- a/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -82,7 +82,7 @@ The CLI accepts several config filenames. The recommended file is `kilo.json`:
 | **Project** | `./kilo.json` or `./.kilo/kilo.json` | `kilo.jsonc`, `opencode.jsonc`, `opencode.json`                |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 MCP server configurations can be managed at two levels: **global** (applies across all workspaces) and **project-level** (specific to a single project). Project-level configuration takes precedence over global settings.
 
@@ -123,7 +123,7 @@ Add MCP servers under the `mcp` key in your config file. Each server has a uniqu
 You can disable a server by setting `enabled` to `false` without removing it from your config.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Both global and project-level files use a JSON format with a `mcpServers` object containing named server configurations:
 
@@ -205,7 +205,7 @@ In the VS Code extension, open **Settings → MCP**, click **Add Server**, and c
 | `timeout`     | Number  | No       | Timeout in ms for fetching tools from the MCP server. Default: 30000. |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ```json
 {
@@ -269,7 +269,7 @@ In the VS Code extension, open **Settings → MCP**, click **Add Server**, and c
 | `timeout` | Number  | No       | Timeout in ms for fetching tools from the MCP server. Default: 30000. |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ```json
 {
@@ -386,7 +386,7 @@ Use `{env:VARIABLE_NAME}` syntax in config files to reference environment variab
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Editing MCP Settings Files
 
@@ -432,7 +432,7 @@ Set the `timeout` field (in milliseconds) in the server's config entry. The defa
 Set the `timeout` field (in milliseconds) in the server's config entry. The default is 30000 (30 seconds).
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 To set the maximum time to wait for a response after a tool call to the MCP server:
 
@@ -485,7 +485,7 @@ Add `permission` entries to your config to auto-approve specific tools. MCP tool
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 MCP tool auto-approval works on a per-tool basis and is disabled by default. To configure auto-approval:
 
@@ -565,7 +565,7 @@ Use `npx` directly:
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Windows
 
@@ -689,7 +689,7 @@ Example: "Analyze the performance of my API" might use an MCP tool that tests AP
 - **Slow Performance:** Increase the `timeout` value for the specific MCP server in your config.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 - **Server Not Responding:** Check if the server process is running and verify network connectivity
 - **Permission Errors:** Ensure proper API keys and credentials are configured in your `mcp_settings.json` (for global settings) or `.kilocode/mcp.json` (for project settings).

--- a/packages/kilo-docs/pages/automate/tools/index.md
+++ b/packages/kilo-docs/pages/automate/tools/index.md
@@ -95,7 +95,7 @@ These tools help manage the conversation and task flow:
 - `skill` - Invokes a reusable skill (Markdown instruction module)
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Tools are organized into logical groups based on their functionality:
 

--- a/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
@@ -26,7 +26,7 @@ Click the Kilo Code icon ({% kiloCodeIcon /%}) in VS Code's Primary Side Bar to 
 Open your terminal and run `kilo` to launch the interactive terminal interface (TUI). You'll see a prompt where you can start typing requests immediately. The TUI is fully keyboard-driven — no mouse required.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Find the Kilo Code icon ({% kiloCodeIcon /%}) in VS Code's Primary Side Bar. Click it to open the chat panel.
 
@@ -94,7 +94,7 @@ The extension automatically passes context from your editor, including your open
 Type `@` in the TUI to get file autocomplete suggestions, or mention file paths directly in your message (e.g., "look at src/utils.ts") and the agent will read them. When using the non-interactive `kilo run` command, you can pass `-f path/to/file.ts` to explicitly include files. The agent can also discover files on its own using its built-in tools.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% image src="/docs/img/the-chat-interface/the-chat-interface-1.png" alt="Chat interface components labeled with callouts" width="800" caption="Everything you need is right here" /%}
 
@@ -206,7 +206,7 @@ This feature streamlines the interaction when Kilo Code requires clarification, 
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% callout type="tip" %}
 **Move Kilo Code to the Secondary Side Bar** for a better layout. Right-click on the Kilo Code icon in the Activity Bar and select **Move To → Secondary Side Bar**. This lets you see the Explorer, Search, Source Control, etc. alongside Kilo Code.

--- a/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
@@ -111,7 +111,7 @@ This means the agent can explore your entire project as needed, rather than bein
 | **Trust the agent's tools**    | The agent can search, read, and explore your codebase — let it do the discovery work               |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Context mentions are a powerful way to provide Kilo Code with specific information about your project, allowing it to perform tasks more accurately and efficiently. You can use mentions to refer to files, folders, problems, and Git commits. Context mentions start with the `@` symbol.
 

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -38,7 +38,7 @@ While the specifics change constantly, some principles stay consistent:
 - **Model precedence:** `--model` flag → Per-agent config → Last used in session → Global config → Recent models → First available.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 - Use the **model dropdown** in the chat panel to select a model for each conversation.
 - Configure **API profiles** in Settings to group provider + model combinations and switch between them quickly.

--- a/packages/kilo-docs/pages/code-with-ai/agents/using-agents.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/using-agents.md
@@ -40,7 +40,7 @@ There are several ways to switch agents:
 - **Config file:** Set the `default_agent` key in your configuration to change the default agent on startup.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% youtube url="https://youtu.be/cS4vQfX528w" caption="Explaining the different modes in Kilo Code" /%}
 
@@ -195,7 +195,7 @@ The VSCode extension and CLI do not include a built-in Review agent. Code review
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Code Mode (Default)
 

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -50,7 +50,7 @@ You can temporarily disable autocomplete by clicking the status bar item to **sn
 The extension automatically detects if **GitHub Copilot** inline suggestions are enabled and warns you about potential conflicts. Disable Copilot's inline completions for the best experience with Kilo Code autocomplete.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## How Autocomplete Works
 
@@ -146,7 +146,7 @@ If using Cursor, go to **Settings** > **Cursor Settings** > **Tab**, and toggle 
 4. **Check the status bar tooltip**: Hover the status bar item to see autocomplete state and cost tracking
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 4. **Balance speed and quality**: Faster models provide quicker suggestions but may be less accurate
 5. **Adjust trigger delay**: Find the sweet spot between responsiveness and avoiding too many API calls

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/mistral-setup.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/mistral-setup.md
@@ -74,7 +74,7 @@ Your Editor → Kilo Gateway (with your key) → Mistral
 - **Seeing charges on your Kilo balance?** If you haven't configured BYOK, autocomplete defaults to using your Kilo credits. Add your Codestral key via BYOK to route requests through your own Mistral account.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Video Walkthrough
 

--- a/packages/kilo-docs/pages/code-with-ai/features/browser-use.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/browser-use.md
@@ -37,7 +37,7 @@ Kilo Code uses [Playwright](https://playwright.dev/) for browser automation. Add
 Playwright downloads Chromium automatically on first use.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 By default, Kilo Code uses a built-in browser that:
 
@@ -98,7 +98,7 @@ Key characteristics:
 | `browser_drag`       | Drags an element to a target        | Drag-and-drop interactions            |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 The browser_action tool controls a browser instance that returns screenshots and console logs after each action, allowing you to see the results of interactions.
 
@@ -140,7 +140,7 @@ Browser automation settings are available under **Settings → Browser**:
 Browser automation is configured in your `kilo.jsonc` file. No additional settings are required — Playwright manages the browser lifecycle automatically.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% callout type="info" title="Default Browser Settings" %}
 

--- a/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
@@ -51,7 +51,7 @@ Checkpoints are controlled by the `snapshot` boolean in your `kilo.jsonc` config
 When enabled, the system automatically captures snapshots at each step of a task.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Access checkpoint settings in Kilo Code settings under the "Checkpoints" section:
 
@@ -88,7 +88,7 @@ Snapshots respect your `.gitignore` rules. Files ignored by Git (such as `node_m
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% callout type="info" title="Important Notes" %}
 
@@ -176,7 +176,7 @@ Checkpoints are captured automatically at each step of a task. In the CLI termin
 - **Per-file revert**: Selectively undo changes to specific files while keeping others
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Checkpoints are integrated directly into your workflow through the chat interface.
 
@@ -272,7 +272,7 @@ Snapshot data is stored per-project and is periodically cleaned up. A background
 When using the Agent Manager with git worktrees, each worktree gets its own isolated snapshot repository. This prevents snapshot data from one worktree interfering with another while sharing underlying Git objects for storage efficiency.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Checkpoint Architecture
 

--- a/packages/kilo-docs/pages/code-with-ai/features/code-actions.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/code-actions.md
@@ -36,7 +36,7 @@ The extension also adds code actions to the **terminal context menu**:
 - **Explain Command:** Asks Kilo to explain a terminal command or its output.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## What are Code Actions?
 

--- a/packages/kilo-docs/pages/code-with-ai/features/git-commit-generation.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/git-commit-generation.md
@@ -65,7 +65,7 @@ Git commit message generation is a **VS Code extension feature**. It is not avai
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Customizing the Commit Template
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
@@ -41,7 +41,7 @@ Key features include:
 The extension shares its configuration with the CLI. Settings in `~/.config/kilo/kilo.jsonc` (global) and `./kilo.jsonc` (project) apply to both the CLI and the extension.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Installation
 

--- a/packages/kilo-docs/pages/customize/agents-md.md
+++ b/packages/kilo-docs/pages/customize/agents-md.md
@@ -165,7 +165,7 @@ In the new platform, AGENTS.md is loaded alongside other instruction sources. Th
 | **[Skills](/docs/customize/skills)**             | Both      | `.kilo/skills/`, config `skills` key       | Loaded on demand |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 AGENTS.md works alongside Kilo Code's other configuration systems:
 
@@ -205,7 +205,7 @@ export KILO_DISABLE_EXTERNAL_SKILLS=true
 AGENTS.md itself cannot be individually disabled — it is always loaded if present. To override its instructions, use higher-priority sources like the `instructions` config key or agent-specific prompts.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 AGENTS.md support is **enabled by default**. To disable it, edit `settings.json`:
 

--- a/packages/kilo-docs/pages/customize/context/context-condensing.md
+++ b/packages/kilo-docs/pages/customize/context/context-condensing.md
@@ -195,7 +195,7 @@ If no compaction agent is set, the current session's model is used.
 | `KILO_EXPERIMENTAL_OUTPUT_TOKEN_MAX` | Overrides the 32,000 default output-token ceiling |
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## The Solution: Intelligent Condensing
 

--- a/packages/kilo-docs/pages/customize/context/kilocodeignore.md
+++ b/packages/kilo-docs/pages/customize/context/kilocodeignore.md
@@ -66,7 +66,7 @@ You can also exclude paths from the file watcher separately using `watcher.ignor
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 1. Create a `.kilocodeignore` file at the root of your project.
 2. Add patterns for files or folders you want Kilo Code to avoid.
@@ -132,7 +132,7 @@ In addition to your explicit permission rules:
 If a file is denied by a permission rule, the tool will report that access was blocked.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Kilo Code checks `.kilocodeignore` before accessing files in tools like:
 
@@ -231,7 +231,7 @@ The `watcher.ignore` setting controls which paths the file watcher skips. This i
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Visibility in Lists
 

--- a/packages/kilo-docs/pages/customize/custom-instructions.md
+++ b/packages/kilo-docs/pages/customize/custom-instructions.md
@@ -153,7 +153,7 @@ URL-based instruction sources are fetched at session start with a 5-second timeo
 If your project contains `.kilocoderules` files from the VSCode extension, these are still loaded via auto-migration. However, migrating to `AGENTS.md` is recommended for new projects.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Setting Custom Instructions
 

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -453,7 +453,7 @@ If you have existing `.kilocodemodes` or `custom_modes.yaml` files from the VSCo
 Default legacy mode slugs (`code`, `build`, `architect`, `ask`, `debug`, `orchestrator`) are skipped during migration since they map to built-in agents (`build` → `code`, `architect` → `plan`).
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Sticky Models for Efficient Workflow
 
@@ -579,7 +579,7 @@ Create a new agent called "Documentation Writer". It should only be able to read
 Kilo will create the appropriate `.kilo/agents/docs-writer.md` file with the right frontmatter.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 You can create and configure custom modes in several ways:
 
@@ -912,7 +912,7 @@ permission:
 The **VSCode (Legacy)** version's `fileRegex` approach is automatically converted to permission rules during migration.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Regular expressions (`fileRegex`) in the **VSCode** version offer fine-grained control over file editing permissions within tool groups.
 
@@ -1147,7 +1147,7 @@ Focus on:
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Basic Documentation Writer (YAML)
 
@@ -1242,7 +1242,7 @@ customModes:
 - **Legacy modes are auto-migrated:** If you have `.kilocodemodes` files, they'll be converted on startup — no manual migration needed
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Common Issues
 

--- a/packages/kilo-docs/pages/customize/custom-rules.md
+++ b/packages/kilo-docs/pages/customize/custom-rules.md
@@ -101,7 +101,7 @@ The CLI is backward compatible with `.kilocode/rules/` directories. Existing rul
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Project Rules
 
@@ -176,7 +176,7 @@ Rules are managed by editing the `instructions` array in your `kilo.jsonc` confi
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Kilo Code provides a built-in interface for managing your custom rules without manually editing files in the `.kilocode/rules/` directories. To access the UI, click on the <Codicon name="law" /> icon in the **bottom right corner** of the Kilo Code window.
 
@@ -225,7 +225,7 @@ If `.kilocode/rules/` directories exist in your project, their contents are auto
 {% /callout %}
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### General Rules (Any Mode)
 
@@ -297,7 +297,7 @@ Rules are applied on the next interaction. You can also edit `kilo.jsonc` throug
 Rules are applied on the next interaction.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Using the UI Interface
 
@@ -421,7 +421,7 @@ If your rules aren't being followed:
 3. **Restart the session**: Start a new chat session to pick up config changes.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 If your custom rules aren't being properly followed:
 

--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -154,7 +154,7 @@ You can configure extra skill locations and remote skill URLs in your `kilo.json
 The `skills.paths` key accepts absolute paths, `~/` home-relative paths, or paths relative to the project root. The `skills.urls` key accepts URLs pointing to remote `SKILL.md` files that are fetched on demand.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ### Global Skills (User-Level)
 
@@ -213,7 +213,7 @@ The new platform does not use mode-specific skill directories. All skills are lo
 If you need a skill to only apply in certain situations, write a clear and specific `description` in the SKILL.md frontmatter so the agent knows when to use it.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 To create a skill that only appears in a specific mode, place it in a `skills-{mode-slug}` directory:
 
@@ -243,7 +243,7 @@ When multiple skills share the same name, project-level skills (`.kilo/skills/`)
 When multiple skills share the same name, project-level skills (`.kilo/skills/`) take precedence over global skills (`~/.kilo/skills/`). Skills from compatibility directories (`.claude/skills/`, `.agents/skills/`) and additional configured paths are loaded alongside project and global skills.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 When multiple skills share the same name, Kilo Code uses these priority rules:
 
@@ -282,7 +282,7 @@ Skills are discovered when a session starts. The CLI scans all configured skill 
 Skills are re-scanned at the start of each new session. To pick up newly added or modified skills, start a new session.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Skills are discovered when Kilo Code initializes:
 
@@ -414,7 +414,7 @@ These additional files can be referenced from your skill's instructions, allowin
 3. Start a new session to pick up the skill
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 1. Create the skill directory:
 
@@ -487,7 +487,7 @@ The new platform does not have a marketplace UI yet. You can find and share skil
 - **Remote URLs** — Use the `skills.urls` config key to load skills directly from URLs without manually downloading them
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 You can discover and install community-created skills through:
 
@@ -524,7 +524,7 @@ You can discover and install community-created skills through:
 4. **Check config paths**: If using `skills.paths` or `skills.urls`, verify the paths and URLs are correct in your `kilo.jsonc`.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 1. **Check the Output panel**: Open `View` → `Output` → Select "Kilo Code" from dropdown. Look for skill-related errors.
 
@@ -562,7 +562,7 @@ When the agent uses a skill, it invokes the `skill` tool with the skill's name. 
 When the agent uses a skill, it invokes the `skill` tool with the skill's name. Look for a `skill` tool call in the conversation to confirm a skill was loaded. The tool output includes the full skill content injected into context.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 To see if a skill was actually used during a conversation, look for a `read_file` tool call in the chat that targets a `SKILL.md` file. When the agent decides to use a skill, it reads the full skill file into context—this appears as a file read operation in the conversation.
 
@@ -594,7 +594,7 @@ While the new platform does not yet have a built-in marketplace UI, skills from 
 While the new platform does not yet have a built-in marketplace UI, skills from the [Kilo Marketplace repository](https://github.com/Kilo-Org/kilo-marketplace) can be manually downloaded into your `.kilo/skills/` directory or loaded via `skills.urls` in config.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Skills submitted to the marketplace are browsable and installable directly from the Marketplace tab in the **VSCode** version.
 

--- a/packages/kilo-docs/pages/customize/workflows.md
+++ b/packages/kilo-docs/pages/customize/workflows.md
@@ -57,7 +57,7 @@ Workflows can leverage all built-in tools: `read`, `glob`, `grep`, `edit`, `writ
 The new extension automatically migrates legacy workflows from `.kilocode/workflows/` to the new command format on startup. You can also manually move files and remove the `.md` extension from invocations.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Workflows are markdown files stored in `.kilocode/workflows/`:
 
@@ -146,7 +146,7 @@ Parameters needed (ask if not provided):
 Trigger this workflow by typing `/submit-pr` in the chat.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Create a file called `submit-pr.md` in your `.kilocode/workflows` directory:
 

--- a/packages/kilo-docs/pages/getting-started/installing.md
+++ b/packages/kilo-docs/pages/getting-started/installing.md
@@ -10,7 +10,7 @@ Get started with Kilo Code by installing it on your preferred platform. Choose y
 ## Choose Your Platform
 
 {% tabs %}
-{% tab label="VS Code" %}
+{% tab label="VSCode" %}
 
 ## VS Code Extension
 
@@ -33,11 +33,13 @@ The "pre-release" label is a VS Code Marketplace distribution channel — the ex
 {% partial file="install-cli.md" /%}
 
 {% /tab %}
-{% tab label="VS Code (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
+
+The JetBrains plugin is based on the legacy VS Code extension, so both are covered here.
 
 ## VS Code Legacy Extension
 
-The legacy extension is the previous version of Kilo Code for VS Code. It is still available but is no longer actively developed. We recommend installing the current extension (see the **VS Code** tab).
+The legacy extension is the previous version of Kilo Code for VS Code. It is still available but is no longer actively developed. We recommend installing the current extension (see the **VSCode** tab).
 
 To install or switch back to the legacy version:
 
@@ -45,9 +47,6 @@ To install or switch back to the legacy version:
 2. Go to Extensions (`Ctrl+Shift+X` / `Cmd+Shift+X`)
 3. Search for "Kilo Code"
 4. Click the dropdown arrow next to **Install** and select **Switch to Release Version**
-
-{% /tab %}
-{% tab label="JetBrains" %}
 
 ## JetBrains IDEs
 

--- a/packages/kilo-docs/pages/getting-started/quickstart.md
+++ b/packages/kilo-docs/pages/getting-started/quickstart.md
@@ -105,7 +105,7 @@ kilo run --auto "fix the failing tests in test/auth.test.ts"
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Video Tour
 

--- a/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
+++ b/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
@@ -257,7 +257,7 @@ This is a custom example showing the available configuration options — it does
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 ## Quick Start Guide
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -96,7 +96,7 @@ For **session** export and import, use the CLI commands:
 - `kilo import` -- import session data
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 Kilo Code allows you to manage your configuration settings effectively through export, import, and reset options. These features are useful for backing up your setup, sharing configurations with others, or restoring default settings if needed.
 
@@ -188,7 +188,7 @@ Refer to the auto-generated `$schema` in your `kilo.jsonc` for the full list of 
 The CLI does not currently expose the same experimental feature toggles as the **VSCode (Legacy)** version. Configuration of model behavior, file editing strategies, and other advanced options is handled directly in the JSONC config files. Refer to the auto-generated `$schema` in your `kilo.jsonc` for the full list of available options.
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 {% callout type="info" %}
 These features are experimental and may change in future releases. They provide advanced control over Kilo Code's behavior for specific use cases.

--- a/packages/kilo-docs/pages/getting-started/setup-authentication.md
+++ b/packages/kilo-docs/pages/getting-started/setup-authentication.md
@@ -32,7 +32,7 @@ kilo auth list
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 1. Click **"Try Kilo Code for Free"** in the extension
 2. Sign in with your Google account
@@ -134,7 +134,7 @@ To set a default model:
 ```
 
 {% /tab %}
-{% tab label="VSCode (Legacy)" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
 1. Click the {% kilo-code-icon /%} icon in the VS Code sidebar
 2. Select your API provider from the dropdown

--- a/packages/kilo-docs/pages/getting-started/troubleshooting/troubleshooting-extension.md
+++ b/packages/kilo-docs/pages/getting-started/troubleshooting/troubleshooting-extension.md
@@ -10,15 +10,24 @@ Providing console logs helps us pinpoint exactly what's going wrong with your in
 ## Opening Developer Tools
 
 {% tabs %}
-{% tab label="VS Code" %}
+{% tab label="VSCode" %}
 
 1. **Open the Command Palette**: Press `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (Mac)
 2. **Search for Developer Tools**: Type `Developer: Open Webview Developer Tools` and select it
 
 {% /tab %}
-{% tab label="JetBrains" %}
+{% tab label="VSCode (Legacy) & JetBrains" %}
 
-### Enable JCEF Debugging
+### VS Code (Legacy)
+
+1. **Open the Command Palette**: Press `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (Mac)
+2. **Search for Developer Tools**: Type `Developer: Open Webview Developer Tools` and select it
+
+### JetBrains
+
+The JetBrains plugin is based on the legacy VS Code extension and uses JCEF for its webview.
+
+#### Enable JCEF Debugging
 
 1. Open your JetBrains IDE and go to **Help → Find Action** (or press `Cmd+Shift+A` / `Ctrl+Shift+A`)
 2. Type `Registry` and open it
@@ -27,7 +36,7 @@ Providing console logs helps us pinpoint exactly what's going wrong with your in
    - `ide.browser.jcef.contextMenu.devTools.enabled` → check the box
 4. Restart your IDE after making these changes
 
-### Connect Chrome DevTools
+#### Connect Chrome DevTools
 
 1. Make sure the **Kilo Code panel is open** in your IDE (the debug target won't appear unless the webview is active)
 2. Open Chrome (or any Chromium-based browser like Edge or Arc)


### PR DESCRIPTION
## Summary

Standardizes the platform tabs used across the docs site on a single vocabulary and order:

1. **VSCode**
2. **CLI**
3. **VSCode (Legacy) & JetBrains**

## Why

Tab labels and ordering had drifted across pages — some files led with the legacy tab, others used `VS Code` (with a space), `VSCode (Legacy)` without JetBrains, or a combined `VSCode & CLI` tab. Standalone `JetBrains` tabs duplicated install/debug content that otherwise lives under the legacy tab. Because the JetBrains plugin is still based on the old VS Code extension, it belongs with `VSCode (Legacy)` rather than having its own tab.

## What changed

- Renamed all `VSCode (Legacy)` tab labels → `VSCode (Legacy) & JetBrains` (100 labels).
- Renamed `VS Code` / `VS Code (Legacy)` (with a space) → `VSCode` / `VSCode (Legacy) & JetBrains` in `installing.md` and `troubleshooting-extension.md`.
- Merged the standalone `JetBrains` tab content into the combined legacy tab in `installing.md` and `troubleshooting-extension.md`.
- Split the non-standard `VSCode & CLI` tab in `shell-integration.md` into separate `VSCode` and `CLI` tabs, with the Agent Manager Terminals section kept under `VSCode` only.
- Reordered tabs to `VSCode → CLI → VSCode (Legacy) & JetBrains` across 29 AI provider pages that previously led with the legacy tab.

60 docs files updated. No code or config changes.