### PR TITLE
fix(vscode): re-add skipLibCheck to unblock publish build

### DIFF
--- a/packages/kilo-vscode/tsconfig.json
+++ b/packages/kilo-vscode/tsconfig.json
@@ -7,6 +7,7 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,
+    "skipLibCheck": true,
     "types": ["node", "vscode", "mocha"]
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
## Quick summary

- The `pre-release patch` publish workflow fails when building VSIX packages because we check types on third-party `.d.ts` files (like `effect@4.0.0-beta.57`)

- We had `skipLibCheck: true`, to ignore those errors. Removed it a month ago #6356

- This change adds it back - upstream hides the same noise and uses `skipLibCheck: true` (inherited from `@tsconfig/bun`).

- Upgrading `effect` doesn't fix the issue - Latest `effect@4.0.0-beta.59` fails in a similar way


## Testing

- `bun run check-types` from `packages/kilo-vscode/` now passes
- `bun run typecheck` (the filtered variant) still passes
- Failed run for reference: https://github.com/Kilo-Org/kilocode/actions/runs/25541644878/job/74969028383