### PR TITLE
fix(vscode): preserve Agent Manager local sessions

### DIFF
--- a/.changeset/local-sessions-restart.md
+++ b/.changeset/local-sessions-restart.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve Agent Manager local sessions across panel restarts when session refreshes complete out of order.

--- a/packages/kilo-vscode/tests/unit/navigate.test.ts
+++ b/packages/kilo-vscode/tests/unit/navigate.test.ts
@@ -4,6 +4,7 @@ import {
   validateLocalSession,
   adjacentHint,
   restoreLocalSessions,
+  reconcileLocalSessions,
   LOCAL,
 } from "../../webview-ui/agent-manager/navigate"
 
@@ -292,5 +293,92 @@ describe("restoreLocalSessions", () => {
   it("returns undefined when no disk sessions and no tab order", () => {
     const result = restoreLocalSessions([], [], undefined, isPending, identity)
     expect(result).toBeUndefined()
+  })
+})
+
+describe("reconcileLocalSessions", () => {
+  const isPending = (id: string) => id.startsWith("pending-")
+
+  it("keeps restored local sessions through a partial restart refresh", () => {
+    const managed = [
+      { id: "local-1", worktreeId: null },
+      { id: "worktree-1", worktreeId: "wt-1" },
+    ]
+    const restored = restoreLocalSessions(managed, [], undefined, isPending, (items) => items)?.filter(Boolean) ?? []
+
+    const result = reconcileLocalSessions(restored, ["worktree-1"], managed, isPending)
+
+    expect(restored).toEqual(["local-1"])
+    expect(result).toBeUndefined()
+  })
+
+  it("preserves restored local sessions before sessionsLoaded includes them", () => {
+    const result = reconcileLocalSessions(
+      ["s1", "s2"],
+      [],
+      [
+        { id: "s1", worktreeId: null },
+        { id: "s2", worktreeId: null },
+      ],
+      isPending,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it("does not forget persisted local sessions when only worktree sessions loaded", () => {
+    const result = reconcileLocalSessions(
+      ["local-1"],
+      ["worktree-1"],
+      [
+        { id: "local-1", worktreeId: null },
+        { id: "worktree-1", worktreeId: "wt-1" },
+      ],
+      isPending,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it("waits for managed state before removing sessions restored from webview state", () => {
+    const beforeState = reconcileLocalSessions(["local-1"], ["worktree-1"], [], isPending)
+    const afterState = reconcileLocalSessions(
+      ["local-1"],
+      ["worktree-1"],
+      [
+        { id: "local-1", worktreeId: null },
+        { id: "worktree-1", worktreeId: "wt-1" },
+      ],
+      isPending,
+    )
+
+    expect(beforeState).toEqual({ ids: [], forget: ["local-1"] })
+    expect(afterState).toBeUndefined()
+  })
+
+  it("forgets stale local sessions missing from loaded and managed state", () => {
+    const result = reconcileLocalSessions(["s1", "gone"], ["s1"], [{ id: "s1", worktreeId: null }], isPending)
+
+    expect(result).toEqual({ ids: ["s1"], forget: ["gone"] })
+  })
+
+  it("evicts worktree sessions that raced into local state without forgetting them", () => {
+    const result = reconcileLocalSessions(
+      ["local-1", "worktree-1"],
+      ["local-1", "worktree-1"],
+      [
+        { id: "local-1", worktreeId: null },
+        { id: "worktree-1", worktreeId: "wt-1" },
+      ],
+      isPending,
+    )
+
+    expect(result).toEqual({ ids: ["local-1"], forget: [] })
+  })
+
+  it("keeps pending local tabs during reconciliation", () => {
+    const result = reconcileLocalSessions(["pending-1", "gone"], [], [], isPending)
+
+    expect(result).toEqual({ ids: ["pending-1"], forget: ["gone"] })
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -84,7 +84,7 @@ import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { LanguageBridge, DataBridge } from "../src/App"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
-import { validateLocalSession, nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, LOCAL } from "./navigate"
+import { nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, reconcileLocalSessions, LOCAL } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { createTabOrderSync } from "./tab-order-sync"
 import { ConstrainDragYAxis } from "./sortable-tab"
@@ -720,16 +720,18 @@ const AgentManagerContent: Component = () => {
 
   // Invalidate local session IDs if they no longer exist (preserve pending tabs)
   createEffect(() => {
+    if (!worktreesLoaded()) return
     const all = session.sessions()
     if (all.length === 0) return // sessions not loaded yet
-    const ids = all.map((s) => s.id)
-    const prev = localSessionIDs()
-    const valid = prev.filter((lid) => isPending(lid) || validateLocalSession(lid, ids))
-    if (valid.length !== prev.length) {
-      const removed = prev.filter((lid) => !isPending(lid) && !valid.includes(lid))
-      for (const id of removed) vscode.postMessage({ type: "agentManager.forgetSession", sessionId: id })
-      setLocalSessionIDs(valid)
-    }
+    const next = reconcileLocalSessions(
+      localSessionIDs(),
+      all.map((s) => s.id),
+      managedSessions(),
+      isPending,
+    )
+    if (!next) return
+    for (const id of next.forget) vscode.postMessage({ type: "agentManager.forgetSession", sessionId: id })
+    setLocalSessionIDs(next.ids)
   })
   // Drop in-memory review state for worktrees that no longer exist.
   createEffect(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -129,6 +129,35 @@ export function restoreLocalSessions(
   return changed ? merged : undefined
 }
 
+export function reconcileLocalSessions(
+  current: string[],
+  loaded: string[],
+  managed: { id: string; worktreeId: string | null }[],
+  isPending: (id: string) => boolean,
+): { ids: string[]; forget: string[] } | undefined {
+  const seen = new Set(loaded)
+  const local = new Set(managed.filter((s) => !s.worktreeId).map((s) => s.id))
+  const worktree = new Set(managed.filter((s) => s.worktreeId).map((s) => s.id))
+  const ids: string[] = []
+  const forget: string[] = []
+
+  for (const id of current) {
+    if (isPending(id)) {
+      ids.push(id)
+      continue
+    }
+    if (worktree.has(id)) continue
+    if (seen.has(id) || local.has(id)) {
+      ids.push(id)
+      continue
+    }
+    forget.push(id)
+  }
+
+  if (ids.length === current.length && forget.length === 0) return undefined
+  return { ids, forget }
+}
+
 /**
  * After removing a worktree, pick the nearest remaining sidebar neighbor.
  * Order: the worktree just below → the one above → LOCAL.


### PR DESCRIPTION
Fixes a restart-time Agent Manager race where Local sessions restored from persistent state could be treated as stale before managed state and session refreshes finished loading.

Adds focused regression coverage for Local session reconciliation so persisted `worktreeId: null` sessions survive partial refreshes while stale entries and worktree races are still cleaned up.