### PR TITLE
Show snapshot progress in working indicator

### DIFF
--- a/.changeset/snapshot-spinner.md
+++ b/.changeset/snapshot-spinner.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show snapshot initialization progress in the extension's existing loading indicator.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3351,7 +3351,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   // ── Worktree stats polling (sidebar diff badge) ──────────────────
-
   private startStatsPolling(): void {
     this.statsPoller?.stop()
     this.statsGitOps?.dispose()

--- a/packages/kilo-vscode/tests/unit/session-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-utils.test.ts
@@ -76,6 +76,11 @@ describe("computeStatus", () => {
     const part: Part = { type: "text", id: "p1", text: "hello" }
     expect(computeStatus(part, t)).toBe("session.status.writingResponse")
   })
+
+  it("maps synthetic snapshot progress to snapshot status", () => {
+    const part: Part = { type: "text", id: "p1", text: "⠋ Initializing snapshot…", synthetic: true }
+    expect(computeStatus(part, t)).toBe("Initializing snapshot...")
+  })
 })
 
 describe("calcTotalCost", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -20,6 +20,7 @@ import { useData } from "@kilocode/kilo-ui/context/data"
 import { useSession } from "../../context/session"
 import { useDisplay } from "../../context/display"
 import { useConfig } from "../../context/config"
+import { snapshotProgress } from "../../context/session-utils"
 import { QuestionDock } from "./QuestionDock"
 import { SuggestBar } from "./SuggestBar"
 
@@ -39,7 +40,7 @@ function isRenderable(part: SDKPart): boolean {
     // Always render question tool parts — active ones get the inline QuestionDock
     return true
   }
-  if (part.type === "text") return !!(part as SDKPart & { text: string }).text?.trim()
+  if (part.type === "text") return !snapshotProgress(part) && !!(part as SDKPart & { text: string }).text?.trim()
   if (part.type === "reasoning") return !!(part as SDKPart & { text: string }).text?.trim()
   return !!PART_MAPPING[part.type]
 }

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -1,5 +1,19 @@
 import type { Part } from "../types/messages"
 
+export const SNAPSHOT_PROGRESS_TEXT = "Initializing snapshot..."
+
+type SnapshotPart = {
+  type?: string
+  text?: string
+  synthetic?: boolean
+}
+
+export function snapshotProgress(part: SnapshotPart | undefined): boolean {
+  if (part?.type !== "text") return false
+  if (!part.synthetic) return false
+  return (part.text ?? "").includes("Initializing snapshot")
+}
+
 /** Minimal message shape for cost breakdown helpers. */
 export type CostMessage = { id: string; role: string; cost?: number }
 
@@ -55,7 +69,7 @@ export function computeStatus(
     }
   }
   if (part.type === "reasoning") return t("ui.sessionTurn.status.thinking")
-  if (part.type === "text") return t("session.status.writingResponse")
+  if (part.type === "text") return snapshotProgress(part) ? SNAPSHOT_PROGRESS_TEXT : t("session.status.writingResponse")
   return undefined
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -16,6 +16,7 @@ export interface BasePart {
 export interface TextPart extends BasePart {
   type: "text"
   text: string
+  synthetic?: boolean
 }
 
 export interface FilePartSource {


### PR DESCRIPTION
## Summary
- Route synthetic snapshot initialization progress into the existing working indicator instead of rendering a separate chat row.
- Filter the transient synthetic part from assistant output and cover the status mapping with a unit test.

Before:
<img width="484" height="354" alt="image" src="https://github.com/user-attachments/assets/e4b93429-26e0-4a0b-9e10-9a678155eb9d" />
After:
<img width="537" height="315" alt="image" src="https://github.com/user-attachments/assets/70be72c3-717f-423d-a17a-8eb59ab50dea" />
