### PR TITLE
fix(cli): skip VOUCHED.td and surface git rm errors in upstream merge

### DIFF
--- a/script/upstream/transforms/skip-files.ts
+++ b/script/upstream/transforms/skip-files.ts
@@ -90,11 +90,19 @@ async function fileExistsInRef(file: string, ref: string): Promise<boolean> {
 }
 
 /**
- * Remove a file from the merge (git rm)
+ * Remove a file from the merge (git rm). Retries once on failure since
+ * transient index contention (editor watchers, rerere passes) has been
+ * observed to make the first attempt fail sporadically.
  */
-async function removeFile(file: string): Promise<boolean> {
-  const result = await $`git rm -f ${file}`.quiet().nothrow()
-  return result.exitCode === 0
+async function removeFile(file: string): Promise<{ ok: boolean; err?: string }> {
+  const first = await $`git rm -f ${file}`.quiet().nothrow()
+  if (first.exitCode === 0) return { ok: true }
+
+  const retry = await $`git rm -f ${file}`.quiet().nothrow()
+  if (retry.exitCode === 0) return { ok: true }
+
+  const err = retry.stderr.toString().trim() || first.stderr.toString().trim()
+  return { ok: false, err }
 }
 
 /**
@@ -143,12 +151,12 @@ export async function skipFiles(options: SkipOptions = {}): Promise<SkipResult[]
       info(`[DRY-RUN] Would remove: ${file}`)
       results.push({ file, action: "removed", dryRun: true })
     } else {
-      const removed = await removeFile(file)
-      if (removed) {
+      const res = await removeFile(file)
+      if (res.ok) {
         success(`Removed: ${file}`)
         results.push({ file, action: "removed", dryRun: false })
       } else {
-        warn(`Failed to remove: ${file}`)
+        warn(`Failed to remove ${file}: ${res.err ?? "unknown error"}`)
         results.push({ file, action: "not-found", dryRun: false })
       }
     }
@@ -168,12 +176,12 @@ export async function skipSpecificFiles(files: string[], options: SkipOptions = 
       info(`[DRY-RUN] Would remove: ${file}`)
       results.push({ file, action: "removed", dryRun: true })
     } else {
-      const removed = await removeFile(file)
-      if (removed) {
+      const res = await removeFile(file)
+      if (res.ok) {
         success(`Removed: ${file}`)
         results.push({ file, action: "removed", dryRun: false })
       } else {
-        warn(`Failed to remove: ${file}`)
+        warn(`Failed to remove ${file}: ${res.err ?? "unknown error"}`)
         results.push({ file, action: "not-found", dryRun: false })
       }
     }

--- a/script/upstream/utils/config.ts
+++ b/script/upstream/utils/config.ts
@@ -123,8 +123,10 @@ export const defaultConfig: MergeConfig = {
     ".github/workflows/deploy.yml",
     ".github/workflows/docs-update.yml",
     ".github/workflows/docs-locale-sync.yml",
-    // Vouch files (Kilo doesn't use Vouch)
-    ".github/VOUCHED.md",
+    // Vouch files (Kilo doesn't use Vouch).
+    // Upstream currently ships VOUCHED.td (typo extension). The glob covers both
+    // the current .td file and any future .md rename without another merge breaking.
+    ".github/VOUCHED.*",
     ".github/workflows/vouch-check-issue.yml",
     ".github/workflows/vouch-check-pr.yml",
     ".github/workflows/vouch-manage-by-issue.yml",


### PR DESCRIPTION
## Why

Two files kept falling through to manual resolution during upstream merges even though they're intended to be auto-skipped:

- `.github/VOUCHED.td` — the skip list matched `.github/VOUCHED.md`, but upstream actually ships the file with a `.td` extension. `shouldSkip` only exact-matches non-wildcard patterns, so nothing matched.
- `README.it.md` — correctly listed, but `removeFile`'s `git rm -f` exited non-zero once and we had no visibility into why because stderr was discarded and there was no retry. 20+ other translated READMEs in the same run removed fine.

## What

- Broaden the VOUCHED pattern to `.github/VOUCHED.*` so both `.td` and any future rename are covered.
- Have `removeFile` return `{ ok, err }`, surface real `git rm` stderr in the warning, and retry once on failure so transient index contention (editors/watchers/rerere) doesn't leak through as a mystery manual conflict.
