### PR TITLE
fix(cli): recover provider finish errors

### DIFF
--- a/.changeset/recover-provider-finish-errors.md
+++ b/.changeset/recover-provider-finish-errors.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Recover sessions when providers end a response with an error finish but no error details.

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -3,7 +3,7 @@ import { Telemetry } from "@kilocode/kilo-telemetry"
 import { SessionNetwork } from "@/session/network"
 import type { SessionID } from "@/session/schema"
 import type { SessionStatus } from "@/session/status"
-import type { MessageV2 } from "@/session/message-v2"
+import { MessageV2 } from "@/session/message-v2"
 import * as Log from "@opencode-ai/core/util/log"
 import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -19,6 +19,8 @@ export namespace KiloSessionProcessor {
   export const OUTPUT_LENGTH_WARNING = "The model hit its output limit, so this response may be incomplete."
   export const REASONING_LENGTH_WARNING =
     "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
+  export const PROVIDER_FINISH_ERROR_MESSAGE =
+    "The provider ended the response with an error before returning details. Start a new message to retry; Kilo will compact the oversized conversation first if needed."
 
   export function reviewTelemetry(command: string): ReviewTelemetry | undefined {
     if (command === "local-review" || command === "local-review-uncommitted") {
@@ -165,5 +167,17 @@ export namespace KiloSessionProcessor {
     }
     log.warn("length stop", { messageID: input.msg.id })
     return OUTPUT_LENGTH_WARNING
+  }
+
+  export function providerFinishError(msg: MessageV2.Assistant) {
+    if (msg.finish !== "error") return false
+    if (msg.error) return false
+    const err = new MessageV2.APIError({
+      message: PROVIDER_FINISH_ERROR_MESSAGE,
+      isRetryable: true,
+    }).toObject()
+    msg.error = err
+    log.warn("provider finish error", { messageID: msg.id })
+    return err
   }
 }

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -79,6 +79,27 @@ export namespace KiloSessionPrompt {
     yield* input.sessions.removeMessage({ sessionID: input.sessionID, messageID: tail.info.id })
   })
 
+  export const recoverProviderFinishError = Effect.fn("KiloSessionPrompt.recoverProviderFinishError")(function* (input: {
+    sessionID: SessionID
+    status: Pick<SessionStatus.Interface, "get">
+    sessions: Pick<Session.Interface, "messages" | "removeMessage">
+  }) {
+    const state = yield* input.status.get(input.sessionID)
+    if (state.type !== "idle") return
+
+    const msgs = yield* input.sessions.messages({ sessionID: input.sessionID, limit: 2 })
+    const tail = msgs.at(-1)
+    if (!tail || tail.info.role !== "assistant") return
+    if (tail.info.finish !== "error" || tail.info.error) return
+    if (!tail.parts.some((part) => part.type === "step-finish" && part.reason === "error")) return
+
+    const prev = msgs.at(-2)
+    if (!prev || prev.info.role !== "user") return
+    if (tail.info.parentID !== prev.info.id) return
+
+    yield* input.sessions.removeMessage({ sessionID: input.sessionID, messageID: tail.info.id })
+  })
+
   export function guardPermissions(input: {
     agent: { name: string; permission: Permission.Ruleset }
     session: Pick<Session.Info, "permission">

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -478,6 +478,14 @@ export const layer: Layer.Layer<
                 ignored: true,
               })
             }
+            const providerError = KiloSessionProcessor.providerFinishError(ctx.assistantMessage)
+            if (providerError) {
+              yield* bus.publish(Session.Event.Error, {
+                sessionID: ctx.assistantMessage.sessionID,
+                error: providerError,
+              })
+              yield* status.set(ctx.sessionID, { type: "idle" })
+            }
             // kilocode_change end
             yield* session.updateMessage(ctx.assistantMessage)
             if (ctx.snapshot) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1300,6 +1300,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         yield* revert.cleanup(session)
         // kilocode_change start - persist queued prompts immediately while serializing each follow-up loop
         yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
+        yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
         const message = yield* createUserMessage(input)
         yield* sessions.touch(input.sessionID)
 
@@ -1628,6 +1629,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 yield* sessions.updateMessage(handle.message)
                 return "break" as const
               }
+              // kilocode_change start
+              if (handle.message.finish === "error") {
+                KiloSessionProcessor.providerFinishError(handle.message)
+                yield* sessions.updateMessage(handle.message)
+                closeReasons.set(sessionID, "error")
+                return "break" as const
+              }
+              // kilocode_change end
             }
 
             // kilocode_change start
@@ -1684,6 +1693,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     ) {
       // kilocode_change start
       yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
+      yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
       yield* bus.publish(KiloSession.Event.TurnOpen, { sessionID: input.sessionID })
       return yield* Effect.onExit(
         state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID)),

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -265,6 +265,80 @@ describe("session processor empty tool-calls", () => {
     ),
   )
 
+  it.effect("treats provider finish errors without details as retryable API errors", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "error",
+              usage: usage(),
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          const result = yield* handle.process(input)
+          expect(result).toBe("stop")
+          expect(handle.message.finish).toBe("error")
+          expect(handle.message.error?.name).toBe("APIError")
+          if (handle.message.error?.name !== "APIError") return
+          expect(handle.message.error.data.isRetryable).toBe(true)
+          expect(handle.message.error.data.message).toContain("provider ended the response with an error")
+        }),
+      { git: true },
+    ),
+  )
+
   it.effect("adds generic warning when model stops after text length finish", () =>
     provideTmpdirInstance(
       (dir) =>

--- a/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
@@ -441,4 +441,59 @@ describe("SessionPrompt recovery", () => {
       { git: true, config: providerCfg },
     ),
   )
+
+  it.live("recovers from persisted provider finish errors before replying", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Provider finish error recovery" })
+        const first = yield* user(chat.id, "before provider finish error")
+        const stale = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: first.id,
+          sessionID: chat.id,
+          mode: "code",
+          agent: "code",
+          path: { cwd: "/tmp", root: "/tmp" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          time: { created: Date.now() },
+          finish: "error",
+        } satisfies MessageV2.Assistant)
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: stale.id,
+          sessionID: chat.id,
+          type: "step-start",
+        } satisfies MessageV2.StepStartPart)
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          messageID: stale.id,
+          sessionID: chat.id,
+          type: "step-finish",
+          reason: "error",
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        } satisfies MessageV2.StepFinishPart)
+        yield* llm.text("recovered")
+
+        const result = yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "code",
+          parts: [{ type: "text", text: "continue after provider finish error" }],
+        })
+
+        expect(result.info.role).toBe("assistant")
+        expect(result.info.id).not.toBe(stale.id)
+        expect(result.parts.some((part) => part.type === "text" && part.text === "recovered")).toBe(true)
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        expect(msgs.some((msg) => msg.info.id === stale.id)).toBe(false)
+      }),
+      { git: true, config: providerCfg },
+    ),
+  )
 })

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -501,6 +501,16 @@ export class Reply {
     return this
   }
 
+  // kilocode_change start
+  finish(reason: string) {
+    this.#finish = reason
+    this.#hang = false
+    this.#error = undefined
+    this.#reset = false
+    return this
+  }
+  // kilocode_change end
+
   tool(name: string, input: unknown) {
     const id = this.#id()
     const args = JSON.stringify(input)


### PR DESCRIPTION
## Summary
- Convert provider `finish: error` responses without details into retryable API errors instead of silently closing the turn.
- Recover already persisted broken assistant tails so the next user message can proceed normally.

## What We Found
We debugged a stuck local session in the local SQLite DB. The final assistant rows had `finish: "error"`, no `error` object, and only `step-start` plus `step-finish:error` parts. The logs did not contain a matching thrown stream error or prompt failure for those turns.

The last successful model step before the issue was very close to the usable model context budget, so request size pressure is the likely trigger. The product bug is broader: if a provider reports a terminal error only as a finish reason, Kilo persisted it as a completed assistant turn with no actionable error.

## Why This Fix
The processor already handles thrown stream errors correctly by setting `assistantMessage.error`, publishing `Session.Event.Error`, and stopping the loop. The missing case was a provider finish event where `finishReason === "error"` but no error object is thrown. This PR normalizes that shape into a retryable `APIError`, publishes the session error, and stops the turn.

That means new occurrences now show the user a real retryable error instead of briefly showing the thinking placeholder and silently ending. For sessions already in the broken state, this PR removes only the exact stale tail shape on the next prompt: idle session, assistant tail, `finish: "error"`, no `error`, and a `step-finish:error` part answering the previous user message. New normalized provider errors include an `error` object, so this recovery does not repeatedly delete messages or create an auto-loop.

## Tests
- `bun test test/kilocode/session-processor-empty-tool-calls.test.ts test/kilocode/session-prompt-compaction-safety.test.ts`
- `bun run typecheck` from `packages/opencode`
- `bun run script/check-opencode-annotations.ts --base origin/main`