### PR TITLE
fix(cli): use Kilo cache for npm packages

### DIFF
--- a/.changeset/fuzzy-pigs-drop.md
+++ b/.changeset/fuzzy-pigs-drop.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Install npm-managed plugins and runtime packages under Kilo's cache directory.

--- a/packages/kilo-docs/pages/automate/extending/plugins.md
+++ b/packages/kilo-docs/pages/automate/extending/plugins.md
@@ -90,7 +90,7 @@ The command resolves the package, reads its `package.json` for plugin entrypoint
 
 ### How plugins are installed
 
-- **npm plugins** are installed automatically at startup using Bun. Packages and their dependencies are cached in Kilo's XDG cache directory (`~/.cache/kilo/` on Linux, `~/Library/Caches/kilo/` on macOS, `%LOCALAPPDATA%\kilo\` on Windows).
+- **npm plugins** are installed automatically at startup using Bun. Packages and their dependencies are cached under `packages/` in Kilo's XDG cache directory (`~/.cache/kilo/packages/` by default, or `$XDG_CACHE_HOME/kilo/packages/` when `XDG_CACHE_HOME` is set).
 - **Pinned npm versions** like `my-plugin@1.2.3` install that exact version and do not check for newer registry versions. Bare package names resolve to `latest` and can refresh when the cached copy becomes stale.
 - **Install scripts are disabled** for npm plugins. Kilo installs packages with lifecycle scripts such as `install` and `postinstall` blocked.
 - **Local plugins** are loaded directly from the plugin directory. If your plugin imports external packages, add a `package.json` to your config directory (see [Dependencies](#dependencies)) — Kilo runs `bun install` on startup so imports resolve.
@@ -596,8 +596,8 @@ Host slots include `home_prompt_right`, `session_prompt`, `session_prompt_right`
 - **Package installed but not active in one runtime** — make sure the package exposes the matching entrypoint. Server plugins need `exports["./server"]` or `main`; TUI plugins need `exports["./tui"]` or valid `oc-themes`. Packages that only support the other runtime are skipped with a warning instead of causing a fatal load error.
 
 - **Local plugin can't find an npm import** — add a `package.json` in the config directory so `bun install` picks up the dependency (see [Dependencies](#dependencies)).
-- **Plugin loads in dev but not in CI** — verify `KILO_PURE` is not set, and that npm-installed plugins are cached (Kilo's XDG cache directory — `~/.cache/kilo/` on Linux, `~/Library/Caches/kilo/` on macOS, `%LOCALAPPDATA%\kilo\` on Windows). Run with `--log-level DEBUG` to see install output.
-- **Reset the plugin cache** — delete the `node_modules/` under Kilo's cache directory (or the `node_modules` cache under your config directory) and restart Kilo.
+- **Plugin loads in dev but not in CI** — verify `KILO_PURE` is not set, and that npm-installed plugins are cached under `packages/` in Kilo's XDG cache directory (`~/.cache/kilo/packages/` by default, or `$XDG_CACHE_HOME/kilo/packages/` when `XDG_CACHE_HOME` is set). Run with `--log-level DEBUG` to see install output.
+- **Reset the plugin cache** — delete the plugin package folder under Kilo's `packages/` cache directory (or the `node_modules` cache under your config directory) and restart Kilo.
 
 ---
 

--- a/packages/opencode/test/npm.test.ts
+++ b/packages/opencode/test/npm.test.ts
@@ -9,6 +9,9 @@ import { EffectFlock } from "@opencode-ai/shared/util/effect-flock"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { Npm } from "../src/npm"
 import { tmpdir } from "./fixture/fixture"
+// kilocode_change start
+import { Global as KiloGlobal } from "../src/global"
+// kilocode_change end
 
 const win = process.platform === "win32"
 const encoder = new TextEncoder()
@@ -93,6 +96,20 @@ describe("Npm.install", () => {
     await expect(fs.stat(path.join(tmp.path, "node_modules", "dev-pkg"))).rejects.toThrow()
   })
 })
+
+// kilocode_change start - guards that shared.Global stays aligned with Kilo's Global.Path
+describe("Npm.which", () => {
+  test("resolves cached binaries from Kilo XDG cache", async () => {
+    const dir = path.join(KiloGlobal.Path.cache, "packages", "acme", "node_modules", ".bin")
+    await fs.mkdir(dir, { recursive: true })
+    await Bun.write(path.join(dir, "acme"), "#!/usr/bin/env node\n")
+
+    const result = await Npm.which("acme")
+
+    expect(result).toBe(path.join(dir, "acme"))
+  })
+})
+// kilocode_change end
 
 describe("Npm.outdated", () => {
   test("checks latest via npm view", async () => {

--- a/packages/shared/src/global.ts
+++ b/packages/shared/src/global.ts
@@ -19,7 +19,7 @@ export namespace Global {
   export const layer = Layer.effect(
     Service,
     Effect.gen(function* () {
-      const app = "opencode"
+      const app = "kilo" // kilocode_change - keep shared XDG paths aligned with Kilo's branded Global.Path
       // kilocode_change start - guard against newline-contaminated HOME/XDG paths
       const clean = (p: string | undefined) => p?.replace(/[\r\n]+/g, "")
       const home = clean(process.env.KILO_TEST_HOME ?? os.homedir())!


### PR DESCRIPTION
## Summary
- Routes the npm helper default layer through Kilo's global paths so npm-installed plugins and runtime packages cache under Kilo instead of opencode.
- Adds a regression test for resolving npm-managed binaries from Kilo's cache path.