### PR TITLE
fix(cli): preserve prompt text on dismiss

### DIFF
--- a/.changeset/preserve-input-across-blocking-overlays.md
+++ b/.changeset/preserve-input-across-blocking-overlays.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve typed text in the main prompt when a blocking question, suggestion, permission, or network overlay is shown and then dismissed.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -493,6 +493,7 @@ export function Autocomplete(props: {
   // kilocode_change start - keep slash text intact when overlays hide the prompt,
   // but still allow normal autocomplete dismissal to clean it up.
   function dismiss() {
+    if (!store.visible) return
     command.keybinds(true)
     setStore("visible", false)
   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -52,6 +52,8 @@ export type AutocompleteRef = {
   onInput: (value: string) => void
   onKeyDown: (e: KeyEvent) => void
   onCursorChange: () => void
+  // kilocode_change - let the prompt close autocomplete without mutating draft text
+  dismiss: () => void
   visible: false | "@" | "/"
 }
 
@@ -487,6 +489,13 @@ export function Autocomplete(props: {
     })
   }
 
+  // kilocode_change start - keep slash text intact when overlays hide the prompt,
+  // but still allow normal autocomplete dismissal to clean it up.
+  function dismiss() {
+    command.keybinds(true)
+    setStore("visible", false)
+  }
+
   function hide() {
     const text = props.input().plainText
     if (store.visible === "/" && !text.endsWith(" ") && text.startsWith("/")) {
@@ -497,15 +506,20 @@ export function Autocomplete(props: {
         draft.input = props.input().plainText
       })
     }
-    command.keybinds(true)
-    setStore("visible", false)
+    dismiss()
   }
+  // kilocode_change end
 
   onMount(() => {
     props.ref({
       get visible() {
         return store.visible
       },
+      // kilocode_change start
+      dismiss() {
+        dismiss()
+      },
+      // kilocode_change end
       onInput(value) {
         if (store.visible) {
           if (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -52,8 +52,9 @@ export type AutocompleteRef = {
   onInput: (value: string) => void
   onKeyDown: (e: KeyEvent) => void
   onCursorChange: () => void
-  // kilocode_change - let the prompt close autocomplete without mutating draft text
+  // kilocode_change start - let the prompt close autocomplete without mutating draft text
   dismiss: () => void
+  // kilocode_change end
   visible: false | "@" | "/"
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -440,6 +440,14 @@ export function Prompt(props: PromptProps) {
   })
 
   createEffect(() => {
+    // kilocode_change start - close autocomplete while blocking overlays hide the prompt
+    if (props.visible === false || props.disabled) {
+      auto()?.dismiss()
+    }
+    // kilocode_change end
+  })
+
+  createEffect(() => {
     if (!input || input.isDestroyed) return
     if (props.visible === false || dialog.stack.length > 0) {
       input.blur()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -439,13 +439,13 @@ export function Prompt(props: PromptProps) {
     props.ref?.(undefined)
   })
 
+  // kilocode_change start - close autocomplete while blocking overlays hide the prompt
   createEffect(() => {
-    // kilocode_change start - close autocomplete while blocking overlays hide the prompt
     if (props.visible === false || props.disabled) {
       auto()?.dismiss()
     }
-    // kilocode_change end
   })
+  // kilocode_change end
 
   createEffect(() => {
     if (!input || input.isDestroyed) return

--- a/packages/opencode/src/cli/cmd/tui/plugin/slots.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/slots.tsx
@@ -1,5 +1,6 @@
 import type { TuiPluginApi, TuiSlotContext, TuiSlotMap, TuiSlotProps } from "@kilocode/plugin/tui"
 import { createSlot, createSolidSlotRegistry, type JSX, type SolidPlugin } from "@opentui/solid"
+import { children } from "solid-js"
 import { isRecord } from "@/util/record"
 
 type RuntimeSlotMap = TuiSlotMap<Record<string, object>>
@@ -21,7 +22,18 @@ function empty<Name extends string>(_props: TuiSlotProps<Name>) {
 
 let view: Slot = empty
 
-export const Slot: Slot = (props) => view(props)
+export const Slot = <Name extends string>(props: TuiSlotProps<Name>) => {
+  // kilocode_change start - stabilize fallback children so replace-mode slots
+  // don't recreate stateful defaults like the session prompt on prop changes.
+  const value = children(() => props.children)
+  return view({
+    ...props,
+    get children() {
+      return value()
+    },
+  } as TuiSlotProps<Name>)
+  // kilocode_change end
+}
 
 function isHostSlotPlugin(value: unknown): value is HostSlotPlugin<Record<string, object>> {
   if (!isRecord(value)) return false

--- a/packages/opencode/src/cli/cmd/tui/plugin/slots.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/slots.tsx
@@ -1,6 +1,6 @@
 import type { TuiPluginApi, TuiSlotContext, TuiSlotMap, TuiSlotProps } from "@kilocode/plugin/tui"
 import { createSlot, createSolidSlotRegistry, type JSX, type SolidPlugin } from "@opentui/solid"
-import { children } from "solid-js"
+import { children } from "solid-js" // kilocode_change
 import { isRecord } from "@/util/record"
 
 type RuntimeSlotMap = TuiSlotMap<Record<string, object>>
@@ -22,9 +22,9 @@ function empty<Name extends string>(_props: TuiSlotProps<Name>) {
 
 let view: Slot = empty
 
+// kilocode_change start - stabilize fallback children so replace-mode slots
+// don't recreate stateful defaults like the session prompt on prop changes.
 export const Slot = <Name extends string>(props: TuiSlotProps<Name>) => {
-  // kilocode_change start - stabilize fallback children so replace-mode slots
-  // don't recreate stateful defaults like the session prompt on prop changes.
   const value = children(() => props.children)
   return view({
     ...props,
@@ -32,8 +32,8 @@ export const Slot = <Name extends string>(props: TuiSlotProps<Name>) => {
       return value()
     },
   } as TuiSlotProps<Name>)
-  // kilocode_change end
 }
+// kilocode_change end
 
 function isHostSlotPlugin(value: unknown): value is HostSlotPlugin<Record<string, object>> {
   if (!isRecord(value)) return false

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1295,7 +1295,8 @@ export function Session() {
                 <NetworkPrompt request={network()[0]} />
               </Show>
               {/* kilocode_change end */}
-              <Show when={visible()}>
+              {/* kilocode_change start */}
+              <Show when={!session()?.parentID}>
                 <TuiPluginRuntime.Slot
                   name="session_prompt"
                   mode="replace"
@@ -1317,6 +1318,7 @@ export function Session() {
                   />
                 </TuiPluginRuntime.Slot>
               </Show>
+              {/* kilocode_change end */}
             </box>
           </Show>
           <Toast />


### PR DESCRIPTION
## Why

The text you type in the main input can disappear when a blocking question or similar screen shows up. That is frustrating because you have to type the same thing again.

## What changed

The main input now stays around while these blocking screens are shown, instead of being thrown away and rebuilt. It is still hidden and turned off while the blocking screen is active, but the text and attached prompt items stay in place. I also made the fallback prompt inside the plugin slot stay stable when this state changes. This keeps the draft message there when the screen is dismissed.

## How to test

1. Open a session and type text into the main input without sending it.
2. Trigger a blocking question and dismiss it with `escape`.
3. Check that the text is still in the input.
4. Repeat the same check with a blocking suggestion, permission request, or network prompt.


https://github.com/user-attachments/assets/a95ec0ec-29b4-4e61-8353-74fc2873a166

