### PR TITLE
Add /variant slash command

### DIFF
--- a/.changeset/variant-slash-command.md
+++ b/.changeset/variant-slash-command.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support opening the reasoning effort selector from `/variant` when the selected model has variants.

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -25,6 +25,7 @@ While the specifics change constantly, some principles stay consistent:
 {% tab label="VSCode" %}
 
 - Use the **model selector** in the chat prompt area to pick a model for the current session. You can also type `/models` to open the model picker.
+- When the selected model supports variants, type `/variant` to open the reasoning effort selector.
 - Set per-agent defaults and a global default in the **Settings** panel (Models tab), or directly in the `kilo.jsonc` config file.
 - **Model precedence:** Session override → Last picked per agent → Per-agent config → Global config → Kilo Auto (free).
 - The model selector remembers the last model you picked for each agent — switching agents restores your previous choice. A manual pick always beats config settings; use the **reset button** (visible when your active model differs from config) to go back to the config default.

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -25,7 +25,7 @@
 import { $ } from "bun"
 import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { delimiter, join, resolve } from "node:path"
 import { spawn } from "node:child_process"
 
@@ -208,8 +208,17 @@ async function compile() {
   }
 
   console.log("[launch] Building extension...")
-  await $`bun run package`.cwd(root)
+  await $`bun run package`.cwd(root).env(cleanEnv(process.env))
   console.log("[launch] Build complete")
+}
+
+function cleanEnv(input: NodeJS.ProcessEnv) {
+  const env = { ...input, HOME: homedir().trim() }
+  for (const key of ["XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_STATE_HOME", "KILO_TEST_HOME"]) {
+    const value = env[key]
+    if (value !== undefined) env[key] = value.trim()
+  }
+  return env
 }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +314,7 @@ async function launch() {
 
   // Strip Electron/VS Code env vars so the spawned instance doesn't attach
   // to the current Electron process (e.g. when launched from a VS Code task).
-  const env = { ...process.env }
+  const env = cleanEnv(process.env)
   for (const key of Object.keys(env)) {
     if (key.startsWith("ELECTRON_") || key.startsWith("VSCODE_")) delete env[key]
   }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -82,7 +82,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const mention = useFileMention(vscode, sid, hasGit)
   const terminal = useTerminalContext(vscode)
   const git = useGitChangesContext(vscode, ctx, hasGit)
-  const slash = useSlashCommand(vscode)
+  const slash = useSlashCommand(vscode, () => (session.variantList().length > 0 ? new Set() : new Set(["variant"])))
   const imageAttach = useImageAttachments()
   imageAttach.setFilePathDropHandler((paths) => {
     const cwd = server.workspaceDirectory()

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -7,8 +7,8 @@
  * ThinkingSelector     — thin wrapper wired to session context for chat usage.
  */
 
-import { Component, createSignal, For, Show } from "solid-js"
-import { Popover } from "@kilocode/kilo-ui/popover"
+import { Component, createSignal, For, onCleanup, Show } from "solid-js"
+import { PopupSelector } from "./PopupSelector"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
 
@@ -27,11 +27,76 @@ export interface ThinkingSelectorBaseProps {
 
 export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props) => {
   const [open, setOpen] = createSignal(false)
+  const [focused, setFocused] = createSignal(-1)
+  let listRef: HTMLDivElement | undefined
+
+  function focusItem(idx: number) {
+    const items = listRef?.querySelectorAll<HTMLElement>("[role=option]")
+    if (!items) return
+    const clamped = Math.max(0, Math.min(idx, items.length - 1))
+    setFocused(clamped)
+    items[clamped]?.focus()
+  }
+
+  function refocus() {
+    requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } })))
+  }
+
+  function onOpen(val: boolean) {
+    setOpen(val)
+    if (val) {
+      const idx = props.variants.findIndex((v) => v === props.value)
+      requestAnimationFrame(() => focusItem(idx >= 0 ? idx : 0))
+      return
+    }
+    refocus()
+  }
+
+  const onTrigger = () => {
+    if (props.variants.length === 0) return
+    onOpen(true)
+  }
+  window.addEventListener("openVariantPicker", onTrigger)
+  onCleanup(() => window.removeEventListener("openVariantPicker", onTrigger))
 
   function pick(value: string) {
     props.onSelect(value)
-    setOpen(false)
-    requestAnimationFrame(() => window.dispatchEvent(new Event("focusPrompt")))
+    onOpen(false)
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    const len = props.variants.length
+    const cur = focused()
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      focusItem((cur + 1) % len)
+      return
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault()
+      focusItem((cur - 1 + len) % len)
+      return
+    }
+    if (e.key === "Home") {
+      e.preventDefault()
+      focusItem(0)
+      return
+    }
+    if (e.key === "End") {
+      e.preventDefault()
+      focusItem(len - 1)
+      return
+    }
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      if (cur >= 0 && cur < len) pick(props.variants[cur])
+      return
+    }
+    if (e.key === "Escape") {
+      e.preventDefault()
+      e.stopPropagation()
+      onOpen(false)
+    }
   }
 
   const label = () => {
@@ -41,10 +106,13 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
 
   return (
     <Show when={props.variants.length > 0}>
-      <Popover
+      <PopupSelector
+        expanded={false}
         placement="top-start"
+        preferredWidth={180}
+        minHeight={100}
         open={open()}
-        onOpenChange={setOpen}
+        onOpenChange={onOpen}
         triggerAs={Button}
         triggerProps={{ variant: "ghost", size: "small" }}
         trigger={
@@ -56,21 +124,31 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
           </>
         }
       >
-        <div class="thinking-selector-list" role="listbox">
-          <For each={props.variants}>
-            {(v) => (
-              <div
-                class={`thinking-selector-item${props.value === v ? " selected" : ""}`}
-                role="option"
-                aria-selected={props.value === v}
-                onClick={() => pick(v)}
-              >
-                <span class="thinking-selector-item-name">{v.charAt(0).toUpperCase() + v.slice(1)}</span>
-              </div>
-            )}
-          </For>
-        </div>
-      </Popover>
+        {(bodyH) => (
+          <div
+            class="thinking-selector-list"
+            role="listbox"
+            ref={listRef}
+            onKeyDown={onKeyDown}
+            style={bodyH() !== undefined ? { "max-height": `${bodyH()}px` } : {}}
+          >
+            <For each={props.variants}>
+              {(v, i) => (
+                <div
+                  class={`thinking-selector-item${props.value === v ? " selected" : ""}`}
+                  role="option"
+                  aria-selected={props.value === v}
+                  tabindex={focused() === i() ? 0 : -1}
+                  onClick={() => pick(v)}
+                  onFocus={() => setFocused(i())}
+                >
+                  <span class="thinking-selector-item-name">{v.charAt(0).toUpperCase() + v.slice(1)}</span>
+                </div>
+              )}
+            </For>
+          </div>
+        )}
+      </PopupSelector>
     </Show>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -35,7 +35,7 @@ export interface SlashCommand {
   close: () => void
 }
 
-export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): SlashCommand {
+export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string> | Accessor<Set<string>>): SlashCommand {
   const [server, setServer] = createSignal<SlashCommandInfo[]>([])
   const [query, setQuery] = createSignal<string | null>(null)
   const [index, setIndex] = createSignal(0)
@@ -76,6 +76,14 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
       },
     },
     {
+      name: "variant",
+      description: "Switch the reasoning effort",
+      hints: ["variants", "reasoning", "thinking"],
+      action: () => {
+        window.dispatchEvent(new CustomEvent("openVariantPicker"))
+      },
+    },
+    {
       name: "help",
       description: "Open help documentation",
       hints: [],
@@ -109,12 +117,23 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string>): S
     },
   ]
 
-  const client = exclude ? all.filter((c) => !exclude.has(c.name)) : all
+  const excluded = () => {
+    if (typeof exclude === "function") return exclude()
+    return exclude
+  }
+
+  const client = () => {
+    const set = excluded()
+    if (!set) return all
+    return all.filter((c) => !set.has(c.name))
+  }
 
   const commands = (): SlashCommandEntry[] => {
-    const names = new Set(client.map((c) => c.name))
-    const filtered = server().filter((c) => !names.has(c.name))
-    return [...client, ...filtered]
+    const list = client()
+    const names = new Set(list.map((c) => c.name))
+    const set = excluded()
+    const filtered = server().filter((c) => !names.has(c.name) && !set?.has(c.name))
+    return [...list, ...filtered]
   }
 
   const show = () => query() !== null


### PR DESCRIPTION
## Summary
- Add a `/variant` slash command that opens the reasoning effort selector when the selected model has variants.
- Make the reasoning effort selector keyboard navigable and return focus to the prompt after close or selection.
- Sanitize launch-script path environment variables before building from VS Code tasks.

## Test
- `bun run check-types:extension && bun run check-types:webview && bun run lint`