### PR TITLE
docs: document chat and diff rendering

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -187,6 +187,7 @@ Press `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux) to toggle the diff panel. It sh
 - Select files and click **Apply to local** to copy the worktree's changes onto your local checkout of the base branch
 - Conflicts are surfaced with a resolution dialog
 - Supports unified and split diff views
+- Markdown files include an eye/code toggle in the file header to switch between rendered Markdown and the raw diff
 - **Drag file headers into chat** — drag a file header from the diff panel into the chat input to insert an `@file` mention, giving the agent context about specific changed files
 
 See [Agent Manager Workflows](/docs/automate/agent-manager-workflows#merging-worktree-and-parent-branch) for the full integration story, including when to apply locally vs. merge directly vs. open a pull request.

--- a/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
@@ -128,6 +128,7 @@ Reference files and other context directly in your message using `@`:
 - URLs → Opens in browser
 - Messages → Expand/collapse details
 - Code blocks → Copy button appears
+- Mermaid code blocks → Fenced `mermaid` blocks render as diagrams after the message finishes streaming. The source remains copyable, and invalid Mermaid syntax stays visible in a contained error state.
 
 **Status signals:**
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/vscode/whats-new.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/vscode/whats-new.md
@@ -62,6 +62,7 @@ Modes have been renamed to Agents in the new extension. You can set the default 
 
 Each message that caused file changes shows a **diff badge** in the chat — click it to open the Diff Viewer and review what changed.
 The Agent Manager also includes a built-in diff reviewer that shows every change file by file, in unified or split view.
+For Markdown files, use the eye/code toggle in the file header to switch between rendered Markdown and the raw diff.
 
 ### How do I do code reviews in the new extension?
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -67,6 +67,10 @@ Terminal command blocks stay expanded by default in the VS Code chat UI. Choose 
 
 Valid values are `expanded` and `collapsed`.
 
+### Markdown Diff Rendering
+
+Markdown files in Kilo diff viewers can be shown as rendered Markdown instead of a raw text diff. Use the eye/code toggle in a Markdown file header, or set `kilo-code.new.diff.renderMarkdown` to `true` to render Markdown files by default.
+
 ### Export and Import
 
 You can export and import settings from the **About Kilo Code** tab in the Settings UI:


### PR DESCRIPTION
Document recent public-facing rendering improvements so users know where Mermaid diagrams appear and how to opt into rendered Markdown diffs.

Keep the additions concise and focused on visible behavior rather than implementation details.