### PR TITLE
feat(cli): show which upstream versions are already merged in list-versions

### DIFF
--- a/script/upstream/list-versions.ts
+++ b/script/upstream/list-versions.ts
@@ -7,7 +7,7 @@
  */
 
 import { getAvailableUpstreamVersions, getCurrentKiloVersion } from "./utils/version"
-import { fetchUpstream, hasUpstreamRemote } from "./utils/git"
+import { fetchUpstream, hasUpstreamRemote, isAncestor } from "./utils/git"
 import { header, info, success, warn, error } from "./utils/logger"
 
 async function main() {
@@ -34,11 +34,15 @@ async function main() {
   console.log()
 
   const limit = process.argv.includes("--all") ? versions.length : 20
+  const shown = versions.slice(0, Math.min(limit, versions.length))
 
-  for (let i = 0; i < Math.min(limit, versions.length); i++) {
-    const v = versions[i]
+  // Check merge status in parallel — fast because is-ancestor short-circuits.
+  const merged = await Promise.all(shown.map((v) => isAncestor(v.commit, "HEAD")))
+
+  for (let i = 0; i < shown.length; i++) {
+    const v = shown[i]
     if (!v) continue
-    const marker = i === 0 ? " (latest)" : ""
+    const marker = merged[i] ? " ✓ merged" : i === 0 ? " (latest)" : ""
     console.log(`  ${v.tag.padEnd(12)} ${v.commit.slice(0, 8)}${marker}`)
   }
 

--- a/script/upstream/utils/git.ts
+++ b/script/upstream/utils/git.ts
@@ -172,6 +172,16 @@ export async function getCommitHash(ref: string): Promise<string> {
   return result.trim()
 }
 
+/**
+ * Check if `commit` is an ancestor of `ref` (i.e. reachable from `ref`).
+ * Uses `git merge-base --is-ancestor`, which exits 0 for yes, 1 for no.
+ * Any other exit code (e.g. unknown commit) is treated as "not an ancestor".
+ */
+export async function isAncestor(commit: string, ref = "HEAD"): Promise<boolean> {
+  const result = await $`git merge-base --is-ancestor ${commit} ${ref}`.quiet().nothrow()
+  return result.exitCode === 0
+}
+
 export async function getTagsForCommit(commit: string): Promise<string[]> {
   const result = await $`git tag --points-at ${commit}`.text()
   return result


### PR DESCRIPTION
`bun run list-versions.ts` previously only showed available upstream tags with no indication of which were already merged into Kilo. Kilo's own package version no longer tracks upstream, so semver comparison isn't reliable — and the upstream merge history isn't linear (e.g. `v1.14.23` can be merged while `v1.14.18`–`v1.14.21` are not).

This adds `git merge-base --is-ancestor` per tag (parallelized) and annotates merged versions with `✓ merged`. Completes in ~1.4s for 20 tags including the `git fetch upstream --tags`.

Sample output:

```
  v1.14.28     acd8783a (latest)
  v1.14.27     373cc2a5
  v1.14.26     5ce44035
  v1.14.25     3c85719f
  v1.14.24     da6683fe
  v1.14.23     3d31ae28 ✓ merged
  v1.14.22     596145a7 ✓ merged
  v1.14.21     233c1ea6
  ...
```

## Why the gaps are real

A natural question: how can `v1.14.22` be merged but `v1.14.21` not? The answer is that upstream opencode doesn't tag releases on a single linear branch. `v1.14.21` and `v1.14.22` share a common ancestor but neither is an ancestor of the other:

```
git log --left-right v1.14.21...v1.14.22
> 596145a71d release: v1.14.22              ← one branch
> 38deb0f3ee fix(npm): respect npmrc ...
> ...
> 871789ce64 sync release versions for v1.14.21
< 233c1ea699 release: v1.14.21              ← different branch
```

So when Kilo merged `v1.14.22`, `v1.14.21`'s commit was never brought in — it isn't in `v1.14.22`'s ancestry upstream. The annotation reflects reality, and this is exactly why the ancestor check is better than a semver comparison — naive "`v <= latest merged`" logic would have lied and claimed `v1.14.21` was in Kilo when it isn't.
