### PR TITLE
fix(cli): stop doubling the log directory in rotating-file-stream history path

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -71,7 +71,7 @@ export async function init(options: Options) {
   const stream = createStream(path.basename(logpath), {
     size: "50M",
     maxFiles: 10,
-    history: path.join(dir, ".log-history"),
+    history: ".log-history",
     path: dir,
   })
   stream.on("error", (err: Error) => {


### PR DESCRIPTION
Fixes #8252, #8275, and #9321 (the last was marked a duplicate of the first two).

On every kilo CLI startup the process writes:

`
log stream error: ENOENT: no such file or directory, open
'<log-dir>/<log-dir>/.log-history'
`

Log rotation is effectively disabled because `rotating-file-stream` cannot open its history file.

### Root cause

`rotating-file-stream` (3.2.x) treats the `history` option as a **filename resolved against the `path` option**, not an absolute path. In packages/opencode/src/util/log.ts we were passing:

`	s
const stream = createStream(path.basename(logpath), {
  size: "50M",
  maxFiles: 10,
  history: path.join(dir, ".log-history"), // absolute
  path: dir,                                // also the base dir
})
`

The library then joined path + history, producing the doubled path reported in the issues (<log-dir>/<log-dir>/.log-history) which doesn't exist on disk.

### Fix

Pass just the relative filename to history, so the library resolves it under the configured path directory:

`	s
history: ".log-history",
`

This matches [rotating-file-stream's documented contract](https://github.com/iccicci/rotating-file-stream#history) and restores the 50 MB / 10-file rotation cap.

### Scope

- Single-line change inside the existing // kilocode_change start ... // kilocode_change end block, so the existing fork-delta is preserved.
- No behaviour change for the normal log file path -- only the history-tracking sidecar file.
- No new dependencies.