### PR TITLE
Preserve explicit ask permission gates

### DIFF
--- a/packages/kilo-vscode/src/commands/auto-approve-rules.ts
+++ b/packages/kilo-vscode/src/commands/auto-approve-rules.ts
@@ -1,0 +1,47 @@
+type Action = "allow" | "ask" | "deny"
+type Value = Action | null | Record<string, Action | null>
+
+export type Config = Partial<Record<string, Value>>
+
+type Rule = {
+  permission: string
+  pattern: string
+  action: Action
+}
+
+export function shouldAutoApprove(input: { permission: string; patterns: readonly string[]; config?: Config }): boolean {
+  const patterns = input.patterns.length > 0 ? input.patterns : ["*"]
+  return patterns.every((pattern) => action(input.config, input.permission, pattern) !== "ask")
+}
+
+function action(config: Config | undefined, permission: string, pattern: string): Action | undefined {
+  const list = rules(config)
+  for (const rule of [...list].reverse()) {
+    if (glob(rule.permission, permission) && glob(rule.pattern, pattern)) return rule.action
+  }
+}
+
+function rules(config: Config | undefined): Rule[] {
+  if (!config) return []
+
+  return Object.entries(config)
+    .sort(([a], [b]) => {
+      const aw = a.includes("*")
+      const bw = b.includes("*")
+      return aw === bw ? 0 : aw ? -1 : 1
+    })
+    .flatMap(([permission, value]) => {
+      if (typeof value === "string") return [{ permission, pattern: "*", action: value }]
+      if (!value) return []
+
+      return Object.entries(value)
+        .filter((entry): entry is [string, Action] => entry[1] !== null)
+        .map(([pattern, action]) => ({ permission, pattern, action }))
+    })
+}
+
+function glob(pattern: string, value: string): boolean {
+  if (pattern === "*") return true
+  const source = pattern.replace(/[|\\{}()[\]^$+?.]/g, "\\$&").replace(/\*/g, ".*")
+  return new RegExp(`^${source}$`).test(value)
+}

--- a/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
+++ b/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import type { KiloClient, Event } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../services/cli-backend/connection-service"
+import { shouldAutoApprove, type Config } from "./auto-approve-rules"
 
 /**
  * Callback that resolves the correct working directory for a session.
@@ -82,7 +83,7 @@ export function registerToggleAutoApprove(
     const client = tryGetClient(connectionService)
     if (!client) return
     const dir = resolve(event.properties.sessionID)
-    client.permission.reply({ requestID: event.properties.id, directory: dir, reply: "once" }).catch((err) => {
+    autoReply(client, dir, event).catch((err) => {
       console.error("[Kilo New] toggleAutoApprove: failed to auto-reply:", err)
     })
   })
@@ -106,6 +107,19 @@ export function registerToggleAutoApprove(
       }
     },
   }
+}
+
+async function autoReply(client: KiloClient, dir: string, event: Extract<Event, { type: "permission.asked" }>) {
+  const { data } = await client.config.get({ directory: dir }, { throwOnError: true })
+  if (!shouldAutoApprove({
+    permission: event.properties.permission,
+    patterns: event.properties.patterns ?? [],
+    config: data.permission as Config | undefined,
+  })) {
+    return
+  }
+
+  await client.permission.reply({ requestID: event.properties.id, directory: dir, reply: "once" })
 }
 
 function tryGetClient(connectionService: KiloConnectionService): KiloClient | undefined {

--- a/packages/kilo-vscode/tests/unit/auto-approve-rules.test.ts
+++ b/packages/kilo-vscode/tests/unit/auto-approve-rules.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test"
+import { shouldAutoApprove } from "../../src/commands/auto-approve-rules"
+
+describe("shouldAutoApprove", () => {
+  it("allows auto approval when no explicit config rule matches", () => {
+    expect(shouldAutoApprove({ permission: "bash", patterns: ["pwd"] })).toBe(true)
+  })
+
+  it("blocks auto approval for explicit scalar ask rules", () => {
+    expect(
+      shouldAutoApprove({
+        permission: "supabase_apply_migration",
+        patterns: ["*"],
+        config: { supabase_apply_migration: "ask" },
+      }),
+    ).toBe(false)
+  })
+
+  it("blocks auto approval for explicit wildcard ask rules", () => {
+    expect(
+      shouldAutoApprove({
+        permission: "supabase_apply_migration",
+        patterns: ["*"],
+        config: { "supabase_*": "ask" },
+      }),
+    ).toBe(false)
+  })
+
+  it("auto approves when a specific allow overrides a wildcard ask", () => {
+    expect(
+      shouldAutoApprove({
+        permission: "supabase_get_project_url",
+        patterns: ["*"],
+        config: {
+          "supabase_*": "ask",
+          supabase_get_project_url: "allow",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it("blocks auto approval for matching path-pattern asks", () => {
+    expect(
+      shouldAutoApprove({
+        permission: "bash",
+        patterns: ["pwd"],
+        config: {
+          bash: {
+            "*": "ask",
+            "git status*": "allow",
+          },
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it("auto approves when a path-specific allow overrides a wildcard ask", () => {
+    expect(
+      shouldAutoApprove({
+        permission: "bash",
+        patterns: ["git status --short"],
+        config: {
+          bash: {
+            "*": "ask",
+            "git status*": "allow",
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -16,7 +16,6 @@ import { Flag } from "@/flag/flag"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { Bus } from "@/bus"
-import { Wildcard } from "@/util"
 import { SessionID } from "@/session/schema"
 import { Auth } from "@/auth"
 // kilocode_change start
@@ -261,11 +260,22 @@ const live: Layer.Layer<
         }
         workflowModel.sessionID = input.sessionID
         workflowModel.systemPrompt = system.join("\n")
+        const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
+        const approvedToolsForSession = new Set<string>()
         workflowModel.toolExecutor = async (toolName, argsJson, _requestID) => {
           const t = tools[toolName]
           if (!t || !t.execute) {
             return { result: "", error: `Unknown tool: ${toolName}` }
           }
+
+          const rule = Permission.evaluate(toolName, "*", ruleset)
+          if (rule.action === "deny") {
+            return { result: "", error: `Tool denied by permission rules: ${toolName}` }
+          }
+          if (rule.action === "ask" && !approvedToolsForSession.has(toolName)) {
+            return { result: "", error: `Tool requires approval before execution: ${toolName}` }
+          }
+
           try {
             const result = await t.execute!(JSON.parse(argsJson), {
               toolCallId: _requestID,
@@ -283,16 +293,14 @@ const live: Layer.Layer<
           }
         }
 
-        const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
-        workflowModel.sessionPreapprovedTools = Object.keys(tools).filter((name) => {
-          const match = ruleset.findLast((rule) => Wildcard.match(name, rule.permission))
-          return !match || match.action !== "ask"
-        })
+        workflowModel.sessionPreapprovedTools = preapprovedToolNames(Object.keys(tools), ruleset)
 
         const bridge = yield* EffectBridge.make()
-        const approvedToolsForSession = new Set<string>()
         workflowModel.approvalHandler = Instance.bind(async (approvalTools) => {
           const uniqueNames = [...new Set(approvalTools.map((t: { name: string }) => t.name))] as string[]
+          if (uniqueNames.some((name) => Permission.evaluate(name, "*", ruleset).action === "deny")) {
+            return { approved: false }
+          }
           // Auto-approve tools that were already approved in this session
           // (prevents infinite approval loops for server-side MCP tools)
           if (uniqueNames.every((name) => approvedToolsForSession.has(name))) {
@@ -491,6 +499,10 @@ export function hasToolCalls(messages: ModelMessage[]): boolean {
     }
   }
   return false
+}
+
+export function preapprovedToolNames(toolNames: string[], ruleset: Permission.Ruleset): string[] {
+  return toolNames.filter((name) => Permission.evaluate(name, "*", ruleset).action === "allow")
 }
 
 export * as LLM from "./llm"

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -16,6 +16,7 @@ import type { Agent } from "../../src/agent/agent"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { Permission } from "../../src/permission"
 
 async function getModel(providerID: ProviderID, modelID: ModelID) {
   return AppRuntime.runPromise(
@@ -116,6 +117,46 @@ describe("session.llm.hasToolCalls", () => {
       },
     ] as ModelMessage[]
     expect(LLM.hasToolCalls(messages)).toBe(true)
+  })
+})
+
+describe("session.llm.preapprovedToolNames", () => {
+  test("defaults missing rules to requiring approval", () => {
+    expect(LLM.preapprovedToolNames(["bash", "supabase_apply_migration"], [])).toEqual([])
+  })
+
+  test("only preapproves explicit allow rules", () => {
+    const ruleset = Permission.fromConfig({
+      bash: "allow",
+      read: "deny",
+      supabase_apply_migration: "ask",
+    })
+
+    expect(LLM.preapprovedToolNames(["bash", "read", "supabase_apply_migration"], ruleset)).toEqual(["bash"])
+  })
+
+  test("does not preapprove tools allowed only for specific argument patterns", () => {
+    const ruleset = Permission.fromConfig({
+      bash: {
+        "git status*": "allow",
+      },
+      read: {
+        "*": "allow",
+      },
+    })
+
+    expect(LLM.preapprovedToolNames(["bash", "read"], ruleset)).toEqual(["read"])
+  })
+
+  test("respects specific MCP allow overrides after server wildcard ask", () => {
+    const ruleset = Permission.fromConfig({
+      "supabase_*": "ask",
+      supabase_get_project_url: "allow",
+    })
+
+    expect(
+      LLM.preapprovedToolNames(["supabase_get_project_url", "supabase_apply_migration"], ruleset),
+    ).toEqual(["supabase_get_project_url"])
   })
 })
 


### PR DESCRIPTION
## Summary
- Preserve explicit `ask` permission rules when VS Code Auto Approve is enabled by skipping auto-replies for matching config rules.
- Fail closed for direct/workflow tool execution unless a tool is explicitly allowed or has been approved for the session.
- Add focused tests for Auto Approve rule matching and workflow tool preapproval semantics.

Fixes #9779

## Tests
- `bun test test/session/llm.test.ts`
- `bun test tests/unit/auto-approve-rules.test.ts`
- `bun run typecheck` in `packages/kilo-vscode`
- pre-push `bun turbo typecheck`