### PR TITLE
test(cli): guard queued prompt request tail

### DIFF
--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -63,6 +63,21 @@ function hasText(msg: Awaited<ReturnType<typeof SessionPrompt.prompt>>, text: st
   return msg.parts.some((part) => part.type === "text" && part.text.includes(text))
 }
 
+// Find the last non-system message in an OpenAI-compatible request body. Kept
+// tolerant: we only care about role invariants, not the exact content shape,
+// because providers may serialize `content` as a string or as a parts array.
+function lastConversational(body: Record<string, unknown>): { role: string; content: unknown } | undefined {
+  const msgs = Array.isArray(body.messages) ? (body.messages as Array<Record<string, unknown>>) : []
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const msg = msgs[i]
+    if (!msg || typeof msg !== "object") continue
+    const role = typeof msg.role === "string" ? msg.role : undefined
+    if (!role || role === "system") continue
+    return { role, content: msg.content }
+  }
+  return undefined
+}
+
 function user(sessionID: SessionID, id: MessageID): MessageV2.WithParts {
   return {
     info: {
@@ -303,18 +318,21 @@ describe("session prompt queue", () => {
     const ready = Promise.withResolvers<void>()
     const injected = Promise.withResolvers<void>()
     const calls: number[] = []
+    const bodies: Array<Record<string, unknown>> = []
     const server = Bun.serve({
       port: 0,
-      fetch(req) {
+      async fetch(req) {
         const url = new URL(req.url)
         if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
 
+        const body = (await req.json().catch(() => ({}))) as Record<string, unknown>
+        bodies.push(body)
         calls.push(Date.now())
-        const body =
+        const stream =
           calls.length === 1
             ? reply({ text: "first reply", ready: ready.resolve })
             : reply({ text: "second reply", ready: injected.resolve })
-        return new Response(body, {
+        return new Response(stream, {
           status: 200,
           headers: { "Content-Type": "text/event-stream" },
         })
@@ -408,6 +426,18 @@ describe("session prompt queue", () => {
           }
           expect(firstReply.info.parentID).toBe(firstUser.info.id)
           expect(secondReply.info.parentID).toBe(secondUser.info.id)
+
+          // Regression for #9492: the second LLM request must end with the
+          // queued user prompt, not an assistant tail from the prior turn.
+          // Anthropic's API rejects requests whose final message is assistant
+          // (prefill), and scope() is supposed to partition the queued target
+          // turn to the end before the model request is built.
+          expect(bodies).toHaveLength(2)
+          const second2 = bodies[1]
+          expect(JSON.stringify(second2)).toContain("second prompt")
+          const tail = lastConversational(second2)
+          expect(tail?.role).toBe("user")
+          expect(JSON.stringify(tail?.content)).toContain("second prompt")
         },
       })
     } finally {

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -885,7 +885,13 @@ it.live(
   10_000, // kilocode_change
 )
 
-// kilocode_change start - skip flaky test, tracked in #8990
+// kilocode_change start - #9492: the upstream fork-based shape of this test
+// loses Instance AsyncLocalStorage context in the second forked prompt, which
+// surfaces as a "No context found for instance" die before the queue behavior
+// can be exercised. The Kilo queue semantics (in-flight stream drains, second
+// LLM request ends with the queued user message) are covered end-to-end in
+// packages/opencode/test/kilocode/session-prompt-queue.test.ts — keep this
+// upstream scaffold skipped so future OpenCode merges remain friction-free.
 it.live.skip(
   "prompt submitted during an active run is included in the next LLM input",
   // kilocode_change end


### PR DESCRIPTION
## Why

When you type a new message while the AI is still replying, Kilo has to stash it and send it to the model after the current answer finishes. Issue #9492 reported that the test that proved this was skipped during an upstream merge, so we lost the guard that the second message actually gets delivered correctly.

## What changed

The Kilo prompt queue integration test now captures every request the fake model server receives, not just counts them. After the two prompts finish, it checks that the second request actually ends with the user's queued message instead of leftover text from the previous assistant turn — that's the exact shape Anthropic needs, and the real bug the skipped upstream test was supposed to catch. The upstream-style skipped test stays skipped for now (its fork-based setup loses context before the queue logic runs), but its comment now points reviewers at the Kilo-specific test as the source of truth.

## How to test

1. From `packages/opencode/`, run `bun test test/kilocode/session-prompt-queue.test.ts` and confirm 11 pass.
2. From `packages/opencode/`, run `bun test test/session/prompt-effect.test.ts` and confirm 31 pass with 4 skipped (unchanged baseline).
3. Optional: run the queue test a few times in a row to confirm the new assertion is deterministic, not flaky.