### PR TITLE
docs(kilo-docs): remove redundant BYOK Agent Manager note

### DIFF
--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -69,7 +69,3 @@ Your IAM user or role must have the following permissions:
 - BYOK works with the Kilo Gateway provider. Users should ensure that is set as the active [provider](/docs/ai-providers).
 - Select a model from a provider configured for BYOK, for example Claude Sonnet 4.5 if you configured BYOK for Anthropic.
 - (Optional) Validate with the provider that traffic is being served by that key.
-
-## Use with Agent Manager
-
-Agent Manager supports the same BYOK and custom provider configurations as the extension sidebar.


### PR DESCRIPTION
## Summary
- Remove the redundant Agent Manager section from the BYOK page now that Agent Manager support is covered in the Agent Manager docs.