### PR TITLE
Remove inline summary diff

### DIFF
--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/diff-summary-collapsed-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/diff-summary-collapsed-chromium-linux.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d29bb3a9356cf8bec6bb0a9d6e4d0b59d147c1fa8adee7140c81a061eea407d
-size 6930

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -9,25 +9,11 @@
  * - Simpler flat structure without overflow containers
  */
 
-import { Component, createMemo, For, Show, createSignal, createEffect, on } from "solid-js"
-import { Dynamic } from "solid-js/web"
+import { Component, createMemo, For, Show, createEffect } from "solid-js"
 import { UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
-import { Collapsible } from "@kilocode/kilo-ui/collapsible"
-import { Accordion } from "@kilocode/kilo-ui/accordion"
-import { DiffChanges } from "@kilocode/kilo-ui/diff-changes"
-import { Icon } from "@kilocode/kilo-ui/icon"
-import { StickyAccordionHeader } from "@kilocode/kilo-ui/sticky-accordion-header"
 import { useData } from "@kilocode/kilo-ui/context/data"
-import { useFileComponent } from "@kilocode/kilo-ui/context/file"
-import { normalize } from "@kilocode/kilo-ui/session-diff"
-import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { AssistantMessage } from "./AssistantMessage"
-import type {
-  AssistantMessage as SDKAssistantMessage,
-  Message as SDKMessage,
-  Part as SDKPart,
-  SnapshotFileDiff,
-} from "@kilocode/sdk/v2"
+import type { AssistantMessage as SDKAssistantMessage, Message as SDKMessage, Part as SDKPart } from "@kilocode/sdk/v2"
 import { ErrorDisplay } from "./ErrorDisplay"
 import { useServer } from "../../context/server"
 import { useSession } from "../../context/session"
@@ -35,18 +21,6 @@ import { useLanguage } from "../../context/language"
 import { visibleError } from "../../context/session-errors"
 import type { ErrorDisplayProps } from "./ErrorDisplay"
 import type { Message as WebMessage } from "../../types/messages"
-
-function getDirectory(path: string): string {
-  const sep = path.includes("/") ? "/" : "\\"
-  const idx = path.lastIndexOf(sep)
-  return idx === -1 ? "" : path.slice(0, idx + 1)
-}
-
-function getFilename(path: string): string {
-  const sep = path.includes("/") ? "/" : "\\"
-  const idx = path.lastIndexOf(sep)
-  return idx === -1 ? path : path.slice(idx + 1)
-}
 
 export interface VscodeTurn {
   id: string
@@ -63,14 +37,11 @@ interface VscodeSessionTurnProps {
 
 export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   const data = useData()
-  const i18n = useI18n()
-  const fileComponent = useFileComponent()
   const server = useServer()
   const session = useSession()
   const language = useLanguage()
 
   const emptyParts: SDKPart[] = []
-  const emptyDiffs: SnapshotFileDiff[] = []
 
   createEffect(() => {
     const turn = props.turn
@@ -90,34 +61,6 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
   const interrupted = createMemo(() => assistantMessages().some((m) => m.error?.name === "MessageAbortedError"))
 
   const error = createMemo(() => visibleError(assistantMessages(), session.isErrorHidden))
-
-  // Diffs from message summary
-  const diffs = createMemo(() => {
-    const rawDiffs = (message() as unknown as { summary?: { diffs?: unknown[] } } | undefined)?.summary?.diffs
-    if (!rawDiffs?.length) return emptyDiffs
-    const seen = new Set<string>()
-    return (rawDiffs as SnapshotFileDiff[])
-      .reduceRight<SnapshotFileDiff[]>((result, diff) => {
-        if (seen.has(diff.file)) return result
-        seen.add(diff.file)
-        result.push(diff)
-        return result
-      }, [])
-      .reverse()
-  })
-
-  const [open, setOpen] = createSignal(false)
-  const [expanded, setExpanded] = createSignal<string[]>([])
-
-  createEffect(
-    on(
-      open,
-      (value, prev) => {
-        if (!value && prev) setExpanded([])
-      },
-      { defer: true },
-    ),
-  )
 
   // Copy part ID — the last text part from the last assistant message
   const showAssistantCopyPartID = createMemo(() => {
@@ -176,101 +119,6 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
               <For each={assistantMessages()}>
                 {(msg) => <AssistantMessage message={msg} showAssistantCopyPartID={showAssistantCopyPartID()} />}
               </For>
-            </div>
-          </Show>
-
-          {/* Diff summary — shown after completion */}
-          <Show when={diffs().length > 0 && server.gitInstalled()}>
-            <div class="vscode-session-turn-diffs" data-component="session-turn">
-              <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
-                <Collapsible.Trigger>
-                  <div data-component="session-turn-diffs-trigger">
-                    <div data-slot="session-turn-diffs-title">
-                      <span data-slot="session-turn-diffs-label">{i18n.t("ui.sessionReview.change.modified")}</span>{" "}
-                      <span data-slot="session-turn-diffs-count">
-                        {diffs().length} {i18n.t(diffs().length === 1 ? "ui.common.file.one" : "ui.common.file.other")}
-                      </span>
-                      <div data-slot="session-turn-diffs-meta">
-                        <DiffChanges changes={diffs()} variant="bars" />
-                        <Collapsible.Arrow />
-                      </div>
-                    </div>
-                  </div>
-                </Collapsible.Trigger>
-                <Collapsible.Content>
-                  <Show when={open()}>
-                    <div data-component="session-turn-diffs-content">
-                      <Accordion
-                        multiple
-                        style={{ "--sticky-accordion-offset": "40px" }}
-                        value={expanded()}
-                        onChange={(value) => setExpanded(Array.isArray(value) ? value : value ? [value] : [])}
-                      >
-                        <For each={diffs()}>
-                          {(diff) => {
-                            const active = createMemo(() => expanded().includes(diff.file))
-                            const [visible, setVisible] = createSignal(false)
-
-                            createEffect(
-                              on(
-                                active,
-                                (value) => {
-                                  if (!value) {
-                                    setVisible(false)
-                                    return
-                                  }
-                                  requestAnimationFrame(() => {
-                                    if (active()) setVisible(true)
-                                  })
-                                },
-                                { defer: true },
-                              ),
-                            )
-
-                            return (
-                              <Accordion.Item value={diff.file}>
-                                <StickyAccordionHeader>
-                                  <Accordion.Trigger>
-                                    <div data-slot="session-turn-diff-trigger">
-                                      <span data-slot="session-turn-diff-path">
-                                        <Show when={diff.file.includes("/")}>
-                                          <span data-slot="session-turn-diff-directory">
-                                            {`\u2066${getDirectory(diff.file)}\u2069`}
-                                          </span>
-                                        </Show>
-                                        <span data-slot="session-turn-diff-filename">{getFilename(diff.file)}</span>
-                                      </span>
-                                      <div data-slot="session-turn-diff-meta">
-                                        <span data-slot="session-turn-diff-changes">
-                                          <DiffChanges changes={diff} />
-                                        </span>
-                                        <span data-slot="session-turn-diff-chevron">
-                                          <Icon name="chevron-down" size="small" />
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </Accordion.Trigger>
-                                </StickyAccordionHeader>
-                                <Accordion.Content>
-                                  <Show when={visible()}>
-                                    <div data-slot="session-turn-diff-view" data-scrollable>
-                                      <Dynamic
-                                        component={fileComponent}
-                                        mode="diff"
-                                        fileDiff={normalize(diff).fileDiff}
-                                      />
-                                    </div>
-                                  </Show>
-                                </Accordion.Content>
-                              </Accordion.Item>
-                            )
-                          }}
-                        </For>
-                      </Accordion>
-                    </div>
-                  </Show>
-                </Collapsible.Content>
-              </Collapsible>
             </div>
           </Show>
 

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -11,12 +11,10 @@ import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import type { AssistantMessage as SDKAssistantMessage, TextPart, ToolPart } from "@kilocode/sdk/v2"
 import { StoryProviders, defaultMockData, mockSessionValue } from "./StoryProviders"
 import { AssistantMessage } from "../components/chat/AssistantMessage"
-import { VscodeSessionTurn } from "../components/chat/VscodeSessionTurn"
 import { ChatView } from "../components/chat/ChatView"
 import { Part } from "@kilocode/kilo-ui/message-part"
 import { registerVscodeToolOverrides } from "../components/chat/VscodeToolOverrides"
 import { SessionContext } from "../context/session"
-import { ServerContext } from "../context/server"
 import type { PermissionRequest, QuestionRequest } from "../types/messages"
 
 // Register VS Code tool overrides (bash expanded by default, etc.)
@@ -1134,81 +1132,6 @@ export const McpToolExpanded: Story = {
         <div data-component="tool-part-wrapper" data-part-type="tool">
           <Part part={mcpCompleted} message={baseAssistantMessage as any} defaultOpen />
         </div>
-      </StoryProviders>
-    )
-  },
-}
-
-// ---------------------------------------------------------------------------
-// 19. Diff summary — "Modified N files" collapsed header
-// ---------------------------------------------------------------------------
-
-const USER_MSG_ID = "user-msg-diff-001"
-
-const mockDiffs = [
-  { file: "src/components/App.tsx", before: "", after: "", additions: 12, deletions: 3, status: "modified" as const },
-  { file: "src/utils/helpers.ts", before: "", after: "", additions: 5, deletions: 8, status: "modified" as const },
-  { file: "src/styles/main.css", before: "", after: "", additions: 20, deletions: 0, status: "added" as const },
-]
-
-export const DiffSummaryCollapsed: Story = {
-  name: "Diff Summary — Modified N files (collapsed)",
-  render: () => {
-    const data = {
-      ...defaultMockData,
-      message: {
-        [SESSION_ID]: [
-          {
-            id: USER_MSG_ID,
-            sessionID: SESSION_ID,
-            role: "user",
-            time: { created: now - 10000 },
-            summary: { diffs: mockDiffs },
-          },
-          { ...baseAssistantMessage, parentID: USER_MSG_ID },
-        ],
-      },
-      part: {
-        [USER_MSG_ID]: [
-          { id: "part-user-text", sessionID: SESSION_ID, messageID: USER_MSG_ID, type: "text", text: "Fix the bug" },
-        ],
-        [ASST_MSG_ID]: [textPart],
-      },
-    }
-    const session = {
-      ...mockSessionValue({ id: SESSION_ID, status: "idle" }),
-      messages: () => data.message[SESSION_ID],
-    }
-    const server = {
-      connectionState: () => "connected" as const,
-      serverInfo: () => undefined,
-      extensionVersion: () => "1.0.0",
-      errorMessage: () => undefined,
-      errorDetails: () => undefined,
-      isConnected: () => true,
-      profileData: () => null,
-      deviceAuth: () => ({ status: "idle" as const }),
-      startLogin: () => {},
-      vscodeLanguage: () => "en",
-      languageOverride: () => undefined,
-      workspaceDirectory: () => "/project",
-      gitInstalled: () => true,
-    }
-    return (
-      <StoryProviders data={data} sessionID={SESSION_ID} status="idle" noPadding>
-        <ServerContext.Provider value={server as any}>
-          <SessionContext.Provider value={session as any}>
-            <div style={{ width: "380px", padding: "12px" }}>
-              <VscodeSessionTurn
-                turn={{
-                  id: USER_MSG_ID,
-                  user: data.message[SESSION_ID][0] as any,
-                  assistant: [data.message[SESSION_ID][1] as any],
-                }}
-              />
-            </div>
-          </SessionContext.Provider>
-        </ServerContext.Provider>
       </StoryProviders>
     )
   },

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -207,13 +207,3 @@
   gap: 12px;
   width: 100%;
 }
-
-.vscode-session-turn-diffs {
-  width: 100%;
-}
-
-.vscode-session-turn-diffs [data-slot="session-turn-diffs-title"] {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-}

--- a/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
@@ -17,7 +17,7 @@ export interface Message {
   parentID?: string
   path?: { cwd: string; root: string }
   error?: { name: string; data?: Record<string, unknown> }
-  summary?: { title?: string; body?: string; diffs?: unknown[] } | boolean
+  summary?: { title?: string; body?: string } | boolean
   cost?: number
   tokens?: TokenUsage
   finish?: string


### PR DESCRIPTION

## Context

Removes the line "Modified Files" which also shows a diff view of the changes done by the agent in that turn.


## Screenshots

| before | after |
|---|---|
| <img width="471" height="870" alt="before-remove" src="https://github.com/user-attachments/assets/1b20bab9-2a94-40a0-9e96-d288526324d3" /> | <img width="549" height="971" alt="after-remove" src="https://github.com/user-attachments/assets/26bf9c16-645b-4bdd-91ff-e502274f2711" /> |

## Testing

- Checked tests and typecheck pass
- Sanity tests on the extension

