### PR TITLE
chore(upstream): auto-resolve conflicts with mergiraf + zdiff3 markers

### DIFF
--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -82,32 +82,45 @@ function abortMissingMergiraf(): never {
  * Attempt syntax-aware resolution of conflicted files via mergiraf.
  * Re-materializes each file with diff3 markers first so mergiraf can
  * reconstruct the base revision (needed for its structural heuristics).
- * Returns the number of files fully resolved and staged. Any per-file
- * failure (missing base/theirs, mergiraf crash, stage failure) is logged
- * and skipped so the overall merge continues to the next transform pass.
+ * Only stages files mergiraf resolves completely (no conflict markers
+ * remain). Partial resolutions are left unstaged so the remaining markers
+ * show up for manual review — we never auto-commit a partially-resolved
+ * file. Per-file failures are logged at debug level and skipped so the
+ * overall merge continues to the next transform pass.
  */
-async function runMergiraf(files: string[]): Promise<number> {
+async function runMergiraf(files: string[]): Promise<{ solved: number; partial: number }> {
   let solved = 0
+  let partial = 0
   for (const file of files) {
     const co = await $`git checkout --conflict=diff3 -- ${file}`.quiet().nothrow()
-    if (co.exitCode !== 0) continue
-    const mg = await $`mergiraf solve ${file}`.quiet().nothrow()
-    if (mg.exitCode !== 0) {
-      logger.debug(`mergiraf failed on ${file} (exit ${mg.exitCode}) — leaving for next transform pass`)
+    if (co.exitCode !== 0) {
+      logger.debug(`skipping ${file}: checkout --conflict=diff3 failed (exit ${co.exitCode})`)
       continue
     }
+    const mg = await $`mergiraf solve ${file}`.quiet().nothrow()
     const content = await Bun.file(file)
       .text()
       .catch(() => "")
-    if (!content || content.includes("<<<<<<< ")) continue
+    if (!content) {
+      logger.debug(`skipping ${file}: empty after mergiraf (exit ${mg.exitCode})`)
+      continue
+    }
+    if (content.includes("<<<<<<< ")) {
+      // exit 2 = mergiraf reduced but didn't fully resolve; exit 1 = no change.
+      // Either way the working tree still has markers, so leave it unstaged
+      // for manual review rather than silently staging a half-resolved file.
+      logger.debug(`${file}: mergiraf left conflict markers (exit ${mg.exitCode}) — unstaged for manual review`)
+      if (mg.exitCode === 2) partial++
+      continue
+    }
     const add = await $`git add ${file}`.quiet().nothrow()
     if (add.exitCode !== 0) {
-      logger.debug(`git add failed on ${file} (exit ${add.exitCode}) — leaving for next transform pass`)
+      logger.debug(`${file}: git add failed (exit ${add.exitCode}) — leaving for next transform pass`)
       continue
     }
     solved++
   }
-  return solved
+  return { solved, partial }
 }
 
 function parseArgs(): MergeOptions {
@@ -510,12 +523,17 @@ async function main() {
       // kilocode_change markers, plus JSON/YAML/TOML key merges and other
       // structural conflicts. Presence is enforced at startup.
       logger.info("Running mergiraf on remaining conflicts...")
-      const solved = await runMergiraf(conflictedFiles)
-      if (solved > 0) {
-        logger.success(`mergiraf auto-resolved ${solved} conflict(s)`)
+      const mgResult = await runMergiraf(conflictedFiles)
+      if (mgResult.solved > 0) {
+        logger.success(`mergiraf auto-resolved ${mgResult.solved} conflict(s)`)
         conflictedFiles = await git.getConflictedFiles()
       } else {
-        logger.info("mergiraf did not resolve any conflicts")
+        logger.info("mergiraf did not fully resolve any conflicts")
+      }
+      if (mgResult.partial > 0) {
+        logger.info(
+          `mergiraf partially resolved ${mgResult.partial} file(s) — remaining markers left unstaged for manual review`,
+        )
       }
 
       // Transform i18n files

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -97,7 +97,7 @@ async function runMergiraf(files: string[]): Promise<{ solved: number; partial: 
       logger.debug(`skipping ${file}: checkout --conflict=diff3 failed (exit ${co.exitCode})`)
       continue
     }
-    const mg = await $`mergiraf solve ${file}`.quiet().nothrow()
+    const mg = await $`mergiraf solve --keep-backup=false ${file}`.quiet().nothrow()
     const content = await Bun.file(file)
       .text()
       .catch(() => "")

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -61,6 +61,45 @@ interface MergeOptions {
   author?: string
 }
 
+async function hasMergiraf(): Promise<boolean> {
+  const result = await $`mergiraf --version`.quiet().nothrow()
+  return result.exitCode === 0
+}
+
+function abortMissingMergiraf(): never {
+  logger.error("mergiraf is required but not installed.")
+  logger.info("  It provides syntax-aware resolution for imports, JSON/YAML/TOML,")
+  logger.info("  and other structural conflicts during upstream merges.")
+  logger.info("  Install via one of:")
+  logger.info("    brew install mergiraf                 # macOS / Linuxbrew")
+  logger.info("    cargo install mergiraf                # any platform with rustup")
+  logger.info("    nix profile install nixpkgs#mergiraf  # nix")
+  logger.info("  See https://mergiraf.org/installation.html for more options.")
+  process.exit(1)
+}
+
+/**
+ * Attempt syntax-aware resolution of conflicted files via mergiraf.
+ * Re-materializes each file with diff3 markers first so mergiraf can
+ * reconstruct the base revision (needed for its structural heuristics).
+ * Returns the number of files fully resolved and staged.
+ */
+async function runMergiraf(files: string[]): Promise<number> {
+  let solved = 0
+  for (const file of files) {
+    const co = await $`git checkout --conflict=diff3 -- ${file}`.quiet().nothrow()
+    if (co.exitCode !== 0) continue
+    await $`mergiraf solve ${file}`.quiet().nothrow()
+    const content = await Bun.file(file)
+      .text()
+      .catch(() => "")
+    if (content.includes("<<<<<<< ")) continue
+    await $`git add ${file}`.quiet()
+    solved++
+  }
+  return solved
+}
+
 function parseArgs(): MergeOptions {
   const args = process.argv.slice(2)
 
@@ -137,6 +176,10 @@ async function main() {
     logger.error("No 'upstream' remote found. Please add it:")
     logger.info("  git remote add upstream git@github.com:anomalyco/opencode.git")
     process.exit(1)
+  }
+
+  if (!(await hasMergiraf())) {
+    abortMissingMergiraf()
   }
 
   if (await git.hasUncommittedChanges()) {
@@ -451,6 +494,19 @@ async function main() {
 
     if (conflictedFiles.length > 0) {
       logger.info("Attempting to auto-resolve remaining conflicts...")
+
+      // Step 7c-pre: syntax-aware resolution via mergiraf.
+      // Handles the common pattern of neighbouring import additions around
+      // kilocode_change markers, plus JSON/YAML/TOML key merges and other
+      // structural conflicts. Presence is enforced at startup.
+      logger.info("Running mergiraf on remaining conflicts...")
+      const solved = await runMergiraf(conflictedFiles)
+      if (solved > 0) {
+        logger.success(`mergiraf auto-resolved ${solved} conflict(s)`)
+        conflictedFiles = await git.getConflictedFiles()
+      } else {
+        logger.info("mergiraf did not resolve any conflicts")
+      }
 
       // Transform i18n files
       const i18nResults = await transformConflictedI18n(conflictedFiles, { dryRun: false, verbose: options.verbose })

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -82,19 +82,29 @@ function abortMissingMergiraf(): never {
  * Attempt syntax-aware resolution of conflicted files via mergiraf.
  * Re-materializes each file with diff3 markers first so mergiraf can
  * reconstruct the base revision (needed for its structural heuristics).
- * Returns the number of files fully resolved and staged.
+ * Returns the number of files fully resolved and staged. Any per-file
+ * failure (missing base/theirs, mergiraf crash, stage failure) is logged
+ * and skipped so the overall merge continues to the next transform pass.
  */
 async function runMergiraf(files: string[]): Promise<number> {
   let solved = 0
   for (const file of files) {
     const co = await $`git checkout --conflict=diff3 -- ${file}`.quiet().nothrow()
     if (co.exitCode !== 0) continue
-    await $`mergiraf solve ${file}`.quiet().nothrow()
+    const mg = await $`mergiraf solve ${file}`.quiet().nothrow()
+    if (mg.exitCode !== 0) {
+      logger.debug(`mergiraf failed on ${file} (exit ${mg.exitCode}) — leaving for next transform pass`)
+      continue
+    }
     const content = await Bun.file(file)
       .text()
       .catch(() => "")
-    if (content.includes("<<<<<<< ")) continue
-    await $`git add ${file}`.quiet()
+    if (!content || content.includes("<<<<<<< ")) continue
+    const add = await $`git add ${file}`.quiet().nothrow()
+    if (add.exitCode !== 0) {
+      logger.debug(`git add failed on ${file} (exit ${add.exitCode}) — leaving for next transform pass`)
+      continue
+    }
     solved++
   }
   return solved

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -82,26 +82,51 @@ function abortMissingMergiraf(): never {
  * Attempt syntax-aware resolution of conflicted files via mergiraf.
  * Assumes `git merge` was invoked with `merge.conflictStyle=zdiff3`, so the
  * working tree already contains base-aware markers that mergiraf can feed
- * into its structural heuristics. Only stages files mergiraf resolves
- * completely (no conflict markers remain). Partial resolutions are left
- * unstaged so the remaining markers show up for manual review — we never
- * auto-commit a partially-resolved file. Per-file failures are logged at
- * debug level and skipped so the overall merge continues to the next
- * transform pass.
+ * into its structural heuristics.
+ *
+ * Only runs on files whose working-tree content actually contains text
+ * conflict markers. Delete/modify (UD/DU) and similar non-textual conflicts
+ * have no markers — running `mergiraf solve` + `git add` on them would
+ * silently stage the file with our side of the conflict, losing the signal
+ * that upstream deleted (or that we deleted what upstream modified). Those
+ * are left untouched for manual review.
+ *
+ * Only stages files mergiraf resolves completely (no conflict markers
+ * remain). Partial resolutions are left unstaged so the remaining markers
+ * show up for manual review — we never auto-commit a partially-resolved
+ * file. Per-file failures are logged at debug level and skipped so the
+ * overall merge continues to the next transform pass.
  */
-async function runMergiraf(files: string[]): Promise<{ solved: number; partial: number }> {
+async function runMergiraf(files: string[]): Promise<{ solved: number; partial: number; skipped: number }> {
   let solved = 0
   let partial = 0
+  let skipped = 0
   for (const file of files) {
-    const mg = await $`mergiraf solve --keep-backup=false ${file}`.quiet().nothrow()
-    const content = await Bun.file(file)
+    const before = await Bun.file(file)
       .text()
       .catch(() => "")
-    if (!content) {
+    if (!before) {
+      logger.debug(`skipping ${file}: file missing from working tree (likely delete/modify conflict)`)
+      skipped++
+      continue
+    }
+    if (!before.includes("<<<<<<< ")) {
+      // No text conflict markers — this is a non-textual conflict (UD/DU,
+      // add/add with identical content, submodule, binary, etc.). Running
+      // mergiraf + git add here would silently stage our side as resolved.
+      logger.debug(`skipping ${file}: no conflict markers (non-textual conflict, needs manual review)`)
+      skipped++
+      continue
+    }
+    const mg = await $`mergiraf solve --keep-backup=false ${file}`.quiet().nothrow()
+    const after = await Bun.file(file)
+      .text()
+      .catch(() => "")
+    if (!after) {
       logger.debug(`skipping ${file}: empty after mergiraf (exit ${mg.exitCode})`)
       continue
     }
-    if (content.includes("<<<<<<< ")) {
+    if (after.includes("<<<<<<< ")) {
       // exit 2 = mergiraf reduced but didn't fully resolve; exit 1 = no change.
       // Either way the working tree still has markers, so leave it unstaged
       // for manual review rather than silently staging a half-resolved file.
@@ -116,7 +141,7 @@ async function runMergiraf(files: string[]): Promise<{ solved: number; partial: 
     }
     solved++
   }
-  return { solved, partial }
+  return { solved, partial, skipped }
 }
 
 function parseArgs(): MergeOptions {
@@ -529,6 +554,11 @@ async function main() {
       if (mgResult.partial > 0) {
         logger.info(
           `mergiraf partially resolved ${mgResult.partial} file(s) — remaining markers left unstaged for manual review`,
+        )
+      }
+      if (mgResult.skipped > 0) {
+        logger.info(
+          `mergiraf skipped ${mgResult.skipped} file(s) with non-textual conflicts (delete/modify, binary, etc.) — left for manual review`,
         )
       }
 

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -80,23 +80,19 @@ function abortMissingMergiraf(): never {
 
 /**
  * Attempt syntax-aware resolution of conflicted files via mergiraf.
- * Re-materializes each file with diff3 markers first so mergiraf can
- * reconstruct the base revision (needed for its structural heuristics).
- * Only stages files mergiraf resolves completely (no conflict markers
- * remain). Partial resolutions are left unstaged so the remaining markers
- * show up for manual review — we never auto-commit a partially-resolved
- * file. Per-file failures are logged at debug level and skipped so the
- * overall merge continues to the next transform pass.
+ * Assumes `git merge` was invoked with `merge.conflictStyle=zdiff3`, so the
+ * working tree already contains base-aware markers that mergiraf can feed
+ * into its structural heuristics. Only stages files mergiraf resolves
+ * completely (no conflict markers remain). Partial resolutions are left
+ * unstaged so the remaining markers show up for manual review — we never
+ * auto-commit a partially-resolved file. Per-file failures are logged at
+ * debug level and skipped so the overall merge continues to the next
+ * transform pass.
  */
 async function runMergiraf(files: string[]): Promise<{ solved: number; partial: number }> {
   let solved = 0
   let partial = 0
   for (const file of files) {
-    const co = await $`git checkout --conflict=diff3 -- ${file}`.quiet().nothrow()
-    if (co.exitCode !== 0) {
-      logger.debug(`skipping ${file}: checkout --conflict=diff3 failed (exit ${co.exitCode})`)
-      continue
-    }
     const mg = await $`mergiraf solve --keep-backup=false ${file}`.quiet().nothrow()
     const content = await Bun.file(file)
       .text()

--- a/script/upstream/utils/git.ts
+++ b/script/upstream/utils/git.ts
@@ -122,7 +122,12 @@ export async function commit(message: string): Promise<void> {
 }
 
 export async function merge(branch: string): Promise<{ success: boolean; conflicts: string[] }> {
-  const result = await $`git merge ${branch}`.nothrow()
+  // Use zdiff3 markers so conflicts carry the base version (|||||||) alongside
+  // ours/theirs. This gives mergiraf the base it needs for structural heuristics
+  // and makes any remaining manual resolution dramatically easier (you can see
+  // what both sides changed relative to the common ancestor instead of
+  // reverse-engineering it from a 2-way marker).
+  const result = await $`git -c merge.conflictStyle=zdiff3 merge ${branch}`.nothrow()
 
   if (result.exitCode === 0) {
     return { success: true, conflicts: [] }


### PR DESCRIPTION
## Summary

Automates most of the conflict-resolution grunt work during upstream merges and makes the leftovers dramatically easier to resolve by hand.

- **Mergiraf (syntax-aware resolver):** call `mergiraf solve` on each conflicted file before the kilocode-specific transform cascade in `script/upstream/merge.ts`. Auto-resolves the common pattern of neighbouring import additions around `kilocode_change` markers plus most JSON/YAML/TOML structural conflicts, so the existing i18n/branding/etc. transforms only see what's genuinely ambiguous. On a v1.14.28 merge run this resolved 45 of 74 conflicts.
- **zdiff3 markers for the whole merge:** pass `merge.conflictStyle=zdiff3` to `git merge` in `utils/git.ts`, so every conflicted file carries base (`|||||||`) markers from the start — not just the ones mergiraf happens to touch. Manual resolution then shows what both sides changed relative to the common ancestor, which is much easier than reverse-engineering that from a 2-way marker.
- **Never stage partial resolutions:** mergiraf exit 2 means it reduced but didn't fully close the conflicts. The working tree keeps the reduced content (fewer markers to review), but the file is left unstaged so nothing half-resolved is auto-committed — you still see it in `git status` as needing attention.
- **Resilient to per-file failures:** every subprocess in `runMergiraf` uses `.nothrow()` and logs at debug level on non-zero exit, so a single problem file can't abort the entire merge mid-run.
- **`mergiraf` required at startup:** if missing the script aborts at step 1 with install instructions (`brew` / `cargo` / `nix`) rather than failing mid-merge.
- **No `.orig` pile-up:** pass `--keep-backup=false` to `mergiraf solve` so the working tree isn't littered with backup files afterwards.

Mergiraf is actively maintained (v0.16.3, 2026-01-26) and supports all the file types we hit during upstream merges (TS/TSX, JSON, YAML, TOML, etc.). Docs: https://mergiraf.org/.

## Test plan

Run `bun run script/upstream/merge.ts` against an upstream version known to produce import-shuffle conflicts (e.g. anything recent where upstream moved imports around `CrossSpawnSpawner` / `Config` / `Global`). Verify:

1. Without `mergiraf` installed: script exits at step 1 with install instructions.
2. With `mergiraf` installed:
   - files with purely-additive import conflicts are auto-resolved and staged before the kilocode transform cascade runs;
   - the log reports both a full-resolution count (`mergiraf auto-resolved N conflict(s)`) and a partial-resolution count (`mergiraf partially resolved M file(s) — remaining markers left unstaged for manual review`);
   - files with real semantic conflicts still fall through to manual review — with zdiff3 markers showing the base version alongside ours/theirs.
   
 
## Before: 
<img width="775" height="958" alt="image" src="https://github.com/user-attachments/assets/7158f7a1-10bf-4f44-bb8f-a4deb3a2f284" />


##   After:
   
<img width="833" height="439" alt="CleanShot 2026-04-28 at 14 55 49" src="https://github.com/user-attachments/assets/0c004716-5345-4161-8855-cbbb4be54c2d" />

