### PR TITLE
fix: KaTeX math rendering in VS Code sidebar

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -18,16 +18,21 @@ const max = 200
 const cache = new Map<string, Entry>()
 
 if (typeof window !== "undefined" && DOMPurify.isSupported) {
+  // kilocode_change start: strip style from non-KaTeX elements after sanitization
   DOMPurify.addHook("afterSanitizeAttributes", (node: Element) => {
-    if (!(node instanceof HTMLAnchorElement)) return
-    if (node.target !== "_blank") return
-
-    const rel = node.getAttribute("rel") ?? ""
-    const set = new Set(rel.split(/\s+/).filter(Boolean))
-    set.add("noopener")
-    set.add("noreferrer")
-    node.setAttribute("rel", Array.from(set).join(" "))
+    if (node instanceof HTMLAnchorElement && node.target === "_blank") {
+      const rel = node.getAttribute("rel") ?? ""
+      const set = new Set(rel.split(/\s+/).filter(Boolean))
+      set.add("noopener")
+      set.add("noreferrer")
+      node.setAttribute("rel", Array.from(set).join(" "))
+    }
+    // Only allow inline style on KaTeX elements — strip from everything else
+    if (node.hasAttribute("style") && !node.closest(".katex")) {
+      node.removeAttribute("style")
+    }
   })
+  // kilocode_change end
 }
 
 const config = {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { useMarked, deferredHighlight, fnv1a, katexAttr, katexToken } from "../context/marked"
+import { useMarked, deferredHighlight, fnv1a, katexAttr, katexToken } from "../context/marked" // kilocode_change
 import { useI18n } from "../context/i18n"
 import DOMPurify from "dompurify"
 import morphdom from "morphdom"
@@ -18,6 +18,7 @@ const max = 200
 const cache = new Map<string, Entry>()
 
 if (typeof window !== "undefined" && DOMPurify.isSupported) {
+  // kilocode_change start: scope KaTeX SVG/style sanitizer allowances to generated math.
   DOMPurify.addHook("uponSanitizeAttribute", (node: Element, hook) => {
     if (hook.attrName !== "style") return
     if (node.closest(`[${katexAttr}="${katexToken}"]`)) {
@@ -41,15 +42,16 @@ if (typeof window !== "undefined" && DOMPurify.isSupported) {
     if (node.namespaceURI === "http://www.w3.org/2000/svg" && !math) node.remove()
     if (node.getAttribute(katexAttr) !== katexToken) node.removeAttribute(katexAttr)
   })
+  // kilocode_change end
 }
 
 const config = {
-  USE_PROFILES: { html: true, mathMl: true, svg: true },
+  USE_PROFILES: { html: true, mathMl: true, svg: true }, // kilocode_change
   SANITIZE_NAMED_PROPS: true,
   FORBID_TAGS: ["style"],
-  FORBID_CONTENTS: ["style", "script"],
-  ADD_TAGS: ["svg", "path"],
-  ADD_ATTR: [katexAttr, "d", "viewBox", "preserveAspectRatio", "xmlns"],
+  FORBID_CONTENTS: ["style", "script"], // kilocode_change
+  ADD_TAGS: ["svg", "path"], // kilocode_change
+  ADD_ATTR: [katexAttr, "d", "viewBox", "preserveAspectRatio", "xmlns"], // kilocode_change
 }
 
 const iconPaths = {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { useMarked, deferredHighlight, fnv1a } from "../context/marked"
+import { useMarked, deferredHighlight, fnv1a, katexAttr, katexToken } from "../context/marked"
 import { useI18n } from "../context/i18n"
 import DOMPurify from "dompurify"
 import morphdom from "morphdom"
@@ -18,7 +18,15 @@ const max = 200
 const cache = new Map<string, Entry>()
 
 if (typeof window !== "undefined" && DOMPurify.isSupported) {
-  // kilocode_change start: strip style from non-KaTeX elements after sanitization
+  DOMPurify.addHook("uponSanitizeAttribute", (node: Element, hook) => {
+    if (hook.attrName !== "style") return
+    if (node.closest(`[${katexAttr}="${katexToken}"]`)) {
+      hook.forceKeepAttr = true
+      return
+    }
+    hook.keepAttr = false
+  })
+
   DOMPurify.addHook("afterSanitizeAttributes", (node: Element) => {
     if (node instanceof HTMLAnchorElement && node.target === "_blank") {
       const rel = node.getAttribute("rel") ?? ""
@@ -27,22 +35,21 @@ if (typeof window !== "undefined" && DOMPurify.isSupported) {
       set.add("noreferrer")
       node.setAttribute("rel", Array.from(set).join(" "))
     }
-    // Only allow inline style on KaTeX elements — strip from everything else
-    if (node.hasAttribute("style") && !node.closest(".katex")) {
-      node.removeAttribute("style")
-    }
+
+    const math = node.closest(`[${katexAttr}="${katexToken}"]`)
+    if (node.hasAttribute("style") && !math) node.removeAttribute("style")
+    if (node.namespaceURI === "http://www.w3.org/2000/svg" && !math) node.remove()
+    if (node.getAttribute(katexAttr) !== katexToken) node.removeAttribute(katexAttr)
   })
-  // kilocode_change end
 }
 
 const config = {
-  USE_PROFILES: { html: true, mathMl: true, svg: true }, // kilocode_change: svg needed for KaTeX sqrt/surd rendering
+  USE_PROFILES: { html: true, mathMl: true, svg: true },
   SANITIZE_NAMED_PROPS: true,
-  ADD_ATTR: ["style"], // kilocode_change: KaTeX needs inline style attributes for layout
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
   ADD_TAGS: ["svg", "path"],
-  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns"],
+  ADD_ATTR: [katexAttr, "d", "viewBox", "preserveAspectRatio", "xmlns"],
 }
 
 const iconPaths = {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -31,8 +31,9 @@ if (typeof window !== "undefined" && DOMPurify.isSupported) {
 }
 
 const config = {
-  USE_PROFILES: { html: true, mathMl: true },
+  USE_PROFILES: { html: true, mathMl: true, svg: true }, // kilocode_change: svg needed for KaTeX sqrt/surd rendering
   SANITIZE_NAMED_PROPS: true,
+  ADD_ATTR: ["style"], // kilocode_change: KaTeX needs inline style attributes for layout
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
   ADD_TAGS: ["svg", "path"],

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -14,6 +14,15 @@ import { parseFilePath } from "../file-path" // kilocode_change
 import { createSimpleContext } from "./helper"
 import { getSharedHighlighter, registerCustomTheme, ThemeRegistrationResolved } from "@pierre/diffs"
 
+export const katexAttr = "data-kilo-katex"
+export const katexToken = Math.random().toString(36).slice(2)
+const katexTag = /<span class="(katex(?:-display)?|katex-error)"/
+
+function renderKatex(text: string, display: boolean) {
+  const html = katex.renderToString(text, { displayMode: display, throwOnError: false })
+  return html.replace(katexTag, `<span class="$1" ${katexAttr}="${katexToken}"`)
+}
+
 registerCustomTheme("Kilo", () => {
   return Promise.resolve({
     name: "Kilo",
@@ -396,10 +405,7 @@ function renderMathInText(text: string): string {
   const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
   result = result.replace(displayMathRegex, (_, math) => {
     try {
-      return katex.renderToString(math, {
-        displayMode: true,
-        throwOnError: false,
-      })
+      return renderKatex(math, true)
     } catch {
       return `$$${math}$$`
     }
@@ -693,7 +699,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
               }
             },
             renderer(token) {
-              return `${katex.renderToString(token.text, { displayMode: true, throwOnError: false })}\n`
+              return `${renderKatex(token.text, true)}\n`
             },
           } satisfies TokenizerAndRendererExtension,
           {
@@ -715,7 +721,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
               }
             },
             renderer(token) {
-              return katex.renderToString(token.text, { displayMode: true, throwOnError: false })
+              return renderKatex(token.text, true)
             },
           } satisfies TokenizerAndRendererExtension,
         ],

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -14,6 +14,7 @@ import { parseFilePath } from "../file-path" // kilocode_change
 import { createSimpleContext } from "./helper"
 import { getSharedHighlighter, registerCustomTheme, ThemeRegistrationResolved } from "@pierre/diffs"
 
+// kilocode_change start: tag KaTeX output for scoped sanitizer allowances.
 export const katexAttr = "data-kilo-katex"
 export const katexToken = Math.random().toString(36).slice(2)
 const katexTag = /<span class="(katex(?:-display)?|katex-error)"/
@@ -22,6 +23,7 @@ function renderKatex(text: string, display: boolean) {
   const html = katex.renderToString(text, { displayMode: display, throwOnError: false })
   return html.replace(katexTag, `<span class="$1" ${katexAttr}="${katexToken}"`)
 }
+// kilocode_change end
 
 registerCustomTheme("Kilo", () => {
   return Promise.resolve({
@@ -403,9 +405,9 @@ function renderMathInText(text: string): string {
 
   // Display math: $$...$$
   const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
-  result = result.replace(displayMathRegex, (_, math) => {
+  result = result.replace(displayMathRegex, (_, math) => { // kilocode_change
     try {
-      return renderKatex(math, true)
+      return renderKatex(math, true) // kilocode_change
     } catch {
       return `$$${math}$$`
     }


### PR DESCRIPTION
## Context

KaTeX math formulas in the VS Code sidebar render with missing symbols (sqrt, surd) and broken layout. The DOMPurify sanitizer strips SVG elements and inline style attributes that KaTeX depends on for correct rendering.

Fixes #7905

## Implementation

DOMPurify's default config does not include SVG elements or inline `style` attributes in its allowlists. KaTeX uses both:
- **SVG** for symbols like √ (sqrt/surd) — the radical sign is an SVG path
- **Inline styles** for precise layout positioning (strut heights, kerning, element spacing)

Added `svg: true` to `USE_PROFILES` and `style` to `ADD_ATTR` in the DOMPurify config. This preserves KaTeX's rendered HTML while still blocking `<style>` tags and `<script>` tags.

## How to Test

1. Launch the extension dev host (`bun run extension`)
2. Send a message containing LaTeX: `$$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$`
3. Verify the formula renders with proper layout and the square root symbol is visible