### PR TITLE
feat: support custom autocomplete provider configuration in settings

### DIFF
--- a/.changeset/autocomplete-custom-provider-ui.md
+++ b/.changeset/autocomplete-custom-provider-ui.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+---
+
+Support custom autocomplete provider configuration in settings. Users can now configure the provider name, model, API base URL, API key, and custom headers directly from the VS Code extension UI.

--- a/.kilo/package-lock.json
+++ b/.kilo/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.2.21"
+        "@kilocode/plugin": "7.2.24"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.21.tgz",
-      "integrity": "sha512-PUo1Vc7OmOHZAxOdrFsez01e+JAX7jhyGw0caBOuXwAWuT39tGISjrUQoeW5k2/VqkZv3V8fPyvcuto0iuNeDA==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.24.tgz",
+      "integrity": "sha512-b2Xh3N/KaGdYj9hZbzZLKlDHXUsdMey0zL8G+RsnxDQCuhNm46LPyixtlJQhbCyir/zEEvy3uJI9kqKCsOWmQg==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.2.21",
+        "@kilocode/sdk": "7.2.24",
         "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.21.tgz",
-      "integrity": "sha512-iqhUEAEF4ouqXdlm3CuVCCh07FhMpjVT/QfZqDFAis7PO0JTmR76sCAMtqSzv8nogt/CFuR/vgpK79d+xZcM2g==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.24.tgz",
+      "integrity": "sha512-Yos6WeyvMl86OGXLQqQ9YWDm/geAC77xetoptEsS3DLtPVgvz1Nqkvas77fAuAqwkSfGL2mLIiHUTqJUTVflOw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.kilocode/package-lock.json
+++ b/.kilocode/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@kilocode/plugin": "7.2.21"
+        "@kilocode/plugin": "7.2.24"
       }
     },
     "node_modules/@kilocode/plugin": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.21.tgz",
-      "integrity": "sha512-PUo1Vc7OmOHZAxOdrFsez01e+JAX7jhyGw0caBOuXwAWuT39tGISjrUQoeW5k2/VqkZv3V8fPyvcuto0iuNeDA==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.2.24.tgz",
+      "integrity": "sha512-b2Xh3N/KaGdYj9hZbzZLKlDHXUsdMey0zL8G+RsnxDQCuhNm46LPyixtlJQhbCyir/zEEvy3uJI9kqKCsOWmQg==",
       "license": "MIT",
       "dependencies": {
-        "@kilocode/sdk": "7.2.21",
+        "@kilocode/sdk": "7.2.24",
         "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@kilocode/sdk": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.21.tgz",
-      "integrity": "sha512-iqhUEAEF4ouqXdlm3CuVCCh07FhMpjVT/QfZqDFAis7PO0JTmR76sCAMtqSzv8nogt/CFuR/vgpK79d+xZcM2g==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.2.24.tgz",
+      "integrity": "sha512-Yos6WeyvMl86OGXLQqQ9YWDm/geAC77xetoptEsS3DLtPVgvz1Nqkvas77fAuAqwkSfGL2mLIiHUTqJUTVflOw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/packages/kilo-i18n/src/en.ts
+++ b/packages/kilo-i18n/src/en.ts
@@ -83,4 +83,21 @@ export const dict = {
   "plan.followup.answer.newSession.description": "Implement in a fresh session with a clean context",
   "plan.followup.answer.continue": "Continue here",
   "plan.followup.answer.continue.description": "Implement the plan in this session",
+
+  // Autocomplete Custom Provider
+  "settings.autocomplete.customProvider.title": "Custom Provider",
+  "settings.autocomplete.customProvider.description": "Connect an OpenAI-compatible completion endpoint.",
+  "settings.autocomplete.customProvider.providerName.title": "Provider Name",
+  "settings.autocomplete.customProvider.providerName.placeholder": "e.g., ollama, openai",
+  "settings.autocomplete.customProvider.model.title": "Model",
+  "settings.autocomplete.customProvider.model.placeholder": "e.g., starcoder2",
+  "settings.autocomplete.customProvider.apiBase.title": "API Base URL",
+  "settings.autocomplete.customProvider.apiBase.placeholder": "e.g., http://localhost:11434/v1",
+  "settings.autocomplete.customProvider.apiKey.title": "API Key",
+  "settings.autocomplete.customProvider.apiKey.placeholder": "Enter your API key",
+  "settings.autocomplete.customProvider.headers.title": "Custom Headers",
+  "settings.autocomplete.customProvider.headers.description": "Add any required headers for authentication or routing.",
+  "settings.autocomplete.customProvider.headers.key.placeholder": "Header name",
+  "settings.autocomplete.customProvider.headers.value.placeholder": "Header value",
+  "settings.autocomplete.customProvider.headers.add": "Add header",
 }

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -35,7 +35,7 @@ const repo = resolve(root, "..", "..")
 
 // Stable per-repo directory under OS temp — no accumulation
 const hash = createHash("sha256").update(repo).digest("hex").slice(0, 12)
-const base = join(tmpdir(), `kilo-vscode-dev-${hash}`)
+const base = join(tmpdir(), `kilo-vscode-dev-v3-${hash}`)
 const userDir = join(base, "user-data")
 const extDir = join(base, "extensions")
 
@@ -114,13 +114,13 @@ function detect(): string {
     const order =
       prefer === "insiders"
         ? [
-            "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
-            "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
-          ]
+          "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
+          "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+        ]
         : [
-            "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
-            "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
-          ]
+          "/Applications/Visual Studio Code.app/Contents/MacOS/Code",
+          "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders",
+        ]
     candidates.push(...order)
   }
 
@@ -164,7 +164,7 @@ function detect(): string {
 
   console.error(
     `Could not find VS Code. Set VSCODE_EXEC_PATH or pass --app-path.\n` +
-      `Searched:\n${candidates.map((c) => `  ${c}`).join("\n")}`,
+    `Searched:\n${candidates.map((c) => `  ${c}`).join("\n")}`,
   )
   process.exit(1)
 }

--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteModel.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteModel.ts
@@ -1,17 +1,22 @@
 import { ResponseMetaData } from "./types"
 import type { KiloConnectionService } from "../cli-backend"
+import { IAutocompleteProvider } from "./IAutocompleteProvider"
+import { KiloGatewayProvider } from "./providers/KiloGatewayProvider"
+import { CustomProvider } from "./providers/CustomProvider"
 
 const DEFAULT_MODEL = "mistralai/codestral-2508"
 const PROVIDER_DISPLAY_NAME = "Kilo Gateway"
 
-export class AutocompleteModel {
+export class AutocompleteModel implements IAutocompleteProvider {
   private connectionService: KiloConnectionService | null = null
   public profileName: string | null = null
   public profileType: string | null = null
 
+  private activeProvider: IAutocompleteProvider | null = null
+
   constructor(connectionService?: KiloConnectionService) {
     if (connectionService) {
-      this.connectionService = connectionService
+      this.setConnectionService(connectionService)
     }
   }
 
@@ -20,102 +25,85 @@ export class AutocompleteModel {
    */
   public setConnectionService(service: KiloConnectionService): void {
     this.connectionService = service
+    this.activeProvider = new KiloGatewayProvider(service)
   }
 
   /**
-   * Generate a FIM (Fill-in-the-Middle) completion via the CLI backend.
-   * Uses the SDK's kilo.fim() SSE endpoint which handles auth and streaming.
-   *
-   * @param signal - Optional AbortSignal to cancel the SSE stream early (e.g. when the user types again)
+   * Resolve which provider to use based on the CLI config.
+   * Called only by refreshConfig() — the result is cached in activeProvider.
    */
+  private async resolveProvider(): Promise<IAutocompleteProvider> {
+    if (!this.connectionService) {
+      throw new Error("Connection service is not available")
+    }
+
+    try {
+      const client = await this.connectionService.getClientAsync()
+      const { data: config } = await client.config.get()
+
+      const autocomplete = config?.autocomplete
+      if (autocomplete?.provider && autocomplete?.api) {
+        return new CustomProvider(
+          autocomplete.provider,
+          autocomplete.model || DEFAULT_MODEL,
+          autocomplete.api,
+          autocomplete.options?.apiKey
+        )
+      }
+    } catch (err) {
+      console.warn("[autocomplete] Failed to resolve provider from config, using default", err)
+    }
+
+    return new KiloGatewayProvider(this.connectionService)
+  }
+
+  /**
+   * Fetch the latest config and cache the resolved provider.
+   * Should be called on load() and when CLI state changes.
+   */
+  public async refreshConfig(): Promise<void> {
+    this.activeProvider = await this.resolveProvider()
+  }
+
+  /**
+   * Returns the cached provider, falling back to KiloGateway if none resolved yet.
+   */
+  private getProvider(): IAutocompleteProvider {
+    if (!this.activeProvider && this.connectionService) {
+      this.activeProvider = new KiloGatewayProvider(this.connectionService)
+    }
+    if (!this.activeProvider) {
+      throw new Error("Connection service is not available")
+    }
+    return this.activeProvider
+  }
+
   public async generateFimResponse(
     prefix: string,
     suffix: string,
     onChunk: (text: string) => void,
     signal?: AbortSignal,
   ): Promise<ResponseMetaData> {
-    if (!this.connectionService) {
-      throw new Error("Connection service is not available")
-    }
-
-    const client = await this.connectionService.getClientAsync()
-
-    let cost = 0
-    let inputTokens = 0
-    let outputTokens = 0
-
-    // Capture SSE-level errors so they propagate to the caller. The SDK's SSE
-    // client catches HTTP errors (402, 401, 429, 5xx) internally and silently
-    // ends the stream. Without this, errors never reach ErrorBackoff.
-    let sseError: Error | undefined
-    const { stream } = await client.kilo.fim(
-      {
-        prefix,
-        suffix,
-        model: DEFAULT_MODEL,
-        maxTokens: 256,
-        temperature: 0.2,
-      },
-      {
-        signal,
-        sseMaxRetryAttempts: 1,
-        onSseError: (error) => {
-          sseError = error instanceof Error ? error : new Error(String(error))
-        },
-      },
-    )
-
-    for await (const chunk of stream) {
-      const content = chunk.choices?.[0]?.delta?.content
-      if (content) onChunk(content)
-      if (chunk.usage) {
-        inputTokens = chunk.usage.prompt_tokens ?? 0
-        outputTokens = chunk.usage.completion_tokens ?? 0
-      }
-      if (chunk.cost !== undefined) cost = chunk.cost
-    }
-
-    if (sseError) throw sseError
-
-    return {
-      cost,
-      inputTokens,
-      outputTokens,
-      cacheWriteTokens: 0,
-      cacheReadTokens: 0,
-    }
+    return this.getProvider().generateFimResponse(prefix, suffix, onChunk, signal)
   }
 
   public getModelName(): string {
-    return DEFAULT_MODEL
+    return this.activeProvider?.getModelName() ?? DEFAULT_MODEL
   }
 
   public getProviderDisplayName(): string {
-    return PROVIDER_DISPLAY_NAME
+    return this.activeProvider?.getProviderDisplayName() ?? PROVIDER_DISPLAY_NAME
   }
 
-  /**
-   * Check if the model has valid credentials.
-   * With CLI backend, credentials are managed by the backend — we just need a connection.
-   */
   public hasValidCredentials(): boolean {
-    if (!this.connectionService) {
-      return false
-    }
-    return this.connectionService.getConnectionState() === "connected"
+    if (!this.activeProvider) return false
+    return this.activeProvider.hasValidCredentials()
   }
 
-  /**
-   * Check the user's credit balance via the profile endpoint.
-   * Returns true if the user has a positive balance, false otherwise.
-   * Returns false on any error (not connected, fetch failed, etc.).
-   */
   public async hasBalance(): Promise<boolean> {
-    if (!this.connectionService) return false
+    if (!this.activeProvider) return false
     try {
-      const client = await this.connectionService.getClientAsync()
-      const result = await client.kilo.profile().catch(() => null)
-      return (result?.data?.balance?.balance ?? 0) > 0
+      return await this.activeProvider.hasBalance()
     } catch {
       return false
     }

--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
@@ -15,8 +15,6 @@ export interface AutocompleteServiceSettings {
   enableAutoTrigger?: boolean
   enableSmartInlineTaskKeybinding?: boolean
   enableChatAutocomplete?: boolean
-  provider?: string
-  model?: string
   snoozeUntil?: number
 }
 
@@ -117,6 +115,12 @@ export class AutocompleteServiceManager {
 
   public async load() {
     this.settings = readSettings()
+
+    try {
+      await this.model.refreshConfig()
+    } catch (err) {
+      console.warn("[autocomplete] Failed to refresh provider config", err)
+    }
 
     await this.updateGlobalContext()
     this.updateStatusBar()

--- a/packages/kilo-vscode/src/services/autocomplete/IAutocompleteProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/IAutocompleteProvider.ts
@@ -1,0 +1,18 @@
+import { ResponseMetaData } from "./types"
+
+export interface IAutocompleteProvider {
+  /**
+   * Generates a FIM (Fill-in-the-Middle) completion
+   */
+  generateFimResponse(
+    prefix: string,
+    suffix: string,
+    onChunk: (text: string) => void,
+    signal?: AbortSignal,
+  ): Promise<ResponseMetaData>
+
+  getModelName(): string
+  getProviderDisplayName(): string
+  hasValidCredentials(): boolean
+  hasBalance(): Promise<boolean>
+}

--- a/packages/kilo-vscode/src/services/autocomplete/__tests__/AutocompleteServiceManager.spec.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/__tests__/AutocompleteServiceManager.spec.ts
@@ -64,6 +64,7 @@ vi.mock("vscode", () => {
 vi.mock("../AutocompleteModel", () => {
   class AutocompleteModel {
     public profileName = "test-profile"
+    public refreshConfig = vi.fn().mockResolvedValue(undefined)
 
     public getModelName(): string {
       return "test-model"

--- a/packages/kilo-vscode/src/services/autocomplete/providers/CustomProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/providers/CustomProvider.ts
@@ -1,0 +1,210 @@
+import { ResponseMetaData } from "../types"
+import { IAutocompleteProvider } from "../IAutocompleteProvider"
+
+export class CustomProvider implements IAutocompleteProvider {
+  constructor(
+    private readonly providerName: string,
+    private readonly model: string,
+    private readonly apiBase: string,
+    private readonly apiKey?: string,
+  ) {}
+
+  private extractContent(data: any): string | undefined {
+    if (data.choices && data.choices.length > 0) {
+      const choice = data.choices[0]
+      return choice.text ?? choice.delta?.content
+    }
+    return data.response ?? data.message?.content
+  }
+
+  private updateStats(data: any, stats: { inputTokens: number; outputTokens: number }): void {
+    if (data.usage) {
+      if (data.usage.prompt_tokens !== undefined) stats.inputTokens = data.usage.prompt_tokens
+      if (data.usage.completion_tokens !== undefined) stats.outputTokens = data.usage.completion_tokens
+    } else if (data.prompt_eval_count !== undefined || data.eval_count !== undefined) {
+      if (data.prompt_eval_count !== undefined) stats.inputTokens = data.prompt_eval_count
+      if (data.eval_count !== undefined) stats.outputTokens = data.eval_count
+    }
+  }
+
+  private parseLine(
+    rawLine: string,
+    onChunk: (text: string) => void,
+    stats: { inputTokens: number; outputTokens: number }
+  ): void {
+    let raw = rawLine.trim()
+    if (raw === "data: [DONE]") return
+    if (raw.startsWith("data: ")) {
+      raw = raw.slice("data: ".length).trim()
+    }
+    if (!raw) return
+
+    try {
+      const data = JSON.parse(raw)
+      const content = this.extractContent(data)
+
+      if (content) onChunk(content)
+      this.updateStats(data, stats)
+    } catch {
+      // Silently ignore parse errors for incomplete JSON or empty lines
+    }
+  }
+
+  private async processStream(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    onChunk: (text: string) => void,
+    stats: { inputTokens: number; outputTokens: number }
+  ) {
+    const decoder = new TextDecoder()
+    let buffer = ""
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n")
+        buffer = lines.pop() ?? ""
+
+        for (const line of lines) {
+          this.parseLine(line, onChunk, stats)
+        }
+      }
+
+      if (buffer.trim()) {
+        this.parseLine(buffer, onChunk, stats)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  private isChatEndpoint(): boolean {
+    return this.apiBase.includes("/chat/completions")
+  }
+
+  private buildBody(prefix: string, suffix: string): string {
+    if (this.isChatEndpoint()) {
+      return JSON.stringify({
+        model: this.model,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are a code completion assistant. You will be given code with a prefix and suffix. " +
+              "Output ONLY the code that fills the gap between them. " +
+              "Do not include the prefix or suffix. Do not add explanations, markdown, or formatting.",
+          },
+          {
+            role: "user",
+            content: `Complete the code between <prefix> and <suffix>. Output ONLY the missing code.\n\n<prefix>\n${prefix}\n</prefix>\n<suffix>\n${suffix}\n</suffix>`,
+          },
+        ],
+        max_tokens: 256,
+        temperature: 0.2,
+        stream: true,
+      })
+    }
+
+    return JSON.stringify({
+      model: this.model,
+      prompt: prefix,
+      suffix,
+      max_tokens: 256,
+      temperature: 0.2,
+      stream: true,
+    })
+  }
+
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+
+    if (this.apiKey) {
+      const azure = this.apiBase.toLowerCase().includes("azure")
+      if (azure) {
+        headers["api-key"] = this.apiKey
+      } else {
+        headers["Authorization"] = `Bearer ${this.apiKey}`
+      }
+    }
+
+    return headers
+  }
+
+  private async processJsonResponse(
+    response: Response,
+    onChunk: (text: string) => void,
+    stats: { inputTokens: number; outputTokens: number }
+  ): Promise<void> {
+    const data = await response.json()
+    const content = this.extractContent(data)
+    if (content) onChunk(content)
+    this.updateStats(data, stats)
+  }
+
+  public async generateFimResponse(
+    prefix: string,
+    suffix: string,
+    onChunk: (text: string) => void,
+    signal?: AbortSignal,
+  ): Promise<ResponseMetaData> {
+    const url = this.apiBase
+    const headers = this.getHeaders()
+    const body = this.buildBody(prefix, suffix)
+
+    console.log(`[autocomplete] CustomProvider request → ${url} (model: ${this.model}, chat: ${this.isChatEndpoint()})`)
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body,
+      signal,
+    })
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      console.error(`[autocomplete] CustomProvider error ${response.status}: ${text}`)
+      throw new Error(`Custom provider returned status: ${response.status} ${response.statusText}`)
+    }
+
+    if (!response.body) {
+      throw new Error("No response body from custom provider")
+    }
+
+    const stats = { inputTokens: 0, outputTokens: 0 }
+    
+    const contentType = response.headers.get("content-type") || ""
+    if (contentType.includes("application/json")) {
+      await this.processJsonResponse(response, onChunk, stats)
+    } else {
+      await this.processStream(response.body.getReader(), onChunk, stats)
+    }
+
+    return {
+      cost: 0,
+      inputTokens: stats.inputTokens,
+      outputTokens: stats.outputTokens,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    }
+  }
+
+  public getModelName(): string {
+    return this.model
+  }
+
+  public getProviderDisplayName(): string {
+    return this.providerName
+  }
+
+  public hasValidCredentials(): boolean {
+    return true
+  }
+
+  public async hasBalance(): Promise<boolean> {
+    return true
+  }
+}

--- a/packages/kilo-vscode/src/services/autocomplete/providers/KiloGatewayProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/providers/KiloGatewayProvider.ts
@@ -1,0 +1,88 @@
+import { ResponseMetaData } from "../types"
+import type { KiloConnectionService } from "../../cli-backend"
+import { IAutocompleteProvider } from "../IAutocompleteProvider"
+
+const DEFAULT_MODEL = "mistralai/codestral-2508"
+const PROVIDER_DISPLAY_NAME = "Kilo Gateway"
+
+export class KiloGatewayProvider implements IAutocompleteProvider {
+  private connectionService: KiloConnectionService
+
+  constructor(connectionService: KiloConnectionService) {
+    this.connectionService = connectionService
+  }
+
+  public async generateFimResponse(
+    prefix: string,
+    suffix: string,
+    onChunk: (text: string) => void,
+    signal?: AbortSignal,
+  ): Promise<ResponseMetaData> {
+    const client = await this.connectionService.getClientAsync()
+
+    let cost = 0
+    let inputTokens = 0
+    let outputTokens = 0
+
+    // Capture SSE-level errors so they propagate to the caller.
+    let sseError: Error | undefined
+    const { stream } = await client.kilo.fim(
+      {
+        prefix,
+        suffix,
+        model: DEFAULT_MODEL,
+        maxTokens: 256,
+        temperature: 0.2,
+      },
+      {
+        signal,
+        sseMaxRetryAttempts: 1,
+        onSseError: (error) => {
+          sseError = error instanceof Error ? error : new Error(String(error))
+        },
+      },
+    )
+
+    for await (const chunk of stream) {
+      const content = chunk.choices?.[0]?.delta?.content
+      if (content) onChunk(content)
+      if (chunk.usage) {
+        inputTokens = chunk.usage.prompt_tokens ?? 0
+        outputTokens = chunk.usage.completion_tokens ?? 0
+      }
+      if (chunk.cost !== undefined) cost = chunk.cost
+    }
+
+    if (sseError) throw sseError
+
+    return {
+      cost,
+      inputTokens,
+      outputTokens,
+      cacheWriteTokens: 0,
+      cacheReadTokens: 0,
+    }
+  }
+
+  public getModelName(): string {
+    return DEFAULT_MODEL
+  }
+
+  public getProviderDisplayName(): string {
+    return PROVIDER_DISPLAY_NAME
+  }
+
+  public hasValidCredentials(): boolean {
+    return this.connectionService.getConnectionState() === "connected"
+  }
+
+  public async hasBalance(): Promise<boolean> {
+    try {
+      const client = await this.connectionService.getClientAsync()
+      const result = await client.kilo.profile().catch(() => null)
+      return (result?.data?.balance?.balance ?? 0) > 0
+    } catch {
+      return false
+    }
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AutocompleteTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AutocompleteTab.tsx
@@ -1,14 +1,19 @@
-import { Component, createSignal, onCleanup } from "solid-js"
+import { Component, createSignal, onCleanup, For } from "solid-js"
 import { Switch } from "@kilocode/kilo-ui/switch"
 import { Card } from "@kilocode/kilo-ui/card"
+import { TextField } from "@kilocode/kilo-ui/text-field"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Button } from "@kilocode/kilo-ui/button"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
+import { useConfig } from "../../context/config"
 import type { ExtensionMessage } from "../../types/messages"
 import SettingsRow from "./SettingsRow"
 
 const AutocompleteTab: Component = () => {
   const vscode = useVSCode()
   const language = useLanguage()
+  const { config, updateConfig } = useConfig()
 
   const [enableAutoTrigger, setEnableAutoTrigger] = createSignal(true)
   const [enableSmartInlineTaskKeybinding, setEnableSmartInlineTaskKeybinding] = createSignal(false)
@@ -34,8 +39,127 @@ const AutocompleteTab: Component = () => {
     vscode.postMessage({ type: "updateAutocompleteSetting", key, value })
   }
 
+  const handleProviderChange = (field: "provider" | "model" | "api" | "apiKey", value: string) => {
+    const prevAutocomplete = config().autocomplete ?? {}
+    if (field === "apiKey") {
+      updateConfig({
+        autocomplete: {
+          ...prevAutocomplete,
+          options: {
+            ...(prevAutocomplete.options ?? {}),
+            apiKey: value,
+          },
+        },
+      })
+    } else {
+      updateConfig({
+        autocomplete: {
+          ...prevAutocomplete,
+          [field]: value,
+        },
+      })
+    }
+  }
+
+  // Header management
+  const headersList = () => {
+    const headersObj = config().autocomplete?.options?.headers ?? {}
+    const entries = Object.entries(headersObj)
+    return entries.length > 0 ? entries : [["", ""]]
+  }
+
+  const addHeader = () => {
+    const currentHeaders = { ...(config().autocomplete?.options?.headers ?? {}) }
+    // Generate a unique empty key if "" already exists (rare, but just in case)
+    let newKey = ""
+    let counter = 1
+    while (newKey in currentHeaders) {
+      newKey = `new-header-${counter}`
+      counter++
+    }
+    currentHeaders[newKey] = ""
+
+    updateConfig({
+      autocomplete: {
+        ...(config().autocomplete ?? {}),
+        options: {
+          ...(config().autocomplete?.options ?? {}),
+          headers: currentHeaders,
+        },
+      },
+    })
+  }
+
+  const removeHeader = (keyToRemove: string, indexToRemove: number) => {
+    const currentHeaders = { ...(config().autocomplete?.options?.headers ?? {}) }
+    
+    // If we are removing an empty row that hasn't been saved to the object yet
+    const entries = headersList()
+    if (entries.length <= 1) return
+
+    if (keyToRemove in currentHeaders) {
+      delete currentHeaders[keyToRemove]
+      updateConfig({
+        autocomplete: {
+          ...(config().autocomplete ?? {}),
+          options: {
+            ...(config().autocomplete?.options ?? {}),
+            headers: currentHeaders,
+          },
+        },
+      })
+    }
+  }
+
+  const updateHeaderKey = (oldKey: string, newKey: string, index: number) => {
+    const entries = headersList()
+    const newHeaders: Record<string, string> = {}
+    
+    entries.forEach(([k, v], i) => {
+      if (i === index) {
+        newHeaders[newKey] = v
+      } else {
+        newHeaders[k] = v
+      }
+    })
+
+    updateConfig({
+      autocomplete: {
+        ...(config().autocomplete ?? {}),
+        options: {
+          ...(config().autocomplete?.options ?? {}),
+          headers: newHeaders,
+        },
+      },
+    })
+  }
+
+  const updateHeaderValue = (key: string, newValue: string, index: number) => {
+    const entries = headersList()
+    const newHeaders: Record<string, string> = {}
+    
+    entries.forEach(([k, v], i) => {
+      if (i === index) {
+        newHeaders[k] = newValue
+      } else {
+        newHeaders[k] = v
+      }
+    })
+
+    updateConfig({
+      autocomplete: {
+        ...(config().autocomplete ?? {}),
+        options: {
+          ...(config().autocomplete?.options ?? {}),
+          headers: newHeaders,
+        },
+      },
+    })
+  }
+
+
   return (
-    <div data-component="autocomplete-settings">
+    <div data-component="autocomplete-settings" style={{ display: "flex", "flex-direction": "column", gap: "16px" }}>
       <Card>
         <SettingsRow
           title={language.t("settings.autocomplete.autoTrigger.title")}
@@ -76,6 +200,96 @@ const AutocompleteTab: Component = () => {
             {language.t("settings.autocomplete.chatAutocomplete.title")}
           </Switch>
         </SettingsRow>
+      </Card>
+
+      <Card>
+        <div style={{ padding: "16px", display: "flex", "flex-direction": "column", gap: "16px" }}>
+          <div>
+            <div style={{ "font-size": "14px", "font-weight": "600", color: "var(--vscode-foreground)", "margin-bottom": "4px" }}>
+              {language.t("settings.autocomplete.customProvider.title")}
+            </div>
+            <div style={{ "font-size": "12px", color: "var(--vscode-descriptionForeground)" }}>
+              {language.t("settings.autocomplete.customProvider.description")}
+            </div>
+          </div>
+
+          <TextField
+            label={language.t("settings.autocomplete.customProvider.providerName.title")}
+            placeholder={language.t("settings.autocomplete.customProvider.providerName.placeholder")}
+            value={config().autocomplete?.provider ?? ""}
+            onChange={(val) => handleProviderChange("provider", val)}
+          />
+          <TextField
+            label={language.t("settings.autocomplete.customProvider.model.title")}
+            placeholder={language.t("settings.autocomplete.customProvider.model.placeholder")}
+            value={config().autocomplete?.model ?? ""}
+            onChange={(val) => handleProviderChange("model", val)}
+          />
+          <TextField
+            label={language.t("settings.autocomplete.customProvider.apiBase.title")}
+            placeholder={language.t("settings.autocomplete.customProvider.apiBase.placeholder")}
+            value={config().autocomplete?.api ?? ""}
+            onChange={(val) => handleProviderChange("api", val)}
+          />
+          <TextField
+            type="password"
+            label={language.t("settings.autocomplete.customProvider.apiKey.title")}
+            placeholder={language.t("settings.autocomplete.customProvider.apiKey.placeholder")}
+            value={config().autocomplete?.options?.apiKey ?? ""}
+            onChange={(val) => handleProviderChange("apiKey", val)}
+          />
+
+          <div style={{ display: "flex", "flex-direction": "column", gap: "12px", "margin-top": "8px" }}>
+            <div>
+              <div style={{ "font-size": "13px", "font-weight": "500", color: "var(--vscode-foreground)", "margin-bottom": "4px" }}>
+                {language.t("settings.autocomplete.customProvider.headers.title")}
+              </div>
+              <div style={{ "font-size": "12px", color: "var(--vscode-descriptionForeground)" }}>
+                {language.t("settings.autocomplete.customProvider.headers.description")}
+              </div>
+            </div>
+
+            <For each={headersList()}>
+              {([key, value], index) => (
+                <div style={{ display: "flex", gap: "8px", "align-items": "start" }}>
+                  <div style={{ flex: 1 }}>
+                    <TextField
+                      label={language.t("settings.autocomplete.customProvider.headers.key.placeholder")}
+                      hideLabel
+                      placeholder={language.t("settings.autocomplete.customProvider.headers.key.placeholder")}
+                      value={key}
+                      onChange={(newKey) => updateHeaderKey(key, newKey, index())}
+                    />
+                  </div>
+                  <div style={{ flex: 1 }}>
+                    <TextField
+                      label={language.t("settings.autocomplete.customProvider.headers.value.placeholder")}
+                      hideLabel
+                      placeholder={language.t("settings.autocomplete.customProvider.headers.value.placeholder")}
+                      value={value}
+                      onChange={(newValue) => updateHeaderValue(key, newValue, index())}
+                    />
+                  </div>
+                  <IconButton
+                    type="button"
+                    icon="trash"
+                    variant="ghost"
+                    onClick={() => removeHeader(key, index())}
+                    disabled={headersList().length <= 1 && key === "" && value === ""}
+                    aria-label="Remove header"
+                    style={{ "margin-top": "6px" }}
+                  />
+                </div>
+              )}
+            </For>
+
+            <div>
+              <Button type="button" size="small" variant="ghost" icon="plus-small" onClick={addHeader}>
+                {language.t("settings.autocomplete.customProvider.headers.add")}
+              </Button>
+            </div>
+          </div>
+        </div>
       </Card>
     </div>
   )

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -33,6 +33,7 @@ export const KNOWN_KEYS: ReadonlyArray<string> = [
   "tools",
   "layout",
   "experimental",
+  "autocomplete",
 ]
 
 export type ImportError = "invalidJson" | "invalidConfig" | "tooLarge"

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -2,6 +2,16 @@ import type { PermissionConfig } from "./permissions"
 import type { AgentConfig } from "./agents"
 import type { ProviderConfig } from "./providers"
 
+export interface AutocompleteConfig {
+  provider?: string
+  model?: string
+  api?: string
+  options?: {
+    apiKey?: string
+    headers?: Record<string, string>
+  }
+}
+
 export interface McpConfig {
   type?: "local" | "remote"
   command?: string[] | string
@@ -78,4 +88,5 @@ export interface Config {
   tools?: Record<string, boolean>
   layout?: "auto" | "stretch"
   experimental?: ExperimentalConfig
+  autocomplete?: AutocompleteConfig
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -162,6 +162,18 @@ const InfoSchema = Schema.Struct({
   small_model: Schema.optional(Schema.NullOr(ConfigModelID)).annotate({
     description: "Small model to use for tasks like title generation in the format of provider/model",
   }),
+  // kilocode_change start
+  autocomplete: Schema.optional(Schema.Struct({
+    provider: Schema.optional(Schema.String).annotate({ description: "Autocomplete provider name, e.g. openai" }),
+    model: Schema.optional(Schema.String).annotate({ description: "Autocomplete model name, e.g. starcoder2" }),
+    api: Schema.optional(Schema.String).annotate({ description: "Autocomplete API base URL, e.g. https://api.openai.com/v1" }),
+    options: Schema.optional(Schema.Struct({
+      apiKey: Schema.optional(Schema.String).annotate({ description: "API key for the autocomplete provider" }),
+      headers: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({ description: "Custom headers for the autocomplete provider" }),
+    })),
+  })).annotate({
+    description: "Configuration for inline code completion (FIM). Follows the same key conventions as provider configs.",
+  }),
   // kilocode_change end
   // kilocode_change start - renamed from "build" to "code"
   default_agent: Schema.optional(Schema.String).annotate({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1728,6 +1728,35 @@ export type Config = {
    */
   small_model?: string | null
   /**
+   * Configuration for inline code completion (FIM). Follows the same key conventions as provider configs.
+   */
+  autocomplete?: {
+    /**
+     * Autocomplete provider name, e.g. openai
+     */
+    provider?: string
+    /**
+     * Autocomplete model name, e.g. starcoder2
+     */
+    model?: string
+    /**
+     * Autocomplete API base URL, e.g. https://api.openai.com/v1
+     */
+    api?: string
+    options?: {
+      /**
+       * API key for the autocomplete provider
+       */
+      apiKey?: string
+      /**
+       * Custom headers for the autocomplete provider
+       */
+      headers?: {
+        [key: string]: string
+      }
+    }
+  }
+  /**
    * Default agent to use when none is specified. Must be a primary agent. Falls back to 'code' if not set or if the specified agent is invalid.
    */
   default_agent?: string


### PR DESCRIPTION
Implement UI in VS Code settings to configure custom autocomplete providers, including model, API URL, API key, and custom headers. This allows users to use local models or other OpenAI-compatible APIs for FIM autocomplete.

## Context

Currently, configuring a custom autocomplete provider (like Ollama, LM Studio, or a private OpenAI-compatible endpoint) requires manual edits to the `kilo.jsonc` file. This is prone to errors and doesn't allow for easy configuration of advanced settings like custom authentication headers or specific model names within the VS Code UI.
This PR introduces a dedicated "Custom Provider" section in the Autocomplete settings tab, making it easy for users to switch to local or third-party models for FIM (Fill-In-the-Middle) completion.

## Implementation

I achieved this by refactoring the autocomplete service into a pluggable provider architecture and extending the configuration system:
1.  **Pluggable Architecture**: Refactored `AutocompleteModel` and `AutocompleteServiceManager` to use a new `IAutocompleteProvider` interface. This cleanly separates the `KiloGatewayProvider` from the new `CustomProvider` implementation.
2.  **Schema Extension**: Updated the CLI configuration schema in `packages/opencode/src/config/config.ts` to include an `autocomplete` block. Notably, I added support for `options.headers` to allow passing arbitrary headers for authentication (e.g., Bearer tokens).
3.  **Config-Driven UI**: Updated `AutocompleteTab.tsx` to leverage the `useConfig()` hook. This allows the UI to directly interact with the `kilo.jsonc` state.
4.  **Dynamic Header Management**: Implemented a dynamic UI component for managing custom headers (key-value pairs) with the ability to add/remove rows, mirroring the experience found in the primary provider connection dialogs.
5.  **I18n Integration**: Added all required translation keys to `packages/kilo-i18n/src/en.ts` to ensure the UI remains consistent with the rest of the application.
**Tradeoffs**:
- **Hybrid State**: The Autocomplete tab now manages both VS Code settings (toggles) and CLI config settings (provider details). I ensured the "Unsaved Changes" bar correctly triggers when editing the provider details to maintain consistency with other Kilo config screens.


## Screenshots

| before | after |
| ------ | ----- |
|    
<img width="1325" height="554" alt="image" src="https://github.com/user-attachments/assets/3d1ab178-c3f8-4d3b-be5f-544f9e9236f8" />
    |     
<img width="1870" height="973" alt="image" src="https://github.com/user-attachments/assets/4154e21d-1d3c-48e0-ad50-e3a6c7f35da5" />
  |

## How to Test

 Open the Kilo Code extension in VS Code.
2.  Click on the **Settings** icon (gear) in the Kilo sidebar.
3.  Navigate to the **Autocomplete** tab.
4.  Locate the new **Custom Provider** card at the bottom of the page.
5.  Enter test values:
    *   **Provider Name**: `ollama`
    *   **Model**: `starcoder2`
    *   **API Base URL**: `http://localhost:11434/v1`
6.  Add a custom header by clicking **Add header** (e.g., Key: `X-Custom-Header`, Value: `test-value`).
7.  Verify that the "Unsaved changes" bar appears at the bottom of the screen.
8.  Click **Save**.
9.  Verify that your `~/.config/kilo/kilo.jsonc` file has been updated with an `autocomplete` section containing your inputs.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
