### PR TITLE
feat(cli): prevent idle sleep during turns

### DIFF
--- a/.changeset/prevent-idle-sleep.md
+++ b/.changeset/prevent-idle-sleep.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Prevent the system from sleeping while Kilo is working on a turn. Uses native OS power APIs (IOKit on macOS, PowerCreateRequest on Windows, systemd-inhibit on Linux). Enabled by default; set `prevent_idle_sleep: false` in `kilo.json` to opt out.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -982,6 +982,14 @@ export namespace Config {
         .boolean()
         .optional()
         .describe("Enable remote control of sessions via Kilo Cloud. Equivalent to running /remote on startup."),
+      prevent_idle_sleep: z
+        .boolean()
+        .optional()
+        .describe(
+          "Prevent the system from sleeping while a turn is running. " +
+            "macOS uses IOKit power assertions, Windows uses PowerCreateRequest, " +
+            "Linux uses systemd-inhibit. Defaults to true.",
+        ),
       // kilocode_change end
       autoupdate: z
         .union([z.boolean(), z.literal("notify")])

--- a/packages/opencode/src/kilocode/sleep-inhibitor/index.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/index.ts
@@ -1,0 +1,145 @@
+import { Log } from "@/util/log"
+import { pick } from "./platform/select"
+import type { Inhibitor } from "./platform/types"
+
+/**
+ * Process-wide sleep inhibitor.
+ *
+ * Port of codex's public API in `codex-rs/utils/sleep-inhibitor/src/lib.rs`,
+ * extended with multi-session refcounting because Kilo runs N concurrent
+ * turns (Agent Manager panels, parallel sessions) while codex's TUI has one.
+ *
+ * Codex instantiates a `SleepInhibitor` per `ChatWidget`
+ * (`codex-rs/tui/src/chatwidget.rs:5152`). We instead maintain a single
+ * process-wide instance with a busy-session set: acquire on first busy
+ * session (0 -> 1 transition), release on last idle (n -> 0). Behavior on
+ * any individual session is identical to codex.
+ *
+ * Mapping to codex `lib.rs:28-72`:
+ *
+ *   codex                              |  kilo
+ *   -----------------------------------+-------------------------------------
+ *   SleepInhibitor::new(enabled)       |  configure({ enabled })
+ *   set_turn_running(true)             |  acquire(sessionID)
+ *   set_turn_running(false)            |  release(sessionID)
+ *   is_turn_running()                  |  active() / busy()
+ *   acquire() (private)                |  platform.acquire()  (via refcount)
+ *   release() (private)                |  platform.release()  (via refcount)
+ *
+ * Disabled flag semantics match codex `lib.rs:48-51`: when disabled, any
+ * acquire is a no-op and any live platform assertion is released, while the
+ * busy-session set is still tracked so re-enabling mid-turn re-acquires.
+ */
+
+const log = Log.create({ service: "sleep-inhibitor" })
+
+let enabled = false
+let platform: Inhibitor | undefined
+const busy = new Set<string>()
+
+function ensure(): Inhibitor {
+  if (!platform) platform = pick()
+  return platform
+}
+
+function engaged(): boolean {
+  return enabled && busy.size > 0
+}
+
+/**
+ * Current platform claim state. Kept in step with `engaged()` transitions so
+ * we only call `platform.acquire()` / `platform.release()` on edges.
+ */
+let claimed = false
+
+function sync() {
+  const want = engaged()
+  if (want === claimed) return
+  if (want) ensure().acquire()
+  else ensure().release()
+  claimed = want
+}
+
+export namespace SleepInhibitor {
+  /**
+   * Configure the inhibitor. Typically called once at startup from
+   * `subscribe.ts` after reading `Config.prevent_idle_sleep`, and again
+   * on config reload (matches codex `chatwidget.rs:9747-9749`).
+   *
+   * Mutates in place rather than constructing a new instance, so
+   * busy-session state is preserved across config reloads.
+   */
+  export function configure(input: { enabled: boolean }) {
+    const next = !!input.enabled
+    if (next === enabled) return
+    enabled = next
+    log.info("configured", { enabled, busy: busy.size })
+    sync()
+  }
+
+  /**
+   * Mark a session's turn as started.
+   *
+   * Codex equivalent: `SleepInhibitor::set_turn_running(true)` called from
+   * `codex-rs/tui/src/chatwidget.rs:2483-2484`.
+   *
+   * Idempotent per session — repeated calls with the same sessionID do not
+   * affect platform state once the session is already tracked.
+   */
+  export function acquire(sessionID: string) {
+    const already = busy.has(sessionID)
+    busy.add(sessionID)
+    if (!already) log.debug("acquire", { sessionID, count: busy.size })
+    sync()
+  }
+
+  /**
+   * Mark a session's turn as ended.
+   *
+   * Codex equivalent: `SleepInhibitor::set_turn_running(false)` called from
+   * `codex-rs/tui/src/chatwidget.rs:2578-2579, 2996-2997`.
+   *
+   * Safe to call for a sessionID that was never acquired — the set delete
+   * is a no-op. Releases the platform inhibitor when the last busy session
+   * ends.
+   */
+  export function release(sessionID: string) {
+    const had = busy.delete(sessionID)
+    if (had) log.debug("release", { sessionID, count: busy.size })
+    sync()
+  }
+
+  /**
+   * Forcibly release the platform inhibitor and clear all tracked sessions.
+   * Used on process shutdown so Linux subprocess backends don't outlive us
+   * (see deviations in `./platform/linux.ts`).
+   */
+  export function drain() {
+    busy.clear()
+    sync()
+  }
+
+  /** Whether the platform inhibitor is currently engaged. Test helper. */
+  export function active(): boolean {
+    return claimed
+  }
+
+  /** Number of sessions currently marked busy. Test helper. */
+  export function busyCount(): number {
+    return busy.size
+  }
+
+  /** Test-only: swap the platform implementation and reset state. */
+  export function __setPlatformForTests(impl: Inhibitor | undefined) {
+    // Release the CURRENT platform only if it exists and is engaged. We must
+    // NOT call `ensure()` here because that would lazily instantiate a real
+    // platform inhibitor when `platform` is undefined (the case in tests
+    // between `afterEach` and the next `beforeEach`), which would then run
+    // real FFI/subprocess calls against the host OS.
+    if (claimed && platform) platform.release()
+    platform = impl
+    claimed = false
+    enabled = false
+    busy.clear()
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/linux.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/linux.ts
@@ -1,0 +1,209 @@
+import { spawn, which, type Subprocess } from "bun"
+import { Log } from "@/util/log"
+import { APP, REASON, type Inhibitor } from "./types"
+
+/**
+ * Linux idle-inhibit via subprocess.
+ *
+ * Faithful port of codex's `codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs`.
+ * Codex uses subprocess here as well (not native bindings) because Linux has
+ * no stable libc API for this — the interfaces are D-Bus (systemd-logind,
+ * gnome-SessionManager).
+ *
+ * Spawns `systemd-inhibit --what=idle --mode=block` wrapping a long sleep,
+ * matching codex's command at `linux_inhibitor.rs:176-191`. Falls back to
+ * `gnome-session-inhibit` when systemd is unavailable (codex
+ * `linux_inhibitor.rs:192-203`). Remembers which backend worked and retries
+ * it first on subsequent acquires (codex `linux_inhibitor.rs:66-79, 86`).
+ *
+ * ## Guaranteeing cleanup on parent death
+ *
+ * Codex uses `prctl(PR_SET_PDEATHSIG, SIGTERM)` in the child via `pre_exec`
+ * (`linux_inhibitor.rs:213-223`) so that the kernel kills the inhibitor the
+ * moment the parent process dies — even on SIGKILL / OOM / panic. This is
+ * the key defensive measure that prevents a permanently-caffeinated machine
+ * when things go wrong.
+ *
+ * Bun's `spawn` does not expose `prctl` and has no post-fork hook, so we
+ * cannot call `prctl` in the child. Instead we achieve the same guarantee
+ * with a watchdog shell wrapper that polls the parent's PID and kills the
+ * inhibitor when the parent goes away:
+ *
+ *   trap 'kill -TERM "$c" 2>/dev/null' EXIT
+ *   systemd-inhibit ... &
+ *   c=$!
+ *   while kill -0 <PARENT_PID> 2>/dev/null; do sleep 1; done
+ *
+ * Coverage:
+ *   - Parent exits cleanly → `release()` sends SIGTERM to shell → `EXIT`
+ *     trap fires → inhibitor killed.
+ *   - Parent SIGKILL'd / crashes → shell survives, `kill -0 PARENT` fails
+ *     on next poll (≤1s) → shell exits → `EXIT` trap kills inhibitor.
+ *   - Shell itself SIGKILL'd → EXIT trap does NOT fire → inhibitor
+ *     orphaned. This only happens if an external actor kills our shell
+ *     child directly, not via any normal failure mode.
+ *
+ * Maximum lingering time in the worst realistic case: ~1 second. This is
+ * functionally equivalent to codex's PDEATHSIG guarantee.
+ *
+ * Deliberately NOT used: `sh -c 'trap ... EXIT; exec ...'`. Once `exec`
+ * replaces the shell process image, the trap is gone with it and the
+ * wrapper provides zero protection. The `&` + poll pattern keeps the shell
+ * alive to enforce cleanup.
+ */
+
+const log = Log.create({ service: "sleep-inhibitor:linux" })
+
+// i32::MAX seconds (~68 years) — identical to codex `linux_inhibitor.rs:11`.
+// Sanity-checked by the `sleep_seconds_is_i32_max` test in codex (line 236)
+// and our own sleep-inhibitor test suite.
+export const SLEEP_SECONDS = "2147483647"
+
+// How often the watchdog polls the parent PID. 1s matches the granularity
+// of the existing codex tests and keeps CPU overhead negligible.
+const POLL_INTERVAL_SECONDS = "1"
+
+type Backend = "systemd" | "gnome"
+
+function binary(backend: Backend): string {
+  return backend === "systemd" ? "systemd-inhibit" : "gnome-session-inhibit"
+}
+
+function args(backend: Backend): string[] {
+  if (backend === "systemd") {
+    return [
+      "systemd-inhibit",
+      "--what=idle",
+      "--mode=block",
+      "--who",
+      APP,
+      "--why",
+      REASON,
+      "--",
+      "sleep",
+      SLEEP_SECONDS,
+    ]
+  }
+  return ["gnome-session-inhibit", "--inhibit", "idle", "--reason", REASON, "sleep", SLEEP_SECONDS]
+}
+
+/**
+ * Build a `sh -c` command that runs the inhibitor under a parent-death
+ * watchdog. See module-level comment for the full pattern and its coverage.
+ *
+ * The inner command is single-quoted for inclusion in the shell script, so
+ * any embedded single quote in the REASON constant is escaped using the
+ * standard POSIX `'\''` idiom.
+ */
+export function watchdog(inner: string[], parentPid: number): string[] {
+  const quoted = inner.map((arg) => `'${arg.replace(/'/g, `'\\''`)}'`).join(" ")
+  const script = [
+    `trap 'kill -TERM "$c" 2>/dev/null' EXIT`,
+    `${quoted} &`,
+    `c=$!`,
+    `while kill -0 ${parentPid} 2>/dev/null; do sleep ${POLL_INTERVAL_SECONDS}; done`,
+  ].join("; ")
+  return ["sh", "-c", script]
+}
+
+/**
+ * Attempt to launch a backend under the watchdog. Returns the running shell
+ * wrapper subprocess on success, `undefined` if the backend binary is
+ * missing or the shell fails to start.
+ *
+ * We detect missing binaries via `Bun.which()` *before* spawn instead of
+ * relying on `child.exitCode === null` post-spawn, which is unreliable in
+ * Bun (the exit event is delivered asynchronously, so a doomed child still
+ * shows `exitCode === null` for a short window).
+ *
+ * `quiet` suppresses warnings the first time we observe a missing backend
+ * mid-session, matching codex's `should_log_backend_failures` gating at
+ * `linux_inhibitor.rs:65, 91, 100, 128`.
+ */
+function launch(backend: Backend, quiet: boolean, parentPid: number): Subprocess | undefined {
+  if (!which(binary(backend))) {
+    // Missing binary — silent per codex `linux_inhibitor.rs:128`
+    // (`ErrorKind::NotFound` is explicitly not warned).
+    return undefined
+  }
+  try {
+    return spawn({
+      cmd: watchdog(args(backend), parentPid),
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+  } catch (err) {
+    if (!quiet) {
+      log.warn("failed to start backend", { backend, error: String(err) })
+    }
+    return undefined
+  }
+}
+
+function order(preferred: Backend | undefined): Backend[] {
+  if (preferred === "systemd") return ["systemd", "gnome"]
+  if (preferred === "gnome") return ["gnome", "systemd"]
+  return ["systemd", "gnome"]
+}
+
+export function linux(): Inhibitor {
+  let active: { backend: Backend; child: Subprocess } | undefined
+  let preferred: Backend | undefined
+  // Tracks whether we've already logged a "no backend available" warning.
+  // Reset on successful acquire (codex `linux_inhibitor.rs:87`).
+  let loggedMissing = false
+  // Capture our PID once at factory construction. `process.pid` should be
+  // stable, but caching makes it impossible for a test or caller to mutate
+  // `process.pid` mid-run and break the watchdog wiring.
+  const parentPid = process.pid
+
+  function stop(child: Subprocess) {
+    // Best-effort: send SIGTERM and fire-and-forget. The watchdog's `EXIT`
+    // trap ensures the actual inhibitor process dies when our shell child
+    // receives SIGTERM and exits.
+    try {
+      child.kill("SIGTERM")
+    } catch (err) {
+      log.warn("failed to stop backend", { error: String(err) })
+    }
+  }
+
+  return {
+    acquire() {
+      // Idempotent: if a backend is still running, keep it (codex
+      // `linux_inhibitor.rs:44-46`).
+      if (active && active.child.exitCode === null) return
+
+      if (active) {
+        log.warn("backend exited unexpectedly; restarting", {
+          backend: active.backend,
+          code: active.child.exitCode,
+        })
+        active = undefined
+      }
+
+      const quiet = loggedMissing
+      for (const backend of order(preferred)) {
+        const child = launch(backend, quiet, parentPid)
+        if (!child) continue
+        active = { backend, child }
+        preferred = backend
+        loggedMissing = false
+        return
+      }
+
+      if (!loggedMissing) {
+        log.warn("no Linux sleep inhibitor backend is available")
+        loggedMissing = true
+      }
+    },
+
+    release() {
+      const current = active
+      active = undefined
+      if (!current) return
+      stop(current.child)
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/macos.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/macos.ts
@@ -1,0 +1,144 @@
+import { dlopen, FFIType, ptr, type Pointer } from "bun:ffi"
+import { Log } from "@/util/log"
+import { REASON, type Inhibitor } from "./types"
+
+/**
+ * macOS IOKit power assertion inhibitor.
+ *
+ * Faithful port of codex's `codex-rs/utils/sleep-inhibitor/src/macos.rs`.
+ * Uses `IOPMAssertionCreateWithName` to register a kernel power assertion
+ * of type `PreventUserIdleSystemSleep`, matching codex byte-for-byte at
+ * `macos.rs:23-26, 66-90`.
+ *
+ * The assertion is identical to what `/usr/bin/caffeinate -i` holds, but we
+ * own the lifecycle explicitly so it acquires on turn start and releases
+ * on turn end. The kernel auto-releases on process death.
+ *
+ * FFI signatures are hand-written equivalents of codex's bindgen output
+ * (`codex-rs/utils/sleep-inhibitor/src/iokit_bindings.rs`).
+ */
+
+const log = Log.create({ service: "sleep-inhibitor:macos" })
+
+// kCFStringEncodingUTF8 — Apple's Core Foundation encoding constant.
+const UTF8 = 0x08000100
+// kIOPMAssertionLevelOn — see codex `macos.rs:80` and IOKit `IOPMLib.h`.
+const LEVEL_ON = 255
+// kIOReturnSuccess — codex `macos.rs:85`.
+const OK = 0
+// Apple exposes this assertion type as `CFSTR("PreventUserIdleSystemSleep")`.
+// Codex re-creates the string at runtime (`macos.rs:26, 68`).
+const ASSERTION_TYPE = "PreventUserIdleSystemSleep"
+
+/**
+ * Lazy loaders — keep `dlopen` out of module top-level so the native
+ * frameworks are only probed on macOS (when `platform/select.ts` actually
+ * calls `macos()`). On Linux/Windows these symbols are never loaded.
+ */
+function loadIOKit() {
+  try {
+    return dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", {
+      IOPMAssertionCreateWithName: {
+        // (CFStringRef type, IOPMAssertionLevel level, CFStringRef name, IOPMAssertionID* out)
+        args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.ptr],
+        returns: FFIType.i32,
+      },
+      IOPMAssertionRelease: {
+        // (IOPMAssertionID id)
+        args: [FFIType.u32],
+        returns: FFIType.i32,
+      },
+    })
+  } catch (err) {
+    log.warn("failed to load IOKit", { error: String(err) })
+    return undefined
+  }
+}
+
+function loadCoreFoundation() {
+  try {
+    return dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", {
+      CFStringCreateWithCString: {
+        // (CFAllocatorRef alloc, const char* str, CFStringEncoding enc)
+        args: [FFIType.ptr, FFIType.cstring, FFIType.u32],
+        returns: FFIType.ptr,
+      },
+      CFRelease: {
+        args: [FFIType.ptr],
+        returns: FFIType.void,
+      },
+    })
+  } catch (err) {
+    log.warn("failed to load CoreFoundation", { error: String(err) })
+    return undefined
+  }
+}
+
+export function macos(): Inhibitor {
+  const iokit = loadIOKit()
+  const cf = loadCoreFoundation()
+  if (!iokit || !cf) return { acquire() {}, release() {} }
+
+  /**
+   * Create a CFString from a UTF-8 JS string, passed as a null-terminated
+   * buffer so bun:ffi's `cstring` argument type can consume it directly.
+   * Returns a non-owning Pointer; caller must `CFRelease` it.
+   *
+   * Equivalent to codex's `CFString::new(...)` at `macos.rs:68-69`, which
+   * wraps `CFStringCreateWithCString` in the `core-foundation` crate.
+   */
+  function cfstring(str: string): Pointer | null {
+    const buf = Buffer.from(str + "\0", "utf8")
+    const ref = cf!.symbols.CFStringCreateWithCString(null, buf, UTF8)
+    if (!ref) {
+      log.warn("CFStringCreateWithCString returned null", { str })
+      return null
+    }
+    return ref
+  }
+
+  function cfrelease(handle: Pointer) {
+    cf!.symbols.CFRelease(handle)
+  }
+
+  // AssertionID is a u32 out-param — codex `macos.rs:70-71, 82`.
+  let id: number | null = null
+
+  return {
+    acquire() {
+      if (id !== null) return // idempotent (codex `macos.rs:39-41`)
+
+      const type = cfstring(ASSERTION_TYPE)
+      if (type === null) return
+      const name = cfstring(REASON)
+      if (name === null) {
+        cfrelease(type)
+        return
+      }
+
+      const out = new Uint32Array(1)
+      const result = iokit.symbols.IOPMAssertionCreateWithName(type, LEVEL_ON, name, ptr(out))
+
+      // CFStrings are retained by IOKit for the duration of the assertion, so
+      // we release our references immediately — matches `core-foundation`
+      // Drop behavior in codex (`macos.rs:67-69` CFStrings go out of scope).
+      cfrelease(type)
+      cfrelease(name)
+
+      if (result !== OK) {
+        log.warn("IOPMAssertionCreateWithName failed", { code: result })
+        return
+      }
+      id = out[0]!
+    },
+
+    release() {
+      if (id === null) return
+      const code = iokit.symbols.IOPMAssertionRelease(id)
+      if (code !== OK) {
+        log.warn("IOPMAssertionRelease failed", { code })
+      }
+      id = null
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/noop.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/noop.ts
@@ -1,0 +1,18 @@
+import type { Inhibitor } from "./types"
+
+/**
+ * No-op inhibitor.
+ *
+ * Port of codex's dummy backend — `codex-rs/utils/sleep-inhibitor/src/dummy.rs`
+ * (used when target_os matches none of linux/macos/windows, selected via
+ * `lib.rs:10-11, 19-20`).
+ *
+ * Also used as the safety fallback when a platform-specific implementation
+ * fails to load (e.g. IOKit/PowrProf dlopen failure, all Linux backends missing).
+ */
+export function noop(): Inhibitor {
+  return {
+    acquire() {},
+    release() {},
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/select.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/select.ts
@@ -1,0 +1,35 @@
+import { Log } from "@/util/log"
+import { linux } from "./linux"
+import { macos } from "./macos"
+import { noop } from "./noop"
+import { windows } from "./windows"
+import type { Inhibitor } from "./types"
+
+/**
+ * Platform routing for sleep inhibitor backends.
+ *
+ * Equivalent of codex's `cfg(target_os = ...)` module selection in
+ * `codex-rs/utils/sleep-inhibitor/src/lib.rs:10-26`. Each platform file
+ * exports a factory that returns an `Inhibitor` — if native-library loading
+ * fails inside the factory, the factory itself silently returns an inhibitor
+ * whose `acquire`/`release` are no-ops.
+ *
+ * Any exception thrown at construction time (e.g. bun:ffi refusing to
+ * `dlopen` on an unusual system) is caught here and degraded to `noop`,
+ * so the CLI always stays usable. Matches codex's overall posture where
+ * the feature is best-effort and never fatal.
+ */
+
+const log = Log.create({ service: "sleep-inhibitor" })
+
+export function pick(): Inhibitor {
+  try {
+    if (process.platform === "darwin") return macos()
+    if (process.platform === "win32") return windows()
+    if (process.platform === "linux") return linux()
+    return noop()
+  } catch (err) {
+    log.warn("platform inhibitor construction failed; using noop", { error: String(err) })
+    return noop()
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/types.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared interface for platform-specific sleep inhibitors.
+ *
+ * Mirrors codex's trait-like `imp::SleepInhibitor` used via `cfg`-gated
+ * module selection in `codex-rs/utils/sleep-inhibitor/src/lib.rs:10-26`.
+ *
+ * Implementations must:
+ * - Make `acquire()` idempotent (codex `macos.rs:39-41`, `windows_inhibitor.rs:32-34`,
+ *   `linux_inhibitor.rs:44-62`). A second call while already held is a no-op.
+ * - Make `release()` idempotent. Safe to call when not held.
+ * - Never throw. Log warnings on failure and degrade to no-op. Matches codex's
+ *   `warn!` + continue pattern (`macos.rs:46-52`, `windows_inhibitor.rs:40-45`).
+ */
+export interface Inhibitor {
+  /** Engage the OS-level idle-sleep prevention. Idempotent. */
+  acquire(): void
+  /** Release the OS-level idle-sleep prevention. Idempotent. */
+  release(): void
+}
+
+/** Human-readable reason string attached to OS assertions (where supported). */
+export const REASON = "Kilo is running an active turn"
+
+/** Identifier used in Linux inhibitor backends (`--who` flag). */
+export const APP = "kilo"

--- a/packages/opencode/src/kilocode/sleep-inhibitor/platform/windows.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/platform/windows.ts
@@ -1,0 +1,170 @@
+import { dlopen, FFIType, ptr, type Pointer } from "bun:ffi"
+import { Log } from "@/util/log"
+import { REASON, type Inhibitor } from "./types"
+
+/**
+ * Windows power-request inhibitor.
+ *
+ * Faithful port of codex's `codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs`.
+ * Uses `PowerCreateRequest` + `PowerSetRequest(PowerRequestSystemRequired)` to
+ * prevent idle system sleep, matching codex byte-for-byte at
+ * `windows_inhibitor.rs:60-95`.
+ *
+ * This mirrors `caffeinate -i` behavior on macOS: prevents the system from
+ * falling asleep but does not force the display on (codex comment
+ * `windows_inhibitor.rs:78-79`).
+ *
+ * The reason string surfaces in `powercfg /requests` with the value `REASON`
+ * from `./types.ts`, so sysadmins can see why the machine is kept awake.
+ *
+ * FFI signatures are hand-written equivalents of codex's `windows-sys` usage.
+ */
+
+const log = Log.create({ service: "sleep-inhibitor:windows" })
+
+// REASON_CONTEXT.Version — codex `windows_inhibitor.rs:64`.
+const CONTEXT_VERSION = 0
+// REASON_CONTEXT.Flags = POWER_REQUEST_CONTEXT_SIMPLE_STRING — codex `windows_inhibitor.rs:65`.
+const CONTEXT_SIMPLE_STRING = 0x1
+// PowerRequestSystemRequired — codex `windows_inhibitor.rs:80`.
+// Enum value is 1 per `windows-sys` crate and `winnt.h`:
+//   PowerRequestDisplayRequired    = 0
+//   PowerRequestSystemRequired     = 1  ← this one
+//   PowerRequestAwayModeRequired   = 2
+//   PowerRequestExecutionRequired  = 3
+const REQUEST_SYSTEM_REQUIRED = 1
+
+/**
+ * REASON_CONTEXT struct size on x64 Windows.
+ *
+ *   Version:        u32 @ offset 0  (4 bytes)
+ *   Flags:          u32 @ offset 4  (4 bytes)
+ *   Reason (union): @ offset 8     (24 bytes — sized by largest member Detailed)
+ *
+ * Total = 32 bytes. Codex's `REASON_CONTEXT` via `windows-sys` has the same
+ * layout because it is `#[repr(C)]`.
+ *
+ * For the SIMPLE_STRING variant we only write bytes 0..16; the remaining 16
+ * are zeroed by `Buffer.alloc` and left untouched. Windows reads only the
+ * SimpleReasonString pointer from the union when the flag is set.
+ */
+const CONTEXT_SIZE = 32
+
+/**
+ * Lazy loaders — keep `dlopen` out of module top-level so the native libraries
+ * are only probed on Windows (when `platform/select.ts` actually calls
+ * `windows()`). On macOS/Linux these symbols are never loaded.
+ */
+function loadPowrProf() {
+  try {
+    return dlopen("PowrProf.dll", {
+      PowerCreateRequest: {
+        // (REASON_CONTEXT* ctx) -> HANDLE
+        args: [FFIType.ptr],
+        returns: FFIType.ptr,
+      },
+      PowerSetRequest: {
+        // (HANDLE req, POWER_REQUEST_TYPE type) -> BOOL
+        args: [FFIType.ptr, FFIType.i32],
+        returns: FFIType.i32,
+      },
+      PowerClearRequest: {
+        // (HANDLE req, POWER_REQUEST_TYPE type) -> BOOL
+        args: [FFIType.ptr, FFIType.i32],
+        returns: FFIType.i32,
+      },
+    })
+  } catch (err) {
+    log.warn("failed to load PowrProf.dll", { error: String(err) })
+    return undefined
+  }
+}
+
+function loadKernel() {
+  try {
+    return dlopen("Kernel32.dll", {
+      CloseHandle: {
+        // (HANDLE h) -> BOOL
+        args: [FFIType.ptr],
+        returns: FFIType.i32,
+      },
+    })
+  } catch (err) {
+    log.warn("failed to load Kernel32.dll", { error: String(err) })
+    return undefined
+  }
+}
+
+/**
+ * Build a REASON_CONTEXT pointing at a UTF-16LE reason string.
+ *
+ * Port of codex's struct literal at `windows_inhibitor.rs:62-69`. The wide
+ * string buffer must remain referenced until `PowerCreateRequest` returns,
+ * so we return it alongside the context buffer and hold both on the stack
+ * inside `acquire()`. Windows copies the string before returning per MSDN
+ * (confirmed by codex comment at `windows_inhibitor.rs:70-71`).
+ *
+ * Pointer addresses are converted to `BigInt` before writing into the u64
+ * field. This is safe on all current 64-bit OSes where virtual addresses
+ * stay within the 53-bit safe-integer range (typically 47-48 bits used).
+ */
+function context() {
+  const wide = Buffer.from(REASON + "\0", "utf16le")
+  const ctx = Buffer.alloc(CONTEXT_SIZE)
+  ctx.writeUInt32LE(CONTEXT_VERSION, 0)
+  ctx.writeUInt32LE(CONTEXT_SIMPLE_STRING, 4)
+  ctx.writeBigUInt64LE(BigInt(ptr(wide)), 8)
+  return { ctx, wide }
+}
+
+export function windows(): Inhibitor {
+  const powrprof = loadPowrProf()
+  const kernel = loadKernel()
+  if (!powrprof || !kernel) return { acquire() {}, release() {} }
+
+  let handle: Pointer | null = null
+
+  return {
+    acquire() {
+      if (handle !== null) return // idempotent (codex `windows_inhibitor.rs:32-34`)
+
+      // Keep `ctx` and `wide` alive for the duration of this scope; the wide
+      // string must outlive the PowerCreateRequest call.
+      const built = context()
+      const live = powrprof.symbols.PowerCreateRequest(ptr(built.ctx))
+      if (!live) {
+        log.warn("PowerCreateRequest failed")
+        return
+      }
+
+      const ok = powrprof.symbols.PowerSetRequest(live, REQUEST_SYSTEM_REQUIRED)
+      if (ok === 0) {
+        log.warn("PowerSetRequest failed")
+        // Match codex's error path: close the handle if set fails
+        // (`windows_inhibitor.rs:83-89`).
+        kernel.symbols.CloseHandle(live)
+        return
+      }
+
+      handle = live
+      // Explicitly reference `built` to ensure the buffers stay alive until
+      // after the FFI calls above — Windows copies the reason internally.
+      void built
+    },
+
+    release() {
+      if (handle === null) return
+      const live = handle
+      handle = null
+
+      // Port of codex's Drop impl at `windows_inhibitor.rs:98-118`: clear the
+      // request then close the handle, warning on failure but never throwing.
+      if (powrprof.symbols.PowerClearRequest(live, REQUEST_SYSTEM_REQUIRED) === 0) {
+        log.warn("PowerClearRequest failed")
+      }
+      if (kernel.symbols.CloseHandle(live) === 0) {
+        log.warn("CloseHandle failed")
+      }
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/sleep-inhibitor/subscribe.ts
+++ b/packages/opencode/src/kilocode/sleep-inhibitor/subscribe.ts
@@ -1,0 +1,118 @@
+import { Bus } from "@/bus"
+import { Config } from "@/config/config"
+import { Log } from "@/util/log"
+import { Session } from "@/session"
+import { SleepInhibitor } from "."
+
+/**
+ * Wire the sleep inhibitor into Kilo's session lifecycle.
+ *
+ * Subscribes to the bus events published from
+ * `packages/opencode/src/session/prompt.ts:1596` (`Session.Event.TurnOpen`,
+ * emitted inside `SessionPrompt.loop` at turn start) and `:1600`
+ * (`Session.Event.TurnClose`, emitted inside `Effect.onExit` so it fires on
+ * success, error, and cancellation).
+ *
+ * Subscription pattern matches
+ * `packages/opencode/src/kilo-sessions/kilo-sessions.ts:243-247`.
+ *
+ * **Ordering note**: subscriptions and shutdown handlers are registered
+ * synchronously *before* awaiting config, so a TurnOpen that fires during the
+ * init window is still captured. Until `configure()` runs the SleepInhibitor
+ * has `enabled=false` and tracks busy sessions without engaging the platform;
+ * once config loads, if any sessions are still busy the platform engages
+ * retroactively.
+ */
+
+const log = Log.create({ service: "sleep-inhibitor:subscribe" })
+
+let initialized = false
+
+export async function init() {
+  if (initialized) return
+  initialized = true
+
+  // Register subscriptions and shutdown handlers first — these are
+  // synchronous and need to be live before any turn opens.
+  Bus.subscribe(Session.Event.TurnOpen, (evt) => {
+    SleepInhibitor.acquire(evt.properties.sessionID)
+  })
+  Bus.subscribe(Session.Event.TurnClose, (evt) => {
+    SleepInhibitor.release(evt.properties.sessionID)
+  })
+  registerShutdown()
+
+  // Load config after subscriptions are live. If config read fails, default
+  // to enabled (codex's stable-feature default; users can opt out in
+  // kilo.json).
+  const cfg = await Config.get().catch((err) => {
+    log.warn("failed to read config; defaulting to enabled", { error: String(err) })
+    return undefined
+  })
+  const want = cfg?.prevent_idle_sleep ?? true
+  SleepInhibitor.configure({ enabled: want })
+
+  log.info("initialized", { enabled: want })
+}
+
+let shutdownRegistered = false
+
+/**
+ * Register every reasonable process-termination hook so the sleep inhibitor
+ * is released no matter how we exit.
+ *
+ * Coverage:
+ *   - `exit`                — normal process termination (Node runs handlers
+ *                             synchronously; cleanup must be synchronous).
+ *   - `beforeExit`          — natural exit when the event loop empties.
+ *   - `SIGINT` / `SIGTERM`  — interactive and orchestrator-driven shutdown.
+ *   - `uncaughtException`   — last-chance cleanup on a crash we didn't catch.
+ *   - `unhandledRejection`  — last-chance cleanup on a promise that slipped
+ *                             the error net.
+ *
+ * `SIGKILL` cannot be caught; for that case we rely on the platform-level
+ * guarantees (macOS/Windows: kernel auto-releases; Linux: watchdog shell in
+ * `platform/linux.ts` detects parent death and kills the inhibitor within
+ * ~1 second).
+ *
+ * `uncaughtException` / `unhandledRejection` handlers call `drain()` but do
+ * NOT call `process.exit()` — other modules (e.g. `cli/cmd/tui/thread.ts`)
+ * also register handlers and decide process fate; we must not intercept.
+ */
+function registerShutdown() {
+  if (shutdownRegistered) return
+  shutdownRegistered = true
+
+  const cleanup = () => {
+    try {
+      SleepInhibitor.drain()
+    } catch (err) {
+      log.warn("drain failed", { error: String(err) })
+    }
+  }
+
+  process.on("exit", cleanup)
+  process.on("beforeExit", cleanup)
+  process.on("SIGINT", () => {
+    cleanup()
+    process.exit(130)
+  })
+  process.on("SIGTERM", () => {
+    cleanup()
+    process.exit(143)
+  })
+  // For `uncaughtException` / `unhandledRejection` we drain without calling
+  // `process.exit()`. Other modules may register their own handlers and
+  // decide process fate (e.g. `src/cli/cmd/tui/thread.ts:179-180` logs and
+  // continues). Our job is only to make sure the inhibitor is released in
+  // the crashed-but-still-running window. If the process does terminate
+  // later, our `exit` handler runs again — `drain()` is idempotent.
+  process.on("uncaughtException", (err) => {
+    log.warn("uncaughtException; draining inhibitor", { error: String(err) })
+    cleanup()
+  })
+  process.on("unhandledRejection", (reason) => {
+    log.warn("unhandledRejection; draining inhibitor", { error: String(reason) })
+    cleanup()
+  })
+}

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { FileWatcher } from "@/file/watcher"
 import { KiloSessions } from "@/kilo-sessions/kilo-sessions" // kilocode_change
+import * as SleepInhibitorSubscribe from "@/kilocode/sleep-inhibitor/subscribe" // kilocode_change
 import * as Effect from "effect/Effect"
 
 export const InstanceBootstrap = Effect.gen(function* () {
@@ -18,6 +19,7 @@ export const InstanceBootstrap = Effect.gen(function* () {
   yield* Plugin.Service.use((svc) => svc.init())
   // kilocode_change start - bootstrap Kilo session ingest/remote subscriptions instead of ShareNext
   yield* Effect.promise(() => KiloSessions.init()).pipe(Effect.forkDetach)
+  yield* Effect.promise(() => SleepInhibitorSubscribe.init()).pipe(Effect.forkDetach)
   yield* Effect.all(
     [LSP.Service, Format.Service, File.Service, FileWatcher.Service, Vcs.Service, Snapshot.Service].map((s) =>
       Effect.forkDetach(s.use((i) => i.init())),

--- a/packages/opencode/test/kilocode/sleep-inhibitor.test.ts
+++ b/packages/opencode/test/kilocode/sleep-inhibitor.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { SleepInhibitor } from "../../src/kilocode/sleep-inhibitor"
+import { SLEEP_SECONDS, watchdog } from "../../src/kilocode/sleep-inhibitor/platform/linux"
+import type { Inhibitor } from "../../src/kilocode/sleep-inhibitor/platform/types"
+
+/**
+ * Port of codex's `codex-rs/utils/sleep-inhibitor/src/lib.rs:74-112` tests,
+ * plus Kilo-specific tests covering the multi-session refcount extension.
+ *
+ * The platform backend is replaced with a recording spy so these tests stay
+ * hermetic — no IOKit / PowrProf / systemd-inhibit interaction.
+ */
+
+interface SpyInhibitor extends Inhibitor {
+  readonly acquires: { current: number }
+  readonly releases: { current: number }
+  readonly active: { current: boolean }
+}
+
+function spy(): SpyInhibitor {
+  const acquires = { current: 0 }
+  const releases = { current: 0 }
+  const active = { current: false }
+  return {
+    acquires,
+    releases,
+    active,
+    acquire() {
+      if (active.current) return // match idempotent platform contract
+      active.current = true
+      acquires.current++
+    },
+    release() {
+      if (!active.current) return
+      active.current = false
+      releases.current++
+    },
+  }
+}
+
+let platform: SpyInhibitor
+
+beforeEach(() => {
+  platform = spy()
+  SleepInhibitor.__setPlatformForTests(platform)
+})
+
+afterEach(() => {
+  SleepInhibitor.__setPlatformForTests(undefined)
+})
+
+describe("SleepInhibitor — codex behavior parity", () => {
+  // Port of codex `lib.rs:78-85` — `sleep_inhibitor_toggles_without_panicking`
+  it("toggles acquire and release", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    expect(SleepInhibitor.busyCount()).toBe(1)
+    expect(SleepInhibitor.active()).toBe(true)
+    expect(platform.acquires.current).toBe(1)
+
+    SleepInhibitor.release("s1")
+    expect(SleepInhibitor.busyCount()).toBe(0)
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.releases.current).toBe(1)
+  })
+
+  // Port of codex `lib.rs:87-94` — `sleep_inhibitor_disabled_does_not_panic`.
+  // When disabled, acquire is tracked but never engages the platform.
+  it("disabled does not engage the platform", () => {
+    SleepInhibitor.configure({ enabled: false })
+
+    SleepInhibitor.acquire("s1")
+    expect(SleepInhibitor.busyCount()).toBe(1)
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.acquires.current).toBe(0)
+
+    SleepInhibitor.release("s1")
+    expect(platform.releases.current).toBe(0)
+  })
+
+  // Port of codex `lib.rs:96-103` — `sleep_inhibitor_multiple_true_calls_are_idempotent`.
+  it("repeated acquires for the same session are idempotent", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.acquire("s1")
+    expect(SleepInhibitor.busyCount()).toBe(1)
+    expect(platform.acquires.current).toBe(1)
+
+    SleepInhibitor.release("s1")
+    expect(platform.releases.current).toBe(1)
+  })
+
+  // Port of codex `lib.rs:105-112` — `sleep_inhibitor_can_toggle_multiple_times`.
+  it("can toggle acquire/release multiple times", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.release("s1")
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.release("s1")
+
+    expect(platform.acquires.current).toBe(2)
+    expect(platform.releases.current).toBe(2)
+    expect(SleepInhibitor.active()).toBe(false)
+  })
+})
+
+describe("SleepInhibitor — multi-session refcount (Kilo extension)", () => {
+  it("acquires once on 0->n transition and releases once on n->0", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.acquire("s2")
+    SleepInhibitor.acquire("s3")
+    expect(SleepInhibitor.busyCount()).toBe(3)
+    expect(platform.acquires.current).toBe(1)
+
+    SleepInhibitor.release("s1")
+    expect(SleepInhibitor.active()).toBe(true)
+    expect(platform.releases.current).toBe(0)
+
+    SleepInhibitor.release("s2")
+    expect(SleepInhibitor.active()).toBe(true)
+
+    SleepInhibitor.release("s3")
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.releases.current).toBe(1)
+  })
+
+  it("release for an unknown session is a no-op", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.release("unknown")
+    expect(SleepInhibitor.busyCount()).toBe(1)
+    expect(SleepInhibitor.active()).toBe(true)
+  })
+
+  it("drain releases the platform and clears all sessions", () => {
+    SleepInhibitor.configure({ enabled: true })
+
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.acquire("s2")
+
+    SleepInhibitor.drain()
+
+    expect(SleepInhibitor.busyCount()).toBe(0)
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.releases.current).toBe(1)
+  })
+})
+
+describe("SleepInhibitor — shutdown and latent-state safety", () => {
+  // Kilo-specific: regression test for the lazy-platform bug where
+  // `__setPlatformForTests(undefined)` could silently instantiate a real
+  // platform inhibitor via `ensure()` if `claimed` was true. See index.ts.
+  it("swapping to undefined while claimed releases on the current platform only", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.acquire("s1")
+    expect(platform.active.current).toBe(true)
+
+    // Swap to undefined — must release on the CURRENT (spy) platform, not
+    // lazily construct a real platform.
+    SleepInhibitor.__setPlatformForTests(undefined)
+    expect(platform.releases.current).toBe(1)
+  })
+
+  it("drain with nothing busy is a no-op", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.drain()
+    expect(platform.acquires.current).toBe(0)
+    expect(platform.releases.current).toBe(0)
+    expect(SleepInhibitor.active()).toBe(false)
+  })
+
+  it("release before acquire is a no-op", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.release("never-acquired")
+    expect(SleepInhibitor.busyCount()).toBe(0)
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.releases.current).toBe(0)
+  })
+
+  it("drain then fresh acquire re-engages the platform", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.drain()
+    SleepInhibitor.acquire("s2")
+    expect(SleepInhibitor.active()).toBe(true)
+    expect(platform.acquires.current).toBe(2)
+  })
+
+  it("disable+re-enable preserves the multi-session busy set", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.acquire("s1")
+    SleepInhibitor.acquire("s2")
+    SleepInhibitor.configure({ enabled: false })
+    SleepInhibitor.release("s1")
+    SleepInhibitor.configure({ enabled: true })
+
+    expect(SleepInhibitor.busyCount()).toBe(1)
+    expect(SleepInhibitor.active()).toBe(true)
+    // One acquire before disable + one re-acquire after enable = 2
+    expect(platform.acquires.current).toBe(2)
+  })
+})
+
+describe("Linux backend — codex parity constants", () => {
+  // Port of codex `linux_inhibitor.rs:236-239` `sleep_seconds_is_i32_max`.
+  it("SLEEP_SECONDS is i32::MAX", () => {
+    expect(SLEEP_SECONDS).toBe(String(2 ** 31 - 1))
+    expect(SLEEP_SECONDS).toBe("2147483647")
+  })
+})
+
+describe("Linux watchdog wrapper — parent-death cleanup", () => {
+  // These tests verify the shell script structure that substitutes for
+  // codex's `prctl(PR_SET_PDEATHSIG)` at `linux_inhibitor.rs:213-223`.
+
+  it("produces a sh -c invocation", () => {
+    const cmd = watchdog(["systemd-inhibit", "--what=idle", "--", "sleep", "60"], 12345)
+    expect(cmd[0]).toBe("sh")
+    expect(cmd[1]).toBe("-c")
+    expect(typeof cmd[2]).toBe("string")
+  })
+
+  it("installs an EXIT trap that SIGTERMs the inhibitor child", () => {
+    const cmd = watchdog(["systemd-inhibit", "sleep", "1"], 12345)
+    expect(cmd[2]).toContain(`trap 'kill -TERM "$c" 2>/dev/null' EXIT`)
+  })
+
+  it("polls the parent PID passed in", () => {
+    const cmd = watchdog(["systemd-inhibit", "sleep", "1"], 987654)
+    expect(cmd[2]).toContain("kill -0 987654")
+  })
+
+  it("backgrounds the inhibitor and captures its PID", () => {
+    const cmd = watchdog(["systemd-inhibit", "sleep", "1"], 1)
+    expect(cmd[2]).toMatch(/\s&\s*;\s*c=\$!/)
+  })
+
+  it("escapes single quotes in inner args", () => {
+    const cmd = watchdog(["echo", "it's fine"], 1)
+    // The standard POSIX escape for a single quote inside a single-quoted
+    // string is '\'' (close quote, escaped quote, reopen quote).
+    expect(cmd[2]).toContain(`'it'\\''s fine'`)
+  })
+
+  it("end-to-end: watchdog kills inhibitor within ~1 second of parent death", async () => {
+    // Simulate the core guarantee: when the PID being polled disappears,
+    // the watchdog must kill its child.
+    //
+    // We run the watchdog against a fake parent PID that doesn't exist,
+    // with a harmless inner command (sleep 60). The watchdog should kill
+    // the sleep and exit within ~1 second.
+    const fakeParentPid = 1 // PID 1 (init) always exists, so we invert:
+    // use an impossible PID and expect the watchdog to bail immediately.
+    const impossiblePid = 2 ** 22 // higher than Linux max PID (default 4M); see /proc/sys/kernel/pid_max
+    const cmd = watchdog(["sleep", "60"], impossiblePid)
+
+    const proc = Bun.spawn({ cmd, stdin: "ignore", stdout: "ignore", stderr: "ignore" })
+
+    // Wait up to 3 seconds for the watchdog to notice and exit.
+    const timeout = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 3000))
+    const exited = proc.exited.then(() => "exited" as const)
+    const result = await Promise.race([exited, timeout])
+
+    if (result === "timeout") {
+      proc.kill("SIGKILL")
+      throw new Error("watchdog did not detect dead parent within 3 seconds")
+    }
+
+    expect(result).toBe("exited")
+    // Parameter to silence the unused-var warning — we referenced fakeParentPid above in comments.
+    void fakeParentPid
+  })
+})
+
+describe("SleepInhibitor — config toggle mid-turn", () => {
+  // Equivalent of codex's config reload behavior in `chatwidget.rs:9747-9749`:
+  // toggling `enabled` while a turn is running updates the platform state to
+  // match current busy count.
+  it("disabling mid-turn releases the platform", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.acquire("s1")
+    expect(SleepInhibitor.active()).toBe(true)
+
+    SleepInhibitor.configure({ enabled: false })
+    expect(SleepInhibitor.active()).toBe(false)
+    expect(platform.releases.current).toBe(1)
+    expect(SleepInhibitor.busyCount()).toBe(1)
+  })
+
+  it("re-enabling mid-turn re-acquires the platform", () => {
+    SleepInhibitor.configure({ enabled: false })
+    SleepInhibitor.acquire("s1")
+    expect(SleepInhibitor.active()).toBe(false)
+
+    SleepInhibitor.configure({ enabled: true })
+    expect(SleepInhibitor.active()).toBe(true)
+    expect(platform.acquires.current).toBe(1)
+  })
+
+  it("configure is a no-op when value is unchanged", () => {
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.acquire("s1")
+    const acq = platform.acquires.current
+
+    SleepInhibitor.configure({ enabled: true })
+    SleepInhibitor.configure({ enabled: true })
+
+    expect(platform.acquires.current).toBe(acq)
+  })
+})


### PR DESCRIPTION
## Summary
- Port codex-style sleep inhibition into the CLI with separated macOS, Windows, Linux, and noop platform backends.
- Wire turn-open/turn-close events to a process-wide refcount so all CLI clients, including Agent Manager via `kilo serve`, keep the machine awake only while work is active.
- Add `prevent_idle_sleep` config and coverage for lifecycle, refcount, config toggles, and the Linux watchdog cleanup path.

## Notes
- `prevent_idle_sleep` also needs mirroring in the cloud config schema.