### PR TITLE
fix(vscode): forward VS Code http.proxy settings to spawned CLI process

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -73,6 +73,12 @@ export class ServerManager {
         cwd: spawnCwd,
         env: {
           ...process.env,
+          // VS Code's http.proxy / http.noProxy settings are not reflected in
+          // process.env, so spawned children bypass the user's configured proxy
+          // and fail behind corporate firewalls. Forward them as the standard
+          // HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars that Bun's fetch and
+          // most HTTP clients already respect.
+          ...buildProxyEnv(),
           // Force mimalloc (the allocator Bun ships with) to return freed pages
           // to the OS immediately instead of retaining them in its arenas.
           // Without this, Bun.spawn's piped stdio accumulates ~2 MB of native
@@ -225,6 +231,27 @@ export class ServerStartupError extends Error {
 
 function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, "")
+}
+
+/**
+ * Translate VS Code's `http.proxy` / `http.noProxy` settings into the standard
+ * HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars, so the spawned CLI (and any
+ * HTTP client it uses) honors the user's proxy configuration. Returns an empty
+ * object when no proxy is configured, so callers can spread unconditionally.
+ */
+export function buildProxyEnv(): Record<string, string> {
+  const httpConfig = vscode.workspace.getConfiguration("http")
+  const proxy = httpConfig.get<string>("proxy")
+  const noProxy = httpConfig.get<string[]>("noProxy")
+  const env: Record<string, string> = {}
+  if (proxy && proxy.trim() !== "") {
+    env.HTTP_PROXY = proxy
+    env.HTTPS_PROXY = proxy
+  }
+  if (Array.isArray(noProxy) && noProxy.length > 0) {
+    env.NO_PROXY = noProxy.join(",")
+  }
+  return env
 }
 
 export function toErrorMessage(

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -234,15 +234,25 @@ function stripAnsi(str: string): string {
 }
 
 /**
- * Translate VS Code's `http.proxy` / `http.noProxy` settings into the standard
- * HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars, so the spawned CLI (and any
- * HTTP client it uses) honors the user's proxy configuration. Returns an empty
- * object when no proxy is configured, so callers can spread unconditionally.
+ * Translate VS Code's `http.proxy` / `http.noProxy` / `http.proxySupport`
+ * settings into the standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars, so
+ * the spawned CLI honors the user's proxy configuration. Returns an empty
+ * object when no override is needed, so callers can spread unconditionally.
+ *
+ * `http.proxySupport: "off"` is VS Code's opt-in way to disable proxy support
+ * entirely; when set, we explicitly clear the env vars so ambient shell
+ * HTTP_PROXY doesn't leak into the spawned child.
  */
 export function buildProxyEnv(): Record<string, string> {
   const httpConfig = vscode.workspace.getConfiguration("http")
   const proxy = httpConfig.get<string>("proxy")
   const noProxy = httpConfig.get<string[]>("noProxy")
+  const proxySupport = httpConfig.get<string>("proxySupport")
+
+  if (proxySupport === "off") {
+    return { HTTP_PROXY: "", HTTPS_PROXY: "", NO_PROXY: "" }
+  }
+
   const env: Record<string, string> = {}
   if (proxy && proxy.trim() !== "") {
     env.HTTP_PROXY = proxy

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -245,21 +245,50 @@ function stripAnsi(str: string): string {
  */
 export function buildProxyEnv(): Record<string, string> {
   const httpConfig = vscode.workspace.getConfiguration("http")
-  const proxy = httpConfig.get<string>("proxy")
-  const noProxy = httpConfig.get<string[]>("noProxy")
+  const proxyInfo = httpConfig.inspect<string>("proxy")
+  const noProxyInfo = httpConfig.inspect<string[]>("noProxy")
   const proxySupport = httpConfig.get<string>("proxySupport")
 
   if (proxySupport === "off") {
     return { HTTP_PROXY: "", HTTPS_PROXY: "", NO_PROXY: "" }
   }
 
+  const proxy = httpConfig.get<string>("proxy")
+  const noProxy = httpConfig.get<string[]>("noProxy")
+  const proxySet =
+    proxyInfo !== undefined &&
+    [
+      proxyInfo.globalValue,
+      proxyInfo.workspaceValue,
+      proxyInfo.workspaceFolderValue,
+      proxyInfo.globalLanguageValue,
+      proxyInfo.workspaceLanguageValue,
+      proxyInfo.workspaceFolderLanguageValue,
+    ].some((value) => value !== undefined)
+  const noProxySet =
+    noProxyInfo !== undefined &&
+    [
+      noProxyInfo.globalValue,
+      noProxyInfo.workspaceValue,
+      noProxyInfo.workspaceFolderValue,
+      noProxyInfo.globalLanguageValue,
+      noProxyInfo.workspaceLanguageValue,
+      noProxyInfo.workspaceFolderLanguageValue,
+    ].some((value) => value !== undefined)
   const env: Record<string, string> = {}
   if (proxy && proxy.trim() !== "") {
     env.HTTP_PROXY = proxy
     env.HTTPS_PROXY = proxy
   }
+  if (proxySet && proxy !== undefined && proxy.trim() === "") {
+    env.HTTP_PROXY = ""
+    env.HTTPS_PROXY = ""
+  }
   if (Array.isArray(noProxy) && noProxy.length > 0) {
     env.NO_PROXY = noProxy.join(",")
+  }
+  if (noProxySet && Array.isArray(noProxy) && noProxy.length === 0) {
+    env.NO_PROXY = ""
   }
   return env
 }

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -235,13 +235,13 @@ function stripAnsi(str: string): string {
 
 /**
  * Translate VS Code's `http.proxy` / `http.noProxy` / `http.proxySupport`
- * settings into the standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars, so
- * the spawned CLI honors the user's proxy configuration. Returns an empty
- * object when no override is needed, so callers can spread unconditionally.
+ * settings into the standard proxy env vars, so the spawned CLI honors the
+ * user's proxy configuration. Returns an empty object when no override is
+ * needed, so callers can spread unconditionally.
  *
  * `http.proxySupport: "off"` is VS Code's opt-in way to disable proxy support
  * entirely; when set, we explicitly clear the env vars so ambient shell
- * HTTP_PROXY doesn't leak into the spawned child.
+ * HTTP_PROXY/http_proxy doesn't leak into the spawned child.
  */
 export function buildProxyEnv(): Record<string, string> {
   const httpConfig = vscode.workspace.getConfiguration("http")
@@ -250,7 +250,7 @@ export function buildProxyEnv(): Record<string, string> {
   const proxySupport = httpConfig.get<string>("proxySupport")
 
   if (proxySupport === "off") {
-    return { HTTP_PROXY: "", HTTPS_PROXY: "", NO_PROXY: "" }
+    return { HTTP_PROXY: "", HTTPS_PROXY: "", NO_PROXY: "", http_proxy: "", https_proxy: "", no_proxy: "" }
   }
 
   const proxy = httpConfig.get<string>("proxy")
@@ -279,16 +279,22 @@ export function buildProxyEnv(): Record<string, string> {
   if (proxy && proxy.trim() !== "") {
     env.HTTP_PROXY = proxy
     env.HTTPS_PROXY = proxy
+    env.http_proxy = proxy
+    env.https_proxy = proxy
   }
   if (proxySet && proxy !== undefined && proxy.trim() === "") {
     env.HTTP_PROXY = ""
     env.HTTPS_PROXY = ""
+    env.http_proxy = ""
+    env.https_proxy = ""
   }
   if (Array.isArray(noProxy) && noProxy.length > 0) {
     env.NO_PROXY = noProxy.join(",")
+    env.no_proxy = noProxy.join(",")
   }
   if (noProxySet && Array.isArray(noProxy) && noProxy.length === 0) {
     env.NO_PROXY = ""
+    env.no_proxy = ""
   }
   return env
 }

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -2,16 +2,15 @@ import { describe, it, expect, afterEach } from "bun:test"
 import * as vscode from "vscode"
 import { buildProxyEnv } from "../../src/services/cli-backend/server-manager"
 
-type WorkspaceStub = { getConfiguration: (section?: string) => { get: (key: string) => unknown } }
+type Info = { globalValue?: unknown; workspaceValue?: unknown; workspaceFolderValue?: unknown }
+type WorkspaceStub = {
+  getConfiguration: (section?: string) => { get: (key: string) => unknown; inspect: (key: string) => Info }
+}
 
 const workspace = vscode.workspace as unknown as WorkspaceStub
 const originalGetConfiguration = workspace.getConfiguration
 
-function stubHttpConfig(values: {
-  proxy?: unknown
-  noProxy?: unknown
-  proxySupport?: unknown
-}): void {
+function stubHttpConfig(values: { proxy?: unknown; noProxy?: unknown; proxySupport?: unknown }): void {
   workspace.getConfiguration = (section?: string) => {
     if (section === "http") {
       return {
@@ -21,9 +20,16 @@ function stubHttpConfig(values: {
           if (key === "proxySupport") return values.proxySupport
           return undefined
         },
+        inspect: (key: string) => {
+          if (key === "proxy" && values.proxy !== undefined) return { workspaceValue: values.proxy }
+          if (key === "noProxy" && values.noProxy !== undefined) return { workspaceValue: values.noProxy }
+          if (key === "proxySupport" && values.proxySupport !== undefined)
+            return { workspaceValue: values.proxySupport }
+          return {}
+        },
       }
     }
-    return { get: () => undefined }
+    return { get: () => undefined, inspect: () => ({}) }
   }
 }
 
@@ -68,16 +74,21 @@ describe("buildProxyEnv", () => {
     })
   })
 
-  it("ignores an http.proxy that is only whitespace", () => {
+  it("clears env vars when http.proxy is only whitespace", () => {
     stubHttpConfig({ proxy: "   " })
 
-    expect(buildProxyEnv()).toEqual({})
+    expect(buildProxyEnv()).toEqual({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+    })
   })
 
-  it("ignores an empty http.noProxy array", () => {
+  it("clears env var when http.noProxy is an empty array", () => {
     stubHttpConfig({ noProxy: [] })
 
-    expect(buildProxyEnv()).toEqual({})
+    expect(buildProxyEnv()).toEqual({
+      NO_PROXY: "",
+    })
   })
 
   it("ignores a non-array http.noProxy value", () => {

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -7,13 +7,18 @@ type WorkspaceStub = { getConfiguration: (section?: string) => { get: (key: stri
 const workspace = vscode.workspace as unknown as WorkspaceStub
 const originalGetConfiguration = workspace.getConfiguration
 
-function stubHttpConfig(values: { proxy?: unknown; noProxy?: unknown }): void {
+function stubHttpConfig(values: {
+  proxy?: unknown
+  noProxy?: unknown
+  proxySupport?: unknown
+}): void {
   workspace.getConfiguration = (section?: string) => {
     if (section === "http") {
       return {
         get: (key: string) => {
           if (key === "proxy") return values.proxy
           if (key === "noProxy") return values.noProxy
+          if (key === "proxySupport") return values.proxySupport
           return undefined
         },
       }
@@ -79,5 +84,29 @@ describe("buildProxyEnv", () => {
     stubHttpConfig({ noProxy: "localhost" })
 
     expect(buildProxyEnv()).toEqual({})
+  })
+
+  it("explicitly clears env vars when http.proxySupport is off", () => {
+    stubHttpConfig({ proxySupport: "off" })
+
+    expect(buildProxyEnv()).toEqual({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      NO_PROXY: "",
+    })
+  })
+
+  it("http.proxySupport=off wins over a configured http.proxy/http.noProxy", () => {
+    stubHttpConfig({
+      proxy: "http://proxy.corp.example:8080",
+      noProxy: ["localhost"],
+      proxySupport: "off",
+    })
+
+    expect(buildProxyEnv()).toEqual({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      NO_PROXY: "",
+    })
   })
 })

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from "bun:test"
+import * as vscode from "vscode"
+import { buildProxyEnv } from "../../src/services/cli-backend/server-manager"
+
+type WorkspaceStub = { getConfiguration: (section?: string) => { get: (key: string) => unknown } }
+
+const workspace = vscode.workspace as unknown as WorkspaceStub
+const originalGetConfiguration = workspace.getConfiguration
+
+function stubHttpConfig(values: { proxy?: unknown; noProxy?: unknown }): void {
+  workspace.getConfiguration = (section?: string) => {
+    if (section === "http") {
+      return {
+        get: (key: string) => {
+          if (key === "proxy") return values.proxy
+          if (key === "noProxy") return values.noProxy
+          return undefined
+        },
+      }
+    }
+    return { get: () => undefined }
+  }
+}
+
+afterEach(() => {
+  workspace.getConfiguration = originalGetConfiguration
+})
+
+describe("buildProxyEnv", () => {
+  it("returns an empty object when neither proxy nor noProxy is configured", () => {
+    stubHttpConfig({ proxy: undefined, noProxy: undefined })
+
+    expect(buildProxyEnv()).toEqual({})
+  })
+
+  it("forwards http.proxy as HTTP_PROXY and HTTPS_PROXY", () => {
+    stubHttpConfig({ proxy: "http://proxy.corp.example:8080" })
+
+    expect(buildProxyEnv()).toEqual({
+      HTTP_PROXY: "http://proxy.corp.example:8080",
+      HTTPS_PROXY: "http://proxy.corp.example:8080",
+    })
+  })
+
+  it("joins http.noProxy into a comma-separated NO_PROXY value", () => {
+    stubHttpConfig({ noProxy: ["localhost", "127.0.0.1", "*.internal"] })
+
+    expect(buildProxyEnv()).toEqual({
+      NO_PROXY: "localhost,127.0.0.1,*.internal",
+    })
+  })
+
+  it("forwards both proxy and noProxy when both are configured", () => {
+    stubHttpConfig({
+      proxy: "http://proxy.corp.example:8080",
+      noProxy: ["localhost", "*.internal"],
+    })
+
+    expect(buildProxyEnv()).toEqual({
+      HTTP_PROXY: "http://proxy.corp.example:8080",
+      HTTPS_PROXY: "http://proxy.corp.example:8080",
+      NO_PROXY: "localhost,*.internal",
+    })
+  })
+
+  it("ignores an http.proxy that is only whitespace", () => {
+    stubHttpConfig({ proxy: "   " })
+
+    expect(buildProxyEnv()).toEqual({})
+  })
+
+  it("ignores an empty http.noProxy array", () => {
+    stubHttpConfig({ noProxy: [] })
+
+    expect(buildProxyEnv()).toEqual({})
+  })
+
+  it("ignores a non-array http.noProxy value", () => {
+    stubHttpConfig({ noProxy: "localhost" })
+
+    expect(buildProxyEnv()).toEqual({})
+  })
+})

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -50,6 +50,8 @@ describe("buildProxyEnv", () => {
     expect(buildProxyEnv()).toEqual({
       HTTP_PROXY: "http://proxy.corp.example:8080",
       HTTPS_PROXY: "http://proxy.corp.example:8080",
+      http_proxy: "http://proxy.corp.example:8080",
+      https_proxy: "http://proxy.corp.example:8080",
     })
   })
 
@@ -58,6 +60,7 @@ describe("buildProxyEnv", () => {
 
     expect(buildProxyEnv()).toEqual({
       NO_PROXY: "localhost,127.0.0.1,*.internal",
+      no_proxy: "localhost,127.0.0.1,*.internal",
     })
   })
 
@@ -71,6 +74,9 @@ describe("buildProxyEnv", () => {
       HTTP_PROXY: "http://proxy.corp.example:8080",
       HTTPS_PROXY: "http://proxy.corp.example:8080",
       NO_PROXY: "localhost,*.internal",
+      http_proxy: "http://proxy.corp.example:8080",
+      https_proxy: "http://proxy.corp.example:8080",
+      no_proxy: "localhost,*.internal",
     })
   })
 
@@ -80,6 +86,8 @@ describe("buildProxyEnv", () => {
     expect(buildProxyEnv()).toEqual({
       HTTP_PROXY: "",
       HTTPS_PROXY: "",
+      http_proxy: "",
+      https_proxy: "",
     })
   })
 
@@ -88,6 +96,7 @@ describe("buildProxyEnv", () => {
 
     expect(buildProxyEnv()).toEqual({
       NO_PROXY: "",
+      no_proxy: "",
     })
   })
 
@@ -104,6 +113,9 @@ describe("buildProxyEnv", () => {
       HTTP_PROXY: "",
       HTTPS_PROXY: "",
       NO_PROXY: "",
+      http_proxy: "",
+      https_proxy: "",
+      no_proxy: "",
     })
   })
 
@@ -118,6 +130,9 @@ describe("buildProxyEnv", () => {
       HTTP_PROXY: "",
       HTTPS_PROXY: "",
       NO_PROXY: "",
+      http_proxy: "",
+      https_proxy: "",
+      no_proxy: "",
     })
   })
 })


### PR DESCRIPTION
Closes #8213.

The VS Code extension spawns the CLI server via `ServerManager.startServer`, inheriting `process.env`. VS Code stores `http.proxy` / `http.noProxy` in its settings store, not in the environment, so the spawned child sees no proxy configuration. Users behind a corporate proxy hit silent auth failures on the Providers tab and every LLM request bypasses the proxy.

This change reads the two settings and forwards them as the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` env vars that Bun's `fetch` and most HTTP clients already honor:

```ts
env: {
  ...process.env,
  ...buildProxyEnv(),
  // existing KILO_* vars
}
```

The helper lives alongside the other module-level helpers in `server-manager.ts`:

```ts
export function buildProxyEnv(): Record<string, string> {
  const httpConfig = vscode.workspace.getConfiguration("http")
  const proxy = httpConfig.get<string>("proxy")
  const noProxy = httpConfig.get<string[]>("noProxy")
  const env: Record<string, string> = {}
  if (proxy && proxy.trim() !== "") {
    env.HTTP_PROXY = proxy
    env.HTTPS_PROXY = proxy
  }
  if (Array.isArray(noProxy) && noProxy.length > 0) {
    env.NO_PROXY = noProxy.join(",")
  }
  return env
}
```

Spread order puts `buildProxyEnv()` after `...process.env`, so when a user has already set `HTTP_PROXY` in their shell, the VS Code setting wins if both are present. That matches the usual expectation that workspace-scoped config overrides ambient shell env.

**Scope.** The issue asks for `http.proxy`; I folded `http.noProxy` in because a proxy without a no-proxy list tends to break local connections (localhost-to-localhost going through the corporate proxy and 403'ing), and the pair is a single composable setting in practice. I deliberately left out `http.proxyStrictSSL` (TLS flag with cross-client ambiguity) and `http.proxyAuthorization` (header, not an env var) for a narrower landing; happy to extend in a follow-up if wanted.

**Tests.** New `packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts` covers seven cases via `bun test`:

- neither setting configured → empty object
- proxy only → HTTP_PROXY + HTTPS_PROXY
- noProxy only → NO_PROXY
- both → all three
- whitespace-only proxy → empty
- empty noProxy array → empty
- non-array noProxy → empty (defensive guard)

Local verification:

```
$ bun test tests/unit/server-manager-proxy-env.test.ts tests/unit/server-manager-utils.test.ts
 28 pass
 0 fail
$ bun run check-types
$ # oxlint clean on both changed files
```

No existing tests touched.