### PR TITLE
Add experimental Agent Manager tool

### DIFF
--- a/.changeset/agent-manager-tool.md
+++ b/.changeset/agent-manager-tool.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+---
+
+Support starting Agent Manager local sessions and worktree sessions from an experimental agent tool.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -29,6 +29,7 @@ import { continueInWorktree } from "./continue-in-worktree"
 import { WorktreeDiffController } from "./worktree-diff-controller"
 import { WorktreeImporter } from "./worktree-importer"
 import { diffSummary as localDiffSummary, diffFile as localDiffFile } from "./local-diff"
+import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
 
 import { buildKeybindingMap } from "./format-keybinding"
 import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
@@ -65,6 +66,7 @@ export class AgentManagerProvider implements Disposable {
   private staleWorktreeIds = new Set<string>()
   private cachedWorktreeStats: { type: "agentManager.worktreeStats"; stats: WorktreeStats[] } | undefined
   private cachedLocalStats: { type: "agentManager.localStats"; stats: LocalStats } | undefined
+  private unsubTool: (() => void) | undefined
 
   /** Session ID most recently loaded via a `loadMessages` message from the webview.
    *  Updated synchronously — unlike the session provider's currentSession which depends on
@@ -152,6 +154,10 @@ export class AgentManagerProvider implements Disposable {
       log: (...a) => this.log(...a),
       semaphore,
     })
+    this.unsubTool = this.connectionService.onEventFiltered(
+      (event) => (event as { type?: string }).type === "kilocode.agent_manager.start",
+      (event, directory) => this.onToolEvent(event, directory),
+    )
   }
 
   private log(...args: unknown[]) {
@@ -159,11 +165,11 @@ export class AgentManagerProvider implements Disposable {
     this.outputChannel.appendLine(`${new Date().toISOString()} ${msg}`)
   }
 
-  public openPanel(): void {
+  public openPanel(preserveFocus?: boolean): void {
     if (this.panel) {
       this.log("Panel already open, revealing")
-      this.panel.reveal()
-      this.postToWebview({ type: "action", action: "focusInput" })
+      this.panel.reveal(preserveFocus)
+      if (!preserveFocus) this.postToWebview({ type: "action", action: "focusInput" })
       return
     }
     this.log("Opening Agent Manager panel")
@@ -790,6 +796,43 @@ export class AgentManagerProvider implements Disposable {
   private async waitForStateReady(context: string): Promise<void> {
     if (!this.stateReady) return
     await this.stateReady.catch((err) => this.log(`${context}: stateReady rejected, continuing:`, err))
+  }
+
+  private onToolEvent(event: unknown, directory?: string): void {
+    const properties = (event as { properties?: unknown }).properties
+    const req = parseToolRequest(properties)
+    if (!req) return
+    if (directory) req.directory = directory
+    void this.startToolRequest(req)
+  }
+
+  private async startToolRequest(req: ToolRequest): Promise<void> {
+    await startFromTool(
+      {
+        getClient: () => this.connectionService.getClient(),
+        getRoot: () => this.getRoot(),
+        getState: () => this.getStateManager(),
+        getPanel: () => this.panel,
+        openPanel: (preserveFocus) => this.openPanel(preserveFocus),
+        waitReady: (context) => this.waitForStateReady(context),
+        createWorktree: (opts) => this.createWorktreeOnDisk(opts),
+        cleanupWorktree: async (wid, dir) => {
+          this.getStateManager()?.removeWorktree(wid)
+          await this.getWorktreeManager()?.removeWorktree(dir)
+          this.pushState()
+        },
+        setup: (dir, branch, id) => this.runSetupScriptForWorktree(dir, branch, id),
+        createSessionInWorktree: (dir, branch, id) => this.createSessionInWorktree(dir, branch, id),
+        registerWorktreeSession: (sid, dir) => this.registerWorktreeSession(sid, dir),
+        notifyReady: (sid, result, wid) => this.notifyWorktreeReady(sid, result, wid),
+        push: () => this.pushState(),
+        post: (msg) => this.postToWebview(msg as AgentManagerOutMessage),
+        capture: (event, props) => this.host.capture(event, props),
+        log: (...args) => this.log(...args),
+        error: (msg) => this.host.showError(msg),
+      },
+      req,
+    )
   }
 
   // ---------------------------------------------------------------------------
@@ -1565,6 +1608,7 @@ export class AgentManagerProvider implements Disposable {
   }
 
   public dispose(): void {
+    this.unsubTool?.()
     this.connectionService.unregisterFocused("agent-manager")
     this.connectionService.registerOpen("agent-manager", [])
     this.diffs.stop()

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -1,0 +1,220 @@
+import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
+import { versionedName } from "./branch-name"
+import type { CreateWorktreeResult } from "./WorktreeManager"
+import type { WorktreeStateManager } from "./WorktreeStateManager"
+import type { PanelContext } from "./host"
+import { PLATFORM } from "./constants"
+
+export interface ToolTask {
+  prompt?: string
+  name?: string
+  branchName?: string
+}
+
+export interface ToolRequest {
+  requestID: string
+  sessionID?: string
+  directory?: string
+  mode: "worktree" | "local"
+  versions?: boolean
+  tasks: ToolTask[]
+}
+
+interface WorktreeCreated {
+  worktree: ReturnType<WorktreeStateManager["addWorktree"]>
+  result: CreateWorktreeResult
+}
+
+export interface ToolDeps {
+  getClient: () => KiloClient
+  getRoot: () => string | undefined
+  getState: () => WorktreeStateManager | undefined
+  getPanel: () => PanelContext | undefined
+  openPanel: (preserveFocus?: boolean) => void
+  waitReady: (context: string) => Promise<void>
+  createWorktree: (opts: {
+    groupId?: string
+    branchName?: string
+    name?: string
+    label?: string
+  }) => Promise<WorktreeCreated | null>
+  cleanupWorktree: (wid: string, dir: string) => Promise<void>
+  setup: (dir: string, branch?: string, id?: string) => Promise<void>
+  createSessionInWorktree: (dir: string, branch: string, id?: string) => Promise<Session | null>
+  registerWorktreeSession: (sid: string, dir: string) => void
+  notifyReady: (sid: string, result: CreateWorktreeResult, wid?: string) => void
+  push: () => void
+  post: (msg: unknown) => void
+  capture: (event: string, props?: Record<string, unknown>) => void
+  log: (...args: unknown[]) => void
+  error: (msg: string) => void
+}
+
+function text(task: ToolTask): string | undefined {
+  return task.prompt?.trim() || undefined
+}
+
+function clean(value: string | undefined): string | undefined {
+  return value?.trim() || undefined
+}
+
+async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTask) {
+  const body = text(task)
+  if (!body) return
+  await client.session.promptAsync(
+    {
+      sessionID: sid,
+      directory: dir,
+      parts: [{ type: "text", text: body }],
+    },
+    { throwOnError: true },
+  )
+}
+
+async function local(deps: ToolDeps, client: KiloClient, task: ToolTask, directory?: string) {
+  const root = deps.getRoot()
+  const state = deps.getState()
+  if (!root || !state) return false
+
+  const dir = clean(directory) ?? root
+  const wt = dir === root ? undefined : state.findWorktreeByPath(dir)
+  if (dir !== root && !wt) {
+    deps.log("Agent Manager tool local request ignored unknown directory", dir)
+    deps.post({
+      type: "error",
+      message: `Agent Manager tool cannot start a local session for unknown directory: ${dir}`,
+    })
+    return false
+  }
+  const target = wt?.path ?? root
+  const { data } = await client.session.create({ directory: target, platform: PLATFORM }, { throwOnError: true })
+  const session = data
+  state.addSession(session.id, wt?.id ?? null)
+  if (wt) deps.registerWorktreeSession(session.id, wt.path)
+  deps.push()
+  deps.getPanel()?.sessions.registerSession(session)
+  if (wt) deps.post({ type: "agentManager.sessionAdded", sessionId: session.id, worktreeId: wt.id })
+  await prompt(client, session.id, target, task)
+  deps.capture("Agent Manager Session Started", {
+    source: PLATFORM,
+    sessionId: session.id,
+    tool: true,
+    mode: "local",
+    worktreeId: wt?.id,
+  })
+  return true
+}
+
+async function worktree(
+  deps: ToolDeps,
+  client: KiloClient,
+  task: ToolTask,
+  index: number,
+  total: number,
+  groupId?: string,
+  versions?: boolean,
+) {
+  const name = task.name?.trim() || undefined
+  const branch = task.branchName?.trim() || undefined
+  const version = versionedName(branch || name, versions ? index : 0, versions ? total : 1)
+  const created = await deps.createWorktree({
+    groupId,
+    branchName: version.branch,
+    name: version.branch,
+    label: version.label,
+  })
+  if (!created) return false
+
+  await deps.setup(created.result.path, created.result.branch, created.worktree.id)
+  const session = await deps.createSessionInWorktree(created.result.path, created.result.branch, created.worktree.id)
+  if (!session) {
+    await deps.cleanupWorktree(created.worktree.id, created.result.path)
+    return false
+  }
+
+  const state = deps.getState()
+  if (!state) {
+    await deps.cleanupWorktree(created.worktree.id, created.result.path)
+    return false
+  }
+  state.addSession(session.id, created.worktree.id)
+  deps.registerWorktreeSession(session.id, created.result.path)
+  deps.notifyReady(session.id, created.result, created.worktree.id)
+  deps.getPanel()?.sessions.registerSession(session)
+  await prompt(client, session.id, created.result.path, task)
+  deps.capture("Agent Manager Session Started", {
+    source: PLATFORM,
+    sessionId: session.id,
+    worktreeId: created.worktree.id,
+    branch: created.result.branch,
+    tool: true,
+  })
+  return true
+}
+
+export async function startFromTool(deps: ToolDeps, req: ToolRequest): Promise<void> {
+  deps.openPanel(true)
+  await deps.getPanel()?.waitForReady()
+  await deps.waitReady("startFromTool")
+  const client = deps.getClient()
+  const total = req.tasks.length
+  const versions = req.mode === "worktree" && req.versions === true && total > 1
+  const groupId = versions ? `grp-${Date.now()}` : undefined
+  const state = { ok: 0 }
+
+  deps.post({ type: "agentManager.multiVersionProgress", status: "creating", total, completed: 0, groupId })
+  for (let i = 0; i < req.tasks.length; i++) {
+    const task = req.tasks[i]!
+    try {
+      const done =
+        req.mode === "local"
+          ? await local(deps, client, task, req.directory)
+          : await worktree(deps, client, task, i, total, groupId, versions)
+      if (done) state.ok++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      deps.log("Agent Manager tool task failed", msg)
+      deps.post({ type: "error", message: `Agent Manager tool task failed: ${msg}` })
+    }
+    deps.post({ type: "agentManager.multiVersionProgress", status: "creating", total, completed: state.ok, groupId })
+  }
+
+  deps.post({ type: "agentManager.multiVersionProgress", status: "done", total, completed: state.ok, groupId })
+  if (state.ok === 0) deps.error(`Failed to start any Agent Manager sessions for request ${req.requestID}.`)
+  deps.log(`Agent Manager tool request ${req.requestID} complete: ${state.ok}/${total}`)
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object"
+}
+
+function task(value: unknown): ToolTask | undefined {
+  if (!record(value)) return undefined
+  const out: ToolTask = {}
+  for (const key of ["prompt", "name", "branchName"] as const) {
+    if (typeof value[key] === "string" && value[key].trim()) out[key] = value[key]
+  }
+  if (!out.prompt && !out.name && !out.branchName) return undefined
+  return out
+}
+
+export function parseToolRequest(value: unknown): ToolRequest | undefined {
+  if (!record(value)) return undefined
+  const mode = value.mode
+  const tasks = value.tasks
+  if (mode !== "worktree" && mode !== "local") return undefined
+  if (!Array.isArray(tasks) || tasks.length === 0) return undefined
+  const parsed = tasks
+    .slice(0, 20)
+    .map(task)
+    .filter((item): item is ToolTask => !!item)
+  if (parsed.length === 0) return undefined
+  return {
+    requestID: typeof value.requestID === "string" ? value.requestID : `am-${Date.now()}`,
+    sessionID: typeof value.sessionID === "string" ? value.sessionID : undefined,
+    directory: typeof value.directory === "string" ? value.directory : undefined,
+    mode,
+    versions: typeof value.versions === "boolean" ? value.versions : undefined,
+    tasks: parsed,
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -1,9 +1,12 @@
 import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
-import { versionedName } from "./branch-name"
+import { sanitizeBranchName, versionedName } from "./branch-name"
 import type { CreateWorktreeResult } from "./WorktreeManager"
 import type { WorktreeStateManager } from "./WorktreeStateManager"
 import type { PanelContext } from "./host"
 import { PLATFORM } from "./constants"
+
+const LABEL_MAX = 28
+const PREFIX = new Set(["feat", "fix", "chore", "bug", "issue", "task", "branch"])
 
 export interface ToolTask {
   prompt?: string
@@ -56,6 +59,40 @@ function text(task: ToolTask): string | undefined {
 
 function clean(value: string | undefined): string | undefined {
   return value?.trim() || undefined
+}
+
+function label(value: string | undefined): string | undefined {
+  const raw = clean(value)
+  if (!raw) return undefined
+  const words = raw
+    .toLowerCase()
+    .replace(/[/_.-]+/g, " ")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean)
+  const meaningful = words.filter((word) => !PREFIX.has(word))
+  const picked: string[] = []
+  for (const word of meaningful.length > 0 ? meaningful : words) {
+    const next = [...picked, word].join(" ")
+    if (next.length > LABEL_MAX) break
+    picked.push(word)
+    if (picked.length >= 3) break
+  }
+  return picked.join(" ") || words[0]?.slice(0, LABEL_MAX) || undefined
+}
+
+function branch(value: string | undefined): string | undefined {
+  const raw = clean(value)
+  if (!raw) return undefined
+  return sanitizeBranchName(raw) || undefined
+}
+
+function versionedLabel(base: string | undefined, index: number, total: number): string | undefined {
+  if (!base) return undefined
+  if (total > 1 && index > 0) return `${base} v${index + 1}`
+  return base
 }
 
 async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTask) {
@@ -114,14 +151,14 @@ async function worktree(
   groupId?: string,
   versions?: boolean,
 ) {
-  const name = task.name?.trim() || undefined
-  const branch = task.branchName?.trim() || undefined
-  const version = versionedName(branch || name, versions ? index : 0, versions ? total : 1)
+  const baseBranch = branch(task.branchName) ?? branch(task.name)
+  const baseLabel = label(task.name) ?? label(task.branchName) ?? label(task.prompt)
+  const version = versionedName(baseBranch, versions ? index : 0, versions ? total : 1)
   const created = await deps.createWorktree({
     groupId,
     branchName: version.branch,
     name: version.branch,
-    label: version.label,
+    label: versionedLabel(baseLabel, versions ? index : 0, versions ? total : 1),
   })
   if (!created) return false
 

--- a/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
@@ -96,7 +96,9 @@ describe("agent manager tool start", () => {
     const c = deps()
     await startFromTool(c, { requestID: "am-2", mode: "worktree", tasks: [{ prompt: "Fix", branchName: "fix/one" }] })
 
-    expect(c.createWorktree).toHaveBeenCalledWith(expect.objectContaining({ branchName: "fix/one", name: "fix/one" }))
+    expect(c.createWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ branchName: "fix-one", name: "fix-one", label: "one" }),
+    )
     expect(c.setup).toHaveBeenCalled()
     expect(c.createSessionInWorktree).toHaveBeenCalled()
     expect(c.registerWorktreeSession).toHaveBeenCalledWith("s-wt", "/repo/.kilo/worktrees/wt-1")
@@ -113,7 +115,10 @@ describe("agent manager tool start", () => {
         { prompt: "Fix two", branchName: "fix/two" },
       ],
     })
-    expect(normal.createWorktree).toHaveBeenNthCalledWith(2, expect.objectContaining({ branchName: "fix/two" }))
+    expect(normal.createWorktree).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ branchName: "fix-two", label: "two" }),
+    )
 
     const grouped = deps()
     await startFromTool(grouped, {
@@ -125,7 +130,32 @@ describe("agent manager tool start", () => {
         { prompt: "Try two", branchName: "try/work" },
       ],
     })
-    expect(grouped.createWorktree).toHaveBeenNthCalledWith(2, expect.objectContaining({ branchName: "try/work_v2" }))
+    expect(grouped.createWorktree).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ branchName: "try-work_v2", label: "try work v2" }),
+    )
+  })
+
+  it("sanitizes branch names and keeps card labels short", async () => {
+    const c = deps()
+    await startFromTool(c, {
+      requestID: "am-name",
+      mode: "worktree",
+      tasks: [
+        {
+          prompt: "Fix command permissions persistence regression",
+          name: "Fix command permissions persistence regression that is too long",
+          branchName: "fix command permissions @#$ persistence",
+        },
+      ],
+    })
+
+    expect(c.createWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branchName: "fix-command-permissions-persistence",
+        label: "command permissions",
+      }),
+    )
   })
 
   it("rejects local sessions for unknown worktree directories", async () => {

--- a/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, mock } from "bun:test"
+import { parseToolRequest, startFromTool, type ToolDeps, type ToolRequest } from "../../src/agent-manager/tool-start"
+import type { CreateWorktreeResult } from "../../src/agent-manager/WorktreeManager"
+import type { Session } from "@kilocode/sdk/v2/client"
+
+function session(id: string): Session {
+  return { id, title: id, createdAt: "", updatedAt: "" } as Session
+}
+
+function result(path: string): CreateWorktreeResult {
+  return { path, branch: "kilo/test", parentBranch: "main", startPointSource: "fallback" } as CreateWorktreeResult
+}
+
+function deps(overrides: Partial<ToolDeps> = {}): ToolDeps {
+  const calls: unknown[] = []
+  const panel = {
+    waitForReady: mock(async () => calls.push("waitForReady")),
+    sessions: { registerSession: mock(() => calls.push("registerSession")) },
+  }
+  return {
+    getClient: () =>
+      ({
+        session: {
+          create: mock(async () => ({ data: session("s-local") })),
+          promptAsync: mock(async () => ({})),
+        },
+      }) as never,
+    getRoot: () => "/repo",
+    getState: () => ({ addSession: mock(() => calls.push("addSession")) }) as never,
+    getPanel: () => panel as never,
+    openPanel: mock(() => calls.push("openPanel")),
+    waitReady: mock(async () => calls.push("waitReady")),
+    createWorktree: mock(async () => ({ worktree: { id: "wt-1" }, result: result("/repo/.kilo/worktrees/wt-1") })),
+    cleanupWorktree: mock(async () => calls.push("cleanupWorktree")),
+    setup: mock(async () => calls.push("setup")),
+    createSessionInWorktree: mock(async () => session("s-wt")),
+    registerWorktreeSession: mock(() => calls.push("registerWorktreeSession")),
+    notifyReady: mock(() => calls.push("notifyReady")),
+    push: mock(() => calls.push("push")),
+    post: mock((msg: unknown) => calls.push(msg)),
+    capture: mock(() => calls.push("capture")),
+    log: mock(() => {}),
+    error: mock(() => {}),
+    ...overrides,
+  }
+}
+
+describe("agent manager tool start", () => {
+  it("parses tool start events defensively", () => {
+    const parsed = parseToolRequest({ mode: "local", tasks: [{ prompt: "one" }] })
+    expect(parsed?.requestID.startsWith("am-")).toBe(true)
+    expect(parsed?.sessionID).toBeUndefined()
+    expect(parsed?.directory).toBeUndefined()
+    expect(parsed?.mode).toBe("local")
+    expect(parsed?.versions).toBeUndefined()
+    expect(parsed?.tasks).toEqual([{ prompt: "one" }])
+    expect(parseToolRequest({ mode: "bad", tasks: [{ prompt: "one" }] })).toBeUndefined()
+    expect(parseToolRequest({ mode: "local", tasks: [] })).toBeUndefined()
+    expect(parseToolRequest({ mode: "local", tasks: [{}] })).toBeUndefined()
+  })
+
+  it("starts local sessions and sends the initial prompt", async () => {
+    const client = {
+      session: {
+        create: mock(async () => ({ data: session("s-local") })),
+        promptAsync: mock(async () => ({})),
+      },
+    }
+    const c = deps({ getClient: () => client as never })
+    const req: ToolRequest = {
+      requestID: "am-1",
+      mode: "local",
+      tasks: [{ prompt: "Do work" }],
+    }
+
+    await startFromTool(c, req)
+
+    expect(c.openPanel).toHaveBeenCalledWith(true)
+    const panel = c.getPanel()
+    expect(panel?.waitForReady).toHaveBeenCalled()
+    expect(client.session.create).toHaveBeenCalledWith(
+      { directory: "/repo", platform: "agent-manager" },
+      { throwOnError: true },
+    )
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: "s-local",
+        directory: "/repo",
+        parts: [{ type: "text", text: "Do work" }],
+      }),
+      { throwOnError: true },
+    )
+  })
+
+  it("starts worktree sessions through existing hooks", async () => {
+    const c = deps()
+    await startFromTool(c, { requestID: "am-2", mode: "worktree", tasks: [{ prompt: "Fix", branchName: "fix/one" }] })
+
+    expect(c.createWorktree).toHaveBeenCalledWith(expect.objectContaining({ branchName: "fix/one", name: "fix/one" }))
+    expect(c.setup).toHaveBeenCalled()
+    expect(c.createSessionInWorktree).toHaveBeenCalled()
+    expect(c.registerWorktreeSession).toHaveBeenCalledWith("s-wt", "/repo/.kilo/worktrees/wt-1")
+    expect(c.notifyReady).toHaveBeenCalled()
+  })
+
+  it("only applies version suffixes when versions is true", async () => {
+    const normal = deps()
+    await startFromTool(normal, {
+      requestID: "am-normal",
+      mode: "worktree",
+      tasks: [
+        { prompt: "Fix one", branchName: "fix/one" },
+        { prompt: "Fix two", branchName: "fix/two" },
+      ],
+    })
+    expect(normal.createWorktree).toHaveBeenNthCalledWith(2, expect.objectContaining({ branchName: "fix/two" }))
+
+    const grouped = deps()
+    await startFromTool(grouped, {
+      requestID: "am-versions",
+      mode: "worktree",
+      versions: true,
+      tasks: [
+        { prompt: "Try one", branchName: "try/work" },
+        { prompt: "Try two", branchName: "try/work" },
+      ],
+    })
+    expect(grouped.createWorktree).toHaveBeenNthCalledWith(2, expect.objectContaining({ branchName: "try/work_v2" }))
+  })
+
+  it("rejects local sessions for unknown worktree directories", async () => {
+    const client = {
+      session: {
+        create: mock(async () => ({ data: session("s-local") })),
+        promptAsync: mock(async () => ({})),
+      },
+    }
+    const c = deps({
+      getClient: () => client as never,
+      getState: () => ({ addSession: mock(), findWorktreeByPath: mock(() => undefined) }) as never,
+    })
+
+    await startFromTool(c, {
+      requestID: "am-dir",
+      mode: "local",
+      directory: "/repo/other",
+      tasks: [{ prompt: "Do work" }],
+    })
+
+    expect(client.session.create).not.toHaveBeenCalled()
+    expect(c.error).toHaveBeenCalled()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -181,6 +181,19 @@ const ExperimentalTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.experimental.agentManagerTool.title")}
+          description={language.t("settings.experimental.agentManagerTool.description")}
+        >
+          <Switch
+            checked={experimental().agent_manager_tool ?? false}
+            onChange={(checked) => updateExperimental("agent_manager_tool", checked)}
+            hideLabel
+          >
+            {language.t("settings.experimental.agentManagerTool.title")}
+          </Switch>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.experimental.continueOnDeny.title")}
           description={language.t("settings.experimental.continueOnDeny.description")}
         >

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1184,6 +1184,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "بحث في قاعدة الكود",
   "settings.experimental.codebaseSearch.description": "تمكين البحث بالذكاء الاصطناعي باللغة الطبيعية عبر قاعدة الكود",
+  "settings.experimental.agentManagerTool.title": "أداة Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "السماح للوكلاء ببدء جلسات Agent Manager المحلية وجلسات worktree من استدعاء أداة",
   "settings.experimental.continueOnDeny.title": "المتابعة عند الرفض",
   "settings.experimental.continueOnDeny.description": "متابعة حلقة الوكيل عند رفض الإذن",
   "settings.experimental.mcpTimeout.title": "مهلة MCP (مللي ثانية)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1211,6 +1211,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Pesquisa de código",
   "settings.experimental.codebaseSearch.description":
     "Ativar pesquisa por linguagem natural com IA em toda a base de código",
+  "settings.experimental.agentManagerTool.title": "Ferramenta Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Permitir que agentes iniciem sessões locais e sessões worktree do Agent Manager a partir de uma chamada de ferramenta",
   "settings.experimental.continueOnDeny.title": "Continuar ao negar",
   "settings.experimental.continueOnDeny.description": "Continuar o loop do agente quando uma permissão é negada",
   "settings.experimental.mcpTimeout.title": "Tempo limite MCP (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1211,6 +1211,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Pretraga koda",
   "settings.experimental.codebaseSearch.description": "Omogući AI pretragu prirodnim jezikom kroz bazu koda",
+  "settings.experimental.agentManagerTool.title": "Agent Manager alat",
+  "settings.experimental.agentManagerTool.description":
+    "Dozvoli agentima da pokreću lokalne Agent Manager sesije i worktree sesije iz poziva alata",
   "settings.experimental.continueOnDeny.title": "Nastavi pri odbijanju",
   "settings.experimental.continueOnDeny.description": "Nastavi petlju agenta kada je dozvola odbijena",
   "settings.experimental.mcpTimeout.title": "MCP istek vremena (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1203,6 +1203,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Kodesøgning",
   "settings.experimental.codebaseSearch.description": "Aktiver AI-drevet naturlig sprogsøgning på tværs af kodebasen",
+  "settings.experimental.agentManagerTool.title": "Agent Manager-værktøj",
+  "settings.experimental.agentManagerTool.description":
+    "Tillad agenter at starte lokale Agent Manager-sessioner og worktree-sessioner fra et værktøjskald",
   "settings.experimental.continueOnDeny.title": "Fortsæt ved afvisning",
   "settings.experimental.continueOnDeny.description": "Fortsæt agentløkken, når en tilladelse afvises",
   "settings.experimental.mcpTimeout.title": "MCP-timeout (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1226,6 +1226,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Codebase-Suche",
   "settings.experimental.codebaseSearch.description":
     "KI-gestützte Suche in natürlicher Sprache über die gesamte Codebasis aktivieren",
+  "settings.experimental.agentManagerTool.title": "Agent Manager-Werkzeug",
+  "settings.experimental.agentManagerTool.description":
+    "Agenten erlauben, lokale Agent Manager-Sitzungen und Worktree-Sitzungen per Werkzeugaufruf zu starten",
   "settings.experimental.continueOnDeny.title": "Bei Ablehnung fortfahren",
   "settings.experimental.continueOnDeny.description":
     "Agent-Schleife fortsetzen, wenn eine Berechtigung abgelehnt wird",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1197,6 +1197,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Codebase Search",
   "settings.experimental.codebaseSearch.description": "Enable AI-powered natural language search across your codebase",
+  "settings.experimental.agentManagerTool.title": "Agent Manager Tool",
+  "settings.experimental.agentManagerTool.description":
+    "Allow agents to start Agent Manager local sessions and worktree sessions from a tool call",
   "settings.experimental.continueOnDeny.title": "Continue on Deny",
   "settings.experimental.continueOnDeny.description": "Continue the agent loop when a permission is denied",
   "settings.experimental.mcpTimeout.title": "MCP Timeout (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1217,6 +1217,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Búsqueda de código",
   "settings.experimental.codebaseSearch.description":
     "Habilitar búsqueda por lenguaje natural con IA en toda la base de código",
+  "settings.experimental.agentManagerTool.title": "Herramienta Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Permitir que los agentes inicien sesiones locales y sesiones de worktree de Agent Manager desde una llamada de herramienta",
   "settings.experimental.continueOnDeny.title": "Continuar al denegar",
   "settings.experimental.continueOnDeny.description": "Continuar el bucle del agente cuando se deniega un permiso",
   "settings.experimental.mcpTimeout.title": "Tiempo de espera MCP (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1229,6 +1229,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Recherche de code",
   "settings.experimental.codebaseSearch.description":
     "Activer la recherche en langage naturel par IA dans toute la base de code",
+  "settings.experimental.agentManagerTool.title": "Outil Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Autoriser les agents à démarrer des sessions locales Agent Manager et des sessions worktree depuis un appel d'outil",
   "settings.experimental.continueOnDeny.title": "Continuer en cas de refus",
   "settings.experimental.continueOnDeny.description":
     "Continuer la boucle de l'agent lorsqu'une autorisation est refusée",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1200,6 +1200,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "コードベース検索",
   "settings.experimental.codebaseSearch.description": "コードベース全体でAIによる自然言語検索を有効にする",
+  "settings.experimental.agentManagerTool.title": "Agent Manager ツール",
+  "settings.experimental.agentManagerTool.description":
+    "エージェントがツール呼び出しから Agent Manager のローカルセッションとワークツリーセッションを開始できるようにする",
   "settings.experimental.continueOnDeny.title": "拒否時に続行",
   "settings.experimental.continueOnDeny.description": "権限が拒否された場合にエージェントループを続行",
   "settings.experimental.mcpTimeout.title": "MCPタイムアウト（ミリ秒）",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1193,6 +1193,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "코드베이스 검색",
   "settings.experimental.codebaseSearch.description": "코드베이스 전체에서 AI 기반 자연어 검색 활성화",
+  "settings.experimental.agentManagerTool.title": "Agent Manager 도구",
+  "settings.experimental.agentManagerTool.description":
+    "에이전트가 도구 호출로 Agent Manager 로컬 세션 및 워크트리 세션을 시작하도록 허용",
   "settings.experimental.continueOnDeny.title": "거부 시 계속",
   "settings.experimental.continueOnDeny.description": "권한이 거부되면 에이전트 루프 계속",
   "settings.experimental.mcpTimeout.title": "MCP 타임아웃 (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1213,6 +1213,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Codebase Zoeken",
   "settings.experimental.codebaseSearch.description":
     "Schakel AI-aangedreven zoeken in natuurlijke taal door je codebase in",
+  "settings.experimental.agentManagerTool.title": "Agent Manager-tool",
+  "settings.experimental.agentManagerTool.description":
+    "Sta agents toe om lokale Agent Manager-sessies en worktree-sessies te starten vanuit een tool call",
   "settings.experimental.continueOnDeny.title": "Doorgaan bij weigering",
   "settings.experimental.continueOnDeny.description":
     "Ga door met de agent loop wanneer een toestemming wordt geweigerd",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1180,6 +1180,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Kodesøk",
   "settings.experimental.codebaseSearch.description": "Aktiver AI-drevet naturlig språksøk på tvers av kodebasen",
+  "settings.experimental.agentManagerTool.title": "Agent Manager-verktøy",
+  "settings.experimental.agentManagerTool.description":
+    "Tillat agenter å starte lokale Agent Manager-økter og worktree-økter fra et verktøykall",
   "settings.experimental.continueOnDeny.title": "Fortsett ved avvisning",
   "settings.experimental.continueOnDeny.description": "Fortsett agentløkken når en tillatelse avvises",
   "settings.experimental.mcpTimeout.title": "MCP-tidsavbrudd (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1180,6 +1180,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Wyszukiwanie kodu",
   "settings.experimental.codebaseSearch.description": "Włącz wyszukiwanie w języku naturalnym z AI w całej bazie kodu",
+  "settings.experimental.agentManagerTool.title": "Narzędzie Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Zezwól agentom na uruchamianie lokalnych sesji Agent Manager i sesji worktree z wywołania narzędzia",
   "settings.experimental.continueOnDeny.title": "Kontynuuj przy odmowie",
   "settings.experimental.continueOnDeny.description": "Kontynuuj pętlę agenta po odmowie uprawnienia",
   "settings.experimental.mcpTimeout.title": "Limit czasu MCP (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1208,6 +1208,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Поиск по коду",
   "settings.experimental.codebaseSearch.description": "Включить поиск на естественном языке с ИИ по всей кодовой базе",
+  "settings.experimental.agentManagerTool.title": "Инструмент Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Разрешить агентам запускать локальные сеансы Agent Manager и сеансы worktree через вызов инструмента",
   "settings.experimental.continueOnDeny.title": "Продолжить при отказе",
   "settings.experimental.continueOnDeny.description": "Продолжить цикл агента при отказе в разрешении",
   "settings.experimental.mcpTimeout.title": "Таймаут MCP (мс)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1191,6 +1191,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "ค้นหาโค้ดเบส",
   "settings.experimental.codebaseSearch.description": "เปิดใช้งานการค้นหาด้วยภาษาธรรมชาติโดย AI ทั่วทั้งโค้ดเบส",
+  "settings.experimental.agentManagerTool.title": "เครื่องมือ Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "อนุญาตให้เอเจนต์เริ่มเซสชัน Agent Manager ในเครื่องและเซสชัน worktree จากการเรียกเครื่องมือ",
   "settings.experimental.continueOnDeny.title": "ดำเนินต่อเมื่อถูกปฏิเสธ",
   "settings.experimental.continueOnDeny.description": "ดำเนินลูปเอเจนต์ต่อเมื่อสิทธิ์ถูกปฏิเสธ",
   "settings.experimental.mcpTimeout.title": "หมดเวลา MCP (มิลลิวินาที)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1206,6 +1206,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Kod Tabanı Araması",
   "settings.experimental.codebaseSearch.description":
     "Kod tabanınız genelinde yapay zeka destekli doğal dil aramasını etkinleştir",
+  "settings.experimental.agentManagerTool.title": "Agent Manager Aracı",
+  "settings.experimental.agentManagerTool.description":
+    "Ajanların bir araç çağrısından Agent Manager yerel oturumları ve worktree oturumları başlatmasına izin ver",
   "settings.experimental.continueOnDeny.title": "Reddetme Durumunda Devam Et",
   "settings.experimental.continueOnDeny.description": "Bir izin reddedildiğinde ajan döngüsüne devam et",
   "settings.experimental.mcpTimeout.title": "MCP Zaman Aşımı (ms)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1209,6 +1209,9 @@ export const dict = {
   "settings.experimental.codebaseSearch.title": "Пошук по кодовій базі",
   "settings.experimental.codebaseSearch.description":
     "Увімкнути пошук природною мовою на основі ШІ по всій кодовій базі",
+  "settings.experimental.agentManagerTool.title": "Інструмент Agent Manager",
+  "settings.experimental.agentManagerTool.description":
+    "Дозволити агентам запускати локальні сесії Agent Manager і сесії worktree через виклик інструмента",
   "settings.experimental.continueOnDeny.title": "Продовжувати при відхиленні",
   "settings.experimental.continueOnDeny.description": "Продовжувати цикл агента, коли дозвіл відхилено",
   "settings.experimental.mcpTimeout.title": "Тайм-аут MCP (мс)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1176,6 +1176,8 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "代码库搜索",
   "settings.experimental.codebaseSearch.description": "启用 AI 驱动的自然语言代码库搜索",
+  "settings.experimental.agentManagerTool.title": "Agent Manager 工具",
+  "settings.experimental.agentManagerTool.description": "允许智能体通过工具调用启动 Agent Manager 本地会话和工作树会话",
   "settings.experimental.continueOnDeny.title": "拒绝后继续",
   "settings.experimental.continueOnDeny.description": "权限被拒绝时继续智能体循环",
   "settings.experimental.mcpTimeout.title": "MCP 超时（毫秒）",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1153,6 +1153,9 @@ export const dict = {
     "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "程式碼庫搜尋",
   "settings.experimental.codebaseSearch.description": "啟用 AI 驅動的自然語言程式碼庫搜尋",
+  "settings.experimental.agentManagerTool.title": "Agent Manager 工具",
+  "settings.experimental.agentManagerTool.description":
+    "允許 Agent 透過工具呼叫啟動 Agent Manager 本機工作階段和工作樹工作階段",
   "settings.experimental.continueOnDeny.title": "拒絕後繼續",
   "settings.experimental.continueOnDeny.description": "權限被拒絕時繼續 Agent 迴圈",
   "settings.experimental.mcpTimeout.title": "MCP 逾時（毫秒）",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -41,6 +41,7 @@ export interface ExperimentalConfig {
   batch_tool?: boolean
   semantic_indexing?: boolean
   codebase_search?: boolean
+  agent_manager_tool?: boolean
   primary_tools?: string[]
   continue_loop_on_deny?: boolean
   mcp_timeout?: number

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -288,6 +288,9 @@ export const Info = Schema.Struct({
       semantic_indexing: Schema.optional(Schema.Boolean).annotate({
         description: "Enable semantic codebase indexing and the semantic_search tool",
       }),
+      agent_manager_tool: Schema.optional(Schema.Boolean).annotate({
+        description: "Enable the VS Code Agent Manager orchestration tool",
+      }),
       // kilocode_change end
       // kilocode_change start - enable telemetry by default
       openTelemetry: Schema.Boolean.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(true))).annotate({

--- a/packages/opencode/src/config/permission.ts
+++ b/packages/opencode/src/config/permission.ts
@@ -47,6 +47,7 @@ const InputObject = Schema.StructWithRest(
     lsp: Schema.optional(Rule),
     doom_loop: Schema.optional(Action),
     skill: Schema.optional(Rule),
+    agent_manager: Schema.optional(Rule), // kilocode_change
   }),
   [Schema.Record(Schema.String, Rule)],
 )

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -8,15 +8,14 @@ import { Flock } from "@opencode-ai/shared/util/flock"
 const app = "kilo" // kilocode_change
 
 // kilocode_change start
-// Defensively strip surrounding whitespace from the resolved XDG paths.
+// Defensively strip newline characters from the resolved XDG paths.
 // If `$HOME` (or any `$XDG_*_HOME` override) has a trailing newline in
 // the user's shell — e.g. because a shell snippet did `export HOME=$(cmd)`
 // against a command with an implicit newline — the unsanitised path
 // makes `fs.mkdir` try to create `/Users/<name>\n` and fail with EACCES,
 // which breaks every `kilo` invocation at startup (including the SDK
-// regen that runs during `bun run extension`). A trim is cheap and
-// trailing whitespace is never legitimate in a filesystem path.
-const clean = (p: string | undefined) => p?.trim()
+// regen that runs during `bun run extension`).
+const clean = (p: string | undefined) => p?.replace(/[\r\n]+/g, "")
 const data = path.join(clean(xdgData)!, app)
 const cache = path.join(clean(xdgCache)!, app)
 const config = path.join(clean(xdgConfig)!, app)

--- a/packages/opencode/src/kilocode/agent-manager/event.ts
+++ b/packages/opencode/src/kilocode/agent-manager/event.ts
@@ -5,8 +5,8 @@ import { Schema } from "effect"
 
 export const AgentManagerTask = Schema.Struct({
   prompt: Schema.optional(Schema.String).annotate({ description: "Initial prompt to send to the new session" }),
-  name: Schema.optional(Schema.String).annotate({ description: "Display name or branch-name seed" }),
-  branchName: Schema.optional(Schema.String).annotate({ description: "Explicit worktree branch name" }),
+  name: Schema.optional(Schema.String).annotate({ description: "Short display name for the Agent Manager card" }),
+  branchName: Schema.optional(Schema.String).annotate({ description: "Git branch name seed for worktree mode" }),
 })
 
 export const AgentManagerMode = Schema.Literals(["worktree", "local"])

--- a/packages/opencode/src/kilocode/agent-manager/event.ts
+++ b/packages/opencode/src/kilocode/agent-manager/event.ts
@@ -1,0 +1,26 @@
+// kilocode_change - new file
+import { BusEvent } from "@/bus/bus-event"
+import { SessionID } from "@/session/schema"
+import { Schema } from "effect"
+
+export const AgentManagerTask = Schema.Struct({
+  prompt: Schema.optional(Schema.String).annotate({ description: "Initial prompt to send to the new session" }),
+  name: Schema.optional(Schema.String).annotate({ description: "Display name or branch-name seed" }),
+  branchName: Schema.optional(Schema.String).annotate({ description: "Explicit worktree branch name" }),
+})
+
+export const AgentManagerMode = Schema.Literals(["worktree", "local"])
+
+export const AgentManagerStart = Schema.Struct({
+  requestID: Schema.String,
+  sessionID: SessionID,
+  mode: AgentManagerMode,
+  versions: Schema.optional(Schema.Boolean),
+  tasks: Schema.Array(AgentManagerTask).check(Schema.isMinLength(1), Schema.isMaxLength(20)),
+})
+
+export type AgentManagerStart = Schema.Schema.Type<typeof AgentManagerStart>
+
+export const AgentManagerEvent = {
+  Start: BusEvent.define("kilocode.agent_manager.start", AgentManagerStart),
+}

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -1,0 +1,69 @@
+// kilocode_change - new file
+import { Bus } from "@/bus"
+import { AgentManagerEvent } from "@/kilocode/agent-manager/event"
+import { Tool } from "@/tool"
+import { Effect, Schema } from "effect"
+import DESCRIPTION from "./agent-manager.txt"
+
+const Task = Schema.Struct({
+  prompt: Schema.optional(Schema.String).annotate({ description: "Initial prompt to send to the new session" }),
+  name: Schema.optional(Schema.String).annotate({ description: "Display name or branch-name seed" }),
+  branchName: Schema.optional(Schema.String).annotate({ description: "Explicit branch name for worktree mode" }),
+})
+
+export const Params = Schema.Struct({
+  mode: Schema.Literals(["worktree", "local"]).annotate({
+    description: "Use worktree for isolated git worktrees, or local for same-directory Agent Manager sessions",
+  }),
+  versions: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Set true only when tasks are alternative versions of the same work to compare. Omit or false for independent sessions.",
+  }),
+  tasks: Schema.Array(Task)
+    .check(Schema.isMinLength(1), Schema.isMaxLength(20))
+    .annotate({ description: "Agent Manager sessions to start" }),
+})
+
+export const AgentManagerTool = Tool.define<
+  typeof Params,
+  { requestID: string; count: number },
+  Bus.Service,
+  "agent_manager"
+>(
+  "agent_manager",
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    return {
+      description: DESCRIPTION,
+      parameters: Params,
+      execute: (params, ctx) =>
+        Effect.gen(function* () {
+          yield* ctx.ask({
+            permission: "agent_manager",
+            patterns: [params.mode],
+            always: [params.mode],
+            metadata: { mode: params.mode, count: params.tasks.length },
+          })
+
+          const requestID = `am-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+          yield* bus.publish(AgentManagerEvent.Start, {
+            requestID,
+            sessionID: ctx.sessionID,
+            mode: params.mode,
+            versions: params.versions,
+            tasks: params.tasks,
+          })
+
+          return {
+            title: `Requested ${params.tasks.length} Agent Manager ${params.mode === "worktree" ? "worktree" : "local"} session${params.tasks.length === 1 ? "" : "s"}`,
+            output: [
+              `Requested ${params.tasks.length} Agent Manager ${params.mode === "worktree" ? "worktree" : "local"} session${params.tasks.length === 1 ? "" : "s"}.`,
+              `request_id: ${requestID}`,
+              "The VS Code extension will create the sessions asynchronously and show progress in Agent Manager.",
+            ].join("\n"),
+            metadata: { requestID, count: params.tasks.length },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -7,8 +7,8 @@ import DESCRIPTION from "./agent-manager.txt"
 
 const Task = Schema.Struct({
   prompt: Schema.optional(Schema.String).annotate({ description: "Initial prompt to send to the new session" }),
-  name: Schema.optional(Schema.String).annotate({ description: "Display name or branch-name seed" }),
-  branchName: Schema.optional(Schema.String).annotate({ description: "Explicit branch name for worktree mode" }),
+  name: Schema.optional(Schema.String).annotate({ description: "Short display name for the Agent Manager card" }),
+  branchName: Schema.optional(Schema.String).annotate({ description: "Git branch name seed for worktree mode" }),
 })
 
 export const Params = Schema.Struct({

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -9,7 +9,13 @@ const Task = Schema.Struct({
   prompt: Schema.optional(Schema.String).annotate({ description: "Initial prompt to send to the new session" }),
   name: Schema.optional(Schema.String).annotate({ description: "Short display name for the Agent Manager card" }),
   branchName: Schema.optional(Schema.String).annotate({ description: "Git branch name seed for worktree mode" }),
-})
+}).check(
+  Schema.makeFilter((task: { prompt?: string; name?: string; branchName?: string }) =>
+    task.prompt?.trim() || task.name?.trim() || task.branchName?.trim()
+      ? undefined
+      : "Each task must include prompt, name, or branchName",
+  ),
+)
 
 export const Params = Schema.Struct({
   mode: Schema.Literals(["worktree", "local"]).annotate({

--- a/packages/opencode/src/kilocode/tool/agent-manager.txt
+++ b/packages/opencode/src/kilocode/tool/agent-manager.txt
@@ -6,7 +6,7 @@ Modes:
 - `worktree`: creates a new Agent Manager git worktree for each task, like the New Worktree dialog.
 - `local`: creates Agent Manager sessions in the current workspace directory without git worktree isolation.
 
-Each task may provide a prompt, display name, and branch name. The agent, model, reasoning, and base branch settings always use the normal defaults.
+Each task may provide a prompt, a short display name, and a branch name. Keep display names short because Agent Manager cards are narrow. Branch names are sanitized before worktree creation. The agent, model, reasoning, and base branch settings always use the normal defaults.
 
 By default, multiple tasks are started as independent Agent Manager sessions. Set `versions` to true only when all tasks are alternate versions of the same work that should be compared together. Versioned worktrees are grouped in Agent Manager and branch names may receive version suffixes.
 

--- a/packages/opencode/src/kilocode/tool/agent-manager.txt
+++ b/packages/opencode/src/kilocode/tool/agent-manager.txt
@@ -1,0 +1,13 @@
+Start Agent Manager sessions in the VS Code extension.
+
+Use this tool when the user explicitly asks you to fan out work into Agent Manager, create Agent Manager worktrees, or start multiple Agent Manager sessions for independent tasks.
+
+Modes:
+- `worktree`: creates a new Agent Manager git worktree for each task, like the New Worktree dialog.
+- `local`: creates Agent Manager sessions in the current workspace directory without git worktree isolation.
+
+Each task may provide a prompt, display name, and branch name. The agent, model, reasoning, and base branch settings always use the normal defaults.
+
+By default, multiple tasks are started as independent Agent Manager sessions. Set `versions` to true only when all tasks are alternate versions of the same work that should be compared together. Versioned worktrees are grouped in Agent Manager and branch names may receive version suffixes.
+
+Do not use this for ordinary subagent research. Use the `task` tool for internal subagents, and use this only when the user wants visible Agent Manager sessions in the extension.

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -1,6 +1,7 @@
 // kilocode_change - new file
 import { CodebaseSearchTool } from "../../tool/warpgrep"
 import { RecallTool } from "../../tool/recall"
+import { AgentManagerTool } from "./agent-manager"
 import * as Tool from "../../tool/tool"
 import { Flag } from "@/flag/flag"
 import { Effect } from "effect"
@@ -18,17 +19,19 @@ export namespace KiloToolRegistry {
     return Effect.gen(function* () {
       const codebase = yield* CodebaseSearchTool
       const recall = yield* RecallTool
-      return { codebase, recall }
+      const manager = yield* AgentManagerTool
+      return { codebase, recall, manager }
     })
   }
 
   /** Finalize Kilo-specific tools into Tool.Defs. Call this inside the InstanceState state Effect —
    * it has no Service deps beyond what Tool.init itself needs. */
-  export function build(tools: { codebase: Tool.Info; recall: Tool.Info }, deps: Deps) {
+  export function build(tools: { codebase: Tool.Info; recall: Tool.Info; manager: Tool.Info }, deps: Deps) {
     return Effect.gen(function* () {
       const base = yield* Effect.all({
         codebase: Tool.init(tools.codebase),
         recall: Tool.init(tools.recall),
+        manager: Tool.init(tools.manager),
       })
       const semantic = yield* semanticTool(deps)
       return { ...base, semantic }
@@ -37,7 +40,9 @@ export namespace KiloToolRegistry {
 
   function semanticTool(deps: Deps) {
     return Effect.gen(function* () {
-      const ready = yield* Effect.tryPromise(() => import("@/kilocode/indexing").then((mod) => mod.KiloIndexing.ready())).pipe(
+      const ready = yield* Effect.tryPromise(() =>
+        import("@/kilocode/indexing").then((mod) => mod.KiloIndexing.ready()),
+      ).pipe(
         Effect.catch((err) =>
           Effect.sync(() => {
             log.warn("semantic search unavailable", { err })
@@ -83,13 +88,15 @@ export namespace KiloToolRegistry {
 
   /** Kilo-specific tools to append to the builtin list */
   export function extra(
-    tools: { codebase: Tool.Def; semantic?: Tool.Def; recall: Tool.Def },
-    cfg: { experimental?: { codebase_search?: boolean } },
+    tools: { codebase: Tool.Def; semantic?: Tool.Def; recall: Tool.Def; manager: Tool.Def },
+    cfg: { experimental?: { codebase_search?: boolean; agent_manager_tool?: boolean } },
   ): Tool.Def[] {
     return [
       ...(cfg.experimental?.codebase_search === true ? [tools.codebase] : []),
       ...(tools.semantic ? [tools.semantic] : []),
       tools.recall,
+      // The extension is the only client that can consume the Agent Manager start event.
+      ...(Flag.KILO_CLIENT === "vscode" && cfg.experimental?.agent_manager_tool === true ? [tools.manager] : []),
     ]
   }
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -519,7 +519,6 @@ const SCALAR_ONLY_PERMISSIONS = new Set([
   "websearch",
   "codesearch",
   "doom_loop",
-  "agent_manager", // kilocode_change
 ])
 
 export function toConfig(rules: Ruleset): ConfigPermission.Info {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -519,6 +519,7 @@ const SCALAR_ONLY_PERMISSIONS = new Set([
   "websearch",
   "codesearch",
   "doom_loop",
+  "agent_manager", // kilocode_change
 ])
 
 export function toConfig(rules: Ruleset): ConfigPermission.Info {

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { AgentManagerTool } from "../../src/kilocode/tool/agent-manager"
+import { Bus } from "../../src/bus"
+import { Tool } from "../../src/tool"
+import { Truncate } from "../../src/tool"
+import { Agent } from "../../src/agent/agent"
+
+const runtime = ManagedRuntime.make(
+  Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer, Bus.defaultLayer, CrossSpawnSpawner.defaultLayer),
+)
+
+async function init() {
+  return runtime.runPromise(
+    Effect.gen(function* () {
+      const info = yield* AgentManagerTool
+      return yield* Tool.init(info)
+    }),
+  )
+}
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "call_agent_manager",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("agent_manager tool", () => {
+  test("asks for agent_manager permission", async () => {
+    const tool = await init()
+    const calls: unknown[] = []
+
+    await runtime.runPromise(
+      provideTmpdirInstance(() =>
+        tool.execute(
+          { mode: "local", tasks: [{ prompt: "Fix issue" }] },
+          { ...ctx, ask: (input: unknown) => Effect.sync(() => calls.push(input)) },
+        ),
+      ).pipe(Effect.scoped),
+    )
+
+    expect(calls).toEqual([
+      {
+        permission: "agent_manager",
+        patterns: ["local"],
+        always: ["local"],
+        metadata: { mode: "local", count: 1 },
+      },
+    ])
+  })
+})

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -56,4 +56,16 @@ describe("agent_manager tool", () => {
       },
     ])
   })
+
+  test("rejects empty tasks", async () => {
+    const tool = await init()
+
+    await expect(
+      runtime.runPromise(
+        provideTmpdirInstance(() =>
+          tool.execute({ mode: "local", tasks: [{}] }, { ...ctx, ask: () => Effect.void }),
+        ).pipe(Effect.scoped),
+      ),
+    ).rejects.toThrow("Each task must include prompt, name, or branchName")
+  })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -590,6 +590,30 @@ export type EventVcsBranchUpdated = {
   }
 }
 
+export type EventKilocodeAgentManagerStart = {
+  type: "kilocode.agent_manager.start"
+  properties: {
+    requestID: string
+    sessionID: string
+    mode: "worktree" | "local"
+    versions?: boolean
+    tasks: Array<{
+      /**
+       * Initial prompt to send to the new session
+       */
+      prompt?: string
+      /**
+       * Display name or branch-name seed
+       */
+      name?: string
+      /**
+       * Explicit worktree branch name
+       */
+      branchName?: string
+    }>
+  }
+}
+
 export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
@@ -1331,6 +1355,7 @@ export type GlobalEvent = {
     | EventSessionIdle
     | EventTodoUpdated
     | EventVcsBranchUpdated
+    | EventKilocodeAgentManagerStart
     | EventSessionCompacted
     | EventKiloSessionsRemoteStatusChanged
     | EventWorktreeReady
@@ -1539,6 +1564,7 @@ export type PermissionConfig =
       lsp?: PermissionRuleConfig
       doom_loop?: PermissionActionConfig
       skill?: PermissionRuleConfig
+      agent_manager?: PermissionRuleConfig
       [key: string]: PermissionRuleConfig | PermissionActionConfig | undefined
     }
 
@@ -2022,6 +2048,10 @@ export type Config = {
      */
     semantic_indexing?: boolean
     /**
+     * Enable the VS Code Agent Manager orchestration tool
+     */
+    agent_manager_tool?: boolean
+    /**
      * Enable telemetry. Set to false to opt-out.
      */
     openTelemetry?: boolean
@@ -2453,6 +2483,7 @@ export type Event =
   | EventSessionIdle
   | EventTodoUpdated
   | EventVcsBranchUpdated
+  | EventKilocodeAgentManagerStart
   | EventSessionCompacted
   | EventKiloSessionsRemoteStatusChanged
   | EventWorktreeReady

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -603,11 +603,11 @@ export type EventKilocodeAgentManagerStart = {
        */
       prompt?: string
       /**
-       * Display name or branch-name seed
+       * Short display name for the Agent Manager card
        */
       name?: string
       /**
-       * Explicit worktree branch name
+       * Git branch name seed for worktree mode
        */
       branchName?: string
     }>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -12261,11 +12261,11 @@
                       "type": "string"
                     },
                     "name": {
-                      "description": "Display name or branch-name seed",
+                      "description": "Short display name for the Agent Manager card",
                       "type": "string"
                     },
                     "branchName": {
-                      "description": "Explicit worktree branch name",
+                      "description": "Git branch name seed for worktree mode",
                       "type": "string"
                     }
                   }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -12225,46 +12225,54 @@
         },
         "required": ["type", "properties"]
       },
-      "IndexingStatusState": {
-        "type": "string",
-        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
-      },
-      "IndexingStatus": {
-        "type": "object",
-        "properties": {
-          "state": {
-            "$ref": "#/components/schemas/IndexingStatusState"
-          },
-          "message": {
-            "type": "string"
-          },
-          "processedFiles": {
-            "type": "number"
-          },
-          "totalFiles": {
-            "type": "number"
-          },
-          "percent": {
-            "type": "number"
-          }
-        },
-        "required": ["state", "message", "processedFiles", "totalFiles", "percent"]
-      },
-      "Event.indexing.status": {
+      "Event.kilocode.agent_manager.start": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "const": "indexing.status"
+            "const": "kilocode.agent_manager.start"
           },
           "properties": {
             "type": "object",
             "properties": {
-              "status": {
-                "$ref": "#/components/schemas/IndexingStatus"
+              "requestID": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["worktree", "local"]
+              },
+              "versions": {
+                "type": "boolean"
+              },
+              "tasks": {
+                "minItems": 1,
+                "maxItems": 20,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prompt": {
+                      "description": "Initial prompt to send to the new session",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Display name or branch-name seed",
+                      "type": "string"
+                    },
+                    "branchName": {
+                      "description": "Explicit worktree branch name",
+                      "type": "string"
+                    }
+                  }
+                }
               }
             },
-            "required": ["status"]
+            "required": ["requestID", "sessionID", "mode", "tasks"]
           }
         },
         "required": ["type", "properties"]
@@ -13968,6 +13976,50 @@
         },
         "required": ["type", "properties"]
       },
+      "IndexingStatusState": {
+        "type": "string",
+        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
+      },
+      "IndexingStatus": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/IndexingStatusState"
+          },
+          "message": {
+            "type": "string"
+          },
+          "processedFiles": {
+            "type": "number"
+          },
+          "totalFiles": {
+            "type": "number"
+          },
+          "percent": {
+            "type": "number"
+          }
+        },
+        "required": ["state", "message", "processedFiles", "totalFiles", "percent"]
+      },
+      "Event.indexing.status": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "indexing.status"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/IndexingStatus"
+              }
+            },
+            "required": ["status"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "SyncEvent.message.updated": {
         "type": "object",
         "properties": {
@@ -14578,7 +14630,7 @@
                 "$ref": "#/components/schemas/Event.vcs.branch.updated"
               },
               {
-                "$ref": "#/components/schemas/Event.indexing.status"
+                "$ref": "#/components/schemas/Event.kilocode.agent_manager.start"
               },
               {
                 "$ref": "#/components/schemas/Event.session.compacted"
@@ -14636,6 +14688,9 @@
               },
               {
                 "$ref": "#/components/schemas/Event.session.deleted"
+              },
+              {
+                "$ref": "#/components/schemas/Event.indexing.status"
               },
               {
                 "$ref": "#/components/schemas/SyncEvent.message.updated"
@@ -14970,6 +15025,9 @@
                 "$ref": "#/components/schemas/PermissionActionConfig"
               },
               "skill": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
+              "agent_manager": {
                 "$ref": "#/components/schemas/PermissionRuleConfig"
               }
             },
@@ -15582,6 +15640,11 @@
           "indexing": {
             "$ref": "#/components/schemas/IndexingConfig"
           },
+          "terminal_command_display": {
+            "description": "Controls whether terminal command blocks are expanded or collapsed by default in the VS Code chat UI",
+            "type": "string",
+            "enum": ["expanded", "collapsed"]
+          },
           "model": {
             "description": "Model to use in the format of provider/model, eg anthropic/claude-2",
             "anyOf": [
@@ -15919,6 +15982,10 @@
               },
               "semantic_indexing": {
                 "description": "Enable semantic codebase indexing and the semantic_search tool",
+                "type": "boolean"
+              },
+              "agent_manager_tool": {
+                "description": "Enable the VS Code Agent Manager orchestration tool",
                 "type": "boolean"
               },
               "openTelemetry": {
@@ -17202,7 +17269,7 @@
             "$ref": "#/components/schemas/Event.vcs.branch.updated"
           },
           {
-            "$ref": "#/components/schemas/Event.indexing.status"
+            "$ref": "#/components/schemas/Event.kilocode.agent_manager.start"
           },
           {
             "$ref": "#/components/schemas/Event.session.compacted"
@@ -17260,6 +17327,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.session.deleted"
+          },
+          {
+            "$ref": "#/components/schemas/Event.indexing.status"
           }
         ]
       },

--- a/packages/shared/src/global.ts
+++ b/packages/shared/src/global.ts
@@ -20,11 +20,14 @@ export namespace Global {
     Service,
     Effect.gen(function* () {
       const app = "opencode"
-      const home = process.env.KILO_TEST_HOME ?? os.homedir()
-      const data = path.join(xdgData!, app)
-      const cache = path.join(xdgCache!, app)
-      const cfg = path.join(xdgConfig!, app)
-      const state = path.join(xdgState!, app)
+      // kilocode_change start - guard against newline-contaminated HOME/XDG paths
+      const clean = (p: string | undefined) => p?.replace(/[\r\n]+/g, "")
+      const home = clean(process.env.KILO_TEST_HOME ?? os.homedir())!
+      const data = path.join(clean(xdgData)!, app)
+      const cache = path.join(clean(xdgCache)!, app)
+      const cfg = path.join(clean(xdgConfig)!, app)
+      const state = path.join(clean(xdgState)!, app)
+      // kilocode_change end
       const bin = path.join(cache, "bin")
       const log = path.join(data, "log")
 


### PR DESCRIPTION
## Summary
- Add an experimental CLI tool that lets VS Code sessions request Agent Manager local sessions or worktree sessions.
- Wire the extension to consume Agent Manager start events, expose the setting in Experimental settings, and preserve default model/agent behavior.
- Harden newline-contaminated HOME/XDG path handling used during extension builds.