### PR TITLE
fix: add extractReasoning: true for DeepSeek thinking mode compatibility

### DIFF
--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -79,8 +79,8 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const openrouter = createOpenRouter(sdkOptions)
   const alibaba = createAlibaba(sdkOptions)
   const anthropic = createAnthropic(sdkOptions)
-  const openai = createOpenAI(sdkOptions)
-  const openaiCompatible = createOpenAICompatible({ ...sdkOptions, name: "openaiCompatible" })
+  const openai = createOpenAI({ ...sdkOptions, extractReasoning: true })
+  const openaiCompatible = createOpenAICompatible({ ...sdkOptions, name: "openaiCompatible", extractReasoning: true })
 
   return {
     languageModel(modelId) {


### PR DESCRIPTION
## Problem

When using DeepSeek v4 Flash (or any OpenAI-compatible model that returns `reasoning_content` in streaming deltas), subsequent requests with tool calls fail with:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

This happens because the Vercel AI SDK's `createOpenAI` and `createOpenAICompatible` providers silently drop `reasoning_content` from streaming deltas unless `extractReasoning: true` is passed.

## Fix

Add `extractReasoning: true` to both `createOpenAI` and `createOpenAICompatible` calls in `packages/kilo-gateway/src/provider.ts`. This tells the AI SDK to preserve `reasoning_content` from streaming responses, which ensures it can be sent back to the API on subsequent requests — a requirement for DeepSeek thinking mode when tool calls are involved.

Per DeepSeek docs: "If your code does not correctly pass back `reasoning_content`, the API will return a 400 error."

Related: the interleaved transform in `transform.ts` already has logic to preserve empty `reasoning_content` for DeepSeek — this just wires the SDK-level option needed to actually extract it from the stream.
