### PR TITLE
fix(cli): fix slow CLI startup

### DIFF
--- a/.changeset/cli-sync-ready-debug-leftover.md
+++ b/.changeset/cli-sync-ready-debug-leftover.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix a 1-2 second startup delay before home content (agents, news, tips) appears in the TUI.

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -630,7 +630,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         return store.status
       },
       get ready() {
-        return true
+        // kilocode_change - drop unreachable `return true` debug leftover from upstream #23037; caused the TUI to flip `ready` before sync finished, producing a 1-2s startup delay before home content (agents/news/tips) appears.
         if (process.env.KILO_FAST_BOOT) return true
         return store.status !== "loading"
       },

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -630,7 +630,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         return store.status
       },
       get ready() {
-        // kilocode_change - drop unreachable `return true` debug leftover from upstream #23037; caused the TUI to flip `ready` before sync finished, producing a 1-2s startup delay before home content (agents/news/tips) appears.
+        // return true // kilocode_change - upstream #23037 left this debug path enabled; keep it commented so future merges do not restore eager ready state.
         if (process.env.KILO_FAST_BOOT) return true
         return store.status !== "loading"
       },


### PR DESCRIPTION
## Summary
- Drops a debug short-circuit accidentally shipped in upstream opencode [#23037](https://github.com/anomalyco/opencode/pull/23037) that made `sync.ready` always true, leaving the rest of the getter unreachable.
- Caused a visible 1-2s delay at TUI open before home content (agents, news, tips) appeared, since `ready` was flipping before sync actually finished and downstream consumers were racing it.

Bisected from `origin/main` (`a915fe74be2` good → `dd7b3c894fd` bad) to `65b2a10e97d` ("fade in prompt metadata transitions"). This PR undoes only the sync.tsx portion of that commit; the fade-in animation added in the same upstream commit is a separate issue tracked on the Kilo fork.

## Testing

Compare `bun dev` on `main` vs `fix/cli-sync-ready-debug-leftover`. 


https://github.com/user-attachments/assets/95fec973-e24a-436c-bb23-e33490cf9126

