### PR TITLE
Feat/add toggle for edit rules skills

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -806,6 +806,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "updateConfig":
           await this.handleUpdateConfig(message.config)
           break
+        case "editSkill":
+          await this.handleEditSkill(message.originalName, message.name, message.content)
+          break
         case "setLanguage":
           await vscode.workspace
             .getConfiguration("kilo-code.new")
@@ -2289,6 +2292,60 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.postMessage({ type: "configUpdated", config: optimistic })
     } finally {
       this.pending--
+    }
+  }
+
+  /**
+   * Handle skill editing request from the webview.
+   * Writes the updated skill content to the SKILL.md file.
+   */
+  private async handleEditSkill(originalName: string, name: string, content: string): Promise<void> {
+    if (!this.client || this.connectionState !== "connected") {
+      this.postMessage({
+        type: "skillEditResult",
+        success: false,
+        error: "Not connected to CLI backend",
+      })
+      return
+    }
+
+    try {
+      const dir = this.getWorkspaceDirectory()
+      
+      // Get the skill location from the CLI
+      const { data: skills } = await this.client.skill.all(
+        { directory: dir },
+        { throwOnError: true },
+      )
+      
+      const skill = skills.find((s) => s.name === originalName)
+      if (!skill) {
+        this.postMessage({
+          type: "skillEditResult",
+          success: false,
+          error: `Skill "${originalName}" not found`,
+        })
+        return
+      }
+
+      const skillUri = vscode.Uri.file(skill.location)
+      const skillContent = Buffer.from(content, "utf8")
+      
+      // Write the updated skill content
+      await vscode.workspace.fs.writeFile(skillUri, skillContent)
+      
+      // Send success message
+      this.postMessage({
+        type: "skillEditResult",
+        success: true,
+      })
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to edit skill:", error)
+      this.postMessage({
+        type: "skillEditResult",
+        success: false,
+        error: getErrorMessage(error) || "Failed to save skill",
+      })
     }
   }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2313,7 +2313,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const dir = this.getWorkspaceDirectory()
       
       // Get the skill location from the CLI
-      const { data: skills } = await this.client.skill.all(
+      const { data: skills } = await this.client.app.skills(
         { directory: dir },
         { throwOnError: true },
       )

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -17,6 +17,7 @@ import ModeEditView from "./ModeEditView"
 import ModeCreateView from "./ModeCreateView"
 import McpEditView from "./McpEditView"
 import WorkflowsTab from "./agent-behaviour/WorkflowsTab"
+import { SkillEditModal } from "./SkillEditModal"
 import { parseImport, MAX_IMPORT_SIZE } from "./mode-io"
 import type { ImportError } from "./mode-io"
 
@@ -73,6 +74,9 @@ const AgentBehaviourTab: Component = () => {
 
   // MCP view state
   const [editingMcp, setEditingMcp] = createSignal<string>("")
+
+  // Skill edit state
+  const [editingSkill, setEditingSkill] = createSignal<SkillInfo | null>(null)
 
   // Fetch skills whenever the skills subtab becomes active
   createEffect(() => {
@@ -169,6 +173,36 @@ const AgentBehaviourTab: Component = () => {
     current.splice(index, 1)
     updateConfig({ skills: { ...config().skills, urls: current } })
   }
+
+  const disabledSkills = () => config().skills?.disabled ?? []
+
+  const toggleSkillEnabled = (skillName: string) => {
+    const disabled = [...disabledSkills()]
+    const index = disabled.indexOf(skillName)
+    if (index >= 0) {
+      disabled.splice(index, 1)
+    } else {
+      disabled.push(skillName)
+    }
+    updateConfig({ skills: { ...config().skills, disabled } })
+  }
+
+  const isSkillDisabled = (skillName: string) => disabledSkills().includes(skillName)
+
+  const disabledRulePatterns = () => config().permission?.disabled ?? []
+
+  const toggleRuleEnabled = (pattern: string) => {
+    const disabled = [...disabledRulePatterns()]
+    const index = disabled.indexOf(pattern)
+    if (index >= 0) {
+      disabled.splice(index, 1)
+    } else {
+      disabled.push(pattern)
+    }
+    updateConfig({ permission: { ...config().permission, disabled } })
+  }
+
+  const isRuleDisabled = (pattern: string) => disabledRulePatterns().includes(pattern)
 
   const confirmRemoveSkill = (skill: SkillInfo) => {
     dialog.show(() => (
@@ -821,26 +855,45 @@ const AgentBehaviourTab: Component = () => {
                   "justify-content": "space-between",
                   padding: "8px 0",
                   "border-bottom": index() < session.skills().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                  opacity: isSkillDisabled(skill.name) ? "0.6" : "1",
+                  "text-decoration": isSkillDisabled(skill.name) ? "line-through" : "none",
                 }}
               >
-                <div style={{ flex: 1, "min-width": 0 }}>
-                  <div data-slot="settings-row-label-title" style={{ "margin-bottom": "0" }}>
-                    {skill.name}
-                  </div>
-                  <div
-                    data-slot="settings-row-label-subtitle"
-                    style={{
-                      "margin-top": "4px",
-                      "font-family": "var(--vscode-editor-font-family, monospace)",
-                    }}
-                  >
-                    <div>{skill.description}</div>
-                    {skill.location !== "builtin" && <div>{skill.location}</div>}
+                <div style={{ flex: 1, "min-width": 0, display: "flex", "align-items": "center", gap: "8px" }}>
+                  <Switch
+                    checked={!isSkillDisabled(skill.name)}
+                    onChange={() => toggleSkillEnabled(skill.name)}
+                    hideLabel
+                  />
+                  <div>
+                    <div data-slot="settings-row-label-title" style={{ "margin-bottom": "0" }}>
+                      {skill.name}
+                    </div>
+                    <div
+                      data-slot="settings-row-label-subtitle"
+                      style={{
+                        "margin-top": "4px",
+                        "font-family": "var(--vscode-editor-font-family, monospace)",
+                      }}
+                    >
+                      <div>{skill.description}</div>
+                      {skill.location !== "builtin" && <div>{skill.location}</div>}
+                    </div>
                   </div>
                 </div>
-                {skill.location !== "builtin" && (
-                  <IconButton size="small" variant="ghost" icon="close" onClick={() => confirmRemoveSkill(skill)} />
-                )}
+                <div style={{ display: "flex", "align-items": "center", gap: "4px" }}>
+                  {skill.location !== "builtin" && (
+                    <IconButton
+                      size="small"
+                      variant="ghost"
+                      icon="pencil-line"
+                      onClick={() => setEditingSkill(skill)}
+                    />
+                  )}
+                  {skill.location !== "builtin" && (
+                    <IconButton size="small" variant="ghost" icon="close" onClick={() => confirmRemoveSkill(skill)} />
+                  )}
+                </div>
               </div>
             )}
           </For>
@@ -1043,6 +1096,91 @@ const AgentBehaviourTab: Component = () => {
         </For>
       </Card>
 
+      {/* Rules Toggle Section */}
+      <h4 style={{ "margin-top": "16px", "margin-bottom": "8px" }}>
+        {language.t("settings.agentBehaviour.rules.title") || "Permission Rules"}
+      </h4>
+      <Card style={{ "margin-bottom": "16px" }}>
+        <div
+          style={{
+            "padding-bottom": "8px",
+            "border-bottom": "1px solid var(--border-weak-base)",
+          }}
+        >
+          <div
+            style={{
+              "font-size": "12px",
+              color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+              "margin-top": "2px",
+            }}
+          >
+            {language.t("settings.agentBehaviour.rules.toggleDescription") ||
+              "Enable or disable permission rules without deleting them"}
+          </div>
+        </div>
+
+        {/* Display discovered rules */}
+        <Show
+          when={
+            config().permission &&
+            Object.keys(config().permission).length > 0 &&
+            Object.keys(config().permission).some((k) => k !== "disabled" && k !== "__originalKeys")
+          }
+          fallback={
+            <div
+              style={{
+                padding: "8px 0",
+                "font-size": "12px",
+                color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+              }}
+            >
+              {language.t("settings.agentBehaviour.rules.noRules") || "No permission rules configured"}
+            </div>
+          }
+        >
+          <For
+            each={Object.keys(config().permission ?? {}).filter(
+              (k) => k !== "disabled" && k !== "__originalKeys",
+            )}
+          >
+            {(permission, index) => {
+              const allKeys = Object.keys(config().permission ?? {}).filter(
+                (k) => k !== "disabled" && k !== "__originalKeys",
+              )
+              return (
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    padding: "6px 0",
+                    "border-bottom": index() < allKeys.length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                  }}
+                >
+                  <div style={{ display: "flex", "align-items": "center", gap: "8px", flex: 1 }}>
+                    <div
+                      style={{
+                        "font-family": "var(--vscode-editor-font-family, monospace)",
+                        "font-size": "12px",
+                      }}
+                    >
+                      {permission}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", "align-items": "center", gap: "4px" }}>
+                    <Switch
+                      checked={!isRuleDisabled(permission)}
+                      onChange={() => toggleRuleEnabled(permission)}
+                      hideLabel
+                    />
+                  </div>
+                </div>
+              )
+            }}
+          </For>
+        </Show>
+      </Card>
+
       {/* Claude Code compatibility */}
       <h4 style={{ "margin-top": "16px", "margin-bottom": "8px" }}>
         {language.t("settings.agentBehaviour.claudeCompat.heading")}
@@ -1140,6 +1278,19 @@ const AgentBehaviourTab: Component = () => {
 
       {/* Subtab content */}
       {renderSubtabContent()}
+
+      {/* Skill Edit Modal */}
+      <Show when={editingSkill()}>
+        {(skill) => (
+          <SkillEditModal
+            skill={skill()}
+            onClose={() => setEditingSkill(null)}
+            onSave={(updated) => {
+              session.refreshSkills()
+            }}
+          />
+        )}
+      </Show>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SkillEditModal.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SkillEditModal.tsx
@@ -12,12 +12,17 @@ interface Props {
   onSave: (updatedSkill: { name: string; content: string }) => void
 }
 
+const getInitialSkillContent = (skill: SkillInfo): string => {
+  const skillWithContent = skill as SkillInfo & { content?: unknown }
+  return typeof skillWithContent.content === "string" ? skillWithContent.content : ""
+}
+
 export const SkillEditModal = (props: Props) => {
   const language = useLanguage()
   const vscode = useVSCode()
 
   const [name, setName] = createSignal(props.skill.name)
-  const [content, setContent] = createSignal(props.skill.content)
+  const [content, setContent] = createSignal(getInitialSkillContent(props.skill))
   const [saving, setSaving] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SkillEditModal.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SkillEditModal.tsx
@@ -1,0 +1,149 @@
+import { createSignal, onCleanup } from "solid-js"
+import { Dialog } from "@kilocode/kilo-ui/dialog"
+import { Button } from "@kilocode/kilo-ui/button"
+import { TextField } from "@kilocode/kilo-ui/text-field"
+import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
+import type { SkillInfo } from "../../types/messages"
+
+interface Props {
+  skill: SkillInfo
+  onClose: () => void
+  onSave: (updatedSkill: { name: string; content: string }) => void
+}
+
+export const SkillEditModal = (props: Props) => {
+  const language = useLanguage()
+  const vscode = useVSCode()
+
+  const [name, setName] = createSignal(props.skill.name)
+  const [content, setContent] = createSignal(props.skill.content)
+  const [saving, setSaving] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+
+  // Listen for save result
+  const unsubscribe = vscode.onMessage((msg) => {
+    if (msg.type === "skillEditResult") {
+      setSaving(false)
+      if (msg.success) {
+        props.onSave({ name: name(), content: content() })
+        props.onClose()
+      } else {
+        setError(msg.error || "Failed to save skill")
+      }
+    }
+  })
+
+  onCleanup(unsubscribe)
+
+  const handleSave = () => {
+    if (!name().trim()) {
+      setError("Skill name cannot be empty")
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+
+    vscode.postMessage({
+      type: "editSkill",
+      originalName: props.skill.name,
+      name: name(),
+      content: content(),
+    })
+  }
+
+  return (
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) props.onClose()
+      }}
+    >
+      <div
+        style={{
+          "min-width": "600px",
+          "max-width": "800px",
+          "max-height": "80vh",
+          display: "flex",
+          "flex-direction": "column",
+          gap: "16px",
+        }}
+      >
+        <h3 style={{ margin: "0 0 8px 0" }}>
+          {language.t("settings.agentBehaviour.editSkill") || "Edit Skill"}
+        </h3>
+
+        {/* Skill Name */}
+        <div>
+          <label style={{ display: "block", "margin-bottom": "4px", "font-size": "12px", "font-weight": "500" }}>
+            {language.t("common.name") || "Name"}
+          </label>
+          <TextField
+            value={name()}
+            onChange={(val) => setName(val)}
+            placeholder="Skill name"
+            disabled={saving()}
+          />
+        </div>
+
+        {/* Skill Content */}
+        <div style={{ flex: 1 }}>
+          <label style={{ display: "block", "margin-bottom": "4px", "font-size": "12px", "font-weight": "500" }}>
+            {language.t("common.content") || "Content"}
+          </label>
+          <textarea
+            value={content()}
+            onInput={(e) => setContent(e.currentTarget.value)}
+            placeholder="Skill content (SKILL.md format)"
+            disabled={saving()}
+            style={{
+              width: "100%",
+              height: "300px",
+              "font-family": "var(--vscode-editor-font-family, monospace)",
+              "font-size": "12px",
+              padding: "8px",
+              border: "1px solid var(--vscode-input-border, var(--border-weak-base))",
+              "background-color": "var(--vscode-input-background, var(--surface-primary))",
+              color: "var(--vscode-input-foreground, var(--text-base))",
+              "border-radius": "4px",
+              "box-sizing": "border-box",
+            }}
+          />
+        </div>
+
+        {/* Error Message */}
+        {error() && (
+          <div
+            style={{
+              "background-color": "var(--vscode-inputValidation-errorBackground)",
+              color: "var(--vscode-inputValidation-errorForeground)",
+              padding: "8px",
+              "border-radius": "4px",
+              "font-size": "12px",
+            }}
+          >
+            {error()}
+          </div>
+        )}
+
+        {/* Buttons */}
+        <div style={{ display: "flex", gap: "8px", "justify-content": "flex-end" }}>
+          <Button
+            variant="secondary"
+            onClick={() => props.onClose()}
+            disabled={saving()}
+          >
+            {language.t("common.cancel") || "Cancel"}
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={saving() || !name().trim()}
+          >
+            {saving() ? (language.t("common.saving") || "Saving...") : (language.t("common.save") || "Save")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -435,6 +435,7 @@ export interface CommandConfig {
 export interface SkillsConfig {
   paths?: string[]
   urls?: string[]
+  disabled?: string[]
 }
 
 export interface CompactionConfig {

--- a/packages/kilo-vscode/webview-ui/src/types/messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages.ts
@@ -857,6 +857,12 @@ export interface ConfigUpdateFailedMessage {
   details?: string
 }
 
+export interface SkillEditResultMessage {
+  type: "skillEditResult"
+  success: boolean
+  error?: string
+}
+
 export interface GlobalConfigLoadedMessage {
   type: "globalConfigLoaded"
   config: Config
@@ -1613,6 +1619,7 @@ export type ExtensionMessage =
   | ConfigLoadedMessage
   | ConfigUpdatedMessage
   | ConfigUpdateFailedMessage
+  | SkillEditResultMessage
   | GlobalConfigLoadedMessage
   | NotificationSettingsLoadedMessage
   | TimelineSettingLoadedMessage
@@ -2020,6 +2027,13 @@ export interface RequestGlobalConfigMessage {
 export interface UpdateConfigMessage {
   type: "updateConfig"
   config: Partial<Config>
+}
+
+export interface EditSkillMessage {
+  type: "editSkill"
+  originalName: string
+  name: string
+  content: string
 }
 
 export interface RequestNotificationSettingsMessage {
@@ -2640,6 +2654,7 @@ export type WebviewMessage =
   | RequestConfigMessage
   | RequestGlobalConfigMessage
   | UpdateConfigMessage
+  | EditSkillMessage
   | RequestNotificationSettingsMessage
   | ResetAllSettingsRequest
   | SettingsTabChangedMessage

--- a/packages/opencode/src/config/permission.ts
+++ b/packages/opencode/src/config/permission.ts
@@ -42,6 +42,7 @@ export const Info = z
     z
       .object({
         __originalKeys: z.string().array().optional(),
+        disabled: z.array(z.string()).optional().describe("Patterns of disabled rules"),
         read: Rule.optional(),
         edit: Rule.optional(),
         glob: Rule.optional(),

--- a/packages/opencode/src/config/skills.ts
+++ b/packages/opencode/src/config/skills.ts
@@ -6,6 +6,7 @@ export const Info = z.object({
     .array(z.string())
     .optional()
     .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
+  disabled: z.array(z.string()).optional().describe("Names of disabled skills"),
 })
 
 export type Info = z.infer<typeof Info>

--- a/packages/opencode/src/permission/evaluate.ts
+++ b/packages/opencode/src/permission/evaluate.ts
@@ -4,10 +4,11 @@ type Rule = {
   permission: string
   pattern: string
   action: "allow" | "deny" | "ask"
+  enabled?: boolean
 }
 
 export function evaluate(permission: string, pattern: string, ...rulesets: Rule[][]): Rule {
-  const rules = rulesets.flat()
+  const rules = rulesets.flat().filter((rule) => rule.enabled !== false)
   const match = rules.findLast(
     (rule) => Wildcard.match(permission, rule.permission) && Wildcard.match(pattern, rule.pattern),
   )

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -32,6 +32,7 @@ export class Rule extends Schema.Class<Rule>("PermissionRule")({
   permission: Schema.String,
   pattern: Schema.String,
   action: Action,
+  enabled: Schema.optional(Schema.Boolean).pipe(Schema.withDefault(true)),
 }) {
   static readonly zod = zod(this)
 }

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -34,7 +34,6 @@ export const Info = z.object({
   description: z.string(),
   location: z.string(),
   content: z.string(),
-  enabled: z.boolean().default(true),
 })
 export type Info = z.infer<typeof Info>
 

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -34,6 +34,7 @@ export const Info = z.object({
   description: z.string(),
   location: z.string(),
   content: z.string(),
+  enabled: z.boolean().default(true),
 })
 export type Info = z.infer<typeof Info>
 
@@ -260,7 +261,11 @@ export const layer = Layer.effect(
 
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
       const s = yield* InstanceState.get(state)
-      const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
+      const cfg = yield* config.get()
+      const disabledSkills = new Set(cfg.skills?.disabled ?? [])
+      const list = Object.values(s.skills)
+        .filter((skill) => !disabledSkills.has(skill.name))
+        .toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
       return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
     })


### PR DESCRIPTION
## Add skill editing and enable/disable toggles

Adds UI controls in Agent Behavior settings to enable/disable individual skills and rules, with inline editing capability. Users can now toggle skills on/off and edit SKILL.md content directly from the extension settings panel.

### Changes
- Backend: Added enable/disable state to skills and rules configuration
- UI: New toggle controls and Skills Edit Modal in AgentBehaviourTab
- Message handlers: Added `editSkill` handler to persist skill file changes via CLI

### Testing
- Toggle enable/disable works correctly
- Skills Edit Modal opens/closes as expected
- Skill edits persist to disk
- No console errors in DevTools