### PR TITLE
test(cli): cover indexing registry isolation

### DIFF
--- a/packages/opencode/test/kilocode/tool-registry-indexing-import-failure.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-indexing-import-failure.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, mock, spyOn } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { testEffect } from "../lib/effect"
+
+const err = new Error("indexing import failed")
+
+mock.module("@/kilocode/indexing", () => {
+  throw err
+})
+
+const { ToolRegistry } = await import("../../src/tool/registry")
+
+const node = CrossSpawnSpawner.defaultLayer
+const it = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, node))
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("kilocode tool registry indexing import failure", () => {
+  it.live("keeps non-indexing tools when the indexing module cannot load", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const logger = Log.create({ service: "kilocode-tool-registry" })
+          const warn = spyOn(logger, "warn").mockImplementation(() => {})
+
+          try {
+            const registry = yield* ToolRegistry.Service
+            const ids = yield* registry.ids()
+
+            expect(ids).not.toContain("semantic_search")
+            expect(ids).toContain("question")
+            expect(ids).toContain("read")
+            expect(ids).toContain("suggest")
+            expect(warn.mock.calls[0]?.[0]).toBe("semantic search unavailable")
+            expect(warn.mock.calls[0]?.[1]?.err).toBeDefined()
+          } finally {
+            warn.mockRestore()
+          }
+        }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
@@ -1,7 +1,12 @@
-import { afterEach, describe, expect, spyOn } from "bun:test"
-import { Effect, Layer } from "effect"
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
 import { KiloIndexing } from "../../src/kilocode/indexing"
+import { KilocodeBootstrap } from "../../src/kilocode/bootstrap"
+import { KiloSessions } from "../../src/kilo-sessions/kilo-sessions"
+import { KiloToolRegistry } from "../../src/kilocode/tool/registry"
 import { ToolRegistry } from "../../src/tool/registry"
+import type * as Tool from "../../src/tool/tool"
 import { Instance } from "../../src/project/instance"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
@@ -15,6 +20,8 @@ afterEach(async () => {
 })
 
 describe("kilocode tool registry indexing", () => {
+  const logger = Log.create({ service: "kilocode-tool-registry" })
+
   it.live("omits semantic_search without waiting for slow indexing startup", () =>
     provideTmpdirInstance(
       () =>
@@ -32,6 +39,62 @@ describe("kilocode tool registry indexing", () => {
             expect(avail).not.toHaveBeenCalled()
           } finally {
             avail.mockRestore()
+          }
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("keeps non-indexing tools when indexing readiness throws", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const err = new Error("ready failed")
+          const ready = spyOn(KiloIndexing, "ready").mockImplementation(() => {
+            throw err
+          })
+          const warn = spyOn(logger, "warn").mockImplementation(() => {})
+
+          try {
+            const registry = yield* ToolRegistry.Service
+            const ids = yield* registry.ids()
+
+            expect(ids).not.toContain("semantic_search")
+            expect(ids).toContain("question")
+            expect(ids).toContain("read")
+            expect(ids).toContain("suggest")
+            expect(warn.mock.calls[0]?.[0]).toBe("semantic search unavailable")
+            expect(warn.mock.calls[0]?.[1]?.err).toBeDefined()
+          } finally {
+            ready.mockRestore()
+            warn.mockRestore()
+          }
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("keeps non-indexing tools when indexing readiness rejects", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const err = new Error("ready rejected")
+          const ready = spyOn(KiloIndexing, "ready").mockImplementation(() => Promise.reject(err) as unknown as boolean)
+          const warn = spyOn(logger, "warn").mockImplementation(() => {})
+
+          try {
+            const registry = yield* ToolRegistry.Service
+            const ids = yield* registry.ids()
+
+            expect(ids).not.toContain("semantic_search")
+            expect(ids).toContain("question")
+            expect(ids).toContain("read")
+            expect(ids).toContain("suggest")
+            expect(warn.mock.calls[0]?.[0]).toBe("semantic search unavailable")
+            expect(warn.mock.calls[0]?.[1]?.err).toBeDefined()
+          } finally {
+            ready.mockRestore()
+            warn.mockRestore()
           }
         }),
       { git: true },
@@ -56,4 +119,62 @@ describe("kilocode tool registry indexing", () => {
       { git: true },
     ),
   )
+
+  test("conditionally includes Kilo registry extras", () => {
+    const prev = process.env["KILO_CLIENT"]
+    const def = (id: string): Tool.Def => ({
+      id,
+      description: id,
+      parameters: Schema.String,
+      execute: () => Effect.succeed({ title: id, output: id, metadata: {} }),
+    })
+    const tools = {
+      codebase: def("codebase_search"),
+      semantic: def("semantic_search"),
+      recall: def("recall"),
+      manager: def("agent_manager"),
+    }
+
+    try {
+      process.env["KILO_CLIENT"] = "cli"
+      expect(KiloToolRegistry.extra(tools, {}).map((tool) => tool.id)).toEqual(["semantic_search", "recall"])
+      expect(
+        KiloToolRegistry.extra(tools, { experimental: { codebase_search: true, agent_manager_tool: true } }).map(
+          (tool) => tool.id,
+        ),
+      ).toEqual(["codebase_search", "semantic_search", "recall"])
+
+      process.env["KILO_CLIENT"] = "vscode"
+      expect(
+        KiloToolRegistry.extra(tools, { experimental: { codebase_search: true, agent_manager_tool: true } }).map(
+          (tool) => tool.id,
+        ),
+      ).toEqual(["codebase_search", "semantic_search", "recall", "agent_manager"])
+      expect(KiloToolRegistry.extra({ ...tools, semantic: undefined }, {}).map((tool) => tool.id)).toEqual(["recall"])
+    } finally {
+      if (prev === undefined) delete process.env["KILO_CLIENT"]
+      if (prev !== undefined) process.env["KILO_CLIENT"] = prev
+    }
+  })
+
+  test("logs indexing bootstrap failures without blocking session bootstrap", async () => {
+    const logger = Log.create({ service: "kilocode-bootstrap" })
+    const err = new Error("indexing init failed")
+    const sessions = spyOn(KiloSessions, "init").mockResolvedValue(undefined)
+    const indexing = spyOn(KiloIndexing, "init").mockRejectedValue(err)
+    const warn = spyOn(logger, "warn").mockImplementation(() => {})
+
+    try {
+      await KilocodeBootstrap.init()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(sessions).toHaveBeenCalledTimes(1)
+      expect(indexing).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledWith("indexing bootstrap failed", { err })
+    } finally {
+      sessions.mockRestore()
+      indexing.mockRestore()
+      warn.mockRestore()
+    }
+  })
 })

--- a/packages/opencode/test/kilocode/tool-registry-semantic-import-failure.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-semantic-import-failure.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, mock, spyOn } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { Instance } from "../../src/project/instance"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { testEffect } from "../lib/effect"
+
+const err = new Error("semantic tool import failed")
+
+mock.module("@/kilocode/indexing", () => ({
+  KiloIndexing: {
+    ready: () => true,
+  },
+}))
+
+mock.module("@/kilocode/tool/semantic-search", () => {
+  throw err
+})
+
+const { ToolRegistry } = await import("../../src/tool/registry")
+
+const node = CrossSpawnSpawner.defaultLayer
+const it = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, node))
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("kilocode tool registry semantic tool import failure", () => {
+  it.live("keeps non-indexing tools when the semantic search tool cannot load", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const logger = Log.create({ service: "kilocode-tool-registry" })
+          const warn = spyOn(logger, "warn").mockImplementation(() => {})
+
+          try {
+            const registry = yield* ToolRegistry.Service
+            const ids = yield* registry.ids()
+
+            expect(ids).not.toContain("semantic_search")
+            expect(ids).toContain("question")
+            expect(ids).toContain("read")
+            expect(ids).toContain("suggest")
+            expect(warn.mock.calls[0]?.[0]).toBe("semantic search tool unavailable")
+            expect(warn.mock.calls[0]?.[1]?.err).toBeDefined()
+          } finally {
+            warn.mockRestore()
+          }
+        }),
+      { git: true },
+    ),
+  )
+})


### PR DESCRIPTION
## Summary
- Add regression coverage for semantic indexing failures leaving the tool registry usable.
- Cover readiness failures, dynamic import failures, conditional semantic tool registration, and bootstrap warning behavior from #9615.