### PR TITLE
fix(cli): warn on output length stops

### DIFF
--- a/.changeset/quiet-ollamas-think.md
+++ b/.changeset/quiet-ollamas-think.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Warn when a model hits its output limit while only producing reasoning.

--- a/.changeset/quiet-ollamas-think.md
+++ b/.changeset/quiet-ollamas-think.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Warn when a model hits its output limit while only producing reasoning.
+Warn when a model hits its output limit before finishing a response.

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -10,6 +10,8 @@ import { Flag } from "@/flag/flag"
 
 export namespace KiloSessionProcessor {
   const log = Log.create({ service: "session.processor.kilo" })
+  export const REASONING_LENGTH_WARNING =
+    "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
 
   /**
    * Track LLM completion telemetry for a finished step.
@@ -121,5 +123,17 @@ export namespace KiloSessionProcessor {
       log.warn("empty tool-calls", { messageID: msg.id })
       msg.finish = "stop"
     }
+  }
+
+  export function reasoningLengthWarning(input: {
+    msg: MessageV2.Assistant
+    step: { reasoning: boolean; text: boolean; tool: boolean }
+  }) {
+    if (input.msg.summary) return
+    if (input.msg.finish !== "length") return
+    if (!input.step.reasoning) return
+    if (input.step.text || input.step.tool) return
+    log.warn("reasoning-only length stop", { messageID: input.msg.id })
+    return REASONING_LENGTH_WARNING
   }
 }

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -10,6 +10,7 @@ import { Flag } from "@/flag/flag"
 
 export namespace KiloSessionProcessor {
   const log = Log.create({ service: "session.processor.kilo" })
+  export const OUTPUT_LENGTH_WARNING = "The model hit its output limit, so this response may be incomplete."
   export const REASONING_LENGTH_WARNING =
     "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
 
@@ -125,15 +126,17 @@ export namespace KiloSessionProcessor {
     }
   }
 
-  export function reasoningLengthWarning(input: {
+  export function lengthWarning(input: {
     msg: MessageV2.Assistant
     step: { reasoning: boolean; text: boolean; tool: boolean }
   }) {
     if (input.msg.summary) return
     if (input.msg.finish !== "length") return
-    if (!input.step.reasoning) return
-    if (input.step.text || input.step.tool) return
-    log.warn("reasoning-only length stop", { messageID: input.msg.id })
-    return REASONING_LENGTH_WARNING
+    if (input.step.reasoning && !input.step.text && !input.step.tool) {
+      log.warn("reasoning-only length stop", { messageID: input.msg.id })
+      return REASONING_LENGTH_WARNING
+    }
+    log.warn("length stop", { messageID: input.msg.id })
+    return OUTPUT_LENGTH_WARNING
   }
 }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -909,7 +909,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         parts: [],
       }
       for (const part of msg.parts) {
-        if (part.type === "text")
+        if (part.type === "text" && !part.ignored) // kilocode_change - keep local UI warnings out of future prompts
           assistantMessage.parts.push({
             type: "text",
             text: part.text,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -448,8 +448,8 @@ export const layer: Layer.Layer<
               tokens: usage.tokens,
               cost: usage.cost,
             })
-            // kilocode_change start - surface local reasoning models that hit length before producing output
-            const warn = KiloSessionProcessor.reasoningLengthWarning({ msg: ctx.assistantMessage, step: ctx.step })
+            // kilocode_change start - surface output limit stops, with a stronger message for reasoning-only stops
+            const warn = KiloSessionProcessor.lengthWarning({ msg: ctx.assistantMessage, step: ctx.step })
             if (warn) {
               yield* session.updatePart({
                 id: PartID.ascending(),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -75,6 +75,7 @@ interface ProcessorContext extends Input {
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
   stepStart: number // kilocode_change
+  step: { reasoning: boolean; text: boolean; tool: boolean } // kilocode_change
 }
 
 type StreamEvent = Event
@@ -126,6 +127,7 @@ export const layer: Layer.Layer<
         currentText: undefined,
         reasoningMap: {},
         stepStart: 0, // kilocode_change
+        step: { reasoning: false, text: false, tool: false }, // kilocode_change
       }
       let aborted = false
       const ac = new AbortController() // kilocode_change — abort controller for offline handler
@@ -249,6 +251,7 @@ export const layer: Layer.Layer<
 
           case "reasoning-start":
             if (value.id in ctx.reasoningMap) return
+            ctx.step.reasoning = true // kilocode_change
             ctx.reasoningMap[value.id] = {
               id: PartID.ascending(),
               messageID: ctx.assistantMessage.id,
@@ -288,6 +291,7 @@ export const layer: Layer.Layer<
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
+            ctx.step.tool = true // kilocode_change
             const part = yield* session.updatePart({
               id: ctx.toolcalls[value.id]?.partID ?? PartID.ascending(),
               messageID: ctx.assistantMessage.id,
@@ -316,6 +320,7 @@ export const layer: Layer.Layer<
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
+            ctx.step.tool = true // kilocode_change
             // kilocode_change start — create tool part if tool-input-start was never emitted
             if (!ctx.toolcalls[value.toolCallId]) {
               log.warn("tool-call without prior tool-input-start", {
@@ -401,6 +406,7 @@ export const layer: Layer.Layer<
 
           case "start-step":
             ctx.stepStart = performance.now() // kilocode_change
+            ctx.step = { reasoning: false, text: false, tool: false } // kilocode_change
             if (!ctx.snapshot) ctx.snapshot = yield* snapshot.track()
             yield* session.updatePart({
               id: PartID.ascending(),
@@ -442,6 +448,19 @@ export const layer: Layer.Layer<
               tokens: usage.tokens,
               cost: usage.cost,
             })
+            // kilocode_change start - surface local reasoning models that hit length before producing output
+            const warn = KiloSessionProcessor.reasoningLengthWarning({ msg: ctx.assistantMessage, step: ctx.step })
+            if (warn) {
+              yield* session.updatePart({
+                id: PartID.ascending(),
+                messageID: ctx.assistantMessage.id,
+                sessionID: ctx.assistantMessage.sessionID,
+                type: "text",
+                text: warn,
+                ignored: true,
+              })
+            }
+            // kilocode_change end
             yield* session.updateMessage(ctx.assistantMessage)
             if (ctx.snapshot) {
               const patch = yield* snapshot.patch(ctx.snapshot)
@@ -488,6 +507,7 @@ export const layer: Layer.Layer<
           case "text-delta":
             if (!ctx.currentText) return
             ctx.currentText.text += value.text
+            if (value.text.trim()) ctx.step.text = true // kilocode_change
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
             yield* session.updatePartDelta({
               sessionID: ctx.currentText.sessionID,
@@ -511,6 +531,7 @@ export const layer: Layer.Layer<
               },
               { text: ctx.currentText.text },
             )).text
+            if (ctx.currentText.text.trim()) ctx.step.text = true // kilocode_change
             {
               const end = Date.now()
               ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }
@@ -618,6 +639,7 @@ export const layer: Layer.Layer<
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
+            ctx.step = { reasoning: false, text: false, tool: false } // kilocode_change
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -18,6 +18,7 @@ import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
 import { Snapshot } from "../../src/snapshot"
+import { KiloSessionProcessor } from "../../src/kilocode/session/processor"
 import { Log } from "../../src/util"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { provideTmpdirInstance } from "../fixture/fixture"
@@ -178,6 +179,87 @@ describe("session processor empty tool-calls", () => {
           const parts = MessageV2.parts(msg.id)
           const tools = parts.filter((p) => p.type === "tool")
           expect(tools.length).toBe(0)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.effect("adds warning when model stops after reasoning-only length finish", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "reasoning-start", id: "reasoning", providerMetadata: undefined } as LLM.Event,
+            { type: "reasoning-delta", id: "reasoning", text: "thinking", providerMetadata: undefined } as LLM.Event,
+            { type: "reasoning-end", id: "reasoning", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "length",
+              usage: usage(),
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          yield* handle.process(input)
+          const parts = MessageV2.parts(msg.id)
+          const warning = parts.find(
+            (part): part is MessageV2.TextPart =>
+              part.type === "text" && part.text === KiloSessionProcessor.REASONING_LENGTH_WARNING,
+          )
+
+          expect(warning?.ignored).toBe(true)
+
+          const modelMsgs = yield* MessageV2.toModelMessagesEffect([{ info: handle.message, parts }], mdl)
+          expect(JSON.stringify(modelMsgs)).not.toContain(KiloSessionProcessor.REASONING_LENGTH_WARNING)
         }),
       { git: true },
     ),

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -265,6 +265,89 @@ describe("session processor empty tool-calls", () => {
     ),
   )
 
+  it.effect("adds generic warning when model stops after text length finish", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "text-start", id: "text", providerMetadata: undefined } as LLM.Event,
+            { type: "text-delta", id: "text", text: "partial answer", providerMetadata: undefined } as LLM.Event,
+            { type: "text-end", id: "text", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "length",
+              usage: usage(),
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          yield* handle.process(input)
+          const parts = MessageV2.parts(msg.id)
+          const warning = parts.find(
+            (part): part is MessageV2.TextPart =>
+              part.type === "text" && part.text === KiloSessionProcessor.OUTPUT_LENGTH_WARNING,
+          )
+
+          expect(warning?.ignored).toBe(true)
+
+          const modelMsgs = yield* MessageV2.toModelMessagesEffect([{ info: handle.message, parts }], mdl)
+          const json = JSON.stringify(modelMsgs)
+          expect(json).toContain("partial answer")
+          expect(json).not.toContain(KiloSessionProcessor.OUTPUT_LENGTH_WARNING)
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("ignores deleted session during cost reconciliation", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
## Summary
Models can finish with `length` when they hit their output limit, which means the response may be incomplete even if Kilo otherwise looks idle or done. This PR adds a generic visible warning for that case.

Local/OpenAI-compatible reasoning models, especially Ollama models, have a worse version of this failure mode: they can spend the whole output budget in reasoning before producing any assistant text or tool call. For that exact case (`finish=length`, reasoning emitted, no text, no tool call), Kilo now shows a stronger warning that the model hit its limit while reasoning and produced no actionable output.

Both warnings are marked ignored so they are visible to the user but are not sent back into future model context. This does not change model behavior or automatically retry, it makes output-limit stops understandable instead of looking like Kilo silently stopped.

## Related local-model issues
Related, not fully closed by this mitigation: #659, #8194.
