### PR TITLE
Render Markdown files in diff viewers

### DIFF
--- a/.changeset/render-markdown-diffs.md
+++ b/.changeset/render-markdown-diffs.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support rendering Markdown files in diff viewers with a persisted toggle.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -847,6 +847,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show the task timeline graph in the chat header"
+        },
+        "kilo-code.new.diff.renderMarkdown": {
+          "type": "boolean",
+          "default": false,
+          "description": "Render Markdown files in Kilo diff viewers by default. Toggle this from a Markdown file header in the diff viewer."
         }
       }
     }

--- a/packages/kilo-vscode/src/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/DiffViewerProvider.ts
@@ -10,6 +10,7 @@ import {
   openWorkspaceRelativeFile,
   resolveLocalDiffTarget,
 } from "./review-utils"
+import { getDiffMarkdownRender, setDiffMarkdownRender } from "./review-settings"
 
 /**
  * DiffViewerProvider opens a full-screen diff viewer in an editor tab.
@@ -90,6 +91,7 @@ export class DiffViewerProvider implements vscode.Disposable {
         languageOverride: vscode.workspace.getConfiguration("kilo-code.new").get<string>("language"),
         workspaceDirectory: getWorkspaceRoot(),
       })
+      this.post({ type: "diffViewer.markdownRender", render: getDiffMarkdownRender() })
       this.startDiffPolling()
       return
     }
@@ -105,6 +107,11 @@ export class DiffViewerProvider implements vscode.Disposable {
     }
 
     if (type === "diffViewer.setDiffStyle" && (msg.style === "unified" || msg.style === "split")) {
+      return
+    }
+
+    if (type === "diffViewer.setMarkdownRender" && typeof msg.render === "boolean") {
+      void setDiffMarkdownRender(msg.render)
       return
     }
 

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { buildWebviewHtml } from "./utils"
 import { appendOutput, getWorkspaceRoot } from "./review-utils"
+import { getDiffMarkdownRender, setDiffMarkdownRender } from "./review-settings"
 
 export interface DiffVirtualFile {
   file: string
@@ -79,12 +80,22 @@ export class DiffVirtualProvider implements vscode.Disposable {
 
     if (type === "diffVirtual.close") {
       this.panel?.dispose()
+      return
+    }
+
+    if (type === "diffVirtual.setMarkdownRender" && typeof msg.render === "boolean") {
+      void setDiffMarkdownRender(msg.render)
     }
   }
 
   private pushData(): void {
     if (!this.pending) return
-    this.post({ type: "diffVirtual.data", diff: this.pending, initialDiffStyle: this.pending.initialDiffStyle })
+    this.post({
+      type: "diffVirtual.data",
+      diff: this.pending,
+      initialDiffStyle: this.pending.initialDiffStyle,
+      markdownRender: getDiffMarkdownRender(),
+    })
   }
 
   private post(message: Record<string, unknown>): void {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -4,6 +4,7 @@ import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { getErrorMessage } from "../kilo-provider-utils"
 import { resolveLocalDiffTarget } from "../review-utils"
+import { getDiffMarkdownRender, setDiffMarkdownRender } from "../review-settings"
 import { isAbsolutePath } from "../path-utils"
 import { WorktreeManager, type CreateWorktreeResult } from "./WorktreeManager"
 import { remoteRef, WorktreeStateManager } from "./WorktreeStateManager"
@@ -497,6 +498,10 @@ export class AgentManagerProvider implements Disposable {
     if (this.handleSection(m)) return null
     if (m.type === "agentManager.setReviewDiffStyle") {
       this.state?.setReviewDiffStyle(m.style)
+      return null
+    }
+    if (m.type === "agentManager.setReviewMarkdownRender") {
+      void setDiffMarkdownRender(m.render).then(() => this.pushState())
       return null
     }
     if (m.type === "agentManager.setDefaultBaseBranch") {
@@ -1401,6 +1406,7 @@ export class AgentManagerProvider implements Disposable {
       worktreeOrder: state.getWorktreeOrder(),
       sessionsCollapsed: state.getSessionsCollapsed(),
       reviewDiffStyle: state.getReviewDiffStyle(),
+      reviewMarkdownRender: getDiffMarkdownRender(),
       isGitRepo: true,
       defaultBaseBranch: state.getDefaultBaseBranch(),
       ...run,
@@ -1422,6 +1428,7 @@ export class AgentManagerProvider implements Disposable {
       sessions: [],
       staleWorktreeIds: [],
       reviewDiffStyle: "unified",
+      reviewMarkdownRender: getDiffMarkdownRender(),
       isGitRepo: false,
       runStatuses: [],
       runScriptConfigured: false,

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -127,6 +127,7 @@ interface StateMessage {
   worktreeOrder?: string[]
   sessionsCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
+  reviewMarkdownRender?: boolean
   isGitRepo?: boolean
   defaultBaseBranch?: string
   runStatuses?: RunStatus[]
@@ -460,6 +461,11 @@ interface SetReviewDiffStyleIn {
   style: "unified" | "split"
 }
 
+interface SetReviewMarkdownRenderIn {
+  type: "agentManager.setReviewMarkdownRender"
+  render: boolean
+}
+
 interface SetDefaultBaseBranchIn {
   type: "agentManager.setDefaultBaseBranch"
   branch?: string
@@ -725,6 +731,7 @@ export type AgentManagerInMessage =
   | SetWorktreeOrderIn
   | SetSessionsCollapsedIn
   | SetReviewDiffStyleIn
+  | SetReviewMarkdownRenderIn
   | SetDefaultBaseBranchIn
   | RequestExternalWorktreesIn
   | ImportFromBranchIn

--- a/packages/kilo-vscode/src/review-settings.ts
+++ b/packages/kilo-vscode/src/review-settings.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode"
+
+const CONFIG = "kilo-code.new"
+const KEY = "diff.renderMarkdown"
+
+export function getDiffMarkdownRender(): boolean {
+  return vscode.workspace.getConfiguration(CONFIG).get<boolean>(KEY, false)
+}
+
+export async function setDiffMarkdownRender(value: boolean): Promise<void> {
+  await vscode.workspace.getConfiguration(CONFIG).update(KEY, value, vscode.ConfigurationTarget.Global)
+}

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -24,6 +24,7 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/sortable-tab.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/DiffPanel.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/FullScreenDiffView.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/MarkdownDiffView.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/DiffEndMarker.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/FileTree.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/review-annotations.ts"),

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -359,13 +359,11 @@ const AgentManagerContent: Component = () => {
   const [diffFileLoading, setDiffFileLoading] = createSignal<Record<string, Record<string, true>>>({})
   const [diffWidth, setDiffWidth] = createSignal(Math.round(window.innerWidth * 0.5))
 
-  // Full-screen review state (in-memory, per sidebar context: local/worktree)
   const [reviewOpenByContext, setReviewOpenByContext] = createSignal<Record<string, boolean>>({})
   const [reviewCommentsByContext, setReviewCommentsByContext] = createSignal<Record<string, ReviewComment[]>>({})
   const [reviewActive, setReviewActive] = createSignal(false)
   const [reviewDiffStyle, setReviewDiffStyle] = createSignal<"unified" | "split">("unified")
   const markdown = createMarkdownRender(vscode)
-
   // Per-worktree git stats (diff additions/deletions, commits missing from origin)
   const [worktreeStats, setWorktreeStats] = createSignal<Record<string, WorktreeGitStats>>({})
 
@@ -3104,7 +3102,8 @@ const AgentManagerContent: Component = () => {
                         sessionKey={diffSessionKey()}
                         diffStyle={reviewDiffStyle()}
                         onDiffStyleChange={setSharedDiffStyle}
-                        markdownRender={markdown.render()} onMarkdownRenderChange={markdown.update}
+                        markdownRender={markdown.render()}
+                        onMarkdownRenderChange={markdown.update}
                         comments={reviewComments()}
                         onCommentsChange={setReviewCommentsForSelection}
                         onClose={() => setSidePanel(null)}
@@ -3138,7 +3137,8 @@ const AgentManagerContent: Component = () => {
                   onSendAll={closeReviewTab}
                   diffStyle={reviewDiffStyle()}
                   onDiffStyleChange={setSharedDiffStyle}
-                  markdownRender={markdown.render()} onMarkdownRenderChange={markdown.update}
+                  markdownRender={markdown.render()}
+                  onMarkdownRenderChange={markdown.update}
                   onRequestDiff={requestDiffFile}
                   onOpenFile={(file, line) => {
                     const id = currentDiffSessionId()

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -114,6 +114,7 @@ import {
 import { sectionAwareDetector } from "./section-dnd"
 import { ConstrainDragXAxis } from "./constrain-drag-x"
 import { mergeWorktreeDiffs } from "./diff-state"
+import { createMarkdownRender } from "./review-preferences"
 import "./agent-manager.css"
 import "./agent-manager-review.css"
 
@@ -363,7 +364,7 @@ const AgentManagerContent: Component = () => {
   const [reviewCommentsByContext, setReviewCommentsByContext] = createSignal<Record<string, ReviewComment[]>>({})
   const [reviewActive, setReviewActive] = createSignal(false)
   const [reviewDiffStyle, setReviewDiffStyle] = createSignal<"unified" | "split">("unified")
-  // reviewOpen (memo below) controls tab presence for selected context.
+  const markdown = createMarkdownRender(vscode)
 
   // Per-worktree git stats (diff additions/deletions, commits missing from origin)
   const [worktreeStats, setWorktreeStats] = createSignal<Record<string, WorktreeGitStats>>({})
@@ -1326,6 +1327,7 @@ const AgentManagerContent: Component = () => {
         if (state.reviewDiffStyle === "split" || state.reviewDiffStyle === "unified") {
           setReviewDiffStyle(state.reviewDiffStyle)
         }
+        markdown.setRender(state.reviewMarkdownRender === true)
         if ("defaultBaseBranch" in state) setDefaultBaseBranch(state.defaultBaseBranch || undefined)
         setRunScriptConfigured(state.runScriptConfigured === true)
         syncRunStatuses(state.runStatuses)
@@ -3102,6 +3104,7 @@ const AgentManagerContent: Component = () => {
                         sessionKey={diffSessionKey()}
                         diffStyle={reviewDiffStyle()}
                         onDiffStyleChange={setSharedDiffStyle}
+                        markdownRender={markdown.render()} onMarkdownRenderChange={markdown.update}
                         comments={reviewComments()}
                         onCommentsChange={setReviewCommentsForSelection}
                         onClose={() => setSidePanel(null)}
@@ -3135,6 +3138,7 @@ const AgentManagerContent: Component = () => {
                   onSendAll={closeReviewTab}
                   diffStyle={reviewDiffStyle()}
                   onDiffStyleChange={setSharedDiffStyle}
+                  markdownRender={markdown.render()} onMarkdownRenderChange={markdown.update}
                   onRequestDiff={requestDiffFile}
                   onOpenFile={(file, line) => {
                     const id = currentDiffSessionId()

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -24,6 +24,7 @@ import {
 import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 import { treeOrder } from "./file-tree-utils"
+import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
 
 // --- Data model ---
 
@@ -35,6 +36,8 @@ interface DiffPanelProps {
   sessionKey?: string
   diffStyle?: "unified" | "split"
   onDiffStyleChange?: (style: "unified" | "split") => void
+  markdownRender?: boolean
+  onMarkdownRenderChange?: (render: boolean) => void
   comments: ReviewComment[]
   onCommentsChange: (comments: ReviewComment[]) => void
   onSendAll?: () => void
@@ -499,6 +502,23 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                                 />
                               </Tooltip>
                             </Show>
+                            <Show when={isMarkdownFile(diff.file) && props.onMarkdownRenderChange}>
+                              <Tooltip
+                                value={props.markdownRender ? "Show raw Markdown" : "Render Markdown"}
+                                placement="top"
+                              >
+                                <IconButton
+                                  icon={props.markdownRender ? "code" : "eye"}
+                                  size="small"
+                                  variant="ghost"
+                                  label={props.markdownRender ? "Show raw Markdown" : "Render Markdown"}
+                                  onClick={(e: MouseEvent) => {
+                                    e.stopPropagation()
+                                    props.onMarkdownRenderChange?.(!props.markdownRender)
+                                  }}
+                                />
+                              </Tooltip>
+                            </Show>
                             <span data-slot="session-review-diff-chevron">
                               <Icon name="chevron-down" size="small" />
                             </span>
@@ -521,19 +541,26 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                             </div>
                           }
                         >
-                          <Diff<AnnotationMeta>
-                            before={{ name: diff.file, contents: diff.before }}
-                            after={{ name: diff.file, contents: diff.after }}
-                            diffStyle={props.diffStyle ?? "unified"}
-                            annotations={annotationsForFile(diff.file)}
-                            renderAnnotation={buildAnnotation}
-                            enableGutterUtility={true}
-                            onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
-                            onLineNumberClick={(event) => {
-                              if (event.annotationSide === "deletions") return
-                              props.onOpenFile?.(diff.file, event.lineNumber)
-                            }}
-                          />
+                          <Show
+                            when={props.markdownRender && isMarkdownFile(diff.file)}
+                            fallback={
+                              <Diff<AnnotationMeta>
+                                before={{ name: diff.file, contents: diff.before }}
+                                after={{ name: diff.file, contents: diff.after }}
+                                diffStyle={props.diffStyle ?? "unified"}
+                                annotations={annotationsForFile(diff.file)}
+                                renderAnnotation={buildAnnotation}
+                                enableGutterUtility={true}
+                                onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                                onLineNumberClick={(event) => {
+                                  if (event.annotationSide === "deletions") return
+                                  props.onOpenFile?.(diff.file, event.lineNumber)
+                                }}
+                              />
+                            }
+                          >
+                            <MarkdownDiffView diff={diff} />
+                          </Show>
                         </Show>
                       </Show>
                     </Accordion.Content>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -31,6 +31,7 @@ import {
 } from "./review-annotations"
 import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
+import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
 
 type DiffStyle = "unified" | "split"
 
@@ -45,6 +46,8 @@ interface FullScreenDiffViewProps {
   onSendAll?: () => void
   diffStyle: DiffStyle
   onDiffStyleChange: (style: DiffStyle) => void
+  markdownRender?: boolean
+  onMarkdownRenderChange?: (render: boolean) => void
   onRequestDiff?: (file: string) => void
   onOpenFile?: (relativePath: string, line?: number) => void
   onRevertFile?: (file: string) => void
@@ -580,6 +583,23 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                     />
                                   </Tooltip>
                                 </Show>
+                                <Show when={isMarkdownFile(diff.file) && props.onMarkdownRenderChange}>
+                                  <Tooltip
+                                    value={props.markdownRender ? "Show raw Markdown" : "Render Markdown"}
+                                    placement="top"
+                                  >
+                                    <IconButton
+                                      icon={props.markdownRender ? "code" : "eye"}
+                                      size="small"
+                                      variant="ghost"
+                                      label={props.markdownRender ? "Show raw Markdown" : "Render Markdown"}
+                                      onClick={(e: MouseEvent) => {
+                                        e.stopPropagation()
+                                        props.onMarkdownRenderChange?.(!props.markdownRender)
+                                      }}
+                                    />
+                                  </Tooltip>
+                                </Show>
                                 <span data-slot="session-review-diff-chevron">
                                   <Icon name="chevron-down" size="small" />
                                 </span>
@@ -602,19 +622,26 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                 </div>
                               }
                             >
-                              <Diff<AnnotationMeta>
-                                before={{ name: diff.file, contents: diff.before }}
-                                after={{ name: diff.file, contents: diff.after }}
-                                diffStyle={props.diffStyle}
-                                annotations={annotationsForFile(diff.file)}
-                                renderAnnotation={buildAnnotation}
-                                enableGutterUtility={true}
-                                onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
-                                onLineNumberClick={(event) => {
-                                  if (event.annotationSide === "deletions") return
-                                  props.onOpenFile?.(diff.file, event.lineNumber)
-                                }}
-                              />
+                              <Show
+                                when={props.markdownRender && isMarkdownFile(diff.file)}
+                                fallback={
+                                  <Diff<AnnotationMeta>
+                                    before={{ name: diff.file, contents: diff.before }}
+                                    after={{ name: diff.file, contents: diff.after }}
+                                    diffStyle={props.diffStyle}
+                                    annotations={annotationsForFile(diff.file)}
+                                    renderAnnotation={buildAnnotation}
+                                    enableGutterUtility={true}
+                                    onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                                    onLineNumberClick={(event) => {
+                                      if (event.annotationSide === "deletions") return
+                                      props.onOpenFile?.(diff.file, event.lineNumber)
+                                    }}
+                                  />
+                                }
+                              >
+                                <MarkdownDiffView diff={diff} />
+                              </Show>
                             </Show>
                           </Show>
                         </Accordion.Content>

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownDiffView.tsx
@@ -1,0 +1,47 @@
+import { type Component, Show } from "solid-js"
+import { Markdown } from "@kilocode/kilo-ui/markdown"
+
+interface MarkdownDiffFile {
+  file: string
+  before: string
+  after: string
+  status?: "added" | "deleted" | "modified"
+}
+
+interface MarkdownDiffViewProps {
+  diff: MarkdownDiffFile
+}
+
+export function isMarkdownFile(file: string): boolean {
+  return /\.(md|mdx|markdown)$/i.test(file)
+}
+
+export const MarkdownDiffView: Component<MarkdownDiffViewProps> = (props) => {
+  const before = () => (props.diff.status === "added" ? "" : props.diff.before)
+  const after = () => (props.diff.status === "deleted" ? "" : props.diff.after)
+  const split = () => before().length > 0 && after().length > 0 && before() !== after()
+
+  return (
+    <div class="am-markdown-diff" data-split={split() ? "true" : undefined}>
+      <Show
+        when={split()}
+        fallback={
+          <section class="am-markdown-pane">
+            <Markdown text={after() || before()} cacheKey={`${props.diff.file}:rendered`} />
+          </section>
+        }
+      >
+        <>
+          <section class="am-markdown-pane">
+            <div class="am-markdown-pane-title">Before</div>
+            <Markdown text={before()} cacheKey={`${props.diff.file}:before`} />
+          </section>
+          <section class="am-markdown-pane">
+            <div class="am-markdown-pane-title">After</div>
+            <Markdown text={after()} cacheKey={`${props.diff.file}:after`} />
+          </section>
+        </>
+      </Show>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1661,6 +1661,46 @@ body.am-wt-dragging-active * {
   gap: 8px;
 }
 
+.am-markdown-diff {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1px;
+  background: var(--border-weak-base);
+  border-top: 1px solid var(--border-weak-base);
+  cursor: auto;
+}
+
+.am-markdown-diff[data-split="true"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.am-markdown-pane {
+  min-width: 0;
+  padding: 16px 20px 24px;
+  background: var(--vscode-editor-background, var(--surface-base));
+  color: var(--vscode-editor-foreground, var(--text-base));
+  overflow-x: auto;
+}
+
+.am-markdown-pane-title {
+  margin: -4px 0 12px;
+  color: var(--text-weak);
+  font-size: var(--font-size-small);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.am-markdown-pane [data-component="markdown"] {
+  max-width: 900px;
+}
+
+@media (max-width: 840px) {
+  .am-markdown-diff[data-split="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 /* Keep +N/-N indicators at consistent size across side/fullscreen views */
 .am-diff-panel [data-component="diff-changes"] [data-slot="diff-changes-additions"],
 .am-diff-panel [data-component="diff-changes"] [data-slot="diff-changes-deletions"],

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-preferences.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-preferences.ts
@@ -1,0 +1,16 @@
+import { createSignal } from "solid-js"
+
+interface VscodeLike {
+  postMessage: (message: { type: "agentManager.setReviewMarkdownRender"; render: boolean }) => void
+}
+
+export function createMarkdownRender(vscode: VscodeLike) {
+  const [render, setRender] = createSignal(false)
+  const update = (value: boolean) => {
+    if (render() === value) return
+    setRender(value)
+    vscode.postMessage({ type: "agentManager.setReviewMarkdownRender", render: value })
+  }
+
+  return { render, setRender, update }
+}

--- a/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
@@ -26,6 +26,7 @@ const DiffViewerContent: Component = () => {
   const [loading, setLoading] = createSignal(true)
   const [comments, setComments] = createSignal<ReviewComment[]>([])
   const [diffStyle, setDiffStyle] = createSignal<DiffStyle>("unified")
+  const [markdown, setMarkdown] = createSignal(false)
   const [reverting, setReverting] = createSignal<Set<string>>(new Set())
 
   const markReverting = (file: string, active: boolean) => {
@@ -50,6 +51,11 @@ const DiffViewerContent: Component = () => {
 
     if (msg.type === "diffViewer.revertFileResult") {
       markReverting(msg.file, false)
+      return
+    }
+
+    if (msg.type === "diffViewer.markdownRender") {
+      setMarkdown(msg.render)
       return
     }
   })
@@ -78,6 +84,11 @@ const DiffViewerContent: Component = () => {
       onDiffStyleChange={(style) => {
         setDiffStyle(style)
         post({ type: "diffViewer.setDiffStyle", style })
+      }}
+      markdownRender={markdown()}
+      onMarkdownRenderChange={(render) => {
+        setMarkdown(render)
+        post({ type: "diffViewer.setMarkdownRender", render })
       }}
       onOpenFile={(relativePath) => {
         post({ type: "openFile", filePath: relativePath })

--- a/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
@@ -14,11 +14,11 @@ import { FullScreenDiffView } from "../agent-manager/FullScreenDiffView"
 import { LanguageProvider } from "../src/context/language"
 import { ServerProvider, useServer } from "../src/context/server"
 import { getVSCodeAPI, VSCodeProvider, useVSCode } from "../src/context/vscode"
-import type { ReviewComment, WorktreeFileDiff } from "../src/types/messages"
+import type { ReviewComment, WebviewMessage, WorktreeFileDiff } from "../src/types/messages"
 
 type DiffStyle = "unified" | "split"
 
-const post = (message: Record<string, unknown>) => getVSCodeAPI().postMessage(message as never)
+const post = (message: WebviewMessage) => getVSCodeAPI().postMessage(message)
 
 const DiffViewerContent: Component = () => {
   const vscode = useVSCode()

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -8,12 +8,15 @@ import { Code } from "@kilocode/kilo-ui/code"
 import { Diff } from "@kilocode/kilo-ui/diff"
 import { File } from "@kilocode/kilo-ui/file"
 import { FileIcon } from "@kilocode/kilo-ui/file-icon"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { RadioGroup } from "@kilocode/kilo-ui/radio-group"
 import { ThemeProvider } from "@kilocode/kilo-ui/theme"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { normalize, text } from "@kilocode/kilo-ui/session-diff"
 import { LanguageProvider, useLanguage } from "../src/context/language"
 import { ServerProvider, useServer } from "../src/context/server"
-import { VSCodeProvider } from "../src/context/vscode"
+import { getVSCodeAPI, VSCodeProvider } from "../src/context/vscode"
+import { isMarkdownFile, MarkdownDiffView } from "../agent-manager/MarkdownDiffView"
 
 type DiffStyle = "unified" | "split"
 
@@ -30,12 +33,19 @@ const DiffVirtualContent: Component = () => {
   const { t } = useLanguage()
   const [diff, setDiff] = createSignal<DiffVirtualFile | null>(null)
   const [style, setStyle] = createSignal<DiffStyle>("unified")
+  const [markdown, setMarkdown] = createSignal(false)
 
   const handler = (event: MessageEvent) => {
-    const msg = event.data as { type: string; diff?: DiffVirtualFile; initialDiffStyle?: DiffStyle }
+    const msg = event.data as {
+      type: string
+      diff?: DiffVirtualFile
+      initialDiffStyle?: DiffStyle
+      markdownRender?: boolean
+    }
     if (msg?.type === "diffVirtual.data" && msg.diff) {
       setDiff(msg.diff)
       setStyle(msg.initialDiffStyle ?? "unified")
+      setMarkdown(msg.markdownRender === true)
     }
   }
 
@@ -93,13 +103,35 @@ const DiffVirtualContent: Component = () => {
                   <span class="am-review-toolbar-dels">-{d().deletions}</span>
                 </span>
               </div>
+              <Show when={isMarkdownFile(d().file)}>
+                <Tooltip value={markdown() ? "Show raw Markdown" : "Render Markdown"} placement="bottom">
+                  <IconButton
+                    icon={markdown() ? "code" : "eye"}
+                    size="small"
+                    variant="ghost"
+                    label={markdown() ? "Show raw Markdown" : "Render Markdown"}
+                    onClick={() => {
+                      const next = !markdown()
+                      setMarkdown(next)
+                      getVSCodeAPI().postMessage({ type: "diffVirtual.setMarkdownRender", render: next })
+                    }}
+                  />
+                </Tooltip>
+              </Show>
             </div>
             <div class="am-review-diff" style={{ width: "100%" }}>
-              <Diff
-                before={{ name: d().file, contents: resolved().before }}
-                after={{ name: d().file, contents: resolved().after }}
-                diffStyle={style()}
-              />
+              <Show
+                when={markdown() && isMarkdownFile(d().file)}
+                fallback={
+                  <Diff
+                    before={{ name: d().file, contents: resolved().before }}
+                    after={{ name: d().file, contents: resolved().after }}
+                    diffStyle={style()}
+                  />
+                }
+              >
+                <MarkdownDiffView diff={{ file: d().file, before: resolved().before, after: resolved().after }} />
+              </Show>
             </div>
           </>
         )}

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -498,6 +498,7 @@ export interface AgentManagerStateMessage {
   worktreeOrder?: string[]
   sessionsCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
+  reviewMarkdownRender?: boolean
   isGitRepo?: boolean
   defaultBaseBranch?: string
   runStatuses?: RunStatus[]
@@ -717,6 +718,11 @@ export interface DiffViewerRevertFileResultMessage {
   message: string
 }
 
+export interface DiffViewerMarkdownRenderMessage {
+  type: "diffViewer.markdownRender"
+  render: boolean
+}
+
 export interface ClearPendingPromptsMessage {
   type: "clearPendingPrompts"
 }
@@ -917,6 +923,7 @@ export type ExtensionMessage =
   | DiffViewerDiffsMessage
   | DiffViewerLoadingMessage
   | DiffViewerRevertFileResultMessage
+  | DiffViewerMarkdownRenderMessage
   | MarketplaceDataMessage
   | MarketplaceInstallResultMessage
   | MarketplaceRemoveResultMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -4,7 +4,7 @@ import type { MessageLoadMode } from "./sessions"
 import type { PermissionFileDiff } from "./permissions"
 import type { ModelSelection, ProviderConfig } from "./providers"
 import type { Config } from "./config"
-import type { ModelAllocation } from "./agent-manager"
+import type { ModelAllocation, ReviewComment } from "./agent-manager"
 import type {
   ClearLegacyDataMessage,
   FinalizeLegacyMigrationMessage,
@@ -750,6 +750,36 @@ export interface OpenDiffVirtualRequest {
   initialDiffStyle: "unified" | "split"
 }
 
+export interface DiffViewerSendCommentsRequest {
+  type: "diffViewer.sendComments"
+  comments: ReviewComment[]
+  autoSend: boolean
+}
+
+export interface DiffViewerSetDiffStyleRequest {
+  type: "diffViewer.setDiffStyle"
+  style: "unified" | "split"
+}
+
+export interface DiffViewerSetMarkdownRenderRequest {
+  type: "diffViewer.setMarkdownRender"
+  render: boolean
+}
+
+export interface DiffViewerRevertFileRequest {
+  type: "diffViewer.revertFile"
+  file: string
+}
+
+export interface DiffViewerCloseRequest {
+  type: "diffViewer.close"
+}
+
+export interface DiffVirtualSetMarkdownRenderRequest {
+  type: "diffVirtual.setMarkdownRender"
+  render: boolean
+}
+
 export interface RetryConnectionRequest {
   type: "retryConnection"
 }
@@ -1080,6 +1110,12 @@ export type WebviewMessage =
   | EnhancePromptRequest
   | OpenChangesRequest
   | OpenDiffVirtualRequest
+  | DiffViewerSendCommentsRequest
+  | DiffViewerSetDiffStyleRequest
+  | DiffViewerSetMarkdownRenderRequest
+  | DiffViewerRevertFileRequest
+  | DiffViewerCloseRequest
+  | DiffVirtualSetMarkdownRenderRequest
   | RetryConnectionRequest
   | OpenSubAgentViewerRequest
   | PreviewImageRequest

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -638,6 +638,12 @@ export interface SetReviewDiffStyleRequest {
   style: "unified" | "split"
 }
 
+// Persist Markdown render preference in diff viewers
+export interface SetReviewMarkdownRenderRequest {
+  type: "agentManager.setReviewMarkdownRender"
+  render: boolean
+}
+
 export interface RequestBranchesMessage {
   type: "agentManager.requestBranches"
 }
@@ -1045,6 +1051,7 @@ export type WebviewMessage =
   | SetWorktreeOrderRequest
   | SetSessionsCollapsedRequest
   | SetReviewDiffStyleRequest
+  | SetReviewMarkdownRenderRequest
   | PersistVariantRequest
   | RequestVariantsMessage
   | RequestCloudSessionDataMessage


### PR DESCRIPTION
## Summary
- Add a persisted setting and per-file toggle for rendering Markdown files in diff viewers.
- Reuse the preference across Agent Manager, the standalone Changes tab, and virtual diff panels so Markdown-heavy changes are easier to review.
- Works in extension sidebar diff viewer and agent manager inline and fullscreen diff viewer

<img width="174" height="103" alt="image" src="https://github.com/user-attachments/assets/66f307fc-04cb-455d-98f6-8559845a3385" />
<img width="195" height="84" alt="image" src="https://github.com/user-attachments/assets/fec9b7dd-8158-490b-9119-6cdd1bb3a5b8" />
<img width="825" height="217" alt="image" src="https://github.com/user-attachments/assets/317d73c7-47c8-42a1-916f-cc5ed63fd096" />
<img width="1440" height="747" alt="image" src="https://github.com/user-attachments/assets/48c57cf6-b436-4f8b-bf81-ecbbfc48064b" />
