### PR TITLE
fix(vscode): keep new worktree selectors open

### DIFF
--- a/.changeset/agent-manager-selector-clicks.md
+++ b/.changeset/agent-manager-selector-clicks.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Keep Agent Manager mode and model selectors open when clicked in the new worktree dialog.
+Keep Agent Manager branch, mode, and model selectors usable in the new worktree dialog.

--- a/.changeset/agent-manager-selector-clicks.md
+++ b/.changeset/agent-manager-selector-clicks.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager mode and model selectors open when clicked in the new worktree dialog.

--- a/packages/kilo-vscode/webview-ui/agent-manager/BranchSelect.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/BranchSelect.tsx
@@ -1,10 +1,11 @@
 // Reusable branch selector: search input + scrollable list with keyboard navigation
 
-import { type Component, For, Show } from "solid-js"
+import { type Component, For, Show, type JSXElement, type ParentProps } from "solid-js"
 import type { BranchInfo } from "../src/types/messages"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { formatRelativeDate } from "../src/utils/date"
+import { DeferredPopover } from "../src/components/shared/DeferredPopover"
 
 interface AutoOption {
   label: string
@@ -32,6 +33,28 @@ interface BranchSelectProps {
   remoteLabel: string
   autoOption?: AutoOption
 }
+
+interface BranchSelectPopoverProps extends ParentProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  trigger: JSXElement
+}
+
+export const BranchSelectPopover: Component<BranchSelectPopoverProps> = (props) => (
+  <DeferredPopover
+    open={props.open}
+    onOpenChange={props.onOpenChange}
+    placement="top-start"
+    flip={false}
+    sameWidth
+    portal={false}
+    deferDismiss
+    class="am-dropdown"
+    trigger={props.trigger}
+  >
+    {props.children}
+  </DeferredPopover>
+)
 
 export const BranchSelect: Component<BranchSelectProps> = (props) => {
   const isDefault = (branch: BranchInfo) => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -9,7 +9,6 @@ import { showToast } from "@kilocode/kilo-ui/toast"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
-import { Popover } from "@kilocode/kilo-ui/popover"
 import { DeferredPopover } from "../src/components/shared/DeferredPopover"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../src/context/vscode"
@@ -29,7 +28,7 @@ import {
 import { useLanguage } from "../src/context/language"
 import { useImageAttachments, type ImageAttachment } from "../src/hooks/useImageAttachments"
 import { convertToMentionPath } from "../src/utils/path-mentions"
-import { BranchSelect } from "./BranchSelect"
+import { BranchSelect, BranchSelectPopover } from "./BranchSelect"
 
 type VersionCount = 1 | 2 | 3 | 4
 const VERSION_OPTIONS: VersionCount[] = [1, 2, 3, 4]
@@ -447,7 +446,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                 <div class="am-advanced-field">
                   <span class="am-nv-config-label">{t("agentManager.dialog.baseBranch")}</span>
                   <div class="am-selector-wrapper">
-                    <Popover
+                    <BranchSelectPopover
                       open={baseBranchOpen()}
                       onOpenChange={(open) => {
                         setBaseBranchOpen(open)
@@ -456,11 +455,6 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                           setHighlightedIndex(0)
                         }
                       }}
-                      placement="top-start"
-                      flip={false}
-                      sameWidth
-                      portal={false}
-                      class="am-dropdown"
                       trigger={
                         <button class="am-selector-trigger" type="button">
                           <span class="am-selector-left">
@@ -539,7 +533,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                         remoteLabel={t("agentManager.dialog.branchBadge.remote")}
                         defaultName={defaultBranch()}
                       />
-                    </Popover>
+                    </BranchSelectPopover>
                   </div>
                 </div>
               </div>
@@ -701,14 +695,9 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
           <div class="am-import-section">
             <span class="am-nv-config-label">{t("agentManager.import.branches")}</span>
             <div class="am-selector-wrapper">
-              <Popover
+              <BranchSelectPopover
                 open={branchOpen()}
                 onOpenChange={setBranchOpen}
-                placement="top-start"
-                flip={false}
-                sameWidth
-                portal={false}
-                class="am-dropdown"
                 trigger={
                   <button class="am-selector-trigger" disabled={isPending()} type="button">
                     <span class="am-selector-left">
@@ -735,7 +724,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                   defaultLabel={t("agentManager.dialog.branchBadge.default")}
                   remoteLabel={t("agentManager.dialog.branchBadge.remote")}
                 />
-              </Popover>
+              </BranchSelectPopover>
             </div>
           </div>
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import { Icon } from "@kilocode/kilo-ui/icon"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Popover } from "@kilocode/kilo-ui/popover"
+import { DeferredPopover } from "../src/components/shared/DeferredPopover"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useVSCode } from "../src/context/vscode"
 import { useServer } from "../src/context/server"
@@ -388,7 +389,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
               <div class="prompt-input-hint">
                 <div class="prompt-input-hint-selectors">
                   <Show when={session.agents().length > 1}>
-                    <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} />
+                    <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} deferDismiss />
                   </Show>
                   <Show when={!compareMode()}>
                     <ModelSelectorBase
@@ -397,8 +398,14 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                         if (pid && mid) setModel({ providerID: pid, modelID: mid })
                       }}
                       placement="top-start"
+                      deferDismiss
                     />
-                    <ThinkingSelectorBase variants={variants()} value={effectiveVariant()} onSelect={setVariant} />
+                    <ThinkingSelectorBase
+                      variants={variants()}
+                      value={effectiveVariant()}
+                      onSelect={setVariant}
+                      deferDismiss
+                    />
                     <Show when={overridden()}>
                       <Tooltip value={t("prompt.action.resetModel")} placement="top">
                         <Button
@@ -596,12 +603,13 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                     <Icon name="close-small" size="small" />
                   </button>
                 </div>
-                <Popover
+                <DeferredPopover
                   open={compareOpen()}
                   onOpenChange={setCompareOpen}
                   placement="top-start"
                   flip={false}
                   sameWidth
+                  deferDismiss
                   class="am-compare-popover"
                   trigger={
                     <button class="am-selector-trigger" type="button">
@@ -627,7 +635,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                   }
                 >
                   <MultiModelSelector allocations={modelAllocations()} onChange={setModelAllocations} />
-                </Popover>
+                </DeferredPopover>
               </div>
             </Show>
           </div>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2868,7 +2868,7 @@ body.am-wt-dragging-active * {
   padding: 0 16px 16px;
   min-width: 460px;
   max-height: 350px;
-  overflow-y: auto;
+  overflow-y: visible;
 }
 
 .am-import-section {
@@ -3042,7 +3042,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-dropdown-list {
-  max-height: 200px;
+  max-height: min(320px, var(--kb-popper-content-available-height, 320px) - 44px);
   overflow-y: auto;
   overflow-x: hidden;
   padding: 4px;

--- a/packages/kilo-vscode/webview-ui/src/components/shared/DeferredPopover.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/DeferredPopover.tsx
@@ -1,0 +1,54 @@
+import { createEffect, createSignal, onCleanup, splitProps, type ValidComponent } from "solid-js"
+import { Popover as Base, type PopoverProps } from "@kilocode/kilo-ui/popover"
+
+export type { PopoverProps } from "@kilocode/kilo-ui/popover"
+
+export interface DeferredPopoverProps<T extends ValidComponent = "div"> extends PopoverProps<T> {
+  deferDismiss?: boolean
+}
+
+export function DeferredPopover<T extends ValidComponent = "div">(props: DeferredPopoverProps<T>) {
+  const [local, rest] = splitProps(props, ["open", "defaultOpen", "onOpenChange", "deferDismiss"])
+  const [open, setOpen] = createSignal(local.defaultOpen ?? false)
+  const [ready, setReady] = createSignal(true)
+  const defer = () => local.deferDismiss ?? false
+
+  const controlled = () => local.open !== undefined
+  const opened = () => {
+    if (controlled()) return local.open ?? false
+    return open()
+  }
+
+  const change = (next: boolean) => {
+    if (defer() && !next && !ready()) return
+    if (local.onOpenChange) local.onOpenChange(next)
+    if (controlled()) return
+    setOpen(next)
+  }
+
+  createEffect(() => {
+    if (!defer()) return
+    if (!opened()) {
+      setReady(true)
+      return
+    }
+
+    setReady(false)
+
+    const frame = {
+      id: requestAnimationFrame(() => {
+        frame.id = requestAnimationFrame(() => {
+          frame.id = 0
+          setReady(true)
+        })
+      }),
+    }
+
+    onCleanup(() => {
+      setReady(true)
+      if (frame.id) cancelAnimationFrame(frame.id)
+    })
+  })
+
+  return <Base {...rest} open={opened()} onOpenChange={change} />
+}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -34,6 +34,8 @@ export interface ModeSwitcherBaseProps {
   value: string
   /** Called when the user picks an agent */
   onSelect: (name: string) => void
+  /** Delay outside dismissal while the popover opens inside a dialog. */
+  deferDismiss?: boolean
 }
 
 export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
@@ -103,6 +105,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
         expanded={false}
         placement="top-start"
         minHeight={100}
+        deferDismiss={props.deferDismiss}
         open={open()}
         onOpenChange={onOpen}
         triggerAs={Button}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -90,6 +90,8 @@ export interface ModelSelectorBaseProps {
   clearLabel?: string
   /** Include the kilo-auto/small model in the list — defaults to false */
   includeAutoSmall?: boolean
+  /** Delay outside dismissal while the popover opens inside a dialog. */
+  deferDismiss?: boolean
 }
 
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
@@ -523,6 +525,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
       preferredExpandedHeight={800}
       minHeight={200}
       placement={props.placement ?? "top-start"}
+      deferDismiss={props.deferDismiss}
       open={open()}
       onOpenChange={setOpen}
       triggerAs={Button}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/PopupSelector.tsx
@@ -19,8 +19,8 @@ import {
   splitProps,
   type ValidComponent,
 } from "solid-js"
-import { Popover } from "@kilocode/kilo-ui/popover"
-import type { PopoverProps } from "@kilocode/kilo-ui/popover"
+import { DeferredPopover as Popover } from "./DeferredPopover"
+import type { DeferredPopoverProps as PopoverProps } from "./DeferredPopover"
 
 export interface PopupSelectorProps<T extends ValidComponent = ValidComponent>
   extends Omit<PopoverProps<T>, "style" | "children"> {
@@ -40,6 +40,8 @@ export interface PopupSelectorProps<T extends ValidComponent = ValidComponent>
   minWidth?: number
   /** Minimum popup height — never shrinks below this. Default: 100 */
   minHeight?: number
+  /** Delay outside dismissal while portal content and dialog focus settle. */
+  deferDismiss?: boolean
   /** Render prop — receives a reactive `bodyH` accessor (undefined when no preferred height set). */
   children: (bodyH: Accessor<number | undefined>) => JSXElement
 }
@@ -54,6 +56,7 @@ export function PopupSelector<T extends ValidComponent = ValidComponent>(props: 
     "padding",
     "minWidth",
     "minHeight",
+    "deferDismiss",
     "children",
   ])
 
@@ -108,6 +111,7 @@ export function PopupSelector<T extends ValidComponent = ValidComponent>(props: 
       placement="top-start"
       slide={true}
       overflowPadding={local.padding ?? 8}
+      deferDismiss={local.deferDismiss}
       {...(rest as PopoverProps)}
       style={
         popoverW().width !== undefined

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -23,6 +23,8 @@ export interface ThinkingSelectorBaseProps {
   value: string | undefined
   /** Called when the user picks a variant */
   onSelect: (value: string) => void
+  /** Delay outside dismissal while the popover opens inside a dialog. */
+  deferDismiss?: boolean
 }
 
 export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props) => {
@@ -111,6 +113,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
         placement="top-start"
         preferredWidth={180}
         minHeight={100}
+        deferDismiss={props.deferDismiss}
         open={open()}
         onOpenChange={onOpen}
         triggerAs={Button}


### PR DESCRIPTION
## Summary
- Keep Agent Manager New Worktree mode, model, thinking, and compare-model popovers open through the initial mouse/focus settle window.
- Move the Kilo-specific dismissal delay into a Kilo-owned webview wrapper so shared OpenCode UI code stays unchanged.
- Fixes https://github.com/Kilo-Org/kilocode/issues/9940.

## Regression
This regressed in https://github.com/Kilo-Org/kilocode/pull/8870 (OpenCode v1.3.14). The upstream commit `69d047ae7d` (`cleanup event listeners with solid-primitives/event-listener (#20619)`) replaced manual outside-dismiss listener cleanup in `packages/ui/src/components/popover.tsx`. During the Kilo merge conflict resolution (`6d224ad390`), our earlier deferred outside-dismiss arming from `da41fe6958` / `409e4afd5e` was dropped, so Linux webviews could treat the dialog focus reconciliation after a mouse click as an outside interaction and immediately close the selector.

## Validation
- `bun run check-types:webview` still fails on existing unrelated workspace type/module issues (`@xterm/*`, `@kilocode/kilo-indexing/detect`, SDK `IndexingStatus`), but no longer reports errors from this change.
- `bun run script/check-opencode-annotations.ts`
- `bun run check-kilocode-change`
- `git diff --check`