### PR TITLE
Collapse auto-approve exceptions list by default

### DIFF
--- a/.changeset/fold-auto-approve-exceptions.md
+++ b/.changeset/fold-auto-approve-exceptions.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Collapse the Auto-Approve Exceptions list by default when it has more than 2 entries.
+Collapse the Auto-Approve Exceptions list by default when it has more than 5 entries.

--- a/.changeset/fold-auto-approve-exceptions.md
+++ b/.changeset/fold-auto-approve-exceptions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Collapse the Auto-Approve Exceptions list by default when it has more than 2 entries.

--- a/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
@@ -1,6 +1,7 @@
 import { Component, For, Show, createEffect, createMemo, createSignal } from "solid-js"
 import { Select } from "@kilocode/kilo-ui/select"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Icon } from "@kilocode/kilo-ui/icon"
 
 import { useLanguage } from "../../context/language"
 import type { PermissionConfig, PermissionLevel, PermissionRule, PermissionRuleItem } from "../../types/messages"
@@ -318,6 +319,7 @@ const GranularToolRow: Component<{
   const language = useLanguage()
   const [adding, setAdding] = createSignal(false)
   const [input, setInput] = createSignal("")
+  const [expanded, setExpanded] = createSignal(permissionExceptions(props.rule).length <= 2)
   let ref: HTMLInputElement | undefined
 
   createEffect(() => {
@@ -384,57 +386,82 @@ const GranularToolRow: Component<{
 
       <Show when={excs().length > 0}>
         <div style={{ "margin-top": "4px" }}>
-          <div
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
             style={{
+              display: "flex",
+              "align-items": "center",
+              gap: "4px",
+              padding: "0",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
               "font-size": "var(--kilo-font-size-12)",
               color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
               "margin-bottom": "4px",
+              "font-family": "inherit",
             }}
+            aria-expanded={expanded()}
           >
-            {language.t("settings.autoApprove.exceptions")}
-          </div>
-          <For each={excs()}>
-            {(exc) => (
-              <div
-                style={{
-                  display: "flex",
-                  gap: "8px",
-                  "align-items": "center",
-                  padding: "4px 0",
-                  "padding-left": "12px",
-                  "border-top": "1px solid var(--border-weak-base)",
-                }}
-              >
+            <span
+              style={{
+                display: "inline-flex",
+                "align-items": "center",
+                transition: "transform 0.15s ease",
+                transform: expanded() ? "rotate(90deg)" : "rotate(0deg)",
+              }}
+            >
+              <Icon name="chevron-right" size="small" />
+            </span>
+            <span>
+              {language.t("settings.autoApprove.exceptions")} ({excs().length})
+            </span>
+          </button>
+          <Show when={expanded()}>
+            <For each={excs()}>
+              {(exc) => (
                 <div
                   style={{
-                    flex: "1 1 0%",
-                    "min-width": 0,
-                    "font-size": "var(--kilo-font-size-13)",
-                    "font-family": "var(--vscode-editor-font-family, monospace)",
-                    color: "var(--text-base, #ccc)",
-                    overflow: "hidden",
-                    "text-overflow": "ellipsis",
-                    "white-space": "nowrap",
+                    display: "flex",
+                    gap: "8px",
+                    "align-items": "center",
+                    padding: "4px 0",
+                    "padding-left": "12px",
+                    "border-top": "1px solid var(--border-weak-base)",
                   }}
-                  title={exc.pattern}
                 >
-                  {exc.pattern}
+                  <div
+                    style={{
+                      flex: "1 1 0%",
+                      "min-width": 0,
+                      "font-size": "var(--kilo-font-size-13)",
+                      "font-family": "var(--vscode-editor-font-family, monospace)",
+                      color: "var(--text-base, #ccc)",
+                      overflow: "hidden",
+                      "text-overflow": "ellipsis",
+                      "white-space": "nowrap",
+                    }}
+                    title={exc.pattern}
+                  >
+                    {exc.pattern}
+                  </div>
+                  <div style={{ display: "flex", gap: "4px", "align-items": "center", "flex-shrink": 0 }}>
+                    <ActionSelect
+                      level={exc.action}
+                      onChange={(level: PermissionLevel) => props.onExceptionChange(exc.pattern, level)}
+                    />
+                    <IconButton
+                      variant="ghost"
+                      size="small"
+                      icon="close"
+                      onClick={() => props.onExceptionRemove(exc.pattern)}
+                    />
+                  </div>
                 </div>
-                <div style={{ display: "flex", gap: "4px", "align-items": "center", "flex-shrink": 0 }}>
-                  <ActionSelect
-                    level={exc.action}
-                    onChange={(level: PermissionLevel) => props.onExceptionChange(exc.pattern, level)}
-                  />
-                  <IconButton
-                    variant="ghost"
-                    size="small"
-                    icon="close"
-                    onClick={() => props.onExceptionRemove(exc.pattern)}
-                  />
-                </div>
-              </div>
-            )}
-          </For>
+              )}
+            </For>
+          </Show>
         </div>
       </Show>
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
@@ -327,7 +327,7 @@ const GranularToolRow: Component<{
   })
 
   const excs = createMemo(() => permissionExceptions(props.rule))
-  const expanded = createMemo(() => override() ?? excs().length <= 2)
+  const expanded = createMemo(() => override() ?? excs().length <= 5)
   const toggle = () => setOverride(!expanded())
   const level = createMemo(() => wildcardAction(props.rule, props.fallback))
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
@@ -319,7 +319,7 @@ const GranularToolRow: Component<{
   const language = useLanguage()
   const [adding, setAdding] = createSignal(false)
   const [input, setInput] = createSignal("")
-  const [expanded, setExpanded] = createSignal(permissionExceptions(props.rule).length <= 2)
+  const [override, setOverride] = createSignal<boolean | null>(null)
   let ref: HTMLInputElement | undefined
 
   createEffect(() => {
@@ -327,6 +327,8 @@ const GranularToolRow: Component<{
   })
 
   const excs = createMemo(() => permissionExceptions(props.rule))
+  const expanded = createMemo(() => override() ?? excs().length <= 2)
+  const toggle = () => setOverride(!expanded())
   const level = createMemo(() => wildcardAction(props.rule, props.fallback))
 
   const submit = () => {
@@ -388,7 +390,7 @@ const GranularToolRow: Component<{
         <div style={{ "margin-top": "4px" }}>
           <button
             type="button"
-            onClick={() => setExpanded((v) => !v)}
+            onClick={toggle}
             style={{
               display: "flex",
               "align-items": "center",


### PR DESCRIPTION
## Summary

Long Exceptions lists in the Auto-Approve settings (e.g. the bundled Bash exceptions) pushed every other tool below the fold. The Exceptions section is now collapsed by default whenever it has more than 5 entries, with a clickable header showing the count and a chevron to toggle it.

Lists with 0-5 entries still expand by default so common cases stay zero-click.

<img width="1638" height="1322" alt="CleanShot 2026-05-07 at 15 51 39@2x" src="https://github.com/user-attachments/assets/4689ad4f-a975-4365-90f8-a7add093ace4" />

