### PR TITLE
feat: add LLM loop detection for message/tool/reasoning

### DIFF
--- a/packages/opencode/src/session/loop-detection.ts
+++ b/packages/opencode/src/session/loop-detection.ts
@@ -1,0 +1,244 @@
+import { Permission } from "@/permission";
+import { eq, desc, Database } from "@/storage/db";
+import type { MessageV2 } from "./message-v2";
+import { PartTable } from "./session.sql";
+import type { Brand } from "effect/Brand";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** How many identical (tool, input) calls trigger a tool loop. */
+const TOOL_THRESHOLD = 3;
+/** How far back (in parts) to scan for repeated tool calls. */
+const TOOL_SCAN_LIMIT = TOOL_THRESHOLD * 10;
+/** How many recent completed text/reasoning parts to compare current text against. */
+const TEXT_HISTORY_COUNT = 5;
+/** Parts scanned when building the text history. */
+const TEXT_SCAN_LIMIT = 60;
+/** Minimum paragraph length (chars) worth comparing. */
+const MIN_PARAGRAPH_LENGTH = 80;
+/** Number of chars from the end of the text delta to consider for the within-stream loop signal. */
+const LOOP_WINDOW = 500;
+
+/**
+ * Tools that indicate the agent is making genuine progress (modifying files).
+ * If one of these appears between two identical tool calls, the run is reset —
+ * the agent changed something, so it's a test-fix-test cycle, not a loop.
+ */
+const WRITE_TOOLS = new Set(["edit", "multiedit", "write", "apply_patch"]);
+
+// ---------------------------------------------------------------------------
+// Text / reasoning loop detection
+// ---------------------------------------------------------------------------
+
+type TextLoopResult =
+	| { detected: false }
+	| { detected: true; paragraph: string };
+
+// ---------------------------------------------------------------------------
+// LoopDetector class
+// ---------------------------------------------------------------------------
+
+/**
+ * Loop-detector for a single processor session.
+ */
+export class LoopDetector {
+	/** Whether any loop (text, reasoning, or tool) was detected this session. */
+	detected = false;
+	/** Timestamp when the loop was first detected. */
+	stopTime = 0;
+	/** True after a tool loop is rejected — the for-await loop should break. */
+	shouldBreakStream = false;
+
+	private readonly controller: AbortController;
+
+	constructor(parentAbort: AbortSignal) {
+		this.controller = new AbortController();
+		parentAbort.addEventListener("abort", () => this.controller.abort(), {
+			signal: parentAbort,
+		});
+	}
+
+	/** AbortSignal that fires when a text/reasoning loop is detected. */
+	get signal(): AbortSignal {
+		return this.controller.signal;
+	}
+
+	/** Reset per-process() transient state; call at the top of each process() call. */
+	resetForProcess() {
+		this.shouldBreakStream = false;
+	}
+
+	/**
+	 * Check for a repeated text or reasoning delta.
+	 * Aborts the LLM stream automatically if a loop is detected.
+	 *
+	 * Signal 1 — within-stream window: two consecutive `window`-sized slices are identical.
+	 * Signal 2 — cross-session paragraph: the last complete paragraph matches a paragraph
+	 *   from recent text/reasoning history (only runs at \n\n boundaries to avoid DB queries
+	 *   on every delta).
+	 */
+	async checkTextDelta(
+		sessionID: string & Brand<"SessionID">,
+		partID: string,
+		text: string,
+	): Promise<TextLoopResult> {
+		// Signal 1: two consecutive identical windows within the current stream
+		if (text.length >= LOOP_WINDOW * 2) {
+			const recent = text.slice(-LOOP_WINDOW);
+			const earlier = text.slice(-LOOP_WINDOW * 2, -LOOP_WINDOW);
+			if (recent === earlier) {
+				this.detected = true;
+				this.stopTime = Date.now();
+				this.controller.abort();
+				return { detected: true, paragraph: recent };
+			}
+		}
+
+		// Signal 2: cross-session paragraph check (only at paragraph boundaries)
+		if (text.endsWith("\n\n")) {
+			const paragraphs = (s: string) =>
+				s
+					.split(/\n\n+/)
+					.map((p) => p.trim())
+					.filter((p) => p.length >= MIN_PARAGRAPH_LENGTH);
+
+			const currentParagraphs = paragraphs(text);
+			if (currentParagraphs.length > 0) {
+				const lastParagraph = currentParagraphs[currentParagraphs.length - 1];
+				const rows = Database.use((db) =>
+					db
+						.select()
+						.from(PartTable)
+						.where(eq(PartTable.session_id, sessionID))
+						.orderBy(desc(PartTable.id))
+						.limit(TEXT_SCAN_LIMIT)
+						.all(),
+				);
+				let scanned = 0;
+				for (const row of rows) {
+					const p = { ...row.data, id: row.id } as MessageV2.Part;
+					if ((p.type !== "text" && p.type !== "reasoning") || p.id === partID)
+						continue;
+					if (scanned >= TEXT_HISTORY_COUNT) break;
+					scanned++;
+					const historical =
+						p.type === "text"
+							? (p as MessageV2.TextPart).text
+							: (p as MessageV2.ReasoningPart).text;
+					for (const para of paragraphs(historical)) {
+						if (para === lastParagraph) {
+							this.detected = true;
+							this.stopTime = Date.now();
+							this.controller.abort();
+							return { detected: true, paragraph: lastParagraph };
+						}
+					}
+				}
+			}
+		}
+
+		return { detected: false };
+	}
+
+	/**
+	 * Check for a repeated tool call. If detected, prompts the user via the
+	 * doom_loop permission. If the user rejects, sets `shouldBreakStream = true`
+	 * and returns `{ rejected: true, message }` so the caller can write the error
+	 * onto the tool part. Returns `{ rejected: false }` when no loop or user allows.
+	 */
+	async checkToolCall(
+		sessionID: string & Brand<"SessionID">,
+		toolName: string,
+		toolInput: unknown,
+		agentPermission: Permission.Ruleset,
+	): Promise<{ rejected: true; message: string } | { rejected: false }> {
+		const rows = Database.use((db) =>
+			db
+				.select()
+				.from(PartTable)
+				.where(eq(PartTable.session_id, sessionID))
+				.orderBy(desc(PartTable.id))
+				.limit(TOOL_SCAN_LIMIT)
+				.all(),
+		).reverse(); // oldest → newest
+		const inputStr = JSON.stringify(toolInput);
+		const parts = rows.map(
+			(r) =>
+				({
+					...r.data,
+					id: r.id,
+					sessionID: r.session_id,
+					messageID: r.message_id,
+				}) as MessageV2.Part,
+		);
+		let run = 0;
+		let lastMatchIdx = -1;
+		for (let i = 0; i < parts.length; i++) {
+			const p = parts[i];
+			if (p.type !== "tool") continue;
+			const toolPart = p as MessageV2.ToolPart;
+			const partInputStr =
+				toolPart.state.status === "completed" ||
+				toolPart.state.status === "error"
+					? JSON.stringify(toolPart.state.input)
+					: null;
+			const isWriteTool = WRITE_TOOLS.has(p.tool);
+			const isSameToolDifferentInput =
+				p.tool === toolName &&
+				partInputStr !== null &&
+				partInputStr !== inputStr;
+			if ((isWriteTool || isSameToolDifferentInput) && lastMatchIdx !== -1) {
+				run = 0;
+				lastMatchIdx = -1;
+				continue;
+			}
+			if (
+				(p.state.status === "completed" || p.state.status === "error") &&
+				p.tool === toolName &&
+				JSON.stringify(p.state.input) === inputStr
+			) {
+				run++;
+				lastMatchIdx = i;
+			}
+		}
+
+		if (run < TOOL_THRESHOLD - 1) return { rejected: false };
+
+		const message = `Loop detected: "${toolName}" has been called ${run + 1} times with identical input. Please try a different approach to make progress.`;
+		try {
+			await Permission.ask({
+				permission: "doom_loop",
+				patterns: [toolName],
+				sessionID,
+				metadata: { tool: toolName, input: toolInput },
+				always: [toolName],
+				ruleset: agentPermission,
+			});
+			return { rejected: false };
+		} catch (e) {
+			if (
+				e instanceof Permission.RejectedError ||
+				e instanceof Permission.DeniedError
+			) {
+				this.shouldBreakStream = true;
+				return { rejected: true, message };
+			}
+			throw e;
+		}
+	}
+
+	/**
+	 * Stamp loop metadata onto the assistant message before it is saved.
+	 * Call this once at the end of process(), before Session.updateMessage().
+	 */
+	applyToMessage(message: MessageV2.Assistant) {
+		if (!this.detected) return;
+		message.structured = {
+			...(message.structured ?? {}),
+			loopDetected: true,
+			loopStopTime: this.stopTime,
+		};
+	}
+}

--- a/packages/opencode/src/session/loop-detection.ts
+++ b/packages/opencode/src/session/loop-detection.ts
@@ -1,3 +1,5 @@
+// kilocode_change - new file
+
 import { Permission } from "@/permission";
 import { eq, desc, Database } from "@/storage/db";
 import type { MessageV2 } from "./message-v2";

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -26,8 +26,8 @@ import { isRecord } from "@/util/record"
 import { EventV2 } from "@/v2/event"
 import { SessionEvent } from "@/v2/session-event"
 import * as DateTime from "effect/DateTime"
+import { LoopDetector } from "./loop-detection"
 
-const DOOM_LOOP_THRESHOLD = 3
 const log = Log.create({ service: "session.processor" })
 
 export type Result = "compact" | "stop" | "continue"
@@ -110,7 +110,6 @@ export const layer: Layer.Layer<
     const snapshot = yield* Snapshot.Service
     const agents = yield* Agent.Service
     const llm = yield* LLM.Service
-    const permission = yield* Permission.Service
     const plugin = yield* Plugin.Service
     const summary = yield* SessionSummary.Service
     const scope = yield* Scope.Scope
@@ -144,6 +143,7 @@ export const layer: Layer.Layer<
       }
       let aborted = false
       const ac = new AbortController() // kilocode_change — abort controller for offline handler
+      const detector = new LoopDetector(ac.signal)
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
 
       const parse = (e: unknown) =>
@@ -283,18 +283,22 @@ export const layer: Layer.Layer<
             yield* session.updatePart(ctx.reasoningMap[value.id])
             return
 
-          case "reasoning-delta":
+          case "reasoning-delta": {
             if (!(value.id in ctx.reasoningMap)) return
-            ctx.reasoningMap[value.id].text += value.text
-            if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
+            const part = ctx.reasoningMap[value.id]
+            part.text += value.text
+            if (value.providerMetadata) part.metadata = value.providerMetadata
             yield* session.updatePartDelta({
-              sessionID: ctx.reasoningMap[value.id].sessionID,
-              messageID: ctx.reasoningMap[value.id].messageID,
-              partID: ctx.reasoningMap[value.id].id,
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              partID: part.id,
               field: "text",
               delta: value.text,
             })
+            const loop = yield* Effect.promise(() => detector.checkTextDelta(ctx.sessionID, part.id, part.text))
+            if (loop.detected) slog.warn("reasoning loop detected", { paragraph: loop.paragraph.slice(0, 200) })
             return
+          }
 
           case "reasoning-end":
             if (!(value.id in ctx.reasoningMap)) return
@@ -412,31 +416,14 @@ export const layer: Layer.Layer<
                 : value.providerMetadata,
             }))
 
-            const parts = MessageV2.parts(ctx.assistantMessage.id)
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
-
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.toolName &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(value.input),
-              )
-            ) {
-              return
-            }
-
             const agent = yield* agents.get(ctx.assistantMessage.agent)
-            yield* permission.ask({
-              permission: "doom_loop",
-              patterns: [value.toolName],
-              sessionID: ctx.assistantMessage.sessionID,
-              metadata: { tool: value.toolName, input: value.input },
-              always: [value.toolName],
-              ruleset: agent.permission,
-            })
+            const loopResult = yield* Effect.promise(() =>
+              detector.checkToolCall(ctx.sessionID, value.toolName, value.input, agent.permission),
+            )
+            if (loopResult.rejected) {
+              yield* failToolCall(value.toolCallId, new Error(loopResult.message))
+              ctx.blocked = ctx.shouldBreak
+            }
             return
           }
 
@@ -566,6 +553,7 @@ export const layer: Layer.Layer<
             // kilocode_change end
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
+            detector.applyToMessage(ctx.assistantMessage)
             yield* session.updatePart({
               id: PartID.ascending(),
               reason: value.finishReason,
@@ -652,7 +640,7 @@ export const layer: Layer.Layer<
             yield* session.updatePart(ctx.currentText)
             return
 
-          case "text-delta":
+          case "text-delta": {
             if (!ctx.currentText) return
             ctx.currentText.text += value.text
             if (value.text.trim()) ctx.step.text = true // kilocode_change
@@ -664,7 +652,12 @@ export const layer: Layer.Layer<
               field: "text",
               delta: value.text,
             })
+            const loop = yield* Effect.promise(() =>
+              detector.checkTextDelta(ctx.sessionID, ctx.currentText!.id, ctx.currentText!.text),
+            )
+            if (loop.detected) slog.warn("text loop detected", { paragraph: loop.paragraph.slice(0, 200) })
             return
+          }
 
           case "text-end":
             if (!ctx.currentText) return
@@ -767,6 +760,7 @@ export const layer: Layer.Layer<
         // kilocode_change start - reconcile cost with any subagent propagation written during tool calls (#6321)
         yield* reconcile()
         // kilocode_change end
+        detector.applyToMessage(ctx.assistantMessage)
         yield* session.updateMessage(ctx.assistantMessage)
       })
 
@@ -811,6 +805,7 @@ export const layer: Layer.Layer<
         ctx.needsCompaction = false
         ctx.compactionError = undefined // kilocode_change
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        detector.resetForProcess()
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -821,7 +816,7 @@ export const layer: Layer.Layer<
 
             yield* stream.pipe(
               Stream.tap((event) => handleEvent(event)),
-              Stream.takeUntil(() => ctx.needsCompaction),
+              Stream.takeUntil(() => ctx.needsCompaction || detector.signal.aborted),
               Stream.runDrain,
             )
           }).pipe(
@@ -869,7 +864,7 @@ export const layer: Layer.Layer<
           )
 
           if (ctx.needsCompaction) return "compact"
-          if (ctx.blocked || ctx.assistantMessage.error) return "stop"
+          if (ctx.blocked || ctx.assistantMessage.error || detector.detected) return "stop"
           return "continue" // kilocode_change - remove once compactError is no longer Kilo-specific
         })
       })


### PR DESCRIPTION

## Context

This Introduces LoopDetector to detect text/reasoning and tool loops. The detector aborts LLM streams on repeated text/reasoning deltas, prompts the doom_loop permission for repeated identical tool calls (and can reject them), and stamps loop metadata onto assistant messages.


## Implementation



## Screenshots

| before | after |
|---|---|
|  |  |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
