### PR TITLE
feat(cli): add os, osVersion, arch to telemetry properties

### DIFF
--- a/.changeset/telemetry-os-field.md
+++ b/.changeset/telemetry-os-field.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Capture host OS, kernel release, and CPU architecture on telemetry events.

--- a/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
+++ b/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
@@ -88,4 +88,20 @@ describe("Telemetry", () => {
     expect(typeof Telemetry.trackIndexingBatchRetry).toBe("function")
     expect(typeof Telemetry.trackIndexingError).toBe("function")
   })
+
+  test("TelemetryProperties includes os, osVersion, arch", () => {
+    // Type-level assertion: omitting os/osVersion/arch must be a compile error.
+    // Runtime assertion: shape is correct.
+    const sample: import("../telemetry.js").TelemetryProperties = {
+      appName: "kilo-cli",
+      appVersion: "0.0.0",
+      platform: "cli",
+      os: "darwin",
+      osVersion: "23.0.0",
+      arch: "arm64",
+    }
+    expect(sample.os).toBe("darwin")
+    expect(sample.osVersion).toBe("23.0.0")
+    expect(sample.arch).toBe("arm64")
+  })
 })

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -1,3 +1,4 @@
+import os from "os"
 import { Client } from "./client.js"
 import { Identity } from "./identity.js"
 import { TelemetryEvent } from "./events.js"
@@ -8,6 +9,9 @@ export interface TelemetryProperties {
   platform: string
   editorName?: string
   vscodeVersion?: string
+  os: string
+  osVersion: string
+  arch: string
 }
 
 export interface IndexingTelemetryProperties extends Record<string, unknown> {
@@ -56,6 +60,9 @@ export namespace Telemetry {
     appName: "kilo-cli",
     appVersion: "unknown",
     platform: process.platform,
+    os: process.platform,
+    osVersion: os.release(),
+    arch: process.arch,
   }
 
   export async function init(options: { dataPath: string; version: string; enabled: boolean }): Promise<void> {


### PR DESCRIPTION
Adds explicit `os`, `osVersion`, and `arch` fields to the shared telemetry props in `@kilocode/kilo-telemetry`. They're populated once at `Telemetry.init()` from `process.platform`, `os.release()`, and `process.arch`, and flow into every PostHog event and OTel span via the existing `track()` spread.

Context: paired with #9759. Today the `platform` property accidentally double-serves as both client identity (`cli`/`vscode`/`jetbrains`) and host OS (via `process.platform` fallback when `KILO_PLATFORM` is unset). #9759 collapses `platform` to pure client identity; this PR restores OS as a first-class dimension so triage queries, Windows-vs-macOS breakdowns, etc. keep working.

Field naming uses non-prefixed `os` / `osVersion` / `arch` instead of PostHog's `$os` / `$os_version` conventions. The browser SDK auto-captures `$os` with a different value space (`"Mac OS X"`, `"Windows"`, `"Linux"`) while Node's `process.platform` returns `"darwin"` / `"win32"` / `"linux"` — mixing them under one name would muddy existing browser-event queries in dbt (`stg_posthog__person_identity.sql`). Downstream can `coalesce(properties:"$os", properties:"os")` if it ever needs a unified view.

No embedder changes required: VS Code, JetBrains, cloud code-review, and app-builder all spawn `kilo serve` so they inherit these values automatically from the CLI process.
