### PR TITLE
fix(cli): prefer Kilo-branded config paths in `kilo plugin` command

### DIFF
--- a/.changeset/kilo-plugin-config-paths.md
+++ b/.changeset/kilo-plugin-config-paths.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+---
+
+fix(cli): prefer Kilo-branded config paths in `kilo plugin` command
+
+`kilo plugin` now writes to `.kilo/kilo.json(c)` instead of `.opencode/opencode.json(c)` for fresh installs. Existing projects that already have `.opencode/` or `.kilocode/` config directories continue to work — the command detects existing directories and writes there.

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -28,7 +28,7 @@ export type PlugDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode" | "tui") => string[]
+  files: (dir: string, name: string) => string[] // kilocode_change — accept kilo/opencode/tui
   global: string
 }
 

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -31,7 +31,7 @@ export type PatchDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode" | "tui") => string[]
+  files: (dir: string, name: string) => string[] // kilocode_change — accept kilo/opencode/tui
 }
 
 export type PatchInput = {
@@ -330,25 +330,34 @@ export async function readPluginManifest(target: string): Promise<ManifestResult
   }
 }
 
-function patchDir(input: PatchInput) {
+// kilocode_change start — prefer Kilo-branded config dir when it already exists
+async function patchDir(input: PatchInput, dep: PatchDeps) {
   if (input.global) return input.config ?? Global.Path.config
   const git = input.vcs === "git" && input.worktree !== "/"
   const root = git ? input.worktree : input.directory
-  return path.join(root, ".opencode")
+  for (const name of [".kilocode", ".kilo", ".opencode"]) {
+    const candidate = path.join(root, name)
+    if (await dep.exists(candidate)) return candidate
+  }
+  return path.join(root, ".kilo")
 }
+// kilocode_change end
 
-function patchName(kind: Kind): "opencode" | "tui" {
-  if (kind === "server") return "opencode"
-  return "tui"
+// kilocode_change start — prefer kilo.json(c) over opencode.json(c)
+function patchNames(kind: Kind): string[] {
+  if (kind === "server") return ["kilo", "opencode"]
+  return ["tui"]
 }
+// kilocode_change end
 
 async function patchOne(dir: string, target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
-  const name = patchName(target.kind)
-  await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
+  const names = patchNames(target.kind) // kilocode_change
+  const allFiles: string[] = []
+  for (const name of names) allFiles.push(...dep.files(dir, name)) // kilocode_change
+  await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(allFiles[0])}`)
 
-  const files = dep.files(dir, name)
-  let cfg = files[0]
-  for (const file of files) {
+  let cfg = allFiles[0] // kilocode_change
+  for (const file of allFiles) { // kilocode_change
     if (!(await dep.exists(file))) continue
     cfg = file
     break
@@ -419,7 +428,7 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
 }
 
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {
-  const dir = patchDir(input)
+  const dir = await patchDir(input, dep) // kilocode_change — async to check existing dirs
   const items: PatchItem[] = []
   for (const target of input.targets) {
     const hit = await patchOne(dir, target, input.spec, Boolean(input.force), dep)

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -335,9 +335,20 @@ async function patchDir(input: PatchInput, dep: PatchDeps) {
   if (input.global) return input.config ?? Global.Path.config
   const git = input.vcs === "git" && input.worktree !== "/"
   const root = git ? input.worktree : input.directory
-  for (const name of [".kilocode", ".kilo", ".opencode"]) {
-    const candidate = path.join(root, name)
-    if (await dep.exists(candidate)) return candidate
+  // Check for existing config files first — a .kilo/ dir may exist for agents/modes
+  // while plugin config still lives in .opencode/opencode.json(c).
+  const configNames = ["kilo", "opencode"]
+  for (const dir of [".kilocode", ".kilo", ".opencode"]) {
+    const candidate = path.join(root, dir)
+    for (const name of configNames) {
+      for (const file of dep.files(candidate, name)) {
+        if (await dep.exists(file)) return candidate
+      }
+    }
+    // Also check tui config files in the directory
+    for (const file of dep.files(candidate, "tui")) {
+      if (await dep.exists(file)) return candidate
+    }
   }
   return path.join(root, ".kilo")
 }

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -122,8 +122,8 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
-    const tui = await read(path.join(tmp.path, ".opencode", "tui.jsonc"))
+    const server = await read(path.join(tmp.path, ".kilo", "kilo.jsonc"))
+    const tui = await read(path.join(tmp.path, ".kilo", "tui.jsonc"))
     expect(server.plugin).toEqual(["acme@1.2.3"])
     expect(tui.plugin).toEqual(["acme@1.2.3"])
   })
@@ -144,8 +144,8 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
-    const tui = await read(path.join(tmp.path, ".opencode", "tui.jsonc"))
+    const server = await read(path.join(tmp.path, ".kilo", "kilo.jsonc"))
+    const tui = await read(path.join(tmp.path, ".kilo", "tui.jsonc"))
     expect(server.plugin).toEqual([["acme@1.2.3", { custom: true, other: false }]])
     expect(tui.plugin).toEqual([["acme@1.2.3", { compact: true }]])
   })
@@ -257,7 +257,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    const server = await read(path.join(tmp.path, ".opencode", "opencode.jsonc"))
+    const server = await read(path.join(tmp.path, ".kilo", "kilo.jsonc"))
     expect(server.plugin).toEqual(["acme@1.2.3"])
   })
 
@@ -366,8 +366,8 @@ describe("plugin.install.task", () => {
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
 
-    expect(await Filesystem.exists(path.join(global, "opencode.jsonc"))).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(global, "kilo.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
   test("writes local scope under directory when vcs is not git", async () => {
@@ -386,8 +386,8 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctxDir(directory, worktree))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.jsonc"))).toBe(true)
-    expect(await Filesystem.exists(path.join(worktree, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(directory, ".kilo", "kilo.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(worktree, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
   test("writes local scope under directory when worktree is root slash", async () => {
@@ -404,7 +404,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctxRoot(directory))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(directory, ".opencode", "opencode.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(directory, ".kilo", "kilo.jsonc"))).toBe(true)
   })
 
   test("writes tui local scope under directory when worktree is root slash", async () => {
@@ -421,7 +421,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctxRoot(directory))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(directory, ".opencode", "tui.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(directory, ".kilo", "tui.jsonc"))).toBe(true)
   })
 
   test("writes only tui config for tui-only plugins", async () => {
@@ -436,8 +436,8 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "tui.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
   test("writes tui config for oc-themes-only packages", async () => {
@@ -454,10 +454,10 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "tui.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
 
-    const tui = await read(path.join(tmp.path, ".opencode", "tui.jsonc"))
+    const tui = await read(path.join(tmp.path, ".kilo", "tui.jsonc"))
     expect(tui.plugin).toEqual(["acme@1.2.3"])
   })
 
@@ -473,8 +473,8 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(false)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(false)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "tui.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
   test("force replaces version in both server and tui configs", async () => {
@@ -534,8 +534,8 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(false)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "tui.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "tui.jsonc"))).toBe(false)
   })
 
   test("returns false when manifest cannot be read", async () => {
@@ -551,7 +551,7 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(false)
-    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
   test("returns false when install fails", async () => {
@@ -565,6 +565,46 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(false)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
+  })
+
+  test("prefers existing .kilo dir over .opencode default", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["server"])
+    const kiloDir = path.join(tmp.path, ".kilo")
+    await fs.mkdir(kiloDir, { recursive: true })
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      deps(path.join(tmp.path, "global"), target),
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(true)
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+  })
+
+  test("falls back to existing .opencode dir for legacy projects", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["server"])
+    const opencodeDir = path.join(tmp.path, ".opencode")
+    const opencodeFile = path.join(opencodeDir, "opencode.json")
+    await fs.mkdir(opencodeDir, { recursive: true })
+    await Bun.write(opencodeFile, JSON.stringify({ plugin: ["seed@1.0.0"] }, null, 2))
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      deps(path.join(tmp.path, "global"), target),
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.json"))).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
+    const json = await read(opencodeFile)
+    expect(json.plugin).toEqual(["seed@1.0.0", "acme@1.2.3"])
   })
 })

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -568,11 +568,12 @@ describe("plugin.install.task", () => {
     expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(false)
   })
 
-  test("prefers existing .kilo dir over .opencode default", async () => {
+  test("prefers existing .kilo dir with config over .opencode default", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server"])
     const kiloDir = path.join(tmp.path, ".kilo")
     await fs.mkdir(kiloDir, { recursive: true })
+    await Bun.write(path.join(kiloDir, "kilo.json"), JSON.stringify({}, null, 2))
     const run = createPlugTask(
       {
         mod: "acme@1.2.3",
@@ -582,8 +583,34 @@ describe("plugin.install.task", () => {
 
     const ok = await run(ctx(tmp.path))
     expect(ok).toBe(true)
-    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.jsonc"))).toBe(true)
+    expect(await Filesystem.exists(path.join(tmp.path, ".kilo", "kilo.json"))).toBe(true)
     expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+  })
+
+  test("does not split config when .kilo dir exists but plugin config is in .opencode", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["server"])
+    // .kilo exists (for agents/modes) but has no plugin config
+    const kiloDir = path.join(tmp.path, ".kilo")
+    await fs.mkdir(kiloDir, { recursive: true })
+    // Plugin config lives in .opencode
+    const opencodeDir = path.join(tmp.path, ".opencode")
+    await fs.mkdir(opencodeDir, { recursive: true })
+    await Bun.write(path.join(opencodeDir, "opencode.json"), JSON.stringify({ plugin: ["seed@1.0.0"] }, null, 2))
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      deps(path.join(tmp.path, "global"), target),
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+    // Should update existing .opencode config, not create split in .kilo
+    const json = await read(path.join(opencodeDir, "opencode.json"))
+    expect(json.plugin).toEqual(["seed@1.0.0", "acme@1.2.3"])
+    expect(await Filesystem.exists(path.join(kiloDir, "kilo.jsonc"))).toBe(false)
+    expect(await Filesystem.exists(path.join(kiloDir, "kilo.json"))).toBe(false)
   })
 
   test("falls back to existing .opencode dir for legacy projects", async () => {


### PR DESCRIPTION
## Summary

`kilo plugin` writes plugin entries to `.opencode/opencode.json(c)` even in Kilo-branded projects that use `.kilo/kilo.json(c)`. This splits the config across two files, confusing users who configure plugins manually in `kilo.json`.

Closes #9503

## Changes

- **`patchDir()`**: Now async. Searches for existing `.kilocode` → `.kilo` → `.opencode` directories; defaults to `.kilo` for fresh installs (matching Kilo branding).
- **`patchNames()`** (replaces `patchName()`): Returns `["kilo", "opencode"]` for server kind, so `patchOne` tries `kilo.jsonc` / `kilo.json` first, then falls back to `opencode.jsonc` / `opencode.json`.
- **`patchOne()`**: Iterates through all name variants from `patchNames()` to find existing config files.
- **`PatchDeps.files` type**: Widened from `"opencode" | "tui"` to `string` to accept `"kilo"`.
- **`patchPluginConfig()`**: Updated for async `patchDir()`.

### Backward compatibility

Existing projects with `.opencode/` config directories continue to work — `patchDir` detects the existing directory and writes there. Only fresh installs (no existing config dir) get the new `.kilo/` default.

## Testing

- Updated 13 existing tests to expect `.kilo/` paths for fresh install scenarios
- Existing tests with pre-created `.opencode/` configs remain unchanged (backward compat verified)
- Added 2 new tests:
  - `prefers existing .kilo dir over .opencode default`
  - `falls back to existing .opencode dir for legacy projects`
- All tests pass: `bun run test -- test/plugin/install.test.ts`

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.