### PR TITLE
test(cli): port upstream provider plugin fixture

### DIFF
--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -56,13 +56,15 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
+// kilocode_change start - upstream #24416 fixture adapted for @kilocode/plugin
 async function markPluginDependenciesReady(dir: string) {
   await mkdir(path.join(dir, "node_modules"), { recursive: true })
   await Bun.write(
     path.join(dir, "package-lock.json"),
-    JSON.stringify({ packages: { "": { dependencies: { "@opencode-ai/plugin": "0.0.0" } } } }),
+    JSON.stringify({ packages: { "": { dependencies: { "@kilocode/plugin": "0.0.0" } } } }),
   )
 }
+// kilocode_change end
 
 function paid(providers: Awaited<ReturnType<typeof list>>) {
   const item = providers[ProviderID.make("opencode")]
@@ -2492,11 +2494,13 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
 test("plugin config providers persist after instance dispose", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
+      // kilocode_change start - upstream #24416 avoids real plugin dependency installs
       const configDir = path.join(dir, ".opencode")
       const root = path.join(configDir, "plugin")
       await mkdir(root, { recursive: true })
       await markPluginDependenciesReady(configDir)
       await markPluginDependenciesReady(Global.Path.config)
+      // kilocode_change end
       await Bun.write(
         path.join(root, "demo-provider.ts"),
         [

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -56,6 +56,14 @@ async function defaultModel() {
   return run((provider) => provider.defaultModel())
 }
 
+async function markPluginDependenciesReady(dir: string) {
+  await mkdir(path.join(dir, "node_modules"), { recursive: true })
+  await Bun.write(
+    path.join(dir, "package-lock.json"),
+    JSON.stringify({ packages: { "": { dependencies: { "@opencode-ai/plugin": "0.0.0" } } } }),
+  )
+}
+
 function paid(providers: Awaited<ReturnType<typeof list>>) {
   const item = providers[ProviderID.make("opencode")]
   if (!item) return 0 // kilocode_change - Kilo drops opencode provider without apiKey/auth
@@ -2484,8 +2492,11 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
 test("plugin config providers persist after instance dispose", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      const root = path.join(dir, ".opencode", "plugin")
+      const configDir = path.join(dir, ".opencode")
+      const root = path.join(configDir, "plugin")
       await mkdir(root, { recursive: true })
+      await markPluginDependenciesReady(configDir)
+      await markPluginDependenciesReady(Global.Path.config)
       await Bun.write(
         path.join(root, "demo-provider.ts"),
         [


### PR DESCRIPTION
Ports anomalyco/opencode#24416 onto a clean branch so this PR only touches `packages/opencode/test/provider/provider.test.ts` and avoids runtime/plugin/flock changes.

The first commit is the upstream cherry-pick of `179e540ccb556fc48934a5a34bbd0920c8af87b4`; the follow-up only swaps the fixture dependency to Kilo's `@kilocode/plugin` package and adds required `kilocode_change` annotations.

This keeps the fix aligned with OpenCode's provider-test fixture change while avoiding future merge conflicts from unrelated shared-code edits.