### PR TITLE
Update native tab titles from sessions

### DIFF
--- a/.changeset/native-tab-titles.md
+++ b/.changeset/native-tab-titles.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Update regular Kilo editor tab titles to follow the current session title.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -123,8 +123,7 @@ import { fetchOpenAIModels, FetchModelsError } from "./shared/fetch-models"
 import type { Agent } from "@kilocode/sdk/v2/client"
 import { configFeatures } from "./features"
 import { createAutoApproveBridge } from "./kilo-provider/auto-approve"
-
-type KiloProviderOptions = { projectDirectory?: string | null; slimEditMetadata?: boolean; tabTitle?: (title: string) => void }
+import type { KiloProviderOptions } from "./kilo-provider/options"
 
 type MessageLoadMode = "replace" | "prepend" | "focus" | "reconcile"
 // Helper to map agent data to the subset of fields sent to the webview

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -105,6 +105,7 @@ import {
   fetchAndSendPendingQuestions,
 } from "./kilo-provider/handlers/question"
 import { fetchAndSendPendingSuggestions, routeSuggestionWebviewMessage } from "./kilo-provider/handlers/suggestion"
+import { nativeTitle } from "./kilo-provider/native-tab-title"
 
 import {
   buildActionContext,
@@ -123,10 +124,9 @@ import type { Agent } from "@kilocode/sdk/v2/client"
 import { configFeatures } from "./features"
 import { createAutoApproveBridge } from "./kilo-provider/auto-approve"
 
-type KiloProviderOptions = { projectDirectory?: string | null; slimEditMetadata?: boolean }
+type KiloProviderOptions = { projectDirectory?: string | null; slimEditMetadata?: boolean; tabTitle?: (title: string) => void }
 
 type MessageLoadMode = "replace" | "prepend" | "focus" | "reconcile"
-
 // Helper to map agent data to the subset of fields sent to the webview
 const mapAgent = (a: Agent) => ({
   name: a.name,
@@ -251,10 +251,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
     private readonly extensionContext?: vscode.ExtensionContext,
-    options?: KiloProviderOptions,
+    private readonly opts: KiloProviderOptions = {},
   ) {
-    this.projectDirectory = options?.projectDirectory
-    this.slimEditMetadata = options?.slimEditMetadata ?? true
+    this.projectDirectory = opts.projectDirectory
+    this.slimEditMetadata = opts.slimEditMetadata ?? true
 
     TelemetryProxy.getInstance().setProvider(this)
   }
@@ -269,6 +269,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.autoApproveBridge = createAutoApproveBridge(ctrl, (msg) => this.postMessage(msg), this.onBeforeMessage)
     this.onBeforeMessage = (msg) => this.autoApproveBridge!.handle(msg)
   }
+
+  private setCurrentSession(session: Session | null): void {
+    this.currentSession = session
+    this.opts.tabTitle?.(nativeTitle(session))
+  }
+
   private sendRemoteStatus(): void {
     const s = this.remoteService?.getState()
     if (s) this.postMessage({ type: "remoteStatus", enabled: s.enabled, connected: s.connected })
@@ -466,12 +472,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.initializeConnection()
   }
 
-  /**
-   * Register a session created externally (e.g., worktree sessions from AgentManagerProvider).
-   * Sets currentSession, adds to trackedSessionIds, and notifies the webview.
-   */
+  /** Register a session created externally and notify the webview. */
   public registerSession(session: Session): void {
-    this.currentSession = session
+    this.setCurrentSession(session)
     this.contextSessionID = session.id
     this.trackedSessionIds.add(session.id)
     this.postMessage({
@@ -480,10 +483,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
   }
 
-  /**
-   * Add a session ID to the tracked set without changing currentSession.
-   * Used to re-register worktree sessions after clearSession wipes the set.
-   */
+  /** Add a session ID to the tracked set without changing currentSession. */
   public trackSession(sessionId: string): void {
     this.trackedSessionIds.add(sessionId)
   }
@@ -680,7 +680,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "clearSession":
           this.contextSessionID = this.currentSession?.id ?? this.contextSessionID
-          this.currentSession = null
+          this.setCurrentSession(null)
           this.focusSession()
           break
         case "loadMessages":
@@ -1316,7 +1316,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     try {
       const workspaceDir = this.getContextDirectory()
       const { data: session } = await this.client.session.create({ directory: workspaceDir }, { throwOnError: true })
-      this.currentSession = session
+      this.setCurrentSession(session)
       this.contextSessionID = session.id
       this.trackDirectory(session.id, workspaceDir)
       this.trackedSessionIds.add(session.id)
@@ -1342,7 +1342,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       .get({ sessionID, directory: dir })
       .then((r) => {
         if (r.data && !signal?.aborted) {
-          this.currentSession = r.data
+          this.setCurrentSession(r.data)
           this.contextSessionID = r.data.id
         }
       })
@@ -1582,7 +1582,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.lastReconciledAt.delete(sessionID)
       this.connectionService.pruneSession(sessionID)
       if (this.currentSession?.id === sessionID) {
-        this.currentSession = null
+        this.setCurrentSession(null)
         this.focusSession(undefined)
       }
       this.postMessage({ type: "sessionDeleted", sessionID })
@@ -1611,7 +1611,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         { throwOnError: true },
       )
       if (this.currentSession?.id === sessionID) {
-        this.currentSession = updated
+        this.setCurrentSession(updated)
       }
       this.postMessage({ type: "sessionUpdated", session: this.sessionToWebview(updated) })
     } catch (error) {
@@ -2375,7 +2375,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     if (!sessionID && !this.currentSession) {
       const { data: session } = await this.client.session.create({ directory: dir }, { throwOnError: true })
-      this.currentSession = session
+      this.setCurrentSession(session)
       this.contextSessionID = session.id
       this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
@@ -2748,7 +2748,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         return self.currentSession
       },
       set currentSession(session) {
-        self.currentSession = session
+        self.setCurrentSession(session)
         if (session) self.contextSessionID = session.id
       },
       trackedSessionIds: this.trackedSessionIds,
@@ -3043,12 +3043,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Forward relevant events to webview
     // Side effects that must happen before the webview message is sent
     if (event.type === "session.created" && !this.currentSession) {
-      this.currentSession = event.properties.info
+      this.setCurrentSession(event.properties.info)
       this.contextSessionID = event.properties.info.id
       this.trackedSessionIds.add(event.properties.info.id)
     }
     if (event.type === "session.updated" && this.currentSession?.id === event.properties.info.id) {
-      this.currentSession = event.properties.info
+      this.setCurrentSession(event.properties.info)
       this.contextSessionID = event.properties.info.id
     }
 

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -23,6 +23,10 @@ import { markWorkspace } from "./util/spotlight"
 
 let agentManager: AgentManagerProvider | undefined
 
+const panelTitleHandler = (panel: vscode.WebviewPanel) => (title: string) => {
+  panel.title = title || EXTENSION_DISPLAY_NAME
+}
+
 // Activated via "onStartupFinished" (package.json) so that commands, code actions, keybindings,
 // autocomplete, commit-message generation, and URI deep links all work immediately — without
 // requiring the user to open a Kilo sidebar or panel first. The CLI backend is NOT spawned here;
@@ -174,7 +178,9 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.registerWebviewPanelSerializer("kilo-code.new.TabPanel", {
       deserializeWebviewPanel(panel: vscode.WebviewPanel) {
-        const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+        const tabProvider = new KiloProvider(context.extensionUri, connectionService, context, {
+          tabTitle: panelTitleHandler(panel),
+        })
         tabProvider.setRemoteService(remoteService)
         tabProvider.setAutoApproveController(autoApprove)
         tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>
@@ -468,7 +474,9 @@ async function openKiloInNewTab(
     dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "kilo-dark.svg"),
   }
 
-  const tabProvider = new KiloProvider(context.extensionUri, connectionService, context)
+  const tabProvider = new KiloProvider(context.extensionUri, connectionService, context, {
+    tabTitle: panelTitleHandler(panel),
+  })
   tabProvider.setRemoteService(remoteService)
   tabProvider.setAutoApproveController(autoApprove)
   tabProvider.setContinueInWorktreeHandler((sessionId, progress) =>

--- a/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
+++ b/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
@@ -1,0 +1,10 @@
+import type { Session } from "@kilocode/sdk/v2/client"
+import { EXTENSION_DISPLAY_NAME } from "../constants"
+
+const DEFAULT_SESSION_TITLE = /^(New session|Child session) - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+export const nativeTitle = (session: Session | null) => {
+  const title = session?.title?.trim()
+  if (!title || DEFAULT_SESSION_TITLE.test(title)) return EXTENSION_DISPLAY_NAME
+  return title
+}

--- a/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
+++ b/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
@@ -2,9 +2,11 @@ import type { Session } from "@kilocode/sdk/v2/client"
 import { EXTENSION_DISPLAY_NAME } from "../constants"
 
 const DEFAULT_SESSION_TITLE = /^(New session|Child session) - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+const TITLE_LIMIT = 19
 
 export const nativeTitle = (session: Session | null) => {
   const title = session?.title?.trim()
   if (!title || DEFAULT_SESSION_TITLE.test(title)) return EXTENSION_DISPLAY_NAME
-  return title
+  if (title.length <= TITLE_LIMIT) return title
+  return `${title.slice(0, TITLE_LIMIT)}...`
 }

--- a/packages/kilo-vscode/src/kilo-provider/options.ts
+++ b/packages/kilo-vscode/src/kilo-provider/options.ts
@@ -1,0 +1,5 @@
+export type KiloProviderOptions = {
+  projectDirectory?: string | null
+  slimEditMetadata?: boolean
+  tabTitle?: (title: string) => void
+}

--- a/packages/kilo-vscode/tests/unit/native-tab-title.test.ts
+++ b/packages/kilo-vscode/tests/unit/native-tab-title.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test"
+import type { Session } from "@kilocode/sdk/v2/client"
+import { nativeTitle } from "../../src/kilo-provider/native-tab-title"
+
+const session = (title: string | null) => ({ title }) as Session
+
+describe("nativeTitle", () => {
+  it("uses the default title without a useful session title", () => {
+    expect(nativeTitle(null)).toBe("Kilo Code")
+    expect(nativeTitle(session(""))).toBe("Kilo Code")
+    expect(nativeTitle(session("New session - 2026-05-06T10:39:00.000Z"))).toBe("Kilo Code")
+  })
+
+  it("keeps short session titles", () => {
+    expect(nativeTitle(session("Greeting"))).toBe("Greeting")
+  })
+
+  it("truncates long session titles", () => {
+    expect(nativeTitle(session("Dynamic VS Code tab titles for Kilo sessions"))).toBe("Dynamic VS Code tab...")
+  })
+})


### PR DESCRIPTION
## Summary
- Update regular Kilo editor tabs to use the current session title as the native VS Code tab title.
- Keep untitled/default sessions labeled as Kilo Code and leave Agent Manager tabs unchanged.
- Add a changeset for the VS Code extension release notes.
- We cap session titles around 18 to limit the tab width

<img width="455" height="230" alt="image" src="https://github.com/user-attachments/assets/6f51bf7c-e886-4982-a813-e8341a3e477f" />
<img width="434" height="214" alt="image" src="https://github.com/user-attachments/assets/6b560623-f3c1-4ee9-9f57-d08969bfb648" />
<img width="387" height="109" alt="image" src="https://github.com/user-attachments/assets/1f388a20-0452-4cb4-b1cb-6b6b69b872e4" />

