### PR TITLE
fix(vscode): preserve revert after model error switch

### DIFF
--- a/.changeset/model-switch-revert.md
+++ b/.changeset/model-switch-revert.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep checkpoint revert actions available when switching models clears a stale provider error.

--- a/packages/kilo-vscode/tests/unit/session-errors.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-errors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test"
+import { errorIDs, visibleError } from "../../webview-ui/src/context/session-errors"
+import type { Message } from "../../webview-ui/src/types/messages"
+
+const base = {
+  sessionID: "session",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  time: { created: 1 },
+}
+
+const assistant = (id: string, error?: Message["error"]): Message => ({
+  ...base,
+  id,
+  role: "assistant",
+  error,
+})
+
+describe("errorIDs", () => {
+  it("returns only message IDs with errors", () => {
+    const messages = [
+      assistant("message_1"),
+      assistant("message_2", { name: "ProviderError" }),
+      assistant("message_3", { name: "RateLimitError" }),
+    ]
+
+    expect(errorIDs(messages)).toEqual(["message_2", "message_3"])
+  })
+})
+
+describe("visibleError", () => {
+  it("hides only selected error messages", () => {
+    const hidden = new Set(["message_2"])
+    const messages = [
+      assistant("message_1"),
+      assistant("message_2", { name: "ProviderError" }),
+      assistant("message_3", { name: "RateLimitError" }),
+    ]
+
+    expect(visibleError(messages, (id) => hidden.has(id))).toEqual({ name: "RateLimitError" })
+  })
+
+  it("ignores aborted assistant messages", () => {
+    const messages = [assistant("message_1", { name: "MessageAbortedError" })]
+
+    expect(visibleError(messages, () => false)).toBeUndefined()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ErrorDisplay.tsx
@@ -12,7 +12,7 @@ import {
   isUnauthorizedPromotionLimitError,
 } from "../../utils/errorUtils"
 
-interface ErrorDisplayProps {
+export interface ErrorDisplayProps {
   error: NonNullable<AssistantMessage["error"]>
   onLogin?: () => void
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -32,6 +32,8 @@ import { ErrorDisplay } from "./ErrorDisplay"
 import { useServer } from "../../context/server"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { visibleError } from "../../context/session-errors"
+import type { ErrorDisplayProps } from "./ErrorDisplay"
 import type { Message as WebMessage } from "../../types/messages"
 
 function getDirectory(path: string): string {
@@ -87,9 +89,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
 
   const interrupted = createMemo(() => assistantMessages().some((m) => m.error?.name === "MessageAbortedError"))
 
-  const error = createMemo(
-    () => assistantMessages().find((m) => m.error && m.error.name !== "MessageAbortedError")?.error,
-  )
+  const error = createMemo(() => visibleError(assistantMessages(), session.isErrorHidden))
 
   // Diffs from message summary
   const diffs = createMemo(() => {
@@ -276,7 +276,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
 
           {/* Error handling */}
           <Show when={error()}>
-            <ErrorDisplay error={error()!} onLogin={server.startLogin} />
+            {(err) => <ErrorDisplay error={err() as ErrorDisplayProps["error"]} onLogin={server.startLogin} />}
           </Show>
         </div>
       )}

--- a/packages/kilo-vscode/webview-ui/src/context/session-errors.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-errors.ts
@@ -1,0 +1,12 @@
+import type { Message } from "../types/messages"
+
+type Entry = { id: string; error?: Message["error"] }
+type Error = NonNullable<Message["error"]>
+
+export function errorIDs(messages: Entry[]) {
+  return messages.filter((msg) => !!msg.error).map((msg) => msg.id)
+}
+
+export function visibleError(messages: Entry[], hidden: (id: string) => boolean): Error | undefined {
+  return messages.find((msg) => msg.error && msg.error.name !== "MessageAbortedError" && !hidden(msg.id))?.error
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -46,6 +46,7 @@ import {
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { resolveSessionAgent } from "./session-agent"
+import { errorIDs } from "./session-errors"
 import { PartStash } from "./part-stash"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
@@ -120,6 +121,10 @@ interface SessionContextValue {
 
   // Parts for a specific message
   getParts: (messageID: string) => Part[]
+
+  // Hidden after model changes so switching models can clear stale provider errors
+  // without removing messages and their checkpoint restore actions.
+  isErrorHidden: (messageID: string) => boolean
 
   // Move stashed parts into the reactive store for the given message IDs.
   // Called by VscodeSessionTurn when the virtualizer renders a turn.
@@ -352,6 +357,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Cloud session preview state
   const [cloudPreviewId, setCloudPreviewId] = createSignal<string | null>(null)
+  const [hiddenErrors, setHiddenErrors] = createSignal<Set<string>>(new Set())
 
   // Live worktree diff stats from extension polling
   const [worktreeStats, setWorktreeStats] = createSignal<
@@ -462,8 +468,28 @@ export const SessionProvider: ParentComponent = (props) => {
     applyModel(selectedAgentName(), { providerID, modelID })
     const sid = currentSessionID()
     if (sid) {
-      setStore("messages", sid, (msgs = []) => msgs.filter((m) => !m.error))
+      hideErrors(sid)
     }
+  }
+
+  function hideErrors(sid: string) {
+    const ids = errorIDs(store.messages[sid] ?? [])
+    if (ids.length === 0) return
+    setHiddenErrors((prev) => {
+      const next = new Set(prev)
+      for (const id of ids) next.add(id)
+      return next
+    })
+  }
+
+  function clearHiddenErrors(ids: string[]) {
+    if (ids.length === 0) return
+    setHiddenErrors((prev) => {
+      const next = new Set(prev)
+      for (const id of ids) next.delete(id)
+      if (next.size === prev.size) return prev
+      return next
+    })
   }
 
   /** The config/default model for the current mode (what settings says). */
@@ -1372,6 +1398,7 @@ export const SessionProvider: ParentComponent = (props) => {
       const msgs = store.messages[sessionID] ?? []
       const msgIds = msgs.map((m) => m.id)
       for (const id of msgIds) stash.remove(id)
+      clearHiddenErrors(msgIds)
 
       setStore(
         "sessions",
@@ -1463,6 +1490,7 @@ export const SessionProvider: ParentComponent = (props) => {
   // Splices the message from the store and deletes its parts.
   function handleMessageRemoved(sessionID: string, messageID: string) {
     setStore("messages", sessionID, (msgs = []) => msgs.filter((m) => m.id !== messageID))
+    clearHiddenErrors([messageID])
     setStore(
       "parts",
       produce((parts) => {
@@ -2148,6 +2176,7 @@ export const SessionProvider: ParentComponent = (props) => {
     messages,
     userMessages,
     getParts,
+    isErrorHidden: (messageID: string) => hiddenErrors().has(messageID),
     hydrateParts,
     todos,
     permissions,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -531,6 +531,7 @@ export const SessionProvider: ParentComponent = (props) => {
           delete overrides[sid]
         }),
       )
+      hideErrors(sid)
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -182,6 +182,7 @@ export function mockSessionValue(overrides?: {
     allParts: () => ({}),
     allStatusMap: () => ({}),
     getParts: () => [],
+    isErrorHidden: () => false,
     hydrateParts: noop,
     todos: () => [],
     permissions: () => permissions,


### PR DESCRIPTION
## Summary
- Fixes https://github.com/Kilo-Org/kilocode/issues/9641 for the reproduced model-switch failure path.
- We reproduced this when a prompt ends in an assistant error card, such as provider/rate-limit failure, then switching models clears that stale error and removes the revert/checkpoint action.
- The regression was introduced by https://github.com/Kilo-Org/kilocode/pull/8435, which fixed #8203 by deleting errored assistant messages from the webview store on model switch.

## Fix
- Keep errored assistant messages in session state and hide stale error cards instead of filtering messages out.
- This preserves the turn structure used to show revert/checkpoint actions while still clearing obsolete provider errors after a model switch.

## Verification
- Reproduced the failure card case before the fix and verified the revert/checkpoint action remains available after switching models with the fix.
- Verified the successful-response case does not reproduce locally, so this PR intentionally targets the confirmed error-card regression.
- Ran `bun test tests/unit/session-errors.test.ts tests/unit/session-queue.test.ts`.
- Ran targeted ESLint on changed webview files.