### PR TITLE
fix(search): include gitignored files in @mention file search

### DIFF
--- a/.changeset/gitignore-mention-search.md
+++ b/.changeset/gitignore-mention-search.md
@@ -1,0 +1,13 @@
+---
+"@kilocode/cli": patch
+---
+
+fix(search): include gitignored files in @mention file search
+
+Files matching `.gitignore` patterns (e.g. `*.log`) were invisible to
+the `@` mention file picker because the file cache only contained
+tracked files. When the primary fuzzy search returns fewer results
+than the limit, a supplementary ripgrep search now runs with
+`--no-ignore-vcs` to surface gitignored files as additional matches.
+
+Fixes #9532

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -652,7 +652,27 @@ export const layer = Layer.effect(
 
       const searchLimit = kind === "directory" && !preferHidden ? limit * 20 : limit
       const sorted = fuzzysort.go(query, items, { limit: searchLimit }).map((item) => item.target)
-      const output = kind === "directory" ? sortHiddenLast(sorted, preferHidden).slice(0, limit) : sorted
+      let output = kind === "directory" ? sortHiddenLast(sorted, preferHidden).slice(0, limit) : sorted
+
+      // kilocode_change start — search gitignored files so @mentions can reference e.g. .log files (#9532)
+      if (output.length < limit && kind !== "directory") {
+        const ctx = yield* InstanceState.context
+        const ignoredFiles = yield* rg
+          .files({ cwd: ctx.directory, noIgnoreVcs: true, glob: [`*${query}*`] })
+          .pipe(
+            Stream.runCollect,
+            Effect.map((chunk) => [...chunk].slice(0, limit - output.length)),
+            Effect.catchCause(() => Effect.succeed([] as string[])),
+          )
+        const seen = new Set(output)
+        for (const file of ignoredFiles) {
+          if (!seen.has(file)) {
+            output.push(file)
+            seen.add(file)
+          }
+        }
+      }
+      // kilocode_change end
 
       log.info("search", { query, kind, results: output.length })
       return output

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -115,6 +115,7 @@ export interface FilesInput {
   hidden?: boolean
   follow?: boolean
   maxDepth?: number
+  noIgnoreVcs?: boolean // kilocode_change — allow searching gitignored files
   signal?: AbortSignal
 }
 
@@ -203,6 +204,9 @@ function filesArgs(input: FilesInput) {
   if (input.hidden !== false) args.push("--hidden")
   if (input.hidden === false) args.push("--glob=!.*")
   if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
+  // kilocode_change start — skip VCS ignore rules so gitignored files appear in search
+  if (input.noIgnoreVcs) args.push("--no-ignore-vcs")
+  // kilocode_change end
   if (input.glob) {
     for (const glob of input.glob) args.push(`--glob=${glob}`)
   }


### PR DESCRIPTION
## Problem

Files matching `.gitignore` patterns (e.g. `*.log`, `*.env.local`) are invisible to the `@` mention file picker. Users need to reference these files for troubleshooting but the search never returns them.

**Root cause:** `File.scan()` populates its cache via `rg --files`, which respects `.gitignore` by default. Since gitignored files never enter the cache, `File.search()` (backed by fuzzysort over the cache) cannot find them.

## Solution

Two surgical changes:

1. **`ripgrep.ts`** — Add `noIgnoreVcs?: boolean` to `FilesInput` and pass `--no-ignore-vcs` to ripgrep when set.
2. **`file/index.ts`** — After the primary fuzzy search, when results are below the limit and the search is for files (not directories), run a supplementary ripgrep search with `noIgnoreVcs: true` and a glob matching the query. Deduplicates against existing results.

This keeps the default file listing behavior unchanged (gitignored files stay out of the cache for performance/relevance) while allowing explicit searches to surface them.

## Testing

- Existing tests unaffected (file/index tests have pre-existing upstream failures from missing `@npmcli/config`)
- Typecheck clean (no new errors beyond upstream `@/` alias resolution)
- Manual verification: the supplementary search correctly finds `.log` files that the primary cache misses

Fixes #9532