### PR TITLE
fix(vscode): scope thinking level by mode and model

### DIFF
--- a/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test"
+import {
+  getStoredVariant,
+  legacyVariantKey,
+  variantKey,
+} from "../../webview-ui/src/context/session-variant-store"
+import type { ModelSelection } from "../../webview-ui/src/types/messages"
+
+const qwen: ModelSelection = { providerID: "openrouter", modelID: "qwen/qwen3.6-plus" }
+const claude: ModelSelection = { providerID: "anthropic", modelID: "claude-sonnet-4" }
+
+describe("session-variant-store", () => {
+  describe("variantKey", () => {
+    it("includes the agent so two modes using the same model do not collide", () => {
+      expect(variantKey("plan", qwen)).not.toBe(variantKey("code", qwen))
+    })
+
+    it("matches the documented shape", () => {
+      expect(variantKey("plan", qwen)).toBe("plan:openrouter/qwen/qwen3.6-plus")
+    })
+  })
+
+  describe("getStoredVariant", () => {
+    it("returns undefined when nothing is stored for either key shape", () => {
+      expect(getStoredVariant({}, "plan", qwen)).toBeUndefined()
+    })
+
+    it("returns the per-mode entry when present", () => {
+      const variants = { [variantKey("plan", qwen)]: "thinking" }
+      expect(getStoredVariant(variants, "plan", qwen)).toBe("thinking")
+    })
+
+    it("does not leak one mode's choice into another mode (regression for #9757)", () => {
+      const variants = {
+        [variantKey("plan", qwen)]: "thinking",
+        [variantKey("code", qwen)]: "instant",
+      }
+      expect(getStoredVariant(variants, "plan", qwen)).toBe("thinking")
+      expect(getStoredVariant(variants, "code", qwen)).toBe("instant")
+    })
+
+    it("falls back to a legacy single-model entry when no per-mode entry exists", () => {
+      const variants = { [legacyVariantKey(qwen)]: "thinking" }
+      expect(getStoredVariant(variants, "plan", qwen)).toBe("thinking")
+      expect(getStoredVariant(variants, "code", qwen)).toBe("thinking")
+    })
+
+    it("prefers a per-mode entry over a legacy entry for the same model", () => {
+      const variants = {
+        [variantKey("plan", qwen)]: "thinking",
+        [legacyVariantKey(qwen)]: "instant",
+      }
+      expect(getStoredVariant(variants, "plan", qwen)).toBe("thinking")
+      expect(getStoredVariant(variants, "code", qwen)).toBe("instant")
+    })
+
+    it("isolates variants by model identity within the same mode", () => {
+      const variants = {
+        [variantKey("plan", qwen)]: "thinking",
+        [variantKey("plan", claude)]: "instant",
+      }
+      expect(getStoredVariant(variants, "plan", qwen)).toBe("thinking")
+      expect(getStoredVariant(variants, "plan", claude)).toBe("instant")
+    })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
@@ -1,0 +1,33 @@
+import type { ModelSelection } from "../types/messages"
+
+/**
+ * Variant (thinking effort) key construction and lookup.
+ *
+ * Variants are persisted per (mode, model) pair so that two modes using
+ * the same model can keep independent thinking levels. The compound key
+ * `${agent}:${providerID}/${modelID}` separates the mode dimension from
+ * the model identifier with a colon so legacy single-model keys remain
+ * distinguishable for read fallback.
+ */
+
+export function variantKey(agent: string, sel: ModelSelection): string {
+  return `${agent}:${sel.providerID}/${sel.modelID}`
+}
+
+export function legacyVariantKey(sel: ModelSelection): string {
+  return `${sel.providerID}/${sel.modelID}`
+}
+
+/**
+ * Look up the stored variant for (agent, model). Falls back to the
+ * legacy single-model key so users carrying pre-fix entries keep their
+ * last-chosen variant on first read; subsequent writes upgrade to the
+ * compound key.
+ */
+export function getStoredVariant(
+  variants: Record<string, string>,
+  agent: string,
+  sel: ModelSelection,
+): string | undefined {
+  return variants[variantKey(agent, sel)] ?? variants[legacyVariantKey(sel)]
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -46,6 +46,7 @@ import {
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { resolveSessionAgent } from "./session-agent"
+import { getStoredVariant, variantKey } from "./session-variant-store"
 import { errorIDs } from "./session-errors"
 import { PartStash } from "./part-stash"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
@@ -80,7 +81,7 @@ interface SessionStore {
   modelSelections: Record<string, ModelSelection | null> // agentName -> model (global, extension-lifetime)
   sessionOverrides: Record<string, ModelSelection> // sessionID -> per-session model override (compare mode)
   agentSelections: Record<string, string> // sessionID -> agent name
-  variantSelections: Record<string, string> // "providerID/modelID" -> variant name
+  variantSelections: Record<string, string> // "agent:providerID/modelID" -> variant name (legacy "providerID/modelID" entries still readable)
   recentModels: ModelSelection[]
   favoriteModels: ModelSelection[]
 }
@@ -654,9 +655,9 @@ export const SessionProvider: ParentComponent = (props) => {
     clearTimeout(fallback)
   })
 
-  // Variant (thinking effort) selection — keyed by "providerID/modelID"
-  const variantKey = (sel: ModelSelection) => `${sel.providerID}/${sel.modelID}`
-
+  // Variant (thinking effort) selection — keyed by "agent:providerID/modelID"
+  // so two modes using the same model keep independent thinking levels (#9757).
+  // Legacy "providerID/modelID" entries remain readable as a fallback.
   const variantList = () => {
     const sel = selected()
     if (!sel) return []
@@ -670,14 +671,14 @@ export const SessionProvider: ParentComponent = (props) => {
     if (!sel) return undefined
     const list = variantList()
     if (list.length === 0) return undefined
-    const stored = store.variantSelections[variantKey(sel)]
+    const stored = getStoredVariant(store.variantSelections, selectedAgentName(), sel)
     return stored && list.includes(stored) ? stored : list[0]
   }
 
   const selectVariant = (value: string) => {
     const sel = selected()
     if (!sel) return
-    const key = variantKey(sel)
+    const key = variantKey(selectedAgentName(), sel)
     setStore("variantSelections", key, value)
     vscode.postMessage({ type: "persistVariant", key, value })
   }


### PR DESCRIPTION
Variant (thinking effort) selection was keyed by `providerID/modelID` only, so two modes using the same model shared a single stored variant. Switching the thinking level in Plan applied it to Code as well, and vice versa.

Keys are now `agent:providerID/modelID`, matching how the rest of the per-agent state is stored. Reads fall back to the legacy single-model entry so users carrying pre-fix selections keep their last-chosen variant on first load; the next write upgrades the entry to the compound key. No globalState migration is needed.

Extracted the key construction and lookup into `webview-ui/src/context/session-variant-store.ts` so the behavior can be unit-tested in isolation. Coverage spans the regression case, the legacy-fallback path, and per-mode/per-model isolation.

Closes https://github.com/Kilo-Org/kilocode/issues/9757