### PR TITLE
fix(cli): persist command permission approvals

### DIFF
--- a/.changeset/command-permissions-persist.md
+++ b/.changeset/command-permissions-persist.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Avoid repeated command approval prompts when multiple sessions request the same saved command permission, without widening bash permission matching.

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -159,6 +159,7 @@ interface PendingEntry {
   info: Request
   ruleset: Ruleset // kilocode_change
   hardRuleset?: Ruleset // kilocode_change
+  saved?: boolean // kilocode_change
   deferred: Deferred.Deferred<void, RejectedError | CorrectedError>
 }
 
@@ -309,40 +310,31 @@ export const layer = Layer.effect(
       // kilocode_change end
 
       for (const pattern of existing.info.always) {
-        approved.push({
-          permission: existing.info.permission,
-          pattern,
-          action: "allow",
-        })
+        // kilocode_change start — saveAlwaysRules may have already persisted selected always-rules
+        if (!existing.saved) {
+          approved.push({
+            permission: existing.info.permission,
+            pattern,
+            action: "allow",
+          })
+        }
+        // kilocode_change end
       }
 
-      for (const [id, item] of pending.entries()) {
-        if (item.info.sessionID !== existing.info.sessionID) continue
-        if (ConfigProtection.isRequest(item.info)) continue // kilocode_change
-        // kilocode_change start
-        const ok = item.info.patterns.every((pattern) => {
-          if (veto(item.info.permission, pattern, item.hardRuleset)) return false
-          return evaluate(item.info.permission, pattern, item.ruleset, approved).action === "allow"
-        })
-        // kilocode_change end
-        if (!ok) continue
-        pending.delete(id)
-        yield* bus.publish(Event.Replied, {
-          sessionID: item.info.sessionID,
-          requestID: item.info.id,
-          reply: "always",
-        })
-        yield* Deferred.succeed(item.deferred, undefined)
-      }
+      // kilocode_change start — drain covered permissions across sibling Agent Manager sessions
+      yield* drainCovered(pending as unknown as Map<string, PendingEntry>, approved, DeniedError)
+      // kilocode_change end
 
       // kilocode_change start — persist always-rules to global config
-      const alwaysRules: Ruleset = existing.info.always.map((pattern) => ({
-        permission: existing.info.permission,
-        pattern,
-        action: "allow" as const,
-      }))
-      if (alwaysRules.length > 0) {
-        yield* Effect.promise(() => Config.updateGlobal({ permission: toConfig(alwaysRules) }, { dispose: false }))
+      if (!existing.saved) {
+        const alwaysRules: Ruleset = existing.info.always.map((pattern) => ({
+          permission: existing.info.permission,
+          pattern,
+          action: "allow" as const,
+        }))
+        if (alwaysRules.length > 0) {
+          yield* Effect.promise(() => Config.updateGlobal({ permission: toConfig(alwaysRules) }, { dispose: false }))
+        }
       }
       // kilocode_change end
       return true // kilocode_change
@@ -377,6 +369,7 @@ export const layer = Layer.effect(
         if (deniedSet.has(pattern)) newRules.push({ permission, pattern, action: "deny" })
       }
       s.approved.push(...newRules)
+      existing.saved = true // kilocode_change
 
       if (newRules.length > 0) {
         yield* Effect.promise(() => Config.updateGlobal({ permission: toConfig(newRules) }, { dispose: false }))

--- a/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
+++ b/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
@@ -625,6 +625,48 @@ describe("saveAlwaysRules", () => {
     ),
   )
 
+  it.live("saveAlwaysRules then reply(always) does not duplicate saved rules", () =>
+    withDir({ git: true }, () =>
+      Effect.gen(function* () {
+        const fiber = yield* ask({
+          id: PermissionID.make("permission_saved_always"),
+          sessionID: SessionID.make("session_saved_always"),
+          permission: "bash",
+          patterns: ["kilo-permission-8353 test"],
+          metadata: { rules: ["kilo-permission-8353 *", "kilo-permission-8353 test"] },
+          always: ["kilo-permission-8353 *", "kilo-permission-8353 test"],
+          ruleset: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+        yield* saveAlwaysRules({
+          requestID: PermissionID.make("permission_saved_always"),
+          approvedAlways: ["kilo-permission-8353 test"],
+        })
+        yield* reply({ requestID: PermissionID.make("permission_saved_always"), reply: "always" })
+        yield* Fiber.join(fiber)
+
+        const cfg = yield* Effect.promise(() => Config.get())
+        expect(cfg.permission?.bash).toMatchObject({ "kilo-permission-8353 test": "allow" })
+        expect(cfg.permission?.bash).not.toMatchObject({ "kilo-permission-8353 *": "allow" })
+
+        const broad = yield* ask({
+          id: PermissionID.make("permission_saved_always_broad"),
+          sessionID: SessionID.make("session_saved_always"),
+          permission: "bash",
+          patterns: ["kilo-permission-8353 install"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+        yield* reply({ requestID: PermissionID.make("permission_saved_always_broad"), reply: "reject" })
+        expectFailure(yield* Fiber.await(broad), Permission.RejectedError)
+      }),
+    ),
+  )
+
   it.live("auto-rejects pending permission from sibling session when denied", () =>
     withDir({ git: true }, () =>
       Effect.gen(function* () {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -949,7 +949,8 @@ it.live("reply - always resolves matching pending requests in same session", () 
   ),
 )
 
-it.live("reply - always keeps other session pending", () =>
+// kilocode_change start
+it.live("reply - always resolves matching pending requests from other sessions", () =>
   withDir({ git: true }, () =>
     Effect.gen(function* () {
       const a = yield* ask({
@@ -976,13 +977,47 @@ it.live("reply - always keeps other session pending", () =>
       yield* reply({ requestID: PermissionID.make("per_test6a"), reply: "always" })
 
       yield* Fiber.join(a)
-      expect((yield* list()).map((item) => item.id)).toEqual([PermissionID.make("per_test6b")])
+      yield* Fiber.join(b)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  ),
+)
+
+it.live("reply - always does not resolve dangerous variants from other sessions", () =>
+  withDir({ git: true }, () =>
+    Effect.gen(function* () {
+      const a = yield* ask({
+        id: PermissionID.make("per_test_safe_a"),
+        sessionID: SessionID.make("session_a"),
+        permission: "bash",
+        patterns: ["npm test"],
+        metadata: {},
+        always: ["npm test"],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      const b = yield* ask({
+        id: PermissionID.make("per_test_safe_b"),
+        sessionID: SessionID.make("session_b"),
+        permission: "bash",
+        patterns: ["npm test > ~/.ssh/authorized_keys"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(2)
+      yield* reply({ requestID: PermissionID.make("per_test_safe_a"), reply: "always" })
+
+      yield* Fiber.join(a)
+      expect((yield* list()).map((item) => item.id)).toEqual([PermissionID.make("per_test_safe_b")])
 
       yield* rejectAll()
       yield* Fiber.await(b)
     }),
   ),
 )
+// kilocode_change end
 
 it.live("reply - publishes replied event", () =>
   withDir({ git: true }, () =>


### PR DESCRIPTION
## Summary
Fix repeated command approval prompts by draining covered pending permissions across sessions when an always approval is applied.
Avoid saving broader command rules twice when the selected always-rules path already persisted them, while keeping redirected command variants distinct.

Closes https://github.com/Kilo-Org/kilocode/issues/8353