### PR TITLE
fix(cli): publish docker image to ghcr.io/kilo-org/kilocode

### DIFF
--- a/.changeset/ghcr-docker-image-rename.md
+++ b/.changeset/ghcr-docker-image-rename.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Rename the published Docker image from `ghcr.io/kilo-org/kilo` to `ghcr.io/kilo-org/kilocode` so it lives alongside the active `kilocode` repo instead of the archived `kilo` one.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,12 +116,3 @@ The following secrets must be configured in the repository:
 ### Concurrency
 
 The workflow uses concurrency control (`workflow-ref-bump/version`) to prevent parallel releases from conflicting.
-
-## One-Time Follow-Up After Renaming the Docker Image
-
-The CLI Docker image was renamed from `ghcr.io/kilo-org/kilo` to `ghcr.io/kilo-org/kilocode`. The first release after the rename will create a brand-new GHCR package; after that publish succeeds, do the following once:
-
-1. Open `https://github.com/orgs/Kilo-Org/packages/container/kilocode/package-settings`.
-2. **Make the package public** — "Danger Zone" → "Change visibility" → Public. Without this, `docker pull` will return 401 for everyone.
-3. **Connect it to the `kilocode` repo** — "Manage Actions access" / "Repository" → select `Kilo-Org/kilocode`. This makes the package appear under the repo's Packages sidebar and fixes the source repo shown in the GHCR UI.
-4. (Optional) Deprecate the old `ghcr.io/kilo-org/kilo` package at `https://github.com/orgs/Kilo-Org/packages/container/kilo/package-settings` so users stop pulling from the archived-repo-linked package.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -63,7 +63,7 @@ Downloads all build artifacts and publishes to every distribution channel:
 
 - Publishes platform-specific binary packages to **npm** (e.g. `@kilocode/cli-linux-x64`, `@kilocode/cli-darwin-arm64`, etc.).
 - Publishes the main `@kilocode/cli` package to **npm** with optional dependencies on the binary packages.
-- Builds and pushes a multi-arch **Docker image** (`ghcr.io/kilo-org/kilo`) to GitHub Container Registry (linux/amd64 + linux/arm64).
+- Builds and pushes a multi-arch **Docker image** (`ghcr.io/kilo-org/kilocode`) to GitHub Container Registry (linux/amd64 + linux/arm64).
 
 #### SDK (`@kilocode/sdk`)
 
@@ -116,3 +116,12 @@ The following secrets must be configured in the repository:
 ### Concurrency
 
 The workflow uses concurrency control (`workflow-ref-bump/version`) to prevent parallel releases from conflicting.
+
+## One-Time Follow-Up After Renaming the Docker Image
+
+The CLI Docker image was renamed from `ghcr.io/kilo-org/kilo` to `ghcr.io/kilo-org/kilocode`. The first release after the rename will create a brand-new GHCR package; after that publish succeeds, do the following once:
+
+1. Open `https://github.com/orgs/Kilo-Org/packages/container/kilocode/package-settings`.
+2. **Make the package public** — "Danger Zone" → "Change visibility" → Public. Without this, `docker pull` will return 401 for everyone.
+3. **Connect it to the `kilocode` repo** — "Manage Actions access" / "Repository" → select `Kilo-Org/kilocode`. This makes the package appear under the repo's Packages sidebar and fixes the source repo shown in the GHCR UI.
+4. (Optional) Deprecate the old `ghcr.io/kilo-org/kilo` package at `https://github.com/orgs/Kilo-Org/packages/container/kilo/package-settings` so users stop pulling from the archived-repo-linked package.

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -73,7 +73,7 @@ const tasks = Object.entries(binaries).map(async ([name]) => {
 await Promise.all(tasks)
 await publish(`./dist/${pkg.name}`, pkg.name, version) // kilocode_change
 
-const image = "ghcr.io/kilo-org/kilo" // kilocode_change
+const image = "ghcr.io/kilo-org/kilocode" // kilocode_change
 const platforms = "linux/amd64,linux/arm64"
 const tags = [`${image}:${version}`, `${image}:${Script.channel}`]
 const tagFlags = tags.flatMap((t) => ["-t", t])

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -146,7 +146,7 @@ const TIPS = [
   "Press {highlight}Ctrl+X S{/highlight} or {highlight}/status{/highlight} to see system status info",
   "Enable {highlight}scroll_acceleration{/highlight} in {highlight}tui.json{/highlight} for smooth macOS-style scrolling",
   "Toggle username display in chat via command palette ({highlight}Ctrl+P{/highlight})",
-  "Run {highlight}docker run -it --rm ghcr.io/kilo-org/kilo{/highlight} for containerized use",
+  "Run {highlight}docker run -it --rm ghcr.io/kilo-org/kilocode{/highlight} for containerized use",
   "Use {highlight}/connect{/highlight} with OpenCode Zen for curated, tested models",
   "Commit your project's {highlight}AGENTS.md{/highlight} file to Git for team sharing",
   "Use {highlight}/review{/highlight} to review uncommitted changes, branches, or PRs",


### PR DESCRIPTION
## Summary

The released Docker image is still named `ghcr.io/kilo-org/kilo`, which on GHCR is attached to the archived `Kilo-Org/kilo` repo (see the "This repository was archived" banner on its package page). Rename the image to `ghcr.io/kilo-org/kilocode` so the next release creates a fresh GHCR package under the active `kilocode` repo instead.

Renamed in three spots:
- `packages/opencode/script/publish.ts` — the `image` constant used by `docker buildx build --push`
- `packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx` — the user-facing tip
- `RELEASING.md` — the release channel description

## One-time follow-up after merging and releasing

The first release after this merges will create a brand-new GHCR package. Once that publish succeeds, do the following once:

1. Open `https://github.com/orgs/Kilo-Org/packages/container/kilocode/package-settings`.
2. **Make the package public** — "Danger Zone" → "Change visibility" → Public. Without this, `docker pull` will return 401 for everyone.
3. **Connect it to the `kilocode` repo** — "Manage Actions access" / "Repository" → select `Kilo-Org/kilocode`. This makes the package appear under the repo's Packages sidebar and fixes the source repo shown in the GHCR UI.
4. (Optional) Deprecate the old `ghcr.io/kilo-org/kilo` package at `https://github.com/orgs/Kilo-Org/packages/container/kilo/package-settings` so users stop pulling from the archived-repo-linked package.
