### PR TITLE
refactor(cli): extract resetTerminalState to kilocode-specific file

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -64,7 +64,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
-import { resetTerminalState } from "@tui/util/terminal" // kilocode_change
+import { resetTerminalState } from "@/kilocode/cli/cmd/tui/util/terminal" // kilocode_change
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -2,7 +2,7 @@ import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { win32FlushInputBuffer } from "../win32"
-import { resetTerminalState } from "@tui/util/terminal" // kilocode_change
+import { resetTerminalState } from "@/kilocode/cli/cmd/tui/util/terminal" // kilocode_change
 type Exit = ((reason?: unknown) => Promise<void>) & {
   message: {
     set: (value?: string) => () => void

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -1,29 +1,5 @@
 import { RGBA } from "@opentui/core"
 
-// kilocode_change start
-/**
- * Write escape sequences to disable all mouse tracking modes and reset terminal state.
- * This is a safety net to ensure the terminal is clean after exit, even if the renderer's
- * cleanup didn't flush properly (e.g. on Windows).
- */
-export function resetTerminalState() {
-  const sequences = [
-    "\x1b[?1000l", // disable normal mouse tracking
-    "\x1b[?1002l", // disable button-event mouse tracking
-    "\x1b[?1003l", // disable any-event mouse tracking (all movement)
-    "\x1b[?1006l", // disable SGR extended mouse mode
-    "\x1b[?1015l", // disable RXVT mouse mode
-    "\x1b[<u", // pop/disable Kitty keyboard protocol
-    "\x1b[0m", // reset text attributes
-  ]
-  try {
-    process.stdout.write(sequences.join(""))
-  } catch (err) {
-    console.error("resetTerminalState failed", err)
-  }
-}
-// kilocode_change end
-
 export type Colors = Awaited<ReturnType<typeof colors>>
 
 function parse(color: string): RGBA | null {

--- a/packages/opencode/src/kilocode/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/util/terminal.ts
@@ -1,0 +1,22 @@
+// kilocode_change - new file
+/**
+ * Write escape sequences to disable all mouse tracking modes and reset terminal state.
+ * This is a safety net to ensure the terminal is clean after exit, even if the renderer's
+ * cleanup didn't flush properly (e.g. on Windows).
+ */
+export function resetTerminalState() {
+  const sequences = [
+    "\x1b[?1000l", // disable normal mouse tracking
+    "\x1b[?1002l", // disable button-event mouse tracking
+    "\x1b[?1003l", // disable any-event mouse tracking (all movement)
+    "\x1b[?1006l", // disable SGR extended mouse mode
+    "\x1b[?1015l", // disable RXVT mouse mode
+    "\x1b[<u", // pop/disable Kitty keyboard protocol
+    "\x1b[0m", // reset text attributes
+  ]
+  try {
+    process.stdout.write(sequences.join(""))
+  } catch (err) {
+    console.error("resetTerminalState failed", err)
+  }
+}


### PR DESCRIPTION
## Summary

Move the `resetTerminalState` helper out of the shared `packages/opencode/src/cli/cmd/tui/util/terminal.ts` into a Kilo-specific file at `packages/opencode/src/kilocode/cli/cmd/tui/util/terminal.ts` to reduce the diff against upstream opencode and minimize future merge conflicts.

Two import sites (`app.tsx`, `context/exit.tsx`) updated to point at the new path via the `@/kilocode/...` alias.
