### PR TITLE
fix(cli): pin @types/bun in script/upstream so bun install works standalone

### DIFF
--- a/script/upstream/package.json
+++ b/script/upstream/package.json
@@ -19,6 +19,6 @@
     "ts-morph": "^24.0.0"
   },
   "devDependencies": {
-    "@types/bun": "catalog:"
+    "@types/bun": "1.3.13"
   }
 }


### PR DESCRIPTION
Running `cd script/upstream && bun install` (as the README instructs) failed with `@types/bun@catalog: failed to resolve` because `script/upstream` isn't in the root workspace, so Bun can't resolve the `catalog:` protocol there.

`script/upstream` is intentionally decoupled from the monorepo — it runs during upstream merges when the root workspace may be half-broken — so pinning the version directly is a better fit than adding it to `workspaces`. Bumped to `1.3.13` while here.
