### PR TITLE
fix: handle skipped and Kilo-only paths in upstream merges

### DIFF
--- a/script/upstream/README.md
+++ b/script/upstream/README.md
@@ -76,6 +76,7 @@ The merge automation follows this process, applying **all transformations BEFORE
    - `<author>/opencode-<version>` - Transformed upstream branch
 
 5. **Apply ALL transformations to upstream branch (PRE-MERGE)**:
+   - Remove files that should not exist in Kilo (`skipFiles`)
    - Transform package names (opencode-ai -> @kilocode/cli)
    - Preserve Kilo's versions
    - Transform i18n files with Kilo branding
@@ -161,15 +162,16 @@ Configuration is defined in `utils/config.ts`:
 
 The following transforms are applied to the opencode branch before merging:
 
-1. **Package names** - `opencode-ai` -> `@kilocode/cli`, etc.
-2. **Versions** - Preserve Kilo's version numbers
-3. **i18n files** - OpenCode -> Kilo in user-visible strings
-4. **Branding files** - UI components, configs with branding only
-5. **Tauri configs** - Desktop app identifiers, names
-6. **package.json** - Names, dependencies, Kilo injections
-7. **Scripts** - GitHub API references
-8. **Extensions** - Zed, etc.
-9. **Web/docs** - Documentation files
+1. **Skip files** - Remove upstream-only packages/files that should not exist in Kilo
+2. **Package names** - `opencode-ai` -> `@kilocode/cli`, etc.
+3. **Versions** - Preserve Kilo's version numbers
+4. **i18n files** - OpenCode -> Kilo in user-visible strings
+5. **Branding files** - UI components, configs with branding only
+6. **Tauri configs** - Desktop app identifiers, names
+7. **package.json** - Names, dependencies, Kilo injections
+8. **Scripts** - GitHub API references
+9. **Extensions** - Zed, etc.
+10. **Web/docs** - Documentation files
 
 ### Post-Merge Strategies
 

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -405,6 +405,13 @@ async function main() {
   // This reduces conflicts by transforming upstream code to Kilo conventions BEFORE merging
   logger.step(6, 8, "Applying transformations to opencode branch (pre-merge)...")
 
+  logger.info("Removing files skipped in Kilo...")
+  const skips = await skipFiles({ dryRun: false, verbose: options.verbose, force: true })
+  const count = skips.filter((r) => r.action === "removed").length
+  if (count > 0) {
+    logger.success(`Removed ${count} skipped file(s) from opencode branch`)
+  }
+
   // 6a. Transform package names (opencode-ai -> @kilocode/cli)
   logger.info("Transforming package names...")
   const nameResults = await transformPackageNames({ dryRun: false, verbose: options.verbose })

--- a/script/upstream/transforms/keep-ours.test.ts
+++ b/script/upstream/transforms/keep-ours.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { shouldKeepOurs } from "./keep-ours"
+
+test("keeps files in Kilo-specific directories", () => {
+  expect(shouldKeepOurs("packages/kilo-vscode/.prettierignore", [])).toBe(true)
+  expect(shouldKeepOurs("packages/kilo-vscode/webview-ui/tsconfig.json", [])).toBe(true)
+  expect(shouldKeepOurs("packages/kilo-i18n/tsconfig.json", [])).toBe(true)
+  expect(shouldKeepOurs("script/upstream/tsconfig.json", [])).toBe(true)
+})
+
+test("keeps explicitly configured files", () => {
+  expect(shouldKeepOurs("README.md", ["README.md"])).toBe(true)
+})
+
+test("does not keep unrelated files", () => {
+  expect(shouldKeepOurs("packages/opencode/src/index.ts", [])).toBe(false)
+})

--- a/script/upstream/transforms/keep-ours.ts
+++ b/script/upstream/transforms/keep-ours.ts
@@ -10,6 +10,7 @@ import { $ } from "bun"
 import { info, success, warn, error, debug } from "../utils/logger"
 import { defaultConfig } from "../utils/config"
 import { checkoutOurs, stageFiles, getConflictedFiles } from "../utils/git"
+import { matches } from "../utils/match"
 
 export interface KeepOursResult {
   file: string
@@ -27,17 +28,8 @@ export interface KeepOursOptions {
  * Check if a file matches any keep-ours patterns
  */
 export function shouldKeepOurs(filePath: string, patterns: string[]): boolean {
-  return patterns.some((pattern) => {
-    // Exact match
-    if (filePath === pattern) return true
-    // Pattern match (simple glob)
-    if (pattern.includes("*")) {
-      const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$")
-      return regex.test(filePath)
-    }
-    // Contains match
-    return filePath.includes(pattern)
-  })
+  const dirs = defaultConfig.kiloDirectories.map((dir) => `${dir}/**`)
+  return matches(filePath, [...patterns, ...dirs]) || patterns.some((pattern) => filePath.includes(pattern))
 }
 
 /**

--- a/script/upstream/transforms/skip-files.test.ts
+++ b/script/upstream/transforms/skip-files.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { shouldSkip } from "./skip-files"
+
+test("matches hosted package glob paths", () => {
+  expect(shouldSkip("packages/web/package.json", ["packages/web/**"])).toBe(true)
+  expect(shouldSkip("packages/web/src/content/docs/ja/zen.mdx", ["packages/web/**"])).toBe(true)
+  expect(shouldSkip("packages/console/app/package.json", ["packages/console/**"])).toBe(true)
+})
+
+test("does not match sibling package glob paths", () => {
+  expect(shouldSkip("packages/app/package.json", ["packages/web/**"])).toBe(false)
+})
+
+test("matches extension glob paths", () => {
+  expect(shouldSkip(".github/VOUCHED.td", [".github/VOUCHED.*"])).toBe(true)
+})

--- a/script/upstream/transforms/skip-files.ts
+++ b/script/upstream/transforms/skip-files.ts
@@ -13,6 +13,7 @@
 import { $ } from "bun"
 import { info, success, warn, debug } from "../utils/logger"
 import { defaultConfig } from "../utils/config"
+import { matches } from "../utils/match"
 
 export interface SkipResult {
   file: string
@@ -24,30 +25,14 @@ export interface SkipOptions {
   dryRun?: boolean
   verbose?: boolean
   patterns?: string[]
+  force?: boolean
 }
 
 /**
  * Check if a file matches any skip patterns
  */
 export function shouldSkip(filePath: string, patterns: string[]): boolean {
-  return patterns.some((pattern) => {
-    // Exact match
-    if (filePath === pattern) return true
-
-    // Regex pattern (e.g., README\.[a-z]+\.md)
-    if (pattern.startsWith("^") || pattern.includes("\\")) {
-      const regex = new RegExp(pattern)
-      return regex.test(filePath)
-    }
-
-    // Glob-style pattern
-    if (pattern.includes("*")) {
-      const regex = new RegExp("^" + pattern.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$")
-      return regex.test(filePath)
-    }
-
-    return false
-  })
+  return matches(filePath, patterns)
 }
 
 /**
@@ -71,6 +56,21 @@ async function getUpstreamFiles(): Promise<string[]> {
  */
 async function getUnmergedFiles(): Promise<string[]> {
   const result = await $`git diff --name-only --diff-filter=U`.quiet().nothrow()
+
+  if (result.exitCode !== 0) return []
+
+  return result.stdout
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((f) => f.length > 0)
+}
+
+/**
+ * Get tracked files from the current branch.
+ */
+async function getTrackedFiles(): Promise<string[]> {
+  const result = await $`git ls-files`.quiet().nothrow()
 
   if (result.exitCode !== 0) return []
 
@@ -125,7 +125,8 @@ export async function skipFiles(options: SkipOptions = {}): Promise<SkipResult[]
   // Get all files involved in the merge
   const stagedFiles = await getUpstreamFiles()
   const unmergedFiles = await getUnmergedFiles()
-  const allFiles = [...new Set([...stagedFiles, ...unmergedFiles])]
+  const tracked = options.force ? await getTrackedFiles() : []
+  const allFiles = [...new Set([...stagedFiles, ...unmergedFiles, ...tracked])]
 
   if (allFiles.length === 0) {
     info("No files to process")
@@ -138,7 +139,7 @@ export async function skipFiles(options: SkipOptions = {}): Promise<SkipResult[]
     if (!shouldSkip(file, patterns)) continue
 
     // Check if file existed in Kilo before merge (HEAD~1 or the merge base)
-    const existedInKilo = await fileExistsInRef(file, "HEAD")
+    const existedInKilo = options.force ? false : await fileExistsInRef(file, "HEAD")
 
     if (existedInKilo) {
       debug(`Skipping ${file} - exists in Kilo, not removing`)

--- a/script/upstream/utils/match.ts
+++ b/script/upstream/utils/match.ts
@@ -1,0 +1,34 @@
+/**
+ * Match repository paths against exact, regex, or simple glob patterns.
+ */
+
+function esc(text: string): string {
+  return text.replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+}
+
+function glob(pattern: string): RegExp {
+  const source = pattern
+    .split("**")
+    .map((part) => part.split("*").map(esc).join("[^/]*"))
+    .join(".*")
+
+  return new RegExp(`^${source}$`)
+}
+
+export function match(path: string, pattern: string): boolean {
+  if (path === pattern) return true
+
+  if (pattern.startsWith("^") || pattern.includes("\\")) {
+    return new RegExp(pattern).test(path)
+  }
+
+  if (pattern.includes("*")) {
+    return glob(pattern).test(path)
+  }
+
+  return false
+}
+
+export function matches(path: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => match(path, pattern))
+}

--- a/script/upstream/utils/report.test.ts
+++ b/script/upstream/utils/report.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { getRecommendation } from "./report"
+
+test("recommends skip for hosted package globs", () => {
+  expect(getRecommendation("packages/web/src/content/docs/ja/zen.mdx", [], ["packages/web/**"]).recommendation).toBe(
+    "skip",
+  )
+  expect(getRecommendation("packages/console/app/package.json", [], ["packages/console/**"]).recommendation).toBe(
+    "skip",
+  )
+})
+
+test("does not recommend skip for unrelated packages", () => {
+  expect(getRecommendation("packages/app/package.json", [], ["packages/web/**"]).recommendation).toBe(
+    "package-transform",
+  )
+})

--- a/script/upstream/utils/report.test.ts
+++ b/script/upstream/utils/report.test.ts
@@ -15,3 +15,8 @@ test("does not recommend skip for unrelated packages", () => {
     "package-transform",
   )
 })
+
+test("recommends keep ours for Kilo directories", () => {
+  expect(getRecommendation("packages/kilo-vscode/.prettierignore", [], []).recommendation).toBe("keep-ours")
+  expect(getRecommendation("packages/kilo-i18n/tsconfig.json", [], []).recommendation).toBe("keep-ours")
+})

--- a/script/upstream/utils/report.ts
+++ b/script/upstream/utils/report.ts
@@ -4,6 +4,7 @@
  */
 
 import { $ } from "bun"
+import { matches } from "./match"
 
 export interface ConflictReport {
   timestamp: string
@@ -119,7 +120,7 @@ export function classifyFile(path: string): ConflictFile["type"] {
  * Check if a file should be skipped (not added from upstream)
  */
 function shouldSkipFile(path: string, skipPatterns: string[]): boolean {
-  return skipPatterns.some((pattern) => path === pattern || path.includes(pattern))
+  return matches(path, skipPatterns)
 }
 
 /**

--- a/script/upstream/utils/report.ts
+++ b/script/upstream/utils/report.ts
@@ -4,6 +4,7 @@
  */
 
 import { $ } from "bun"
+import { defaultConfig } from "./config"
 import { matches } from "./match"
 
 export interface ConflictReport {
@@ -151,7 +152,7 @@ export function getRecommendation(
   }
 
   // Kilo directories should always keep ours
-  if (path.includes("kilocode") || path.includes("kilo-gateway") || path.includes("kilo-telemetry")) {
+  if (matches(path, defaultConfig.kiloDirectories.map((dir) => `${dir}/**`))) {
     return {
       recommendation: "keep-ours",
       reason: "File is in a Kilo-specific directory",


### PR DESCRIPTION
## Summary
- Remove upstream-only `skipFiles` paths from the transformed opencode branch before merging, so hosted packages like `packages/web/**` and `packages/console/**` do not reappear as delete/modify conflicts.
- Share exact/regex/glob matching between skip removal and conflict-report recommendations, so patterns like `packages/web/**` are classified as `Skip (Auto-Remove)` instead of web/package transforms.
- Treat configured Kilo-specific directories as `keep-ours` during conflict resolution and reporting, covering paths such as `packages/kilo-vscode/**`, `packages/kilo-i18n/**`, and `script/upstream/**`.

## Findings
- Git can report Kilo-only files as `deleted by them` even when upstream never had those paths.
- The cause is rename detection: Git infers renames from removed hosted-package files, for example `packages/slack/.gitignore` -> `packages/kilo-vscode/.prettierignore`, then reports the upstream deletion of the source file against the Kilo destination path.
- Keeping configured Kilo directories resolves those misleading rename/delete conflicts automatically without disabling rename detection globally.

## Validation
- `cd script/upstream && bun test`
- Push hook ran `bun turbo typecheck` successfully
