### PR TITLE
fix(config): backfill missing entries in existing .kilo/.gitignore

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -525,24 +525,26 @@ export const layer = Layer.effect(
       ]
       // kilocode_change end
 
-      const existing = yield* fs.readFileString(gitignore).pipe(
-        Effect.catchIf(
-          (e) => e.reason._tag === "NotFound",
-          () => Effect.succeed(undefined),
-        ),
-        Effect.orDie,
-      )
+      const hasIgnore = yield* fs.existsSafe(gitignore)
 
-      const next = (() => {
-        if (existing === undefined) return required.join("\n")
+      let next: string
+      if (!hasIgnore) {
+        next = required.join("\n")
+      } else {
+        const existing = yield* fs.readFileString(gitignore).pipe(
+          Effect.catchIf(
+            (e) => e.reason._tag === "PermissionDenied",
+            () => Effect.succeed(undefined),
+          ),
+          Effect.orDie,
+        )
+        if (existing === undefined) return
         const present = new Set(existing.split("\n").map((line) => line.trim()))
         const missing = required.filter((entry) => !present.has(entry))
-        if (missing.length === 0) return undefined
+        if (missing.length === 0) return
         const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n"
-        return existing + sep + missing.join("\n") + "\n"
-      })()
-
-      if (next === undefined) return
+        next = existing + sep + missing.join("\n") + "\n"
+      }
 
       yield* fs
         .writeFileString(gitignore, next)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -513,30 +513,45 @@ export const layer = Layer.effect(
 
     const ensureGitignore = Effect.fn("Config.ensureGitignore")(function* (dir: string) {
       const gitignore = path.join(dir, ".gitignore")
-      const hasIgnore = yield* fs.existsSafe(gitignore)
-      if (!hasIgnore) {
-        yield* fs
-          .writeFileString(
-            gitignore,
-            // kilocode_change start - added pnpm-lock.yaml and yarn.lock (not in upstream)
-            [
-              "node_modules",
-              "package.json",
-              "package-lock.json",
-              "pnpm-lock.yaml",
-              "bun.lock",
-              "yarn.lock",
-              ".gitignore",
-            ].join("\n"),
-            // kilocode_change end
-          )
-          .pipe(
-            Effect.catchIf(
-              (e) => e.reason._tag === "PermissionDenied",
-              () => Effect.void,
-            ),
-          )
-      }
+      // kilocode_change start - added pnpm-lock.yaml and yarn.lock (not in upstream)
+      const required = [
+        "node_modules",
+        "package.json",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "bun.lock",
+        "yarn.lock",
+        ".gitignore",
+      ]
+      // kilocode_change end
+
+      const existing = yield* fs.readFileString(gitignore).pipe(
+        Effect.catchIf(
+          (e) => e.reason._tag === "NotFound",
+          () => Effect.succeed(undefined),
+        ),
+        Effect.orDie,
+      )
+
+      const next = (() => {
+        if (existing === undefined) return required.join("\n")
+        const present = new Set(existing.split("\n").map((line) => line.trim()))
+        const missing = required.filter((entry) => !present.has(entry))
+        if (missing.length === 0) return undefined
+        const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n"
+        return existing + sep + missing.join("\n") + "\n"
+      })()
+
+      if (next === undefined) return
+
+      yield* fs
+        .writeFileString(gitignore, next)
+        .pipe(
+          Effect.catchIf(
+            (e) => e.reason._tag === "PermissionDenied",
+            () => Effect.void,
+          ),
+        )
     })
 
     const loadInstanceState = Effect.fn("Config.loadInstanceState")(


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
I keep seeing a `.kilocode/package-lock.json` show up and it's not part of it's own .gitignore. This seems to be related to recent choices switching from a bun runner to an npm runner. as outlined below.

Robit 🤖 says: 

`Config.ensureGitignore` only wrote the .gitignore file when it didn't yet exist. Anyone whose .kilo/ or .kilocode/ was bootstrapped before package-lock.json (and pnpm-lock.yaml / yarn.lock) were added to the template still has the old 4-line gitignore on disk, and the new entries never get backfilled.

Concretely, after `Npm.Service.install` (in
packages/opencode/src/npm/index.ts) calls `arborist.reify()` to install @kilocode/plugin into the .kilo/ dir, an npm-format `package-lock.json` gets written next to the existing `.kilocode/.gitignore`. If that gitignore was generated by an older opencode build, package-lock.json is not listed, and it shows up as untracked in every project the user has touched with Kilo.

This change makes ensureGitignore idempotent against schema drift:
- if no .gitignore exists, write the full template (unchanged behavior)
- if one exists, parse it, append any required entries that aren't already present (exact line match after trim), and leave the rest of the user's content untouched
- preserve trailing newline behavior

The required[] list is hoisted out of the `writeFileString` call so the new-file path and the backfill path share a single source of truth.

Repro:
1. Use any opencode build from before commit 25a2b739e6 ("warn only and ignore plugins without entrypoints, default config via exports", #20284, 2026-03-31), which seeded .kilo/.gitignore with: node_modules / package.json / bun.lock / .gitignore.
2. Update to a current build. Run any project — the bootstrap calls `Config.ensureGitignore`, sees the existing file, and bails out without adding `package-lock.json`.
3. The npm-arborist-based installer (introduced in c9326fc1, #18308, "refactor: replace BunProc with Npm module using @npmcli/arborist", 2026-04-01) writes package-lock.json into the same dir, and it shows up as untracked in `git status`.

References:
- 25a2b739e6 (#20284) — added package-lock.json to the new-file template, fixing the bug only for fresh installs
- c9326fc1 (#18308) — switched from `bun install` shell-out to in-process arborist; this is the change that started writing package-lock.json instead of bun.lock
- 629e866f — follow-up arborist fix for compiled binaries

Files / call chain investigated to confirm the install source:
- bin/kilo (Bun-compiled binary) → embeds @npmcli/arborist
- packages/opencode/src/npm/index.ts — `Npm.Service.install` → `arborist.reify({ add })`
- packages/opencode/src/cli/cmd/tui/config/tui.ts — invokes `Npm.install(dir, { add: [{ name: "@kilocode/plugin", ... }] })` for every config dir at TUI startup
