### PR TITLE
Skip embedding web UI in extension build script

### DIFF
--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -135,7 +135,8 @@ async function ensureBuiltBinary(): Promise<string> {
   await $`bun install --frozen-lockfile`.cwd(opencodeDir)
 
   // Build using the opencode package script.
-  await $`bun run build --single`.cwd(opencodeDir)
+  // --skip-embed-web-ui avoids bundling packages/app; the extension uses its own webview.
+  await $`bun run build --single --skip-embed-web-ui`.cwd(opencodeDir)
 
   const built = await findKiloBinaryInOpencodeDist()
   if (!built) {


### PR DESCRIPTION
## Context

`prepare:cli-binary` was broken after `packages/app/` got removed from main — `opencode/script/build.ts` still tries to bundle it. Passing `--skip-embed-web-ui` skips that step; the VS Code extension doesn't need the embedded web UI anyway since it has its own webview.

## Testing

Run `bun run prepare:cli-binary --force` from `packages/kilo-vscode/` and confirm it finishes with Copied CLI binary from `opencode/dist/...` -> `bin/kilo` and `bin/kilo --version` prints a version.
