### PR TITLE
chore(upstream): drop stale kilocode_change markers + minor cosmetic drift

### DIFF
--- a/packages/opencode/src/acp/session.ts
+++ b/packages/opencode/src/acp/session.ts
@@ -1,7 +1,7 @@
 import { RequestError, type McpServer } from "@agentclientprotocol/sdk"
 import type { ACPSessionState } from "./types"
-import type { KiloClient } from "@kilocode/sdk/v2"
 import * as Log from "@opencode-ai/core/util/log"
+import type { KiloClient } from "@kilocode/sdk/v2"
 
 const log = Log.create({ service: "acp-session-manager" })
 

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -169,7 +169,9 @@ export function DialogProvider(props: ParentProps) {
           evt.preventDefault()
           evt.stopPropagation()
         }}
-        onMouseUp={!Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT ? () => Selection.copy(renderer, toast) : undefined}
+        onMouseUp={
+          !Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT ? () => Selection.copy(renderer, toast) : undefined
+        }
       >
         <Show when={value.stack.length}>
           <Dialog onClose={() => value.clear()} size={value.size}>

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -44,8 +44,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
   get clientMetadata(): OAuthClientMetadata {
     return {
       redirect_uris: [this.redirectUrl],
-      client_name: "Kilo", // kilocode_change
-      client_uri: "https://kilo.ai", // kilocode_change
+      client_name: "Kilo",
+      client_uri: "https://kilo.ai",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: this.config.clientSecret ? "client_secret_post" : "none",


### PR DESCRIPTION
Round-1 harvest from `find-reset-candidates.ts` across the whole repo. Started from 128 classifier suggestions, kept only the three where the reset is genuinely zero-impact — stale `kilocode_change` markers on branding the translate transforms already emit, and two cosmetic drifts that match upstream's formatting/import order.

Every other candidate was reverted because it touched real behavior (branding strings, DB paths, Discord URLs, disabled workflows, agent name renames in tests, security-hardened containment checks, etc.).
