### PR TITLE
fix(core): restore Skill tool as allow by default

### DIFF
--- a/.changeset/skill-tool-default-agents.md
+++ b/.changeset/skill-tool-default-agents.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore Skill tool access for Plan, Ask, Explore, and other non-system agents so skill workflows are available by default.

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -142,6 +142,7 @@ function askGuard(mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
     grep: "allow",
     glob: "allow",
     list: "allow",
+    skill: "allow",
     question: "allow",
     webfetch: "allow",
     websearch: "allow",
@@ -160,6 +161,7 @@ function planGuard(mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
     "*": "deny",
     question: "allow",
     suggest: "allow",
+    skill: "allow",
     plan_exit: "allow",
     bash: readOnlyBash,
     read: {
@@ -317,6 +319,7 @@ export function patchAgents(
           glob: "allow",
           list: "allow",
           bash: "allow",
+          skill: "allow",
           webfetch: "allow",
           websearch: "allow",
           codesearch: "allow",
@@ -371,6 +374,7 @@ export function patchAgents(
         glob: "allow",
         list: "allow",
         question: "allow",
+        skill: "allow",
         suggest: "allow", // kilocode_change
         task: "allow",
         todoread: "allow",

--- a/packages/opencode/test/kilocode/agent-skill-permissions.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-permissions.test.ts
@@ -1,0 +1,38 @@
+// kilocode_change - new file
+import { afterEach, test, expect } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Agent } from "../../src/agent/agent"
+import { Permission } from "../../src/permission"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function action(name: string, ruleset: Permission.Ruleset) {
+  return Permission.evaluate("skill", name, ruleset).action
+}
+
+test("skill tool available for non-system native agents and denied for system agents", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const allow = ["code", "plan", "debug", "orchestrator", "ask", "general", "explore"]
+      for (const name of allow) {
+        const agent = await Agent.get(name)
+        expect(agent).toBeDefined()
+        expect(action("using-superpowers", agent!.permission)).toBe("allow")
+        expect(Permission.disabled(["skill"], agent!.permission).has("skill")).toBe(false)
+      }
+
+      const deny = ["compaction", "title", "summary"]
+      for (const name of deny) {
+        const agent = await Agent.get(name)
+        expect(agent).toBeDefined()
+        expect(action("using-superpowers", agent!.permission)).toBe("deny")
+        expect(Permission.disabled(["skill"], agent!.permission).has("skill")).toBe(true)
+      }
+    },
+  })
+})


### PR DESCRIPTION
## Context

Access to the Skill tool was revoked from many agents, such as Plan, Ask, and Explore. This is undesirable. This change restores access to the Skill tool to all non-system agents as allow-by-default, so that the agent can load skills.

## Screenshots

<img width="875" height="691" alt="image" src="https://github.com/user-attachments/assets/563a53d3-7754-4a5f-a205-8b8fd928ff36" />

## Get in Touch

ExpedientFalcon on Discord
