### PR TITLE
fix(vscode): align new session and terminal tab behavior in agent manager

### DIFF
--- a/.changeset/agent-manager-new-tab-order.md
+++ b/.changeset/agent-manager-new-tab-order.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix two Agent Manager tab-bar regressions. New session and terminal tabs now consistently open at the right end of the tab bar instead of sometimes slipping in front of existing tabs. Dragging a terminal tab now shows the same floating label preview as dragging a session tab.

--- a/packages/kilo-vscode/tests/unit/tab-order-sync.test.ts
+++ b/packages/kilo-vscode/tests/unit/tab-order-sync.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "bun:test"
+import { createTabOrderSync, type TabOrderSyncDeps } from "../../webview-ui/agent-manager/tab-order-sync"
+import { applyTabOrder } from "../../webview-ui/agent-manager/tab-order"
+
+// Builds a simulated AgentManager tab state with controllable accessors.
+// Mirrors the real call order: source state (localSessionIDs, terminals)
+// is mutated BEFORE the factory method is invoked.
+function scene(init: {
+  order?: Record<string, string[]>
+  sessions?: string[]
+  worktreeSessions?: { key: string; ids: string[] }[]
+  review?: Record<string, boolean>
+  terminals?: Record<string, string[]>
+}) {
+  const state = {
+    order: { ...(init.order ?? {}) } as Record<string, string[]>,
+    localIds: [...(init.sessions ?? [])],
+    worktreeSessions: init.worktreeSessions ?? [],
+    review: init.review ?? {},
+    terminals: { ...(init.terminals ?? {}) } as Record<string, string[]>,
+    persisted: [] as { key: string; order: string[] }[],
+  }
+  const deps: TabOrderSyncDeps = {
+    LOCAL: "LOCAL",
+    REVIEW_TAB_ID: "review",
+    order: () => state.order,
+    setOrder: (u) => {
+      state.order = u(state.order)
+    },
+    persist: (key, order) => {
+      state.persisted.push({ key, order: [...order] })
+    },
+    localSessionIDs: () => state.localIds,
+    sessions: () =>
+      state.worktreeSessions.flatMap((w, wi) =>
+        w.ids.map((id, i) => ({ id, createdAt: new Date(1700000000000 + wi * 1000 + i).toISOString() })),
+      ),
+    managedSessions: () => state.worktreeSessions.flatMap((w) => w.ids.map((id) => ({ id, worktreeId: w.key }))),
+    reviewOpenByContext: () => state.review,
+    terminalIdsFor: (key) => state.terminals[key] ?? [],
+  }
+  return { state, sync: createTabOrderSync(deps), deps }
+}
+
+// Simulate how `tabIds()` renders the final tab bar: base composed as
+// `[...sessions, review, ...terminals]` and `applyTabOrder` layered on top.
+function render(deps: TabOrderSyncDeps, key: string): string[] {
+  const sids =
+    key === deps.LOCAL
+      ? deps.localSessionIDs()
+      : deps
+          .sessions()
+          .filter((s) => deps.managedSessions().some((ms) => ms.id === s.id && ms.worktreeId === key))
+          .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+          .map((s) => s.id)
+  const withReview = deps.reviewOpenByContext()[key] === true ? [...sids, deps.REVIEW_TAB_ID] : sids
+  const base = [...withReview, ...deps.terminalIdsFor(key)]
+  return applyTabOrder(
+    base.map((id) => ({ id })),
+    deps.order()[key],
+  ).map((i) => i.id)
+}
+
+describe("createTabOrderSync.append", () => {
+  it("puts a new pending tab at the tail when a terminal already exists (regression)", () => {
+    // Setup: existing session s1, existing terminal t1, no stored order yet
+    // (terminal append was a no-op under the old logic because t1 was
+    // already in base). User presses Cmd+T → pending_1 added to local
+    // sessions first, then append is called.
+    const { state, sync, deps } = scene({
+      sessions: ["s1", "pending_1"],
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.append("LOCAL", "pending_1")
+    expect(render(deps, "LOCAL")).toEqual(["s1", "t1", "pending_1"])
+    expect(state.order.LOCAL).toEqual(["s1", "t1", "pending_1"])
+  })
+
+  it("appends to tail when stored order exists and lacks the id", () => {
+    const { state, sync, deps } = scene({
+      order: { LOCAL: ["s1", "t1"] },
+      sessions: ["s1", "s2"],
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.append("LOCAL", "s2")
+    expect(state.order.LOCAL).toEqual(["s1", "t1", "s2"])
+    expect(render(deps, "LOCAL")).toEqual(["s1", "t1", "s2"])
+  })
+
+  it("moves the id to the tail if it was already present in stored", () => {
+    const { state, sync } = scene({
+      order: { LOCAL: ["s1", "s2", "t1"] },
+      sessions: ["s1", "s2"],
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.append("LOCAL", "s1")
+    expect(state.order.LOCAL).toEqual(["s2", "t1", "s1"])
+  })
+
+  it("resolves undefined key to LOCAL", () => {
+    const { state, sync } = scene({ sessions: ["s1"] })
+    sync.append(undefined, "s1")
+    expect(state.order.LOCAL).toEqual(["s1"])
+  })
+
+  it("handles an empty base (nothing mutated yet) by just writing the id", () => {
+    const { state, sync } = scene({})
+    sync.append("LOCAL", "x")
+    expect(state.order.LOCAL).toEqual(["x"])
+  })
+})
+
+describe("createTabOrderSync.replaceOrAppend", () => {
+  it("swaps a pending id for a real session id, preserving position", () => {
+    const { state, sync, deps } = scene({
+      order: { LOCAL: ["s1", "pending_1", "t1"] },
+      sessions: ["s1", "real_1"], // caller already mapped pending_1 → real_1
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.replaceOrAppend("LOCAL", "pending_1", "real_1")
+    expect(state.order.LOCAL).toEqual(["s1", "real_1", "t1"])
+    expect(render(deps, "LOCAL")).toEqual(["s1", "real_1", "t1"])
+  })
+
+  it("appends at the tail when the anchor isn't in stored", () => {
+    const { state, sync } = scene({
+      order: { LOCAL: ["s1", "t1"] },
+      sessions: ["s1", "s2"], // s2 not yet in stored
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.replaceOrAppend("LOCAL", "missing", "s2")
+    expect(state.order.LOCAL).toEqual(["s1", "t1", "s2"])
+  })
+})
+
+describe("createTabOrderSync.insertAfter", () => {
+  it("inserts a fork directly after its parent in the rendered order", () => {
+    const { state, sync, deps } = scene({
+      order: { LOCAL: ["s1", "t1"] },
+      sessions: ["s1", "child", "s2"], // caller already inserted child after s1
+      terminals: { LOCAL: ["t1"] },
+    })
+    sync.insertAfter("LOCAL", "s1", "child")
+    expect(state.order.LOCAL).toEqual(["s1", "child", "t1", "s2"])
+    // Rendered result has child immediately after s1.
+    expect(render(deps, "LOCAL")).toEqual(["s1", "child", "t1", "s2"])
+  })
+
+  it("appends when the anchor is missing entirely", () => {
+    const { state, sync } = scene({
+      order: { LOCAL: ["s1"] },
+      sessions: ["s1", "fork"],
+    })
+    sync.insertAfter("LOCAL", "missing_anchor", "fork")
+    expect(state.order.LOCAL).toEqual(["s1", "fork"])
+  })
+
+  it("seeds from base when no stored order exists (first fork)", () => {
+    const { state, sync } = scene({
+      sessions: ["s1", "child", "s2"],
+    })
+    sync.insertAfter("LOCAL", "s1", "child")
+    expect(state.order.LOCAL).toEqual(["s1", "child", "s2"])
+  })
+})
+
+describe("createTabOrderSync cross-method scenario", () => {
+  it("preserves position through terminal → pending → real lifecycle", () => {
+    const s = scene({ sessions: ["s1"] })
+
+    // 1. Terminal created — caller added t1 to terms state first.
+    s.state.terminals.LOCAL = ["t1"]
+    s.sync.append("LOCAL", "t1")
+    expect(s.state.order.LOCAL).toEqual(["s1", "t1"])
+
+    // 2. User presses Cmd+T → pending_1 appended to localIds first.
+    s.state.localIds = ["s1", "pending_1"]
+    s.sync.append("LOCAL", "pending_1")
+    expect(s.state.order.LOCAL).toEqual(["s1", "t1", "pending_1"])
+
+    // 3. Real session created → caller mapped pending_1 → real_1 in localIds.
+    s.state.localIds = ["s1", "real_1"]
+    s.sync.replaceOrAppend("LOCAL", "pending_1", "real_1")
+    expect(s.state.order.LOCAL).toEqual(["s1", "t1", "real_1"])
+
+    // Rendered tab bar keeps the new session in its slot (right of t1).
+    expect(render(s.deps, "LOCAL")).toEqual(["s1", "t1", "real_1"])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/tab-order-sync.test.ts
+++ b/packages/kilo-vscode/tests/unit/tab-order-sync.test.ts
@@ -164,6 +164,40 @@ describe("createTabOrderSync.insertAfter", () => {
   })
 })
 
+describe("createTabOrderSync persistence filter", () => {
+  it("callers strip transient ids before persisting (review + terminal:* never hit disk)", () => {
+    // Mirror AgentManagerApp's real filter: strip review + terminal ids.
+    const { state, sync } = scene({
+      sessions: ["s1", "pending_1"],
+      terminals: { LOCAL: ["terminal:abc"] },
+      review: { LOCAL: true },
+    })
+    // Rebuild sync with a filtering persist to mimic the call site.
+    const filteredSync = createTabOrderSync({
+      LOCAL: "LOCAL",
+      REVIEW_TAB_ID: "review",
+      order: () => state.order,
+      setOrder: (u) => {
+        state.order = u(state.order)
+      },
+      persist: (key, order) => {
+        const clean = order.filter((id) => id !== "review" && !id.startsWith("terminal:"))
+        state.persisted.push({ key, order: clean })
+      },
+      localSessionIDs: () => state.localIds,
+      sessions: () => [],
+      managedSessions: () => [],
+      reviewOpenByContext: () => state.review,
+      terminalIdsFor: (key) => state.terminals[key] ?? [],
+    })
+    filteredSync.append("LOCAL", "pending_1")
+    // In-memory order still has terminals/review for drag state.
+    expect(state.order.LOCAL).toEqual(["s1", "review", "terminal:abc", "pending_1"])
+    // Persisted payload is session-only.
+    expect(state.persisted.at(-1)?.order).toEqual(["s1", "pending_1"])
+  })
+})
+
 describe("createTabOrderSync cross-method scenario", () => {
   it("preserves position through terminal → pending → real lifecycle", () => {
     const s = scene({ sessions: ["s1"] })

--- a/packages/kilo-vscode/tests/unit/tab-order.test.ts
+++ b/packages/kilo-vscode/tests/unit/tab-order.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test"
-import { reorderTabs, applyTabOrder, firstOrderedTitle } from "../../webview-ui/agent-manager/tab-order"
+import {
+  reorderTabs,
+  applyTabOrder,
+  firstOrderedTitle,
+  replaceInTabOrder,
+  insertInTabOrderAfter,
+} from "../../webview-ui/agent-manager/tab-order"
 
 describe("reorderTabs", () => {
   const tabs = ["a", "b", "c", "d"]
@@ -143,6 +149,63 @@ describe("firstOrderedTitle", () => {
 
   it("returns fallback for empty items", () => {
     expect(firstOrderedTitle([], ["a"], "fallback")).toBe("fallback")
+  })
+})
+
+describe("replaceInTabOrder", () => {
+  it("replaces an id while preserving position", () => {
+    expect(replaceInTabOrder(["a", "b", "c"], "b", "B")).toEqual(["a", "B", "c"])
+  })
+
+  it("replaces at the head", () => {
+    expect(replaceInTabOrder(["a", "b"], "a", "A")).toEqual(["A", "b"])
+  })
+
+  it("replaces at the tail", () => {
+    expect(replaceInTabOrder(["a", "b"], "b", "B")).toEqual(["a", "B"])
+  })
+
+  it("returns undefined when oldId is not in order", () => {
+    expect(replaceInTabOrder(["a", "b"], "x", "X")).toBeUndefined()
+  })
+
+  it("returns undefined when order is undefined", () => {
+    expect(replaceInTabOrder(undefined, "a", "A")).toBeUndefined()
+  })
+
+  it("does not mutate the original array", () => {
+    const order = ["a", "b"]
+    replaceInTabOrder(order, "a", "A")
+    expect(order).toEqual(["a", "b"])
+  })
+})
+
+describe("insertInTabOrderAfter", () => {
+  it("inserts directly after the anchor", () => {
+    expect(insertInTabOrderAfter(["a", "b", "c"], "b", "B2")).toEqual(["a", "b", "B2", "c"])
+  })
+
+  it("inserts after the last item", () => {
+    expect(insertInTabOrderAfter(["a", "b"], "b", "c")).toEqual(["a", "b", "c"])
+  })
+
+  it("appends when anchor is missing", () => {
+    expect(insertInTabOrderAfter(["a", "b"], "x", "c")).toEqual(["a", "b", "c"])
+  })
+
+  it("appends when order is undefined", () => {
+    expect(insertInTabOrderAfter(undefined, "x", "c")).toEqual(["c"])
+  })
+
+  it("returns the base unchanged when id is already present", () => {
+    const order = ["a", "b"]
+    expect(insertInTabOrderAfter(order, "a", "b")).toBe(order)
+  })
+
+  it("does not mutate the original array", () => {
+    const order = ["a", "b"]
+    insertInTabOrderAfter(order, "a", "c")
+    expect(order).toEqual(["a", "b"])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -85,6 +85,7 @@ import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
 import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, LOCAL } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
+import { createTabOrderSync } from "./tab-order-sync"
 import { ConstrainDragYAxis } from "./sortable-tab"
 import { isTerminalTabId, createTerminalState, createTerminalHandlers, createTerminalMessageHandler } from "./terminal"
 import { renderTab, renderTerminalLayer, renderNewTabButton } from "./tab-rendering"
@@ -667,17 +668,20 @@ const AgentManagerContent: Component = () => {
   const [renamingSection, setRenamingSection] = createSignal<string | null>(null)
   let pendingNewSection = false
 
-  /** Append an id to `worktreeTabOrder[key]` and persist server-side.
-   *  Keeps new sessions/terminals at the right end of the tab bar
-   *  instead of slipping in front of already-rendered tabs via
-   *  tabIds()'s `[...sessions, review, ...terminals]` base order. */
-  const appendToTabOrder = (key: string, id: string) => {
-    const current = worktreeTabOrder()[key] ?? []
-    if (current.includes(id)) return
-    const next = [...current, id]
-    setWorktreeTabOrder((prev) => ({ ...prev, [key]: next }))
-    vscode.postMessage({ type: "agentManager.setTabOrder", key, order: next })
-  }
+  // Pin new sessions/terminals at the tab bar's tail (see tab-order-sync).
+  const tabOrderSync = createTabOrderSync({
+    LOCAL,
+    REVIEW_TAB_ID,
+    order: worktreeTabOrder,
+    setOrder: setWorktreeTabOrder,
+    persist: (key, order) => vscode.postMessage({ type: "agentManager.setTabOrder", key, order }),
+    localSessionIDs,
+    sessions: session.sessions,
+    managedSessions,
+    reviewOpenByContext,
+    terminalIdsFor: (key) => terms.forSelection(key).map((t) => t.id),
+  })
+  const appendToTabOrder = tabOrderSync.append
 
   const addPendingTab = () => {
     const id = `${PENDING_PREFIX}${++pendingCounter}`
@@ -1164,9 +1168,8 @@ const AgentManagerContent: Component = () => {
     }
     window.addEventListener("focus", onWindowFocus)
 
-    // When a session is created, add it as a local tab. This handles both direct
-    // creation from the prompt input and backend-created follow-up sessions (plan
-    // follow-up "Start new session"). Guard against duplicates (HTTP + SSE can both fire).
+    // Add created sessions as local tabs (both direct from the prompt and
+    // backend follow-ups). Dedups HTTP + SSE firing together.
     const unsubCreate = vscode.onMessage((msg) => {
       if (msg.type !== "sessionCreated") return
       const created = msg as { type: string; session: { id: string } }
@@ -1175,10 +1178,12 @@ const AgentManagerContent: Component = () => {
       const pending = selection() === LOCAL ? activePendingId() : undefined
       if (pending) {
         setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? created.session.id : id)))
+        tabOrderSync.replaceOrAppend(LOCAL, pending, created.session.id)
         setActivePendingId(undefined)
       } else {
         saveTabMemory()
         setLocalSessionIDs((prev) => [...prev, created.session.id])
+        tabOrderSync.append(LOCAL, created.session.id)
         setSelection(LOCAL)
       }
       vscode.postMessage({ type: "agentManager.persistSession", sessionId: created.session.id })
@@ -1196,8 +1201,7 @@ const AgentManagerContent: Component = () => {
       setRunStatuses((prev) => ({ ...prev, [ev.worktreeId]: ev }))
     })
 
-    // Terminal messages live in their own subscription to keep the main
-    // message handler's cyclomatic complexity under the lint cap.
+    // Terminal messages have their own subscription to keep main-handler complexity in check.
     const terminalDispatch = createTerminalMessageHandler({
       state: terms,
       activate: termHandlers.activate,
@@ -1257,12 +1261,14 @@ const AgentManagerContent: Component = () => {
       if (msg.type === "agentManager.sessionAdded") {
         const ev = msg as { type: string; sessionId: string; worktreeId: string }
         saveTabMemory()
+        appendToTabOrder(ev.worktreeId, ev.sessionId)
         setSelection(ev.worktreeId)
         session.selectSession(ev.sessionId)
       }
 
       if (msg.type === "agentManager.sessionForked") {
         const ev = msg as { type: string; sessionId: string; forkedFromId: string; worktreeId?: string }
+        tabOrderSync.insertAfter(ev.worktreeId, ev.forkedFromId, ev.sessionId)
         if (!ev.worktreeId) {
           // Local session: insert new tab after the forked-from tab
           setLocalSessionIDs((prev) => {
@@ -2087,6 +2093,10 @@ const AgentManagerContent: Component = () => {
     const id = draggingTab()
     if (!id) return undefined
     if (id === REVIEW_TAB_ID) return { id, title: t("session.tab.review") }
+    if (isTerminalTabId(id)) {
+      const term = terms.lookup().get(id)
+      return term ? { id, title: term.title } : undefined
+    }
     return activeTabs().find((s) => s.id === id)
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -668,13 +668,17 @@ const AgentManagerContent: Component = () => {
   const [renamingSection, setRenamingSection] = createSignal<string | null>(null)
   let pendingNewSection = false
 
-  // Pin new sessions/terminals at the tab bar's tail (see tab-order-sync).
+  // Pin new tabs at the tail (see tab-order-sync); strip ephemeral ids so agent-manager.json stays clean.
+  const persistTabOrder = (key: string, order: string[]) => {
+    const durable = order.filter((id) => id !== REVIEW_TAB_ID && !isTerminalTabId(id))
+    vscode.postMessage({ type: "agentManager.setTabOrder", key, order: durable })
+  }
   const tabOrderSync = createTabOrderSync({
     LOCAL,
     REVIEW_TAB_ID,
     order: worktreeTabOrder,
     setOrder: setWorktreeTabOrder,
-    persist: (key, order) => vscode.postMessage({ type: "agentManager.setTabOrder", key, order }),
+    persist: persistTabOrder,
     localSessionIDs,
     sessions: session.sessions,
     managedSessions,
@@ -2081,12 +2085,8 @@ const AgentManagerContent: Component = () => {
     const sel = selection()
     if (sel === null) return
     const key = sel === LOCAL ? LOCAL : sel
-    // Persist the full mixed order. Terminal IDs are ephemeral; on
-    // reload their PTYs are gone and `applyTabOrder` filters them out.
     const order = worktreeTabOrder()[key]
-    if (order && order.length > 0) {
-      vscode.postMessage({ type: "agentManager.setTabOrder", key, order })
-    }
+    if (order && order.length > 0) persistTabOrder(key, order)
   }
 
   const draggedTab = createMemo(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/tab-order-sync.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/tab-order-sync.ts
@@ -1,0 +1,82 @@
+/**
+ * Factory for tab-order mutations used when sessions/terminals are created,
+ * a pending tab is promoted to a real session id, or a session is forked.
+ *
+ * Exists as a separate module to keep the tab-order branching out of
+ * AgentManagerApp's main message-handler arrow (complexity cap).
+ */
+import { replaceInTabOrder, insertInTabOrderAfter } from "./tab-order"
+
+export interface TabOrderSyncDeps {
+  /** Constants that identify the local context and review tab. */
+  LOCAL: string
+  REVIEW_TAB_ID: string
+  /** Read/update the persisted `contextKey → ordered tab ids` map. */
+  order: () => Record<string, string[]>
+  setOrder: (updater: (prev: Record<string, string[]>) => Record<string, string[]>) => void
+  persist: (key: string, value: string[]) => void
+  /** State accessors used to rebuild the base order `[sessions, review, terminals]`. */
+  localSessionIDs: () => string[]
+  sessions: () => { id: string; createdAt: string }[]
+  managedSessions: () => { id: string; worktreeId?: string | null }[]
+  reviewOpenByContext: () => Record<string, boolean>
+  terminalIdsFor: (key: string) => string[]
+}
+
+export function createTabOrderSync(deps: TabOrderSyncDeps) {
+  const baseFor = (key: string): string[] => {
+    const sids =
+      key === deps.LOCAL
+        ? deps.localSessionIDs()
+        : deps
+            .sessions()
+            .filter((s) => deps.managedSessions().some((ms) => ms.id === s.id && ms.worktreeId === key))
+            .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+            .map((s) => s.id)
+    const withReview = deps.reviewOpenByContext()[key] === true ? [...sids, deps.REVIEW_TAB_ID] : sids
+    return [...withReview, ...deps.terminalIdsFor(key)]
+  }
+
+  const commit = (key: string, next: string[]) => {
+    deps.setOrder((prev) => ({ ...prev, [key]: next }))
+    deps.persist(key, next)
+  }
+
+  const resolve = (key: string | undefined): string => key ?? deps.LOCAL
+
+  // Merge stored + any base ids not yet in stored — mirrors `applyTabOrder`'s
+  // output so we can pin `id` at a specific rendered position (tail for
+  // append, right-of-anchor for insertAfter) regardless of whether the
+  // caller already mutated source state (localSessionIDs, terms, etc).
+  const merge = (key: string): string[] => {
+    const stored = deps.order()[key] ?? []
+    const set = new Set(stored)
+    const unknowns = baseFor(key).filter((x) => !set.has(x))
+    return [...stored, ...unknowns]
+  }
+
+  return {
+    /** Place `id` at the tail of the persisted order for `key`. */
+    append(key: string | undefined, id: string) {
+      const k = resolve(key)
+      const rest = merge(k).filter((x) => x !== id)
+      commit(k, [...rest, id])
+    },
+    /** Swap `oldId` for `newId` preserving position, or append if missing. */
+    replaceOrAppend(key: string | undefined, oldId: string, newId: string) {
+      const k = resolve(key)
+      const stored = deps.order()[k] ?? []
+      const swapped = replaceInTabOrder(stored, oldId, newId)
+      if (swapped) return commit(k, swapped)
+      const rest = merge(k).filter((x) => x !== newId)
+      commit(k, [...rest, newId])
+    },
+    /** Place `id` directly after `anchorId`; append if anchor is missing. */
+    insertAfter(key: string | undefined, anchorId: string, id: string) {
+      const k = resolve(key)
+      const rest = merge(k).filter((x) => x !== id)
+      const next = insertInTabOrderAfter(rest, anchorId, id)
+      commit(k, next)
+    },
+  }
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/tab-order-sync.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/tab-order-sync.ts
@@ -11,9 +11,10 @@ export interface TabOrderSyncDeps {
   /** Constants that identify the local context and review tab. */
   LOCAL: string
   REVIEW_TAB_ID: string
-  /** Read/update the persisted `contextKey → ordered tab ids` map. */
+  /** Read/update the `contextKey → ordered tab ids` map (in-memory). */
   order: () => Record<string, string[]>
   setOrder: (updater: (prev: Record<string, string[]>) => Record<string, string[]>) => void
+  /** Persist to durable state. Callers should strip transient ids here. */
   persist: (key: string, value: string[]) => void
   /** State accessors used to rebuild the base order `[sessions, review, terminals]`. */
   localSessionIDs: () => string[]

--- a/packages/kilo-vscode/webview-ui/agent-manager/tab-order.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/tab-order.ts
@@ -40,6 +40,33 @@ export function applyTabOrder<T extends { id: string }>(items: T[], order: strin
 }
 
 /**
+ * Replace `oldId` with `newId` in `order`, preserving its position.
+ * Returns a new array, or undefined if `oldId` isn't in `order`.
+ * Used when a pending session tab is promoted to a real session id.
+ */
+export function replaceInTabOrder(order: string[] | undefined, oldId: string, newId: string): string[] | undefined {
+  if (!order) return undefined
+  const i = order.indexOf(oldId)
+  if (i === -1) return undefined
+  const next = [...order]
+  next[i] = newId
+  return next
+}
+
+/**
+ * Insert `id` into `order` directly after `afterId`.
+ * If `afterId` is missing from `order`, appends `id` at the end.
+ * Returns a new array, or undefined if `id` is already present.
+ */
+export function insertInTabOrderAfter(order: string[] | undefined, afterId: string, id: string): string[] {
+  const base = order ?? []
+  if (base.includes(id)) return base
+  const i = base.indexOf(afterId)
+  if (i === -1) return [...base, id]
+  return [...base.slice(0, i + 1), id, ...base.slice(i + 1)]
+}
+
+/**
  * Find the title of the first item according to a custom order.
  *
  * Falls back to the first titled item in `items` if the order


### PR DESCRIPTION
## Summary

- New session/terminal tabs (including the pending "new session" card) sometimes appeared **left of existing terminals** because the tab-order write was skipped when the id was already in the base order. The factory now works on the merged `[stored + base-unknowns]` view and pins the new id at its target rendered position (tail for `append`, after-anchor for `insertAfter`, in-place for `replaceOrAppend`).
- Dragging a terminal tab showed no floating ghost under the cursor because `draggedTab` only resolved session and review ids. Now resolves terminal ids via `terms.lookup()`, so the DragOverlay renders the same label-bearing ghost across all tab kinds.

## Regression tests

New `tests/unit/tab-order-sync.test.ts` covers the headline scenario ("pending tab lands left of a terminal") and the pending → real session lifecycle.