### PR TITLE
fix(session): clamp max output tokens to remaining context window

### DIFF
--- a/.changeset/dynamic-max-output-tokens.md
+++ b/.changeset/dynamic-max-output-tokens.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Dynamically clamp max output tokens based on the model's context window and estimated input size. When the input prompt approaches the context limit, output tokens are reduced to fit within the remaining space instead of always requesting a static 32,000. This prevents ContextOverflowError during autocompact on models with strict context validation (e.g., local LLMs via LiteLLM).

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -28,6 +28,7 @@ import { Identity } from "@kilocode/kilo-telemetry"
 import { makeRuntime } from "@/effect/run-service"
 // kilocode_change end
 import { Installation } from "@/installation"
+import { Token } from "@/util/token"
 import { InstallationVersion } from "@/installation/version"
 import { EffectBridge } from "@/effect"
 import * as Option from "effect/Option"
@@ -378,7 +379,20 @@ export namespace LLM {
           activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
           tools,
           toolChoice: input.toolChoice,
-          maxOutputTokens: params.maxOutputTokens,
+          maxOutputTokens: (() => {
+            const context = input.model.limit.context
+            if (context > 0 && params.maxOutputTokens) {
+              const inputEstimate = messages.reduce((sum, m) => {
+                if (typeof m.content === "string") return sum + Token.estimate(m.content)
+                if (Array.isArray(m.content))
+                  return sum + m.content.reduce((s, p) => s + ("text" in p ? Token.estimate(p.text) : 0), 0)
+                return sum
+              }, 0)
+              const available = context - inputEstimate
+              if (available > 0 && available < params.maxOutputTokens) return available
+            }
+            return params.maxOutputTokens
+          })(),
           abortSignal: input.abort,
           headers: {
               ...(input.model.providerID.startsWith("kilo") // kilocode_change


### PR DESCRIPTION
## Summary

Fixes #9404

When the input prompt approaches the model's context limit, the static `max_tokens=32000` request can exceed the total context window, causing `ContextOverflowError` from providers with strict validation (e.g. LiteLLM + vLLM).

## Changes

**`packages/opencode/src/session/llm.ts`**: Before passing `maxOutputTokens` to the AI SDK's `streamText`, estimate the input token count from the constructed message array using the existing `Token.estimate()` utility. If the model has a known context limit and the remaining space is less than the configured output maximum, clamp `maxOutputTokens` to the available space.

This is a **defensive clamp** — it only activates when the input is large enough that the default output token budget would overflow the context window. Normal conversations are unaffected.

## How it works

```
context_limit = 131,072
input_estimate = ~99,073
available = 131,072 - 99,073 = 31,999

// Before: maxOutputTokens = 32,000 → total = 131,073 → ContextOverflowError
// After:  maxOutputTokens = 31,999 → total = 131,072 → fits
```

## Verification

- Reviewed the error scenario from the issue: Qwen 27B (131k context) with ~99k input tokens
- The `Token.estimate()` function uses a conservative 4 chars/token heuristic, which may undercount but provides a reasonable lower bound
- The clamp only reduces `maxOutputTokens` (never increases), so it cannot introduce new failures
- Changeset included