### PR TITLE
fix(indexing): allow custom dimensions with kilo embedding provider

### DIFF
--- a/.changeset/common-ties-unite.md
+++ b/.changeset/common-ties-unite.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-indexing": patch
+---
+
+Fix custom dimensions with Kilo embedding provider

--- a/packages/kilo-indexing/src/indexing/embedders/kilo.ts
+++ b/packages/kilo-indexing/src/indexing/embedders/kilo.ts
@@ -18,6 +18,7 @@ export class KiloEmbedder implements IEmbedder {
     baseUrl?: string
     organizationId?: string
     modelId?: string
+    dimensions?: number
   }) {
     if (!input.apiKey) throw new Error("Kilo API key is required for embedding.")
 
@@ -33,7 +34,7 @@ export class KiloEmbedder implements IEmbedder {
       input.apiKey,
       this.model,
       MAX_ITEM_TOKENS,
-      { headers },
+      { headers, dimensions: input.dimensions },
     )
   }
 

--- a/packages/kilo-indexing/src/indexing/service-factory.ts
+++ b/packages/kilo-indexing/src/indexing/service-factory.ts
@@ -72,6 +72,7 @@ export class CodeIndexServiceFactory {
         baseUrl: config.kiloOptions.baseUrl,
         organizationId: config.kiloOptions.organizationId,
         modelId: config.modelId,
+        dimensions: config.modelDimension,
       })
     }
     if (provider === "openai") {


### PR DESCRIPTION
## Context

Currently, using a custom `dimension` setting with the Kilo indexing provider causes indexing to error out.

## Implementation

The Kilo provider was not taking the configured dimension parameter and passing it on to the OpenAI-Compatible embedding class. This meant that there was a mismatch between the dimensions retrieved from Kilo and the dimensions expected by the storage provider. Passing the parameter keeps the dimensions in sync, allowing the functionality to work.

## Screenshots

<img width="385" height="110" alt="image" src="https://github.com/user-attachments/assets/e6a3a107-e4d3-4f41-9670-825b6b511166" />

<img width="1017" height="241" alt="image" src="https://github.com/user-attachments/assets/d43236e4-9d5f-40d3-a028-7249d9d11d61" />

## How to Test

- Configure embedding with Kilo provider and custom dimension parameter e.g.:
```
    "provider": "kilo",
    "model": "qwen/qwen3-embedding-8b",
    "dimension": 1536,
```
- Load a project with indexing enabled
- Indexing should work without erroring or stalling

## Get in Touch

ExpedientFalcon on Discord
