### PR TITLE
fix(vscode): keep local Agent Manager sessions in workspace

### DIFF
--- a/.changeset/local-tab-worktree-context.md
+++ b/.changeset/local-tab-worktree-context.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager local tab sessions scoped to the main workspace after switching from a worktree.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -31,6 +31,7 @@ import {
   loadSessions as loadSessionsUtil,
   flushPendingSessionRefresh as flushPendingSessionRefreshUtil,
   resolveContextDirectory,
+  resolveNewSessionDirectory,
   resolveWorkspaceDirectory,
   SessionStreamScheduler,
   type SessionRefreshContext,
@@ -624,6 +625,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             message.agent,
             message.variant,
             files,
+            typeof message.agentManagerContext === "string" ? message.agentManagerContext : undefined,
           )
           break
         }
@@ -640,6 +642,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             message.agent,
             message.variant,
             files,
+            typeof message.agentManagerContext === "string" ? message.agentManagerContext : undefined,
           )
           break
         }
@@ -2360,18 +2363,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  /**
-   * Ensure a session exists, creating one if needed. Returns the resolved
-   * session ID and workspace directory, or undefined when the client is
-   * disconnected.
-   */
-  private async resolveSession(
-    sessionID?: string,
-    draftID?: string,
-  ): Promise<{ sid: string; dir: string } | undefined> {
+  private async resolveSession(sessionID?: string, draftID?: string, context?: string) {
     if (!this.client) return undefined
 
-    const dir = sessionID ? this.getWorkspaceDirectory(sessionID) : this.getContextDirectory()
+    const dir = resolveNewSessionDirectory({
+      sessionID,
+      currentSessionID: this.currentSession?.id,
+      contextSessionID: this.contextSessionID,
+      agentManagerContext: context,
+      sessionDirectories: this.sessionDirectories,
+      workspaceDirectory: this.getRootDirectory(),
+    })
 
     if (!sessionID && !this.currentSession) {
       const { data: session } = await this.client.session.create({ directory: dir }, { throwOnError: true })
@@ -2379,7 +2381,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.contextSessionID = session.id
       this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
-      if (draftID) this.contextSessionID = session.id
       this.postMessage({
         type: "sessionCreated",
         session: this.sessionToWebview(session),
@@ -2478,6 +2479,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     agent?: string,
     variant?: string,
     files?: MessageFile[],
+    context?: string,
   ): Promise<void> {
     if (!this.client) {
       this.postMessage({
@@ -2494,7 +2496,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     let resolved: { sid: string; dir: string } | undefined
     try {
-      resolved = await this.resolveSession(sessionID, draftID)
+      resolved = await this.resolveSession(sessionID, draftID, context)
 
       const parts: Array<TextPartInput | FilePartInput> = []
       if (files) {
@@ -2554,6 +2556,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     agent?: string,
     variant?: string,
     files?: MessageFile[],
+    context?: string,
   ): Promise<void> {
     if (!this.client) {
       this.postMessage({
@@ -2570,7 +2573,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     let resolved: { sid: string; dir: string } | undefined
     try {
-      resolved = await this.resolveSession(sessionID, draftID)
+      resolved = await this.resolveSession(sessionID, draftID, context)
 
       if (messageID) {
         this.connectionService.recordMessageSessionId(messageID, resolved!.sid)
@@ -3235,10 +3238,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  /**
-   * Get the workspace directory for a session.
-   * Checks session directory overrides first (e.g., worktree paths), then falls back to workspace root.
-   */
   private getWorkspaceDirectory(sessionId?: string): string {
     return resolveWorkspaceDirectory({
       sessionID: sessionId,

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -587,6 +587,7 @@ interface SendMessageIn {
   agent?: string
   variant?: string
   files?: Array<{ mime: string; url: string; filename?: string; source?: FileSourceIn }>
+  agentManagerContext?: string
 }
 
 interface SendCommandIn {
@@ -601,6 +602,7 @@ interface SendCommandIn {
   agent?: string
   variant?: string
   files?: Array<{ mime: string; url: string; filename?: string; source?: FileSourceIn }>
+  agentManagerContext?: string
 }
 
 interface RequestTerminalContextIn {

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -322,11 +322,39 @@ export function resolveContextDirectory(input: {
   contextSessionID?: string
   sessionDirectories: Map<string, string>
   workspaceDirectory: string
+  forceWorkspaceRoot?: boolean
 }) {
+  if (input.forceWorkspaceRoot) return input.workspaceDirectory
+
   return resolveWorkspaceDirectory({
     sessionID: input.currentSessionID ?? input.contextSessionID,
     sessionDirectories: input.sessionDirectories,
     workspaceDirectory: input.workspaceDirectory,
+  })
+}
+
+export function resolveNewSessionDirectory(input: {
+  sessionID?: string
+  currentSessionID?: string
+  contextSessionID?: string
+  agentManagerContext?: string
+  sessionDirectories: Map<string, string>
+  workspaceDirectory: string
+}) {
+  if (input.sessionID) {
+    return resolveWorkspaceDirectory({
+      sessionID: input.sessionID,
+      sessionDirectories: input.sessionDirectories,
+      workspaceDirectory: input.workspaceDirectory,
+    })
+  }
+
+  return resolveContextDirectory({
+    currentSessionID: input.currentSessionID,
+    contextSessionID: input.contextSessionID,
+    sessionDirectories: input.sessionDirectories,
+    workspaceDirectory: input.workspaceDirectory,
+    forceWorkspaceRoot: input.agentManagerContext === "local",
   })
 }
 

--- a/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test"
-import { resolveContextDirectory, resolveNewSessionDirectory, resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
+import {
+  resolveContextDirectory,
+  resolveNewSessionDirectory,
+  resolveWorkspaceDirectory,
+} from "../../src/kilo-provider-utils"
 
 describe("resolveWorkspaceDirectory", () => {
   it("uses an explicit session worktree override", () => {

--- a/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-worktree-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { resolveContextDirectory, resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
+import { resolveContextDirectory, resolveNewSessionDirectory, resolveWorkspaceDirectory } from "../../src/kilo-provider-utils"
 
 describe("resolveWorkspaceDirectory", () => {
   it("uses an explicit session worktree override", () => {
@@ -47,6 +47,53 @@ describe("resolveContextDirectory", () => {
     const dir = resolveContextDirectory({
       contextSessionID: "ses_local",
       sessionDirectories: new Map(),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo")
+  })
+
+  it("can force local context even when the last session was in a worktree", () => {
+    const dir = resolveContextDirectory({
+      contextSessionID: "ses_worktree",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+      forceWorkspaceRoot: true,
+    })
+
+    expect(dir).toBe("/repo")
+  })
+})
+
+describe("resolveNewSessionDirectory", () => {
+  it("keeps existing worktree sessions in their registered directory", () => {
+    const dir = resolveNewSessionDirectory({
+      sessionID: "ses_worktree",
+      contextSessionID: "ses_local",
+      agentManagerContext: "local",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo/.kilo/worktrees/feature")
+  })
+
+  it("creates follow-up worktree sessions in the last worktree after clearSession", () => {
+    const dir = resolveNewSessionDirectory({
+      contextSessionID: "ses_worktree",
+      agentManagerContext: "wt_feature",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
+      workspaceDirectory: "/repo",
+    })
+
+    expect(dir).toBe("/repo/.kilo/worktrees/feature")
+  })
+
+  it("creates local Agent Manager sessions in the workspace root after a worktree was selected", () => {
+    const dir = resolveNewSessionDirectory({
+      contextSessionID: "ses_worktree",
+      agentManagerContext: "local",
+      sessionDirectories: new Map([["ses_worktree", "/repo/.kilo/worktrees/feature"]]),
       workspaceDirectory: "/repo",
     })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -381,7 +381,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (message.type === "triggerTask") {
       if (isDisabled()) return
       const sel = session.selected()
-      session.sendMessage(message.text, sel?.providerID, sel?.modelID)
+      session.sendMessage(message.text, sel?.providerID, sel?.modelID, undefined, undefined, ctx())
     }
 
     if (message.type === "sendMessageFailed") {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -699,9 +699,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (matched) {
       const rest = draft.slice(cmdMatch![0].length).trim()
       const args = review && rest ? `${review}\n\n${rest}` : rest || review
-      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments, pendingId)
+      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments, pendingId, ctx())
     } else {
-      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments, pendingId)
+      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments, pendingId, ctx())
     }
 
     history.append(draft)

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -198,7 +198,14 @@ interface SessionContextValue {
   // Actions
   revertSession: (messageID: string) => void
   unrevertSession: () => void
-  sendMessage: (text: string, providerID?: string, modelID?: string, files?: FileAttachment[], draftID?: string) => void
+  sendMessage: (
+    text: string,
+    providerID?: string,
+    modelID?: string,
+    files?: FileAttachment[],
+    draftID?: string,
+    context?: string,
+  ) => void
   sendCommand: (
     command: string,
     args: string,
@@ -206,6 +213,7 @@ interface SessionContextValue {
     modelID?: string,
     files?: FileAttachment[],
     draftID?: string,
+    context?: string,
   ) => void
   abort: () => void
   compact: () => void
@@ -1634,6 +1642,7 @@ export const SessionProvider: ParentComponent = (props) => {
     modelID?: string,
     files?: FileAttachment[],
     draftID?: string,
+    context?: string,
   ) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot send message: not connected")
@@ -1680,6 +1689,7 @@ export const SessionProvider: ParentComponent = (props) => {
       agent,
       variant: currentVariant(),
       files,
+      agentManagerContext: context,
     })
   }
 
@@ -1690,6 +1700,7 @@ export const SessionProvider: ParentComponent = (props) => {
     modelID?: string,
     files?: FileAttachment[],
     draftID?: string,
+    context?: string,
   ) {
     if (!server.isConnected()) {
       console.warn("[Kilo New] Cannot send command: not connected")
@@ -1740,6 +1751,7 @@ export const SessionProvider: ParentComponent = (props) => {
       agent,
       variant: currentVariant(),
       files,
+      agentManagerContext: context,
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -28,6 +28,7 @@ export interface SendMessageRequest {
   agent?: string
   variant?: string
   files?: FileAttachment[]
+  agentManagerContext?: string
 }
 
 export interface AbortRequest {
@@ -226,6 +227,7 @@ export interface SendCommandRequest {
   agent?: string
   variant?: string
   files?: FileAttachment[]
+  agentManagerContext?: string
 }
 
 export interface RemoveSkillMessage {


### PR DESCRIPTION
## Summary
- Route Agent Manager local-tab sends, commands, and triggered tasks with explicit local context so pending sessions stay in the main workspace.
- Preserve selected-worktree routing for worktree sessions while covering local, worktree, and explicit session directory resolution with regression tests.

Fixes #9646.