### PR TITLE
fix(cli): check annotations across shared upstream paths

### DIFF
--- a/.github/workflows/check-opencode-annotations.yml
+++ b/.github/workflows/check-opencode-annotations.yml
@@ -1,11 +1,21 @@
-name: Check opencode annotations
+name: Check shared upstream annotations
 
 on:
   pull_request:
     paths:
+      - ".github/**"
+      - "github/**"
+      - "sdks/vscode/**"
+      - "packages/app/**"
+      - "packages/desktop/**"
+      - "packages/desktop-electron/**"
+      - "packages/extensions/**"
       - "packages/opencode/**"
-      - "script/check-opencode-annotations.ts"
-      - ".github/workflows/check-opencode-annotations.yml"
+      - "packages/script/**"
+      - "packages/shared/**"
+      - "packages/storybook/**"
+      - "packages/ui/**"
+      - "script/**"
   workflow_dispatch:
 
 jobs:
@@ -21,7 +31,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
-      - name: Check kilocode_change annotations in shared opencode files
+      - name: Check kilocode_change annotations in shared upstream files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/packages/script/tests/check-opencode-annotations.test.ts
+++ b/packages/script/tests/check-opencode-annotations.test.ts
@@ -1,18 +1,45 @@
 import { describe, expect, test } from "bun:test"
 import path from "node:path"
 
-const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx"])
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml"])
+const SCOPES = [
+  "sdks/vscode",
+  "packages/opencode",
+  "packages/extensions",
+  "packages/ui",
+  "packages/app",
+  "packages/desktop",
+  "packages/desktop-electron",
+  "packages/shared",
+  "packages/script",
+  "packages/storybook",
+  "script",
+  ".github",
+  "github",
+]
+const EXEMPT_SCOPES = [
+  "script/upstream",
+  "script/check-opencode-annotations.ts",
+  "packages/script/tests/check-opencode-annotations.test.ts",
+  ".github/workflows/check-opencode-annotations.yml",
+]
+
+function isChecked(file: string) {
+  const norm = file.replaceAll("\\", "/")
+  return SCOPES.some((scope) => norm === scope || norm.startsWith(`${scope}/`))
+}
 
 function isExempt(file: string) {
   const norm = file.replaceAll("\\", "/").toLowerCase()
-  return norm.split("/").some((part) => part.includes("kilocode"))
+  if (norm.split("/").some((part) => part.includes("kilocode") || part.startsWith("kilo-"))) return true
+  return EXEMPT_SCOPES.some((scope) => norm === scope || norm.startsWith(`${scope}/`))
 }
 
 function isSource(file: string) {
   return SOURCE_EXTS.has(path.extname(file))
 }
 
-const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*)\s*kilocode_change\b/
+const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\b/
 
 function hasMarker(line: string) {
   return MARKER_PREFIX.test(line)
@@ -22,8 +49,8 @@ function coveredLines(text: string): Set<number> {
   const lines = text.split(/\r?\n/)
   const covered = new Set<number>()
 
-  const first = lines.find((x) => x.trim() !== "")
-  if (first?.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s*-\s*new\s*file\b/)) {
+  const first = lines.find((x) => x.trim() !== "" && !x.startsWith("#!"))
+  if (first?.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s*-\s*new\s*file\b/)) {
     for (let i = 1; i <= lines.length; i++) covered.add(i)
     return covered
   }
@@ -33,13 +60,13 @@ function coveredLines(text: string): Set<number> {
     const n = i + 1
     const line = lines[i] ?? ""
 
-    if (line.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s+start\b/)) {
+    if (line.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s+start\b/)) {
       block = true
       covered.add(n)
       continue
     }
 
-    if (line.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s+end\b/)) {
+    if (line.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s+end\b/)) {
       covered.add(n)
       block = false
       continue
@@ -54,13 +81,6 @@ function coveredLines(text: string): Set<number> {
   }
 
   return covered
-}
-
-function checkLine(line: string, covered: Set<number>, n: number): boolean {
-  const trim = line.trim()
-  if (!trim) return true
-  if (hasMarker(trim)) return true
-  return covered.has(n)
 }
 
 // ─── hasMarker tests ──────────────────────────────────────────────────────────
@@ -93,6 +113,14 @@ describe("hasMarker", () => {
     ["/* kilocode_change start */", true],
     ["/* kilocode_change end */", true],
 
+    // YAML/TOML-style inline
+    ["# kilocode_change", true],
+    ["  # kilocode_change", true],
+    ["name: test # kilocode_change", true],
+    ['name = "zed" # kilocode_change', true],
+    ["# kilocode_change start", true],
+    ["# kilocode_change end", true],
+
     // Non-markers
     ["const x = 1", false],
     ["<text fg={color}>{label}</text>", false],
@@ -123,6 +151,13 @@ describe("isExempt", () => {
     ["packages/opencode/test/kilocode/bar.test.ts", true],
     ["packages/opencode/src/some/kilocode/deep/path.ts", true],
     ["packages/opencode/src/kilocode/deep/nested/file.tsx", true],
+    ["packages/opencode/src/kilo-sessions/session.ts", true],
+    ["packages/kilo-ui/src/components/icon.tsx", true],
+    ["packages/kilo-vscode/src/extension.ts", true],
+    ["script/upstream/merge.ts", true],
+    ["script/check-opencode-annotations.ts", true],
+    ["packages/script/tests/check-opencode-annotations.test.ts", true],
+    [".github/workflows/check-opencode-annotations.yml", true],
     // exempt — "kilocode" in filename
     ["packages/opencode/src/foo/kilocode.ts", true],
     ["packages/opencode/src/bar/kilocode.test.ts", true],
@@ -137,12 +172,45 @@ describe("isExempt", () => {
     ["packages/opencode/src/tool/registry.ts", false],
     ["packages/opencode/src/config/config.ts", false],
     ["packages/opencode/src/indexing/search-service.ts", false],
+    ["packages/ui/src/components/icon.tsx", false],
+    ["packages/app/src/index.ts", false],
+    ["packages/desktop/src/main.ts", false],
+    ["packages/desktop-electron/src/main/index.ts", false],
+    ["sdks/vscode/src/extension.ts", false],
+    ["packages/extensions/zed/extension.toml", false],
+    ["script/changelog.ts", false],
     // kilocode_change is not the same as kilocode
     ["packages/opencode/src/check-opencode-annotations.ts", false],
   ]
 
   test.each(cases)("%j → exempt=%j", (file, expected) => {
     expect(isExempt(file)).toBe(expected)
+  })
+})
+
+describe("isChecked", () => {
+  const cases: Array<[string, boolean]> = [
+    ["packages/opencode/src/index.ts", true],
+    ["packages/ui/src/components/icon.tsx", true],
+    ["packages/app/src/index.ts", true],
+    ["packages/desktop/src/main.ts", true],
+    ["packages/desktop-electron/src/main/index.ts", true],
+    ["sdks/vscode/src/extension.ts", true],
+    ["packages/extensions/zed/extension.toml", true],
+    ["packages/shared/src/index.ts", true],
+    ["packages/script/src/index.ts", true],
+    ["packages/storybook/.storybook/main.ts", true],
+    ["script/check-opencode-annotations.ts", true],
+    [".github/workflows/test.yml", true],
+    ["github/action.yml", true],
+    ["packages/kilo-ui/src/components/icon.tsx", false],
+    ["packages/kilo-vscode/src/extension.ts", false],
+    ["packages/sdk/js/src/index.ts", false],
+    ["README.md", false],
+  ]
+
+  test.each(cases)("%j → checked=%j", (file, expected) => {
+    expect(isChecked(file)).toBe(expected)
   })
 })
 
@@ -156,6 +224,9 @@ describe("isSource", () => {
     ["foo.js", true],
     ["foo.jsx", true],
     [".json", false],
+    ["workflow.yml", true],
+    ["workflow.yaml", true],
+    ["extension.toml", true],
     [".md", false],
     [".txt", false],
     ["Makefile", false],
@@ -186,8 +257,23 @@ describe("coveredLines", () => {
     expect(covered).toEqual(new Set([1, 2, 3]))
   })
 
+  test("whole-file JS annotation after shebang", () => {
+    const covered = coveredLines("#!/usr/bin/env bun\n// kilocode_change - new file\nexport const x = 1")
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
   test("whole-file JSX annotation", () => {
     const covered = coveredLines("{/* kilocode_change - new file */}\nexport const x = 1\nexport const y = 2")
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("whole-file YAML annotation", () => {
+    const covered = coveredLines("# kilocode_change - new file\nname: test\non: pull_request")
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("whole-file TOML annotation", () => {
+    const covered = coveredLines('# kilocode_change - new file\nid = "opencode"\nname = "OpenCode"')
     expect(covered).toEqual(new Set([1, 2, 3]))
   })
 
@@ -231,6 +317,18 @@ describe("coveredLines", () => {
 
   test("bare /* */ block markers", () => {
     const text = ["/* kilocode_change start */", "const b = 2", "/* kilocode_change end */"].join("\n")
+    const covered = coveredLines(text)
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("YAML block markers", () => {
+    const text = ["# kilocode_change start", "name: test", "# kilocode_change end"].join("\n")
+    const covered = coveredLines(text)
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("TOML block markers", () => {
+    const text = ['# kilocode_change start', 'id = "opencode"', '# kilocode_change end'].join("\n")
     const covered = coveredLines(text)
     expect(covered).toEqual(new Set([1, 2, 3]))
   })
@@ -451,6 +549,10 @@ describe("MARKER_PREFIX regex edge cases", () => {
 
   test("handles // with lots of spaces", () => {
     expect(hasMarker("//    kilocode_change")).toBe(true)
+  })
+
+  test("handles # with lots of spaces", () => {
+    expect(hasMarker("#    kilocode_change")).toBe(true)
   })
 
   test("does not match {/* without kilocode_change", () => {

--- a/packages/script/tests/check-opencode-annotations.test.ts
+++ b/packages/script/tests/check-opencode-annotations.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import path from "node:path"
 
-const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml"])
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml", ".sh", ".bash", ".zsh"])
+const FILES = new Map<string, string>()
 const SCOPES = [
   "sdks/vscode",
   "packages/opencode",
@@ -36,7 +37,10 @@ function isExempt(file: string) {
 }
 
 function isSource(file: string) {
-  return SOURCE_EXTS.has(path.extname(file))
+  const ext = path.extname(file)
+  if (SOURCE_EXTS.has(ext)) return true
+  if (ext) return false
+  return FILES.get(file)?.startsWith("#!") ?? false
 }
 
 const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\b/
@@ -113,11 +117,12 @@ describe("hasMarker", () => {
     ["/* kilocode_change start */", true],
     ["/* kilocode_change end */", true],
 
-    // YAML/TOML-style inline
+    // YAML/TOML/shell-style inline
     ["# kilocode_change", true],
     ["  # kilocode_change", true],
     ["name: test # kilocode_change", true],
     ['name = "zed" # kilocode_change', true],
+    ['export FOO="bar" # kilocode_change', true],
     ["# kilocode_change start", true],
     ["# kilocode_change end", true],
 
@@ -178,6 +183,8 @@ describe("isExempt", () => {
     ["packages/desktop-electron/src/main/index.ts", false],
     ["sdks/vscode/src/extension.ts", false],
     ["packages/extensions/zed/extension.toml", false],
+    ["github/script/release", false],
+    ["github/script/publish", false],
     ["script/changelog.ts", false],
     // kilocode_change is not the same as kilocode
     ["packages/opencode/src/check-opencode-annotations.ts", false],
@@ -203,6 +210,8 @@ describe("isChecked", () => {
     ["script/check-opencode-annotations.ts", true],
     [".github/workflows/test.yml", true],
     ["github/action.yml", true],
+    ["github/script/release", true],
+    ["github/script/publish", true],
     ["packages/kilo-ui/src/components/icon.tsx", false],
     ["packages/kilo-vscode/src/extension.ts", false],
     ["packages/sdk/js/src/index.ts", false],
@@ -227,15 +236,23 @@ describe("isSource", () => {
     ["workflow.yml", true],
     ["workflow.yaml", true],
     ["extension.toml", true],
+    ["script.sh", true],
+    ["script.bash", true],
+    ["script.zsh", true],
     [".md", false],
     [".txt", false],
     ["Makefile", false],
+    ["github/script/release", true],
+    ["github/script/plain", false],
     ["foo.go", false],
     ["foo.rs", false],
   ]
 
   test.each(cases)("%j → isSource=%j", (file, expected) => {
+    FILES.set("github/script/release", "#!/usr/bin/env bash\n")
+    FILES.set("github/script/plain", "set -euo pipefail\n")
     expect(isSource(file)).toBe(expected)
+    FILES.clear()
   })
 })
 
@@ -274,6 +291,11 @@ describe("coveredLines", () => {
 
   test("whole-file TOML annotation", () => {
     const covered = coveredLines('# kilocode_change - new file\nid = "opencode"\nname = "OpenCode"')
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("whole-file shell annotation after shebang", () => {
+    const covered = coveredLines('#!/usr/bin/env bash\n# kilocode_change - new file\nset -euo pipefail')
     expect(covered).toEqual(new Set([1, 2, 3]))
   })
 
@@ -329,6 +351,12 @@ describe("coveredLines", () => {
 
   test("TOML block markers", () => {
     const text = ['# kilocode_change start', 'id = "opencode"', '# kilocode_change end'].join("\n")
+    const covered = coveredLines(text)
+    expect(covered).toEqual(new Set([1, 2, 3]))
+  })
+
+  test("shell block markers", () => {
+    const text = ["# kilocode_change start", "set -euo pipefail", "# kilocode_change end"].join("\n")
     const covered = coveredLines(text)
     expect(covered).toEqual(new Set([1, 2, 3]))
   })

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Verifies that every Kilo-specific change in shared packages/opencode/ files
+ * Verifies that every Kilo-specific change in shared upstream-owned source files
  * is annotated with a kilocode_change marker.
  *
  * Usage:
@@ -11,18 +11,20 @@
  * A line is "covered" if it:
  *   - contains a kilocode_change marker comment           (inline annotation)
  *   - falls inside a kilocode_change start/end block      (block annotation)
- *   - is in a file whose first non-empty line is          (whole-file annotation)
+ *   - is in a file whose first non-shebang non-empty line is (whole-file annotation)
  *     // kilocode_change - new file
  *   - is empty / whitespace-only                          (skipped)
  *   - is itself a marker line                             (auto-covered)
  *
- * Both JS (//) and JSX ({/ * ... * /}) comment styles are recognized.
+ * JS (//), JSX ({/ * ... * /}), YAML (#), and TOML (#) comment styles are recognized.
  *
  * Exempt paths (no markers needed — entirely Kilo-specific):
  *   - packages/opencode/src/kilocode/**
  *   - packages/opencode/test/kilocode/**
  *   - Any path containing "kilocode" in directory or filename
  *   - Any path with a directory starting with "kilo-" (e.g. kilo-sessions/)
+ *   - script/upstream/**
+ *   - Kilo-specific annotation checker support files
  */
 
 import { spawnSync } from "node:child_process"
@@ -30,7 +32,28 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 
 const ROOT = path.resolve(import.meta.dir, "..")
-const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx"])
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml"])
+const SCOPES = [
+  "sdks/vscode",
+  "packages/opencode",
+  "packages/extensions",
+  "packages/ui",
+  "packages/app",
+  "packages/desktop",
+  "packages/desktop-electron",
+  "packages/shared",
+  "packages/script",
+  "packages/storybook",
+  "script",
+  ".github",
+  "github",
+]
+const EXEMPT_SCOPES = [
+  "script/upstream",
+  "script/check-opencode-annotations.ts",
+  "packages/script/tests/check-opencode-annotations.test.ts",
+  ".github/workflows/check-opencode-annotations.yml",
+]
 
 const args = process.argv.slice(2)
 const baseIdx = args.indexOf("--base")
@@ -47,7 +70,7 @@ function run(cmd: string, args: string[]) {
 }
 
 function changedFiles() {
-  const out = run("git", ["diff", "--name-only", "--diff-filter=AMRT", `${base}...HEAD`, "--", "packages/opencode"])
+  const out = run("git", ["diff", "--name-only", "--diff-filter=AMRT", `${base}...HEAD`, "--", ...SCOPES])
   return out ? out.split("\n").filter(Boolean) : []
 }
 
@@ -63,7 +86,13 @@ function isUpstreamMerge() {
 
 function isExempt(file: string) {
   const norm = file.replaceAll("\\", "/").toLowerCase()
-  return norm.split("/").some((part) => part.includes("kilocode") || part.startsWith("kilo-"))
+  if (norm.split("/").some((part) => part.includes("kilocode") || part.startsWith("kilo-"))) return true
+  return EXEMPT_SCOPES.some((scope) => norm === scope || norm.startsWith(`${scope}/`))
+}
+
+function isChecked(file: string) {
+  const norm = file.replaceAll("\\", "/")
+  return SCOPES.some((scope) => norm === scope || norm.startsWith(`${scope}/`))
 }
 
 function isSource(file: string) {
@@ -83,8 +112,8 @@ function addedLines(file: string): Set<number> {
   return out
 }
 
-// Matches the start of a kilocode_change marker in both JS (//) and JSX ({/* */}) comments
-const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*)\s*kilocode_change\b/
+// Matches the start of a kilocode_change marker in JS, JSX, YAML, and TOML comments.
+const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\b/
 
 function hasMarker(line: string) {
   return MARKER_PREFIX.test(line)
@@ -94,9 +123,9 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
   const lines = text.split(/\r?\n/)
   const covered = new Set<number>()
 
-  // Whole-file annotation: first non-empty line is "// kilocode_change - new file"
-  const first = lines.find((x) => x.trim() !== "")
-  if (first?.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s*-\s*new\s*file\b/)) {
+  // Whole-file annotation: first non-shebang non-empty line is a kilocode_change - new file marker.
+  const first = lines.find((x) => x.trim() !== "" && !x.startsWith("#!"))
+  if (first?.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s*-\s*new\s*file\b/)) {
     for (let i = 1; i <= lines.length; i++) covered.add(i)
     return { lines, covered }
   }
@@ -106,13 +135,13 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
     const n = i + 1
     const line = lines[i] ?? ""
 
-    if (line.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s+start\b/)) {
+    if (line.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s+start\b/)) {
       block = true
       covered.add(n)
       continue
     }
 
-    if (line.match(/(?:\/\/|\{?\s*\/\*)\s*kilocode_change\s+end\b/)) {
+    if (line.match(/(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\s+end\b/)) {
       covered.add(n)
       block = false
       continue
@@ -132,14 +161,14 @@ function coveredLines(text: string): { lines: string[]; covered: Set<number> } {
 // --- main ---
 
 if (isUpstreamMerge()) {
-  console.log("Skipping opencode annotation check — upstream opencode merge detected.")
+  console.log("Skipping shared upstream annotation check — upstream merge detected.")
   process.exit(0)
 }
 
-const files = changedFiles().filter((f) => !isExempt(f) && isSource(f))
+const files = changedFiles().filter((f) => isChecked(f) && !isExempt(f) && isSource(f))
 
 if (files.length === 0) {
-  console.log("No shared opencode source files changed — nothing to check.")
+  console.log("No shared upstream source files changed — nothing to check.")
   process.exit(0)
 }
 
@@ -163,17 +192,20 @@ for (const file of files) {
 }
 
 if (violations.length === 0) {
-  console.log("All shared opencode changes are annotated with kilocode_change markers.")
+  console.log("All shared upstream changes are annotated with kilocode_change markers.")
   process.exit(0)
 }
 
 console.error(
   [
-    "Unannotated Kilo changes found in shared opencode files:",
+    "Unannotated Kilo changes found in shared upstream files:",
     "",
     ...violations,
     "",
-    "Every Kilo-specific change in packages/opencode/ must be annotated.",
+    "Every Kilo-specific change in shared upstream source files must be annotated.",
+    "",
+    "Checked paths:",
+    ...SCOPES.map((scope) => `  - ${scope}/**`),
     "",
     "Inline (single line):",
     "  const url = Flag.KILO_MODELS_URL || 'https://models.dev' // kilocode_change",
@@ -189,6 +221,12 @@ console.error(
     "  ...",
     "  {/* kilocode_change end */}",
     "",
+    "YAML:",
+    "  # kilocode_change",
+    "  # kilocode_change start",
+    "  ...",
+    "  # kilocode_change end",
+    "",
     "New file:",
     "  // kilocode_change - new file",
     "",
@@ -197,6 +235,8 @@ console.error(
     "  - packages/opencode/test/kilocode/**",
     "  - Any path containing 'kilocode' in the directory or filename",
     "  - Any directory starting with 'kilo-' (e.g. kilo-sessions/)",
+    "  - script/upstream/**",
+    "  - Kilo-specific annotation checker support files",
     "",
     "See AGENTS.md for details.",
   ].join("\n"),

--- a/script/check-opencode-annotations.ts
+++ b/script/check-opencode-annotations.ts
@@ -16,7 +16,8 @@
  *   - is empty / whitespace-only                          (skipped)
  *   - is itself a marker line                             (auto-covered)
  *
- * JS (//), JSX ({/ * ... * /}), YAML (#), and TOML (#) comment styles are recognized.
+ * JS (//), JSX ({/ * ... * /}), YAML (#), TOML (#), and shell (#) comment styles are recognized.
+ * Extensionless files with shebangs are treated as source files.
  *
  * Exempt paths (no markers needed — entirely Kilo-specific):
  *   - packages/opencode/src/kilocode/**
@@ -32,7 +33,7 @@ import { readFileSync } from "node:fs"
 import path from "node:path"
 
 const ROOT = path.resolve(import.meta.dir, "..")
-const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml"])
+const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".yml", ".yaml", ".toml", ".sh", ".bash", ".zsh"])
 const SCOPES = [
   "sdks/vscode",
   "packages/opencode",
@@ -96,7 +97,10 @@ function isChecked(file: string) {
 }
 
 function isSource(file: string) {
-  return SOURCE_EXTS.has(path.extname(file))
+  const ext = path.extname(file)
+  if (SOURCE_EXTS.has(ext)) return true
+  if (ext) return false
+  return readFileSync(path.join(ROOT, file), "utf8").startsWith("#!")
 }
 
 function addedLines(file: string): Set<number> {
@@ -112,7 +116,7 @@ function addedLines(file: string): Set<number> {
   return out
 }
 
-// Matches the start of a kilocode_change marker in JS, JSX, YAML, and TOML comments.
+// Matches the start of a kilocode_change marker in JS, JSX, YAML, TOML, and shell comments.
 const MARKER_PREFIX = /(?:\/\/|\{?\s*\/\*|#)\s*kilocode_change\b/
 
 function hasMarker(line: string) {
@@ -221,7 +225,7 @@ console.error(
     "  ...",
     "  {/* kilocode_change end */}",
     "",
-    "YAML:",
+    "YAML/TOML/shell:",
     "  # kilocode_change",
     "  # kilocode_change start",
     "  ...",


### PR DESCRIPTION
## Summary
- Broaden the `kilocode_change` annotation check from `packages/opencode` to all shared upstream-maintained surfaces called out by `AGENTS.md` guidance.
- Include upstream-merged paths we verified exist in OpenCode, such as `.github`, `github`, `packages/ui`, app/desktop packages, `sdks/vscode`, and `packages/extensions`.
- Add YAML/TOML marker support and tests so workflows and extension metadata can be annotated consistently.

## Why
`AGENTS.md` says Kilo-specific edits to shared OpenCode files should be annotated, but CI only enforced this for `packages/opencode`. We found real upstream merge surfaces outside that package, so this prevents future agent oversights like unannotated shared UI or workflow/extension changes.

## Validation
- `bun test tests/check-opencode-annotations.test.ts` from `packages/script`
- `bun run script/check-opencode-annotations.ts --base origin/main`
- `git diff --check`