### PR TITLE
fix(cli): chdir to repo root in upstream merge script

### DIFF
--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -115,6 +115,12 @@ async function createBackupBranch(baseBranch: string): Promise<string> {
 }
 
 async function main() {
+  // Ensure all relative paths resolve against the repo root, not whichever
+  // directory the user invoked the script from. Transforms feed git-reported
+  // paths (repo-relative) straight into Bun.file() and Glob.scan(), so running
+  // from script/upstream/ would silently break every file lookup.
+  process.chdir((await $`git rev-parse --show-toplevel`.text()).trim())
+
   const options = parseArgs()
   const config = loadConfig(options.baseBranch ? { baseBranch: options.baseBranch } : undefined)
 


### PR DESCRIPTION
## Summary

Running `script/upstream/merge.ts` from the `script/upstream/` directory (as the README instructs) silently broke every file lookup: pre-merge transforms returned zero results, and the auto-resolve phase crashed with `ENOENT: no such file or directory, open 'packages/app/src/i18n/en.ts'`.

Transforms feed git-reported (repo-relative) paths straight into `Bun.file()` and `Glob.scan()`, both of which resolve against `process.cwd()`. `chdir`ing to the repo root at the start of `main()` makes all existing paths correct regardless of invocation directory.
