### PR TITLE
docs: verify and update wasteland workflow + admin pages

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/admin.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/admin.md
@@ -115,7 +115,7 @@ The inbox classifies incoming DoltHub PRs into typed cards:
 | **Wanted post** | Someone posted a new wanted item — review title, description, type, priority |
 | **Wanted edit** | An existing item was updated (`update`), withdrawn (`delete`), or unclaimed (`unclaim`) |
 | **Work submission** | A rig submitted evidence for a claimed item — review the evidence URL |
-| **Admin action** | An accept, reject, or close was performed — review the stamp details |
+| **Admin action** | An accept (`accept` / `accept-upstream`), reject (`reject`), or close (`close` / `close-upstream`) was performed — review the stamp details. The `-upstream` subkinds indicate a fork submission was accepted or closed at the upstream level. |
 | **Unknown** | A PR from outside the `wl` toolchain — foreign commits not matching any known verb |
 
 ### Inspecting evidence
@@ -127,6 +127,10 @@ When a work submission appears, you can:
 3. **Check the rig's history** — See the rig's past completions and stamps
 
 The review page also supports drawer navigation — clicking a rig handle in a PR opens a rig detail panel without losing your place.
+
+### Commenting on PRs
+
+Admins can post comments directly on upstream DoltHub PRs from the review interface. This is useful for requesting clarification or leaving feedback before stamping, without leaving the dashboard.
 
 ## Stamping Work
 
@@ -286,3 +290,45 @@ Each wasteland instance maintains its own:
 - **Claims and evidence** — Only visible within the instance where the work was done.
 - **Configuration** — Workflow mode, validator membership, and moderation rules are local to each instance.
 - **Members list** — Your instance's member roster is independent.
+
+## Admin Settings
+
+The wasteland settings page exposes additional controls when your credential has `is_upstream_admin = true`. These are visible only to owners.
+
+### Test admin access
+
+The **Test admin access** button probes DoltHub by attempting a no-op write against a scratch branch on the upstream. If the probe succeeds, you see a green "Admin access verified" badge. If it fails (expired PAT, wrong org, insufficient permissions), you see a red error banner with guidance to fix the credential.
+
+This is useful after rotating your DoltHub PAT or toggling the admin checkbox — it confirms that your stored credential actually has push rights before you attempt admin operations.
+
+### Pending PRs
+
+The settings page lists all open upstream PRs cross-referenced against the wanted board. Each row shows:
+
+- PR title and number
+- Associated wanted item ID
+- State (open, merging, merged)
+- Age and contributor rig
+
+Per-row actions: **View on DoltHub** (external link), **Merge**, **Close without merging**. These actions use the stored admin credential to call DoltHub's merge/close APIs directly.
+
+{% callout type="warning" %}
+DoltHub merge is **asynchronous**. After clicking Merge, the PR state may not update for 5–30 seconds. The UI polls the PR state to confirm.
+{% /callout %}
+
+### Rig management
+
+The rig management panel lists all rigs registered on the upstream commons. Each row shows:
+
+- Handle and display name
+- Trust level (0–3)
+- DoltHub org and contact email
+- Registration date and last-seen timestamp
+
+Owners can change a rig's trust level directly from this panel. This writes to the upstream `rigs` table via the DoltHub write API — it's the only currently-available way to elevate or demote contributors, since `wl` doesn't expose a CLI command for it.
+
+Setting a rig's trust level to 0 is the closest equivalent to a ban — it signals that the rig is restricted, though there is no API-level enforcement that blocks a trust-level-0 rig from claiming items. See [Moderation](#moderation) for the full escalation workflow.
+
+### Delete wasteland
+
+The existing Delete section in settings keeps its danger styling. In admin mode, an additional warning appears: deleting the wasteland does **not** delete the upstream DoltHub repository. To fully decommission, you must also archive or delete the `<owner>/<db>` repo on DoltHub.

--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/admin.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/admin.md
@@ -27,12 +27,12 @@ Running your own wasteland means creating a new DoltHub database and configuring
 2. Click **Connect** → choose **Create your own** (instead of joining an existing one)
 3. Enter your wasteland name and upstream (e.g., `my-org/wl-internal`)
 4. Provide your DoltHub PAT — this must have write access to the upstream repo
-5. Check **"I own this upstream"** — this enables admin mode for your credential
+5. Check **"I own this upstream"** — this sets `is_upstream_admin = true` on your credential, enabling admin mode
 6. Click **Connect**
 
 Behind the scenes, this runs `wl create <org/db>` on the wasteland container, which bootstraps a fresh DoltHub repo with the wasteland schema (the `wanted`, `rigs`, `completions`, `stamps`, and metadata tables). You're automatically registered as the first rig with `role = 'owner'` and `trust_level = 3`.
 
-<!-- TODO: verify — confirm whether the "Create your own" split in the Connect dialog has shipped or is still in the single-dialog form -->
+<!-- TODO: verify — the "Create your own" entry point in the Connect dialog (WS-Admin 7) has not shipped yet. Currently the dialog uses a single linear flow. The split into "Join" and "Create" branches is planned. For now, creating a new wasteland uses the existing dialog with the upstream field populated manually, followed by `createUpstream` after the credential is stored. -->
 
 ### Via CLI
 
@@ -48,7 +48,7 @@ This creates the DoltHub repo and initializes the schema. You'd then connect you
 
 <!-- TODO: verify — confirm whether Kilo Cloud offers a hosted wasteland creation flow or if self-serve is CLI/dashboard only -->
 
-Kilo Cloud provides the managed infrastructure (containers, encryption, billing) but the upstream DoltHub database is always user-owned. There is no fully-hosted wasteland where Kilo manages the DoltHub repo on your behalf — you always create and own the upstream.
+Kilo Cloud provides the managed infrastructure (Cloudflare containers, encryption, billing) but the upstream DoltHub database is always user-owned. There is no fully-hosted wasteland where Kilo manages the DoltHub repo on your behalf — you always create and own the upstream. The wasteland container runs on Kilo's infrastructure, but data lives in your DoltHub account.
 
 ## Posting Wanted Items
 
@@ -80,19 +80,25 @@ Navigate to your wasteland → **Wanted** tab → click **Post new item**.
 
 ### Optional fields
 
-| Field | Values | Description |
-|---|---|---|
-| **Priority** | `low`, `medium`, `high`, `critical` | How urgent is this? Defaults to `medium` if unset. |
-| **Type** | `feature`, `bug`, `docs`, `other` | What kind of work is this? |
-| **Tags** | Free-form labels | Arbitrary labels for categorization and filtering |
-| **Project** | String | Optional project tag for filtering |
-| **Effort level** | `small`, `medium`, `large` | Expected effort |
+| Field | Values | Description | Available through |
+|---|---|---|---|
+| **Priority** | `low`, `medium`, `high`, `critical` | How urgent is this? Defaults to `medium` if unset. | Dashboard, Mayor, `wl` CLI |
+| **Type** | `feature`, `bug`, `docs`, `other` | What kind of work is this? | Dashboard, Mayor, `wl` CLI |
+| **Project** | String | Optional project tag for filtering | `wl` CLI only <!-- TODO: verify --> |
+| **Tags** | Free-form labels | Arbitrary labels for categorization and filtering | `wl` CLI only <!-- TODO: verify --> |
+| **Effort level** | `small`, `medium`, `large` | Expected effort | `wl` CLI only <!-- TODO: verify --> |
+
+The dashboard UI and Mayor tool currently expose only `title`, `description`, `priority`, and `type`. The additional fields (`project`, `tags`, `effort_level`) are stored in the `wanted` table and visible on the board, but must be set through the `wl post` CLI directly.
 
 In PR mode (the default), posting creates a DoltHub branch with the `INSERT INTO wanted` DML and opens a PR upstream. In direct mode (admin only), the insert goes straight to main.
 
 ## The Review Inbox
 
 The review inbox is where validators see incoming submissions that need attention. Access it from your wasteland → **Review** tab.
+
+{% callout type="info" %}
+The review inbox requires **both** owner-level membership and admin mode (`is_upstream_admin = true`). If you don't see the Review tab, check that you have the owner role and that your DoltHub credential has "I own this upstream" checked.
+{% /callout %}
 
 <!-- TODO(screenshots): replace placeholder with real UI capture -->
 {% browserFrame url="app.kilo.ai/wasteland/my-org/wl-internal/review" caption="The review inbox — pending submissions grouped by type" %}
@@ -107,9 +113,10 @@ The inbox classifies incoming DoltHub PRs into typed cards:
 |---|---|
 | **Rig registration** | A new rig wants to join — review their handle, org, and version |
 | **Wanted post** | Someone posted a new wanted item — review title, description, type, priority |
-| **Wanted edit** | An existing item was updated, deleted, or unclaimed |
+| **Wanted edit** | An existing item was updated (`update`), withdrawn (`delete`), or unclaimed (`unclaim`) |
 | **Work submission** | A rig submitted evidence for a claimed item — review the evidence URL |
 | **Admin action** | An accept, reject, or close was performed — review the stamp details |
+| **Unknown** | A PR from outside the `wl` toolchain — foreign commits not matching any known verb |
 
 ### Inspecting evidence
 
@@ -136,13 +143,13 @@ The `wl accept` command takes a `--quality` flag with four levels:
 | `fair` | Partially meets expectations — works but has gaps |
 | `poor` | Below expectations — significant issues remain |
 
-<!-- TODO: verify — the tRPC schema uses an enum of excellent/good/fair/poor for quality; confirm this matches the wl CLI's --quality values -->
+Quality is stored in the `stamps.valence` JSON field alongside reliability: `{"quality":"good","reliability":"good"}`. The `--quality` flag sets the quality dimension; reliability is recorded as part of the same valence object.
 
 ### Set confidence
 
-<!-- TODO: verify — confirm whether confidence is a separate numeric score or a categorical level in the current implementation -->
+<!-- TODO: verify — confirm whether confidence is a separate numeric score or a categorical level in the current `wl accept` CLI -->
 
-Confidence indicates how certain you are in your assessment. Higher confidence means you reviewed the work thoroughly; lower confidence means you're stamping based on partial review.
+Confidence indicates how certain you are in your assessment. It's stored in `stamps.confidence` (which accepts either a string or a number). Higher confidence means you reviewed the work thoroughly; lower confidence means you're stamping based on partial review.
 
 ### Write a justification
 
@@ -152,7 +159,7 @@ The `--message` flag on `wl accept` lets you attach a free-form justification. T
 
 **You cannot stamp your own work.** The `stamps` table has a `CHECK (author != subject)` constraint — if your rig handle matches the rig that completed the work, the stamp INSERT silently fails (the commit doesn't land on the branch). This is enforced at the database level, not just the application level.
 
-Always verify that the submitting rig is different from your own before accepting.
+Always verify that the submitting rig is different from your own before accepting. The admin UI should not offer "Accept" actions on your own rig's submissions.
 
 ### Merge vs reject DoltHub PR
 
@@ -182,7 +189,9 @@ Members are managed on the wasteland's **Members** tab. Access requires owner-le
 | **Maintainer** | 2 | Post wanted items, accept/reject/close submissions, manage validators |
 | **Contributor** | 1 | Browse wanted board, claim items, submit evidence |
 
-Trust levels (1–3) are stored on the `wasteland_members` table and are also reflected in the upstream `rigs` table. Higher trust levels indicate greater responsibility and access.
+Trust levels (0–3) are stored on the `wasteland_members` table and are also reflected in the upstream `rigs` table. Level 0 is reserved for demoted or restricted rigs (no API enforcement exists, but it serves as a signal). Higher trust levels indicate greater responsibility and access.
+
+The API enforces two permission tiers: **any member** (who can browse, claim, post, submit evidence, accept, reject, and close) and **owner only** (who can manage members, change config, and access admin tools like PR management and rig trust levels). The maintainer role's additional permissions — posting wanted items, reviewing submissions — are enforced at the UI level, not the API level.
 
 ### Inviting members
 
@@ -211,13 +220,16 @@ Owners can remove any member except themselves. Removing a member:
 | Browse wanted board | ✅ | ✅ | ✅ |
 | Claim items | ✅ | ✅ | ✅ |
 | Submit evidence | ✅ | ✅ | ✅ |
-| Post wanted items | ✅ | ✅ | ❌ <!-- TODO: verify — contributors may be able to post depending on instance config --> |
-| Accept/reject/close items | ✅ | ✅ | ❌ |
+| Post wanted items | ✅ | ✅ | ❌ <!-- TODO: verify — the API allows any member to post; restriction may be UI-only --> |
+| Accept/reject/close items | ✅ | ✅ | ❌ <!-- TODO: verify — the API allows any member to accept/reject/close; restriction is enforced by the Review tab requiring owner+admin --> |
+| View review inbox | ✅ | ❌ | ❌ |
 | Add/remove members | ✅ | ❌ | ❌ |
 | Change wasteland config | ✅ | ❌ | ❌ |
 | Delete wasteland | ✅ | ❌ | ❌ |
 | Disconnect towns | ✅ | ❌ | ❌ |
 | Toggle admin mode | ✅ | ❌ | ❌ |
+| Change rig trust levels | ✅ | ❌ | ❌ |
+| Merge/close upstream PRs | ✅ | ❌ | ❌ |
 
 ## Moderation
 
@@ -231,7 +243,7 @@ There is no built-in "ban" mechanism in the current protocol. To block a problem
 
 1. **Remove their membership** — Use the Members tab to remove the member from your wasteland instance.
 2. **Reject their open PRs** — Close any pending DoltHub PRs from the rig's fork.
-3. **Lower their trust level** — If the rig is registered on upstream, use the admin rig management panel to set `trust_level = 0`. <!-- TODO: verify — confirm whether trust_level=0 has any enforcement effect or if it's purely informational -->
+3. **Set trust level to 0** — Admins can use the rig management panel in settings to set `trust_level = 0` on the upstream `rigs` table. This is the closest equivalent to a ban — it signals that the rig is restricted, though there is no API-level enforcement that blocks a trust_level 0 rig from claiming items.
 4. **Unclaim their items** — Admins can unclaim items held by other rigs, returning them to `open` for other claimers.
 
 For the public commons (`hop/wl-commons`), moderation is handled by the maintainers of that upstream repo.
@@ -264,7 +276,7 @@ What you **can** control:
 
 - **Who joins your instance** — Private wastelands restrict membership. Only invited rigs can browse, claim, and submit evidence.
 - **Who can validate** — You control the validator set. Only members with appropriate roles can issue stamps on your instance.
-- **Visibility of your board** — Private wastelands have a `visibility = 'private'` flag that restricts wanted board access to members only.
+- **Visibility of your board** — Wasteland instances have a `visibility` setting (`public` or `private`) that restricts wanted board access. Private wastelands are invisible to non-members.
 
 ### What is not shared across federation
 

--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/concepts.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/concepts.md
@@ -106,7 +106,7 @@ If you need to release a claim, you can abandon it at any time before evidence i
 
 When you're working through Gas Town, your Mayor submits evidence automatically via `wl done` when a bead closes. The Mayor packages the PR URL and pushes it to your Wasteland fork as a DoltHub pull request.
 
-<!-- TODO: verify — confirm the exact Mayor tool name (e.g., gt_wasteland_done or similar) in wasteland-tools.handler.ts -->
+<!-- TODO: verify — the Mayor tool is `gt_wasteland_done` (gastown handler at `/api/mayor/:townId/tools/wasteland/done`), which calls `WASTELAND_SERVICE.markWantedItemDone`. Confirm this is the canonical tool name exposed to the Mayor's agent. -->
 
 In the standalone `wl` CLI, you'd use `wl done <id> --evidence "..."` to submit manually.
 
@@ -118,16 +118,16 @@ Each stamp scores across dimensions:
 
 | Dimension | What it measures |
 |---|---|
-| **Quality** | How well was the work done? (1–5) |
-| **Reliability** | Did the rig deliver on time and to spec? (1–5) |
+| **Quality** | How well was the work done? (`excellent`, `good`, `fair`, `poor`) |
+| **Reliability** | Did the rig deliver on time and to spec? (stored in `stamps.valence` JSON alongside quality) |
 
-Validators also set a **severity** — `leaf`, `branch`, or `root` — indicating how impactful the work was, and attach **skill tags** (e.g., `go`, `federation`) to build the completer's profile.
+Validators also set a **severity** — `leaf`, `branch`, or `root` — indicating how impactful the work was, and attach **skill tags** (e.g., `go`, `federation`) to build the completer's profile. The `stamps.confidence` field records how certain the validator is in their assessment.
 
 <!-- TODO: verify — confirm whether Gas Town adds a Creativity dimension on top of the open-source wl protocol's Quality/Reliability/Severity -->
 
 The **yearbook rule** enforces that you can't stamp your own work. Your reputation is built exclusively from what other validators write about you. This keeps the system honest and evidence-backed — every stamp traces back to verifiable work.
 
-<!-- TODO: verify — confirm whether confidence is a separate numeric score or a categorical level -->
+<!-- TODO: verify — confirm whether confidence is a numeric score or a categorical level; the schema accepts string or number -->
 
 ## Reputation Ledger
 
@@ -146,7 +146,7 @@ You can view your reputation from the Wasteland page in your Gas Town dashboard,
 Validator responsibilities:
 
 - Review submitted evidence (commits, PRs, deployed URLs)
-- Assess work across quality and reliability dimensions (1–5 each)
+- Assess work across quality and reliability dimensions
 - Set severity level (`leaf`, `branch`, `root`)
 - Attach skill tags relevant to the work
 - Write justifications for their assessment
@@ -169,6 +169,6 @@ In **PR mode** (the default), the flow looks like this:
 3. **DoltHub PR** — The branch is proposed upstream as a pull request. Reviewers can see the full diff (claim + evidence) in one place.
 4. **Accept/Reject** — Validators approve (merge the PR, issue a stamp) or reject (request changes, sending it back for rework).
 
-In **wild-west mode**, changes push directly to the upstream commons without a review gate. This is intended for maintainers with write access who don't need the PR review step.
+In **direct mode** (enabled when `is_upstream_admin = true`), changes push directly to the upstream commons without creating a PR. This is intended for maintainers with write access who don't need the PR review step. Direct mode is off by default — the `--direct` flag must be passed explicitly, and is silently downgraded to PR mode if the caller's credential isn't marked as admin.
 
 This model means the entire history of a wanted item — from posting to completion — is versioned, auditable, and cryptographically signed (when GPG signing is enabled). See [Workflow](/docs/code-with-ai/gastown/wasteland/workflow) for the end-to-end walkthrough and [Administration](/docs/code-with-ai/gastown/wasteland/admin) for running your own instance.

--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/quick-start.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/quick-start.md
@@ -118,8 +118,8 @@ Stamps score across:
 
 | Dimension | What it measures |
 |---|---|
-| **Quality** | How well was the work done? (1–5) |
-| **Reliability** | Did the rig deliver on time and to spec? (1–5) |
+| **Quality** | How well was the work done? (`excellent`, `good`, `fair`, `poor`) |
+| **Reliability** | Did the rig deliver on time and to spec? |
 
 Validators also set a **severity** — `leaf`, `branch`, or `root` — indicating how impactful the work was. Skill tags (e.g., `go`, `federation`) are attached to build the completer's profile.
 

--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/workflow.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/workflow.md
@@ -102,7 +102,7 @@ When the bead closes successfully, your Mayor **auto-submits** the completion ev
 
 ### Types of evidence
 
-Evidence is a free-form URL that proves the work was done. Acceptable types:
+Evidence is a **URL** that proves the work was done (the `wl done --evidence` flag requires a valid URL). Acceptable types:
 
 | Type | Example |
 |---|---|
@@ -111,7 +111,7 @@ Evidence is a free-form URL that proves the work was done. Acceptable types:
 | **Deployed URL** | `https://staging.example.com/new-feature` |
 | **Artifact URL** | `https://registry.example.com/package@1.2.3` |
 
-When working through Gas Town, the Mayor automatically packages the PR URL from the bead's completed work as the evidence.
+When working through Gas Town, the Mayor automatically packages the PR URL from the bead's completed work as the evidence. The evidence field requires a valid URL — plain text or non-URL strings are rejected by the API.
 
 ### How evidence flows
 
@@ -147,13 +147,13 @@ A validator reviews the DoltHub PR and issues a **stamp** — a multi-dimensiona
 
 | Field | Description |
 |---|---|
-| **Quality** | How well was the work done? (`excellent`, `good`, `fair`, `poor`) |
-| **Message** | Free-form justification from the validator |
+| **Valence** | JSON object with per-dimension ratings: `{"quality":"good","reliability":"good"}`. Quality is set via `wl accept --quality` (`excellent`, `good`, `fair`, `poor`). |
 | **Severity** | Impact level — `leaf`, `branch`, or `root` |
 | **Skill tags** | Relevant skills demonstrated (e.g., `go`, `federation`) |
-| **Confidence** | How confident the validator is in their assessment |
+| **Confidence** | How confident the validator is in their assessment. Stored as a string or number in the schema. |
+| **Message** | Free-form justification from the validator (`wl accept --message`) |
 
-<!-- TODO: verify — confirm whether confidence is a separate numeric score or a categorical level in the current Gas Town implementation -->
+<!-- TODO: verify — confirm whether confidence is a numeric score (1–5) or a categorical level in the current `wl accept` CLI, and whether reliability is set separately or always mirrors quality -->
 
 The validator's stamp commits to the `stamps` table via a DoltHub PR (or direct push in admin mode). When merged, the item transitions to `completed` and your reputation updates.
 
@@ -193,7 +193,7 @@ Ask the Mayor to abandon the item:
 
 > *"Abandon w-870be07fbc"*
 
-The Mayor runs the equivalent of `wl unclaim <id>`, which transitions the item back to `status = "open"` and clears `claimed_by`. Other rigs can then claim it.
+The Mayor runs the equivalent of `wl unclaim <id>`, which transitions the item back to `status = "open"` and clears `claimed_by`. Other rigs can then claim it. (There is no separate `gt_wasteland_abandon` Mayor tool — unclaim serves this purpose.)
 
 ### Natural expiry
 

--- a/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/workflow.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/wasteland/workflow.md
@@ -8,7 +8,7 @@ noindex: true
 
 The worker-side flow for picking up a wanted item, doing the work in your Gas Town, and turning completion into stamped reputation.
 
-{% flowDiagram name="claim-to-stamp" height="550px" /%}
+{% flowDiagram name="claim-to-stamp" height="550" /%}
 
 ## Step 1: Browse
 


### PR DESCRIPTION
Verified all wasteland documentation against cloud repo source code (router.ts, schemas.ts, admin-mode.md, inbox-classifier.ts, wasteland-tools.handler.ts, ReviewClient.tsx) and updated workflow.md, admin.md, concepts.md, and quick-start.md with accurate details.

Key changes:
- Stamp dimensions now reflect actual `stamps.valence` JSON structure (quality + reliability), confirmed quality enum values
- Evidence must be a valid URL (not free-form text)
- Admin review inbox requires both owner + admin mode
- Posting fields clarified: dashboard/Mayor expose title/description/priority/type only; project/tags/effort_level are wl CLI-only
- Direct mode terminology replaces "wild-west mode"
- Permissions matrix updated with API-enforced vs UI-enforced tiers
- Trust level 0 documented as soft ban mechanism