### PR TITLE
Show paid Kilo models when signed out

### DIFF
--- a/.changeset/show-paid-models-anonymous.md
+++ b/.changeset/show-paid-models-anonymous.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+"@kilocode/kilo-gateway": patch
+---
+
+Show paid Kilo models to signed-out users so selecting one prompts them to log in.

--- a/packages/kilo-gateway/src/loader.ts
+++ b/packages/kilo-gateway/src/loader.ts
@@ -26,19 +26,6 @@ export async function kiloCustomLoader(provider: ProviderInfo): Promise<CustomLo
   const initialCount = Object.keys(provider.models).length
   console.log(`[kilo-provider] Loaded ${initialCount} models, hasAuth: ${hasKey}`)
 
-  // If no key, remove paid models
-  if (!hasKey) {
-    for (const [key, value] of Object.entries(provider.models)) {
-      if (value.cost?.input > 0 || value.cost?.output > 0) {
-        delete provider.models[key]
-      }
-    }
-    const freeCount = Object.keys(provider.models).length
-    console.log(
-      `[kilo-provider] Filtered to ${freeCount} free models (removed ${initialCount - freeCount} paid models)`,
-    )
-  }
-
   const autoload = Object.keys(provider.models).length > 0
   console.log(`[kilo-provider] Autoload: ${autoload}`)
 

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -124,13 +124,6 @@ export function kiloCustomLoaders(dep: CustomDep): Record<string, CustomLoader> 
         return false
       })
 
-      if (!hasKey) {
-        for (const [key, value] of Object.entries(input.models)) {
-          if ((value as any).cost.input === 0) continue
-          delete input.models[key]
-        }
-      }
-
       const options: Record<string, string> = {}
       if (env.KILO_ORG_ID) {
         options.kilocodeOrganizationId = env.KILO_ORG_ID

--- a/packages/opencode/test/kilocode/kilo-loader-auth.test.ts
+++ b/packages/opencode/test/kilocode/kilo-loader-auth.test.ts
@@ -1,6 +1,6 @@
 // kilocode_change - new file
 //
-// Tests that the kilo custom loader gates paid models behind authentication.
+// Tests that the kilo custom loader keeps paid models visible without authentication.
 // Mocks fetchKiloModels from @kilocode/kilo-gateway to avoid real network
 // calls (which fail on Windows CI).
 
@@ -48,7 +48,7 @@ function paid(providers: Awaited<ReturnType<typeof Provider.list>>) {
   return Object.values(item.models).filter((model) => model.cost.input > 0).length
 }
 
-test("kilo loader keeps paid models when config apiKey is present", async () => {
+test("kilo loader keeps paid models without auth and when config apiKey is present", async () => {
   // Reset state that may be stale from other test files sharing this process.
   // Auth.set from other tests persists in the shared auth.json, ModelsDev.Data
   // holds a lazy singleton whose resolved object gets mutated in-place by get(),
@@ -96,11 +96,11 @@ test("kilo loader keeps paid models when config apiKey is present", async () => 
     fn: async () => paid(await Provider.list()),
   })
 
-  expect(none).toBe(0)
+  expect(none).toBeGreaterThan(0)
   expect(count).toBeGreaterThan(0)
 })
 
-test("kilo loader keeps paid models when auth exists", async () => {
+test("kilo loader keeps paid models without auth and when auth exists", async () => {
   await Auth.remove("kilo")
   ModelCache.clear("kilo")
   ModelsDev.Data.reset()
@@ -155,7 +155,7 @@ test("kilo loader keeps paid models when auth exists", async () => {
       fn: async () => paid(await Provider.list()),
     })
 
-    expect(none).toBe(0)
+    expect(none).toBeGreaterThan(0)
     expect(count).toBeGreaterThan(0)
   } finally {
     if (prev !== undefined) {


### PR DESCRIPTION
## Summary
- Keep paid Kilo models visible in the model catalog for signed-out users.
- Preserve anonymous access for free models so paid selections fall through to the existing login-required prompt.
- Update the Kilo loader auth test expectations and add a changeset.

<img width="400" height="837" alt="image" src="https://github.com/user-attachments/assets/b8f284da-8dcc-435c-bc4b-6172ea3ee958" />
