### PR TITLE
Add basic mermaid support

### DIFF
--- a/.changeset/fresh-mermaids-render.md
+++ b/.changeset/fresh-mermaids-render.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Render Mermaid diagrams in chat Markdown responses.

--- a/bun.lock
+++ b/bun.lock
@@ -683,6 +683,7 @@
         "marked": "catalog:",
         "marked-katex-extension": "5.1.6",
         "marked-shiki": "catalog:",
+        "mermaid": "11.14.0",
         "morphdom": "2.7.8",
         "motion": "12.34.5",
         "motion-dom": "12.34.3",
@@ -2520,6 +2521,8 @@
     "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.5", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.6.0", "", { "peerDependencies": { "valibot": "^1.3.0" } }, "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A=="],
 
@@ -5291,6 +5294,8 @@
 
     "@opencode-ai/ui/@solid-primitives/resize-observer": ["@solid-primitives/resize-observer@2.1.3", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/rootless": "^1.5.2", "@solid-primitives/static-store": "^0.1.2", "@solid-primitives/utils": "^6.3.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-zBLje5E06TgOg93S7rGPldmhDnouNGhvfZVKOp+oG2XU8snA+GoCSSCz1M+jpNAg5Ek2EakU5UVQqL152WmdXQ=="],
 
+    "@opencode-ai/ui/mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
+
     "@opencode-ai/ui/tailwindcss": ["tailwindcss@4.1.11", "", {}, "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA=="],
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
@@ -6024,6 +6029,12 @@
     "@opencode-ai/storybook/storybook/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "@opencode-ai/ui/@solid-primitives/resize-observer/@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA=="],
+
+    "@opencode-ai/ui/mermaid/dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "@opencode-ai/ui/mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "@opencode-ai/ui/mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 

--- a/packages/kilo-ui/src/components/markdown.css
+++ b/packages/kilo-ui/src/components/markdown.css
@@ -49,4 +49,9 @@
     background: var(--background-stronger);
     margin-bottom: 1rem;
   }
+
+  [data-component="markdown-code"][data-kind="mermaid"] {
+    border: 0.5px solid var(--border-weak-base);
+    border-radius: 6px;
+  }
 }

--- a/packages/kilo-ui/src/components/markdown.css
+++ b/packages/kilo-ui/src/components/markdown.css
@@ -50,8 +50,4 @@
     margin-bottom: 1rem;
   }
 
-  [data-component="markdown-code"][data-kind="mermaid"] {
-    border: 0.5px solid var(--border-weak-base);
-    border-radius: 6px;
-  }
 }

--- a/packages/kilo-vscode/docs/chat-ui-features/mermaid-diagram-features.md
+++ b/packages/kilo-vscode/docs/chat-ui-features/mermaid-diagram-features.md
@@ -1,21 +1,16 @@
-# Mermaid Diagram Features
+# Mermaid Diagrams
 
-**Priority:** P2
+Chat Markdown renders fenced `mermaid` code blocks as diagrams after a response finishes streaming.
 
-No mermaid rendering exists in the VS Code extension or kilo-ui.
+## Behavior
 
-## Location (kilocode-legacy)
+- Valid `mermaid` fences render inline as SVG diagrams.
+- The original Mermaid source remains available through the existing code-block copy button.
+- Invalid Mermaid syntax shows a contained error state and keeps the source visible.
+- Diagrams are not rendered while a message is streaming, which avoids repeated parse/render work on every token.
+- Diagram colors are derived from the active VS Code/Kilo CSS variables so light, dark, and high-contrast themes can render with matching backgrounds, text, borders, and link colors.
 
-These components exist in the [kilocode-legacy](https://github.com/Kilo-Org/kilocode-legacy) repo, not in this extension:
+## Limitations
 
-- `webview-ui/src/components/common/MermaidBlock.tsx`
-- `webview-ui/src/components/common/MermaidButton.tsx`
-
-## Remaining Work
-
-- Mermaid diagram rendering in chat messages (code blocks with `mermaid` language tag)
-- "Fix with AI" button for mermaid syntax errors — route to CLI
-- Copy button for diagram code
-- Click to open rendered diagram as PNG in editor
-- Error expansion with original code display
-- Loading states during processing
+- Mermaid is bundled by the current webview build, so bundle splitting remains a future optimization.
+- Advanced legacy actions are not restored yet: AI syntax fixing, PNG open/save, export, and zoom modal.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,6 +60,7 @@
     "marked": "catalog:",
     "marked-katex-extension": "5.1.6",
     "marked-shiki": "catalog:",
+    "mermaid": "11.14.0",
     "morphdom": "2.7.8",
     "motion": "12.34.5",
     "motion-dom": "12.34.3",

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -457,9 +457,9 @@ export function Markdown(
 
   // kilocode_change start: Mermaid diagram rendering
   function kickMermaid(container: HTMLDivElement, streaming: boolean) {
-    if (!hasMermaid(container)) return
     mermaidState.signal.aborted = true
     mermaidState.gen++
+    if (!hasMermaid(container)) return
     if (streaming) return
 
     const gen = mermaidState.gen

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -7,6 +7,7 @@ import { ComponentProps, createEffect, createResource, createSignal, onCleanup, 
 import { isServer } from "solid-js/web"
 import { stream } from "./markdown-stream"
 import { tryFastRender } from "../kilocode/markdown-fast-path" // kilocode_change
+import { hasMermaid, preserveMermaid, renderMermaid } from "../kilocode/markdown-mermaid" // kilocode_change
 
 type Entry = {
   hash: string
@@ -294,6 +295,10 @@ export function Markdown(
   const highlightState = { gen: 0, signal: { aborted: false } }
   // kilocode_change end
 
+  // kilocode_change start: Mermaid diagram rendering
+  const mermaidState = { gen: 0, signal: { aborted: false } }
+  // kilocode_change end
+
   // kilocode_change start: rAF-coalesced morphdom render.
   // During LLM token streaming, content updates arrive at 60–200Hz. Each
   // token reparses the full accumulated HTML (temp.innerHTML = content) and
@@ -323,6 +328,10 @@ export function Markdown(
       }
       // kilocode_change end
       container.innerHTML = ""
+      // kilocode_change start: Mermaid diagram rendering
+      mermaidState.signal.aborted = true
+      mermaidState.gen++
+      // kilocode_change end
       return
     }
 
@@ -343,6 +352,7 @@ export function Markdown(
         pendingLabels = undefined
       }
       copyCleanup = fast.copyCleanup
+      kickMermaid(container, local.streaming ?? false)
       kickHighlight(container, labels)
       return
     }
@@ -383,6 +393,11 @@ export function Markdown(
             setCopyState(toEl, nextLabels, true)
           }
           if (fromEl.isEqualNode(toEl)) return false
+          // kilocode_change start: preserve rendered Mermaid diagrams across
+          // normal markdown morphdom refreshes so they do not flicker back to
+          // their source code while being re-rendered.
+          if (preserveMermaid(fromEl, toEl)) return false
+          // kilocode_change end
           // Preserve Shiki-highlighted blocks — don't let morphdom revert them
           // to plain <pre><code> during streaming re-renders.
           // Note: "shiki" class is on <pre> (set by Shiki's codeToHtml output).
@@ -411,6 +426,7 @@ export function Markdown(
       })
       // kilocode_change end
 
+      kickMermaid(container, local.streaming ?? false)
       kickHighlight(container, nextLabels)
     })
     // kilocode_change end
@@ -439,11 +455,32 @@ export function Markdown(
   }
   // kilocode_change end
 
+  // kilocode_change start: Mermaid diagram rendering
+  function kickMermaid(container: HTMLDivElement, streaming: boolean) {
+    if (!hasMermaid(container)) return
+    mermaidState.signal.aborted = true
+    mermaidState.gen++
+    if (streaming) return
+
+    const gen = mermaidState.gen
+    const signal = { aborted: false }
+    mermaidState.signal = signal
+    void renderMermaid(container, signal).catch((err) => {
+      if (gen !== mermaidState.gen || signal.aborted) return
+      console.warn("Mermaid render failed", err)
+    })
+  }
+  // kilocode_change end
+
   onCleanup(() => {
     // kilocode_change: cancel any in-flight deferredHighlight pass so its
     // completion callback doesn't touch the unmounted DOM.
     highlightState.signal.aborted = true
     highlightState.gen++
+    // kilocode_change start: Mermaid diagram rendering
+    mermaidState.signal.aborted = true
+    mermaidState.gen++
+    // kilocode_change end
     // kilocode_change: cancel any queued rAF parse so it doesn't touch the
     // unmounted DOM after dispose.
     if (pendingFrame !== undefined) {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -426,7 +426,7 @@ export function Markdown(
       })
       // kilocode_change end
 
-      kickMermaid(container, local.streaming ?? false)
+      kickMermaid(container, local.streaming ?? false) // kilocode_change
       kickHighlight(container, nextLabels)
     })
     // kilocode_change end

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -541,7 +541,9 @@ export async function deferredHighlight(
   onComplete?: () => void,
   signal?: { aborted: boolean },
 ): Promise<void> {
-  const blocks = Array.from(container.querySelectorAll("pre > code[data-lang]:not([data-highlighted])"))
+  const blocks = Array.from(
+    container.querySelectorAll('pre > code[data-lang]:not([data-highlighted]):not([data-lang="mermaid"])'),
+  )
   if (blocks.length === 0) {
     onComplete?.()
     return
@@ -663,7 +665,8 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
             // chars, so "c++" doesn't become "c" (wrong language highlight).
             const normalized = lang ? (LANG_ALIASES[lang] ?? lang) : ""
             const safe = normalized ? normalized.replace(/[^a-zA-Z0-9_-]/g, "") : ""
-            const attr = safe ? ` class="language-${safe}" data-lang="${safe}"` : ' data-lang="text"'
+            const data = safe.toLowerCase() === "mermaid" ? "mermaid" : safe
+            const attr = data ? ` class="language-${data}" data-lang="${data}"` : ' data-lang="text"'
             return `<pre><code${attr}>${escaped}</code></pre>`
           },
           // kilocode_change end

--- a/packages/ui/src/kilocode/markdown-mermaid.css
+++ b/packages/ui/src/kilocode/markdown-mermaid.css
@@ -1,14 +1,16 @@
 [data-component="markdown"] {
   [data-component="markdown-code"][data-kind="mermaid"] {
+    border: 0.5px solid var(--border-weak-base);
+    border-radius: 6px;
+    background: var(--surface-base);
     overflow: hidden;
   }
 
   [data-component="markdown-mermaid"] {
-    margin: 12px 0 32px;
+    margin: 0;
     padding: 12px;
-    border: 0.5px solid var(--border-weak-base);
-    border-radius: 6px;
-    background: var(--surface-base);
+    border: 0;
+    background: transparent;
     overflow: auto;
   }
 

--- a/packages/ui/src/kilocode/markdown-mermaid.css
+++ b/packages/ui/src/kilocode/markdown-mermaid.css
@@ -1,0 +1,34 @@
+[data-component="markdown"] {
+  [data-component="markdown-code"][data-kind="mermaid"] {
+    overflow: hidden;
+  }
+
+  [data-component="markdown-mermaid"] {
+    margin: 12px 0 32px;
+    padding: 12px;
+    border: 0.5px solid var(--border-weak-base);
+    border-radius: 6px;
+    background: var(--surface-base);
+    overflow: auto;
+  }
+
+  [data-component="markdown-mermaid"][data-state="rendered"] {
+    display: flex;
+    justify-content: center;
+  }
+
+  [data-component="markdown-mermaid"][data-state="rendered"] > svg {
+    max-width: 100%;
+    height: auto;
+  }
+
+  [data-component="markdown-mermaid"][data-state="rendering"] {
+    color: var(--text-weak);
+    font-style: italic;
+  }
+
+  [data-component="markdown-mermaid"][data-state="error"] {
+    color: var(--text-danger, var(--text-strong));
+    white-space: pre-wrap;
+  }
+}

--- a/packages/ui/src/kilocode/markdown-mermaid.stories.tsx
+++ b/packages/ui/src/kilocode/markdown-mermaid.stories.tsx
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import { Markdown } from "../components/markdown"
+
+const text = `Diagram:
+
+\`\`\`mermaid
+flowchart TD
+  A[Prompt] --> B{Needs tools?}
+  B -->|Yes| C[Run tool]
+  B -->|No| D[Respond]
+  C --> D
+\`\`\`
+`
+
+export default {
+  title: "Kilo/Markdown Mermaid",
+  id: "kilocode-markdown-mermaid",
+}
+
+export const Mermaid = {
+  render: () => <Markdown text={text} />,
+}
+
+export const MermaidError = {
+  render: () => (
+    <Markdown
+      text={`Broken diagram:
+
+\`\`\`mermaid
+flowchart TD
+  A -->
+\`\`\`
+`}
+    />
+  ),
+}
+
+export const MermaidThemes = {
+  render: () => (
+    <div style={{ display: "grid", gap: "24px" }}>
+      <div
+        style={{
+          padding: "16px",
+          color: "#1f2328",
+          "background-color": "#ffffff",
+          "--vscode-editor-background": "#ffffff",
+          "--vscode-editor-foreground": "#1f2328",
+          "--vscode-editorWidget-background": "#f6f8fa",
+          "--vscode-editorWidget-border": "#d0d7de",
+          "--vscode-descriptionForeground": "#57606a",
+          "--vscode-textLink-foreground": "#0969da",
+        }}
+      >
+        <Markdown text={text} />
+      </div>
+      <div
+        style={{
+          padding: "16px",
+          color: "#d4d4d4",
+          "background-color": "#1e1e1e",
+          "--vscode-editor-background": "#1e1e1e",
+          "--vscode-editor-foreground": "#d4d4d4",
+          "--vscode-editorWidget-background": "#252526",
+          "--vscode-editorWidget-border": "#454545",
+          "--vscode-descriptionForeground": "#cccccc",
+          "--vscode-textLink-foreground": "#3794ff",
+        }}
+      >
+        <Markdown text={text} />
+      </div>
+    </div>
+  ),
+}

--- a/packages/ui/src/kilocode/markdown-mermaid.ts
+++ b/packages/ui/src/kilocode/markdown-mermaid.ts
@@ -1,0 +1,290 @@
+import DOMPurify from "dompurify"
+import { fnv1a } from "../context/marked"
+
+const svgConfig = {
+  USE_PROFILES: { html: true, svg: true, svgFilters: true },
+  ADD_TAGS: ["foreignObject"],
+  FORBID_TAGS: ["script"],
+  FORBID_CONTENTS: ["script"],
+}
+
+type Mermaid = typeof import("mermaid").default
+
+const cache: { promise?: Promise<Mermaid>; id: number; queue: Promise<void> } = {
+  id: 0,
+  queue: Promise.resolve(),
+}
+
+async function load() {
+  if (!cache.promise) {
+    cache.promise = import("mermaid").then((mod) => mod.default)
+  }
+  return cache.promise
+}
+
+function parse(color: string) {
+  const value = color.trim()
+  const hex = value.match(/^#([0-9a-f]{6})/i)
+  if (hex?.[1]) {
+    return [
+      parseInt(hex[1].slice(0, 2), 16),
+      parseInt(hex[1].slice(2, 4), 16),
+      parseInt(hex[1].slice(4, 6), 16),
+    ]
+  }
+
+  const short = value.match(/^#([0-9a-f]{3})/i)
+  if (short?.[1]) return short[1].split("").map((part) => parseInt(`${part}${part}`, 16))
+
+  const rgb = value.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i)
+  if (rgb?.[1] && rgb[2] && rgb[3]) return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])]
+}
+
+function resolve(root: Element, value: string) {
+  const trimmed = value.trim()
+  if (!trimmed) return
+  if (!trimmed.includes("var(")) return trimmed
+
+  const doc = root.ownerDocument
+  const probe = doc.createElement("span")
+  probe.style.color = trimmed
+  probe.style.position = "absolute"
+  probe.style.visibility = "hidden"
+  probe.style.pointerEvents = "none"
+
+  const parent = root instanceof HTMLElement ? root : doc.body
+  parent.appendChild(probe)
+  const color = getComputedStyle(probe).color.trim()
+  probe.remove()
+  return color || trimmed
+}
+
+function css(root: Element, names: string[], fallback: string) {
+  const style = getComputedStyle(root)
+  for (const name of names) {
+    const value = resolve(root, style.getPropertyValue(name))
+    if (value) return value
+  }
+  return resolve(root, fallback) ?? fallback
+}
+
+function dark(root: Element, background: string) {
+  if (document.body.classList.contains("vscode-light")) return false
+  if (document.body.classList.contains("vscode-dark") || document.body.classList.contains("vscode-high-contrast")) return true
+
+  const scheme = getComputedStyle(root).colorScheme
+  if (scheme.includes("dark")) return true
+  if (scheme.includes("light")) return false
+
+  const rgb = parse(background)
+  if (!rgb) return true
+  return (0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]) / 255 < 0.5
+}
+
+function config(root: Element) {
+  const style = getComputedStyle(root)
+  const background = css(
+    root,
+    ["--vscode-editor-background", "--background-base", "--surface-base"],
+    style.backgroundColor || "#1e1e1e",
+  )
+  const panel = css(root, ["--vscode-editorWidget-background", "--surface-raised-base", "--surface-base"], background)
+  const alt = css(root, ["--vscode-input-background", "--surface-weak", "--surface-base"], panel)
+  const text = css(root, ["--vscode-editor-foreground", "--text-strong", "--vscode-foreground"], style.color || "#ffffff")
+  const weak = css(root, ["--vscode-descriptionForeground", "--text-weak", "--vscode-foreground"], text)
+  const border = css(root, ["--vscode-editorWidget-border", "--vscode-editorGroup-border", "--border-weak-base"], weak)
+  const accent = css(root, ["--vscode-textLink-foreground", "--vscode-charts-blue", "--text-interactive-base"], "#6cb6ff")
+  const critical = css(root, ["--vscode-errorForeground", "--vscode-charts-red", "--syntax-critical"], "#ff9580")
+  const criticalBg = css(root, ["--vscode-inputValidation-errorBackground", "--surface-critical-base"], alt)
+
+  return {
+    startOnLoad: false,
+    securityLevel: "strict" as const,
+    suppressErrorRendering: true,
+    theme: "base" as const,
+    themeVariables: {
+      darkMode: dark(root, background),
+      background,
+      textColor: text,
+      mainBkg: panel,
+      nodeBorder: border,
+      lineColor: weak,
+      primaryColor: panel,
+      primaryTextColor: text,
+      primaryBorderColor: border,
+      secondaryColor: alt,
+      tertiaryColor: background,
+      classText: text,
+      labelColor: text,
+      actorLineColor: weak,
+      actorBkg: panel,
+      actorBorder: border,
+      actorTextColor: text,
+      fillType0: panel,
+      fillType1: alt,
+      fillType2: background,
+      fontSize: "16px",
+      fontFamily: "var(--font-family-sans)",
+      noteTextColor: text,
+      noteBkgColor: alt,
+      noteBorderColor: border,
+      critBorderColor: critical,
+      critBkgColor: criticalBg,
+      taskTextColor: text,
+      taskTextOutsideColor: text,
+      taskTextLightColor: text,
+      sectionBkgColor: panel,
+      sectionBkgColor2: alt,
+      altBackground: panel,
+      linkColor: accent,
+      compositeBackground: panel,
+      compositeBorder: border,
+      titleColor: text,
+      edgeLabelBackground: background,
+    },
+  }
+}
+
+function enqueue<T>(run: () => Promise<T>) {
+  const next = cache.queue.then(run, run)
+  cache.queue = next.then(
+    () => undefined,
+    () => undefined,
+  )
+  return next
+}
+
+function sanitize(svg: string) {
+  if (!DOMPurify.isSupported) return ""
+  return DOMPurify.sanitize(svg, svgConfig)
+}
+
+function message(err: unknown) {
+  if (err instanceof Error) return err.message
+  if (typeof err === "string") return err
+  return "Unable to render Mermaid diagram."
+}
+
+function panel(wrapper: HTMLElement) {
+  const found = Array.from(wrapper.children).find(
+    (child): child is HTMLDivElement =>
+      child instanceof HTMLDivElement && child.getAttribute("data-component") === "markdown-mermaid",
+  )
+  if (found) return found
+
+  const el = document.createElement("div")
+  el.setAttribute("data-component", "markdown-mermaid")
+  wrapper.insertBefore(el, wrapper.firstChild)
+  return el
+}
+
+function fail(wrapper: HTMLElement, pre: HTMLPreElement, err: unknown) {
+  const el = panel(wrapper)
+  el.setAttribute("data-state", "error")
+  el.textContent = `Mermaid render failed: ${message(err)}`
+  wrapper.setAttribute("data-mermaid-state", "error")
+  pre.hidden = false
+}
+
+export function preserveMermaid(fromEl: Element, toEl: Element) {
+  if (!(fromEl instanceof HTMLElement)) return false
+  if (!(toEl instanceof HTMLElement)) return false
+  if (fromEl.getAttribute("data-component") !== "markdown-code") return false
+  if (fromEl.getAttribute("data-kind") !== "mermaid") return false
+  if (fromEl.getAttribute("data-mermaid-state") !== "rendered") return false
+  if (toEl.getAttribute("data-component") !== "markdown-code") return false
+
+  const from = fromEl.querySelector('pre > code[data-lang="mermaid"]')?.textContent ?? ""
+  const to = toEl.querySelector('pre > code[data-lang="mermaid"]')?.textContent ?? ""
+  if (!from || from !== to) return false
+  return true
+}
+
+export function hasMermaid(root: HTMLElement) {
+  return root.querySelector('pre > code[data-lang="mermaid"]') !== null
+}
+
+async function svg(renderer: Mermaid, source: string, cfg: ReturnType<typeof config>) {
+  return enqueue(async () => {
+    renderer.initialize(cfg)
+    await renderer.parse(source)
+    return renderer.render(`markdown-mermaid-${fnv1a(source)}-${cache.id++}`, source)
+  })
+}
+
+export async function renderMermaid(root: HTMLDivElement, signal: { aborted: boolean }) {
+  const blocks = Array.from(root.querySelectorAll('pre > code[data-lang="mermaid"]'))
+  if (blocks.length === 0) return
+
+  const renderer = await load().catch((err) => {
+    for (const block of blocks) {
+      const pre = block.parentElement
+      const wrapper = pre?.parentElement
+      if (!(pre instanceof HTMLPreElement)) continue
+      if (!(wrapper instanceof HTMLElement)) continue
+      if (wrapper.getAttribute("data-component") !== "markdown-code") continue
+      fail(wrapper, pre, err)
+    }
+  })
+  if (!renderer) return
+
+  for (const block of blocks) {
+    if (signal.aborted || !root.isConnected) return
+    if (!(block instanceof HTMLElement)) continue
+
+    const pre = block.parentElement
+    if (!(pre instanceof HTMLPreElement)) continue
+
+    const wrapper = pre.parentElement
+    if (!(wrapper instanceof HTMLElement)) continue
+    if (wrapper.getAttribute("data-component") !== "markdown-code") continue
+
+    const source = block.textContent ?? ""
+    if (!source.trim()) continue
+
+    const cfg = config(wrapper)
+    const hash = fnv1a(source)
+    const theme = fnv1a(JSON.stringify(cfg.themeVariables))
+    const state = wrapper.getAttribute("data-mermaid-state")
+    if (
+      state === "rendered" &&
+      wrapper.getAttribute("data-mermaid-hash") === hash &&
+      wrapper.getAttribute("data-mermaid-theme") === theme
+    ) {
+      pre.hidden = true
+      continue
+    }
+
+    const keep = state === "rendered" && wrapper.getAttribute("data-mermaid-hash") === hash
+
+    wrapper.setAttribute("data-kind", "mermaid")
+    wrapper.setAttribute("data-mermaid-hash", hash)
+    wrapper.setAttribute("data-mermaid-theme", theme)
+    wrapper.setAttribute("data-mermaid-state", "rendering")
+
+    const el = panel(wrapper)
+    if (!keep) {
+      el.setAttribute("data-state", "rendering")
+      el.textContent = "Rendering Mermaid diagram..."
+      pre.hidden = false
+    } else {
+      pre.hidden = true
+    }
+
+    try {
+      const result = await svg(renderer, source, cfg)
+      if (signal.aborted || !root.isConnected || !wrapper.isConnected) return
+
+      const safe = sanitize(result.svg)
+      if (!safe) throw new Error("Mermaid rendered an empty diagram.")
+
+      el.setAttribute("data-state", "rendered")
+      el.innerHTML = safe
+      wrapper.setAttribute("data-mermaid-state", "rendered")
+      pre.hidden = true
+    } catch (err) {
+      if (signal.aborted || !root.isConnected || !wrapper.isConnected) return
+      fail(wrapper, pre, err)
+    }
+  }
+}

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -34,6 +34,7 @@
 @import "../components/list.css" layer(components);
 @import "../components/logo.css" layer(components);
 @import "../components/markdown.css" layer(components);
+@import "../kilocode/markdown-mermaid.css" layer(components); /* kilocode_change */
 @import "../components/message-part.css" layer(components);
 @import "../components/message-nav.css" layer(components);
 @import "../components/popover.css" layer(components);


### PR DESCRIPTION
Render fenced Mermaid code blocks as inline diagrams in chat Markdown, with source copy fallback and contained parse errors.
Keep the renderer isolated in Kilo-specific UI helpers so shared Markdown changes stay minimal, and derive diagram colors from active VS Code/Kilo theme variables.


Out of scope:
- zooming, dragging and dropping, any interactive feature. We will ship that later.


<img width="443" height="658" alt="image" src="https://github.com/user-attachments/assets/ffba57cc-2848-4b41-a486-5272aa1d2d55" />

<img width="1045" height="721" alt="image" src="https://github.com/user-attachments/assets/7a1b96d0-406d-493b-9cee-4108b98bc387" />
