### PR TITLE
Fix OAuth callback port flake

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -742,7 +742,7 @@ export const layer = Layer.effect(
       return mcpConfig
     })
 
-    const startAuth = Effect.fn("MCP.startAuth")(function* (mcpName: string) {
+    const startAuth = Effect.fn("MCP.startAuth")(function* (mcpName: string, opts?: { callback?: boolean }) {
       const mcpConfig = yield* getMcpConfig(mcpName)
       if (!mcpConfig) throw new Error(`MCP server ${mcpName} not found or disabled`)
       if (mcpConfig.type !== "remote") throw new Error(`MCP server ${mcpName} is not a remote server`)
@@ -751,8 +751,11 @@ export const layer = Layer.effect(
       // OAuth config is optional - if not provided, we'll use auto-discovery
       const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
 
-      // Start the callback server with custom redirectUri if configured
-      yield* Effect.promise(() => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri))
+      // kilocode_change start - authenticate() defers binding the callback port until a redirect is needed
+      if (opts?.callback !== false) {
+        yield* Effect.promise(() => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri))
+      }
+      // kilocode_change end
 
       const oauthState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
         .map((b) => b.toString(16).padStart(2, "0"))
@@ -798,7 +801,7 @@ export const layer = Layer.effect(
     })
 
     const authenticate = Effect.fn("MCP.authenticate")(function* (mcpName: string) {
-      const result = yield* startAuth(mcpName)
+      const result = yield* startAuth(mcpName, { callback: false })
       if (!result.authorizationUrl) {
         const client = "client" in result ? result.client : undefined
         const mcpConfig = yield* getMcpConfig(mcpName)
@@ -819,6 +822,12 @@ export const layer = Layer.effect(
       }
 
       log.info("opening browser for oauth", { mcpName, url: result.authorizationUrl, state: result.oauthState })
+
+      const mcpConfig = yield* getMcpConfig(mcpName)
+      if (!mcpConfig) return { status: "failed", error: "MCP config not found after auth" } as Status
+      if (mcpConfig.type !== "remote") return { status: "failed", error: `MCP server ${mcpName} is not a remote server` } as Status
+      const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
+      yield* Effect.promise(() => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri))
 
       const callbackPromise = McpOAuthCallback.waitForCallback(result.oauthState, mcpName)
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -742,7 +742,7 @@ export const layer = Layer.effect(
       return mcpConfig
     })
 
-    const startAuth = Effect.fn("MCP.startAuth")(function* (mcpName: string, opts?: { callback?: boolean }) {
+    const startAuth = Effect.fn("MCP.startAuth")(function* (mcpName: string, opts?: { callback?: boolean }) { // kilocode_change
       const mcpConfig = yield* getMcpConfig(mcpName)
       if (!mcpConfig) throw new Error(`MCP server ${mcpName} not found or disabled`)
       if (mcpConfig.type !== "remote") throw new Error(`MCP server ${mcpName} is not a remote server`)
@@ -801,7 +801,7 @@ export const layer = Layer.effect(
     })
 
     const authenticate = Effect.fn("MCP.authenticate")(function* (mcpName: string) {
-      const result = yield* startAuth(mcpName, { callback: false })
+      const result = yield* startAuth(mcpName, { callback: false }) // kilocode_change
       if (!result.authorizationUrl) {
         const client = "client" in result ? result.client : undefined
         const mcpConfig = yield* getMcpConfig(mcpName)
@@ -823,11 +823,29 @@ export const layer = Layer.effect(
 
       log.info("opening browser for oauth", { mcpName, url: result.authorizationUrl, state: result.oauthState })
 
+      // kilocode_change start - bind only after redirect exists, and clean up if binding fails
       const mcpConfig = yield* getMcpConfig(mcpName)
       if (!mcpConfig) return { status: "failed", error: "MCP config not found after auth" } as Status
       if (mcpConfig.type !== "remote") return { status: "failed", error: `MCP server ${mcpName} is not a remote server` } as Status
       const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
-      yield* Effect.promise(() => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri))
+      const err = yield* Effect.tryPromise({
+        try: () => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.match({
+          onFailure: (err) => err,
+          onSuccess: () => undefined,
+        }),
+      )
+      if (err) {
+        const transport = pendingOAuthTransports.get(mcpName)
+        pendingOAuthTransports.delete(mcpName)
+        yield* auth.clearOAuthState(mcpName)
+        yield* auth.clearCodeVerifier(mcpName)
+        yield* Effect.tryPromise(() => transport?.close() ?? Promise.resolve()).pipe(Effect.ignore)
+        return { status: "failed", error: err.message } as Status
+      }
+      // kilocode_change end
 
       const callbackPromise = McpOAuthCallback.waitForCallback(result.oauthState, mcpName)
 

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, mock, beforeEach } from "bun:test"
 import { Effect } from "effect"
-import { createServer } from "http"
+import { createServer } from "http" // kilocode_change
 
 // Mock UnauthorizedError to match the SDK's class
 class MockUnauthorizedError extends Error {
@@ -110,6 +110,7 @@ beforeEach(() => {
   connectSucceedsImmediately = false
 })
 
+// kilocode_change start
 async function occupy(port: number) {
   const srv = createServer()
   const bound = await new Promise<boolean>((resolve, reject) => {
@@ -136,12 +137,13 @@ async function occupy(port: number) {
     },
   }
 }
+// kilocode_change end
 
 // Import modules after mocking
 const { MCP } = await import("../../src/mcp/index")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
-const { OAUTH_CALLBACK_PORT } = await import("../../src/mcp/oauth-provider")
+const { OAUTH_CALLBACK_PORT } = await import("../../src/mcp/oauth-provider") // kilocode_change
 
 test("first connect to OAuth server shows needs_auth instead of failed", async () => {
   await using tmp = await tmpdir({
@@ -280,8 +282,10 @@ test("authenticate() stores a connected client when auth completes without redir
       )
     },
   })
+  // kilocode_change start
   await using port = await occupy(OAUTH_CALLBACK_PORT)
   void port
+  // kilocode_change end
 
   await Instance.provide({
     directory: tmp.path,

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, mock, beforeEach } from "bun:test"
 import { Effect } from "effect"
+import { createServer } from "http"
 
 // Mock UnauthorizedError to match the SDK's class
 class MockUnauthorizedError extends Error {
@@ -109,10 +110,38 @@ beforeEach(() => {
   connectSucceedsImmediately = false
 })
 
+async function occupy(port: number) {
+  const srv = createServer()
+  const bound = await new Promise<boolean>((resolve, reject) => {
+    const fail = (err: Error & { code?: string }) => {
+      srv.off("error", fail)
+      if (err.code === "EADDRINUSE") {
+        resolve(false)
+        return
+      }
+      reject(err)
+    }
+
+    srv.once("error", fail)
+    srv.listen(port, "127.0.0.1", () => {
+      srv.off("error", fail)
+      resolve(true)
+    })
+  })
+
+  return {
+    async [Symbol.asyncDispose]() {
+      if (!bound) return
+      await new Promise<void>((resolve) => srv.close(() => resolve()))
+    },
+  }
+}
+
 // Import modules after mocking
 const { MCP } = await import("../../src/mcp/index")
 const { Instance } = await import("../../src/project/instance")
 const { tmpdir } = await import("../fixture/fixture")
+const { OAUTH_CALLBACK_PORT } = await import("../../src/mcp/oauth-provider")
 
 test("first connect to OAuth server shows needs_auth instead of failed", async () => {
   await using tmp = await tmpdir({
@@ -251,6 +280,8 @@ test("authenticate() stores a connected client when auth completes without redir
       )
     },
   })
+  await using port = await occupy(OAUTH_CALLBACK_PORT)
+  void port
 
   await Instance.provide({
     directory: tmp.path,


### PR DESCRIPTION
## Summary
- Defer binding the MCP OAuth callback server until an auth flow actually needs a browser redirect.
- Cover the no-redirect authenticate path while the default callback port is already occupied.