### PR TITLE
fix(vscode): make Auto-Approve section titles respect VS Code theme

### DIFF
--- a/.changeset/auto-approve-header-light-theme.md
+++ b/.changeset/auto-approve-header-light-theme.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix unreadable section titles on the Auto-Approve settings page when using a light VS Code color theme. Tool headers (External Directory, Bash, Read, Edit, etc.) now follow the active VS Code theme foreground color instead of always rendering in white.

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
@@ -296,7 +296,7 @@ const SimpleToolRow: Component<{
       }}
     >
       <div style={{ flex: 1, "min-width": 0 }}>
-        <div style={{ "font-size": "13px", color: "var(--text-strong, var(--vscode-foreground))" }}>
+        <div style={{ "font-size": "13px", color: "var(--text-base, var(--vscode-foreground))" }}>
           {toolTitle(props.id)}
         </div>
         <div
@@ -354,7 +354,7 @@ const GranularToolRow: Component<{
       {/* Tool header with name and description */}
       <div style={{ display: "flex", gap: "24px", "align-items": "flex-start", "justify-content": "space-between" }}>
         <div style={{ flex: 1, "min-width": 0 }}>
-          <div style={{ "font-size": "13px", color: "var(--text-strong, var(--vscode-foreground))" }}>
+          <div style={{ "font-size": "13px", color: "var(--text-base, var(--vscode-foreground))" }}>
             {toolTitle(props.tool.id)}
           </div>
           <div

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AutoApproveTab.tsx
@@ -296,7 +296,9 @@ const SimpleToolRow: Component<{
       }}
     >
       <div style={{ flex: 1, "min-width": 0 }}>
-        <div style={{ "font-size": "13px", color: "var(--text-strong-base, white)" }}>{toolTitle(props.id)}</div>
+        <div style={{ "font-size": "13px", color: "var(--text-strong, var(--vscode-foreground))" }}>
+          {toolTitle(props.id)}
+        </div>
         <div
           style={{
             "font-size": "12px",
@@ -352,7 +354,9 @@ const GranularToolRow: Component<{
       {/* Tool header with name and description */}
       <div style={{ display: "flex", gap: "24px", "align-items": "flex-start", "justify-content": "space-between" }}>
         <div style={{ flex: 1, "min-width": 0 }}>
-          <div style={{ "font-size": "13px", color: "var(--text-strong-base, white)" }}>{toolTitle(props.tool.id)}</div>
+          <div style={{ "font-size": "13px", color: "var(--text-strong, var(--vscode-foreground))" }}>
+            {toolTitle(props.tool.id)}
+          </div>
           <div
             style={{
               "font-size": "12px",


### PR DESCRIPTION
## Summary

Fixes #8879. Tool headers on the Auto-Approve settings page (External Directory, Bash, Read, Edit, Glob, Grep, …) were always rendered in `white` and became unreadable under light VS Code themes.

The inline style referenced `var(--text-strong-base, white)`, but `--text-strong-base` is not defined anywhere — the actual token in `packages/kilo-ui/src/styles/vscode-bridge.css` is `--text-strong`. Because the variable was undefined, the literal `white` fallback was always used. Swapped to `var(--text-strong, var(--vscode-foreground))` so it follows the active VS Code theme foreground.