### PR TITLE
docs(kilo-cli): tighten upstream-manual-merge command

### DIFF
--- a/.kilo/command/upstream-manual-merge.md
+++ b/.kilo/command/upstream-manual-merge.md
@@ -153,7 +153,7 @@ approval flow.
 
 ### 7. Verify each resolution before moving on
 
-- confirm `grep -c "^<<<<<<<\|^|||||||\|^=======$\|^>>>>>>>" <file>` returns 0
+- confirm `script/upstream/find-conflict-markers.sh <file>` prints nothing
 - read the final file region (the new shape after edit) and sanity-check imports
 - for apparently-unused symbols upstream introduced, `grep` the file and the
   rest of the package before deleting — they may be called from non-conflicted

--- a/.kilo/command/upstream-manual-merge.md
+++ b/.kilo/command/upstream-manual-merge.md
@@ -10,67 +10,225 @@ Use the first argument as the upstream version, for example `v1.1.50` or
 `1.1.50`. If no argument is provided, infer the version from the current branch
 name, `upstream-merge-report-<version>.md`, or the newest relevant report file.
 
-Workflow:
+## Workflow
 
-1. Inspect the current merge state:
-   - `git status --short`
-   - `git diff --name-only --diff-filter=U`
-   - `upstream-merge-report-<version>.md` when present
-   - `.worktrees/opencode-merge/auto-merge` for the automated merge snapshot when present
-2. Before editing, write a concise plan in the chat:
-   - file-by-file strategy
-   - expected resolution kind: `hybrid`, `take-ours`, `take-theirs`, `regenerated`, `removed`, `renamed`, or `other`
-   - risk level: `low`, `medium`, or `high`
-   - verification commands you expect to run
-3. Ask the user to approve the plan before applying any manual conflict
-   resolution. Do not resolve a file until the user has approved that file's
-   strategy.
-4. Resolve each conflict carefully, one file at a time.
+### 1. Inspect the current merge state
 
-   **Reference worktrees when present:**
-   - `.worktrees/opencode-merge/opencode` is the pristine upstream opencode tree
-   - `.worktrees/opencode-merge/kilo-main` is the Kilo base snapshot
-   - `.worktrees/opencode-merge/auto-merge` is the automated merge snapshot and the original conflict reference
+- `git status --short`
+- `git diff --name-only --diff-filter=U`
+- `upstream-merge-report-<version>.md` when present
+- `.worktrees/opencode-merge/auto-merge` for the automated merge snapshot when present
 
-   **Inspect conflicts (optional):**
-   - `script/upstream/find-conflict-markers.sh <file>` on the working tree
-   - `script/upstream/find-conflict-markers.sh .worktrees/opencode-merge/auto-merge/<file>` on the auto-merge snapshot
+### 2. Read every conflicted file end-to-end before planning
 
-   **Apply the resolution rules:**
-   - prefer upstream code and architecture whenever compatible with Kilo behavior
-   - preserve Kilo-specific behavior marked with `kilocode_change`
-   - keep `kilocode_change` markers around Kilo-specific changes in shared opencode files
-   - keep Kilo-specific text, code, and marker comments the same as the auto-merge conflict snapshot unless a refactor is required
-   - if Kilo-specific code must be refactored to fit new upstream architecture, explain the refactor in the final summary
-   - if upstream moved the relevant logic to another file, port the Kilo behavior there and list both paths in the final summary
-   - if upstream deleted a file, analyze whether the Kilo behavior should be ported elsewhere or removed rather than restoring the deleted file
-   - if tests fail only because upstream intentionally removed behavior, remove or update the obsolete tests rather than adding the old file back
-   - do not modify unrelated files
-5. After each file is resolved, verify the decision before moving on:
-   - inspect the resolved file and confirm it has no conflict markers
-   - compare against the opencode, kilo-main, and auto-merge references when present
-   - run the smallest relevant check for that file when practical
-   - summarize the exact resolution, tradeoff, and verification result in chat
-   - ask the user to approve the resolved file before staging it or resolving the next file
-6. Run the appropriate checks:
-   - stage resolved files with `git add -A` so git no longer reports unmerged paths
-   - if `packages/opencode/` shared files changed, run `bun run script/check-opencode-annotations.ts`
-   - run targeted typechecks/tests when practical for touched packages
-   - run `bun run typecheck` from the repo root before declaring the merge ready
-7. Finish with:
-   - files resolved
-   - resolution choices and rationale
-   - checks run and results
-   - any remaining high-risk areas for reviewer attention
+Use `script/upstream/find-conflict-markers.sh <file>` to jump to each region,
+then read enough surrounding lines to understand the code — not just the
+conflict hunk. Specifically check:
 
-Every manual merge decision requires explicit user approval before applying and
-again after verification. Be especially cautious when a decision is destructive,
-changes auth, billing, data deletion, public API compatibility, config schema
-behavior, migrations, provider routing, or security posture.
+- is this a plain 3-way on a single expression, or a structural refactor?
+- does upstream rename/move something that invalidates a HEAD-only declaration?
+- does a `kilocode_change` marker in HEAD encode a bug fix, a feature, or a
+  defensive check?
+- is the conflicted block referenced by *non-conflicted* code elsewhere in the
+  same file (imports, signatures, call sites) that will break if we drop it?
 
-Common pitfalls to watch for:
-- auto-merged code can reference declarations that still live inside conflict blocks
-- related sibling files can need edits even when they are not listed as unmerged
-- `renamed` should be used only when behavior moves to a different file
-- function signatures can drift across conflict boundaries
-- full repo typecheck is the catch-all for non-conflicted call-site breakage
+When HEAD includes a non-obvious Kilo-specific wrapper (e.g. a helper in
+`packages/opencode/src/kilocode/`), find out why it exists before deciding to
+keep or bypass it:
+
+```bash
+git log --all --oneline -S "<symbol>" -- packages/opencode/src/kilocode/
+git log --all --oneline -- <kilo-file>
+```
+
+Look at the commit message and any PR reference. "We wrote our own because of
+PR #NNNN" is a real constraint; "we wrote our own because of a typo" is not.
+
+### 3. Write a plan in chat and get approval
+
+For every conflicted file (and any adjacent file the resolution forces you to
+touch — see §6) include:
+
+- expected resolution kind: `hybrid`, `take-ours`, `take-theirs`, `regenerated`,
+  `removed`, `renamed`, or `other`
+- risk level: `low`, `medium`, or `high`
+- one-sentence rationale (what Kilo behaviour is preserved, what upstream
+  feature is adopted, what is dropped)
+- verification commands you expect to run (targeted tests, typecheck)
+
+Group files by risk level. Ask the user which batch to start with. You can
+resolve an entire `low` batch in one pass if the user approves the batch, but
+resolve `medium` and `high` files one at a time.
+
+**Do not resolve a file until the user has approved that file's (or batch's)
+strategy.**
+
+### 4. Before every edit, explain reasoning before showing the diff
+
+The user needs to review intent, not just the raw change. For each file, in
+order:
+
+1. Show the conflict's surrounding context (10–30 lines around each conflict
+   region, in chat).
+2. Explain what each of the three sides (HEAD, merge-base, upstream) is doing.
+3. State which Kilo behaviour must survive and why (reference PR numbers /
+   `kilocode_change` comments when possible).
+4. State the resolution and why it is better than the alternatives.
+5. Then apply the edit. The tool will display the diff — the user only has to
+   verify the diff matches the reasoning.
+
+Do not lead with the diff. A diff without reasoning forces the user to
+reverse-engineer the decision.
+
+### 5. Apply resolution rules
+
+Reference worktrees when present:
+
+- `.worktrees/opencode-merge/opencode` — pristine upstream tree
+- `.worktrees/opencode-merge/kilo-main` — Kilo base snapshot
+- `.worktrees/opencode-merge/auto-merge` — automated merge snapshot (original
+  conflict reference)
+
+Apply in order:
+
+- prefer upstream code and architecture whenever compatible with Kilo behaviour
+- preserve Kilo-specific behaviour marked with `kilocode_change`
+- keep `kilocode_change` markers around Kilo-specific code in shared opencode
+  files
+- when upstream refactors a region that HEAD had annotated with
+  `kilocode_change`, **check whether the marker encodes a bug fix or a feature
+  delta**. Bug fixes (missing `await`, defensive null-check, error capture)
+  usually need to be re-applied on top of the upstream refactor. Example from
+  v1.14.30: `Workspace.isSyncing` was missing an `await` — upstream's Effect
+  refactor reintroduced the same bug, so we had to port the fix into the new
+  `Effect.gen` block.
+- when a `take-theirs` drops a line that was the target of a Kilo pre-filter,
+  the upstream line may be actively wrong for Kilo — e.g. an inner `continue`
+  filter whose condition collides with an outer filter Kilo added. Re-read the
+  surrounding 20 lines before committing to `take-theirs`.
+- if Kilo-specific code must be refactored to fit new upstream architecture,
+  explain the refactor in the final summary
+- if upstream moved the relevant logic to another file, port the Kilo behaviour
+  there and list both paths in the final summary. Verify the new file already
+  carries the Kilo-renamed symbols (e.g. `x-kilo-directory`) by diffing against
+  pristine upstream.
+- if upstream deleted a file, analyse whether the Kilo behaviour should be
+  ported elsewhere or removed rather than restoring the deleted file
+- if tests fail only because upstream intentionally removed behaviour, remove
+  or update the obsolete tests rather than adding the old file back
+- do not modify unrelated files
+
+When removing code that existed in one side of a conflict, prefer
+**commenting it out with `kilocode_change` markers** over deletion when the
+surrounding structure (an `if`, a loop) still makes sense. That keeps the
+intent visible to the next merger. Example:
+
+```ts
+} else if (input?.scope !== "project" && !Flag.KILO_EXPERIMENTAL_WORKSPACES) {
+  // kilocode_change start - directory filtering handled by KiloSession.filters above
+  // if (input?.directory) {
+  //   conditions.push(eq(SessionTable.directory, input.directory))
+  // }
+  // kilocode_change end
+}
+```
+
+Use `TODO:` not `NOTE:` for follow-ups. `TODO` is searchable and implies an
+owner will act on it; `NOTE` reads as permanent commentary.
+
+### 6. Look for adjacent files the conflict forces you to touch
+
+Upstream restructures sometimes split one file into several (e.g. `permission.ts`
+→ `groups/permission.ts` + `handlers/permission.ts`). Only the *renamed* file
+shows up in `git diff --diff-filter=U`; the new sibling may need a Kilo feature
+ported in too. After resolving the flagged file, check:
+
+- files that import from the resolved file — do they compile?
+- files at paths implied by new imports (e.g. `../middleware/*`, `./handlers/*`)
+- `kilocode_change` comments in the *auto-merge* snapshot that didn't end up in
+  the working tree because the hosting file was renamed
+
+Add any such files to the plan as `hybrid` or `take-ours` with the same
+approval flow.
+
+### 7. Verify each resolution before moving on
+
+- confirm `grep -c "^<<<<<<<\|^|||||||\|^=======$\|^>>>>>>>" <file>` returns 0
+- read the final file region (the new shape after edit) and sanity-check imports
+- for apparently-unused symbols upstream introduced, `grep` the file and the
+  rest of the package before deleting — they may be called from non-conflicted
+  code elsewhere. Example: `isTheme` in `theme.tsx` looked unused at the
+  resolution site but was called twice further down.
+- run the smallest relevant check (single `bun test` file, or `bun run
+  typecheck` in the touched package)
+- summarise the exact resolution, tradeoff, and verification result in chat
+- ask the user to approve the resolved file before staging it or resolving the
+  next one (for `medium` / `high`; `low` batches can be staged together)
+
+### 8. Run the full checks once everything is resolved
+
+- `git diff --name-only --diff-filter=U` returns empty
+- `bun run typecheck` from `packages/opencode/` (targeted) and from repo root
+  (catches non-conflicted call-site breakage)
+- relevant targeted tests. Tests that hang or time out in an unrelated part of
+  the graph may be pre-existing — note them, don't block the merge on them
+- `bun run script/check-opencode-annotations.ts` if `packages/opencode/` shared
+  files changed. Note that this tool compares against the merge base via `HEAD`
+  and will be silent until the merge commit lands
+- other CI guards that touched files imply (knip for `kilo-vscode/`,
+  `check-kilocode-change`, source-links, visual regression)
+
+### 9. Commit with the standard message
+
+Per `script/upstream/README.md`:
+
+```bash
+git commit -m "resolve merge conflicts"
+```
+
+The default `git merge` auto-message (`Merge branch '…' into …`) is also fine,
+but `resolve merge conflicts` is the convention for these PRs.
+
+### 10. Write the PR body
+
+Structure the description so reviewers can skim:
+
+- **Non-trivial merge decisions**: a short section per file (or group of
+  related files) that required more than a mechanical `take-ours`/`take-theirs`.
+  Focus on *what Kilo behaviour survived* and *what upstream features were
+  adopted*. Link to Kilo PRs when a `kilocode_change` encodes a specific fix.
+- **Notable auto-merged changes**: new columns, new helper files, renamed
+  middleware — anything reviewers should eyeball even though git didn't flag
+  it.
+- **What to test**: explicit, scenario-level test steps for each non-trivial
+  change. Don't list tests; list *user-visible behaviour* so a tester who
+  doesn't read the diff can exercise it.
+- **CI guards to watch**: typecheck, knip, annotation check, visual regression.
+- **Follow-ups**: any `TODO:` you left in code, as a bullet list with links.
+
+## User-approval checkpoints
+
+Every manual merge decision requires explicit user approval **before applying**
+and **again after verification**. Be especially cautious when a decision is
+destructive, changes auth, billing, data deletion, public API compatibility,
+config schema behaviour, migrations, provider routing, or security posture.
+
+## Common pitfalls
+
+- Auto-merged code can reference declarations that still live inside conflict
+  blocks.
+- Related sibling files can need edits even when they are not listed as
+  unmerged — especially after upstream structural splits.
+- `renamed` should be used only when behaviour moves to a different file.
+- Function signatures can drift across conflict boundaries (args added, return
+  types widened). Grep for every call site before finalising.
+- Full-repo typecheck is the catch-all for non-conflicted call-site breakage.
+- Upstream can reintroduce bugs a Kilo `kilocode_change` had already fixed —
+  during big refactors check every `kilocode_change` the refactor touched.
+- "Take-theirs" on an inner conditional is often wrong when Kilo added an outer
+  pre-filter whose whole point was to widen what makes it to the inner block.
+- Apparently-unused upstream-added declarations may be called from
+  non-conflicted code elsewhere. Grep before deleting.
+- Stricter DOM lib types (upstream TS upgrade) can surface latent casting
+  issues around `WebSocket.send`, `Headers`, etc. — prefer narrowing the Kilo
+  type over adding `any` casts.


### PR DESCRIPTION
## Summary

Incorporates lessons from the v1.14.30 manual merge (PR #9911) into `.kilo/command/upstream-manual-merge.md` so the next merge goes smoother.

## What changed

The command now tells the agent to:

- **Explain reasoning before showing the diff, not after.** Reviewers need intent, not a raw patch to reverse-engineer.
- **Investigate why a Kilo-specific helper exists before bypassing it.** Concretely: `git log -S <symbol>` + commit-message/PR-reference check. The v1.14.30 merge broke a session-list test because `KiloSession.filters` existed for a specific reason (PR #8875: keep worktree sessions across project_id changes) that wasn't obvious from the code alone.
- **Check whether a `kilocode_change` marker encodes a bug fix or a feature, during upstream refactors.** Upstream can reintroduce the same bug a Kilo change had fixed — happened in v1.14.30 with `Workspace.isSyncing` losing its `await` when the proxy moved to Effect.
- **Be skeptical of `take-theirs` on an inner conditional when Kilo added an outer pre-filter.** The upstream inner filter's condition can become actively wrong for Kilo (v1.14.30: `tui.ts` config directory filter).
- **Prefer commenting-out with `kilocode_change` markers over deletion** when the surrounding structure still matters; keeps intent visible to the next merger.
- **Use `TODO:` not `NOTE:`** for follow-ups.
- **Look for adjacent files that structural splits force you to touch** (v1.14.30: `permission.ts` → `groups/permission.ts` + `handlers/permission.ts`; only the renamed file was flagged unmerged).
- **Grep for usages before deleting apparently-unused upstream declarations** — they may be called from non-conflicted code elsewhere in the same file (`isTheme` in `theme.tsx`).
- **Use batch approval for `low` risk, per-file approval for `medium`/`high`.**
- **Commit with `resolve merge conflicts`** per `script/upstream/README.md`.
- **Write a structured PR body**: non-trivial decisions, notable auto-merged changes, scenario-level test steps, CI guards, follow-ups.

## Testing

- `bun run typecheck` passes locally (no code change — docs only).
- Command file still parses (frontmatter + markdown body unchanged).
