### PR TITLE
fix(vscode): keep active terminal for @terminal context

### DIFF
--- a/.changeset/terminal-context-active.md
+++ b/.changeset/terminal-context-active.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Capture the active VS Code terminal when using `@terminal` in Agent Manager.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -392,7 +392,7 @@ export class AgentManagerProvider implements Disposable {
     }
 
     if (m.type === "requestTerminalContext") {
-      if (m.sessionID) this.terminalManager.showExisting(m.sessionID)
+      if (m.sessionID && !this.terminalManager.hasActiveTerminal()) this.terminalManager.showExisting(m.sessionID)
       return msg
     }
 

--- a/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
@@ -182,6 +182,10 @@ export class SessionTerminalManager {
     return entry !== undefined && entry.terminal.exitStatus === undefined
   }
 
+  hasActiveTerminal(): boolean {
+    return this.host.activeTerminal() !== undefined
+  }
+
   dispose(): void {
     void this.host.setContext("kilo-code.agentTerminalFocus", false)
     for (const entry of this.terminals.values()) entry.terminal.dispose()

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -229,6 +229,15 @@ describe("Agent Manager Provider — onMessage routing", () => {
     expect(text).toContain("syncOnSessionSwitch")
   })
 
+  it("terminal context keeps the current active terminal when present", () => {
+    const text = body("onSessionMessage")
+    const check = text.indexOf("!this.terminalManager.hasActiveTerminal()")
+    const show = text.indexOf("this.terminalManager.showExisting(m.sessionID)")
+    expect(check).toBeGreaterThan(-1)
+    expect(show).toBeGreaterThan(-1)
+    expect(check, "active terminal check must guard session terminal reveal").toBeLessThan(show)
+  })
+
   it("session routing handles clearSession for SSE re-registration", () => {
     const text = body("onSessionMessage")
     expect(text).toContain("clearSession")

--- a/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
@@ -87,4 +87,9 @@ describe("SessionTerminalManager structure", () => {
     expect(text).toContain("if (!this.panelOpen)")
     expect(text).toContain("this.showExistingLocal()")
   })
+
+  it("exposes active terminal state for terminal context routing", () => {
+    const text = body("hasActiveTerminal")
+    expect(text).toContain("this.host.activeTerminal()")
+  })
 })


### PR DESCRIPTION
Agent Manager now preserves the active VS Code integrated terminal when resolving `@terminal` context, so Run task output and manually focused integrated terminals can be sent to the model.

It only falls back to the session/worktree terminal when there is no active integrated terminal, avoiding unexpected terminal switches during prompt send.