### PR TITLE
refactor(cli): inline question-tool client gating

### DIFF
--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -37,7 +37,9 @@ export namespace KiloToolRegistry {
 
   function semanticTool(deps: Deps) {
     return Effect.gen(function* () {
-      const ready = yield* Effect.tryPromise(() => import("@/kilocode/indexing").then((mod) => mod.KiloIndexing.ready())).pipe(
+      const ready = yield* Effect.tryPromise(() =>
+        import("@/kilocode/indexing").then((mod) => mod.KiloIndexing.ready()),
+      ).pipe(
         Effect.catch((err) =>
           Effect.sync(() => {
             log.warn("semantic search unavailable", { err })
@@ -64,11 +66,6 @@ export namespace KiloToolRegistry {
       if (!info) return undefined
       return yield* Tool.init(info)
     })
-  }
-
-  /** Override question-tool client gating (adds "vscode" to allowed clients) */
-  export function question(): boolean {
-    return ["app", "cli", "desktop", "vscode"].includes(Flag.KILO_CLIENT) || Flag.KILO_ENABLE_QUESTION_TOOL
   }
 
   /** Plan tool is always registered in Kilo (gated by agent permission instead) */

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -188,8 +188,10 @@ export const layer: Layer.Layer<
         }
 
         const cfg = yield* config.get()
+        // kilocode_change start: add "vscode" to allowed clients
         const questionEnabled =
-          ["app", "cli", "desktop", "vscode"].includes(Flag.KILO_CLIENT) || Flag.KILO_ENABLE_QUESTION_TOOL // kilocode_change: add "vscode" to allowed clients
+          ["app", "cli", "desktop", "vscode"].includes(Flag.KILO_CLIENT) || Flag.KILO_ENABLE_QUESTION_TOOL
+        // kilocode_change end
 
         // kilocode_change start
         const tool = yield* Effect.all({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -188,7 +188,8 @@ export const layer: Layer.Layer<
         }
 
         const cfg = yield* config.get()
-        const questionEnabled = KiloToolRegistry.question() // kilocode_change
+        const questionEnabled =
+          ["app", "cli", "desktop", "vscode"].includes(Flag.KILO_CLIENT) || Flag.KILO_ENABLE_QUESTION_TOOL // kilocode_change: add "vscode" to allowed clients
 
         // kilocode_change start
         const tool = yield* Effect.all({


### PR DESCRIPTION
## Summary

**🚨 DO NOT MERGE BEFORE THE OPENCODE v1.14.29 MERGE 🚨**

Inlines the question-tool client gating back into `packages/opencode/src/tool/registry.ts` instead of going through `KiloToolRegistry.question()`. Extracting that one-liner into a helper reshaped the surrounding upstream line, which was making the opencode rebase harder than it needed to be. Inlining keeps the only real Kilo delta (adding `"vscode"` to the allowed clients) as a single-line `kilocode_change` patch over the upstream code — much easier to carry across merges.

Also drops the now-unused `KiloToolRegistry.question()` export.
