### PR TITLE
fix(indexing): prevent indexing home directory when no project is open

### DIFF
--- a/.changeset/no-home-indexing.md
+++ b/.changeset/no-home-indexing.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Prevent VS Code empty windows from starting codebase indexing against the home directory.

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -15,6 +15,17 @@ export interface ServerInstance {
 
 const STARTUP_TIMEOUT_SECONDS = 30
 
+type WorkspaceFolderLike = { uri: { fsPath: string } }
+
+export function resolveServerCwd(folders: readonly WorkspaceFolderLike[] | undefined, storage: string): string {
+  return folders?.[0]?.uri.fsPath ?? storage
+}
+
+export function resolveIndexingEnv(folders: readonly WorkspaceFolderLike[] | undefined): Record<string, string> {
+  if (folders && folders.length > 0) return {}
+  return { KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" }
+}
+
 export class ServerManager {
   private instance: ServerInstance | null = null
   private startupPromise: Promise<ServerInstance> | null = null
@@ -69,7 +80,11 @@ export class ServerManager {
       const cfg = vscode.workspace.getConfiguration("kilo-code.new")
       const claudeCompat = cfg.get<boolean>("claudeCodeCompat", false)
       // Pin cwd so the CLI doesn't inherit the extension host's cwd ("/" under F5 debug)
-      const spawnCwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.env.HOME ?? require("os").homedir()
+      // or "$HOME" in empty VS Code windows.
+      const folders = vscode.workspace.workspaceFolders
+      const spawnCwd = resolveServerCwd(folders, this.context.globalStorageUri.fsPath)
+      fs.mkdirSync(spawnCwd, { recursive: true })
+      const indexingEnv = resolveIndexingEnv(folders)
       // TLS / corporate-proxy support:
       //   - Default NODE_USE_SYSTEM_CA=1 so the bundled Bun CLI trusts the OS
       //     trust store (Windows cert store, macOS keychain, Linux /etc/ssl).
@@ -100,6 +115,7 @@ export class ServerManager {
           KILO_CLIENT: "vscode",
           KILO_ENABLE_QUESTION_TOOL: "true",
           KILOCODE_FEATURE: "vscode-extension",
+          ...indexingEnv,
           KILO_TELEMETRY_LEVEL: vscode.env.isTelemetryEnabled ? "all" : "off",
           KILO_APP_NAME: "kilo-code",
           KILO_EDITOR_NAME: vscode.env.appName,

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { parseServerPort } from "../../src/services/cli-backend/server-utils"
-import { toErrorMessage } from "../../src/services/cli-backend/server-manager"
+import { resolveServerCwd, resolveIndexingEnv, toErrorMessage } from "../../src/services/cli-backend/server-manager"
 
 describe("parseServerPort", () => {
   it("parses port from standard CLI startup message", () => {
@@ -101,5 +101,24 @@ describe("toErrorMessage", () => {
   it("returns original error string as error field", () => {
     const result = toErrorMessage("startup failed", ["some output"])
     expect(result.error).toBe("startup failed")
+  })
+})
+
+describe("server workspace helpers", () => {
+  it("uses first workspace folder as server cwd when present", () => {
+    const folders = [{ uri: { fsPath: "/repo" } }]
+
+    expect(resolveServerCwd(folders, "/global-storage")).toBe("/repo")
+  })
+
+  it("uses extension storage as server cwd when no workspace folder is open", () => {
+    expect(resolveServerCwd(undefined, "/global-storage")).toBe("/global-storage")
+    expect(resolveServerCwd([], "/global-storage")).toBe("/global-storage")
+  })
+
+  it("disables codebase indexing only when no workspace folder is open", () => {
+    expect(resolveIndexingEnv(undefined)).toEqual({ KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" })
+    expect(resolveIndexingEnv([])).toEqual({ KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" })
+    expect(resolveIndexingEnv([{ uri: { fsPath: "/repo" } }])).toEqual({})
   })
 })

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -26,6 +26,8 @@ import { LanceDBRuntime } from "./lancedb" // kilocode_change
 
 const log = Log.create({ service: "kilocode-indexing" })
 const missing = () => disabledIndexingStatus("Indexing plugin is not enabled for this workspace.")
+const noWorkspace = () =>
+  disabledIndexingStatus("Codebase indexing is disabled because no workspace folder is open in VS Code.")
 
 function worktreeDisabled(): z.infer<typeof IndexingStatus> {
   return {
@@ -200,6 +202,9 @@ export namespace KiloIndexing {
   const boot = async (hit: Cache): Promise<Entry> => {
     const dir = Instance.directory
     const cfg = await Config.get()
+    if (process.env["KILO_DISABLE_CODEBASE_INDEXING"] === "vscode-no-workspace") {
+      return track(hit, await inert(() => noWorkspace()))
+    }
     if (!hasIndexingPlugin(cfg.plugin)) {
       return track(hit, await inert(() => missing()))
     }

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -42,6 +42,7 @@ const off: Partial<Config.Info> = {
   },
 }
 const configDir = process.env["KILO_CONFIG_DIR"]
+const disabled = process.env["KILO_DISABLE_CODEBASE_INDEXING"]
 const error = new Error("test indexing initialization failed")
 
 async function wait(read: () => Promise<KiloIndexing.Status>, state: KiloIndexing.Status["state"]) {
@@ -64,6 +65,8 @@ async function called(init: ReturnType<typeof spyOn<CodeIndexManager, "initializ
 afterEach(async () => {
   if (configDir === undefined) delete process.env["KILO_CONFIG_DIR"]
   else process.env["KILO_CONFIG_DIR"] = configDir
+  if (disabled === undefined) delete process.env["KILO_DISABLE_CODEBASE_INDEXING"]
+  else process.env["KILO_DISABLE_CODEBASE_INDEXING"] = disabled
   await Instance.disposeAll()
 })
 
@@ -247,5 +250,33 @@ describe("indexing startup degradation", () => {
         expect(init).not.toHaveBeenCalled()
       },
     })
+  })
+
+  test("stays disabled when VS Code starts without a workspace folder", async () => {
+    await using tmp = await tmpdir({ git: true, config: cfg })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    process.env["KILO_DISABLE_CODEBASE_INDEXING"] = "vscode-no-workspace"
+    const init = spyOn(CodeIndexManager.prototype, "initialize")
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        init: () => AppRuntime.runPromise(InstanceBootstrap),
+        fn: async () => {
+          const status = await KiloIndexing.current()
+
+          expect(status).toMatchObject({
+            state: "Disabled",
+            message: "Codebase indexing is disabled because no workspace folder is open in VS Code.",
+          })
+          expect(await KiloIndexing.available()).toBe(false)
+          expect(KiloIndexing.ready()).toBe(false)
+          expect(await KiloIndexing.search("no workspace")).toEqual([])
+          expect(init).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      init.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Context

A user reported that the VSCode extension indexes the user's entire home directory if they open VSCode with no project active. This was traced back to how the VSCode extension spawns the CLI with the user's HOME as the working directory as a fallback if no current project is open.

## Implementation

- Added VS Code-side guard helpers and wiring in `packages/kilo-vscode/src/services/cli-backend/server-manager.ts`.
  - `resolveServerCwd(...)` now uses workspace folder if present, else extension global storage path (not `$HOME`).
  - `resolveIndexingEnv(...)` sets `KILO_DISABLE_CODEBASE_INDEXING=vscode-no-workspace` only when no workspace folder open.
  - Server spawn now creates fallback cwd dir and injects env guard.
- Added unit coverage for new behavior in `packages/kilo-vscode/tests/unit/server-manager-utils.test.ts`.
- Added CLI-side indexing short-circuit in `packages/opencode/src/kilocode/indexing.ts`.
  - When env guard present, indexing returns Disabled status with message: "Codebase indexing is disabled because no workspace folder is open in VS Code."
  - Prevents `CodeIndexManager.initialize()` from running in that mode.
- Added regression test in `packages/opencode/test/kilocode/indexing-startup.test.ts` proving no-workspace guard keeps indexing disabled.

## How to Test

- Open VSCode with no folder open
- Indexing should not run

## Get in Touch

ExpedientFalcon on Discord