### PR TITLE
docs: document CLI permission behavior

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/agents/custom-models.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/custom-models.md
@@ -129,6 +129,8 @@ The `limit` object controls how Kilo manages the model's context window and outp
 }
 ```
 
+If a model stops because it reaches `limit.output`, Kilo shows a visible warning that the response may be incomplete. For reasoning models that spend the whole response reasoning and produce no text or tool call, the warning suggests disabling reasoning or increasing `limit.output`.
+
 #### How limits are resolved
 
 Kilo resolves token limits in this order:

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -270,6 +270,8 @@ Any directory allowed here inherits the same defaults as the current workspace. 
 }
 ```
 
+In Ask and Plan modes, `external_directory` allow rules can still permit reads outside the workspace. They do not enable writes or mutating commands that those modes deny, and explicit `external_directory` deny rules still win.
+
 **Aliases:** `/t` and `/history` can be used as shorthand for `/tasks`
 
 ## Configuration
@@ -398,10 +400,10 @@ When running in interactive mode, command approval requests show hierarchical op
 Selecting an "Always run" option will:
 
 1. Approve and execute the current command
-2. Add the pattern to your `execute.allowed` list in the config
-3. Auto-approve matching commands in the future
+2. Save the selected pattern as an `allow` rule under `permission.bash` in your global config
+3. Auto-approve future matching commands, including matching approvals already waiting in other open sessions
 
-This allows you to progressively build your auto-approval rules without manually editing the config file.
+Kilo only saves the pattern you select. Approving a specific command does not approve redirected variants or broader command patterns unless that broader option is shown and selected.
 
 ## Autonomous Mode (Non-Interactive)
 

--- a/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
+++ b/packages/kilo-docs/pages/getting-started/settings/auto-approving-actions.md
@@ -201,8 +201,10 @@ When a tool is set to `"ask"`, Kilo pauses and displays a permission prompt. You
 | Option | Behavior |
 |---|---|
 | **Allow once** | Allow this specific invocation only |
-| **Allow always** | Allow this tool (or pattern) for the rest of the session |
+| **Allow always** | Save an allow rule for the matching tool or pattern in your global config |
 | **Reject** | Block this specific invocation |
+
+For shell commands, saved approvals are written under `permission.bash` and apply across CLI sessions.
 
 ## Defaults
 


### PR DESCRIPTION
## Summary
- Clarify how CLI command approvals persist as global `permission.bash` rules.
- Document the user-facing external-directory Ask/Plan behavior and output-limit warning guidance.