### PR TITLE
Delete custom providers from config

### DIFF
--- a/.changeset/remove-custom-providers.md
+++ b/.changeset/remove-custom-providers.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+"@kilocode/sdk": patch
+---
+
+Remove custom providers from settings when disconnecting them so they do not reappear after being disabled and re-enabled.

--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -223,7 +223,7 @@ async function removeCustom(ctx: ActionContext, id: string, global: Config, merg
       }),
     )
   }
-  if (customProvider(effective) && (!customProvider(cfg) || !same(cfg, effective))) {
+  if (customProvider(effective)) {
     tasks.push(saveProject(ctx, { provider: { [id]: null } }))
   }
   await Promise.all(tasks)

--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -2,14 +2,14 @@
  * Provider action handlers extracted from KiloProvider to stay under max-lines.
  * These are pure async functions that operate on the SDK client — no vscode dependency.
  */
-import type { KiloClient } from "@kilocode/sdk/v2"
+import type { Config, KiloClient } from "@kilocode/sdk/v2"
 import { validateProviderID as validateProviderIDShared } from "./shared/custom-provider"
 import {
   resolveCustomProviderAuth,
   sanitizeCustomProviderConfig,
   withCustomProviderDeletions,
 } from "./shared/custom-provider"
-import { KILO_AUTO, parseModelString } from "./shared/provider-model"
+import { CUSTOM_PROVIDER_PACKAGE, KILO_AUTO, parseModelString } from "./shared/provider-model"
 import { configFeatures } from "./features"
 
 /**
@@ -20,6 +20,28 @@ type AuthState = "api" | "oauth" | "wellknown"
 
 function disabledWithout(list: string[] | undefined, id: string) {
   return (list ?? []).filter((item) => item !== id)
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function customProvider(config: unknown) {
+  return record(config) && config.npm === CUSTOM_PROVIDER_PACKAGE
+}
+
+function same(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false
+    if (a.length !== b.length) return false
+    return a.every((value, index) => same(value, b[index]))
+  }
+  if (!record(a) || !record(b)) return false
+  const akeys = Object.keys(a).sort()
+  const bkeys = Object.keys(b).sort()
+  if (akeys.length !== bkeys.length) return false
+  return akeys.every((key, index) => key === bkeys[index] && same(a[key], b[key]))
 }
 
 /** Fetch auth methods alongside the provider list. Auth states default to empty (endpoint not yet available). */
@@ -123,6 +145,7 @@ export function computeDefaultSelection(
 
 type PostMessage = (message: unknown) => void
 type GetErrorMessage = (error: unknown) => string
+type SetCachedConfig = (msg: unknown) => void
 
 interface ActionContext {
   client: KiloClient
@@ -153,6 +176,69 @@ function validateID(
   if ("value" in result) return result.value
   postError(ctx, requestId, providerID, action, result.error)
   return null
+}
+
+async function configs(ctx: ActionContext) {
+  const [{ data: global }, { data: merged }] = await Promise.all([
+    ctx.client.global.config.get({ throwOnError: true }),
+    ctx.client.config.get({ directory: ctx.workspaceDir }, { throwOnError: true }),
+  ])
+  return { global: global ?? {}, merged: merged ?? {} }
+}
+
+async function refreshConfig(ctx: ActionContext, setCachedConfig: SetCachedConfig) {
+  const { data: config } = await ctx.client.config.get({ directory: ctx.workspaceDir }, { throwOnError: true })
+  if (!config) return
+  const features = configFeatures(config)
+  setCachedConfig({ type: "configLoaded", config, features })
+  ctx.postMessage({ type: "configUpdated", config, features })
+}
+
+async function saveGlobal(ctx: ActionContext, config: Config) {
+  await ctx.client.global.config.update({ config }, { throwOnError: true })
+}
+
+async function saveProject(ctx: ActionContext, config: Config) {
+  await ctx.client.config.update({ config, directory: ctx.workspaceDir }, { throwOnError: true })
+}
+
+async function removeAuth(ctx: ActionContext, id: string, configured: boolean) {
+  try {
+    await ctx.client.auth.remove({ providerID: id }, { throwOnError: true })
+  } catch (err) {
+    if (!configured) throw err
+    console.warn(`[Kilo New] auth.remove failed for configured provider ${id} (non-fatal):`, err)
+  }
+}
+
+async function removeCustom(ctx: ActionContext, id: string, global: Config, merged: Config) {
+  const cfg = global.provider?.[id]
+  const effective = merged.provider?.[id]
+  const tasks = []
+  if (customProvider(cfg)) {
+    tasks.push(
+      saveGlobal(ctx, {
+        provider: { [id]: null },
+        disabled_providers: disabledWithout(global.disabled_providers, id),
+      }),
+    )
+  }
+  if (customProvider(effective) && (!customProvider(cfg) || !same(cfg, effective))) {
+    tasks.push(saveProject(ctx, { provider: { [id]: null } }))
+  }
+  await Promise.all(tasks)
+}
+
+async function disableConfigured(ctx: ActionContext, id: string, config: Config) {
+  const disabled = config.disabled_providers ?? []
+  if (disabled.includes(id)) return
+  await saveGlobal(ctx, { disabled_providers: [...disabled, id] })
+}
+
+async function enableConfigured(ctx: ActionContext, id: string, config: Config) {
+  const disabled = disabledWithout(config.disabled_providers, id)
+  if (disabled.length === (config.disabled_providers ?? []).length) return
+  await saveGlobal(ctx, { disabled_providers: disabled })
 }
 
 export async function connectProvider(ctx: ActionContext, requestId: string, providerID: string, apiKey: string) {
@@ -230,63 +316,44 @@ export async function disconnectProvider(
   requestId: string,
   providerID: string,
   cachedConfigMessage: unknown,
-  setCachedConfig: (msg: unknown) => void,
+  setCachedConfig: SetCachedConfig,
 ) {
   const id = validateID(ctx, requestId, providerID, "disconnect")
   if (!id) return
   try {
-    const globalConfig = (await ctx.client.global.config.get({ throwOnError: true })).data ?? {}
-    const configured = !!globalConfig.provider?.[id]
+    const config = await configs(ctx)
+    const cfg = config.global.provider?.[id]
+    const effective = config.merged.provider?.[id]
+    const configured = !!cfg || !!effective
+    const custom = customProvider(cfg) || customProvider(effective)
     const { response } = await fetchProviderData(ctx.client, ctx.workspaceDir)
     const active = response.all.find((item) => item.id === id)
-    const oauth = active?.source === "custom" && configured
+    const oauth = active?.source === "custom" && configured && !custom
 
-    // Remove auth store entry. Config-sourced providers may not have an auth
-    // store entry (credentials come from config or env), so failure is non-fatal.
-    // For auth-only providers, failure means disconnect failed.
-    try {
-      await ctx.client.auth.remove({ providerID: id }, { throwOnError: true })
-    } catch (err) {
-      if (!configured) throw err
-      console.warn(`[Kilo New] auth.remove failed for configured provider ${id} (non-fatal):`, err)
-    }
+    // Config-sourced providers may not have auth store entries because
+    // credentials can come from config or env, so auth removal is non-fatal.
+    await removeAuth(ctx, id, configured)
 
     if (id === "kilo") {
       ctx.postMessage({ type: "profileData", data: null })
     }
 
-    // Config-sourced providers stay "connected" after auth.remove because the
-    // server rebuilds state from config. Add to disabled_providers so the server
-    // excludes them. The config entry is preserved (user may re-enable later).
-    // This mirrors the server's disabled provider config behavior.
-    if (configured && !oauth) {
-      const disabled = globalConfig.disabled_providers ?? []
-      if (!disabled.includes(id)) {
-        const merged = (
-          await ctx.client.global.config.update(
-            { config: { disabled_providers: [...disabled, id] } },
-            { throwOnError: true },
-          )
-        ).data
-        if (merged) {
-          setCachedConfig({ type: "configLoaded", config: merged, features: configFeatures(merged) })
-          ctx.postMessage({ type: "configUpdated", config: merged, features: configFeatures(merged) })
-        }
-      }
+    if (custom) {
+      await removeCustom(ctx, id, config.global, config.merged)
+    }
+
+    // Config-sourced built-in providers stay "connected" after auth.remove
+    // because the server rebuilds state from config. Add to disabled_providers
+    // so the server excludes them while preserving config for re-enable.
+    if (configured && !oauth && !custom) {
+      await disableConfigured(ctx, id, config.global)
     }
 
     if (oauth) {
-      const disabled = disabledWithout(globalConfig.disabled_providers, id)
-      if (disabled.length !== (globalConfig.disabled_providers ?? []).length) {
-        const merged = (
-          await ctx.client.global.config.update({ config: { disabled_providers: disabled } }, { throwOnError: true })
-        ).data
-        if (merged) {
-          setCachedConfig({ type: "configLoaded", config: merged })
-          ctx.postMessage({ type: "configUpdated", config: merged })
-        }
-      }
+      await enableConfigured(ctx, id, config.global)
     }
+
+    if (configured) await refreshConfig(ctx, setCachedConfig)
 
     await ctx.disposeGlobal(`provider disconnect (${id})`)
     await ctx.fetchAndSendProviders()

--- a/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
@@ -305,6 +305,7 @@ describe("disconnectProvider", () => {
       provider: { myprovider: null },
       disabled_providers: ["openai"],
     })
+    expect(calls.project).toEqual([{ config: { provider: { myprovider: null } }, directory: "/tmp" }])
     expect(calls.remove).toEqual([{ providerID: "myprovider" }])
     expect(calls.refresh).toBe(1)
   })

--- a/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
@@ -3,12 +3,13 @@ import { disconnectProvider, fetchProviderData, saveCustomProvider } from "../..
 
 type ExistingGlobal = { disabled_providers?: string[]; provider?: Record<string, unknown> }
 
-function createCtx(existing: ExistingGlobal = { disabled_providers: [] }) {
+function createCtx(existing: ExistingGlobal = { disabled_providers: [] }, merged: ExistingGlobal = existing) {
   const calls = {
     set: [] as Array<{ providerID: string; auth: { type: string; key: string } }>,
     remove: [] as Array<{ providerID: string }>,
     posts: [] as unknown[],
     config: [] as Array<{ config: Record<string, unknown> }>,
+    project: [] as Array<{ config: Record<string, unknown> }>,
     cached: [] as unknown[],
     refresh: 0,
     dispose: 0,
@@ -53,6 +54,13 @@ function createCtx(existing: ExistingGlobal = { disabled_providers: [] }) {
           },
         },
       },
+      config: {
+        get: async () => ({ data: merged }),
+        update: async (input: { config: Record<string, unknown> }) => {
+          calls.project.push(input)
+          return { data: input }
+        },
+      },
     },
     postMessage: (message: unknown) => calls.posts.push(message),
     getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
@@ -79,6 +87,13 @@ function createProvider() {
     models: {
       "model-1": { name: "Model One" },
     },
+  }
+}
+
+function createSavedProvider() {
+  return {
+    npm: "@ai-sdk/openai-compatible",
+    ...createProvider(),
   }
 }
 
@@ -271,6 +286,75 @@ describe("disconnectProvider", () => {
     await disconnectProvider(ctx, "req", "myprovider", null, setCachedConfig)
 
     expect(calls.config).toHaveLength(0)
+    expect(calls.refresh).toBe(1)
+  })
+
+  it("deletes saved custom provider config when disconnecting", async () => {
+    const existing = {
+      disabled_providers: ["myprovider", "openai"],
+      provider: {
+        myprovider: createSavedProvider(),
+      },
+    }
+    const { ctx, calls, setCachedConfig } = createCtx(existing)
+
+    await disconnectProvider(ctx, "req", "myprovider", null, setCachedConfig)
+
+    expect(calls.config).toHaveLength(1)
+    expect(calls.config[0].config).toEqual({
+      provider: { myprovider: null },
+      disabled_providers: ["openai"],
+    })
+    expect(calls.remove).toEqual([{ providerID: "myprovider" }])
+    expect(calls.refresh).toBe(1)
+  })
+
+  it("deletes project custom provider config when it is not in global config", async () => {
+    const merged = {
+      provider: {
+        myprovider: createSavedProvider(),
+      },
+    }
+    const { ctx, calls, setCachedConfig } = createCtx({ disabled_providers: [] }, merged)
+
+    await disconnectProvider(ctx, "req", "myprovider", null, setCachedConfig)
+
+    expect(calls.config).toHaveLength(0)
+    expect(calls.project).toEqual([{ config: { provider: { myprovider: null } }, directory: "/tmp" }])
+    expect(calls.remove).toEqual([{ providerID: "myprovider" }])
+    expect(calls.refresh).toBe(1)
+  })
+
+  it("deletes both global and project custom provider config when project overrides global", async () => {
+    const global = {
+      disabled_providers: ["myprovider", "openai"],
+      provider: {
+        myprovider: createSavedProvider(),
+      },
+    }
+    const merged = {
+      ...global,
+      provider: {
+        myprovider: {
+          ...createSavedProvider(),
+          name: "Project Provider",
+        },
+      },
+    }
+    const { ctx, calls, setCachedConfig } = createCtx(global, merged)
+
+    await disconnectProvider(ctx, "req", "myprovider", null, setCachedConfig)
+
+    expect(calls.config).toEqual([
+      {
+        config: {
+          provider: { myprovider: null },
+          disabled_providers: ["openai"],
+        },
+      },
+    ])
+    expect(calls.project).toEqual([{ config: { provider: { myprovider: null } }, directory: "/tmp" }])
+    expect(calls.remove).toEqual([{ providerID: "myprovider" }])
     expect(calls.refresh).toBe(1)
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
@@ -271,7 +271,7 @@ const ProvidersTab: Component = () => {
                       </Button>
                     </Show>
                     <Button size="large" variant="ghost" onClick={() => disconnect(item.id, item.name)}>
-                      {language.t("common.disconnect")}
+                      {language.t(isCustom(item) ? "common.delete" : "common.disconnect")}
                     </Button>
                   </Show>
                 </div>

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -375,7 +375,7 @@ export const ProvidersLoginCommand = cmd({
           existingProviders: providers,
           disabled,
           enabled,
-          providerNames: Object.fromEntries(Object.entries(config.provider ?? {}).map(([id, p]) => [id, p.name])),
+          providerNames: Object.fromEntries(Object.entries(config.provider ?? {}).flatMap(([id, p]) => (p ? [[id, p.name]] : []))), // kilocode_change
         })
         const options = [
           ...pipe(

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -225,7 +225,7 @@ export const Info = Schema.Struct({
       [Schema.Record(Schema.String, ConfigAgent.Info)],
     ),
   ).annotate({ description: "Agent configuration, see https://opencode.ai/docs/agents" }),
-  provider: Schema.optional(Schema.Record(Schema.String, ConfigProvider.Info)).annotate({
+  provider: Schema.optional(Schema.Record(Schema.String, Schema.NullOr(ConfigProvider.Info))).annotate({ // kilocode_change - nullable for delete sentinel
     description: "Custom provider configurations and model overrides",
   }),
   mcp: Schema.optional(

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -95,7 +95,8 @@ export namespace KilocodeConfig {
     writable: (config: Config.Info) => Config.Info
   }) {
     const file = yield* projectConfigUpdateTarget(input)
-    const before = (yield* input.read(file)) ?? "{}"
+    const source = yield* input.read(file)
+    const before = source ?? "{}"
     const patch = input.writable(input.config)
 
     if (file.endsWith(".jsonc")) {
@@ -106,6 +107,7 @@ export namespace KilocodeConfig {
 
     const existing = input.parse(before, file)
     const merged = mergeConfig(input.writable(existing), patch)
+    if (source === undefined && Object.keys(merged).length === 0) return
     yield* input.fs.writeWithDirs(file, JSON.stringify(merged, null, 2)).pipe(Effect.orDie)
   })
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1140,6 +1140,7 @@ const layer: Layer.Layer<
 
         // extend database from config
         for (const [providerID, provider] of configProviders) {
+          if (!provider) continue // kilocode_change - null entries are transient delete sentinels
           const existing = database[providerID]
           const parsed: Info = {
             id: ProviderID.make(providerID),
@@ -1316,6 +1317,7 @@ const layer: Layer.Layer<
 
         // load config - re-apply with updated data
         for (const [id, provider] of configProviders) {
+          if (!provider) continue // kilocode_change - null entries are transient delete sentinels
           const providerID = ProviderID.make(id)
           // kilocode_change start - keep OAuth plugin source when config and Codex auth coexist
           const oauth =

--- a/packages/opencode/test/kilocode/custom-provider-delete.test.ts
+++ b/packages/opencode/test/kilocode/custom-provider-delete.test.ts
@@ -27,6 +27,15 @@ describe("Config.Info — null sentinels for custom provider deletes", () => {
     expect(parsed.success).toBe(true)
   })
 
+  it("accepts a null provider value", () => {
+    const parsed = Config.Info.zod.safeParse({
+      provider: {
+        myprovider: null,
+      },
+    })
+    expect(parsed.success).toBe(true)
+  })
+
   it("accepts a null variant value inside a model", () => {
     const parsed = Config.Info.zod.safeParse({
       provider: {
@@ -74,6 +83,29 @@ describe("KilocodeConfig.mergeConfig — custom provider model/variant deletion"
     const models = (merged.provider as Record<string, { models: Record<string, unknown> }>).myprovider.models
     expect(models["model-keep"]).toBeDefined()
     expect("model-gone" in models).toBe(false)
+  })
+
+  it("drops a provider when the patch sets it to null", () => {
+    const existing = {
+      provider: {
+        myprovider: {
+          name: "My Provider",
+          models: { keep: { name: "Keep" } },
+        },
+        openai: {
+          name: "OpenAI",
+        },
+      },
+    } as unknown as Config.Info
+    const patch = {
+      provider: {
+        myprovider: null,
+      },
+    } as unknown as Config.Info
+
+    const merged = KilocodeConfig.mergeConfig(existing, patch)
+    expect(merged.provider?.openai).toBeDefined()
+    expect("myprovider" in (merged.provider ?? {})).toBe(false)
   })
 
   it("drops a variant from an existing model when the patch sets it to null", () => {

--- a/packages/opencode/test/kilocode/project-config-update.test.ts
+++ b/packages/opencode/test/kilocode/project-config-update.test.ts
@@ -70,6 +70,18 @@ test("project config update creates .kilo/kilo.json and reloads it", async () =>
   })
 })
 
+test("project config update skips empty delete-only writes when no config exists", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await save({ provider: { missing: null } } as any)
+
+      await expect(fs.access(path.join(tmp.path, ".kilo", "kilo.json"))).rejects.toThrow()
+    },
+  })
+})
+
 test("project config update prefers existing root kilo.json", async () => {
   await using tmp = await tmpdir()
   await writeConfig(tmp.path, { username: "alice" })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1950,7 +1950,7 @@ export type Config = {
    * Custom provider configurations and model overrides
    */
   provider?: {
-    [key: string]: ProviderConfig
+    [key: string]: ProviderConfig | null
   }
   /**
    * MCP (Model Context Protocol) server configurations

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15892,7 +15892,14 @@
               "type": "string"
             },
             "additionalProperties": {
-              "$ref": "#/components/schemas/ProviderConfig"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/ProviderConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "mcp": {


### PR DESCRIPTION
## Summary
- Delete UI-created custom provider config entries instead of only hiding them in disabled providers.
- Support provider delete sentinels through the CLI config schema and SDK.
- Preserve the existing disconnect/disable behavior for built-in and ChatGPT/OpenAI providers.

<img width="489" height="405" alt="image" src="https://github.com/user-attachments/assets/dfa323c7-c339-4666-a9f9-8c73e236b34d" />


Related to #9787. This does not close it because the broader provider sync/freeze report may need more investigation.