### PR TITLE
fix(cli): serialize model.json writes to prevent torn JSON on Windows

### DIFF
--- a/.changeset/fix-model-json-torn-writes.md
+++ b/.changeset/fix-model-json-torn-writes.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent `model.json` from being corrupted when per-agent model selections, recent models, or favorites are changed rapidly. Concurrent writes are now serialized so they cannot tear the file into invalid JSON on Windows or under heavy I/O contention.

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -133,8 +133,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
 
       const filePath = path.join(Global.Path.state, "model.json")
+      // kilocode_change start - serialize writes so rapid save() calls cannot tear model.json
+      // (writeJson is fire-and-forget; without a chain, concurrent writeFile calls can interleave
+      // and leave the file as truncated/invalid JSON on Windows and under I/O contention).
       const state = {
         pending: false,
+        chain: Promise.resolve() as Promise<unknown>,
       }
 
       function save() {
@@ -143,13 +147,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return
         }
         state.pending = false
-        Filesystem.writeJson(filePath, {
-          model: modelStore.model, // kilocode_change
+        const data = {
+          model: modelStore.model,
           recent: modelStore.recent,
           favorite: modelStore.favorite,
           variant: modelStore.variant,
-        })
+        }
+        state.chain = state.chain.then(() => Filesystem.writeJson(filePath, data)).catch(() => {})
       }
+      // kilocode_change end
 
       Filesystem.readJson(filePath)
         .then((x: any) => {


### PR DESCRIPTION
## Summary

Rapid `model.set` / `cycle` / `favorite` / variant updates call `Filesystem.writeJson` without awaiting. On Windows and under I/O contention, the concurrent non-atomic `writeFile` calls can interleave and leave `model.json` as truncated / invalid JSON — showing up as a `SyntaxError: JSON Parse error: Unterminated string` when the TUI reloads, and as an intermittent Windows unit-test failure for `test/kilocode/local-model.test.ts`.

This is a pre-existing flake on `main` (runs [`24783752397`](https://github.com/Kilo-Org/kilocode/actions/runs/24783752397), [`24783098767`](https://github.com/Kilo-Org/kilocode/actions/runs/24783098767), [`24830788756`](https://github.com/Kilo-Org/kilocode/actions/runs/24830788756), [`24789659448`](https://github.com/Kilo-Org/kilocode/actions/runs/24789659448), [`24772677476`](https://github.com/Kilo-Org/kilocode/actions/runs/24772677476)) that has been failing unrelated PRs. Root cause is in `local.tsx`, not in the tests.

## Fix

Serialize `save()` calls through a `Promise` chain so only one `writeJson` is in flight at a time. Subsequent writes overwrite the file cleanly instead of racing.

```ts
state.chain = state.chain.then(() => Filesystem.writeJson(filePath, data)).catch(() => {})
```

## Verification

- `bun test test/kilocode/local-model.test.ts` → **16 pass, 0 fail** across 5 consecutive local runs
- `bun test test/share/share-next.test.ts` → **7 pass, 0 fail** (sanity check; unrelated)
- `bun turbo typecheck --filter=@kilocode/cli` → green