### PR TITLE
fix(agent-manager): keep metadata out of worktrees

### DIFF
--- a/.changeset/clean-worktree-metadata.md
+++ b/.changeset/clean-worktree-metadata.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager worktree recovery metadata out of worktree git changes.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -86,6 +86,7 @@ import { KILO_DIR, LEGACY_DIR, migrateAgentManagerData } from "./constants"
 
 const SESSION_ID_FILE = "session-id"
 const METADATA_FILE = "metadata.json"
+const GIT_METADATA_FILE = "kilo-agent-manager-metadata.json"
 
 export class WorktreeManager {
   private readonly root: string
@@ -438,30 +439,65 @@ export class WorktreeManager {
   }
 
   async writeMetadata(worktreePath: string, sessionId: string, parentBranch: string, remote?: string): Promise<void> {
-    const dir = path.join(worktreePath, KILO_DIR)
-    if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true })
-
     const meta: Record<string, string> = { sessionId, parentBranch }
     if (remote) meta.remote = remote
 
-    // Write both formats: session-id for backward compat, metadata.json for parentBranch+remote
-    await Promise.all([
-      fs.promises.writeFile(path.join(dir, SESSION_ID_FILE), sessionId, "utf-8"),
-      fs.promises.writeFile(path.join(dir, METADATA_FILE), JSON.stringify(meta), "utf-8"),
-    ])
+    const file = await this.gitMetadataPath(worktreePath)
+    if (!file) throw new Error(`Could not resolve git metadata directory for ${worktreePath}`)
+    await fs.promises.writeFile(file, JSON.stringify(meta), "utf-8")
     this.log(`Wrote metadata for session ${sessionId} to ${worktreePath}`)
-    await this.ensureWorktreeExclude(worktreePath)
   }
 
   async readMetadata(
     worktreePath: string,
   ): Promise<{ sessionId: string; parentBranch?: string; remote?: string } | undefined> {
+    const current = await this.readCurrentMetadata(worktreePath)
+    if (current) return current
+
     // Check .kilo/ first, then legacy .kilocode/
     for (const dirName of [KILO_DIR, LEGACY_DIR]) {
       const result = await this.readMetadataFrom(worktreePath, dirName)
       if (result) return result
     }
     return undefined
+  }
+
+  private async readCurrentMetadata(
+    worktreePath: string,
+  ): Promise<{ sessionId: string; parentBranch?: string; remote?: string } | undefined> {
+    try {
+      const file = await this.gitMetadataPath(worktreePath)
+      if (!file) return undefined
+      const content = await fs.promises.readFile(file, "utf-8")
+      const data = JSON.parse(content) as { sessionId?: string; parentBranch?: string; remote?: string }
+      if (!data.sessionId) return undefined
+      return {
+        sessionId: data.sessionId,
+        parentBranch: data.parentBranch,
+        remote: data.remote,
+      }
+    } catch (e) {
+      this.log(`readMetadata: git metadata unreadable in ${worktreePath}: ${e}`)
+      return undefined
+    }
+  }
+
+  private async gitMetadataPath(worktreePath: string): Promise<string | undefined> {
+    const dir = await this.worktreeGitDir(worktreePath)
+    if (!dir) return undefined
+    return path.join(dir, GIT_METADATA_FILE)
+  }
+
+  private async worktreeGitDir(worktreePath: string): Promise<string | undefined> {
+    const gitPath = path.join(worktreePath, ".git")
+    const stat = await fs.promises.stat(gitPath)
+    if (stat.isDirectory()) return gitPath
+    if (!stat.isFile()) return undefined
+
+    const content = await fs.promises.readFile(gitPath, "utf-8")
+    const match = content.match(/^gitdir:\s*(.+)$/m)
+    if (!match) return undefined
+    return path.resolve(worktreePath, match[1].trim())
   }
 
   private async readMetadataFrom(
@@ -523,20 +559,6 @@ export class WorktreeManager {
 
     for (const [entry, comment] of items) {
       await this.addExcludeEntry(excludePath, entry, comment)
-    }
-  }
-
-  private async ensureWorktreeExclude(worktreePath: string): Promise<void> {
-    try {
-      const content = await fs.promises.readFile(path.join(worktreePath, ".git"), "utf-8")
-      const match = content.match(/^gitdir:\s*(.+)$/m)
-      if (!match) return
-
-      const worktreeGitDir = path.resolve(worktreePath, match[1].trim())
-      const mainGitDir = path.dirname(path.dirname(worktreeGitDir))
-      await this.addExcludeEntry(path.join(mainGitDir, "info", "exclude"), `${KILO_DIR}/`, "Kilo Code session metadata")
-    } catch (error) {
-      this.log(`Warning: Failed to update git exclude for worktree: ${error}`)
     }
   }
 

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test"
 import os from "node:os"
 import path from "node:path"
 import fs from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { WorktreeManager } from "../../src/agent-manager/WorktreeManager"
 import { generateBranchName, sanitizeBranchName, versionedName } from "../../src/agent-manager/branch-name"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
@@ -35,6 +36,12 @@ async function createTempRepo(): Promise<string> {
 function createManager(root: string): WorktreeManager {
   const logs: string[] = []
   return new WorktreeManager(root, (msg) => logs.push(msg))
+}
+
+// Test-only helper to verify metadata writes keep the temp worktree checkout clean.
+async function changedFiles(cwd: string): Promise<string[]> {
+  const raw = await simpleGit(cwd).raw(["status", "--porcelain", "--untracked-files=all", "--"])
+  return raw.trim().split("\n").filter(Boolean)
 }
 
 /** Create a temp repo with a bare origin remote so origin/<branch> refs exist. */
@@ -549,6 +556,18 @@ describe("WorktreeManager metadata", () => {
     expect(meta?.sessionId).toBe("sess-abc-123")
     expect(meta?.parentBranch).toBe("feature-branch")
     expect(meta?.remote).toBe("origin")
+  })
+
+  it("writes metadata outside the worktree checkout", async () => {
+    const root = await createTempRepo()
+    const mgr = createManager(root)
+    const result = await mgr.createWorktree({ prompt: "session-status" })
+
+    await mgr.writeMetadata(result.path, "sess-clean-123", "feature-branch", "origin")
+
+    expect(existsSync(path.join(result.path, ".kilo", "session-id"))).toBe(false)
+    expect(existsSync(path.join(result.path, ".kilo", "metadata.json"))).toBe(false)
+    expect(await changedFiles(result.path)).toEqual([])
   })
 
   it("returns undefined when no metadata exists", async () => {


### PR DESCRIPTION
## Summary
- Keep Agent Manager restart-recovery metadata in git's private worktree metadata directory instead of writing `.kilo/session-id` and `.kilo/metadata.json` into managed worktree checkouts.
- Preserve the #9939 recovery path by reading the new sidecar first, then falling back to existing `.kilo` and legacy `.kilocode` metadata files.
- Avoid deleting anything from the user's checkout. Existing legacy checkout metadata remains readable for recovery, but new registration writes no longer create those files.

## Regression History
PR #9939 fixed Agent Manager restart recovery by discovering managed worktrees on startup and reconstructing missing or corrupt `.kilo/agent-manager.json` state from disk. That change made `registerWorktreeSession(...)` persist per-worktree session metadata more often, using an older `writeMetadata(...)` helper that wrote generated files directly into each worktree checkout.

Because managed Agent Manager worktrees are real git worktrees, those generated `.kilo/session-id` and `.kilo/metadata.json` files could appear as untracked user changes. This PR keeps the durable recovery metadata but moves new writes outside the checkout.

## Test Plan
- `bun test tests/unit/worktree-manager.test.ts`
- `bun run lint`

`bun run typecheck` currently fails locally on unrelated SDK/indexing type errors outside the touched Agent Manager files. CI typecheck is expected to be authoritative for this branch.