### PR TITLE
fix(cli): proactive context overflow detection before LLM request

### DIFF
--- a/.changeset/pre-request-overflow-guard.md
+++ b/.changeset/pre-request-overflow-guard.md
@@ -1,0 +1,16 @@
+---
+"@kilocode/cli": patch
+---
+
+fix(cli): proactive context overflow detection before LLM request
+
+Adds a pre-request overflow guard that estimates input token count before
+sending to the LLM. When the estimated input exceeds the model's context
+limit and auto-compress is enabled, compaction is triggered proactively
+instead of sending a request that will be rejected.
+
+Previously, the overflow check only ran after receiving a response, so
+new content added between turns (user messages, tool results) could push
+the input past the limit without triggering compaction. The API would
+reject the request, and if the provider's error message didn't match the
+known overflow patterns, the session could enter a retry loop.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -9,7 +9,7 @@ import { Question } from "@/question" // kilocode_change
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
-import { Log } from "../util"
+import { Log, Token } from "../util" // kilocode_change — Token for pre-request overflow estimation
 import { SessionRevert } from "./revert"
 import { makeRuntime } from "@/effect/run-service" // kilocode_change
 import * as Session from "./session"
@@ -36,7 +36,7 @@ import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import * as Stream from "effect/Stream"
 import { Command } from "../command"
 import { pathToFileURL, fileURLToPath } from "url"
-import { ConfigMarkdown } from "../config"
+import { Config, ConfigMarkdown } from "../config" // kilocode_change — Config for pre-request overflow check
 import { SessionSummary } from "./summary"
 import { NamedError } from "@opencode-ai/shared/util/error"
 import { SessionProcessor } from "./processor"
@@ -96,6 +96,7 @@ export const layer = Layer.effect(
     const provider = yield* Provider.Service
     const processor = yield* SessionProcessor.Service
     const compaction = yield* SessionCompaction.Service
+    const config = yield* Config.Service // kilocode_change — for pre-request overflow check
     const plugin = yield* Plugin.Service
     const commands = yield* Command.Service
     const permission = yield* Permission.Service
@@ -1551,6 +1552,45 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const system = [...env, ...(skills ? [skills] : []), ...instructions]
             const format = lastUser.format ?? { type: "text" as const }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+
+            // kilocode_change start — pre-request overflow guard (#9500)
+            const cfg = yield* config.get()
+            if (cfg.compaction?.auto !== false && model.limit.context !== 0) {
+              // Estimate input tokens: system prompts + model messages
+              const systemText = system.map((s) => (typeof s === "string" ? s : JSON.stringify(s))).join("")
+              const messagesText = JSON.stringify(modelMsgs)
+              const estimatedTokens = Token.estimate(systemText + messagesText)
+
+              const reserved = cfg.compaction?.reserved ?? Math.min(20_000, ProviderTransform.maxOutputTokens(model))
+              const limit = model.limit.input
+                ? model.limit.input - reserved
+                : model.limit.context - ProviderTransform.maxOutputTokens(model)
+
+              if (estimatedTokens >= limit) {
+                const guard = KiloSessionPrompt.guardCompactionAttempt({
+                  sessionID,
+                  attempts: compactionAttempts,
+                  closeReasons,
+                  message: handle.message,
+                })
+                if (guard.exhausted) {
+                  yield* sessions.updateMessage(handle.message)
+                  yield* bus.publish(Session.Event.Error, { sessionID, error: guard.error })
+                  return "break" as const
+                }
+                compactionAttempts++
+                yield* compaction.create({
+                  sessionID,
+                  agent: lastUser.agent,
+                  model: lastUser.model,
+                  auto: true,
+                  overflow: true,
+                })
+                return "continue" as const
+              }
+            }
+            // kilocode_change end
+
             const result = yield* handle.process({
               user: lastUser,
               agent,


### PR DESCRIPTION
## Problem

When the total token count exceeds a model's maximum context window, the auto-compress feature fails to trigger, causing the agent to repeatedly send oversized requests that get rejected by the API.

**Root cause:** The existing overflow check (`isOverflow` in `overflow.ts`) only runs **after** receiving a response, using token counts from the previous turn. Between turns, new content (user messages, tool results) can push the input past the model's context limit without triggering compaction. When the API rejects the request, the error must match specific patterns (`OVERFLOW_PATTERNS`) to be classified as a `ContextOverflowError` and trigger compaction. Providers with non-standard error formats may not match these patterns, leaving the session stuck.

## Solution

Add a **pre-request overflow guard** in `prompt.ts` that estimates input token count before sending to the LLM. After preparing system prompts and model messages, the guard:

1. Serializes system prompts + model messages and estimates token count via `Token.estimate()`
2. Calculates the usable input limit (same formula as existing `isOverflow`)
3. If estimated tokens exceed the limit and auto-compress is enabled, triggers compaction proactively instead of sending the request

This prevents the API error entirely, regardless of provider error format.

### Guard behavior:
- Respects `compaction.auto` config setting
- Uses `KiloSessionPrompt.guardCompactionAttempt` to cap compaction attempts (same as existing compaction path)
- Falls through to normal LLM call when estimate is within limits

## Changes

- `packages/opencode/src/session/prompt.ts`: Added pre-request overflow guard with `Token` and `Config` imports

Closes #9500