### PR TITLE
fix(cli): process queued compaction markers

### DIFF
--- a/.changeset/fair-mice-compact.md
+++ b/.changeset/fair-mice-compact.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Fix queued-turn auto-compaction so overflow recovery runs instead of exhausting compaction attempts.

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -42,8 +42,8 @@ export namespace KiloSessionPromptQueue {
 
   /**
    * Exempt an injected user message from being hidden by scope().
-   * Called after PlanFollowup.inject() so the injected follow-up is visible
-   * without also unhiding unrelated prompts that were queued mid-turn.
+   * Called after internal follow-ups or compaction markers are persisted so
+   * they are visible without also unhiding unrelated prompts queued mid-turn.
    */
   export function retarget(sessionID: SessionID, id: MessageID) {
     const current = targets.get(sessionID)

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -18,6 +18,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { isOverflow as overflow, usable } from "./overflow"
 import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
+import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue" // kilocode_change
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -583,6 +584,9 @@ export const layer: Layer.Layer<
         auto: input.auto,
         overflow: input.overflow,
       })
+      // kilocode_change start - keep auto-compaction markers visible during queued turns
+      KiloSessionPromptQueue.retarget(input.sessionID, msg.id)
+      // kilocode_change end
     })
 
     return Service.of({

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -2,13 +2,14 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Bus } from "../../src/bus"
-import { KiloSessionPromptQueue } from "../../src/kilocode/session/prompt-queue"
+import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
 import { Suggestion } from "../../src/kilocode/suggestion"
 import { Question } from "../../src/question"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
+import { SessionCompaction } from "../../src/session/compaction"
 import { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, SessionID } from "../../src/session/schema"
 import * as Log from "@opencode-ai/core/util/log"
@@ -237,6 +238,51 @@ describe("session prompt queue", () => {
     expect(ids).not.toContain(queued)
     expect(ids).toContain(injected)
     expect(ids[ids.length - 1]).toBe(injected)
+  })
+
+  test("keeps auto-compaction markers created during a queued turn visible", async () => {
+    // Regression for ses_20d25cccbffeVAw7Y9XGfL9p5O: an overflow inside a queued
+    // turn creates an auto-compaction user message after the queued prompt. If
+    // scope() hides that marker, runLoop never processes the compaction task and
+    // instead retries the same oversized request until compaction is exhausted.
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "Queued compaction regression" })
+        const first = MessageID.ascending()
+        const ans = MessageID.ascending()
+        const queued = MessageID.ascending()
+
+        await Session.updateMessage(user(session.id, first).info)
+        await Session.updateMessage(assistant(session.id, ans, first).info)
+        await Session.updateMessage(user(session.id, queued).info)
+
+        const result = await Effect.runPromise(
+          KiloSessionPromptQueue.enqueue(
+            session.id,
+            queued,
+            Effect.promise(async () => {
+              await SessionCompaction.create({
+                sessionID: session.id,
+                agent: "code",
+                model: { providerID: ProviderID.make("test"), modelID: ModelID.make("model") },
+                auto: true,
+                overflow: true,
+              })
+              const messages = await Session.messages({ sessionID: session.id })
+              const compact = messages.find((msg) => msg.parts.some((part) => part.type === "compaction"))?.info.id
+              return { compact, ids: KiloSessionPromptQueue.scope(session.id, messages).map((item) => item.info.id) }
+            }),
+            Effect.succeed({ compact: undefined, ids: [] }),
+          ),
+        )
+
+        if (!result.compact) throw new Error("missing compaction marker")
+        expect(result.ids).toEqual([first, ans, queued, result.compact])
+        expect(result.ids[result.ids.length - 1]).toBe(result.compact)
+      },
+    })
   })
 
   test("hasFollowup reports true only for prompts enqueued after the active slot started", async () => {


### PR DESCRIPTION
## Why

Some queued prompts could get stuck after the conversation got too large. Kilo tried to make room, but the cleanup message was hidden, so it kept trying until it gave up.

## What changed

Kilo now keeps the internal cleanup message visible to the queued prompt that is already running. This lets the cleanup run before the same prompt is tried again. Normal queued prompts still stay hidden until their turn, so prompts do not run early. A regression test now checks this exact case.

## How to test

1. Run `bun test ./test/kilocode/session-prompt-queue.test.ts` from `packages/opencode`.
2. Run `bun test ./test/session/compaction.test.ts` from `packages/opencode`.
3. Run `bun run typecheck` from `packages/opencode`.