### PR TITLE
docs(kilo-docs): document agent manager tool

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -136,6 +136,21 @@ Imported work stays associated with its branch or worktree and can be continued 
 - Use session history to reopen local sessions or preview cloud sessions
 - Continue a cloud session locally from Agent Manager using the same extension sign-in and provider settings
 
+## Starting Sessions From Chat
+
+Kilo can start Agent Manager sessions from chat with the experimental `agent_manager` tool. Enable it in **Settings > Experimental > Agent Manager Tool**, or set `experimental.agent_manager_tool` to `true` in `kilo.jsonc`.
+
+The tool is available only in the VS Code extension because Agent Manager is an extension feature. It supports two modes:
+
+| Mode | Behavior |
+|---|---|
+| `worktree` | Creates one Agent Manager git worktree and session per task |
+| `local` | Creates Agent Manager sessions in the current workspace without git worktree isolation |
+
+Each request can include 1-20 tasks. Each task must include at least one of `prompt`, `name`, or `branchName`. Use `versions: true` only when the tasks are alternate versions of the same work to compare; otherwise, multiple tasks start as independent sessions.
+
+The tool uses the `agent_manager` permission. Approval prompts are scoped to the requested mode, so approving `worktree` does not automatically approve `local`.
+
 ## Sections
 
 Sections let you group worktrees into collapsible, color-coded folders in the sidebar. Use them to organize your workflow however you like — by status ("Review Pending", "In Progress"), by project area ("Frontend", "Backend"), priority, or any other scheme that fits.

--- a/packages/kilo-docs/pages/automate/tools/index.md
+++ b/packages/kilo-docs/pages/automate/tools/index.md
@@ -24,7 +24,7 @@ Tools are organized into logical groups based on their functionality:
 | **Web Group** | Fetch and search web content | `webfetch`, `websearch`, `codesearch` | Research, documentation lookup |
 | **Browser Group** | Web browser automation | `kilo-playwright_*` (via built-in Playwright MCP) | Browser testing and interaction |
 | **MCP Group** | External tool integration | MCP server tools (namespaced as `{server}_{tool}`) | Specialized functionality via MCP |
-| **Workflow Group** | Sub-agents and task management | `question`, `task`, `todowrite`, `todoread`, `plan`, `skill` | Context switching and task organization |
+| **Workflow Group** | Sub-agents and task management | `question`, `task`, `todowrite`, `todoread`, `plan`, `skill`, `agent_manager` (experimental) | Context switching and task organization |
 
 ### Always Available Tools
 
@@ -94,6 +94,7 @@ These tools help manage the conversation and task flow:
 - `todoread` - Reads the current session TODO list
 - `plan` - Enters structured planning mode
 - `skill` - Invokes a reusable skill (Markdown instruction module)
+- `agent_manager` - Starts Agent Manager local or worktree sessions when the experimental Agent Manager Tool setting is enabled in VS Code
 
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}

--- a/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
+++ b/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
@@ -45,6 +45,7 @@ The Auto Approve tab lists the following tool-specific permissions. Some tools a
 | `glob` | File pattern matching / searching by name |
 | `grep` | Searching file contents by regex |
 | `task` | Launching sub-agents |
+| `agent_manager` | Starting Agent Manager local or worktree sessions |
 | `skill` | Loading specialized skills |
 | `lsp` | Language server protocol operations |
 | `todoread` / `todowrite` | Reading and updating the todo list |
@@ -62,6 +63,8 @@ When a tool is set to `"ask"`, Kilo pauses and displays a permission prompt with
 | **Deny** | Block this specific invocation |
 
 Expand **Manage Auto-Approve Rules** to add commands or patterns to your allowed or denied lists. These rules are then appended to the bottom of the approval rules in settings and the config file.
+
+For the experimental `agent_manager` tool, runtime approvals use the requested mode as the pattern: `worktree` or `local`.
 
 ## MCP Tool Permissions
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -193,6 +193,7 @@ Available experimental toggles include:
 - **LSP integration** — expose language server diagnostics to the agent
 - **Paste summary** — summarize large clipboard pastes before including them
 - **Batch tool** — allow the agent to batch multiple tool calls in one step
+- **Agent Manager Tool** - allow agents to start Agent Manager local and worktree sessions from chat
 - **OpenTelemetry** — enable Kilo telemetry and optional OTLP export when configured
 
 Advanced options not exposed in the UI can be configured via the `experimental` key in `kilo.jsonc`:
@@ -202,6 +203,7 @@ Advanced options not exposed in the UI can be configured via the `experimental` 
   "experimental": {
     "codebase_search": true,
     "batch_tool": false,
+    "agent_manager_tool": false,
     "openTelemetry": true,
     "disable_paste_summary": false,
     "mcp_timeout": 30000


### PR DESCRIPTION
Documents the experimental Agent Manager tool where users configure and evaluate it: Agent Manager, tool overview, experimental settings, and auto-approve permissions.

This keeps the public docs focused on enablement, VS Code-only scope, supported modes, task limits, and mode-scoped approvals.