### PR TITLE
Persist auto-approve toggle preference

### DIFF
--- a/.changeset/quiet-shields-remember.md
+++ b/.changeset/quiet-shields-remember.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember the main auto-approve toggle preference across VS Code reloads and extension restarts.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -781,6 +781,11 @@
           "default": false,
           "description": "Load CLAUDE.md instructions and skills from your Claude Code configuration directory into Kilo sessions. Enable this if you want Kilo to use your Claude Code instructions and skills."
         },
+        "kilo-code.new.autoApprove.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Start Kilo Code with the main auto-approve toggle enabled. When enabled, permission prompts are approved automatically."
+        },
         "kilo-code.new.browserAutomation.enabled": {
           "type": "boolean",
           "default": false,

--- a/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
+++ b/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
@@ -20,6 +20,9 @@ export interface AutoApproveController {
   onChange(listener: (active: boolean) => void): { dispose(): void }
 }
 
+const CONFIG = "kilo-code.new.autoApprove"
+const KEY = "enabled"
+
 /**
  * Runtime auto-accept toggle for permissions.
  *
@@ -34,7 +37,7 @@ export function registerToggleAutoApprove(
   resolve: DirectoryResolver,
   directories: AllDirectories,
 ): AutoApproveController {
-  let active = false
+  let active = readActive()
   // Bumped on disable to invalidate in-flight enable drains
   let generation = 0
   const listeners = new Set<(active: boolean) => void>()
@@ -43,10 +46,15 @@ export function registerToggleAutoApprove(
     for (const listener of listeners) listener(active)
   }
 
-  const toggle = async () => {
-    active = !active
+  const setActive = async (next: boolean) => {
+    active = next
     generation++
     notify()
+    await vscode.workspace.getConfiguration(CONFIG).update(KEY, active, target())
+  }
+
+  const toggle = async () => {
+    await setActive(!active)
     const snapshot = generation
 
     if (!active) {
@@ -88,6 +96,16 @@ export function registerToggleAutoApprove(
   })
 
   context.subscriptions.push({ dispose: unsubscribe })
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (!event.affectsConfiguration(`${CONFIG}.${KEY}`)) return
+      const next = readActive()
+      if (next === active) return
+      active = next
+      generation++
+      notify()
+    }),
+  )
 
   context.subscriptions.push(vscode.commands.registerCommand("kilo-code.new.toggleAutoApprove", toggle))
 
@@ -106,6 +124,17 @@ export function registerToggleAutoApprove(
       }
     },
   }
+}
+
+function readActive(): boolean {
+  return vscode.workspace.getConfiguration(CONFIG).get(KEY, false)
+}
+
+function target(): vscode.ConfigurationTarget {
+  const info = vscode.workspace.getConfiguration(CONFIG).inspect<boolean>(KEY)
+  if (info?.workspaceFolderValue !== undefined) return vscode.ConfigurationTarget.WorkspaceFolder
+  if (info?.workspaceValue !== undefined) return vscode.ConfigurationTarget.Workspace
+  return vscode.ConfigurationTarget.Global
 }
 
 function tryGetClient(connectionService: KiloConnectionService): KiloClient | undefined {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1017,6 +1017,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   ? language.t("prompt.action.autoApprove.disable")
                   : language.t("prompt.action.autoApprove.enable")
               }
+              aria-pressed={autoApprove()}
               class={`prompt-auto-approve-button ${autoApprove() ? "prompt-auto-approve-button--active" : ""}`}
             >
               <Icon name="shield" size="small" />


### PR DESCRIPTION
## Summary
- Persist the main auto-approve toggle in VS Code settings so it survives reloads and extension restarts.
- Keep new users safe with the default off state and leave existing permission rule behavior unchanged.

Closes #9814