### PR TITLE
fix(vscode): refine prompt toolbar layout

### DIFF
--- a/.changeset/center-sidebar-toolbar.md
+++ b/.changeset/center-sidebar-toolbar.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Center the sidebar prompt toolbar on wider sidebars and hide unavailable toolbar actions.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fbf2dc34c9c1ba549244a750a5ce828089fc378fa2352645c9a2267270a0c08
-size 18021
+oid sha256:d7eede94f30f617eab9435e21861f2d56b85bdf347c94f1acfdedef0be65ee77
+size 16452

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -190,116 +190,120 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     vscode.postMessage({ type: "agentManager.requestRepoInfo" })
   })
 
+  const canStartSession = (hasChat: boolean) => hasChat
+
+  const canStartWorktree = () => isSidebar() && server.gitInstalled()
+
+  const canMoveToWorktree = (hasChat: boolean) => hasChat && canContinueInWorktree() && server.gitInstalled()
+
+  const hasActions = (hasChat: boolean) => canStartSession(hasChat) || canStartWorktree() || canMoveToWorktree(hasChat)
+
   const renderActions = (hasChat: boolean) => (
-    <div class="new-task-button-wrapper" classList={{ "new-task-button-wrapper--empty": !hasChat }}>
-      <div class="session-actions-row">
-        <Tooltip
-          value={
-            hasChat
-              ? language.t("sidebar.session.newSession.tooltip")
-              : language.t("sidebar.session.newSession.disabled")
-          }
-          placement="top"
-        >
-          <Button
-            variant="secondary"
-            size="small"
-            class="session-new-button"
-            onClick={startSession}
-            disabled={!hasChat}
-            aria-label={language.t("sidebar.session.newSession")}
-          >
-            {language.t("sidebar.session.newSession")}
-          </Button>
-        </Tooltip>
-        <Show when={isSidebar() && server.gitInstalled()}>
-          <div class="session-worktree-split" ref={worktreeRef}>
-            <Tooltip value={worktreeTooltip} placement="top">
+    <Show when={hasActions(hasChat)}>
+      <div class="new-task-button-wrapper" classList={{ "new-task-button-wrapper--empty": !hasChat }}>
+        <div class="session-actions-row">
+          <Show when={canStartSession(hasChat)}>
+            <Tooltip value={language.t("sidebar.session.newSession.tooltip")} placement="top">
               <Button
                 variant="secondary"
                 size="small"
-                class="session-worktree-main"
-                onClick={startWorktree}
-                aria-label={language.t("sidebar.session.newWorktree")}
+                class="session-new-button"
+                onClick={startSession}
+                aria-label={language.t("sidebar.session.newSession")}
               >
-                {language.t("sidebar.session.newWorktree")}
+                {language.t("sidebar.session.newSession")}
               </Button>
             </Tooltip>
-            <DropdownMenu gutter={4} placement="top-start" getAnchorRect={() => worktreeRef?.getBoundingClientRect()}>
-              <Tooltip value={advancedTooltip} placement="top">
-                <DropdownMenu.Trigger
-                  class="session-worktree-split-arrow"
-                  aria-label={language.t("agentManager.worktree.advancedOptions")}
+          </Show>
+          <Show when={canStartWorktree()}>
+            <div class="session-worktree-split" ref={worktreeRef}>
+              <Tooltip value={worktreeTooltip} placement="top">
+                <Button
+                  variant="secondary"
+                  size="small"
+                  class="session-worktree-main"
+                  onClick={startWorktree}
+                  aria-label={language.t("sidebar.session.newWorktree")}
                 >
-                  <Icon name="chevron-down" size="small" />
-                </DropdownMenu.Trigger>
+                  {language.t("sidebar.session.newWorktree")}
+                </Button>
               </Tooltip>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content class="session-worktree-split-menu">
-                  <DropdownMenu.Item disabled={!repoBranch()} onSelect={startWorktreeFromBranch}>
-                    <span class="session-worktree-menu-gap" aria-hidden="true" />
-                    <DropdownMenu.ItemLabel class="session-worktree-menu-label">
-                      <span>{language.t("sidebar.session.newWorktree.from")}</span>
-                      <span class="session-worktree-menu-branch">
-                        <Icon name="branch" size="small" />
-                        <strong>{repoBranch() ?? language.t("sidebar.session.currentBranch")}</strong>
-                      </span>
-                    </DropdownMenu.ItemLabel>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item onSelect={showAdvancedWorktree}>
-                    <Icon name="settings-gear" size="small" />
-                    <DropdownMenu.ItemLabel>
-                      {language.t("agentManager.dialog.configureWorktree")}
-                    </DropdownMenu.ItemLabel>
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu>
-          </div>
-        </Show>
-        <Show when={hasChat && canContinueInWorktree() && server.gitInstalled()}>
-          <>
-            <Tooltip value={moveTooltip()} placement="top">
-              <Button
-                variant="ghost"
-                size="small"
-                class="session-move-action"
-                aria-disabled={transferring()}
-                onClick={moveToWorktree}
-                aria-label={language.t("sidebar.session.moveToWorktree")}
-              >
-                <Show when={transferring()} fallback={<Icon name="branch" size="small" />}>
-                  <Spinner class="chat-spinner-small" />
-                </Show>
-                <span class="session-move-label">
-                  {transferring() ? transferDetail() : language.t("sidebar.session.moveToWorktree")}
-                </span>
-              </Button>
-            </Tooltip>
-            <Tooltip value={changesTooltip()} placement="top" class="session-move-changes-trigger">
-              <Button
-                variant="ghost"
-                size="small"
-                class="session-move-changes"
-                classList={{
-                  "session-move-changes--empty": !session.worktreeStats()?.files,
-                  "session-move-changes--has-changes": !!session.worktreeStats()?.files,
-                }}
-                onClick={openChanges}
-                aria-label={language.t("command.session.show.changes")}
-              >
-                <Icon name="layers" size="small" />
-                <Show when={session.worktreeStats()?.files}>
-                  <span class="session-diff-add">+{session.worktreeStats()!.additions}</span>
-                  <span class="session-diff-del">-{session.worktreeStats()!.deletions}</span>
-                  <span class="session-move-dot" aria-hidden="true" />
-                </Show>
-              </Button>
-            </Tooltip>
-          </>
-        </Show>
+              <DropdownMenu gutter={4} placement="top-start" getAnchorRect={() => worktreeRef?.getBoundingClientRect()}>
+                <Tooltip value={advancedTooltip} placement="top">
+                  <DropdownMenu.Trigger
+                    class="session-worktree-split-arrow"
+                    aria-label={language.t("agentManager.worktree.advancedOptions")}
+                  >
+                    <Icon name="chevron-down" size="small" />
+                  </DropdownMenu.Trigger>
+                </Tooltip>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content class="session-worktree-split-menu">
+                    <DropdownMenu.Item disabled={!repoBranch()} onSelect={startWorktreeFromBranch}>
+                      <span class="session-worktree-menu-gap" aria-hidden="true" />
+                      <DropdownMenu.ItemLabel class="session-worktree-menu-label">
+                        <span>{language.t("sidebar.session.newWorktree.from")}</span>
+                        <span class="session-worktree-menu-branch">
+                          <Icon name="branch" size="small" />
+                          <strong>{repoBranch() ?? language.t("sidebar.session.currentBranch")}</strong>
+                        </span>
+                      </DropdownMenu.ItemLabel>
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={showAdvancedWorktree}>
+                      <Icon name="settings-gear" size="small" />
+                      <DropdownMenu.ItemLabel>
+                        {language.t("agentManager.dialog.configureWorktree")}
+                      </DropdownMenu.ItemLabel>
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu>
+            </div>
+          </Show>
+          <Show when={canMoveToWorktree(hasChat)}>
+            <>
+              <Tooltip value={moveTooltip()} placement="top">
+                <Button
+                  variant="ghost"
+                  size="small"
+                  class="session-move-action"
+                  aria-disabled={transferring()}
+                  onClick={moveToWorktree}
+                  aria-label={language.t("sidebar.session.moveToWorktree")}
+                >
+                  <Show when={transferring()} fallback={<Icon name="branch" size="small" />}>
+                    <Spinner class="chat-spinner-small" />
+                  </Show>
+                  <span class="session-move-label">
+                    {transferring() ? transferDetail() : language.t("sidebar.session.moveToWorktree")}
+                  </span>
+                </Button>
+              </Tooltip>
+              <Tooltip value={changesTooltip()} placement="top" class="session-move-changes-trigger">
+                <Button
+                  variant="ghost"
+                  size="small"
+                  class="session-move-changes"
+                  classList={{
+                    "session-move-changes--empty": !session.worktreeStats()?.files,
+                    "session-move-changes--has-changes": !!session.worktreeStats()?.files,
+                  }}
+                  onClick={openChanges}
+                  aria-label={language.t("command.session.show.changes")}
+                >
+                  <Icon name="layers" size="small" />
+                  <Show when={session.worktreeStats()?.files}>
+                    <span class="session-diff-add">+{session.worktreeStats()!.additions}</span>
+                    <span class="session-diff-del">-{session.worktreeStats()!.deletions}</span>
+                    <span class="session-move-dot" aria-hidden="true" />
+                  </Show>
+                </Button>
+              </Tooltip>
+            </>
+          </Show>
+        </div>
       </div>
-    </div>
+    </Show>
   )
 
   return (
@@ -332,7 +336,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
               />
             )}
           </Show>
-          <Show when={!props.readonly && idle() && !blocked() && (hasMessages() || isSidebar())}>
+          <Show when={!props.readonly && idle() && !blocked() && hasActions(hasMessages())}>
             {renderActions(hasMessages())}
           </Show>
           <Show when={!props.readonly}>

--- a/packages/kilo-vscode/webview-ui/src/styles/session-actions.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/session-actions.css
@@ -22,7 +22,7 @@
   align-items: center;
   flex-wrap: nowrap;
   min-height: 22px;
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 .session-actions-row > * {
@@ -34,10 +34,6 @@
 .session-actions-row > [data-component="tooltip-trigger"] {
   display: flex;
   flex: 0 0 auto;
-}
-
-.session-actions-row > .session-move-changes-trigger {
-  margin-left: auto;
 }
 
 .session-actions-row > [data-component="tooltip-trigger"] > [data-component="button"] {
@@ -333,6 +329,7 @@
   .session-actions-row {
     gap: 4px;
     flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .session-actions-row > *,
@@ -361,11 +358,5 @@
 
   .session-move-dot {
     opacity: 1;
-  }
-}
-
-@container (max-width: 420px) {
-  .session-actions-row > .session-move-changes-trigger {
-    margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- Center the prompt toolbar as a group on wider sidebar and Agent Manager chat layouts.
- Hide unavailable toolbar actions, including the disabled empty-state New Session button, while keeping New Session available in Agent Manager chats.

## Screenshot

<img width="1696" height="962" alt="Screen Shot 2026-04-28 at 8 52 33 PM" src="https://github.com/user-attachments/assets/c571c955-d639-4721-84ae-fcd48c151f1f" />


## Resize demo

<img width="820" height="813" alt="GIF Recording 2026-04-29 at 10 07 14 AM" src="https://github.com/user-attachments/assets/6c96442e-fcf2-4d00-a289-939eba5b3590" />


<img width="964" height="784" alt="GIF Recording 2026-04-29 at 10 08 35 AM" src="https://github.com/user-attachments/assets/747f3442-d6ac-437f-933c-9f6c97127383" />
