### PR TITLE
fix(cli): keep env reads behind ask

### DIFF
--- a/.changeset/quiet-envs-ask.md
+++ b/.changeset/quiet-envs-ask.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prompt before reading `.env` files even after broad read permissions were previously approved.

--- a/packages/opencode/src/kilocode/permission/drain.ts
+++ b/packages/opencode/src/kilocode/permission/drain.ts
@@ -27,7 +27,7 @@ export function drainCovered(
       // Never auto-resolve config file edit permissions
       if (ConfigProtection.isRequest(entry.info)) continue
       const actions = entry.info.patterns.map((pattern: string) => {
-        const rule = Permission.evaluate(entry.info.permission, pattern, entry.ruleset, approved)
+        const rule = Permission.resolve(entry.info.permission, pattern, entry.ruleset, approved)
         const hard = entry.hardRuleset
           ? Permission.evaluate(entry.info.permission, pattern, entry.hardRuleset)
           : undefined

--- a/packages/opencode/src/kilocode/permission/external-directory.ts
+++ b/packages/opencode/src/kilocode/permission/external-directory.ts
@@ -1,21 +1,10 @@
 import { evaluate as evalRule } from "@/permission/evaluate"
-
-type Rule = {
-  permission: string
-  pattern: string
-  action: "allow" | "deny" | "ask"
-}
-
-type Ruleset = Rule[]
-
-function mode(rule: Rule) {
-  return rule.permission === "*" && rule.pattern === "*" && rule.action === "deny"
-}
+import { PermissionRule, type Ruleset } from "@/kilocode/permission/rule"
 
 function rules(permission: string, ruleset?: Ruleset) {
   if (!ruleset) return []
   if (permission !== "external_directory") return ruleset
-  return ruleset.filter((rule) => !mode(rule))
+  return ruleset.filter((rule) => !PermissionRule.mode(rule))
 }
 
 export namespace ExternalDirectoryPermission {

--- a/packages/opencode/src/kilocode/permission/read.ts
+++ b/packages/opencode/src/kilocode/permission/read.ts
@@ -1,0 +1,24 @@
+import { Wildcard } from "@/util/wildcard"
+
+type Rule = {
+  permission: string
+  pattern: string
+  action: "allow" | "deny" | "ask"
+}
+
+function guard(pattern: string) {
+  if (Wildcard.match(pattern, "*.env.example")) return
+  if (Wildcard.match(pattern, "*.env")) return "*.env"
+  if (Wildcard.match(pattern, "*.env.*")) return "*.env.*"
+}
+
+export namespace ReadPermission {
+  export function harden(permission: string, pattern: string, rule: Rule): Rule {
+    if (permission !== "read") return rule
+    if (rule.action !== "allow") return rule
+    const match = guard(pattern)
+    if (!match) return rule
+    if (rule.pattern !== "*" && rule.permission !== "*") return rule
+    return { permission, pattern: match, action: "ask" }
+  }
+}

--- a/packages/opencode/src/kilocode/permission/read.ts
+++ b/packages/opencode/src/kilocode/permission/read.ts
@@ -1,10 +1,5 @@
 import { Wildcard } from "@/util/wildcard"
-
-type Rule = {
-  permission: string
-  pattern: string
-  action: "allow" | "deny" | "ask"
-}
+import { PermissionRule, type Rule } from "@/kilocode/permission/rule"
 
 function guard(pattern: string) {
   if (Wildcard.match(pattern, "*.env.example")) return
@@ -18,7 +13,7 @@ export namespace ReadPermission {
     if (rule.action !== "allow") return rule
     const match = guard(pattern)
     if (!match) return rule
-    if (rule.pattern !== "*" && rule.permission !== "*") return rule
+    if (!PermissionRule.broad(rule)) return rule
     return { permission, pattern: match, action: "ask" }
   }
 }

--- a/packages/opencode/src/kilocode/permission/rule.ts
+++ b/packages/opencode/src/kilocode/permission/rule.ts
@@ -1,0 +1,17 @@
+export type Rule = {
+  permission: string
+  pattern: string
+  action: "allow" | "deny" | "ask"
+}
+
+export type Ruleset = Rule[]
+
+export namespace PermissionRule {
+  export function broad(rule: Rule) {
+    return rule.permission === "*" || rule.pattern === "*"
+  }
+
+  export function mode(rule: Rule) {
+    return rule.permission === "*" && rule.pattern === "*" && rule.action === "deny"
+  }
+}

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -177,6 +177,36 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Rules
 }
 
 // kilocode_change start
+function readGuard(pattern: string) {
+  if (Wildcard.match(pattern, "*.env.example")) return
+  if (Wildcard.match(pattern, "*.env")) return "*.env"
+  if (Wildcard.match(pattern, "*.env.*")) return "*.env.*"
+}
+
+function harden(permission: string, pattern: string, rule: Rule): Rule {
+  if (permission !== "read") return rule
+  if (rule.action !== "allow") return rule
+  const guard = readGuard(pattern)
+  if (!guard) return rule
+  if (rule.pattern !== "*" && rule.permission !== "*") return rule
+  return { permission, pattern: guard, action: "ask" }
+}
+
+export function resolve(permission: string, pattern: string, ruleset: Ruleset, ...overrides: Ruleset[]): Rule {
+  const base = harden(permission, pattern, evaluate(permission, pattern, ruleset))
+  const saved = evaluate(permission, pattern, ...overrides)
+  if (base.action === "deny") return base
+  if (saved.action === "deny") return saved
+  if (base.action === "ask") {
+    if (saved.action === "allow" && Wildcard.match(saved.pattern, base.pattern)) return saved
+    return base
+  }
+  if (saved.action === "allow") return saved
+  return base
+}
+// kilocode_change end
+
+// kilocode_change start
 function veto(permission: string, pattern: string, ruleset?: Ruleset) {
   if (!ruleset) return false
   return evaluate(permission, pattern, ruleset).action === "deny"
@@ -229,7 +259,7 @@ export const layer = Layer.effect(
       // kilocode_change end
 
       for (const pattern of request.patterns) {
-        const rule = evaluate(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
+        const rule = resolve(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
         log.info("evaluated", { permission: request.permission, pattern, action: rule })
         // kilocode_change start — saved/session approvals cannot override hard Ask/Plan denials
         if (veto(request.permission, pattern, hardRuleset)) {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -21,6 +21,7 @@ import { makeRuntime } from "@/effect/run-service" // kilocode_change
 import { ConfigProtection } from "@/kilocode/permission/config-paths" // kilocode_change
 import { Identifier } from "@/id/id" // kilocode_change
 import { drainCovered } from "@/kilocode/permission/drain" // kilocode_change
+import { ReadPermission } from "@/kilocode/permission/read" // kilocode_change
 
 const log = Log.create({ service: "permission" })
 
@@ -177,23 +178,8 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Rules
 }
 
 // kilocode_change start
-function readGuard(pattern: string) {
-  if (Wildcard.match(pattern, "*.env.example")) return
-  if (Wildcard.match(pattern, "*.env")) return "*.env"
-  if (Wildcard.match(pattern, "*.env.*")) return "*.env.*"
-}
-
-function harden(permission: string, pattern: string, rule: Rule): Rule {
-  if (permission !== "read") return rule
-  if (rule.action !== "allow") return rule
-  const guard = readGuard(pattern)
-  if (!guard) return rule
-  if (rule.pattern !== "*" && rule.permission !== "*") return rule
-  return { permission, pattern: guard, action: "ask" }
-}
-
 export function resolve(permission: string, pattern: string, ruleset: Ruleset, ...overrides: Ruleset[]): Rule {
-  const base = harden(permission, pattern, evaluate(permission, pattern, ruleset))
+  const base = ReadPermission.harden(permission, pattern, evaluate(permission, pattern, ruleset))
   const saved = evaluate(permission, pattern, ...overrides)
   if (base.action === "deny") return base
   if (saved.action === "deny") return saved
@@ -214,6 +200,14 @@ function veto(permission: string, pattern: string, ruleset?: Ruleset) {
 
 function subset(permission: string, ruleset: Ruleset) {
   return ruleset.filter((rule) => Wildcard.match(permission, rule.permission))
+}
+
+function covered(entry: PendingEntry, approved: Ruleset, local: Ruleset) {
+  if (ConfigProtection.isRequest(entry.info)) return false
+  return entry.info.patterns.every((pattern) => {
+    if (veto(entry.info.permission, pattern, entry.hardRuleset)) return false
+    return resolve(entry.info.permission, pattern, entry.ruleset, approved, local).action === "allow"
+  })
 }
 // kilocode_change end
 
@@ -437,9 +431,7 @@ export const layer = Layer.effect(
 
       if (input.requestID) {
         const entry = s.pending.get(PermissionID.make(input.requestID))
-        const ok = entry
-          ? entry.info.patterns.every((pattern) => !veto(entry.info.permission, pattern, entry.hardRuleset))
-          : false // kilocode_change
+        const ok = entry ? covered(entry, s.approved, s.session[entry.info.sessionID] ?? []) : false // kilocode_change
         if (entry && ok && (!input.sessionID || entry.info.sessionID === input.sessionID)) {
           s.pending.delete(PermissionID.make(input.requestID))
           yield* bus.publish(Event.Replied, {
@@ -453,8 +445,7 @@ export const layer = Layer.effect(
 
       for (const [id, entry] of s.pending) {
         if (input.sessionID && entry.info.sessionID !== input.sessionID) continue
-        if (ConfigProtection.isRequest(entry.info)) continue
-        if (entry.info.patterns.some((pattern) => veto(entry.info.permission, pattern, entry.hardRuleset))) continue // kilocode_change
+        if (!covered(entry, s.approved, s.session[entry.info.sessionID] ?? [])) continue // kilocode_change
         s.pending.delete(id)
         yield* bus.publish(Event.Replied, {
           sessionID: entry.info.sessionID,

--- a/packages/opencode/test/kilocode/permission/env-read.test.ts
+++ b/packages/opencode/test/kilocode/permission/env-read.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Effect, Fiber, Layer } from "effect"
+import { Bus } from "../../../src/bus"
+import * as Config from "../../../src/config/config"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Global } from "@opencode-ai/core/global"
+import { Permission } from "../../../src/permission"
+import { PermissionID } from "../../../src/permission/schema"
+import { SessionID } from "../../../src/session/schema"
+import { provideTmpdirInstance } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+const bus = Bus.layer
+const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(bus)), bus, CrossSpawnSpawner.defaultLayer)
+const it = testEffect(env)
+
+afterAll(async () => {
+  const dir = Global.Path.config
+  for (const file of ["kilo.jsonc", "kilo.json", "config.json", "opencode.json", "opencode.jsonc"]) {
+    await fs.rm(path.join(dir, file), { force: true }).catch(() => {})
+  }
+  await Config.invalidate(true)
+})
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask(input)
+  })
+
+const reply = (input: Parameters<Permission.Interface["reply"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.reply(input)
+  })
+
+const allow = (input: Parameters<Permission.Interface["allowEverything"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.allowEverything(input)
+  })
+
+const rejectAll = () =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    for (const req of yield* permission.list()) {
+      yield* permission.reply({ requestID: req.id, reply: "reject" })
+    }
+  })
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    for (let i = 0; i < 100; i++) {
+      const items = yield* permission.list()
+      if (items.length >= count) return items
+      yield* Effect.sleep("10 millis")
+    }
+    return yield* Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`))
+  })
+
+const rules = () =>
+  Permission.fromConfig({
+    read: {
+      "*": "allow",
+      "*.env": "ask",
+      "*.env.*": "ask",
+      "*.env.example": "allow",
+    },
+  })
+
+function withDir(self: () => Effect.Effect<any, any, any>) {
+  return provideTmpdirInstance(self, { git: true })
+}
+
+describe("env read permissions", () => {
+  it.live("broad read allow does not bypass env ask", () =>
+    Effect.sync(() => {
+      const set = Permission.merge(rules(), Permission.fromConfig({ read: { "*": "allow" } }))
+      expect(Permission.resolve("read", "project/.env", set).action).toBe("ask")
+      expect(Permission.resolve("read", "project/.env.local", set).action).toBe("ask")
+      expect(Permission.resolve("read", "project/.env.example", set).action).toBe("allow")
+    }),
+  )
+
+  it.live("saved wildcard read approval does not bypass env ask", () =>
+    withDir(() =>
+      Effect.gen(function* () {
+        const session = SessionID.make("session_env")
+        const first = yield* ask({
+          id: PermissionID.make("per_env_first"),
+          sessionID: session,
+          permission: "read",
+          patterns: ["README.md"],
+          metadata: {},
+          always: ["*"],
+          ruleset: Permission.fromConfig({ read: "ask" }),
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+        yield* reply({ requestID: PermissionID.make("per_env_first"), reply: "always" })
+        yield* Fiber.join(first)
+
+        const second = yield* ask({
+          id: PermissionID.make("per_env_second"),
+          sessionID: session,
+          permission: "read",
+          patterns: ["project/.env"],
+          metadata: {},
+          always: ["*"],
+          ruleset: rules(),
+        }).pipe(Effect.forkScoped)
+
+        const items = yield* waitForPending(1)
+        expect(items[0].id).toBe(PermissionID.make("per_env_second"))
+
+        yield* rejectAll()
+        yield* Fiber.await(second)
+      }),
+    ),
+  )
+
+  it.live("allow everything does not resolve pending env reads", () =>
+    withDir(() =>
+      Effect.gen(function* () {
+        const asking = yield* ask({
+          id: PermissionID.make("per_env_everything"),
+          sessionID: SessionID.make("session_env"),
+          permission: "read",
+          patterns: ["project/.env"],
+          metadata: {},
+          always: ["*"],
+          ruleset: rules(),
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+        yield* allow({ enable: true, requestID: "per_env_everything" })
+
+        const items = yield* waitForPending(1)
+        expect(items[0].id).toBe(PermissionID.make("per_env_everything"))
+
+        yield* rejectAll()
+        yield* Fiber.await(asking)
+      }),
+    ),
+  )
+})

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -204,6 +204,26 @@ test("evaluate - matches expanded $HOME pattern", () => {
   expect(result.action).toBe("allow")
 })
 
+// kilocode_change start
+test("resolve - broad read allow does not bypass env ask", () => {
+  const ruleset = Permission.merge(
+    Permission.fromConfig({
+      read: {
+        "*": "allow",
+        "*.env": "ask",
+        "*.env.*": "ask",
+        "*.env.example": "allow",
+      },
+    }),
+    Permission.fromConfig({ read: { "*": "allow" } }),
+  )
+
+  expect(Permission.resolve("read", "project/.env", ruleset).action).toBe("ask")
+  expect(Permission.resolve("read", "project/.env.local", ruleset).action).toBe("ask")
+  expect(Permission.resolve("read", "project/.env.example", ruleset).action).toBe("allow")
+})
+// kilocode_change end
+
 // merge tests
 
 test("merge - simple concatenation", () => {
@@ -602,6 +622,52 @@ it.live("ask - throws DeniedError when action is deny", () =>
     }),
   ),
 )
+
+// kilocode_change start
+it.live("ask - saved wildcard read approval does not bypass env ask", () =>
+  withDir({ git: true }, () =>
+    Effect.gen(function* () {
+      const session = SessionID.make("session_env")
+      const first = yield* ask({
+        id: PermissionID.make("per_env_first"),
+        sessionID: session,
+        permission: "read",
+        patterns: ["README.md"],
+        metadata: {},
+        always: ["*"],
+        ruleset: Permission.fromConfig({ read: "ask" }),
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(1)
+      yield* reply({ requestID: PermissionID.make("per_env_first"), reply: "always" })
+      yield* Fiber.join(first)
+
+      const second = yield* ask({
+        id: PermissionID.make("per_env_second"),
+        sessionID: session,
+        permission: "read",
+        patterns: ["project/.env"],
+        metadata: {},
+        always: ["*"],
+        ruleset: Permission.fromConfig({
+          read: {
+            "*": "allow",
+            "*.env": "ask",
+            "*.env.*": "ask",
+            "*.env.example": "allow",
+          },
+        }),
+      }).pipe(Effect.forkScoped)
+
+      const items = yield* waitForPending(1)
+      expect(items[0].id).toBe(PermissionID.make("per_env_second"))
+
+      yield* rejectAll()
+      yield* Fiber.await(second)
+    }),
+  ),
+)
+// kilocode_change end
 
 it.live("ask - stays pending when action is ask", () =>
   withDir({ git: true }, () =>

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -204,26 +204,6 @@ test("evaluate - matches expanded $HOME pattern", () => {
   expect(result.action).toBe("allow")
 })
 
-// kilocode_change start
-test("resolve - broad read allow does not bypass env ask", () => {
-  const ruleset = Permission.merge(
-    Permission.fromConfig({
-      read: {
-        "*": "allow",
-        "*.env": "ask",
-        "*.env.*": "ask",
-        "*.env.example": "allow",
-      },
-    }),
-    Permission.fromConfig({ read: { "*": "allow" } }),
-  )
-
-  expect(Permission.resolve("read", "project/.env", ruleset).action).toBe("ask")
-  expect(Permission.resolve("read", "project/.env.local", ruleset).action).toBe("ask")
-  expect(Permission.resolve("read", "project/.env.example", ruleset).action).toBe("allow")
-})
-// kilocode_change end
-
 // merge tests
 
 test("merge - simple concatenation", () => {
@@ -622,52 +602,6 @@ it.live("ask - throws DeniedError when action is deny", () =>
     }),
   ),
 )
-
-// kilocode_change start
-it.live("ask - saved wildcard read approval does not bypass env ask", () =>
-  withDir({ git: true }, () =>
-    Effect.gen(function* () {
-      const session = SessionID.make("session_env")
-      const first = yield* ask({
-        id: PermissionID.make("per_env_first"),
-        sessionID: session,
-        permission: "read",
-        patterns: ["README.md"],
-        metadata: {},
-        always: ["*"],
-        ruleset: Permission.fromConfig({ read: "ask" }),
-      }).pipe(Effect.forkScoped)
-
-      yield* waitForPending(1)
-      yield* reply({ requestID: PermissionID.make("per_env_first"), reply: "always" })
-      yield* Fiber.join(first)
-
-      const second = yield* ask({
-        id: PermissionID.make("per_env_second"),
-        sessionID: session,
-        permission: "read",
-        patterns: ["project/.env"],
-        metadata: {},
-        always: ["*"],
-        ruleset: Permission.fromConfig({
-          read: {
-            "*": "allow",
-            "*.env": "ask",
-            "*.env.*": "ask",
-            "*.env.example": "allow",
-          },
-        }),
-      }).pipe(Effect.forkScoped)
-
-      const items = yield* waitForPending(1)
-      expect(items[0].id).toBe(PermissionID.make("per_env_second"))
-
-      yield* rejectAll()
-      yield* Fiber.await(second)
-    }),
-  ),
-)
-// kilocode_change end
 
 it.live("ask - stays pending when action is ask", () =>
   withDir({ git: true }, () =>


### PR DESCRIPTION
## Summary
- Fix a permission regression where broad saved read approvals could let sensitive `.env` files be read without showing the expected ask prompt.
- Keep the `.env`-specific guard in Kilo-specific permission code and apply it consistently to normal reads, saved approvals, pending request draining, and Allow Everything handling.
- Move the regression coverage into Kilo-specific tests and add a CLI patch changeset.

## Context
A user reported that Kilo read a real `.env` file even though read permissions were configured to ask for environment files. The root cause was that persisted wildcard approvals like `read * allow` were evaluated after the more-specific `.env` ask rule, so the saved approval could win.

## Manual Test
- Created an isolated temporary workspace and config with broad `read * allow`.
- Launched the VS Code extension from this branch and opened the temporary workspace.
- Asked Kilo to read `README.md`, `.env.example`, and `.env`.
- Verified `.env` still prompted before showing contents, including after approving and reading it again.

## Review Follow-Up
The first version fixed normal saved approvals, but review pointed out that Allow Everything could still auto-resolve an already-pending `.env` read. This PR now uses the same resolver there too, so pending `.env` reads are not silently approved by broad allow rules.