### PR TITLE
fix(cli): isolate indexing from tool registry

### DIFF
--- a/.changeset/tool-registry-indexing.md
+++ b/.changeset/tool-registry-indexing.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep interactive tools available when semantic indexing fails to load.

--- a/packages/opencode/src/kilocode/bootstrap.ts
+++ b/packages/opencode/src/kilocode/bootstrap.ts
@@ -1,8 +1,13 @@
 import { KiloSessions } from "@/kilo-sessions/kilo-sessions"
-import { KiloIndexing } from "@/kilocode/indexing"
+import { Log } from "@/util"
+
+const log = Log.create({ service: "kilocode-bootstrap" })
 
 export namespace KilocodeBootstrap {
   export async function init() {
-    await Promise.all([KiloSessions.init(), KiloIndexing.init()])
+    await KiloSessions.init()
+    void import("@/kilocode/indexing")
+      .then((mod) => mod.KiloIndexing.init())
+      .catch((err) => log.warn("indexing bootstrap failed", { err }))
   }
 }

--- a/packages/opencode/src/kilocode/server/routes/indexing.ts
+++ b/packages/opencode/src/kilocode/server/routes/indexing.ts
@@ -1,9 +1,11 @@
 import { lazy } from "@/util/lazy"
-import { KiloIndexing } from "@/kilocode/indexing"
 import { createIndexingRoutes } from "@kilocode/kilo-indexing/server"
 
 export const IndexingRoutes = lazy(() =>
   createIndexingRoutes({
-    current: () => KiloIndexing.current(),
+    current: async () => {
+      const mod = await import("@/kilocode/indexing")
+      return mod.KiloIndexing.current()
+    },
   }),
 )

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -4,8 +4,12 @@ import { RecallTool } from "../../tool/recall"
 import * as Tool from "../../tool/tool"
 import { Flag } from "@/flag/flag"
 import { Effect } from "effect"
-import { KiloIndexing } from "@/kilocode/indexing"
-import { SemanticSearchTool } from "@/kilocode/tool/semantic-search"
+import { Log } from "@/util"
+import { Agent } from "@/agent/agent"
+import * as Truncate from "@/tool/truncate"
+
+const log = Log.create({ service: "kilocode-tool-registry" })
+type Deps = { agent: Agent.Interface; truncate: Truncate.Interface }
 
 export namespace KiloToolRegistry {
   /** Resolve Kilo-specific tool Infos outside any InstanceState, so their Truncate/Agent deps are
@@ -13,19 +17,52 @@ export namespace KiloToolRegistry {
   export function infos() {
     return Effect.gen(function* () {
       const codebase = yield* CodebaseSearchTool
-      const semantic = yield* SemanticSearchTool
       const recall = yield* RecallTool
-      return { codebase, semantic, recall }
+      return { codebase, recall }
     })
   }
 
   /** Finalize Kilo-specific tools into Tool.Defs. Call this inside the InstanceState state Effect —
    * it has no Service deps beyond what Tool.init itself needs. */
-  export function build(tools: { codebase: Tool.Info; semantic: Tool.Info; recall: Tool.Info }) {
-    return Effect.all({
-      codebase: Tool.init(tools.codebase),
-      semantic: Tool.init(tools.semantic),
-      recall: Tool.init(tools.recall),
+  export function build(tools: { codebase: Tool.Info; recall: Tool.Info }, deps: Deps) {
+    return Effect.gen(function* () {
+      const base = yield* Effect.all({
+        codebase: Tool.init(tools.codebase),
+        recall: Tool.init(tools.recall),
+      })
+      const semantic = yield* semanticTool(deps)
+      return { ...base, semantic }
+    })
+  }
+
+  function semanticTool(deps: Deps) {
+    return Effect.gen(function* () {
+      const ready = yield* Effect.tryPromise(() => import("@/kilocode/indexing").then((mod) => mod.KiloIndexing.ready())).pipe(
+        Effect.catch((err) =>
+          Effect.sync(() => {
+            log.warn("semantic search unavailable", { err })
+            return false
+          }),
+        ),
+      )
+      if (!ready) return undefined
+
+      const mod = yield* Effect.tryPromise(() => import("@/kilocode/tool/semantic-search")).pipe(
+        Effect.catch((err) =>
+          Effect.sync(() => {
+            log.warn("semantic search tool unavailable", { err })
+            return undefined
+          }),
+        ),
+      )
+      if (!mod) return undefined
+
+      const info = yield* mod.SemanticSearchTool.pipe(
+        Effect.provideService(Agent.Service, deps.agent),
+        Effect.provideService(Truncate.Service, deps.truncate),
+      )
+      if (!info) return undefined
+      return yield* Tool.init(info)
     })
   }
 
@@ -46,13 +83,12 @@ export namespace KiloToolRegistry {
 
   /** Kilo-specific tools to append to the builtin list */
   export function extra(
-    tools: { codebase: Tool.Def; semantic: Tool.Def; recall: Tool.Def },
+    tools: { codebase: Tool.Def; semantic?: Tool.Def; recall: Tool.Def },
     cfg: { experimental?: { codebase_search?: boolean } },
   ): Tool.Def[] {
-    const ready = KiloIndexing.ready()
     return [
       ...(cfg.experimental?.codebase_search === true ? [tools.codebase] : []),
-      ...(ready ? [tools.semantic] : []),
+      ...(tools.semantic ? [tools.semantic] : []),
       tools.recall,
     ]
   }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -213,7 +213,7 @@ export const layer: Layer.Layer<
         })
         // kilocode_change end
 
-        const kilo = yield* KiloToolRegistry.build(kiloToolInfos) // kilocode_change
+        const kilo = yield* KiloToolRegistry.build(kiloToolInfos, { agent: agents, truncate }) // kilocode_change
 
         // kilocode_change start
         return {

--- a/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
@@ -26,6 +26,9 @@ describe("kilocode tool registry indexing", () => {
             const ids = yield* registry.ids()
 
             expect(ids).not.toContain("semantic_search")
+            expect(ids).toContain("question")
+            expect(ids).toContain("read")
+            expect(ids).toContain("suggest")
             expect(avail).not.toHaveBeenCalled()
           } finally {
             avail.mockRestore()


### PR DESCRIPTION
## Summary
- Fixes the tool-registry regression introduced by #6966 (`feat: implement codebase indexing`).
- Keeps `question`, `read`, `suggest`, and other non-indexing tools available when semantic indexing fails to load or is still starting.
- Adds regression coverage that interactive tools remain registered while indexing startup is unavailable.

## Root Cause
#6966 moved semantic indexing onto shared startup paths: `KiloToolRegistry` imported `KiloIndexing`/`SemanticSearchTool` at module load time, and `KilocodeBootstrap.init()` ran `KiloSessions.init()` and `KiloIndexing.init()` together via `Promise.all`. As a result, an indexing import/init failure could abort the entire shared tool registry or Kilo session bootstrap path, making unrelated tools such as `question`, `read`, and `suggest` unavailable.

## Fix
This PR lazy-loads indexing only where indexing is actually needed. Indexing failures now degrade to omitting `semantic_search`, while normal tool registration and session/view/question status syncing continue independently.