### PR TITLE
test(cli): quarantine flaky MCP OAuth browser tests

### DIFF
--- a/packages/opencode/script/kilocode-test-skips.ts
+++ b/packages/opencode/script/kilocode-test-skips.ts
@@ -1,0 +1,5 @@
+export const skipped = new Set([
+  // Upstream browser OAuth integration tests bind the fixed callback port and
+  // race with other parallel OAuth tests in CI.
+  "mcp/oauth-browser.test.ts",
+])

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -7,6 +7,7 @@
 import os from "os"
 import path from "path"
 import fs from "fs/promises"
+import { skipped } from "./kilocode-test-skips" // kilocode_change
 
 const root = path.resolve(import.meta.dir, "..")
 const argv = process.argv.slice(2)
@@ -80,8 +81,9 @@ const bold = (s: string) => (tty ? `\x1b[1m${s}\x1b[0m` : s)
 const glob = new Bun.Glob("**/*.test.{ts,tsx}")
 const all = (await Array.fromAsync(glob.scan({ cwd: path.join(root, "test") }))).sort()
 
-const files =
+const matched =
   patterns.length > 0 ? all.filter((f) => patterns.some((p) => f.includes(p) || path.join("test", f).includes(p))) : all
+const files = matched.filter((f) => !skipped.has(f)) // kilocode_change
 
 if (files.length === 0) {
   console.log("No test files found")

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -83,7 +83,7 @@ const all = (await Array.fromAsync(glob.scan({ cwd: path.join(root, "test") })))
 
 const matched =
   patterns.length > 0 ? all.filter((f) => patterns.some((p) => f.includes(p) || path.join("test", f).includes(p))) : all
-const files = matched.filter((f) => !skipped.has(f)) // kilocode_change
+const files = patterns.length > 0 ? matched : matched.filter((f) => !skipped.has(f)) // kilocode_change
 
 if (files.length === 0) {
   console.log("No test files found")


### PR DESCRIPTION
Quarantine the upstream MCP OAuth browser integration test through a Kilo-specific skip list in the isolated CLI test runner.

This avoids a CI-only fixed callback port race while keeping the upstream test file itself untouched for easier merges.