### PR TITLE
Recover dangling assistant turns

### DIFF
--- a/.changeset/stale-turns-recover.md
+++ b/.changeset/stale-turns-recover.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Recover sessions left unable to continue after an assistant turn was created but never started.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -2,10 +2,11 @@
 import path from "path"
 import fs from "fs/promises"
 import { StringDecoder } from "string_decoder"
-import { Cause, Exit } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { SessionID, PartID } from "@/session/schema"
 import { MessageV2 } from "@/session/message-v2"
 import { Session } from "@/session/session"
+import type { SessionStatus } from "@/session/status"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { PlanFollowup } from "@/kilocode/plan-followup"
 import { KiloSession } from "@/kilocode/session"
@@ -56,6 +57,26 @@ export namespace KiloSessionPrompt {
   export function abortPlanFollowup(sessionID: SessionID) {
     return PlanFollowup.abort(sessionID)
   }
+
+  export const recoverDanglingAssistant = Effect.fn("KiloSessionPrompt.recoverDanglingAssistant")(function* (input: {
+    sessionID: SessionID
+    status: Pick<SessionStatus.Interface, "get">
+    sessions: Pick<Session.Interface, "messages" | "removeMessage">
+  }) {
+    const state = yield* input.status.get(input.sessionID)
+    if (state.type !== "idle") return
+
+    const msgs = yield* input.sessions.messages({ sessionID: input.sessionID, limit: 2 })
+    const tail = msgs.at(-1)
+    if (!tail || tail.info.role !== "assistant") return
+    if (tail.parts.length > 0 || tail.info.finish || tail.info.error) return
+
+    const prev = msgs.at(-2)
+    if (!prev || prev.info.role !== "user") return
+    if (tail.info.parentID !== prev.info.id) return
+
+    yield* input.sessions.removeMessage({ sessionID: input.sessionID, messageID: tail.info.id })
+  })
 
   export function guardPermissions(input: {
     agent: { name: string; permission: Permission.Ruleset }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1287,6 +1287,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         const session = yield* sessions.get(input.sessionID)
         yield* revert.cleanup(session)
         // kilocode_change start - persist queued prompts immediately while serializing each follow-up loop
+        yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
         const message = yield* createUserMessage(input)
         yield* sessions.touch(input.sessionID)
 
@@ -1663,6 +1664,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       input: LoopInput,
     ) {
       // kilocode_change start
+      yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
       yield* bus.publish(KiloSession.Event.TurnOpen, { sessionID: input.sessionID })
       return yield* Effect.onExit(
         state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID)),

--- a/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
@@ -270,6 +270,24 @@ const assistant = Effect.fn("prompt-safety.assistant")(function* (
   return msg
 })
 
+const dangling = Effect.fn("prompt-safety.dangling")(function* (sessionID: SessionID, parentID: MessageID) {
+  const sessions = yield* Session.Service
+  return yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID,
+    sessionID,
+    mode: "build",
+    agent: "build",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+  } satisfies MessageV2.Assistant)
+})
+
 const file = Effect.fn("prompt-safety.file")(function* (
   sessionID: SessionID,
   messageID: MessageID,
@@ -384,6 +402,41 @@ describe("SessionPrompt compaction safety", () => {
         expect(body).toContain("src/app.ts")
         expect(body).not.toContain("OLDIMAGE")
         expect(body).not.toContain("[Attached image/png: current.png]")
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
+})
+
+describe("SessionPrompt recovery", () => {
+  it.live("recovers from a dangling assistant row before replying", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Prompt tail recovery" })
+        const first = yield* user(chat.id, "Before the crash")
+        const stale = yield* dangling(chat.id, first.id)
+
+        yield* llm.text("recovered")
+
+        const result = yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          parts: [{ type: "text", text: "Continue after the dangling assistant" }],
+        })
+
+        expect(result.info.role).toBe("assistant")
+        expect(result.info.id).not.toBe(stale.id)
+        expect(result.parts.some((part) => part.type === "text" && part.text === "recovered")).toBe(true)
+        expect(yield* llm.calls).toBe(1)
+
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        const empty = msgs.filter(
+          (msg) => msg.info.role === "assistant" && msg.parts.length === 0 && !msg.info.finish && !msg.info.error,
+        )
+        expect(empty).toHaveLength(0)
+        expect(msgs.some((msg) => msg.info.id === stale.id)).toBe(false)
       }),
       { git: true, config: providerCfg },
     ),


### PR DESCRIPTION
## Summary
- Recover sessions left with a persisted assistant row that has no parts, no `finish`, no error, and points to the previous user message. This is the stuck state created when a crash or revert race allocates an assistant turn but never starts writing assistant parts.
- Before accepting the next prompt or direct loop, Kilo removes only that idle, unstarted assistant tail so the session can continue normally.
- Keep the recovery logic in Kilo-owned prompt code with tiny annotated hooks in shared prompt handling, plus a Kilo-owned regression test and changeset.

## Validation
- `bun test ./test/kilocode/session-prompt-compaction-safety.test.ts`
- `bun test ./test/session/prompt.test.ts --test-name-pattern "empty assistant|cancel records MessageAbortedError"`
- `bun run typecheck`
- `bun run script/check-opencode-annotations.ts --base main`

## Manual verification
- Verified manually against the affected `buttoned-molybdenum` session. Sending a new prompt recovered the stuck session and produced a normal reply.