### PR TITLE
feat(cli): support compact and summarize in kilo run --command

### DIFF
--- a/.changeset/run-compact-summarize.md
+++ b/.changeset/run-compact-summarize.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support `kilo run --command compact` and `--command summarize` to compact the current session, matching the TUI's `/compact` and `/summarize` slash commands.

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -23,7 +23,7 @@ import { ServerAuth } from "@/server/auth"
 import { buildRunMessage } from "@/kilocode/cli/cmd/run-message" // kilocode_change
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
-import { createKiloClient, type KiloClient, type ToolPart } from "@kilocode/sdk/v2"
+import { createKiloClient, type KiloClient, type Session, type ToolPart } from "@kilocode/sdk/v2"
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -76,6 +76,7 @@ type SessionInfo = {
   id: string
   title?: string
   directory?: string
+  model?: Session["model"]
 }
 
 function inline(info: Inline) {
@@ -371,21 +372,24 @@ export const RunCommand = effectCmd({
         }
       }
 
-      const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
-      message = resolveRunInput(message, piped) ?? ""
-      const initialInput = resolveRunInput(rawMessage, piped)
-
-      if (message.trim().length === 0 && !args.command && !args.interactive) {
+      // kilocode_change start - defer stdin until endpoint-backed commands are classified
+      const input = { initial: undefined as string | undefined, loaded: false }
+      async function loadInput() {
+        if (input.loaded) return
+        const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
+        message = resolveRunInput(message, piped) ?? ""
+        input.initial = resolveRunInput(rawMessage, piped)
+        input.loaded = true
+        if (message.trim().length > 0 || args.command || args.interactive) return
         UI.error("You must provide a message or a command")
         process.exit(1)
       }
+      // kilocode_change end
 
       if (args.fork && !args.continue && !args.session) {
         UI.error("--fork requires --continue or --session")
         process.exit(1)
       }
-
-      KiloRun.validateBuiltin(args) // kilocode_change
 
       // kilocode_change start - validate cloud session imports before local lookup
       const cloudForkError = validateCloudFork({
@@ -450,6 +454,7 @@ export const RunCommand = effectCmd({
             id: current.data.id,
             title: current.data.title,
             directory: current.data.directory,
+            model: current.data.model,
           }
         }
         // kilocode_change end
@@ -479,6 +484,7 @@ export const RunCommand = effectCmd({
               id,
               title: forked.data?.title ?? current.data.title,
               directory: forked.data?.directory ?? current.data.directory,
+              model: forked.data?.model ?? current.data.model,
             }
           }
 
@@ -486,6 +492,7 @@ export const RunCommand = effectCmd({
             id: current.data.id,
             title: current.data.title,
             directory: current.data.directory,
+            model: current.data.model,
           }
         }
 
@@ -504,6 +511,7 @@ export const RunCommand = effectCmd({
             id,
             title: forked.data?.title ?? base.title,
             directory: forked.data?.directory ?? base.directory,
+            model: forked.data?.model ?? base.model,
           }
         }
 
@@ -512,6 +520,7 @@ export const RunCommand = effectCmd({
             id: base.id,
             title: base.title,
             directory: base.directory,
+            model: base.model,
           }
         }
 
@@ -529,6 +538,7 @@ export const RunCommand = effectCmd({
           id,
           title: result.data?.title ?? name,
           directory: result.data?.directory,
+          model: result.data?.model,
         }
       }
 
@@ -668,6 +678,15 @@ export const RunCommand = effectCmd({
       }
 
       async function execute(sdk: KiloClient) {
+        // kilocode_change start - preserve custom command precedence and avoid reading stdin for built-ins
+        const deferred = Boolean(args.attach && args.session && !directory)
+        const initial = deferred ? undefined : await KiloRun.resolveBuiltin(sdk, args.command, directory)
+        if (!deferred) {
+          KiloRun.validateBuiltin({ command: initial, continue: args.continue, session: args.session })
+          if (!initial) await loadInput()
+        }
+        // kilocode_change end
+
         const sess = await session(sdk)
         if (!sess?.id) {
           UI.error("Session not found")
@@ -868,6 +887,13 @@ export const RunCommand = effectCmd({
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk
+        // kilocode_change start - classify deferred attach commands in the session directory
+        const builtin = deferred ? await KiloRun.resolveBuiltin(client, args.command, cwd) : initial
+        if (deferred) {
+          KiloRun.validateBuiltin({ command: builtin, continue: args.continue, session: args.session })
+          if (!builtin) await loadInput()
+        }
+        // kilocode_change end
 
         // Validate agent if specified
         const agent = await pickAgent(client)
@@ -882,8 +908,8 @@ export const RunCommand = effectCmd({
           })
 
           // kilocode_change start - handle built-in session commands
-          if (KiloRun.isBuiltin(args.command)) {
-            const result = await KiloRun.runBuiltin(client, sessionID, args.command, args.model, cwd)
+          if (builtin) {
+            const result = await KiloRun.runBuiltin(client, sessionID, builtin, args.model, sess.model, cwd)
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
@@ -938,7 +964,7 @@ export const RunCommand = effectCmd({
             model,
             variant: args.variant,
             files,
-            initialInput,
+            initialInput: input.initial,
             createSession: createFreshSession,
             thinking,
             demo: args.demo,
@@ -950,6 +976,7 @@ export const RunCommand = effectCmd({
       }
 
       if (args.interactive && !args.attach && !args.session && !args.continue) {
+        await loadInput() // kilocode_change - interactive local mode still consumes its initial input
         const model = pick(args.model)
         const { runInteractiveLocalMode } = await runtimeTask
         const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -972,7 +999,7 @@ export const RunCommand = effectCmd({
             replay,
             replayLimit: args["replay-limit"],
             files,
-            initialInput,
+            initialInput: input.initial,
             thinking,
             demo: args.demo,
           })

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -33,7 +33,7 @@ import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.
 import { event as normalizeEvent } from "./run/event"
 import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 import { KiloRunAuto } from "@/kilocode/cli/run-auto" // kilocode_change
-import { KiloRunDaemon } from "@/kilocode/cli/cmd/run" // kilocode_change
+import { KiloRun, KiloRunDaemon } from "@/kilocode/cli/cmd/run" // kilocode_change
 
 const runtimeTask = import("./run/runtime")
 type ModelInput = Parameters<KiloClient["session"]["prompt"]>[0]["model"]
@@ -384,6 +384,8 @@ export const RunCommand = effectCmd({
         UI.error("--fork requires --continue or --session")
         process.exit(1)
       }
+
+      KiloRun.validateBuiltin(args) // kilocode_change
 
       // kilocode_change start - validate cloud session imports before local lookup
       const cloudForkError = validateCloudFork({
@@ -878,6 +880,17 @@ export const RunCommand = effectCmd({
             console.error(e)
             process.exit(1)
           })
+
+          // kilocode_change start - handle built-in session commands
+          if (KiloRun.isBuiltin(args.command)) {
+            const result = await KiloRun.runBuiltin(client, sessionID, args.command, args.model, cwd)
+            if (result.error) {
+              if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+              process.exitCode = 1
+            }
+            return
+          }
+          // kilocode_change end
 
           if (args.command) {
             const result = await client.session.command({

--- a/packages/opencode/src/kilocode/cli/cmd/run.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/run.ts
@@ -1,6 +1,45 @@
 import { createKiloClient, type KiloClient } from "@kilocode/sdk/v2"
-import { Filesystem } from "@/util/filesystem"
+import { UI } from "@/cli/ui"
 import { DaemonClient } from "@/kilocode/daemon/client"
+import { isBuiltinCommand, type BuiltinCommand } from "@/kilocode/session/builtin-commands"
+import { Provider } from "@/provider/provider"
+import { Filesystem } from "@/util/filesystem"
+
+export namespace KiloRun {
+  export const isBuiltin = isBuiltinCommand
+
+  export function validateBuiltin(args: { command?: string; continue?: boolean; session?: string }) {
+    if (!isBuiltin(args.command)) return
+    if (args.continue || args.session) return
+    UI.error(`--command ${args.command} requires --continue or --session`)
+    process.exit(1)
+  }
+
+  export async function runBuiltin(
+    sdk: KiloClient,
+    sessionID: string,
+    command: BuiltinCommand,
+    model?: string,
+    directory?: string,
+  ) {
+    const selected = await resolve(sdk, model)
+    if (!selected) {
+      UI.error("No model specified and no default provider configured")
+      process.exit(1)
+    }
+
+    switch (command) {
+      case "compact":
+      case "summarize":
+        return sdk.session.summarize({
+          sessionID,
+          directory,
+          providerID: selected.providerID,
+          modelID: selected.modelID,
+        })
+    }
+  }
+}
 
 export namespace KiloRunDaemon {
   export type Input = {
@@ -16,4 +55,16 @@ export namespace KiloRunDaemon {
     await input.execute(client)
     return true
   }
+}
+
+async function resolve(sdk: KiloClient, model?: string) {
+  if (model) {
+    const parsed = Provider.parseModel(model)
+    return { providerID: parsed.providerID, modelID: parsed.modelID }
+  }
+  const result = await sdk.config.providers()
+  const defaults = result.data?.default ?? {}
+  const providerID = Object.keys(defaults)[0]
+  if (!providerID) return undefined
+  return { providerID, modelID: defaults[providerID] }
 }

--- a/packages/opencode/src/kilocode/cli/cmd/run.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/run.ts
@@ -6,10 +6,16 @@ import { Provider } from "@/provider/provider"
 import { Filesystem } from "@/util/filesystem"
 
 export namespace KiloRun {
-  export const isBuiltin = isBuiltinCommand
+  export async function resolveBuiltin(sdk: KiloClient, command?: string, directory?: string) {
+    if (!isBuiltinCommand(command)) return
+    const result = await sdk.command.list({ directory })
+    if (result.error) return
+    if (result.data?.some((item) => item.name === command)) return
+    return command
+  }
 
-  export function validateBuiltin(args: { command?: string; continue?: boolean; session?: string }) {
-    if (!isBuiltin(args.command)) return
+  export function validateBuiltin(args: { command?: BuiltinCommand; continue?: boolean; session?: string }) {
+    if (!args.command) return
     if (args.continue || args.session) return
     UI.error(`--command ${args.command} requires --continue or --session`)
     process.exit(1)
@@ -20,11 +26,12 @@ export namespace KiloRun {
     sessionID: string,
     command: BuiltinCommand,
     model?: string,
+    current?: { id: string; providerID: string },
     directory?: string,
   ) {
-    const selected = await resolve(sdk, model)
+    const selected = resolve(model, current)
     if (!selected) {
-      UI.error("No model specified and no default provider configured")
+      UI.error("No model specified and session has no model")
       process.exit(1)
     }
 
@@ -57,14 +64,11 @@ export namespace KiloRunDaemon {
   }
 }
 
-async function resolve(sdk: KiloClient, model?: string) {
+function resolve(model?: string, current?: { id: string; providerID: string }) {
   if (model) {
     const parsed = Provider.parseModel(model)
     return { providerID: parsed.providerID, modelID: parsed.modelID }
   }
-  const result = await sdk.config.providers()
-  const defaults = result.data?.default ?? {}
-  const providerID = Object.keys(defaults)[0]
-  if (!providerID) return undefined
-  return { providerID, modelID: defaults[providerID] }
+  if (!current) return
+  return { providerID: current.providerID, modelID: current.id }
 }

--- a/packages/opencode/src/kilocode/session/builtin-commands.ts
+++ b/packages/opencode/src/kilocode/session/builtin-commands.ts
@@ -1,0 +1,14 @@
+// Built-in session commands surfaced via `kilo run --command <name>` and the TUI
+// slash menu that don't live in the Command registry. They map to dedicated
+// session endpoints (e.g. `/session/:sessionID/summarize`).
+//
+// Kept in a side-effect-free module so it can be imported from the server
+// (`session/prompt.ts`) without pulling in CLI dependencies.
+export const BUILTIN_COMMANDS = ["compact", "summarize"] as const
+
+export type BuiltinCommand = (typeof BUILTIN_COMMANDS)[number]
+
+export function isBuiltinCommand(name?: string): name is BuiltinCommand {
+  if (!name) return false
+  return (BUILTIN_COMMANDS as readonly string[]).includes(name)
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -9,6 +9,7 @@ import { KiloSessionProcessor } from "@/kilocode/session/processor" // kilocode_
 import { CommandTimeout } from "@/kilocode/command-timeout" // kilocode_change
 import { Suggestion } from "@/kilocode/suggestion" // kilocode_change
 import { Question } from "@/question" // kilocode_change
+import { BUILTIN_COMMANDS } from "@/kilocode/session/builtin-commands" // kilocode_change
 import { zod } from "@opencode-ai/core/effect-zod" // kilocode_change
 import { withStatics } from "@opencode-ai/core/schema" // kilocode_change
 import { SessionID, MessageID, PartID } from "./schema"
@@ -1805,6 +1806,8 @@ export const layer = Layer.effect(
       const cmd = yield* commands.get(input.command)
       if (!cmd) {
         const available = (yield* commands.list()).map((c) => c.name)
+        available.push(...BUILTIN_COMMANDS) // kilocode_change - surface built-in session commands in error hint
+        available.sort() // kilocode_change - alphabetical for stable, easy-to-scan output
         const hint = available.length ? ` Available commands: ${available.join(", ")}` : ""
         const error = new NamedError.Unknown({ message: `Command not found: "${input.command}".${hint}` })
         yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })

--- a/packages/opencode/test/kilocode/cli/cmd/run-message.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/run-message.test.ts
@@ -1,5 +1,58 @@
 import { describe, expect, test } from "bun:test"
+import { KiloRun } from "../../../../src/kilocode/cli/cmd/run"
 import { buildRunMessage } from "../../../../src/kilocode/cli/cmd/run-message"
+
+describe("KiloRun", () => {
+  test("prefers a configured command over an endpoint-backed built-in", async () => {
+    const sdk = {
+      command: {
+        list: async () => ({ data: [{ name: "compact" }] }),
+      },
+    }
+
+    expect(await KiloRun.resolveBuiltin(sdk as never, "compact", "/tmp/project")).toBeUndefined()
+  })
+
+  test("resolves an endpoint-backed built-in when no configured command matches", async () => {
+    const sdk = {
+      command: {
+        list: async () => ({ data: [{ name: "other" }] }),
+      },
+    }
+
+    expect(await KiloRun.resolveBuiltin(sdk as never, "compact", "/tmp/project")).toBe("compact")
+  })
+
+  test("uses the resumed session model for compaction", async () => {
+    const calls: unknown[] = []
+    const sdk = {
+      session: {
+        summarize: async (input: unknown) => {
+          calls.push(input)
+          return { data: true }
+        },
+      },
+    }
+
+    await KiloRun.runBuiltin(
+      sdk as never,
+      "ses_test",
+      "compact",
+      undefined,
+      { providerID: "session-provider", id: "session-model" },
+      "/tmp/project",
+    )
+
+    expect(calls).toEqual([
+      {
+        sessionID: "ses_test",
+        directory: "/tmp/project",
+        providerID: "session-provider",
+        modelID: "session-model",
+      },
+    ])
+  })
+})
 
 describe("buildRunMessage", () => {
   test("preserves shell-bound multi-word positionals via wrap-quote (PR #4979)", () => {

--- a/packages/opencode/test/kilocode/run-network.test.ts
+++ b/packages/opencode/test/kilocode/run-network.test.ts
@@ -94,9 +94,11 @@ function args() {
 
 const timer = globalThis.setTimeout
 const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+const text = Bun.stdin.text
 
 afterEach(() => {
   globalThis.setTimeout = timer
+  Bun.stdin.text = text
   if (tty) {
     Object.defineProperty(process.stdin, "isTTY", tty)
     return
@@ -113,19 +115,19 @@ function instant() {
   }) as unknown as typeof setTimeout
 }
 
-async function run(sdk: Record<string, unknown>) {
+async function run(sdk: Record<string, unknown>, overrides: Record<string, unknown> = {}, terminal = true) {
   mock.module("@kilocode/sdk/v2", () => ({
     createKiloClient: () => sdk,
   }))
 
   Object.defineProperty(process.stdin, "isTTY", {
     configurable: true,
-    value: true,
+    value: terminal,
   })
 
   const key = JSON.stringify({ time: Date.now(), rand: Math.random() })
   const { RunCommand } = await import(`../../src/cli/cmd/run?${key}`)
-  return RunCommand.handler(args() as never)
+  return RunCommand.handler({ ...args(), ...overrides } as never)
 }
 
 describe("cli run network retries", () => {
@@ -226,5 +228,99 @@ describe("cli run network retries", () => {
 
     expect(calls).toStrictEqual(["req_1", "req_2", "req_3", "req_4"])
     expect(state.reject).toBeUndefined()
+  })
+
+  test("built-in compaction uses the session model without reading stdin", async () => {
+    const q = feed<Event>()
+    const calls: unknown[] = []
+    Bun.stdin.text = async () => {
+      throw new Error("stdin should not be read")
+    }
+
+    const sdk = {
+      command: {
+        list: async () => ({ data: [] }),
+      },
+      config: {
+        get: async () => ({ data: { share: "manual" } }),
+      },
+      event: {
+        subscribe: async () => ({ stream: q.stream() }),
+      },
+      session: {
+        get: async (input: { sessionID: string }) => ({
+          data: {
+            id: input.sessionID,
+            directory: "/tmp/project",
+            model: { providerID: "session-provider", id: "session-model" },
+          },
+        }),
+        summarize: async (input: unknown) => {
+          calls.push(input)
+          q.push(idle())
+          q.end()
+          return { data: true }
+        },
+      },
+    }
+
+    await run(sdk, { command: "compact", message: [] }, false)
+
+    expect(calls).toEqual([
+      {
+        sessionID: "ses_test",
+        directory: "/tmp/project",
+        providerID: "session-provider",
+        modelID: "session-model",
+      },
+    ])
+  })
+
+  test("custom compact commands retain piped arguments without a session", async () => {
+    const q = feed<Event>()
+    const calls: unknown[] = []
+    Bun.stdin.text = async () => "from stdin"
+
+    const sdk = {
+      command: {
+        list: async () => ({ data: [{ name: "compact" }] }),
+      },
+      config: {
+        get: async () => ({ data: { share: "manual" } }),
+      },
+      event: {
+        subscribe: async () => ({ stream: q.stream() }),
+      },
+      session: {
+        create: async () => ({
+          data: { id: "ses_created", directory: "/tmp/project" },
+        }),
+        command: async (input: unknown) => {
+          calls.push(input)
+          q.push({
+            type: "session.status",
+            properties: { sessionID: "ses_created", status: { type: "idle" } },
+          })
+          q.end()
+          return { data: undefined }
+        },
+        summarize: async () => {
+          throw new Error("custom command should not summarize")
+        },
+      },
+    }
+
+    await run(sdk, { command: "compact", continue: false, session: undefined, message: ["argument"] }, false)
+
+    expect(calls).toEqual([
+      {
+        sessionID: "ses_created",
+        agent: undefined,
+        model: undefined,
+        command: "compact",
+        arguments: "argument\nfrom stdin",
+        variant: undefined,
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Context

`kilo run --command compact` and `kilo run --command summarize` previously failed with `Command not found`. Those commands work in the TUI (`/compact` / `/summarize`) but aren't entries in the `Command` registry — they're session operations that hit `POST /session/:sessionID/summarize`. This PR makes them work from `kilo run` as well, matching user expectations.

Triggered by trying to compact a session non-interactively for pipeline / `--auto` use cases.

## Implementation

Two new built-ins (`compact`, `summarize`) are surfaced through `kilo run --command`. They live in a small kilocode-only module so the diff against shared upstream code stays minimal.

- `packages/opencode/src/kilocode/session/builtin-commands.ts` — single source of truth for the built-in names. Side-effect-free so it can be imported by both the CLI and the server.
- `packages/opencode/src/kilocode/cli/cmd/run.ts` — `KiloRun` namespace with `isBuiltin`, `validateBuiltin`, `runBuiltin`. Resolves the model from `--model` or falls back to the server's `/config/providers` defaults (so it works under `--attach` too) and calls `sdk.session.summarize`.
- `packages/opencode/src/cli/cmd/run.ts` (shared) — adds 3 small annotated lines: an import, an early-validation hook, and a branch in the dispatcher. The pre-existing `if (args.command) { sdk.session.command(...) }` flow is untouched for non-built-in commands.
- `packages/opencode/src/session/prompt.ts` (shared) — when the slash-command lookup fails, the "Available commands" hint now also includes the built-ins and is sorted alphabetically. Two annotated lines.
- `--command compact|summarize` requires `-c`/`--continue` or `-s`/`--session` (compacting a fresh session is a no-op) — guarded up front.

Trade-off: rather than registering `compact`/`summarize` as fake template entries in the `Command` service, they're handled at the dispatch site. The Command service is template-based and these need different routing (the summarize endpoint), so faking templates would either break the registry contract or require special-casing on both client and server. Intercepting client-side is contained and matches how the TUI handles them.

## Screenshots

### Before
<img width="2484" height="176" alt="image" src="https://github.com/user-attachments/assets/a6f9ee0d-6afe-41e3-8294-75d180baa65c" />

### After
<img width="2787" height="1371" alt="image" src="https://github.com/user-attachments/assets/3f395cd0-58d2-4089-8b90-c1a0924b7a89" />

## How to Test

1. From a directory with an existing kilo session (or run any prompt first), try the new built-ins:
   ```sh
   kilo run -c --command compact
   kilo run -c --command summarize          # alias of compact
   kilo run -s <id> --command compact --model anthropic/claude-opus-4
   ```
   Expected: the session is compacted (a `compaction` part appears at the end of the message list) and the process exits when the session goes idle.
2. Without `-c`/`-s` it should refuse:
   ```sh
   kilo run --command compact
   # Error: --command compact requires --continue or --session
   ```
3. An unknown command should now list the built-ins in the hint, alphabetically:
   ```sh
   kilo run -c --command compact2
   # Error: Command not found: "compact2". Available commands: compact, init, kilo-config, local-review, local-review-uncommitted, review, summarize
   ```
4. Existing slash commands (`init`, `review`, `local-review`, `local-review-uncommitted`, `kilo-config`, plus any user-defined `.kilo/command/*.md`) should keep working unchanged via the standard `sdk.session.command` path.

Verified locally: `bun run typecheck` (in `packages/opencode/`), `bun run lint` (no new warnings on touched files), `bun test ./test/kilocode/run-network.test.ts`.

## Get in Touch

@catrielmuller on Discord.