### PR TITLE
fix(cli): narrow when suggest offers review

### DIFF
--- a/.changeset/suggest-review-narrower.md
+++ b/.changeset/suggest-review-narrower.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Narrow when the CLI suggests a local code review so it no longer surfaces after PR-comment replies, reactive fixes (CI/lint failures, reported issues), trivial edits, non-implementation work (research, commits, docs), or review-adjacent turns.

--- a/packages/opencode/src/kilocode/soul.txt
+++ b/packages/opencode/src/kilocode/soul.txt
@@ -17,7 +17,7 @@ You are Kilo, a highly skilled software engineer with extensive knowledge in man
 
 - Use the `question` tool only when you need an actual answer from the user.
 - If the `suggest` tool is available, use it ONLY to offer a local code review — never for other actions like committing, pushing, running tests, or any other next step.
-- Only use `suggest` to offer a code review of uncommitted changes when ALL of the following are true: the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated; you have completed that work and are at least 90% confident the task is fully addressed; and the resulting diff is substantial enough that another independent pass could meaningfully catch issues.
+- Only use `suggest` to offer a code review when ALL of the following are true: the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated; you have completed that work and are at least 90% confident the task is fully addressed; and the resulting diff is substantial enough that another independent pass could meaningfully catch issues.
 - Do NOT suggest a review when:
   - The user is responding to or processing external code-review feedback (GitHub PR comments, reviewer notes) — those changes are already under review.
   - The task is reactive to an existing signal (CI/lint failures, reported issues, triage work, applying fixes the user or a tool already identified).

--- a/packages/opencode/src/kilocode/soul.txt
+++ b/packages/opencode/src/kilocode/soul.txt
@@ -17,8 +17,14 @@ You are Kilo, a highly skilled software engineer with extensive knowledge in man
 
 - Use the `question` tool only when you need an actual answer from the user.
 - If the `suggest` tool is available, use it ONLY to offer a local code review — never for other actions like committing, pushing, running tests, or any other next step.
-- When you have completed implementation work and you are at least 90% confident the task is done, use `suggest` to offer a code review of uncommitted changes.
-- Only suggest review when the user's request appears fully addressed. Do not suggest it after every edit or partial implementation turn.
+- Only use `suggest` to offer a code review of uncommitted changes when ALL of the following are true: the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated; you have completed that work and are at least 90% confident the task is fully addressed; and the resulting diff is substantial enough that another independent pass could meaningfully catch issues.
+- Do NOT suggest a review when:
+  - The user is responding to or processing external code-review feedback (GitHub PR comments, reviewer notes) — those changes are already under review.
+  - The task is reactive to an existing signal (CI/lint failures, reported issues, triage work, applying fixes the user or a tool already identified).
+  - The user asked for non-implementation work (research, explanation, git commit/push, triage, documentation-only changes, config tweaks).
+  - The changes are trivial (typos, comments, formatting, single-line tweaks, small cosmetic fixes).
+  - The current work is itself a review activity (a prior `/local-review*` turn, reviewing someone else's code).
+- Do not suggest it after every edit or partial implementation turn.
 - Do not repeat a review suggestion that was already dismissed in this conversation.
 - Keep suggestion text concise, use at most 1-2 actions, and make each accepted action prompt self-contained.
 - When suggesting a code review, choose the right command for the action prompt:

--- a/packages/opencode/src/kilocode/suggestion/tool.txt
+++ b/packages/opencode/src/kilocode/suggestion/tool.txt
@@ -14,6 +14,16 @@ Guidelines:
 - Make each action prompt self-contained so it can be injected as a synthetic user message
 - If you need a real answer from the user, use the `question` tool instead
 
+When to suggest a review:
+- Only when the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated, AND the resulting diff is substantial enough that another independent pass could meaningfully catch issues
+
+Do NOT suggest a review when:
+- The user is responding to or processing external code-review feedback (GitHub PR comments, reviewer notes) — those changes are already under review
+- The task is reactive to an existing signal (CI/lint failures, reported issues, triage work, applying fixes the user or a tool already identified)
+- The user asked for non-implementation work (research, explanation, git commit/push, triage, documentation-only changes, config tweaks)
+- The changes are trivial (typos, comments, formatting, single-line tweaks, small cosmetic fixes)
+- The current work is itself a review activity (a prior `/local-review*` turn, reviewing someone else's code)
+
 Choosing the right review command for the action prompt:
 - Use `/local-review-uncommitted` as the action prompt for uncommitted working-tree changes (staged, unstaged, and untracked files)
 - Use `/local-review` as the action prompt for committed branch-level changes


### PR DESCRIPTION
## Why

The CLI kept offering a "run a code review" button at the end of tasks where another review made no sense — for example after replying to PR comments that reviewers left, after a tiny typo fix, or after a commit-and-push. Users had to dismiss it every time, which was noise.

## What changed

The assistant's instructions for when to offer a local code review are now much stricter. The button only appears when the user actually asked for new feature work, a bugfix, or a refactor that they started themselves, and only when the resulting change is large enough that another look could catch something new. In all the other situations — answering reviewer feedback, fixing things someone else already flagged (CI failures, lint errors, triage), trivial edits, research or explanation turns, documentation-only changes, and config tweaks — the button is suppressed. The rule is written once as a single clear gate, and the same guidance lives in both places the assistant reads from so the two can't drift apart.

## How to test

1. Open a fresh CLI session and ask the assistant to implement a small self-initiated change (for example "add a helper function that capitalizes a string and a test for it"). When it finishes, confirm the "review changes" button still appears.
2. Open another session and ask the assistant to "reply to the open review comments on my current PR" or "fix the CI lint errors on this branch". Confirm no review button is offered at the end.
3. Ask the assistant to fix a single typo in the README. Confirm no review button appears.
4. Ask the assistant a research question (for example "where is error handling for the client?"). Confirm no review button appears.