### PR TITLE
docs: fix ZenMux provider page and add to sidebar nav

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -35,6 +35,7 @@ export const AiProvidersNav: NavSection[] = [
         href: "/ai-providers/vercel-ai-gateway",
         children: "Vercel AI Gateway",
       },
+      { href: "/ai-providers/zenmux", children: "ZenMux" },
     ],
   },
   {

--- a/packages/kilo-docs/pages/ai-providers/zenmux.md
+++ b/packages/kilo-docs/pages/ai-providers/zenmux.md
@@ -1,25 +1,25 @@
 ---
-title: ZenMux
+sidebar_label: ZenMux
 ---
-
-import Codicon from "@site/src/components/Codicon";
 
 # Using ZenMux With Kilo Code
 
-[ZenMux](https://zenmux.ai) provides a unified API gateway to access multiple AI models from different providers through a single endpoint. It supports OpenAI, Anthropic, Google, and other major AI providers, automatically handling routing, fallbacks, and cost optimization.
+ZenMux is a unified AI gateway that provides access to multiple AI models from different providers through a single API endpoint. It supports OpenAI, Anthropic, Google, and other major AI providers, with automatic routing, fallbacks, and cost optimization.
 
-## Getting Started
+**Website:** [https://zenmux.ai/](https://zenmux.ai/)
 
-1. **Sign up for ZenMux:** Visit [zenmux.ai](https://zenmux.ai) to create an account.
-2. **Get your API key:** After signing up, navigate to your dashboard to generate an API key.
-3. **Configure in Kilo Code:** Add your API key to Kilo Code settings.
+## Getting an API Key
+
+1. **Sign Up/Sign In:** Go to the [ZenMux website](https://zenmux.ai) and create an account.
+2. **Get an API Key:** Navigate to your dashboard to generate an API key.
+3. **Copy the Key:** Copy the API key.
 
 ## Configuration in Kilo Code
 
 {% tabs %}
 {% tab label="VSCode (Legacy)" %}
 
-1. **Open Kilo Code Settings:** Click the gear icon (<Codicon name="gear" />) in the Kilo Code panel.
+1. **Open Kilo Code Settings:** Click the gear icon ({% codicon name="gear" /%}) in the Kilo Code panel.
 2. **Select Provider:** Choose "ZenMux" from the "API Provider" dropdown.
 3. **Enter API Key:** Paste your ZenMux API key into the "ZenMux API Key" field.
 4. **Select Model:** Choose your desired model from the "Model" dropdown.
@@ -30,7 +30,7 @@ import Codicon from "@site/src/components/Codicon";
 
 Open **Settings** (gear icon) and go to the **Providers** tab to add ZenMux and enter your API key.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly. See the **CLI** tab for the file format.
 
 {% /tab %}
 {% tab label="CLI" %}
@@ -66,176 +66,26 @@ Then set your default model:
 {% /tab %}
 {% /tabs %}
 
-## Supported Models
+## Provider Routing
 
-ZenMux supports a wide range of models from various providers:
+ZenMux can route requests to different inference providers based on your preferences.
 
-Visi [zenmux.ai/models](https://zenmux.ai/models) to see the complete list of available models.
+### Provider Sorting
 
-### Other Providers
+- Default provider sorting: use the setting in your ZenMux account
+- Prefer providers with lower price
+- Prefer providers with higher throughput (more tokens per second)
+- Prefer providers with lower latency (shorter time to first token)
 
-ZenMux also supports models from Meta, Mistral, and many other providers. Check your ZenMux dashboard for the complete list of available models.
+### Data Policy
 
-## API Compatibility
+- **Allow:** allow data collection for service improvement
+- **Deny:** disable all data collection
+- **Zero Data Retention (ZDR):** only providers with a strict zero data retention policy are used, ensuring no request or response data is stored
 
-ZenMux provides multiple API endpoints for different protocols:
+## Tips and Notes
 
-### OpenAI Compatible API
-
-Use the standard OpenAI SDK with ZenMux's base URL:
-
-```javascript
-import OpenAI from "openai"
-
-const openai = new OpenAI({
-  baseURL: "https://zenmux.ai/api/v1",
-  apiKey: "<ZENMUX_API_KEY>",
-})
-
-async function main() {
-  const completion = await openai.chat.completions.create({
-    model: "openai/gpt-5",
-    messages: [
-      {
-        role: "user",
-        content: "What is the meaning of life?",
-      },
-    ],
-  })
-
-  console.log(completion.choices[0].message)
-}
-
-main()
-```
-
-### Anthropic API
-
-For Anthropic models, use the dedicated endpoint:
-
-```typescript
-import Anthropic from "@anthropic-ai/sdk"
-
-// 1. Initialize the Anthropic client
-const anthropic = new Anthropic({
-  // 2. Replace with the API key from your ZenMux console
-  apiKey: "<YOUR ZENMUX_API_KEY>",
-  // 3. Point the base URL to the ZenMux endpoint
-  baseURL: "https://zenmux.ai/api/anthropic",
-})
-
-async function main() {
-  const msg = await anthropic.messages.create({
-    model: "anthropic/claude-sonnet-4.5",
-    max_tokens: 1024,
-    messages: [{ role: "user", content: "Hello, Claude" }],
-  })
-  console.log(msg)
-}
-
-main()
-```
-
-### Platform API
-
-The Get generation interface is used to query generation information, such as usage and costs.
-
-```bash
-curl https://zenmux.ai/api/v1/generation?id=<generation_id> \
-  -H "Authorization: Bearer $ZENMUX_API_KEY"
-```
-
-### Google Vertex AI API
-
-For Google models:
-
-```typescript
-const genai = require("@google/genai")
-
-const client = new genai.GoogleGenAI({
-  apiKey: "$ZENMUX_API_KEY",
-  vertexai: true,
-  httpOptions: {
-    baseUrl: "https://zenmux.ai/api/vertex-ai",
-    apiVersion: "v1",
-  },
-})
-
-const response = await client.models.generateContent({
-  model: "google/gemini-2.5-pro",
-  contents: "How does AI work?",
-})
-console.log(response)
-```
-
-## Features
-
-### Automatic Routing
-
-ZenMux automatically routes your requests to the best available provider based on:
-
-- Model availability
-- Response time
-- Cost optimization
-- Provider health status
-
-### Fallback Support
-
-If a provider is unavailable, ZenMux automatically falls back to alternative providers that support the same model capabilities.
-
-### Cost Optimization
-
-ZenMux can be configured to optimize for cost, routing requests to the most cost-effective provider while maintaining quality.
-
-### Zero Data Retention (ZDR)
-
-Enable ZDR mode to ensure that no request or response data is stored by ZenMux, providing maximum privacy for sensitive applications.
-
-## Advanced Configuration
-
-### Provider Routing
-
-You can specify routing preferences:
-
-- **Price**: Route to the lowest cost provider
-- **Throughput**: Route to the provider with highest tokens/second
-- **Latency**: Route to the provider with fastest response time
-
-### Data Collection Settings
-
-Control how ZenMux handles your data:
-
-- **Allow**: Allow data collection for service improvement
-- **Deny**: Disable all data collection
-
-### Middle-Out Transform
-
-Enable the middle-out transform feature to optimize prompts that exceed model context limits.
-
-## Troubleshooting
-
-### API Key Issues
-
-- Ensure your API key is correctly copied without any extra spaces
-- Check that your ZenMux account is active and has available credits
-- Verify the API key has the necessary permissions
-
-### Model Availability
-
-- Some models may have regional restrictions
-- Check the ZenMux dashboard for current model availability
-- Ensure your account tier has access to the desired models
-
-### Connection Issues
-
-- Verify your internet connection
-- Check if you're behind a firewall that might block API requests
-- Try using a custom base URL if the default endpoint is blocked
-
-## Support
-
-For additional support:
-
-- Visit the [ZenMux documentation](https://zenmux.ai/docs)
-- Contact ZenMux support through their dashboard
-- Check the [Kilo Code GitHub repository](https://github.com/Kilo-Org/kilocode) for integration-specific issues
+- **Model Selection:** ZenMux supports a wide range of models from OpenAI, Anthropic, Google, and more. Visit [zenmux.ai/models](https://zenmux.ai/models) for the full list.
+- **Fallback Support:** If a provider is unavailable, ZenMux automatically falls back to alternative providers that support the same model capabilities.
+- **Pricing:** ZenMux charges based on the underlying model's pricing. Check your ZenMux dashboard for cost details.
+- **Troubleshooting:** Ensure your API key is copied without extra spaces and that your ZenMux account has available credits. Some models may have regional restrictions. Check the ZenMux dashboard for current availability.


### PR DESCRIPTION
Fixes #6141

The ZenMux provider doc had several inconsistencies compared to other provider docs:

- Missing from the sidebar navigation (not listed in `ai-providers.ts`)
- Missing `sidebar_label` frontmatter
- Missing `**Website:**` link
- Used a JSX `<Codicon>` import instead of the `{% codicon /%}` shortcode used by every other provider doc
- Contained large SDK code examples (OpenAI, Anthropic, Vertex AI, Platform API) that belong in ZenMux's own docs, not the Kilo Code integration guide
- Had duplicated Features and Advanced Configuration sections

This PR standardizes the page to match the format of other gateway docs (e.g., openrouter.md, glama.md).