### PR TITLE
fix(vscode): harden message contract union extraction

### DIFF
--- a/packages/kilo-vscode/tests/unit/message-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/message-contract.test.ts
@@ -15,6 +15,8 @@ import path from "node:path"
 
 const ROOT = path.resolve(import.meta.dir, "../..")
 const MESSAGES_DIR = path.join(ROOT, "webview-ui/src/types/messages")
+const EXTENSION_MESSAGES_FILE = path.join(MESSAGES_DIR, "extension-messages.ts")
+const WEBVIEW_MESSAGES_FILE = path.join(MESSAGES_DIR, "webview-messages.ts")
 const KILO_PROVIDER_FILE = path.join(ROOT, "src/KiloProvider.ts")
 const KILO_PROVIDER_UTILS_FILE = path.join(ROOT, "src/kilo-provider-utils.ts")
 // Some wire types (partUpdated, partsUpdated) live in a file shared by the
@@ -37,48 +39,56 @@ function readMessageTypeSources(): string {
   return readMessagesDir() + "\n" + readFile(SHARED_STREAM_MESSAGES_FILE)
 }
 
-describe("ExtensionMessage type members", () => {
-  it("all members of ExtensionMessage union are defined as interfaces/types in messages.ts", () => {
-    const content = readMessagesDir()
-
-    // Extract ExtensionMessage union members
-    const unionMatch = content.match(
-      /export type ExtensionMessage\s*=\s*([\s\S]*?)(?=\nexport type|\nexport interface|\nexport function|\n\/\/|$)/,
-    )
-    if (!unionMatch) {
-      expect(false, "Could not find ExtensionMessage union in messages.ts").toBe(true)
-      return
+/**
+ * Extract the named union's member names from a single source file.
+ *
+ * Reads each `  | MemberName` line after `export type Name =`, skipping
+ * blank lines and `//` comments, and stops at the first other line.
+ */
+function extractUnionMembers(src: string, name: string): string[] {
+  const lines = src.split("\n")
+  const start = lines.findIndex((l) => new RegExp(`^export type ${name}\\s*=\\s*$`).test(l))
+  if (start === -1) throw new Error(`Could not find union "${name}"`)
+  const members: string[] = []
+  for (const line of lines.slice(start + 1)) {
+    const m = line.match(/^\s*\|\s*([A-Z]\w+)\b/)
+    if (m) {
+      members.push(m[1]!)
+      continue
     }
+    if (line.trim() === "" || /^\s*\/\//.test(line)) continue
+    break
+  }
+  return members
+}
 
-    const unionBody = unionMatch[1]!
-    const memberNames = [...unionBody.matchAll(/\|\s*([A-Z]\w+)\b/g)].map((m) => m[1]!)
+describe("ExtensionMessage type members", () => {
+  it("all members of ExtensionMessage union are defined in message type sources", () => {
+    const memberNames = extractUnionMembers(readFile(EXTENSION_MESSAGES_FILE), "ExtensionMessage")
 
     const defined = readMessageTypeSources()
     const missing = memberNames.filter((name) => {
       return !new RegExp(`(interface|type)\\s+${name}\\b`).test(defined)
     })
 
-    expect(missing, `ExtensionMessage members without definitions: ${missing.join(", ")}`).toEqual([])
+    expect(
+      missing,
+      `ExtensionMessage members without definitions in message type sources: ${missing.join(", ")}`,
+    ).toEqual([])
   })
 
-  it("all members of WebviewMessage union are defined as interfaces/types in messages.ts", () => {
-    const content = readMessagesDir()
-
-    const unionMatch = content.match(/export type WebviewMessage\s*=\s*([\s\S]*?)(?=\n\/\/|$)/)
-    if (!unionMatch) {
-      expect(false, "Could not find WebviewMessage union in messages.ts").toBe(true)
-      return
-    }
-
-    const unionBody = unionMatch[1]!
-    const memberNames = [...unionBody.matchAll(/\|\s*([A-Z]\w+)\b/g)].map((m) => m[1]!)
+  it("all members of WebviewMessage union are defined in message type sources", () => {
+    const memberNames = extractUnionMembers(readFile(WEBVIEW_MESSAGES_FILE), "WebviewMessage")
 
     const defined = readMessageTypeSources()
     const missing = memberNames.filter((name) => {
       return !new RegExp(`(interface|type)\\s+${name}\\b`).test(defined)
     })
 
-    expect(missing, `WebviewMessage members without definitions: ${missing.join(", ")}`).toEqual([])
+    expect(
+      missing,
+      `WebviewMessage members without definitions in message type sources: ${missing.join(", ")}`,
+    ).toEqual([])
   })
 })
 
@@ -117,6 +127,9 @@ describe("mapSSEEventToWebviewMessage output types", () => {
 
     const missing = typeMatches.filter((t) => !typeSet.has(t))
 
-    expect(missing, `Types in mapSSEEventToWebviewMessage not in messages.ts: ${missing.join(", ")}`).toEqual([])
+    expect(
+      missing,
+      `Types in mapSSEEventToWebviewMessage not found in message type sources: ${missing.join(", ")}`,
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
## Context

This updates the message contract unit test to avoid brittle union parsing after the message type split in #9445.
The previous regex parsed unions from concatenated files and could overrun into neighboring files depending on directory order and comment placement.

It previously worked mostly by luck: the regex would terminate quickly only because a `// ===` banner happened to sit right after the union, or because the file happened to be last in concatenation order.

## Implementation

Replaced regex-based union extraction with a small line-based extractor that reads each union from its own source file:
- ExtensionMessage members are extracted from webview-ui/src/types/messages/extension-messages.ts
- WebviewMessage members are extracted from webview-ui/src/types/messages/webview-messages.ts
