### PR TITLE
CLI - Fix Remote Badge in TUI

### DIFF
--- a/.changeset/remote-status-badge.md
+++ b/.changeset/remote-status-badge.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep Remote status visible in the TUI while remote control is connecting.

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -6,6 +6,7 @@ import { useConnected } from "../../component/dialog-model"
 import { useSDK } from "../../context/sdk" // kilocode_change
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useEvent } from "../../context/event" // kilocode_change
 import { RemoteIndicator } from "@/kilocode/remote-tui" // kilocode_change
 import { formatIndexingLabel } from "@/kilocode/indexing-label" // kilocode_change
 import type { IndexingStatusState } from "@kilocode/kilo-indexing/status" // kilocode_change
@@ -39,6 +40,7 @@ export function Footer() {
   const directory = useDirectory()
   const connected = useConnected()
   const sdk = useSDK() // kilocode_change
+  const event = useEvent() // kilocode_change
   const indexing = createMemo(() => sync.data.indexing) // kilocode_change
 
   const [store, setStore] = createStore({
@@ -74,7 +76,9 @@ export function Footer() {
     <box flexDirection="row" justifyContent="space-between" gap={1} flexShrink={0}>
       <text fg={theme.textMuted}>{directory()}</text>
       <box gap={2} flexDirection="row" flexShrink={0}>
-        <RemoteIndicator sdk={sdk} theme={theme} kilo={sync.data.provider_next.connected.includes("kilo")} />
+        {/* kilocode_change start */}
+        <RemoteIndicator sdk={sdk} theme={theme} kilo={sync.data.provider_next.connected.includes("kilo")} event={event} />
+        {/* kilocode_change end */}
         <Switch>
           <Match when={store.welcome}>
             <text fg={theme.text}>

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -308,6 +308,7 @@ export namespace KiloSessions {
     if (ingestDisabled) return
     if (enabling) return enabling
     const seq = ++remoteSeq
+    void Bus.publish(Event.RemoteStatusChanged, { enabled: true, connected: false })
     enabling = (async () => {
       const token = await kilocodeToken()
       if (!token) {
@@ -399,17 +400,27 @@ export namespace KiloSessions {
       log.info("remote connection enabled", { connected: conn.connected })
       Telemetry.trackRemoteConnectionOpened()
       void Bus.publish(Event.RemoteStatusChanged, { enabled: true, connected: conn.connected })
-    })().finally(() => {
-      if (remoteSeq === seq) enabling = undefined
-    })
+    })()
+      .catch((err) => {
+        if (remoteSeq === seq && !remote)
+          void Bus.publish(Event.RemoteStatusChanged, { enabled: false, connected: false })
+        throw err
+      })
+      .finally(() => {
+        if (remoteSeq === seq) enabling = undefined
+      })
 
     return enabling
   }
 
   export function disableRemote() {
     remoteSeq += 1
+    const pending = !!enabling
     enabling = undefined
-    if (!remote) return
+    if (!remote) {
+      if (pending) void Bus.publish(Event.RemoteStatusChanged, { enabled: false, connected: false })
+      return
+    }
     remote.sender.dispose()
     remote.conn.close()
     remote = undefined
@@ -419,7 +430,7 @@ export namespace KiloSessions {
 
   export function remoteStatus() {
     return {
-      enabled: !!remote,
+      enabled: !!remote || !!enabling,
       connected: remote?.conn.connected ?? false,
     }
   }

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -86,6 +86,7 @@ export namespace RemoteWS {
     async function open() {
       if (closed) return
       const token = await options.getToken()
+      if (closed) return
       if (!token) {
         options.log.warn("remote-ws no token, will retry")
         schedule()

--- a/packages/opencode/src/kilocode/plugins/home-footer.tsx
+++ b/packages/opencode/src/kilocode/plugins/home-footer.tsx
@@ -15,25 +15,28 @@ import { useSync } from "@/cli/cmd/tui/context/sync"
 
 const id = "internal:kilo-home-footer"
 
+type Status = {
+  enabled: boolean
+  connected: boolean
+}
+
 // ---------------------------------------------------------------------------
 // RemoteIndicator – adapted from @/kilocode/remote-tui for plugin API usage
 // ---------------------------------------------------------------------------
 
 function RemoteIndicator(props: { api: TuiPluginApi; kilo: boolean }) {
   const theme = () => props.api.theme.current
-  const [status, setStatus] = createSignal<{
-    enabled: boolean
-    connected: boolean
-  } | null>(null)
+  const [status, setStatus] = createSignal<Status | null>(null)
 
   onMount(() => {
-    const poll = async () => {
-      const res = await props.api.client.remote.status().catch(() => null)
-      if (res?.data) setStatus(res.data)
-    }
-    poll()
-    const timer = setInterval(poll, 5000)
-    onCleanup(() => clearInterval(timer))
+    void props.api.client.remote
+      .status()
+      .then((res: { data?: Status }) => {
+        if (res.data) setStatus(res.data)
+      })
+      .catch(() => undefined)
+    const off = props.api.event.on("kilo-sessions.remote-status-changed", (evt) => setStatus(evt.properties))
+    onCleanup(off)
   })
 
   return (

--- a/packages/opencode/src/kilocode/remote-tui.tsx
+++ b/packages/opencode/src/kilocode/remote-tui.tsx
@@ -4,26 +4,35 @@
  * RemoteIndicator component for the footer status bar.
  */
 
-import { createSignal, onMount, onCleanup, Show } from "solid-js"
+import type { Event } from "@kilocode/sdk/v2"
+import { createSignal, onCleanup, onMount, Show } from "solid-js"
+
+type Status = {
+  enabled: boolean
+  connected: boolean
+}
 
 /**
  * Footer indicator showing remote connection status.
- * Polls every 5 seconds. Only renders when kilo gateway is connected and remote is enabled.
+ * Uses the TUI event stream after an initial status fetch.
  */
-export function RemoteIndicator(props: { sdk: any; theme: any; kilo: boolean }) {
-  const [status, setStatus] = createSignal<{
-    enabled: boolean
-    connected: boolean
-  } | null>(null)
+export function RemoteIndicator(props: {
+  sdk: any
+  theme: any
+  kilo: boolean
+  event: { on: <Type extends Event["type"]>(type: Type, handler: (event: Extract<Event, { type: Type }>) => void) => () => void }
+}) {
+  const [status, setStatus] = createSignal<Status | null>(null)
 
   onMount(() => {
-    const poll = async () => {
-      const res = await props.sdk.client.remote.status().catch(() => null)
-      if (res?.data) setStatus(res.data)
-    }
-    poll()
-    const timer = setInterval(poll, 5000)
-    onCleanup(() => clearInterval(timer))
+    void props.sdk.client.remote
+      .status()
+      .then((res: { data?: Status }) => {
+        if (res.data) setStatus(res.data)
+      })
+      .catch(() => undefined)
+    const off = props.event.on("kilo-sessions.remote-status-changed", (evt) => setStatus(evt.properties))
+    onCleanup(off)
   })
 
   return (


### PR DESCRIPTION
## Summary
- Keep the TUI Remote badge visible while remote control is connecting.
- Update TUI remote indicators to use the event stream after initial status hydration.
- Clear the connecting badge when an in-flight enable is disabled or fails.