### PR TITLE
fix(core): preserve configured Code model when implementing plan in new session

### DIFF
--- a/.changeset/seven-regions-sit.md
+++ b/.changeset/seven-regions-sit.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve configured Code model when starting plan in new session

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -478,11 +478,14 @@ export namespace PlanFollowup {
 
     if (answer === ANSWER_NEW_SESSION) {
       Telemetry.trackPlanFollowup(input.sessionID, "new_session")
+      const code = await resolveCodeModel({
+        model: user.model,
+      })
       await startNew({
         sessionID: input.sessionID,
         plan,
         messages: input.messages,
-        model: user.model,
+        model: code.model,
         abort: input.abort,
       })
       return "break"

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -416,6 +416,73 @@ describe("plan follow-up", () => {
       expect(part.synthetic).toBe(true)
     }))
 
+  test("ask - uses configured Code model on Start new session", () =>
+    withInstance(async () => {
+      const get = spyOn(PlanFollowupRuntime, "agent").mockImplementation(async (name: string) => {
+        if (name === "code") {
+          return {
+            name: "code",
+            mode: "primary",
+            permission: [],
+            options: {},
+            model: saved,
+            variant: configVar,
+          } as any
+        }
+        return undefined as any
+      })
+      const modelSpy = spyOn(PlanFollowupRuntime, "model").mockImplementation(async (providerID: string, modelID: string) => {
+        if (providerID === saved.providerID && modelID === saved.modelID) return savedConfigFull
+        return fakeModel
+      })
+      const llmSpy = spyOn(LLM, "stream").mockResolvedValue({
+        text: Promise.resolve(""),
+      } as any)
+      const loop = spyOn(PlanFollowupRuntime, "loop").mockResolvedValue({} as any)
+      const created: SessionID[] = []
+      const unsub = Bus.subscribe(TuiEvent.SessionSelect, (event) => {
+        created.push(event.properties.sessionID)
+      })
+      using _ = {
+        [Symbol.dispose]() {
+          get.mockRestore()
+          modelSpy.mockRestore()
+          llmSpy.mockRestore()
+          loop.mockRestore()
+          unsub()
+        },
+      }
+
+      const seeded = await seed({ text: "1. Build\n2. Test" })
+      const pending = PlanFollowup.ask({
+        sessionID: seeded.sessionID,
+        messages: seeded.messages,
+        abort: AbortSignal.any([]),
+      })
+
+      const item = await waitQuestion(seeded.sessionID)
+      expect(item).toBeDefined()
+      if (!item) return
+      await question.reply({
+        requestID: item.id,
+        answers: [[PlanFollowup.ANSWER_NEW_SESSION]],
+      })
+
+      await expect(pending).resolves.toBe("break")
+
+      const newSessionID = created[0]
+      expect(newSessionID).toBeDefined()
+      if (!newSessionID) return
+
+      const messages = await Session.messages({ sessionID: newSessionID })
+      const user = messages.find((item) => item.info.role === "user")
+      expect(user?.info.role).toBe("user")
+      if (!user || user.info.role !== "user") return
+      expect(user.info.agent).toBe("code")
+      expect(user.info.model).toEqual({ ...saved, variant: configVar })
+      expect(user.info.model).not.toEqual(model)
+    }))
+
   test("ask - returns continue and creates plan message for custom text", () =>
     withInstance(async () => {
       const seeded = await seed({ text: "1. Build\n2. Test" })


### PR DESCRIPTION
## Context

This was originally fixed in #7151, but a recent changed caused a regression where implementing a plan in a new session uses the Plan model, not the Code model. We can see that the code model selection is properly applied in the `if (answer === ANSWER_CONTINUE)` block, but was removed from the `if (answer === ANSWER_NEW_SESSION)`. This readds the code model selection to the `if (answer === ANSWER_NEW_SESSION)` block, so that the new session uses the code model as expected.

## Screenshot

<img width="1475" height="993" alt="image" src="https://github.com/user-attachments/assets/885ead79-fecd-41b7-8b10-2a74102ecaa5" />


<img width="1890" height="1306" alt="image" src="https://github.com/user-attachments/assets/a1fb0490-e67f-49fa-adc1-926a51cf80d3" />


## How to Test

- Plan something
- Implement in new session via plan_exit prompt
- It should use the Code model, not the Plan model

## Get in Touch

ExpedientFalcon on Discord
