### PR TITLE
fix: default edit-tool diff to side-by-side (split) view

### DIFF
--- a/.changeset/edit-tool-diff-split-view.md
+++ b/.changeset/edit-tool-diff-split-view.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open edit-tool diffs in side-by-side (split) mode by default; permission-dock expand stays unified.

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -8,6 +8,7 @@ export interface DiffVirtualFile {
   after: string
   additions: number
   deletions: number
+  initialDiffStyle: "unified" | "split"
 }
 
 /**
@@ -83,7 +84,7 @@ export class DiffVirtualProvider implements vscode.Disposable {
 
   private pushData(): void {
     if (!this.pending) return
-    this.post({ type: "diffVirtual.data", diff: this.pending })
+    this.post({ type: "diffVirtual.data", diff: this.pending, initialDiffStyle: this.pending.initialDiffStyle })
   }
 
   private post(message: Record<string, unknown>): void {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -711,7 +711,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           vscode.commands.executeCommand("kilo-code.new.showChanges")
           break
         case "openDiffVirtual":
-          this.openDiffVirtual(message.diff)
+          this.openDiffVirtual(message.diff, message.initialDiffStyle)
           break
         case "continueInWorktree":
           handleContinueInWorktree({
@@ -1062,9 +1062,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     void vscode.env.openExternal(vscode.Uri.parse(url))
   }
 
-  private openDiffVirtual(diff: unknown): void {
+  private openDiffVirtual(diff: unknown, initialDiffStyle?: unknown): void {
     if (!this.diffVirtualProvider || !diff) return
-    this.diffVirtualProvider.open(diff as import("./DiffVirtualProvider").DiffVirtualFile)
+    const d = diff as import("./DiffVirtualProvider").DiffVirtualFile
+    d.initialDiffStyle = initialDiffStyle === "split" ? "split" : "unified"
+    this.diffVirtualProvider.open(d)
   }
 
   /**

--- a/packages/kilo-vscode/tests/unit/databridge-shape.test.ts
+++ b/packages/kilo-vscode/tests/unit/databridge-shape.test.ts
@@ -68,7 +68,9 @@ describe("DataBridge openDiff wiring (regression guard)", () => {
   }
 
   it("wires openDiff to the openDiffVirtual webview message", () => {
-    expect(openDiffBlock()).toMatch(/postMessage\(\{\s*type:\s*["']openDiffVirtual["']\s*,\s*diff\s*\}\)/)
+    expect(openDiffBlock()).toMatch(
+      /postMessage\(\{\s*type:\s*["']openDiffVirtual["']\s*,\s*diff\s*,\s*initialDiffStyle:\s*["']split["']\s*\}\)/,
+    )
     expect(src).toContain("onOpenDiff={openDiff}")
   })
 })

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -32,9 +32,10 @@ const DiffVirtualContent: Component = () => {
   const [style, setStyle] = createSignal<DiffStyle>("unified")
 
   const handler = (event: MessageEvent) => {
-    const msg = event.data as { type: string; diff?: DiffVirtualFile }
+    const msg = event.data as { type: string; diff?: DiffVirtualFile; initialDiffStyle?: DiffStyle }
     if (msg?.type === "diffVirtual.data" && msg.diff) {
       setDiff(msg.diff)
+      setStyle(msg.initialDiffStyle ?? "unified")
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -134,7 +134,7 @@ export const DataBridge: Component<{ children: any }> = (props) => {
   }
 
   const openDiff = (diff: { file: string; before: string; after: string; additions: number; deletions: number }) => {
-    vscode.postMessage({ type: "openDiffVirtual", diff })
+    vscode.postMessage({ type: "openDiffVirtual", diff, initialDiffStyle: "split" })
   }
 
   const openUrl = (url: string) => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDiff.tsx
@@ -39,6 +39,7 @@ export const PermissionDiff: Component<PermissionDiffProps> = (props) => {
     vscode.postMessage({
       type: "openDiffVirtual",
       diff: { ...props.filediff, before, after },
+      initialDiffStyle: "unified",
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -723,6 +723,7 @@ export interface OpenChangesRequest {
 export interface OpenDiffVirtualRequest {
   type: "openDiffVirtual"
   diff: PermissionFileDiff
+  initialDiffStyle: "unified" | "split"
 }
 
 export interface RetryConnectionRequest {


### PR DESCRIPTION
## Context

Add an explicit initialDiffStyle field to the openDiffVirtual message flow so each caller declares the desired diff style up front while having `unified` diff as default to prevent regressions..
Related issue: #9398

## Implementation

- Add `initialDiffStyle` parameter to the diff handlers
- Set `initialDiffStyle` default value to `unified` (as before) but override it to `split` in the edit tool.

## Screenshots

| before | after |
| ------ | ----- |
| <img width="1431" height="901" alt="before" src="https://github.com/user-attachments/assets/3e6555bf-ad50-4036-8f84-a3b1094baf46" />  |  <img width="1431" height="901" alt="after" src="https://github.com/user-attachments/assets/94aba2cb-4457-448b-81ed-6e96a3ae132e" /> |

Agent Manager (split):
<img width="1431" height="901" alt="agent-manager" src="https://github.com/user-attachments/assets/49c9d066-89ac-4ac6-adf8-e228536fa68a" />

Permissions (unified):
<img width="1431" height="901" alt="permissions-stay-unified" src="https://github.com/user-attachments/assets/3b4a55ae-72b6-4ebc-92c9-13fafa9d9562" />


## How to Test

- `bun test tests/unit/kilo-ui-contract.test.ts tests/unit/databridge-shape.test.ts`
- `bun turbo typecheck --force`
- `bun turbo tests --force`
- In the extension, write a prompt asking for an edit, click the edit tool file path, and confirm the diff panel opens.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
