### PR TITLE
fix: deepseek reasoning_content round-tripping on openrouter

### DIFF
--- a/.changeset/openrouter-deepseek-reasoning.md
+++ b/.changeset/openrouter-deepseek-reasoning.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.
+Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter (direct and via Kilo gateway) by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.

--- a/.changeset/openrouter-deepseek-reasoning.md
+++ b/.changeset/openrouter-deepseek-reasoning.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.

--- a/.changeset/openrouter-deepseek-reasoning.md
+++ b/.changeset/openrouter-deepseek-reasoning.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter (direct and via Kilo gateway) by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.
+Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.

--- a/.changeset/openrouter-deepseek-reasoning.md
+++ b/.changeset/openrouter-deepseek-reasoning.md
@@ -1,5 +1,6 @@
 ---
 "@kilocode/cli": patch
+"@kilocode/kilo-gateway": patch
 ---
 
-Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter by bumping `@openrouter/ai-sdk-provider` to 2.8.1 and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes.
+Fix multi-turn DeepSeek reasoning round-tripping on OpenRouter by bumping `@openrouter/ai-sdk-provider` to 2.8.1 in both the CLI and Kilo Gateway packages and letting the SDK handle reasoning details, plus pulling in upstream DeepSeek variant, reasoning-effort, and assistant-reasoning fixes. New DeepSeek conversations are fixed; existing sessions that already stored empty reasoning metadata may still need to be restarted.

--- a/bun.lock
+++ b/bun.lock
@@ -416,7 +416,7 @@
         "@octokit/rest": "catalog:",
         "@openauthjs/openauth": "catalog:",
         "@opencode-ai/script": "workspace:*",
-        "@openrouter/ai-sdk-provider": "2.5.1",
+        "@openrouter/ai-sdk-provider": "2.8.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "2.6.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
@@ -1576,7 +1576,7 @@
 
     "@opencode-ai/ui": ["@opencode-ai/ui@workspace:packages/ui"],
 
-    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.5.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ=="],
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.8.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Y6j3yivgoEUf/kutD/k5GX/mzZfioRFoSx0gbQ+mIOzMaH/vJv1rCkztiuvlLw5xRYQil7oxHUZvmSfXqOx1NQ=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -5084,6 +5084,8 @@
 
     "@kilocode/kilo-gateway/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+POSFVcgiu47BK64dhsI6OpcDC0/VAE2ZSaXdXGNNhpC/ava++uSRJYks0k2bpfY0wwCTgpAWZsXn/dG2Yppiw=="],
 
+    "@kilocode/kilo-gateway/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.5.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ=="],
+
     "@kilocode/kilo-gateway/@opentui/core": ["@opentui/core@0.1.75", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.75", "@opentui/core-darwin-x64": "0.1.75", "@opentui/core-linux-arm64": "0.1.75", "@opentui/core-linux-x64": "0.1.75", "@opentui/core-win32-arm64": "0.1.75", "@opentui/core-win32-x64": "0.1.75", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-8ARRZxSG+BXkJmEVtM2DQ4se7DAF1ZCKD07d+AklgTr2mxCzmdxxPbOwRzboSQ6FM7qGuTVPVbV4O2W9DpUmoA=="],
 
     "@kilocode/kilo-gateway/@opentui/solid": ["@opentui/solid@0.1.75", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.75", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.9", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.9" } }, "sha512-WjKsZIfrm29znfRlcD9w3uUn/+uvoy2MmeoDwTvg1YOa0OjCTCmjZ43L9imp0m9S4HmVU8ma6o2bR4COzcyDdg=="],
@@ -5285,6 +5287,8 @@
     "ai-gateway-provider/@ai-sdk/openai": ["@ai-sdk/openai@3.0.48", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg=="],
 
     "ai-gateway-provider/@ai-sdk/xai": ["@ai-sdk/xai@3.0.75", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.37", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-V8UKK4fNpI9cnrtsZBvUp9O9J6Y9fTKBRoSLyEaNGPirACewixmLDbXsSgAeownPVWiWpK34bFysd+XouI5Ywg=="],
+
+    "ai-gateway-provider/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.5.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ=="],
 
     "ajv-keywords/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -210,7 +210,7 @@
         "@clack/prompts": "1.0.0-alpha.1",
         "@kilocode/plugin": "workspace:*",
         "@kilocode/sdk": "workspace:*",
-        "@openrouter/ai-sdk-provider": "2.5.1",
+        "@openrouter/ai-sdk-provider": "2.8.1",
         "ai": "catalog:",
         "open": "10.1.2",
         "zod": "catalog:",
@@ -5083,8 +5083,6 @@
     "@kilocode/kilo-gateway/@ai-sdk/openai": ["@ai-sdk/openai@3.0.48", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ALmj/53EXpcRqMbGpPJPP4UOSWw0q4VGpnDo7YctvsynjkrKDmoneDG/1a7VQnSPYHnJp6tTRMf5ZdxZ5whulg=="],
 
     "@kilocode/kilo-gateway/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-+POSFVcgiu47BK64dhsI6OpcDC0/VAE2ZSaXdXGNNhpC/ava++uSRJYks0k2bpfY0wwCTgpAWZsXn/dG2Yppiw=="],
-
-    "@kilocode/kilo-gateway/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.5.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ=="],
 
     "@kilocode/kilo-gateway/@opentui/core": ["@opentui/core@0.1.75", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.75", "@opentui/core-darwin-x64": "0.1.75", "@opentui/core-linux-arm64": "0.1.75", "@opentui/core-linux-x64": "0.1.75", "@opentui/core-win32-arm64": "0.1.75", "@opentui/core-win32-x64": "0.1.75", "bun-webgpu": "0.1.4", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-8ARRZxSG+BXkJmEVtM2DQ4se7DAF1ZCKD07d+AklgTr2mxCzmdxxPbOwRzboSQ6FM7qGuTVPVbV4O2W9DpUmoA=="],
 

--- a/packages/kilo-gateway/package.json
+++ b/packages/kilo-gateway/package.json
@@ -33,7 +33,7 @@
     "@ai-sdk/anthropic": "3.0.71",
     "@ai-sdk/openai": "3.0.48",
     "@ai-sdk/openai-compatible": "2.0.37",
-    "@openrouter/ai-sdk-provider": "2.5.1",
+    "@openrouter/ai-sdk-provider": "2.8.1",
     "@clack/prompts": "1.0.0-alpha.1",
     "ai": "catalog:",
     "open": "10.1.2",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -121,7 +121,7 @@
     "@octokit/rest": "catalog:",
     "@openauthjs/openauth": "catalog:",
     "@opencode-ai/script": "workspace:*",
-    "@openrouter/ai-sdk-provider": "2.5.1",
+    "@openrouter/ai-sdk-provider": "2.8.1",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "2.6.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.214.0",

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -201,7 +201,11 @@ function normalizeMessages(
     })
   }
 
-  if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
+  if (
+    typeof model.capabilities.interleaved === "object" &&
+    model.capabilities.interleaved.field &&
+    model.api.npm !== "@openrouter/ai-sdk-provider"
+  ) {
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -425,7 +425,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
 
   if (
-    id.includes("deepseek") ||
+    id.includes("deepseek-chat") ||
+    id.includes("deepseek-reasoner") ||
+    id.includes("deepseek-r1") ||
+    id.includes("deepseek-v3") ||
     id.includes("minimax") ||
     // id.includes("glm") || // kilocode_change
     id.includes("mistral") ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -183,6 +183,8 @@ function normalizeMessages(
     return result
   }
 
+  // kilocode_change start - cherry-picked from anomalyco/opencode#24180;
+  // will be reverted on the next wholesale upstream merge.
   // Deepseek requires all assistant messages to have reasoning on them
   if (model.api.id.includes("deepseek")) {
     msgs = msgs.map((msg) => {
@@ -200,12 +202,15 @@ function normalizeMessages(
       }
     })
   }
+  // kilocode_change end
 
+  // kilocode_change start - cherry-picked from anomalyco/opencode#24435
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
     model.api.npm !== "@openrouter/ai-sdk-provider"
   ) {
+    // kilocode_change end
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
@@ -447,10 +452,12 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
 
   if (
+    // kilocode_change start - cherry-picked from anomalyco/opencode#24157
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
     id.includes("deepseek-r1") ||
     id.includes("deepseek-v3") ||
+    // kilocode_change end
     id.includes("minimax") ||
     // id.includes("glm") || // kilocode_change
     id.includes("mistral") ||
@@ -594,11 +601,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
+      // kilocode_change start - cherry-picked from anomalyco/opencode#24163
       const efforts = [...WIDELY_SUPPORTED_EFFORTS]
       if (model.api.id.includes("deepseek-v4")) {
         efforts.push("max")
       }
       return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
+    // kilocode_change end
 
     case "@ai-sdk/azure":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -204,11 +204,13 @@ function normalizeMessages(
   }
   // kilocode_change end
 
-  // kilocode_change start - cherry-picked from anomalyco/opencode#24435
+  // kilocode_change start - cherry-picked from anomalyco/opencode#24435;
+  // also skip @kilocode/kilo-gateway since it wraps @openrouter/ai-sdk-provider internally.
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
-    model.api.npm !== "@openrouter/ai-sdk-provider"
+    model.api.npm !== "@openrouter/ai-sdk-provider" &&
+    model.api.npm !== "@kilocode/kilo-gateway"
   ) {
     // kilocode_change end
     const field = model.capabilities.interleaved.field

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -572,7 +572,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "venice-ai-sdk-provider":
     // https://docs.venice.ai/overview/guides/reasoning-models#reasoning-effort
     case "@ai-sdk/openai-compatible":
-      return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+      const efforts = [...WIDELY_SUPPORTED_EFFORTS]
+      if (model.api.id.includes("deepseek-v4")) {
+        efforts.push("max")
+      }
+      return Object.fromEntries(efforts.map((effort) => [effort, { reasoningEffort: effort }]))
 
     case "@ai-sdk/azure":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -204,13 +204,11 @@ function normalizeMessages(
   }
   // kilocode_change end
 
-  // kilocode_change start - cherry-picked from anomalyco/opencode#24435;
-  // also skip @kilocode/kilo-gateway since it wraps @openrouter/ai-sdk-provider internally.
+  // kilocode_change start - cherry-picked from anomalyco/opencode#24435
   if (
     typeof model.capabilities.interleaved === "object" &&
     model.capabilities.interleaved.field &&
-    model.api.npm !== "@openrouter/ai-sdk-provider" &&
-    model.api.npm !== "@kilocode/kilo-gateway"
+    model.api.npm !== "@openrouter/ai-sdk-provider"
   ) {
     // kilocode_change end
     const field = model.capabilities.interleaved.field

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -183,6 +183,24 @@ function normalizeMessages(
     return result
   }
 
+  // Deepseek requires all assistant messages to have reasoning on them
+  if (model.api.id.includes("deepseek")) {
+    msgs = msgs.map((msg) => {
+      if (msg.role !== "assistant") return msg
+      if (Array.isArray(msg.content)) {
+        if (msg.content.some((part) => part.type === "reasoning")) return msg
+        return { ...msg, content: [...msg.content, { type: "reasoning", text: "" }] }
+      }
+      return {
+        ...msg,
+        content: [
+          ...(msg.content ? [{ type: "text" as const, text: msg.content }] : []),
+          { type: "reasoning" as const, text: "" },
+        ],
+      }
+    })
+  }
+
   if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -803,6 +803,79 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("preserves OpenRouter reasoning details through provider transform", async () => {
+    const assistantID = "m-assistant"
+    const openrouterModel: Provider.Model = {
+      ...model,
+      id: ModelID.make("deepseek/deepseek-v4-pro"),
+      providerID: ProviderID.make("openrouter"),
+      api: {
+        id: "deepseek/deepseek-v4-pro",
+        url: "https://openrouter.ai/api/v1",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+      capabilities: {
+        ...model.capabilities,
+        reasoning: true,
+        interleaved: { field: "reasoning_details" },
+      },
+    }
+    const reasoningDetails = [
+      {
+        type: "reasoning.text",
+        text: "thinking",
+        format: "unknown",
+        index: 0,
+      },
+    ]
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent", undefined, {
+          providerID: openrouterModel.providerID,
+          modelID: openrouterModel.id,
+        }),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "reasoning",
+            text: "thinking",
+            time: { start: 0 },
+            metadata: {
+              openrouter: {
+                reasoning_details: reasoningDetails,
+              },
+            },
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "text",
+            text: "answer",
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(
+      ProviderTransform.message(await MessageV2.toModelMessages(input, openrouterModel), openrouterModel, {}),
+    ).toStrictEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "thinking",
+            providerOptions: {
+              openrouter: {
+                reasoning_details: reasoningDetails,
+              },
+            },
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ])
+  })
+
   test("splits assistant messages on step-start boundaries", async () => {
     const assistantID = "m-assistant"
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -878,6 +878,63 @@ describe("session.message-v2.toModelMessage", () => {
   })
   // kilocode_change end
 
+  // kilocode_change start - Kilo gateway wraps @openrouter/ai-sdk-provider so same skip applies
+  test("preserves reasoning details through Kilo gateway (wraps openrouter SDK)", async () => {
+    const assistantID = "m-assistant"
+    const gatewayModel: Provider.Model = {
+      ...model,
+      id: ModelID.make("deepseek/deepseek-v4-pro"),
+      providerID: ProviderID.make("kilocode"),
+      api: {
+        id: "deepseek/deepseek-v4-pro",
+        url: "https://api.kilo.ai/api/openrouter",
+        npm: "@kilocode/kilo-gateway",
+      },
+      capabilities: {
+        ...model.capabilities,
+        reasoning: true,
+        interleaved: { field: "reasoning_details" },
+      },
+    }
+    const reasoningDetails = [{ type: "reasoning.text", text: "thinking", format: "unknown", index: 0 }]
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent", undefined, {
+          providerID: gatewayModel.providerID,
+          modelID: gatewayModel.id,
+        }),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "reasoning",
+            text: "thinking",
+            time: { start: 0 },
+            metadata: { openrouter: { reasoning_details: reasoningDetails } },
+          },
+          { ...basePart(assistantID, "a2"), type: "text", text: "answer" },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(
+      ProviderTransform.message(await MessageV2.toModelMessages(input, gatewayModel), gatewayModel, {}),
+    ).toStrictEqual([
+      {
+        role: "assistant",
+        providerOptions: undefined,
+        content: [
+          {
+            type: "reasoning",
+            text: "thinking",
+            providerOptions: { openrouter: { reasoning_details: reasoningDetails } },
+          },
+          { type: "text", text: "answer", providerOptions: undefined },
+        ],
+      },
+    ])
+  })
+  // kilocode_change end
+
   test("splits assistant messages on step-start boundaries", async () => {
     const assistantID = "m-assistant"
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -803,6 +803,7 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  // kilocode_change start - cherry-picked from anomalyco/opencode#24435
   test("preserves OpenRouter reasoning details through provider transform", async () => {
     const assistantID = "m-assistant"
     const openrouterModel: Provider.Model = {
@@ -875,6 +876,7 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ])
   })
+  // kilocode_change end
 
   test("splits assistant messages on step-start boundaries", async () => {
     const assistantID = "m-assistant"

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -878,63 +878,6 @@ describe("session.message-v2.toModelMessage", () => {
   })
   // kilocode_change end
 
-  // kilocode_change start - Kilo gateway wraps @openrouter/ai-sdk-provider so same skip applies
-  test("preserves reasoning details through Kilo gateway (wraps openrouter SDK)", async () => {
-    const assistantID = "m-assistant"
-    const gatewayModel: Provider.Model = {
-      ...model,
-      id: ModelID.make("deepseek/deepseek-v4-pro"),
-      providerID: ProviderID.make("kilocode"),
-      api: {
-        id: "deepseek/deepseek-v4-pro",
-        url: "https://api.kilo.ai/api/openrouter",
-        npm: "@kilocode/kilo-gateway",
-      },
-      capabilities: {
-        ...model.capabilities,
-        reasoning: true,
-        interleaved: { field: "reasoning_details" },
-      },
-    }
-    const reasoningDetails = [{ type: "reasoning.text", text: "thinking", format: "unknown", index: 0 }]
-    const input: MessageV2.WithParts[] = [
-      {
-        info: assistantInfo(assistantID, "m-parent", undefined, {
-          providerID: gatewayModel.providerID,
-          modelID: gatewayModel.id,
-        }),
-        parts: [
-          {
-            ...basePart(assistantID, "a1"),
-            type: "reasoning",
-            text: "thinking",
-            time: { start: 0 },
-            metadata: { openrouter: { reasoning_details: reasoningDetails } },
-          },
-          { ...basePart(assistantID, "a2"), type: "text", text: "answer" },
-        ] as MessageV2.Part[],
-      },
-    ]
-
-    expect(
-      ProviderTransform.message(await MessageV2.toModelMessages(input, gatewayModel), gatewayModel, {}),
-    ).toStrictEqual([
-      {
-        role: "assistant",
-        providerOptions: undefined,
-        content: [
-          {
-            type: "reasoning",
-            text: "thinking",
-            providerOptions: { openrouter: { reasoning_details: reasoningDetails } },
-          },
-          { type: "text", text: "answer", providerOptions: undefined },
-        ],
-      },
-    ])
-  })
-  // kilocode_change end
-
   test("splits assistant messages on step-start boundaries", async () => {
     const assistantID = "m-assistant"
 


### PR DESCRIPTION
## Summary

Fixes multi-turn DeepSeek reasoning on OpenRouter (`reasoning_content not round-tripped`, 400s on tool calls). Bumps `@openrouter/ai-sdk-provider` to 2.8.1 in both `@kilocode/cli` and `@kilocode/kilo-gateway`, so the Kilo Gateway path uses the updated OpenRouter serializer too.

Cherry-picks the upstream fix + three prior DeepSeek dependencies it assumes.

## Cherry-picked upstream PRs

| Upstream PR | Commit | Purpose |
|---|---|---|
| [anomalyco/opencode#24157](https://github.com/anomalyco/opencode/pull/24157) | `67de590e71` | Narrow DeepSeek variant match (`deepseek-chat`, `-reasoner`, `-r1`, `-v3`) instead of any `deepseek`. |
| [anomalyco/opencode#24163](https://github.com/anomalyco/opencode/pull/24163) | `3d219b5ff0` | Add `max` reasoning-effort variant for `deepseek-v4`. |
| [anomalyco/opencode#24180](https://github.com/anomalyco/opencode/pull/24180) | `f724b8f3af` | Ensure every assistant message for DeepSeek has a `reasoning` part (empty if absent) — prerequisite for the round-trip fix. |
| [anomalyco/opencode#24435](https://github.com/anomalyco/opencode/pull/24435) | `be25acb17a` + `c884cea5ba` | Bump `@openrouter/ai-sdk-provider` to 2.8.1 and skip the interleaved-reasoning transform for direct OpenRouter (the new SDK handles it). Adds a regression test. |

Closes the same upstream issues: [#24261](https://github.com/anomalyco/opencode/issues/24261), [#24190](https://github.com/anomalyco/opencode/issues/24190).

## Kilo-specific follow-up

- Also bumps `packages/kilo-gateway` to `@openrouter/ai-sdk-provider@2.8.1`. The Kilo Gateway provider imports `createOpenRouter` directly, so the `kilocode/*` model path was still using 2.5.1 until this was added.
- Reverted the earlier Kilo-specific transform guard for `@kilocode/kilo-gateway`; the correct fix is to use the updated SDK in the gateway package instead of changing opencode's transform behavior.
- Existing sessions that already stored empty OpenRouter reasoning metadata may remain broken and should be restarted; new sessions work with the updated SDK path.

## Validation

- `packages/kilo-gateway`: `bun run typecheck`
- `packages/opencode`: `bun test test/session/message-v2.test.ts`
- repo root: `bun run script/check-opencode-annotations.ts`

## Notes

- All upstream shared-code changes are annotated with `// kilocode_change` markers referencing the source PR, so they can be identified and collapsed on the next wholesale upstream merge.
- `bun.lock` was regenerated locally rather than cherry-picked (upstream's lockfile is incompatible with our fork's workspace layout).