### PR TITLE
fix(cli): keep semantic indexing startup responsive

### DIFF
--- a/.changeset/brave-indexing-startup.md
+++ b/.changeset/brave-indexing-startup.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-indexing": patch
+---
+
+Keep semantic indexing startup responsive while the index initializes in large workspaces.

--- a/packages/kilo-indexing/src/indexing/manager.ts
+++ b/packages/kilo-indexing/src/indexing/manager.ts
@@ -36,6 +36,7 @@ export class CodeIndexManager {
   private _retryAttempt = 0
   private _retryMaxAttempts = MAX_MANAGER_RECOVERY_ATTEMPTS
   private _retryInitialDelayMs = INITIAL_MANAGER_RECOVERY_DELAY_MS
+  private _disposed = false
 
   constructor(
     public readonly workspacePath: string,
@@ -239,6 +240,8 @@ export class CodeIndexManager {
   }
 
   public async initialize(input: IndexingConfigInput): Promise<{ requiresRestart: boolean }> {
+    if (this._disposed) return { requiresRestart: false }
+
     if (!this._configManager) {
       this._configManager = new CodeIndexConfigManager(input)
       log.info("created indexing config manager", { workspacePath: this.workspacePath })
@@ -283,6 +286,7 @@ export class CodeIndexManager {
       log.info("initializing indexing cache", { cacheDirectory: this.cacheDirectory })
       this._cacheManager = new CacheManager(this.cacheDirectory, this.workspacePath)
       await this._cacheManager.initialize()
+      if (this._disposed) return { requiresRestart }
       log.info("indexing cache initialized", { cacheDirectory: this.cacheDirectory })
     }
 
@@ -297,6 +301,12 @@ export class CodeIndexManager {
       try {
         log.info("recreating indexing services", { workspacePath: this.workspacePath })
         await this._recreateServices()
+        if (this._disposed) {
+          this._orchestrator?.cancelIndexing()
+          this._orchestrator = undefined
+          this._searchService = undefined
+          return { requiresRestart }
+        }
         log.info("indexing services recreated", { workspacePath: this.workspacePath })
       } catch (err) {
         log.error("failed to recreate services", { err })
@@ -312,7 +322,7 @@ export class CodeIndexManager {
     const shouldStartOrRestart =
       requiresRestart || (needsServiceRecreation && (!this._orchestrator || this._orchestrator.state !== "Indexing"))
 
-    if (shouldStartOrRestart) {
+    if (shouldStartOrRestart && !this._disposed) {
       log.info("starting background indexing", {
         workspacePath: this.workspacePath,
         requiresRestart,
@@ -327,6 +337,7 @@ export class CodeIndexManager {
   }
 
   public async startIndexing(): Promise<void> {
+    if (this._disposed) return
     if (!this.isFeatureEnabled) return
 
     log.info("manual indexing start requested", { workspacePath: this.workspacePath })
@@ -363,6 +374,7 @@ export class CodeIndexManager {
   }
 
   public async recoverFromError(trigger: IndexingTelemetryTrigger = "background"): Promise<void> {
+    if (this._disposed) return
     if (this._retryTask) {
       await this._retryTask
       return
@@ -388,6 +400,8 @@ export class CodeIndexManager {
   }
 
   public dispose(): void {
+    if (this._disposed) return
+    this._disposed = true
     this.clearRetryTimer()
     this._retryTask = undefined
     // RATIONALE: cancelIndexing() sets _cancelRequested and calls stopWatcher() +

--- a/packages/kilo-indexing/src/indexing/manager.ts
+++ b/packages/kilo-indexing/src/indexing/manager.ts
@@ -147,6 +147,8 @@ export class CodeIndexManager {
   }
 
   private async runRecovery(trigger: IndexingTelemetryTrigger, attempt: number): Promise<void> {
+    if (this._disposed) return
+
     this._isRecoveringFromError = true
     this._retryAttempt = attempt
 
@@ -169,9 +171,12 @@ export class CodeIndexManager {
 
     try {
       await this._recreateServices()
+      if (this._disposed) return
       this.emitStart(trigger)
       await this._orchestrator!.startIndexing(trigger)
+      if (this._disposed) return
     } catch (err) {
+      if (this._disposed) return
       log.error("indexing recovery attempt failed", {
         err,
         attempt,
@@ -206,6 +211,7 @@ export class CodeIndexManager {
 
     const delay = this._retryInitialDelayMs * Math.pow(2, attempt - 1)
     await this.waitForRetry(delay)
+    if (this._disposed) return
     this._isRecoveringFromError = false
     return this.runRecovery(trigger, attempt + 1)
   }

--- a/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
@@ -394,6 +394,34 @@ describe("CodeIndexManager", () => {
     expect(start).toBe(0)
   })
 
+  test("dispose during recovery prevents restart after service recreation", async () => {
+    const mgr = new CodeIndexManager("/tmp/ws", "/tmp/cache")
+    const data = createData(mgr)
+    const gate = Promise.withResolvers<void>()
+    let start = 0
+
+    data._recreateServices = async () => {
+      await gate.promise
+      data._orchestrator = {
+        state: "Standby",
+        stopWatcher() {},
+        async startIndexing() {
+          start += 1
+        },
+      }
+      data._searchService = {}
+    }
+
+    const task = data.handleTelemetry(createStartError())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    mgr.dispose()
+    gate.resolve()
+    await data._retryTask
+
+    expect(task).toBeUndefined()
+    expect(start).toBe(0)
+  })
+
   test("retry exhaustion keeps Error and stops future retries", async () => {
     const mgr = new CodeIndexManager("/tmp/ws", "/tmp/cache")
     const data = createData(mgr)

--- a/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
@@ -349,6 +349,51 @@ describe("CodeIndexManager", () => {
     expect(stop).toBe(0)
   })
 
+  test("dispose during service recreation cancels the recreated orchestrator", async () => {
+    const mgr = new CodeIndexManager("/tmp/ws", "/tmp/cache")
+    const data = mgr as unknown as {
+      _cacheManager: {
+        clearCacheFile(): Promise<void>
+      }
+      _orchestrator?: {
+        state: string
+        cancelIndexing(): void
+        startIndexing(trigger: IndexingTelemetryTrigger): Promise<void>
+      }
+      _searchService?: {}
+      _recreateServices(): Promise<void>
+    }
+    const gate = Promise.withResolvers<void>()
+    let cancel = 0
+    let start = 0
+
+    data._cacheManager = {
+      async clearCacheFile() {},
+    }
+    data._recreateServices = async () => {
+      await gate.promise
+      data._orchestrator = {
+        state: "Standby",
+        cancelIndexing() {
+          cancel += 1
+        },
+        async startIndexing() {
+          start += 1
+        },
+      }
+      data._searchService = {}
+    }
+
+    const init = mgr.initialize(createInput({ openAiKey: "sk-test" }))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    mgr.dispose()
+    gate.resolve()
+    await init
+
+    expect(cancel).toBe(1)
+    expect(start).toBe(0)
+  })
+
   test("retry exhaustion keeps Error and stops future retries", async () => {
     const mgr = new CodeIndexManager("/tmp/ws", "/tmp/cache")
     const data = createData(mgr)

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -54,6 +54,16 @@ function failed(err: unknown): z.infer<typeof IndexingStatus> {
   }
 }
 
+function pending(): z.infer<typeof IndexingStatus> {
+  return {
+    state: "In Progress",
+    message: "Indexing is initializing.",
+    processedFiles: 0,
+    totalFiles: 0,
+    percent: 0,
+  }
+}
+
 function trackTelemetry(event: IndexingTelemetryEvent): void {
   if (event.type === "started") {
     Telemetry.trackIndexingStarted({
@@ -151,6 +161,9 @@ export namespace KiloIndexing {
 
   type Cache = {
     promise: Promise<Entry>
+    ready: Promise<Entry>
+    resolve(entry: Entry): void
+    reject(err: unknown): void
     entry?: Entry
     disposed?: boolean
   }
@@ -177,29 +190,38 @@ export namespace KiloIndexing {
     }
   }
 
-  const boot = async (): Promise<Entry> => {
+  function track(hit: Cache, entry: Entry) {
+    if (!hit.entry) hit.resolve(entry)
+    hit.entry = entry
+    if (hit.disposed) entry.dispose()
+    return entry
+  }
+
+  const boot = async (hit: Cache): Promise<Entry> => {
     const dir = Instance.directory
     const cfg = await Config.get()
     if (!hasIndexingPlugin(cfg.plugin)) {
-      return inert(() => missing())
+      return track(hit, await inert(() => missing()))
     }
 
     if (cfg.experimental?.semantic_indexing !== true) {
-      return inert(() =>
-        disabledIndexingStatus("Semantic indexing is disabled. Enable it in the Experimental settings."),
+      return track(
+        hit,
+        await inert(() => disabledIndexingStatus("Semantic indexing is disabled. Enable it in the Experimental settings.")),
       )
     }
 
     if (isWorktreePath(dir)) {
-      return inert(() => worktreeDisabled())
+      return track(hit, await inert(() => worktreeDisabled()))
     }
 
     log.info("initializing project indexing", { workspacePath: dir })
     const root = path.join(Global.Path.state, "indexing")
     const manager = new CodeIndexManager(dir, root)
     const input = toIndexingConfigInput(cfg.indexing)
-    const box = { status: undefined as Status | undefined }
+    const box = { status: pending() as Status | undefined }
     const current = () => box.status ?? normalizeIndexingStatus(manager)
+    let disposed = false
 
     const publish = async () => {
       await Bus.publish(Event, { status: current() })
@@ -223,11 +245,17 @@ export namespace KiloIndexing {
       current,
       publish,
       dispose() {
+        if (disposed) return
+        disposed = true
         unsub.dispose()
         telemetrySub.dispose()
         manager.dispose()
       },
     }
+    track(hit, base)
+    await report()
+
+    if (hit.disposed) return base
 
     // kilocode_change start
     const err = await LanceDBRuntime.ensure(input.vectorStoreProvider)
@@ -237,6 +265,8 @@ export namespace KiloIndexing {
         (err) => err,
       )
     // kilocode_change end
+    if (hit.disposed) return base
+
     if (err) {
       box.status = failed(err)
       log.error("project indexing initialization failed", {
@@ -246,6 +276,8 @@ export namespace KiloIndexing {
       await report()
       return base
     }
+    box.status = undefined
+    base.manager = manager
 
     log.info("project indexing initialized", {
       workspacePath: dir,
@@ -255,34 +287,36 @@ export namespace KiloIndexing {
     })
     await report()
 
-    return {
-      ...base,
-      manager,
-    }
+    return base
   }
 
-  const state = async () => {
+  const hit = () => {
     const dir = Instance.directory
     const existing = cache.get(dir)
-    if (existing) return existing.promise
+    if (existing) return existing
 
-    const hit: Cache = {
-      promise: boot()
-        .then((entry) => {
-          if (hit.disposed) {
-            entry.dispose()
-            return entry
-          }
-          hit.entry = entry
+    const gate = Promise.withResolvers<Entry>()
+    const next = {
+      ready: gate.promise,
+      resolve: gate.resolve,
+      reject: gate.reject,
+    } as Cache
+    next.promise = boot(next)
+      .then((entry) => {
+        if (next.disposed) {
+          entry.dispose()
           return entry
-        })
-        .catch((err) => {
-          if (cache.get(dir) === hit) cache.delete(dir)
-          throw err
-        }),
-    }
-    cache.set(dir, hit)
-    return hit.promise
+        }
+        next.entry = entry
+        return entry
+      })
+      .catch((err) => {
+        next.reject(err)
+        if (cache.get(dir) === next) cache.delete(dir)
+        throw err
+      })
+    cache.set(dir, next)
+    return next
   }
 
   registerDisposer(async (dir) => {
@@ -296,11 +330,15 @@ export namespace KiloIndexing {
   })
 
   export async function init() {
-    await state()
+    const current = hit()
+    void current.promise.catch((err) => {
+      log.error("failed to initialize indexing", { err })
+    })
+    await current.ready
   }
 
   export async function current(): Promise<Status> {
-    return (await state()).current()
+    return (await hit().ready).current()
   }
 
   export function ready(): boolean {
@@ -310,13 +348,13 @@ export namespace KiloIndexing {
   }
 
   export async function available(): Promise<boolean> {
-    const entry = await state()
+    const entry = await hit().ready
     if (!entry.manager) return false
     return entry.current().state !== "Disabled"
   }
 
   export async function search(query: string, directoryPrefix?: string): Promise<VectorStoreSearchResult[]> {
-    const entry = await state()
+    const entry = await hit().ready
     if (!entry.manager) return []
     return entry.manager.searchIndex(query, directoryPrefix)
   }

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -322,11 +322,11 @@ export namespace KiloIndexing {
   registerDisposer(async (dir) => {
     const hit = cache.get(dir)
     cache.delete(dir)
+    if (hit) hit.disposed = true
     if (hit?.entry) {
       hit.entry.dispose()
       return
     }
-    if (hit) hit.disposed = true
   })
 
   export async function init() {

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
 import { CodeIndexManager } from "@kilocode/kilo-indexing/engine"
 import type { Config } from "../../src/config"
+import { GlobalBus } from "../../src/bus/global"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { KiloIndexing } from "../../src/kilocode/indexing"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
@@ -132,6 +133,41 @@ describe("indexing startup degradation", () => {
         message: "Indexing is initializing.",
       })
     } finally {
+      gate.resolve({ requiresRestart: false })
+      init.mockRestore()
+    }
+  })
+
+  test("does not publish initialized status after in-flight startup is disposed", async () => {
+    await using tmp = await tmpdir({ git: true, config: cfg })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    const gate = Promise.withResolvers<{ requiresRestart: boolean }>()
+    const init = spyOn(CodeIndexManager.prototype, "initialize").mockImplementation(() => gate.promise)
+    const events: KiloIndexing.Status[] = []
+    const on = (data: { directory?: string; payload?: { type?: string; properties?: { status?: KiloIndexing.Status } } }) => {
+      if (data.directory !== tmp.path) return
+      if (data.payload?.type !== KiloIndexing.Event.type) return
+      if (data.payload.properties?.status) events.push(data.payload.properties.status)
+    }
+    GlobalBus.on("event", on)
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        init: () => AppRuntime.runPromise(InstanceBootstrap),
+        fn: async () => {
+          await called(init)
+          expect((await KiloIndexing.current()).state).toBe("In Progress")
+        },
+      })
+
+      await Instance.disposeAll()
+      gate.resolve({ requiresRestart: false })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(events.some((status) => status.state === "Complete" || status.state === "Standby")).toBe(false)
+    } finally {
+      GlobalBus.off("event", on)
       gate.resolve({ requiresRestart: false })
       init.mockRestore()
     }

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
 import { CodeIndexManager } from "@kilocode/kilo-indexing/engine"
-import { Hono } from "hono"
 import type { Config } from "../../src/config"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { KiloIndexing } from "../../src/kilocode/indexing"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { Instance } from "../../src/project/instance"
-import { IndexingRoutes } from "../../src/kilocode/server/routes/indexing"
+import { Server } from "../../src/server/server"
 import { Log } from "../../src/util"
 import { tmpdir } from "../fixture/fixture"
 
@@ -42,6 +43,23 @@ const off: Partial<Config.Info> = {
 const configDir = process.env["KILO_CONFIG_DIR"]
 const error = new Error("test indexing initialization failed")
 
+async function wait(read: () => Promise<KiloIndexing.Status>, state: KiloIndexing.Status["state"]) {
+  for (const _ of Array.from({ length: 100 })) {
+    const status = await read()
+    if (status.state === state) return status
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error(`indexing did not reach ${state}`)
+}
+
+async function called(init: ReturnType<typeof spyOn<CodeIndexManager, "initialize">>) {
+  for (const _ of Array.from({ length: 100 })) {
+    if (init.mock.calls.length > 0) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error("indexing initialization did not start")
+}
+
 afterEach(async () => {
   if (configDir === undefined) delete process.env["KILO_CONFIG_DIR"]
   else process.env["KILO_CONFIG_DIR"] = configDir
@@ -56,22 +74,65 @@ describe("indexing startup degradation", () => {
     process.env["KILO_CONFIG_DIR"] = tmp.path
 
     try {
-      const app = new Hono().route("/indexing", IndexingRoutes())
+      const app = Server.Default().app
 
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const status = await app.request("/indexing/status")
-          expect(status.status).toBe(200)
-
-          const body = await status.json()
-          expect(body).toMatchObject({
-            state: "Error",
-          })
-          expect(body.message).toContain("Failed to initialize: test indexing initialization failed")
+      const config = await app.request("/config", {
+        headers: {
+          "x-kilo-directory": tmp.path,
         },
       })
+      expect(config.status).toBe(200)
+
+      const body = await wait(async () => {
+        const status = await app.request("/indexing/status", {
+          headers: {
+            "x-kilo-directory": tmp.path,
+          },
+        })
+        expect(status.status).toBe(200)
+        return status.json()
+      }, "Error")
+
+      expect(body).toMatchObject({
+        state: "Error",
+      })
+      expect(body.message).toContain("Failed to initialize: test indexing initialization failed")
     } finally {
+      init.mockRestore()
+    }
+  })
+
+  test("reports routes as in progress while initialization is in flight", async () => {
+    await using tmp = await tmpdir({ git: true, config: cfg })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    const gate = Promise.withResolvers<{ requiresRestart: boolean }>()
+    const init = spyOn(CodeIndexManager.prototype, "initialize").mockImplementation(() => gate.promise)
+
+    try {
+      const app = Server.Default().app
+
+      const config = await app.request("/config", {
+        headers: {
+          "x-kilo-directory": tmp.path,
+        },
+      })
+      expect(config.status).toBe(200)
+      await called(init)
+
+      const status = await app.request("/indexing/status", {
+        headers: {
+          "x-kilo-directory": tmp.path,
+        },
+      })
+      expect(status.status).toBe(200)
+
+      const body = await status.json()
+      expect(body).toMatchObject({
+        state: "In Progress",
+        message: "Indexing is initializing.",
+      })
+    } finally {
+      gate.resolve({ requiresRestart: false })
       init.mockRestore()
     }
   })
@@ -85,8 +146,9 @@ describe("indexing startup degradation", () => {
     try {
       await Instance.provide({
         directory: tmp.path,
+        init: () => AppRuntime.runPromise(InstanceBootstrap),
         fn: async () => {
-          const status = await KiloIndexing.current()
+          const status = await wait(() => KiloIndexing.current(), "Error")
 
           expect(status.state).toBe("Error")
           expect(status.message).toContain("Failed to initialize: test indexing initialization failed")
@@ -109,22 +171,14 @@ describe("indexing startup degradation", () => {
     try {
       await Instance.provide({
         directory: tmp.path,
+        init: () => AppRuntime.runPromise(InstanceBootstrap),
         fn: async () => {
-          const boot = KiloIndexing.init()
-          await new Promise<void>((resolve, reject) => {
-            const start = performance.now()
-            const poll = () => {
-              if (init.mock.calls.length > 0) return resolve()
-              if (performance.now() - start > 5000) return reject(new Error("indexing initialization did not start"))
-              setTimeout(poll, 10)
-            }
-            poll()
-          })
+          await called(init)
 
           expect(init).toHaveBeenCalled()
           expect(KiloIndexing.ready()).toBe(false)
-          gate.resolve({ requiresRestart: false })
-          await boot
+          expect(await KiloIndexing.available()).toBe(false)
+          expect(await KiloIndexing.search("boot failure")).toEqual([])
         },
       })
     } finally {
@@ -140,6 +194,7 @@ describe("indexing startup degradation", () => {
 
     await Instance.provide({
       directory: tmp.path,
+      init: () => AppRuntime.runPromise(InstanceBootstrap),
       fn: async () => {
         const status = await KiloIndexing.current()
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1264,7 +1264,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  30_000, // kilocode_change - Windows CI process startup can exceed 3s
 )
 
 it.live(
@@ -1304,7 +1304,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  30_000, // kilocode_change - Windows CI process startup can exceed 3s
 )
 
 // kilocode_change start - TODO(#8990): flaky on Linux CI


### PR DESCRIPTION
## Summary
- Make semantic indexing publish an initial in-progress status before long-running initialization completes.
- Guard indexing managers from starting background scans after disposal during startup.
- Restore full server/bootstrap coverage for the indexing startup tests.

Fixes #9573.

## Validation
- `env -u KILO_PLATFORM bun run script/test-runner.ts --ci --concurrency 1 --file-timeout 60000 kilocode/indexing-startup.test.ts`
- `env -u KILO_PLATFORM bun run script/test-runner.ts --ci --concurrency 4 --file-timeout 60000 kilocode/indexing`
- `bun test test/kilocode/indexing/manager.test.ts test/kilocode/indexing/orchestrator.test.ts`
- `bun run typecheck` in `packages/opencode`
- `bun run typecheck` in `packages/kilo-indexing`
