### PR TITLE
Force-fetch tags when syncing from upstream remote

### DIFF
--- a/script/upstream/utils/git.ts
+++ b/script/upstream/utils/git.ts
@@ -55,7 +55,7 @@ export async function hasUpstreamRemote(): Promise<boolean> {
 }
 
 export async function fetchUpstream(): Promise<void> {
-  const result = await $`git fetch upstream`.quiet().nothrow()
+  const result = await $`git fetch upstream --tags --force`.quiet().nothrow()
   if (result.exitCode !== 0) {
     throw new Error(`Failed to fetch upstream: ${result.stderr.toString()}`)
   }


### PR DESCRIPTION
Fix upstream merge script failing with "Invalid symmetric difference expression" when targeting a tagged upstream version.

git fetch upstream now fetches tags so tag-pointed commits are available for the pre-merge conflict analysis.

