### PR TITLE
fix(cli): default KILO_PLATFORM to 'cli' for standalone CLI use

### DIFF
--- a/.changeset/cli-default-kilo-platform.md
+++ b/.changeset/cli-default-kilo-platform.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Report standalone CLI usage as `platform=cli` in telemetry instead of leaking the host OS name.

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -50,6 +50,16 @@ if (!process.env[ENV_FEATURE]) {
   process.env[ENV_FEATURE] = isServe ? "unknown" : "cli"
 }
 
+// kilocode_change - default KILO_PLATFORM for the direct-CLI path. Same shape as the
+// KILOCODE_FEATURE default above: embedders (extension, jetbrains, cloud code-review,
+// app-builder) set KILO_PLATFORM themselves before spawning 'kilo serve', so this only
+// catches standalone CLI use. Without this, kilo-telemetry falls back to process.platform
+// and PostHog 'platform' rows show 'darwin'/'linux'/'win32' instead of 'cli'.
+if (!process.env["KILO_PLATFORM"]) {
+  const isServe = process.argv.includes("serve")
+  process.env["KILO_PLATFORM"] = isServe ? "unknown" : "cli"
+}
+
 // kilocode_change - set version so kilo-gateway can include it in the editor name header
 if (!process.env[ENV_VERSION]) {
   process.env[ENV_VERSION] = InstallationVersion


### PR DESCRIPTION
Standalone `kilo` CLI usage is reported to PostHog as `platform=darwin`/`linux`/`win32` instead of `platform=cli`, because the CLI entry point never sets `KILO_PLATFORM` and `kilo-telemetry/telemetry.ts:60` falls back to `process.platform`. Over the last 7 days that accounts for ~9.8k users and ~891k `LLM Completion` events mis-tagged as OS values on the new v7 path (`appName=kilo-cli`).

Embedders that spawn `kilo serve` (VS Code extension, JetBrains plugin, cloud code-review, app-builder) already set `KILO_PLATFORM` themselves, and the cloud session-ingest path (`kilo_meta.platform` in `kilo-sessions.ts:684`) already defaults to `"cli"` — so this one-line default just aligns PostHog with the backend signal. Mirrors the shape of the existing `KILOCODE_FEATURE` default immediately above it.

Refs #9599. Does not address the broader overlap between `KILO_PLATFORM`, `KILO_CLIENT`, and `KILOCODE_FEATURE` — that's a separate cleanup.
