### PR TITLE
feat(cli): eliminate silent agent drops and improve stream resilience

### DIFF
--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -139,9 +139,8 @@ export const layer = Layer.effect(
                   log.error("subscriber failed", { type, cause })
                   return cause
                 },
-              }),
+              }).pipe(Effect.retry(Schedule.exponential(Duration.seconds(1)))),
             ),
-            Effect.retry(Schedule.exponential(Duration.seconds(1))),
             Effect.forkScoped,
           ),
         )

--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema, Schedule, Duration, pipe } from "effect"
+import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema, Schedule, Duration, pipe } from "effect" // kilocode_change
 import { EffectBridge } from "@/effect"
 import { Log } from "../util"
 import { BusEvent } from "./bus-event"
@@ -128,6 +128,7 @@ export const layer = Layer.effect(
         const scope = yield* Scope.make()
         const subscription = yield* Scope.provide(scope)(PubSub.subscribe(pubsub))
 
+        // kilocode_change start
         yield* Scope.provide(scope)(
           pipe(
             Stream.fromSubscription(subscription),
@@ -140,9 +141,7 @@ export const layer = Layer.effect(
                 },
               }),
             ),
-            // kilocode_change start
             Effect.retry(Schedule.exponential(Duration.seconds(1))),
-            // kilocode_change end
             Effect.forkScoped,
           ),
         )
@@ -151,6 +150,7 @@ export const layer = Layer.effect(
           log.info("unsubscribing", { type })
           bridge.fork(Scope.close(scope, Exit.void))
         }) as () => void
+        // kilocode_change end
       })
     }
 
@@ -160,12 +160,12 @@ export const layer = Layer.effect(
     ) {
       const s = yield* InstanceState.get(state)
       const ps = yield* getOrCreate(s, def)
-      return (yield* on(ps, def.type, callback)) as () => void
+      return (yield* on(ps, def.type, callback)) as () => void // kilocode_change
     })
 
     const subscribeAllCallback = Effect.fn("Bus.subscribeAllCallback")(function* (callback: (event: any) => unknown) {
       const s = yield* InstanceState.get(state)
-      return (yield* on(s.wildcard, "*", callback)) as () => void
+      return (yield* on(s.wildcard, "*", callback)) as () => void // kilocode_change
     })
 
     return Service.of({ publish, subscribe, subscribeAll, subscribeCallback, subscribeAllCallback })

--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema } from "effect"
+import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema, Schedule, Duration, pipe } from "effect"
 import { EffectBridge } from "@/effect"
 import { Log } from "../util"
 import { BusEvent } from "./bus-event"
@@ -129,23 +129,28 @@ export const layer = Layer.effect(
         const subscription = yield* Scope.provide(scope)(PubSub.subscribe(pubsub))
 
         yield* Scope.provide(scope)(
-          Stream.fromSubscription(subscription).pipe(
-            Stream.runForEach((msg) =>
+          pipe(
+            Stream.fromSubscription(subscription),
+            Stream.runForEach((msg: T) =>
               Effect.tryPromise({
                 try: () => Promise.resolve().then(() => callback(msg)),
                 catch: (cause) => {
                   log.error("subscriber failed", { type, cause })
+                  return cause
                 },
-              }).pipe(Effect.ignore),
+              }),
             ),
+            // kilocode_change start
+            Effect.retry(Schedule.exponential(Duration.seconds(1))),
+            // kilocode_change end
             Effect.forkScoped,
           ),
         )
 
-        return () => {
+        return (() => {
           log.info("unsubscribing", { type })
           bridge.fork(Scope.close(scope, Exit.void))
-        }
+        }) as () => void
       })
     }
 
@@ -155,12 +160,12 @@ export const layer = Layer.effect(
     ) {
       const s = yield* InstanceState.get(state)
       const ps = yield* getOrCreate(s, def)
-      return yield* on(ps, def.type, callback)
+      return (yield* on(ps, def.type, callback)) as () => void
     })
 
     const subscribeAllCallback = Effect.fn("Bus.subscribeAllCallback")(function* (callback: (event: any) => unknown) {
       const s = yield* InstanceState.get(state)
-      return yield* on(s.wildcard, "*", callback)
+      return (yield* on(s.wildcard, "*", callback)) as () => void
     })
 
     return Service.of({ publish, subscribe, subscribeAll, subscribeCallback, subscribeAllCallback })

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -320,10 +320,10 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       path: "/chat/completions",
       modelId: this.modelId,
     })
-    // kilocode_change end
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url,
+      // kilocode_change end
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: this.failedResponseHandler,

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -315,10 +315,12 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
     const metadataExtractor = this.config.metadataExtractor?.createStreamExtractor()
 
+    // kilocode_change start
     const url = this.config.url({
       path: "/chat/completions",
       modelId: this.modelId,
     })
+    // kilocode_change end
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url,

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -315,11 +315,13 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
     const metadataExtractor = this.config.metadataExtractor?.createStreamExtractor()
 
+    const url = this.config.url({
+      path: "/chat/completions",
+      modelId: this.modelId,
+    })
+
     const { responseHeaders, value: response } = await postJsonToApi({
-      url: this.config.url({
-        path: "/chat/completions",
-        modelId: this.modelId,
-      }),
+      url,
       headers: combineHeaders(this.config.headers(), options.headers),
       body,
       failedResponseHandler: this.failedResponseHandler,
@@ -371,6 +373,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
       totalTokens: undefined,
     }
     let isFirstChunk = true
+    let receivedFinishReason = false // kilocode_change
     const providerOptionsName = this.providerOptionsName
     let isActiveReasoning = false
     let isActiveText = false
@@ -403,15 +406,24 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
             metadataExtractor?.processChunk(chunk.rawValue)
 
-            // handle error chunks:
+            // kilocode_change start
             if ("error" in value) {
               finishReason = {
                 unified: "error",
                 raw: undefined,
               }
-              controller.enqueue({ type: "error", error: value.error.message })
+              controller.enqueue({
+                type: "error",
+                error: new APICallError({
+                  message: value.error.message,
+                  url,
+                  requestBodyValues: body,
+                  isRetryable: true,
+                }),
+              })
               return
             }
+            // kilocode_change end
 
             if (isFirstChunk) {
               isFirstChunk = false
@@ -453,6 +465,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             const choice = value.choices[0]
 
             if (choice?.finish_reason != null) {
+              receivedFinishReason = true // kilocode_change
               finishReason = {
                 unified: mapOpenAICompatibleFinishReason(choice.finish_reason),
                 raw: choice.finish_reason ?? undefined,
@@ -645,6 +658,12 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
+            // kilocode_change start
+            if (!receivedFinishReason) {
+              finishReason = { unified: "unknown" as any, raw: undefined }
+            }
+            // kilocode_change end
+
             if (isActiveReasoning) {
               controller.enqueue({
                 type: "reasoning-end",

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -803,6 +803,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       unified: "other",
       raw: undefined,
     }
+    let receivedFinishChunk = false // kilocode_change
     const usage: {
       inputTokens: number | undefined
       outputTokens: number | undefined
@@ -1259,6 +1260,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               }
             } else if (isResponseFinishedChunk(value)) {
+              receivedFinishChunk = true // kilocode_change
               finishReason = {
                 unified: mapOpenAIResponseFinishReason({
                   finishReason: value.response.incomplete_details?.reason,
@@ -1294,6 +1296,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               }
             } else if (isErrorChunk(value)) {
+              finishReason = { unified: "error" as any, raw: undefined } // kilocode_change
               controller.enqueue({ type: "error", error: value })
             }
           },
@@ -1304,6 +1307,12 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               controller.enqueue({ type: "text-end", id: currentTextId })
               currentTextId = null
             }
+
+            // kilocode_change start
+            if (!receivedFinishChunk && responseId !== null) {
+              finishReason = { unified: "unknown" as any, raw: undefined }
+            }
+            // kilocode_change end
 
             const providerMetadata: SharedV3ProviderMetadata = {
               openai: {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -35,7 +35,7 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer"
 
 const log = Log.create({ service: "llm" })
 export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
-type Result = Awaited<ReturnType<typeof streamText>>
+type Result = Awaited<ReturnType<typeof streamText>> & { error: () => unknown } // kilocode_change
 
 export type StreamInput = {
   user: MessageV2.User
@@ -354,10 +354,12 @@ const live: Layer.Layer<
           })
         : undefined
 
-      return streamText({
-        onError(error) {
+      let error: unknown // kilocode_change
+      const result = streamText({
+        onError(e) {
+          error = e // kilocode_change
           l.error("stream error", {
-            error,
+            error: e,
           })
         },
         async experimental_repairToolCall(failed) {
@@ -439,6 +441,7 @@ const live: Layer.Layer<
         },
         // kilocode_change end
       })
+      return { ...result, error: () => error } // kilocode_change
     })
 
     const stream: Interface["stream"] = (input) =>
@@ -451,8 +454,22 @@ const live: Layer.Layer<
             )
 
             const result = yield* run({ ...input, abort: ctrl.signal })
+            const error = result.error // kilocode_change
 
-            return Stream.fromAsyncIterable(result.fullStream, (e) => (e instanceof Error ? e : new Error(String(e))))
+            return Stream.fromAsyncIterable(result.fullStream, (e) =>
+              e instanceof Error ? e : new Error(String(e)),
+            ).pipe(
+              // kilocode_change start
+              Stream.concat(
+                Stream.fromEffect(
+                  Effect.sync(() => {
+                    const err = error()
+                    if (err) throw err
+                  }),
+                ).pipe(Stream.drain),
+              ),
+              // kilocode_change end
+            )
           }),
         ),
       )

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -355,13 +355,15 @@ const live: Layer.Layer<
         : undefined
 
       let error: unknown // kilocode_change
+      // kilocode_change start
       const result = streamText({
         onError(e) {
-          error = e // kilocode_change
+          error = e
           l.error("stream error", {
             error: e,
           })
         },
+      // kilocode_change end
         async experimental_repairToolCall(failed) {
           const lower = failed.toolCall.toolName.toLowerCase()
           if (lower !== failed.toolCall.toolName && tools[lower]) {
@@ -456,10 +458,10 @@ const live: Layer.Layer<
             const result = yield* run({ ...input, abort: ctrl.signal })
             const error = result.error // kilocode_change
 
+            // kilocode_change start
             return Stream.fromAsyncIterable(result.fullStream, (e) =>
               e instanceof Error ? e : new Error(String(e)),
             ).pipe(
-              // kilocode_change start
               Stream.concat(
                 Stream.fromEffect(
                   Effect.sync(() => {
@@ -468,8 +470,8 @@ const live: Layer.Layer<
                   }),
                 ).pipe(Stream.drain),
               ),
-              // kilocode_change end
             )
+            // kilocode_change end
           }),
         ),
       )

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -443,7 +443,7 @@ const live: Layer.Layer<
         },
         // kilocode_change end
       })
-      return { ...result, error: () => error } // kilocode_change
+      return Object.assign(result, { error: () => error }) // kilocode_change
     })
 
     const stream: Interface["stream"] = (input) =>

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -443,6 +443,12 @@ export const layer: Layer.Layer<
               cost: usage.cost,
             })
             yield* session.updateMessage(ctx.assistantMessage)
+
+            // kilocode_change start
+            if (value.finishReason === "error") {
+              throw new Error("Stream finished with error reason (provider overloaded)")
+            }
+            // kilocode_change end
             if (ctx.snapshot) {
               const patch = yield* snapshot.patch(ctx.snapshot)
               if (patch.files.length) {
@@ -625,6 +631,20 @@ export const layer: Layer.Layer<
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
+
+            // kilocode_change start
+            if (ctx.assistantMessage.finish === "unknown") {
+              const parts = MessageV2.parts(ctx.assistantMessage.id)
+              if (!parts.some((p) => p.type === "tool" && p.state.status === "completed")) {
+                yield* Effect.fail(
+                  new MessageV2.APIError({
+                    message: "Stream terminated prematurely without a finish reason",
+                    isRetryable: true,
+                  })
+                )
+              }
+            }
+            // kilocode_change end
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1367,6 +1367,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const envCache: KiloSessionPrompt.EnvCache = {}
         closeReasons.delete(sessionID) // kilocode_change
         let compactionAttempts = 0 // kilocode_change - cap compaction attempts per turn to avoid infinite loops
+        let emptyStopCount = 0 // kilocode_change - cap consecutive empty-stop turns to avoid infinite token burn
         const ctx = yield* InstanceState.context
         const slog = elog.with({ sessionID })
         let structured: unknown | undefined
@@ -1410,6 +1411,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           // kilocode_change start
           const hasContent =
             hasToolCalls || (lastAssistantMsg?.parts.some((p) => p.type === "text" && p.text.trim()) ?? false)
+
+          const MAX_EMPTY_STOP = 3
+          if (!hasContent && lastAssistant?.finish === "stop") {
+            emptyStopCount++
+            if (emptyStopCount >= MAX_EMPTY_STOP) {
+              throw new Error(
+                `Agent received ${MAX_EMPTY_STOP} consecutive empty stop responses — aborting to prevent infinite token burn`,
+              )
+            }
+          } else {
+            emptyStopCount = 0
+          }
           // kilocode_change end
 
           if (

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1407,10 +1407,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const hasToolCalls =
             lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
 
+          // kilocode_change start
+          const hasContent =
+            hasToolCalls || (lastAssistantMsg?.parts.some((p) => p.type === "text" && p.text.trim()) ?? false)
+          // kilocode_change end
+
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
+            hasContent && // kilocode_change
             lastAssistant.parentID === lastUser.id && // kilocode_change - unrelated later assistants do not answer this turn
             lastUser.id < lastAssistant.id
           ) {


### PR DESCRIPTION
# Overview

This PR systematically eliminates "silent drop" failure patterns in the Kilo agent’s session lifecycle. It transitions the architecture from a silent swallowing of errors to a robust "fail-loudly" model, ensuring that network interruptions, stream timeouts, and logic failures are correctly propagated and trigger system-level recovery (retries or explicit halts).

Key improvements include:
- Mandatory finish-reason tracking for Chat and Responses APIs.
- Automatic retry logic for truncated streams.
- Guarding against empty assistant responses with "stop" reasons.
- Explicit error propagation from the underlying LLM stream.
- Exponential backoff for bus subscriber resilience.

These changes significantly improve the reliability of the agent, especially in unstable network conditions or during provider-side hiccups.

---

# Silent Drop Audit — Priority 1 Changes

> **Branch:** `feat/silent-drop-audit-fix`
> **Scope:** 9 critical-path fixes across 7 files to eliminate silent agent interruptions.

## Table of Contents

| # | ID | Title | File |
|---|---|---|---|
| 1 | A1 | Chat API Premature Closure Detection | `openai-compatible-chat-language-model.ts` |
| 2 | A2 | Responses API Premature Closure Detection | `openai-responses-language-model.ts` |
| 3 | A1b | Processor Retry on Unknown Finish Reason | `processor.ts` |
| 4 | A3 | Empty Response Guard | `prompt.ts` |
| 5 | B1 | Stream Error Propagation via `onError` | `llm.ts` |
| 6 | B2 | Chat API Error Chunk Wrapping | `openai-compatible-chat-language-model.ts` |
| 7 | B3 | Processor Error Enforcement | `processor.ts` |
| 8 | B4 | Responses API Error Chunk Parity | `openai-responses-language-model.ts` |
| 9 | F1 | Bus Subscriber Resilience | `bus/index.ts` |

---

# 1. A1 — Chat API Premature Closure Detection

## Context

This change addresses silent agent drops caused by the OpenAI Chat API stream terminating prematurely without providing a `finish_reason`.

## Why

When an LLM stream drops silently due to network instability or provider-side truncation, it often fails to send the final chunk containing the `finish_reason`. Previously, Kilo defaulted this missing state to `"other"`. Because `"other"` is technically a valid completion state, the session processor would silently accept the truncated output as a complete turn. This resulted in the agent stopping halfway through writing code or waiting indefinitely (a "zombie agent" state) without throwing an error or triggering a retry.

## Implementation

We introduced a tracking boolean, `receivedFinishReason`, in `openai-compatible-chat-language-model.ts`. This flag is set to `true` whenever the parser successfully reads a `finish_reason` from a chunk. When the stream concludes and the `flush()` handler is called, we check this flag. If it remains `false`, it means the stream ended abnormally, and we forcefully override the finish reason to `"unknown"`. This allows downstream processors to detect the truncation.

## Screenshots

**Before:**
```typescript
    let isFirstChunk = true
    const providerOptionsName = this.providerOptionsName

    return {
      stream: response.pipeThrough(
// ...
          flush(controller) {
            if (isActiveReasoning) {
              controller.enqueue({
```

**After:**
```typescript
    let isFirstChunk = true
    let receivedFinishReason = false // kilocode_change
    const providerOptionsName = this.providerOptionsName

    return {
      stream: response.pipeThrough(
// ...
            if (choice?.finish_reason != null) {
              receivedFinishReason = true // kilocode_change
              finishReason = {
// ...
          flush(controller) {
            // kilocode_change start
            if (!receivedFinishReason) {
              finishReason = { unified: "unknown" as any, raw: undefined }
            }
            // kilocode_change end

            if (isActiveReasoning) {
              controller.enqueue({
```

## How to Test

1. Configure Kilo to use an OpenAI-compatible Chat API provider.
2. Use an HTTP interceptor to forcefully drop the connection during a streaming response, ensuring the final chunk with `finish_reason` is never sent.
3. The turn's finish reason should be explicitly logged as `"unknown"` rather than defaulting to `"other"`.

---

# 2. A2 — Responses API Premature Closure Detection

## Context

This change addresses silent agent drops caused by the OpenAI Responses API stream terminating prematurely without sending a `response.completed` event.

## Why

The Responses API uses a different event model than the Chat API — it signals completion via `response.completed` chunks rather than per-choice `finish_reason` fields. When this final event is lost (due to network drops, CDN timeouts, or provider-side stream truncation), the finish reason silently defaults to `"other"`. The agent then stops mid-task with no error, no retry, and no user notification. This is the Responses API counterpart of A1, ensuring parity between both provider paths.

## Implementation

Introduced a `receivedFinishChunk` boolean in `openai-responses-language-model.ts`. This flag is set to `true` when the `isResponseFinishedChunk(value)` handler fires. In the `flush()` method, if the flag is still `false` and a `responseId` was received (confirming a response was actually started), we override the finish reason to `"unknown"`. The `responseId !== null` guard prevents false positives on streams that were never established.

## Screenshots

**Before:**
```typescript
    } = {
      unified: "other",
      raw: undefined,
    }
    const usage: {
```

**After:**
```typescript
    } = {
      unified: "other",
      raw: undefined,
    }
    let receivedFinishChunk = false // kilocode_change
    const usage: {
```

**Before (finish handler):**
```typescript
            } else if (isResponseFinishedChunk(value)) {
              finishReason = {
```

**After (finish handler):**
```typescript
            } else if (isResponseFinishedChunk(value)) {
              receivedFinishChunk = true // kilocode_change
              finishReason = {
```

**Before (flush):**
```typescript
          flush(controller) {
            if (currentTextId) {
              controller.enqueue({ type: "text-end", id: currentTextId })
              currentTextId = null
            }

            const providerMetadata = {
```

**After (flush):**
```typescript
          flush(controller) {
            if (currentTextId) {
              controller.enqueue({ type: "text-end", id: currentTextId })
              currentTextId = null
            }

            // kilocode_change start
            if (!receivedFinishChunk && responseId !== null) {
              finishReason = { unified: "unknown" as any, raw: undefined }
            }
            // kilocode_change end

            const providerMetadata = {
```

## How to Test

1. Configure Kilo to use a Responses API provider (e.g. OpenAI `o3`, `o4-mini`).
2. Use an HTTP interceptor to drop the connection before the `response.completed` SSE event is sent.
3. The turn should report `finish: "unknown"` and trigger the downstream retry logic (A1b).

---

# 3. A1b — Processor Retry on Unknown Finish Reason

## Context

This change makes the session processor actively respond to the `"unknown"` finish reason signal introduced by A1/A2, converting it into a retryable error when appropriate.

## Why

A1 and A2 detect premature stream closures and tag them with `finish: "unknown"`. However, without A1b, `"unknown"` is just a label — nothing in the system actually *acts* on it. The processor would record the truncated output, mark the turn as complete, and stop.

A1b closes the loop: it inspects the assistant message after the stream drains and, if the finish reason is `"unknown"` AND no tool calls were successfully completed, it throws a retryable `APIError`. This triggers Kilo's existing retry machinery.

The tool-call guard is important: if the model *did* complete tool calls (e.g. wrote files) before being cut off, retrying blindly could cause duplicate writes. In that case, we accept the partial turn and let the model continue naturally on the next loop iteration.

## Implementation

After `Stream.runDrain` completes in `processor.ts`, we check `ctx.assistantMessage.finish`. If it equals `"unknown"`, we query the message's parts via `MessageV2.parts()`. If none are completed tool calls, we `yield* Effect.fail(new MessageV2.APIError({ message: "...", isRetryable: true }))`.

## Screenshots

**Before:**
```typescript
            yield* stream.pipe(
              Stream.tap((event) => handleEvent(event)),
              Stream.takeUntil(() => ctx.needsCompaction),
              Stream.runDrain,
            )
          }).pipe(
```

**After:**
```typescript
            yield* stream.pipe(
              Stream.tap((event) => handleEvent(event)),
              Stream.takeUntil(() => ctx.needsCompaction),
              Stream.runDrain,
            )

            // kilocode_change start
            if (ctx.assistantMessage.finish === "unknown") {
              const parts = MessageV2.parts(ctx.assistantMessage.id)
              if (!parts.some((p) => p.type === "tool" && p.state.status === "completed")) {
                yield* Effect.fail(
                  new MessageV2.APIError({
                    message: "Stream terminated prematurely without a finish reason",
                    isRetryable: true,
                  })
                )
              }
            }
            // kilocode_change end
          }).pipe(
```

## How to Test

1. Simulate a premature stream closure via an HTTP interceptor.
2. Ensure the model had not yet completed any tool calls at the time of truncation.
3. The processor should log the retryable `APIError` and automatically re-initiate the LLM call.
4. Negative case: simulate a truncation *after* a tool call has completed — the processor should accept the partial turn without retrying.

---

# 4. A3 — Empty Response Guard

## Context

This change prevents the agent from exiting its main loop when the model returns a `finish_reason: "stop"` but provides no actual content.

## Why

Some providers intermittently return empty assistant messages with `finish_reason: "stop"`. This happens during transient provider overloads, rate-limiting edge cases, or when the model's safety layer intervenes without generating an explicit refusal. The user would see a blank response — the agent appeared to have "finished" its task despite doing nothing. There's no error to retry against, and the session history shows a "completed" turn with no content.

## Implementation

Added a `hasContent` check in `prompt.ts` that evaluates whether the last assistant message contains tool calls OR at least one text part with non-whitespace content. The loop now requires `hasContent` to be `true` before it will break on a `"stop"` signal.

## Screenshots

**Before:**
```typescript
          const hasToolCalls =
            lastAssistantMsg?.parts.some(
              (part) => part.type === "tool" && !part.metadata?.providerExecuted
            ) ?? false

          if (
            lastAssistant?.finish &&
            !["tool-calls"].includes(lastAssistant.finish) &&
            !hasToolCalls &&
            lastAssistant.parentID === lastUser.id &&
            lastUser.id < lastAssistant.id
          ) {
```

**After:**
```typescript
          const hasToolCalls =
            lastAssistantMsg?.parts.some(
              (part) => part.type === "tool" && !part.metadata?.providerExecuted
            ) ?? false

          // kilocode_change start
          const hasContent =
            hasToolCalls || (lastAssistantMsg?.parts.some(
              (p) => p.type === "text" && p.text.trim()
            ) ?? false)
          // kilocode_change end

          if (
            lastAssistant?.finish &&
            !["tool-calls"].includes(lastAssistant.finish) &&
            !hasToolCalls &&
            hasContent && // kilocode_change
            lastAssistant.parentID === lastUser.id &&
            lastUser.id < lastAssistant.id
          ) {
```

## How to Test

1. Use a mock LLM provider that returns an empty assistant message with `finish_reason: "stop"`.
2. The agent should **not** exit. It should loop back and re-prompt the model.
3. On the second attempt, have the mock return a valid response. The agent should then exit normally.

---

# 5. B1 — Stream Error Propagation via `onError`

## Context

This change ensures that errors captured by the Vercel AI SDK's `onError` callback in `streamText` are propagated to the session processor instead of being silently logged and discarded.

## Why

The `streamText` function accepts an `onError` callback that fires when the provider stream encounters an error. Previously, Kilo only logged the error and moved on. The stream would appear to complete normally — no exception was thrown, no retry was triggered. This is the most fundamental "silent drop" because it sits at the SDK/Effect boundary. Every other stream error fix (B2, B3, B4) can be bypassed if this layer swallows the error first.

## Implementation

**Part 1 — Error Accumulation (in `run`):** A `let error: unknown` variable captures the error from `onError`. The return value is augmented with an `error: () => error` getter.

**Part 2 — Error Re-throw (in `stream`):** After `fullStream` is consumed, we concatenate a secondary stream that checks the error getter. If an error was captured, it is re-thrown, causing the Effect pipeline to fail and trigger retries.

## Screenshots

**Before (run):**
```typescript
      const result = streamText({
        onError(e) {
          l.error("stream error", { error: e })
        },
        // ...
      })
      return result
```

**After (run):**
```typescript
      let error: unknown // kilocode_change
      const result = streamText({
        onError(e) {
          error = e // kilocode_change
          l.error("stream error", { error: e })
        },
        // ...
      })
      return { ...result, error: () => error } // kilocode_change
```

**Before (stream):**
```typescript
            return Stream.fromAsyncIterable(
              result.fullStream,
              (e) => e instanceof Error ? e : new Error(String(e)),
            )
```

**After (stream):**
```typescript
            return Stream.fromAsyncIterable(
              result.fullStream,
              (e) => e instanceof Error ? e : new Error(String(e)),
            ).pipe(
              // kilocode_change start
              Stream.concat(
                Stream.fromEffect(
                  Effect.sync(() => {
                    const err = error()
                    if (err) throw err
                  }),
                ).pipe(Stream.drain),
              ),
              // kilocode_change end
            )
```

## How to Test

1. Use an HTTP interceptor to inject a malformed JSON chunk or HTTP 500 mid-stream.
2. The error should propagate, the session should show an error state, and the retry policy should attempt recovery.
3. Check logs for `"stream error"` followed by the Error propagation through the Effect pipeline.

---

# 6. B2 — Chat API Error Chunk Wrapping

## Context

This change wraps server-side error chunks received during a Chat API stream in a retryable `APICallError`, replacing the previous behavior of enqueuing a raw string error message.

## Why

When the Chat API sends an error chunk (a JSON object with an `error` field instead of the expected `choices` array), the original code extracted the `error.message` string and enqueued it as-is: `controller.enqueue({ type: "error", error: value.error.message })`. This raw string propagated through the system as a `NamedError.Unknown`, which is classified as **non-retryable** by Kilo's error handling hierarchy.

The consequence: a transient server error (e.g., "The server had an error processing your request") would be treated as a terminal, unrecoverable failure. The agent would stop with a cryptic error message and no retry. In reality, these errors are almost always transient and should be retried.

## Implementation

Replaced the raw string enqueue with a proper `APICallError` instantiation. The `url` and `requestBodyValues` fields (required by the constructor) are sourced from the enclosing scope — the `url` variable was extracted from the inline config call to make it accessible, and `body` was already available.

## Screenshots

**Before:**
```typescript
    const { responseHeaders, value: response } =
      await postJsonToApi({
        url: this.config.url({
          path: "/chat/completions",
          modelId: this.modelId,
        }),
        headers: combineHeaders(this.config.headers(), options.headers),
        body,
```

**After:**
```typescript
    const url = this.config.url({
      path: "/chat/completions",
      modelId: this.modelId,
    })

    const { responseHeaders, value: response } =
      await postJsonToApi({
        url,
        headers: combineHeaders(this.config.headers(), options.headers),
        body,
```

**Before (error chunk handler):**
```typescript
            // handle error chunks:
            if ("error" in value) {
              finishReason = { unified: "error", raw: undefined }
              controller.enqueue({ type: "error", error: value.error.message })
              return
            }
```

**After (error chunk handler):**
```typescript
            // kilocode_change start
            if ("error" in value) {
              finishReason = { unified: "error", raw: undefined }
              controller.enqueue({
                type: "error",
                error: new APICallError({
                  message: value.error.message,
                  url,
                  requestBodyValues: body,
                  isRetryable: true,
                }),
              })
              return
            }
            // kilocode_change end
```

## How to Test

1. Use a mock server to inject an error chunk mid-stream: `data: {"error": {"message": "Server overloaded", "type": "server_error"}}`.
2. The error should be classified as retryable and trigger the retry policy.
3. Verify the error appears in logs as an `APICallError` with `isRetryable: true`.

---

# 7. B3 — Processor Error Enforcement

## Context

This change makes the session processor explicitly fail when a stream step finishes with `finishReason === "error"`, preventing the turn from being silently accepted as successful.

## Why

Even after B2 and B4 correctly set `finishReason` to `"error"` when error chunks are received, the processor's `finish-step` handler didn't actually check for this value. It would record the finish reason on the assistant message, update the step part, and continue as normal. The error was *labeled* but never *acted upon*.

The session history would show `finish: "error"` on the turn, but the agent would treat it as completed. The user sees a partial response and has to manually recognize that the output is incomplete. B3 closes this gap by throwing an exception immediately after processing a `finish-step` event with reason `"error"`.

## Implementation

Added a guard in `processor.ts` inside the `"finish-step"` case handler. After updating the message and parts, we check `value.finishReason === "error"`. If true, we `throw new Error(...)`. This throw creates a defect that propagates through the `Effect.catchCauseIf` handler, ensuring the error is always caught and routed to the retry policy.

## Screenshots

**Before:**
```typescript
            yield* session.updatePart({
              // ...
              tokens: usage.tokens,
              cost: usage.cost,
            })
            yield* session.updateMessage(ctx.assistantMessage)
            if (ctx.snapshot) {
```

**After:**
```typescript
            yield* session.updatePart({
              // ...
              tokens: usage.tokens,
              cost: usage.cost,
            })
            yield* session.updateMessage(ctx.assistantMessage)

            // kilocode_change start
            if (value.finishReason === "error") {
              throw new Error("Stream finished with error reason (provider overloaded)")
            }
            // kilocode_change end
            if (ctx.snapshot) {
```

## How to Test

1. Use a mock LLM provider that sends a valid stream then sends a `finish_reason: "error"` in the final chunk.
2. The processor should throw the error and trigger the retry policy, rather than silently accepting the turn.
3. Verify the error message appears in session logs.

---

# 8. B4 — Responses API Error Chunk Parity

## Context

This change ensures that error chunks received during a Responses API stream correctly set `finishReason` to `"error"`, achieving parity with the Chat API's error handling behavior (B2).

## Why

The Chat API and Responses API handle error chunks asymmetrically. In the Chat API (after B2), when an `"error"` field is found in a chunk, the `finishReason` is explicitly set to `"error"`. However, in the Responses API, the `isErrorChunk` handler only enqueued the error event — it never updated the `finishReason`. This meant:

1. The error chunk was emitted to the stream consumer, but...
2. The `finishReason` remained at its default (`"other"`), so...
3. The `finish-step` handler in the processor (B3) would never detect `"error"`, and...
4. The turn would be silently accepted as a normal completion.

## Implementation

Added a single line before `controller.enqueue({ type: "error", error: value })` in the `isErrorChunk` handler: `finishReason = { unified: "error" as any, raw: undefined }`. The `as any` cast is necessary because `"error"` is not part of the standard `LanguageModelV3FinishReason` union type — it's a Kilo-specific internal signal.

## Screenshots

**Before:**
```typescript
            } else if (isErrorChunk(value)) {
              controller.enqueue({ type: "error", error: value })
            }
```

**After:**
```typescript
            } else if (isErrorChunk(value)) {
              finishReason = { unified: "error" as any, raw: undefined } // kilocode_change
              controller.enqueue({ type: "error", error: value })
            }
```

## How to Test

1. Use a mock server to inject an error event in the Responses API SSE stream.
2. The turn's finish reason should be `"error"`, which triggers B3's enforcement logic.
3. Before this fix: the finish reason would remain `"other"` and the processor would silently accept the partial turn.

---

# 9. F1 — Bus Subscriber Resilience

## Context

This change replaces the `Effect.ignore` pattern in the bus event subscriber pipeline with an exponential backoff retry, preventing subscriber callbacks from dying silently on transient errors.

## Why

Kilo's internal event bus uses an Effect-based PubSub system. When a subscriber callback throws, `Effect.tryPromise` captures the error. Previously, the captured error was passed to `Effect.ignore`, which discarded it entirely. This caused:

- **Silent data loss:** A transient DB lock could cause events to be permanently lost with no trace.
- **No observability:** `Effect.ignore` suppressed the failure in the Effect channel. If `runForEach` itself failed, the entire subscriber fiber would die silently.
- **No recovery:** There was no mechanism to restart a crashed subscriber.

The new approach retains error logging but removes `Effect.ignore`. The `runForEach` pipeline is wrapped in `Effect.retry(Schedule.exponential(Duration.seconds(1)))`, giving transient issues time to resolve.

## Implementation

Three changes in `bus/index.ts`:

1. **Import additions:** Added `Schedule`, `Duration`, and `pipe` to the Effect imports.
2. **Pipeline restructure:** Converted `.pipe()` chaining to top-level `pipe(...)` for clean composition with `Effect.retry`.
3. **Retry policy:** The `catch` block now returns the error (instead of `void`) so it propagates as the Effect's error channel, which the retry schedule can act on.

## Screenshots

**Before (imports):**
```typescript
import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema } from "effect"
```

**After (imports):**
```typescript
import { Effect, Exit, Layer, PubSub, Scope, Context, Stream, Schema, Schedule, Duration, pipe } from "effect"
```

**Before (subscriber):**
```typescript
        yield* Scope.provide(scope)(
          Stream.fromSubscription(subscription).pipe(
            Stream.runForEach((msg) =>
              Effect.tryPromise({
                try: () => Promise.resolve().then(() => callback(msg)),
                catch: (cause) => {
                  log.error("subscriber failed", { type, cause })
                },
              }).pipe(Effect.ignore),
            ),
            Effect.forkScoped,
          ),
        )

        return () => {
          log.info("unsubscribing", { type })
          bridge.fork(Scope.close(scope, Exit.void))
        }
```

**After (subscriber):**
```typescript
        yield* Scope.provide(scope)(
          pipe(
            Stream.fromSubscription(subscription),
            Stream.runForEach((msg: T) =>
              Effect.tryPromise({
                try: () => Promise.resolve().then(() => callback(msg)),
                catch: (cause) => {
                  log.error("subscriber failed", { type, cause })
                  return cause
                },
              }),
            ),
            // kilocode_change start
            Effect.retry(Schedule.exponential(Duration.seconds(1))),
            // kilocode_change end
            Effect.forkScoped,
          ),
        )

        return (() => {
          log.info("unsubscribing", { type })
          bridge.fork(Scope.close(scope, Exit.void))
        }) as () => void
```

## How to Test

1. Create a bus subscriber that intentionally throws on the first N invocations.
2. Publish events to the bus.
3. The subscriber should retry with exponential backoff and eventually succeed.
4. Check logs for `"subscriber failed"` entries followed by successful re-subscriptions.
