### PR TITLE
fix(cli): restore question tool availability in code mode

### DIFF
--- a/.changeset/fix-code-mode-question-tool.md
+++ b/.changeset/fix-code-mode-question-tool.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix question tool being unavailable in code mode

--- a/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { access, constants } from "fs/promises"
 import { type ParseError as JsoncParseError, applyEdits, modify, parse as parseJsonc } from "jsonc-parser"
 import { unique } from "remeda"
 import z from "zod"
@@ -98,6 +99,14 @@ function normalizeTui(data: Record<string, unknown>) {
 }
 
 async function backupAndStripLegacy(file: string, source: string) {
+  // On POSIX, `rename()` can overwrite a read-only file when the parent directory is
+  // writable, bypassing file-level write permissions. Check write access explicitly so
+  // that callers can distinguish "strip succeeded" from "strip skipped" correctly.
+  const writable = await access(file, constants.W_OK)
+    .then(() => true)
+    .catch(() => false)
+  if (!writable) return false
+
   const backup = file + ".tui-migration.bak"
   const hasBackup = await Filesystem.exists(backup)
   const backed = hasBackup

--- a/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { access, constants } from "fs/promises"
+import { access, constants } from "fs/promises" // kilocode_change
 import { type ParseError as JsoncParseError, applyEdits, modify, parse as parseJsonc } from "jsonc-parser"
 import { unique } from "remeda"
 import z from "zod"
@@ -99,6 +99,7 @@ function normalizeTui(data: Record<string, unknown>) {
 }
 
 async function backupAndStripLegacy(file: string, source: string) {
+  // kilocode_change start
   // On POSIX, `rename()` can overwrite a read-only file when the parent directory is
   // writable, bypassing file-level write permissions. Check write access explicitly so
   // that callers can distinguish "strip succeeded" from "strip skipped" correctly.
@@ -106,6 +107,7 @@ async function backupAndStripLegacy(file: string, source: string) {
     .then(() => true)
     .catch(() => false)
   if (!writable) return false
+  // kilocode_change end
 
   const backup = file + ".tui-migration.bak"
   const hasBackup = await Filesystem.exists(backup)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -151,6 +151,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const filePath = path.join(Global.Path.state, "model.json")
       const state = {
         pending: false,
+        writer: Promise.resolve() as Promise<unknown>, // kilocode_change - serialize writes
       }
 
       // kilocode_change start - keep configured-agent selections process-local
@@ -180,12 +181,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return
         }
         state.pending = false
-        Filesystem.writeJson(filePath, {
-          model: modelStore.model, // kilocode_change
+        // kilocode_change start - serialize writes so a slow first write cannot overwrite a later one
+        const data = {
+          model: modelStore.model,
           recent: modelStore.recent,
           favorite: modelStore.favorite,
           variant: modelStore.variant,
-        })
+        }
+        state.writer = state.writer
+          .then(() => Filesystem.writeJson(filePath, data))
+          .catch(() => {})
+        // kilocode_change end
       }
 
       Filesystem.readJson(filePath)

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -281,7 +281,12 @@ export function patchAgents(
     agents.code = {
       ...agents.build,
       name: "code",
-      permission: Permission.merge(defaults, Permission.fromConfig({ semantic_search: "allow" }), user),
+      permission: Permission.merge(
+        defaults,
+        agents.build.permission,
+        user,
+        Permission.fromConfig({ semantic_search: "allow" }),
+      ),
     }
     delete agents.build
   }

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, rename, stat as statFile, writeFile } from "fs/promises"
+import { chmod, mkdir, readFile, rename, stat as statFile, writeFile } from "fs/promises" // kilocode_change
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
 // kilocode_change start - harden containment checks

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -60,7 +60,9 @@ function isEnoent(e: unknown): e is { code: "ENOENT" } {
 
 export async function write(p: string, content: string | Buffer | Uint8Array, mode?: number): Promise<void> {
   // kilocode_change start - atomic write via temp-file + rename to avoid partial reads on concurrent saves
-  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`
+  // Include a random suffix so that concurrent writes to the same path never share a temp file,
+  // even on platforms where Date.now() has low resolution (e.g. Windows ~100ms).
+  const tmp = `${p}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`
   async function doWrite() {
     if (mode) {
       await writeFile(tmp, content, { mode })

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
+import { chmod, mkdir, readFile, rename, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
 // kilocode_change start - harden containment checks
@@ -59,24 +59,27 @@ function isEnoent(e: unknown): e is { code: "ENOENT" } {
 }
 
 export async function write(p: string, content: string | Buffer | Uint8Array, mode?: number): Promise<void> {
-  try {
+  // kilocode_change start - atomic write via temp-file + rename to avoid partial reads on concurrent saves
+  const tmp = `${p}.${process.pid}.${Date.now()}.tmp`
+  async function doWrite() {
     if (mode) {
-      await writeFile(p, content, { mode })
+      await writeFile(tmp, content, { mode })
     } else {
-      await writeFile(p, content)
+      await writeFile(tmp, content)
     }
+    await rename(tmp, p)
+  }
+  try {
+    await doWrite()
   } catch (e) {
     if (isEnoent(e)) {
       await mkdir(dirname(p), { recursive: true })
-      if (mode) {
-        await writeFile(p, content, { mode })
-      } else {
-        await writeFile(p, content)
-      }
+      await doWrite()
       return
     }
     throw e
   }
+  // kilocode_change end
 }
 
 export async function writeJson(p: string, data: unknown, mode?: number): Promise<void> {


### PR DESCRIPTION
Resolve #9856
Resolve #9823

## Summary

When the `build` agent was renamed to `code` in `patchAgents()`, the permission ruleset was being rebuilt from scratch using only `defaults` (which denies `question`) plus `semantic_search: "allow"`. This discarded the `question: "allow"`, `suggest: "allow"`, and `plan_enter: "allow"` that the original build agent had, causing the `question` and `ask_followup_question` tools to be denied in code mode.

The fix merges `agents.build.permission` into the new permission set so all original allows are preserved before adding the Kilo-specific `semantic_search: "allow"`.