### PR TITLE
fix: resolve silent agent termination on stream drop

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -14,6 +14,6 @@ export function mapOpenAICompatibleFinishReason(
     case "tool_calls":
       return "tool-calls"
     default:
-      return "unknown"
+      return "unknown" // kilocode_change
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -14,6 +14,6 @@ export function mapOpenAICompatibleFinishReason(
     case "tool_calls":
       return "tool-calls"
     default:
-      return "unknown" // kilocode_change
+      return "unknown" as any // kilocode_change
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -14,6 +14,6 @@ export function mapOpenAICompatibleFinishReason(
     case "tool_calls":
       return "tool-calls"
     default:
-      return "other"
+      return "unknown"
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -649,7 +649,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           flush(controller) {
             // kilocode_change start
             if (!receivedFinishReason && !isFirstChunk) {
-              finishReason = { unified: "unknown", raw: undefined }
+              finishReason = { unified: "unknown" as any, raw: undefined }
             }
             // kilocode_change end
 

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -345,6 +345,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       unified: "other",
       raw: undefined,
     }
+    let receivedFinishReason = false
     const usage: {
       completionTokens: number | undefined
       completionTokensDetails: {
@@ -453,6 +454,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             const choice = value.choices[0]
 
             if (choice?.finish_reason != null) {
+              receivedFinishReason = true
               finishReason = {
                 unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
                 raw: choice.finish_reason ?? undefined,
@@ -645,6 +647,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
+            if (!receivedFinishReason && !isFirstChunk) {
+              finishReason = { unified: "unknown", raw: undefined }
+            }
+
             if (isActiveReasoning) {
               controller.enqueue({
                 type: "reasoning-end",

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -345,7 +345,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       unified: "other",
       raw: undefined,
     }
-    let receivedFinishReason = false
+    let receivedFinishReason = false // kilocode_change
     const usage: {
       completionTokens: number | undefined
       completionTokensDetails: {
@@ -454,7 +454,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             const choice = value.choices[0]
 
             if (choice?.finish_reason != null) {
-              receivedFinishReason = true
+              receivedFinishReason = true // kilocode_change
               finishReason = {
                 unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
                 raw: choice.finish_reason ?? undefined,
@@ -647,9 +647,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
+            // kilocode_change start
             if (!receivedFinishReason && !isFirstChunk) {
               finishReason = { unified: "unknown", raw: undefined }
             }
+            // kilocode_change end
 
             if (isActiveReasoning) {
               controller.enqueue({

--- a/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
@@ -17,6 +17,6 @@ export function mapOpenAIResponseFinishReason({
     case "content_filter":
       return "content-filter"
     default:
-      return hasFunctionCall ? "tool-calls" : "unknown"
+      return hasFunctionCall ? "tool-calls" : "unknown" // kilocode_change
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
@@ -17,6 +17,6 @@ export function mapOpenAIResponseFinishReason({
     case "content_filter":
       return "content-filter"
     default:
-      return hasFunctionCall ? "tool-calls" : "other"
+      return hasFunctionCall ? "tool-calls" : "unknown"
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
@@ -17,6 +17,6 @@ export function mapOpenAIResponseFinishReason({
     case "content_filter":
       return "content-filter"
     default:
-      return hasFunctionCall ? "tool-calls" : "unknown" // kilocode_change
+      return (hasFunctionCall ? "tool-calls" : "unknown") as any // kilocode_change
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -1309,7 +1309,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
 
             // kilocode_change start
             if (!receivedFinishChunk && responseId !== null) {
-              finishReason = { unified: "unknown", raw: undefined }
+              finishReason = { unified: "unknown" as any, raw: undefined }
             }
             // kilocode_change end
 

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -803,7 +803,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       unified: "other",
       raw: undefined,
     }
-    let receivedFinishChunk = false
+    let receivedFinishChunk = false // kilocode_change
     const usage: {
       inputTokens: number | undefined
       outputTokens: number | undefined
@@ -1260,7 +1260,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               }
             } else if (isResponseFinishedChunk(value)) {
-              receivedFinishChunk = true
+              receivedFinishChunk = true // kilocode_change
               finishReason = {
                 unified: mapOpenAIResponseFinishReason({
                   finishReason: value.response.incomplete_details?.reason,
@@ -1307,9 +1307,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               currentTextId = null
             }
 
+            // kilocode_change start
             if (!receivedFinishChunk && responseId !== null) {
               finishReason = { unified: "unknown", raw: undefined }
             }
+            // kilocode_change end
 
             const providerMetadata: SharedV3ProviderMetadata = {
               openai: {

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -803,6 +803,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       unified: "other",
       raw: undefined,
     }
+    let receivedFinishChunk = false
     const usage: {
       inputTokens: number | undefined
       outputTokens: number | undefined
@@ -1259,6 +1260,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               }
             } else if (isResponseFinishedChunk(value)) {
+              receivedFinishChunk = true
               finishReason = {
                 unified: mapOpenAIResponseFinishReason({
                   finishReason: value.response.incomplete_details?.reason,
@@ -1303,6 +1305,10 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             if (currentTextId) {
               controller.enqueue({ type: "text-end", id: currentTextId })
               currentTextId = null
+            }
+
+            if (!receivedFinishChunk && responseId !== null) {
+              finishReason = { unified: "unknown", raw: undefined }
             }
 
             const providerMetadata: SharedV3ProviderMetadata = {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1164,6 +1164,10 @@ export function fromError(
       ).toObject()
     case OutputLengthError.isInstance(e):
       return e
+    // kilocode_change start
+    case APIError.isInstance(e):
+      return e.toObject()
+    // kilocode_change end
     case LoadAPIKeyError.isInstance(e):
       return new AuthError(
         {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -626,6 +626,7 @@ export const layer: Layer.Layer<
               Stream.runDrain,
             )
 
+            // kilocode_change start
             if (ctx.assistantMessage.finish === "unknown") {
               const parts = MessageV2.parts(ctx.assistantMessage.id)
               if (!parts.some((p) => p.type === "tool")) {
@@ -637,6 +638,7 @@ export const layer: Layer.Layer<
                 )
               }
             }
+            // kilocode_change end
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -629,12 +629,12 @@ export const layer: Layer.Layer<
             // kilocode_change start
             if (ctx.assistantMessage.finish === "unknown") {
               const parts = MessageV2.parts(ctx.assistantMessage.id)
-              if (!parts.some((p) => p.type === "tool")) {
+              if (!parts.some((p) => p.type === "tool" && p.state.status === "completed")) {
                 yield* Effect.fail(
                   new MessageV2.APIError({
                     message: "Stream terminated prematurely without a finish reason",
                     isRetryable: true,
-                  }).toObject()
+                  })
                 )
               }
             }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -625,6 +625,18 @@ export const layer: Layer.Layer<
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
+
+            if (ctx.assistantMessage.finish === "unknown") {
+              const parts = MessageV2.parts(ctx.assistantMessage.id)
+              if (!parts.some((p) => p.type === "tool")) {
+                yield* Effect.fail(
+                  new MessageV2.APIError({
+                    message: "Stream terminated prematurely without a finish reason",
+                    isRetryable: true,
+                  }).toObject()
+                )
+              }
+            }
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1592,7 +1592,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const finished = handle.message.finish && !["tool-calls", "unknown"].includes(handle.message.finish)
+            const finished = handle.message.finish && !["tool-calls", "unknown", "other"].includes(handle.message.finish)
             if (finished && !handle.message.error) {
               if (format.type === "json_schema") {
                 handle.message.error = new MessageV2.StructuredOutputError({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1592,7 +1592,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const finished = handle.message.finish && !["tool-calls", "unknown", "other"].includes(handle.message.finish)
+            const finished = handle.message.finish && !["tool-calls", "unknown", "other"].includes(handle.message.finish) // kilocode_change
             if (finished && !handle.message.error) {
               if (format.type === "json_schema") {
                 handle.message.error = new MessageV2.StructuredOutputError({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1592,7 +1592,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const finished = handle.message.finish && !["tool-calls", "unknown", "other"].includes(handle.message.finish) // kilocode_change
+            const finished = handle.message.finish && !["tool-calls", "unknown"].includes(handle.message.finish) // kilocode_change
             if (finished && !handle.message.error) {
               if (format.type === "json_schema") {
                 handle.message.error = new MessageV2.StructuredOutputError({


### PR DESCRIPTION
## Context

This PR addresses a critical bug where Kilo agents would prematurely stop generating text mid-response without any error shown to the user. This silent failure occurs when the upstream Server-Sent Events (SSE) connection drops unexpectedly before a proper terminal event or `finish_reason` is received from the provider. Previously, the system defaulted to an "other" finish reason, which the agent loop interpreted as a successful completion, skipping the error handling and retry logic entirely.

## fixes

https://github.com/Kilo-Org/kilocode/issues/8476
https://github.com/Kilo-Org/kilocode/issues/9544

## Implementation

To fix this, the system must properly distinguish between a clean generation completion and a premature stream termination:

1. **Provider Tracking:** Updated `openai-compatible-chat-language-model.ts` and `openai-responses-language-model.ts` to actively track whether a terminal finish chunk or reason was successfully received. If the stream flushes prematurely, they now emit an `unknown` finish reason instead of defaulting to `other`.
2. **Mapper Updates:** Modified `map-openai-compatible-finish-reason.ts` and `map-openai-responses-finish-reason.ts` to map unrecognized states to `unknown` instead of `other`.
3. **Triggering Retries:** Updated the session processor (`processor.ts`) to intercept the `unknown` finish reason immediately after the stream drains. If no tool parts were executed, it throws a retryable `MessageV2.APIError` ("Stream terminated prematurely without a finish reason"), which triggers the existing `Effect.retry` pipeline.
4. **Defense in Depth:** Modified the agent loop condition in `prompt.ts` to explicitly exclude `other` as a valid completion signal, ensuring no ambiguous states can cause a silent loop exit.

## Screenshots

| File | Before | After |
| ------ | ----- | ----- |
| `openai-compatible-chat-language-model.ts` | ```typescript<br/>let finishReason = {<br/>  unified: "other",<br/>  raw: undefined<br/>}<br/>``` | ```typescript<br/>let finishReason = { ... }<br/>let receivedFinishReason = false;<br/><br/>/* in flush() */<br/>if (!receivedFinishReason && !isFirstChunk) {<br/>  finishReason = { unified: "unknown", raw: undefined }<br/>}<br/>``` |
| `openai-responses-language-model.ts` | ```typescript<br/>let finishReason = {<br/>  unified: "other",<br/>  raw: undefined<br/>}<br/>``` | ```typescript<br/>let finishReason = { ... }<br/>let receivedFinishChunk = false;<br/><br/>/* in flush() */<br/>if (!receivedFinishChunk && responseId !== null) {<br/>  finishReason = { unified: "unknown", raw: undefined }<br/>}<br/>``` |
| `processor.ts` | ```typescript<br/>yield* stream.pipe(<br/>  Stream.tap(...),<br/>  Stream.takeUntil(...),<br/>  Stream.runDrain<br/>)<br/><br/><br/>``` | ```typescript<br/>yield* stream.pipe(...)<br/><br/>if (ctx.assistantMessage.finish === "unknown") {<br/>  const parts = MessageV2.parts(ctx.assistantMessage.id)<br/>  if (!parts.some(p => p.type === "tool")) {<br/>    yield* Effect.fail(new MessageV2.APIError({<br/>      message: "Stream terminated prematurely...",<br/>      isRetryable: true<br/>    }).toObject())<br/>  }<br/>}<br/>``` |
| `prompt.ts` | ```typescript<br/>const finished = handle.message.finish &&<br/>  !["tool-calls", "unknown"].includes(handle.message.finish)<br/>``` | ```typescript<br/>const finished = handle.message.finish &&<br/>  !["tool-calls", "unknown", "other"].includes(handle.message.finish)<br/>``` |
| Mappers | ```typescript<br/>default:<br/>  return "other"<br/>``` | ```typescript<br/>default:<br/>  return "unknown"<br/>``` |

## How to Test

1. Start an agent generation that produces a long response.
2. Artificially simulate a network drop or prematurely kill the provider stream before it sends the final `finish_reason` chunk.
3. Observe that instead of the agent stopping its execution with a half-written response, it catches the interruption, logs a retryable API Error, and automatically retries the generation.

## Get in Touch

Discord @varuu
