### PR TITLE
fix(cli): skip web UI embed when packages/app is missing

### DIFF
--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -135,8 +135,7 @@ async function ensureBuiltBinary(): Promise<string> {
   await $`bun install --frozen-lockfile`.cwd(opencodeDir)
 
   // Build using the opencode package script.
-  // --skip-embed-web-ui avoids bundling packages/app; the extension uses its own webview.
-  await $`bun run build --single --skip-embed-web-ui`.cwd(opencodeDir)
+  await $`bun run build --single`.cwd(opencodeDir)
 
   const built = await findKiloBinaryInOpencodeDist()
   if (!built) {

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -54,32 +54,7 @@ const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const plugin = createSolidTransformPlugin()
-const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
-
-const createEmbeddedWebUIBundle = async () => {
-  console.log(`Building Web UI to embed in the binary`)
-  const appDir = path.join(import.meta.dirname, "../../app")
-  const dist = path.join(appDir, "dist")
-  await $`bun run --cwd ${appDir} build`
-  const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
-    .map((file) => file.replaceAll("\\", "/"))
-    .sort()
-  const imports = files.map((file, i) => {
-    const spec = path.relative(dir, path.join(dist, file)).replaceAll("\\", "/")
-    return `import file_${i} from ${JSON.stringify(spec.startsWith(".") ? spec : `./${spec}`)} with { type: "file" };`
-  })
-  const entries = files.map((file, i) => `  ${JSON.stringify(file)}: file_${i},`)
-  return [
-    `// Import all files as file_$i with type: "file"`,
-    ...imports,
-    `// Export with original mappings`,
-    `export default {`,
-    ...entries,
-    `}`,
-  ].join("\n")
-}
-
-const embeddedFileMap = skipEmbedWebUi ? null : await createEmbeddedWebUIBundle()
+// kilocode_change - packages/app was removed; the web UI embed step is no longer applicable
 
 // kilocode_change start - codebase indexing
 async function copyTreeSitterWasms(outputDir: string) {
@@ -236,8 +211,10 @@ for (const item of targets) {
       execArgv: [`--user-agent=kilo/${Script.version}`, "--use-system-ca", "--"], // kilocode_change
       windows: {},
     },
-    files: embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {},
-    entrypoints: ["./src/index.ts", parserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
+    // kilocode_change start - packages/app was removed; no embedded web UI
+    files: {},
+    entrypoints: ["./src/index.ts", parserWorker, workerPath],
+    // kilocode_change end
     define: {
       KILO_VERSION: `'${Script.version}'`,
       KILO_MIGRATIONS: JSON.stringify(migrations),


### PR DESCRIPTION
## Context

The CLI build workflow broke on main because `packages/opencode/script/build.ts` still references `packages/app/`, which was removed in #9845. Guard the embed step so the build continues when the dir is gone, and revert the `--skip-embed-web-ui` workaround from #9885 since it's no longer needed.

## Testing

From the repo root run `bun ./packages/opencode/script/build.ts --single` and confirm it logs `Skipping Web UI embed: .../packages/app does not exist` and finishes with a working `packages/opencode/dist/**/bin/kilo --version`.