### PR TITLE
fix(cli): rename managed plist domain to ai.kilo.managed

### DIFF
--- a/.changeset/managed-plist-domain-kilo.md
+++ b/.changeset/managed-plist-domain-kilo.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Rename macOS MDM-managed plist domain from `ai.opencode.managed` to `ai.kilo.managed`. Admins deploying `.mobileconfig` profiles must update the profile domain to `ai.kilo.managed` and rename the plist to `ai.kilo.managed.plist`.

--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -8,9 +8,9 @@ import { warn } from "console"
 
 const log = Log.create({ service: "config" })
 
-const MANAGED_PLIST_DOMAIN = "ai.opencode.managed"
+const MANAGED_PLIST_DOMAIN = "ai.kilo.managed" // kilocode_change
 
-// Keys injected by macOS/MDM into the managed plist that are not OpenCode config
+// Keys injected by macOS/MDM into the managed plist that are not Kilo config
 const PLIST_META = new Set([
   "PayloadDisplayName",
   "PayloadIdentifier",

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2324,9 +2324,9 @@ test("parseManagedPlist strips MDM metadata keys", async () => {
     ConfigParse.jsonc(
       await ConfigManaged.parseManagedPlist(
         JSON.stringify({
-          PayloadDisplayName: "OpenCode Managed",
-          PayloadIdentifier: "ai.opencode.managed.test",
-          PayloadType: "ai.opencode.managed",
+          PayloadDisplayName: "Kilo Managed",
+          PayloadIdentifier: "ai.kilo.managed.test",
+          PayloadType: "ai.kilo.managed",
           PayloadUUID: "AAAA-BBBB-CCCC",
           PayloadVersion: 1,
           _manualProfile: true,


### PR DESCRIPTION
## Summary

The macOS MDM-managed preferences bundle ID in `packages/opencode/src/config/managed.ts` was still using the upstream `ai.opencode.managed` domain. All other managed-config locations (system directories, filenames) are already kilo-branded, so this one constant is the last holdover. Rename it to `ai.kilo.managed` so enterprise admins deploy a Kilo-branded `.mobileconfig`.

## Breaking change

Admins using macOS MDM to deploy managed Kilo CLI settings must update their profile:

- Rename `/Library/Managed Preferences/[user/]ai.opencode.managed.plist` → `ai.kilo.managed.plist`
- Update `PayloadType` and `PayloadIdentifier` in the `.mobileconfig` from `ai.opencode.managed` to `ai.kilo.managed`

Cross-platform managed directory configs (`/Library/Application Support/kilo/`, `%ProgramData%\kilo\`, `/etc/kilo/`) are unchanged.