### PR TITLE
fix(ui): keep settings select dropdown in viewport

### DIFF
--- a/.changeset/select-settings-viewport.md
+++ b/.changeset/select-settings-viewport.md
@@ -1,0 +1,6 @@
+---
+"@opencode-ai/ui": patch
+"@kilocode/kilo-ui": patch
+---
+
+Keep settings select dropdowns within the viewport when opened near the edge.

--- a/packages/kilo-ui/src/components/select.css
+++ b/packages/kilo-ui/src/components/select.css
@@ -57,6 +57,11 @@
   }
 }
 
+[data-component="select"][data-trigger-style="settings"] [data-slot="select-select-trigger"] {
+  box-sizing: border-box;
+  width: 100%;
+}
+
 /* Select dropdown content */
 [data-component="select-content"] {
   min-width: 200px !important;

--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -172,6 +172,7 @@
 
 [data-component="select-content"][data-trigger-style="settings"] {
   min-width: 160px;
+  max-width: min(23rem, var(--kb-popper-content-available-width)); /* kilocode_change */
   border-radius: 8px;
   padding: 0;
 

--- a/packages/ui/src/components/select.test.ts
+++ b/packages/ui/src/components/select.test.ts
@@ -1,0 +1,16 @@
+// kilocode_change - new file
+import { expect, test } from "bun:test"
+import css from "./select.css" with { type: "text" }
+
+const src = await Bun.file(new URL("./select.tsx", import.meta.url)).text()
+
+test("settings select uses horizontal viewport collision handling", () => {
+  expect(src).toContain('placement={local.triggerVariant === "settings" ? "bottom-end" : "bottom-start"}')
+  expect(src).toContain('overlap={local.triggerVariant === "settings"}')
+  expect(src).toContain('fitViewport={local.triggerVariant === "settings"}')
+  expect(src).toContain('overflowPadding={local.triggerVariant === "settings" ? 12 : undefined}')
+})
+
+test("settings select content is constrained by available popper width", () => {
+  expect(css).toContain("max-width: min(23rem, var(--kb-popper-content-available-width));")
+})

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -89,6 +89,9 @@ export function Select<T>(props: SelectProps<T> & Omit<ButtonProps, "children">)
       data-component="select"
       data-trigger-style={local.triggerVariant}
       placement={local.triggerVariant === "settings" ? "bottom-end" : "bottom-start"}
+      overlap={local.triggerVariant === "settings"} // kilocode_change
+      fitViewport={local.triggerVariant === "settings"} // kilocode_change
+      overflowPadding={local.triggerVariant === "settings" ? 12 : undefined} // kilocode_change
       gutter={4}
       value={local.current}
       options={grouped()}


### PR DESCRIPTION
## Context

Fixes #9858. The autocomplete model selector in Kilo settings could sit against the right edge of narrow or right-docked VS Code webviews, and the settings dropdown could overflow or clip at the viewport edge.

## Implementation

Settings selects now enable Kobalte/Floating UI horizontal collision handling with viewport fitting and a small viewport inset. The shared settings dropdown CSS caps content width to the available popper width.

The Kilo UI select override also sizes settings triggers with border-box width: 100%, so the visible trigger stays inside the settings row input slot instead of letting padding and borders render past the right edge.

## Screenshots

| before | after |
|---|---|
| See issue screenshot | Verified manually in the VS Code settings view |

## How to Test

- Open Kilo settings in a narrow or right-docked VS Code panel.
- Go to Models and inspect the Autocomplete model selector.
- Open the autocomplete model selector near the right edge of the webview.
- Confirm the closed selector box stays fully inside the panel and the dropdown remains visible within the viewport.

Automated checks run:
- bun test ./src/components/select.test.ts from packages/ui: passes
- bun run script/check-opencode-annotations.ts --base upstream/main from repo root: passes
- bun turbo typecheck from repo root via pre-push hook: passes

## Get in Touch

