### PR TITLE
test(cli): stabilize prompt shell tests

### DIFF
--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1064,14 +1064,14 @@ unix("shell completes a fast command on the preferred shell", () =>
         const result = yield* prompt.shell({
           sessionID: chat.id,
           agent: "code",
-          command: "pwd",
+          command: "pwd -P", // kilocode_change - compare physical cwd against fixture realpath
         })
 
         expect(result.info.role).toBe("assistant")
         const tool = completedTool(result.parts)
         if (!tool) return
 
-        expect(tool.state.input.command).toBe("pwd")
+        expect(tool.state.input.command).toBe("pwd -P")
         expect(tool.state.output).toContain(dir)
         expect(tool.state.metadata.output).toContain(dir)
         yield* run.assertNotBusy(chat.id)
@@ -1229,6 +1229,7 @@ unix(
         expect(yield* llm.calls).toBe(0)
 
         yield* Fiber.await(sh)
+        yield* llm.wait(1)
         const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
 
         expect(Exit.isSuccess(ea)).toBe(true)


### PR DESCRIPTION
## Summary
- Make the fast shell cwd assertion compare against the physical fixture path returned by the test helper.
- Wait for the queued loop to reach the test LLM before asserting duplicate callers share the resumed result.

## Validation
- bun test test/session/prompt-effect.test.ts --timeout 30000 --test-name-pattern "shell completes a fast command on the preferred shell|shell completion resumes queued loop callers"
- bun run script/test-runner.ts session/prompt-effect.test.ts --timeout 30000 --file-timeout 120000 --verbose