### PR TITLE
test(vscode): cover permission editor patches

### DIFF
--- a/packages/kilo-vscode/tests/unit/permission-editor.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-editor.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "bun:test"
-import { effectiveRuleLevel } from "../../webview-ui/src/components/settings/permission-utils"
-import type { PermissionRuleItem } from "../../webview-ui/src/types/messages"
+import {
+  addExceptionPatch,
+  clearGroupedPatch,
+  clearWildcardPatch,
+  inheritedWildcard,
+  mostRestrictive,
+  permissionExceptions,
+  removeExceptionPatch,
+  setExceptionPatch,
+  setGroupedPatch,
+  setWildcardPatch,
+  wildcardAction,
+  effectiveRuleLevel,
+} from "../../webview-ui/src/components/settings/permission-utils"
+import type { PermissionRule, PermissionRuleItem } from "../../webview-ui/src/types/messages"
 
 describe("effectiveRuleLevel", () => {
   it("uses the last matching wildcard rule from resolved agent rules", () => {
@@ -29,5 +42,63 @@ describe("effectiveRuleLevel", () => {
   it("falls back to ask when no resolved wildcard rule is available", () => {
     expect(effectiveRuleLevel(undefined, "bash")).toBe("ask")
     expect(effectiveRuleLevel([], "bash")).toBe("ask")
+  })
+})
+
+describe("PermissionEditor inherited wildcard state", () => {
+  it("distinguishes inherited defaults from explicit wildcard rules", () => {
+    expect(wildcardAction(undefined, "ask")).toBe("ask")
+    expect(inheritedWildcard(undefined)).toBe(true)
+
+    expect(wildcardAction("deny", "ask")).toBe("deny")
+    expect(inheritedWildcard("deny")).toBe(false)
+
+    expect(wildcardAction({ "*": null, "src/**": "allow" }, "ask")).toBe("ask")
+    expect(inheritedWildcard({ "*": null, "src/**": "allow" })).toBe(true)
+  })
+})
+
+describe("PermissionEditor patch generation", () => {
+  it("emits delete sentinels when clearing wildcard overrides", () => {
+    expect(clearWildcardPatch("deny", "bash")).toEqual({ bash: null })
+
+    expect(clearWildcardPatch({ "*": "deny", "npm test": "allow" }, "bash")).toEqual({
+      bash: { "*": null },
+    })
+  })
+
+  it("preserves exceptions when changing wildcard overrides", () => {
+    expect(setWildcardPatch({ "*": "deny", "src/**": "allow", "dist/**": null }, "edit", "ask")).toEqual({
+      edit: { "*": "ask", "src/**": "allow" },
+    })
+  })
+
+  it("adds, updates, and removes granular exceptions without losing wildcard state", () => {
+    const rule: PermissionRule = { "*": "deny", "src/**": "allow" }
+
+    expect(addExceptionPatch("deny", "bash", "npm test")).toEqual({
+      bash: { "*": "deny", "npm test": "allow" },
+    })
+    expect(setExceptionPatch(rule, "edit", "src/**", "deny")).toEqual({
+      edit: { "*": "deny", "src/**": "deny" },
+    })
+    expect(removeExceptionPatch(rule, "edit", "src/**")).toEqual({
+      edit: { "src/**": null },
+    })
+    expect(removeExceptionPatch("deny", "edit", "src/**")).toBeUndefined()
+  })
+
+  it("generates grouped tool patches for explicit and inherited actions", () => {
+    const ids = ["todoread", "todowrite"]
+
+    expect(mostRestrictive(["allow", "deny", "ask"])).toBe("deny")
+    expect(setGroupedPatch(ids, "allow")).toEqual({ todoread: "allow", todowrite: "allow" })
+    expect(clearGroupedPatch(ids)).toEqual({ todoread: null, todowrite: null })
+  })
+
+  it("filters deleted exceptions from rendered exception rows", () => {
+    expect(permissionExceptions({ "*": "deny", "src/**": "allow", "dist/**": null })).toEqual([
+      { pattern: "src/**", action: "allow" },
+    ])
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
@@ -4,7 +4,21 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 
 import { useLanguage } from "../../context/language"
 import type { PermissionConfig, PermissionLevel, PermissionRule, PermissionRuleItem } from "../../types/messages"
-import { effectiveRuleLevel } from "./permission-utils"
+import {
+  addExceptionPatch,
+  clearGroupedPatch,
+  clearWildcardPatch,
+  effectiveRuleLevel,
+  inheritedWildcard,
+  mostRestrictive,
+  permissionExceptions,
+  removeExceptionPatch,
+  setExceptionPatch,
+  setGroupedPatch,
+  setWildcardPatch,
+  wildcardAction,
+  type PermissionPatch,
+} from "./permission-utils"
 
 type LevelValue = PermissionLevel | "inherit"
 
@@ -109,38 +123,6 @@ const TRAILING_TOOLS: ToolDef[] = [
   { id: "doom_loop", descriptionKey: "settings.autoApprove.tool.doom_loop" },
 ]
 
-const RESTRICTION_ORDER: Record<PermissionLevel, number> = { allow: 0, ask: 1, deny: 2 }
-
-type PermissionPatch = PermissionConfig
-
-function mostRestrictive(levels: PermissionLevel[]): PermissionLevel {
-  return levels.reduce<PermissionLevel>(
-    (best, level) => (RESTRICTION_ORDER[level] > RESTRICTION_ORDER[best] ? level : best),
-    levels[0] ?? "allow",
-  )
-}
-
-function wildcardAction(rule: PermissionRule | undefined, fallback: PermissionLevel): PermissionLevel {
-  if (!rule) return fallback
-  if (typeof rule === "string") return rule
-  if (rule === null) return fallback
-  return rule["*"] ?? fallback
-}
-
-function inheritedWildcard(rule: PermissionRule | undefined): boolean {
-  if (!rule) return true
-  if (typeof rule === "string") return false
-  if (rule === null) return true
-  return rule["*"] === undefined || rule["*"] === null
-}
-
-function exceptions(rule: PermissionRule | undefined): Array<{ pattern: string; action: PermissionLevel }> {
-  if (!rule || typeof rule === "string") return []
-  return Object.entries(rule)
-    .filter(([key, action]) => key !== "*" && action !== null)
-    .map(([pattern, action]) => ({ pattern, action: action as PermissionLevel }))
-}
-
 function toolTitle(id: string): string {
   return id
     .split("_")
@@ -175,57 +157,32 @@ const PermissionEditor: Component<{
   }
 
   const setGrouped = (ids: string[], level: PermissionLevel) => {
-    const patch: PermissionPatch = {}
-    for (const id of ids) patch[id] = level
-    props.onChange(patch)
+    props.onChange(setGroupedPatch(ids, level))
   }
 
   const clearGrouped = (ids: string[]) => {
-    const patch: PermissionPatch = {}
-    for (const id of ids) patch[id] = null
-    props.onChange(patch)
+    props.onChange(clearGroupedPatch(ids))
   }
 
   const setWildcard = (tool: string, level: PermissionLevel) => {
-    const excs = exceptions(ruleFor(tool))
-    if (excs.length === 0) {
-      props.onChange({ [tool]: level })
-      return
-    }
-    const obj: Record<string, PermissionLevel | null> = { "*": level }
-    for (const exc of excs) obj[exc.pattern] = exc.action
-    props.onChange({ [tool]: obj })
+    props.onChange(setWildcardPatch(ruleFor(tool), tool, level))
   }
 
   const clearWildcard = (tool: string) => {
-    const excs = exceptions(ruleFor(tool))
-    if (excs.length === 0) {
-      props.onChange({ [tool]: null })
-      return
-    }
-    props.onChange({ [tool]: { "*": null } })
+    props.onChange(clearWildcardPatch(ruleFor(tool), tool))
   }
 
   const setException = (tool: string, pattern: string, level: PermissionLevel) => {
-    const current = ruleFor(tool)
-    const base: Record<string, PermissionLevel | null> =
-      typeof current === "string" || current === null ? { "*": current } : { ...(current ?? {}) }
-    base[pattern] = level
-    props.onChange({ [tool]: base })
+    props.onChange(setExceptionPatch(ruleFor(tool), tool, pattern, level))
   }
 
   const addException = (tool: string, pattern: string) => {
-    const current = ruleFor(tool)
-    const base: Record<string, PermissionLevel | null> =
-      typeof current === "string" || current === null ? { "*": current } : { ...(current ?? {}) }
-    base[pattern] = "allow"
-    props.onChange({ [tool]: base })
+    props.onChange(addExceptionPatch(ruleFor(tool), tool, pattern))
   }
 
   const removeException = (tool: string, pattern: string) => {
-    const current = ruleFor(tool)
-    if (!current || typeof current === "string") return
-    props.onChange({ [tool]: { [pattern]: null } })
+    const patch = removeExceptionPatch(ruleFor(tool), tool, pattern)
+    if (patch) props.onChange(patch)
   }
 
   return (
@@ -367,7 +324,7 @@ const GranularToolRow: Component<{
     if (adding()) ref?.focus()
   })
 
-  const excs = createMemo(() => exceptions(props.rule))
+  const excs = createMemo(() => permissionExceptions(props.rule))
   const level = createMemo(() => wildcardAction(props.rule, props.fallback))
 
   const submit = () => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
@@ -1,4 +1,8 @@
-import type { PermissionLevel, PermissionRuleItem } from "../../types/messages"
+import type { PermissionConfig, PermissionLevel, PermissionRule, PermissionRuleItem } from "../../types/messages"
+
+export type PermissionPatch = PermissionConfig
+
+const RESTRICTION_ORDER: Record<PermissionLevel, number> = { allow: 0, ask: 1, deny: 2 }
 
 function matchTool(tool: string, pattern: string): boolean {
   if (pattern === tool || pattern === "*") return true
@@ -14,4 +18,89 @@ export function effectiveRuleLevel(rules: PermissionRuleItem[] | undefined, tool
     if (item.pattern === "*" && matchTool(tool, item.permission)) return item.action
   }
   return "ask"
+}
+
+export function mostRestrictive(levels: PermissionLevel[]): PermissionLevel {
+  return levels.reduce<PermissionLevel>(
+    (best, level) => (RESTRICTION_ORDER[level] > RESTRICTION_ORDER[best] ? level : best),
+    levels[0] ?? "allow",
+  )
+}
+
+export function wildcardAction(rule: PermissionRule | undefined, fallback: PermissionLevel): PermissionLevel {
+  if (!rule) return fallback
+  if (typeof rule === "string") return rule
+  if (rule === null) return fallback
+  return rule["*"] ?? fallback
+}
+
+export function inheritedWildcard(rule: PermissionRule | undefined): boolean {
+  if (!rule) return true
+  if (typeof rule === "string") return false
+  if (rule === null) return true
+  return rule["*"] === undefined || rule["*"] === null
+}
+
+export function permissionExceptions(
+  rule: PermissionRule | undefined,
+): Array<{ pattern: string; action: PermissionLevel }> {
+  if (!rule || typeof rule === "string") return []
+  return Object.entries(rule)
+    .filter(([key, action]) => key !== "*" && action !== null)
+    .map(([pattern, action]) => ({ pattern, action: action as PermissionLevel }))
+}
+
+export function setGroupedPatch(ids: string[], level: PermissionLevel): PermissionPatch {
+  const patch: PermissionPatch = {}
+  for (const id of ids) patch[id] = level
+  return patch
+}
+
+export function clearGroupedPatch(ids: string[]): PermissionPatch {
+  const patch: PermissionPatch = {}
+  for (const id of ids) patch[id] = null
+  return patch
+}
+
+export function setWildcardPatch(
+  rule: PermissionRule | undefined,
+  tool: string,
+  level: PermissionLevel,
+): PermissionPatch {
+  const excs = permissionExceptions(rule)
+  if (excs.length === 0) return { [tool]: level }
+  const obj: Record<string, PermissionLevel | null> = { "*": level }
+  for (const exc of excs) obj[exc.pattern] = exc.action
+  return { [tool]: obj }
+}
+
+export function clearWildcardPatch(rule: PermissionRule | undefined, tool: string): PermissionPatch {
+  const excs = permissionExceptions(rule)
+  if (excs.length === 0) return { [tool]: null }
+  return { [tool]: { "*": null } }
+}
+
+export function setExceptionPatch(
+  rule: PermissionRule | undefined,
+  tool: string,
+  pattern: string,
+  level: PermissionLevel,
+): PermissionPatch {
+  const base: Record<string, PermissionLevel | null> =
+    typeof rule === "string" || rule === null ? { "*": rule } : { ...(rule ?? {}) }
+  base[pattern] = level
+  return { [tool]: base }
+}
+
+export function addExceptionPatch(rule: PermissionRule | undefined, tool: string, pattern: string): PermissionPatch {
+  return setExceptionPatch(rule, tool, pattern, "allow")
+}
+
+export function removeExceptionPatch(
+  rule: PermissionRule | undefined,
+  tool: string,
+  pattern: string,
+): PermissionPatch | undefined {
+  if (!rule || typeof rule === "string") return undefined
+  return { [tool]: { [pattern]: null } }
 }


### PR DESCRIPTION
## Summary
- Add focused coverage for PermissionEditor inherited/default state and patch generation from PR #9733.
- Cover wildcard clearing, granular exception add/remove, null delete sentinels, and grouped tool patches without testing cosmetic UI details.

## Checks
- bun test tests/unit/permission-editor.test.ts
- bun eslint webview-ui/src/components/settings/PermissionEditor.tsx webview-ui/src/components/settings/permission-utils.ts tests/unit/permission-editor.test.ts
- bun run check-types:webview (blocked by existing unresolved modules/types in this worktree)
- bun run test:unit (blocked by existing unrelated workspace failures)