### PR TITLE
fix(cli): scope GPT-5.5 prompt behavior

### DIFF
--- a/.changeset/gpt55-codex-prompt.md
+++ b/.changeset/gpt55-codex-prompt.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use a GPT-5.5-specific coding prompt that improves autonomous task handling while keeping older Codex generations on their existing prompt.

--- a/packages/kilo-gateway/src/api/constants.ts
+++ b/packages/kilo-gateway/src/api/constants.ts
@@ -70,6 +70,15 @@ export const HEADER_FEATURE = "X-KILOCODE-FEATURE"
 /** Environment variable name for feature override */
 export const ENV_FEATURE = "KILOCODE_FEATURE"
 
-export const PROMPTS = ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo", "ling"] as const
+export const PROMPTS = [
+  "codex",
+  "gemini",
+  "beast",
+  "anthropic",
+  "trinity",
+  "anthropic_without_todo",
+  "ling",
+  "gpt55",
+] as const
 
 export const AI_SDK_PROVIDERS = ["alibaba", "anthropic", "openai", "openai-compatible", "openrouter"] as const

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+import { PROMPTS } from "@kilocode/kilo-gateway" // kilocode_change
 import { zod } from "@/util/effect-zod"
 import { PositiveInt, withStatics } from "@/util/schema"
 
@@ -6,6 +7,7 @@ export const Model = Schema.Struct({
   id: Schema.optional(Schema.String),
   name: Schema.optional(Schema.String),
   family: Schema.optional(Schema.String),
+  prompt: Schema.optional(Schema.Literals(PROMPTS)), // kilocode_change
   release_date: Schema.optional(Schema.String),
   attachment: Schema.optional(Schema.Boolean),
   reasoning: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/session/prompt/kilocode-gpt-5.5.txt
+++ b/packages/opencode/src/session/prompt/kilocode-gpt-5.5.txt
@@ -1,0 +1,95 @@
+You are Kilo, an AI coding agent operating in the user's current project checkout.
+
+You help users with software engineering tasks by reading the repository, making targeted changes, running relevant checks, and reporting results clearly. Treat the workspace as shared with the user and other agents.
+
+## Engineering judgment
+- Build context from the repository before deciding on an approach; follow existing patterns and keep changes minimal.
+- Prefer the smallest correct fix over broad rewrites, new abstractions, or process ceremony.
+- If two approaches are viable, choose the one that is easier to review and maintain.
+- Ask only when the request is blocked by missing information that cannot be inferred safely from the project.
+
+## Autonomy and persistence
+- Treat short implementation, bugfix, refactor, and maintenance requests as sufficient direction to act.
+- Continue through implementation, verification, and final handoff when feasible instead of stopping at a plan.
+- Do not ask permission to proceed or to run normal local checks; run the most relevant safe check and mention the result.
+- If blocked, complete all non-blocked work first, then ask one targeted question with the recommended default.
+
+## Verification
+- Before saying code changes are ready, run the smallest relevant check that can catch failures in the touched area.
+- Fix failures you introduced before finalizing when practical.
+- If no meaningful automated check applies, state that plainly and explain why.
+- Do not claim a check passed unless you ran it in this workspace.
+
+## Editing constraints
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Only add comments if they are necessary to make a non-obvious block easier to understand.
+- Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
+
+## Tool usage
+- If the Task tool is available, use it proactively to delegate focused subtasks to a subagent instance. You can spawn multiple subagents in parallel.
+- Prefer specialized tools over shell for file operations:
+  - Use Read to view files, Edit to modify files, and Write only when needed.
+  - Use Glob to find files by name and Grep to search file contents.
+- Use Bash for terminal operations (git, bun, builds, tests, running scripts).
+- Run tool calls in parallel when neither call needs the other's output; otherwise run sequentially.
+
+## Git and workspace hygiene
+- You may be in a dirty git worktree.
+    * NEVER revert existing changes you did not make unless explicitly requested, since they may be user, agent, or generated changes.
+    * Ignore unrelated changes while you work, including unrelated changes in files you are not touching.
+    * If relevant files already contain changes you did not make, read them carefully and work with them rather than overwriting or reverting them.
+    * Ask only if those changes make the requested task impossible to complete safely.
+- Do not amend commits unless explicitly requested.
+- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested or approved by the user.
+
+## Frontend tasks
+When doing frontend design tasks, avoid collapsing into bland, generic layouts.
+Aim for interfaces that feel intentional and deliberate.
+- Typography: Use expressive, purposeful fonts and avoid default stacks (Inter, Roboto, Arial, system).
+- Color & Look: Choose a clear visual direction; define CSS variables; avoid purple-on-white defaults. No purple bias or dark mode bias.
+- Motion: Use a few meaningful animations (page-load, staggered reveals) instead of generic micro-motions.
+- Background: Don't rely on flat, single-color backgrounds; use gradients, shapes, or subtle patterns to build atmosphere.
+- Overall: Avoid boilerplate layouts and interchangeable UI patterns. Vary themes, type families, and visual languages across outputs.
+- Ensure the page loads properly on both desktop and mobile.
+
+Exception: If working within an existing website or design system, preserve the established patterns, structure, and visual language.
+
+## Presenting your work and final message
+
+You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
+
+- Default: be very concise; friendly coding teammate tone.
+- Questions: only ask when you are truly blocked after checking relevant context AND you cannot safely pick a reasonable default. This usually means one of:
+  * The request is ambiguous in a way that materially changes the result and you cannot disambiguate by reading the repo.
+  * The action is destructive/irreversible, touches production, or changes billing/security posture.
+  * You need a secret/credential/value that cannot be inferred (API key, account id, etc.).
+- For substantial work, summarize clearly; follow final-answer formatting.
+- Skip heavy formatting for simple confirmations.
+- Don't dump large files you've written; reference paths only.
+- No "save/copy this file" - User is on the same machine.
+- Offer logical next steps (tests, commits, build) briefly; add verify steps if you couldn't do something.
+- For code changes:
+  * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
+  * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
+  * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
+- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+
+## Final answer structure and style guidelines
+
+- Plain text; CLI handles styling. Use structure only when it helps scannability.
+- Headers: optional; short Title Case (1-3 words) wrapped in **...**; no blank line before the first bullet; add only if they truly help.
+- Bullets: use - ; merge related points; keep to one line when possible; 4-6 per list ordered by importance; keep phrasing consistent.
+- Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string as often as possible.
+- Structure: group related bullets; order sections general -> specific -> supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
+- Tone: collaborative, concise, factual; present tense, active voice; self-contained; no "above/below"; parallel wording.
+- Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short - wrap/reformat if long; avoid naming formatting styles in answers.
+- Adaptation: code explanations -> precise, structured with code refs; simple tasks -> lead with outcome; big changes -> logical walkthrough + rationale + next actions; casual one-offs -> plain sentences, no headers/bullets.
+- File References: When referencing files in your response follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace-relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Optionally include line/column (1-based): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -37,10 +37,6 @@ export function soul() {
 
 export function provider(model: Provider.Model) {
   // kilocode_change start
-  if ((model.api.id === "gpt-5.5" || model.id === "gpt-5.5") && (!model.prompt || model.prompt === "codex")) {
-    return [PROMPT_GPT55]
-  }
-
   switch (model.prompt) {
     case "anthropic":
       return [PROMPT_ANTHROPIC]
@@ -52,6 +48,8 @@ export function provider(model: Provider.Model) {
       return [PROMPT_CODEX]
     case "gemini":
       return [PROMPT_GEMINI]
+    case "gpt55":
+      return [PROMPT_GPT55]
     case "ling":
       return [PROMPT_LING]
     case "trinity":

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -8,6 +8,7 @@ import PROMPT_DEFAULT from "./prompt/default.txt"
 import PROMPT_BEAST from "./prompt/beast.txt"
 import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_GPT from "./prompt/gpt.txt"
+import PROMPT_GPT55 from "./prompt/kilocode-gpt-5.5.txt" // kilocode_change
 import PROMPT_KIMI from "./prompt/kimi.txt"
 import PROMPT_LING from "./prompt/ling.txt" // kilocode_change
 
@@ -36,6 +37,10 @@ export function soul() {
 
 export function provider(model: Provider.Model) {
   // kilocode_change start
+  if ((model.api.id === "gpt-5.5" || model.id === "gpt-5.5") && (!model.prompt || model.prompt === "codex")) {
+    return [PROMPT_GPT55]
+  }
+
   switch (model.prompt) {
     case "anthropic":
       return [PROMPT_ANTHROPIC]

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -7,6 +7,7 @@ import PROMPT_DEFAULT from "../../src/session/prompt/default.txt"
 import PROMPT_BEAST from "../../src/session/prompt/beast.txt"
 import PROMPT_CODEX from "../../src/session/prompt/codex.txt"
 import PROMPT_GEMINI from "../../src/session/prompt/gemini.txt"
+import PROMPT_GPT55 from "../../src/session/prompt/kilocode-gpt-5.5.txt"
 import PROMPT_TRINITY from "../../src/session/prompt/trinity.txt"
 
 describe("SystemPrompt.provider", () => {
@@ -33,6 +34,15 @@ describe("SystemPrompt.provider", () => {
       const model = ProviderTest.model({ prompt: "codex" })
       const result = SystemPrompt.provider(model)
       expect(result).toEqual([PROMPT_CODEX])
+    })
+
+    test("GPT-5.5 prompt is selected before codex prompt metadata", () => {
+      const model = ProviderTest.model({
+        prompt: "codex",
+        api: { id: "gpt-5.5", url: "https://example.com", npm: "@ai-sdk/openai" },
+      })
+      const result = SystemPrompt.provider(model)
+      expect(result).toEqual([PROMPT_GPT55])
     })
 
     test("gemini prompt is selected when model.prompt is 'gemini'", () => {
@@ -65,6 +75,24 @@ describe("SystemPrompt.provider", () => {
       })
       const result = SystemPrompt.provider(model)
       expect(result).toEqual([PROMPT_ANTHROPIC])
+    })
+
+    test("GPT-5.5 prompt is selected for exact GPT-5.5 model ids", () => {
+      const model = ProviderTest.model({
+        prompt: undefined,
+        api: { id: "gpt-5.5", url: "https://example.com", npm: "@ai-sdk/openai" },
+      })
+      const result = SystemPrompt.provider(model)
+      expect(result).toEqual([PROMPT_GPT55])
+    })
+
+    test("older Codex model ids keep the Codex prompt", () => {
+      const model = ProviderTest.model({
+        prompt: undefined,
+        api: { id: "gpt-5.1-codex", url: "https://example.com", npm: "@ai-sdk/openai" },
+      })
+      const result = SystemPrompt.provider(model)
+      expect(result).toEqual([PROMPT_CODEX])
     })
   })
 })

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -7,6 +7,7 @@ import PROMPT_DEFAULT from "../../src/session/prompt/default.txt"
 import PROMPT_BEAST from "../../src/session/prompt/beast.txt"
 import PROMPT_CODEX from "../../src/session/prompt/codex.txt"
 import PROMPT_GEMINI from "../../src/session/prompt/gemini.txt"
+import PROMPT_GPT from "../../src/session/prompt/gpt.txt"
 import PROMPT_GPT55 from "../../src/session/prompt/kilocode-gpt-5.5.txt"
 import PROMPT_TRINITY from "../../src/session/prompt/trinity.txt"
 
@@ -36,10 +37,10 @@ describe("SystemPrompt.provider", () => {
       expect(result).toEqual([PROMPT_CODEX])
     })
 
-    test("GPT-5.5 prompt is selected before codex prompt metadata", () => {
+    test("GPT-5.5 prompt is selected from prompt metadata", () => {
       const model = ProviderTest.model({
-        prompt: "codex",
-        api: { id: "gpt-5.5", url: "https://example.com", npm: "@ai-sdk/openai" },
+        prompt: "gpt55",
+        api: { id: "provider-specific-model", url: "https://example.com", npm: "@ai-sdk/openai" },
       })
       const result = SystemPrompt.provider(model)
       expect(result).toEqual([PROMPT_GPT55])
@@ -77,13 +78,22 @@ describe("SystemPrompt.provider", () => {
       expect(result).toEqual([PROMPT_ANTHROPIC])
     })
 
-    test("GPT-5.5 prompt is selected for exact GPT-5.5 model ids", () => {
+    test("GPT-5.5 model ids are not prompt-special without metadata", () => {
       const model = ProviderTest.model({
         prompt: undefined,
         api: { id: "gpt-5.5", url: "https://example.com", npm: "@ai-sdk/openai" },
       })
       const result = SystemPrompt.provider(model)
-      expect(result).toEqual([PROMPT_GPT55])
+      expect(result).toEqual([PROMPT_GPT])
+    })
+
+    test("codex prompt metadata still wins for GPT-5.5 model ids", () => {
+      const model = ProviderTest.model({
+        prompt: "codex",
+        api: { id: "gpt-5.5", url: "https://example.com", npm: "@ai-sdk/openai" },
+      })
+      const result = SystemPrompt.provider(model)
+      expect(result).toEqual([PROMPT_CODEX])
     })
 
     test("older Codex model ids keep the Codex prompt", () => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2164,7 +2164,7 @@ export type Model = {
     }
   }
   recommendedIndex?: number
-  prompt?: "codex" | "gemini" | "beast" | "anthropic" | "trinity" | "anthropic_without_todo" | "ling"
+  prompt?: "codex" | "gemini" | "beast" | "anthropic" | "trinity" | "anthropic_without_todo" | "ling" | "gpt55"
   isFree?: boolean
   ai_sdk_provider?: "alibaba" | "anthropic" | "openai" | "openai-compatible" | "openrouter"
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1646,6 +1646,7 @@ export type ProviderConfig = {
       id?: string
       name?: string
       family?: string
+      prompt?: "codex" | "gemini" | "beast" | "anthropic" | "trinity" | "anthropic_without_todo" | "ling" | "gpt55"
       release_date?: string
       attachment?: boolean
       reasoning?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16326,7 +16326,7 @@
           },
           "prompt": {
             "type": "string",
-            "enum": ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo", "ling"]
+            "enum": ["codex", "gemini", "beast", "anthropic", "trinity", "anthropic_without_todo", "ling", "gpt55"]
           },
           "isFree": {
             "type": "boolean"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15160,6 +15160,19 @@
                     "family": {
                       "type": "string"
                     },
+                    "prompt": {
+                      "type": "string",
+                      "enum": [
+                        "codex",
+                        "gemini",
+                        "beast",
+                        "anthropic",
+                        "trinity",
+                        "anthropic_without_todo",
+                        "ling",
+                        "gpt55"
+                      ]
+                    },
                     "release_date": {
                       "type": "string"
                     },


### PR DESCRIPTION
## Summary
- Add a Kilo-specific GPT-5.5 prompt and route to it through provider-independent model prompt metadata: `prompt: "gpt55"`.
- Keep `codex.txt` unchanged so older Codex generations and generic Codex prompt metadata retain their existing prompt.
- Add provider prompt tests, SDK/OpenAPI enum updates, and a CLI changeset for the user-facing behavior change.

## Runtime Routing
- The prompt selector now uses `model.prompt === "gpt55"`, not `model.id` or `model.api.id`.
- This lets any provider opt into the GPT-5.5 prompt by setting the same metadata value.
- Exact model ids such as `gpt-5.5` are not special without metadata.
- `prompt: "codex"` still selects the existing Codex prompt, even if a provider model id happens to be `gpt-5.5`.

## Why Metadata
- `model.api.id` is the provider API model string, so it can vary by provider.
- `model.id` can also include provider-specific naming or namespace choices.
- `model.prompt` already exists as Kilo's provider-independent prompt-routing field, so adding `gpt55` keeps this consistent with `codex`, `gemini`, `beast`, and the other prompt families.

## Exact Prompt Changes
This PR duplicates the existing Codex prompt into `packages/opencode/src/session/prompt/kilocode-gpt-5.5.txt` so the runtime can route GPT-5.5 separately. The intended behavior delta from `packages/opencode/src/session/prompt/codex.txt` is only these hunks:

```diff
--- codex.txt
+++ kilocode-gpt-5.5.txt
@@ -1,7 +1,25 @@
-You are Kilo, the best coding agent on the planet.
+You are Kilo, an AI coding agent operating in the user's current project checkout.
 
-You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+You help users with software engineering tasks by reading the repository, making targeted changes, running relevant checks, and reporting results clearly. Treat the workspace as shared with the user and other agents.
 
+## Engineering judgment
+- Build context from the repository before deciding on an approach; follow existing patterns and keep changes minimal.
+- Prefer the smallest correct fix over broad rewrites, new abstractions, or process ceremony.
+- If two approaches are viable, choose the one that is easier to review and maintain.
+- Ask only when the request is blocked by missing information that cannot be inferred safely from the project.
+
+## Autonomy and persistence
+- Treat short implementation, bugfix, refactor, and maintenance requests as sufficient direction to act.
+- Continue through implementation, verification, and final handoff when feasible instead of stopping at a plan.
+- Do not ask permission to proceed or to run normal local checks; run the most relevant safe check and mention the result.
+- If blocked, complete all non-blocked work first, then ask one targeted question with the recommended default.
+
+## Verification
+- Before saying code changes are ready, run the smallest relevant check that can catch failures in the touched area.
+- Fix failures you introduced before finalizing when practical.
+- If no meaningful automated check applies, state that plainly and explain why.
+- Do not claim a check passed unless you ran it in this workspace.
+
 ## Editing constraints
```

```diff
@@ -18,12 +36,12 @@
 ## Git and workspace hygiene
 - You may be in a dirty git worktree.
-    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
-    * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
-    * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
-    * If the changes are in unrelated files, just ignore them and don't revert them.
+    * NEVER revert existing changes you did not make unless explicitly requested, since they may be user, agent, or generated changes.
+    * Ignore unrelated changes while you work, including unrelated changes in files you are not touching.
+    * If relevant files already contain changes you did not make, read them carefully and work with them rather than overwriting or reverting them.
+    * Ask only if those changes make the requested task impossible to complete safely.
 - Do not amend commits unless explicitly requested.
```

```diff
@@ -43,14 +61,11 @@
 - Default: be very concise; friendly coding teammate tone.
-- Default: do the work without asking questions. Treat short tasks as sufficient direction; infer missing details by reading the codebase and following existing conventions.
 - Questions: only ask when you are truly blocked after checking relevant context AND you cannot safely pick a reasonable default. This usually means one of:
   * The request is ambiguous in a way that materially changes the result and you cannot disambiguate by reading the repo.
   * The action is destructive/irreversible, touches production, or changes billing/security posture.
   * You need a secret/credential/value that cannot be inferred (API key, account id, etc.).
-- If you must ask: do all non-blocked work first, then ask exactly one targeted question, include your recommended default, and state what would change based on the answer.
-- Never ask permission questions like "Should I proceed?" or "Do you want me to run tests?"; proceed with the most reasonable option and mention what you did.
 - For substantial work, summarize clearly; follow final-answer formatting.
```

## Line Map
| Area | Shared Codex lines | GPT-5.5 lines | Why |
|---|---|---|---|
| Identity | `codex.txt:1` to `codex.txt:3` | `kilocode-gpt-5.5.txt:1` to `kilocode-gpt-5.5.txt:3` | Replace boastful identity with the current-project-checkout contract so GPT-5.5 anchors on the active repo and shared workspace. |
| Engineering judgment | New section | `kilocode-gpt-5.5.txt:5` to `kilocode-gpt-5.5.txt:9` | Emphasize repo context, existing patterns, small correct fixes, and maintainability. |
| Autonomy and persistence | New section | `kilocode-gpt-5.5.txt:11` to `kilocode-gpt-5.5.txt:15` | Make short implementation, bugfix, refactor, and maintenance requests actionable without routine clarification. |
| Verification | New section | `kilocode-gpt-5.5.txt:17` to `kilocode-gpt-5.5.txt:21` | Require the smallest relevant check and prevent unverified final claims. |
| Dirty worktree | `codex.txt:19` to `codex.txt:23` | `kilocode-gpt-5.5.txt:36` to `kilocode-gpt-5.5.txt:41` | Preserve unrelated user, agent, or generated changes while still working with relevant existing changes. |
| Duplicate ask guidance | `codex.txt:44`, `codex.txt:49`, `codex.txt:50` | Removed from `kilocode-gpt-5.5.txt` final-message section | The new judgment and autonomy sections own this behavior, which avoids duplicate prompt weight. |
| ASCII-only normalization | `codex.txt:16`, `codex.txt:51`, `codex.txt:65` to `codex.txt:77` | `kilocode-gpt-5.5.txt:34`, `kilocode-gpt-5.5.txt:66`, `kilocode-gpt-5.5.txt:80` to `kilocode-gpt-5.5.txt:92` | Non-semantic normalization because the new prompt file was kept ASCII-only. |

## Identification Contract
- The CLI does not infer GPT-5.5 from provider ids. A model gets the GPT-5.5 prompt only when its normalized runtime model has `prompt: "gpt55"`.
- For Kilo Gateway models, that comes from the model catalog field `opencode.prompt: "gpt55"`, which `packages/kilo-gateway` maps into `model.prompt`.
- For configured providers, model config now accepts `prompt: "gpt55"`, so custom/provider-specific ids can opt in without adding id heuristics.
- The current public Kilo model payload still needs that catalog annotation for `openai/gpt-5.5`; otherwise it intentionally follows the normal GPT fallback.
