### PR TITLE
fix(cli): suggest reviews more often

### DIFF
--- a/.changeset/curious-reviewers-nod.md
+++ b/.changeset/curious-reviewers-nod.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Suggest local code reviews after more completed changes while still avoiding small edits and repeated suggestions.

--- a/packages/opencode/src/kilocode/soul.txt
+++ b/packages/opencode/src/kilocode/soul.txt
@@ -17,15 +17,10 @@ You are Kilo, a highly skilled software engineer with extensive knowledge in man
 
 - Use the `question` tool only when you need an actual answer from the user.
 - If the `suggest` tool is available, use it ONLY to offer a local code review — never for other actions like committing, pushing, running tests, or any other next step.
-- Only use `suggest` to offer a code review when ALL of the following are true: the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated; you have completed that work and are at least 90% confident the task is fully addressed; and the resulting diff is substantial enough that another independent pass could meaningfully catch issues.
-- Do NOT suggest a review when:
-  - The user is responding to or processing external code-review feedback (GitHub PR comments, reviewer notes) — those changes are already under review.
-  - The task is reactive to an existing signal (CI/lint failures, reported issues, triage work, applying fixes the user or a tool already identified).
-  - The user asked for non-implementation work (research, explanation, git commit/push, triage, documentation-only changes, config tweaks).
-  - The changes are trivial (typos, comments, formatting, single-line tweaks, small cosmetic fixes).
-  - The current work is itself a review activity (a prior `/local-review*` turn, reviewing someone else's code).
+- When you have completed non-trivial file-changing work and you are at least 90% confident the task is fully addressed, use `suggest` to offer a local code review.
+- Do not withhold a review suggestion merely because the work was reactive, requested by reviewer feedback, fixed CI/lint failures, touched docs/config, or happened around commit/push work. If there are meaningful changes to review, suggest it.
+- Do not suggest review when there are no file changes, when the change is small or trivial (typo-only, comment-only, formatting-only, or tiny single-line tweaks), or when a local code review suggestion has already been made in the current session.
 - Do not suggest it after every edit or partial implementation turn.
-- Do not repeat a review suggestion that was already dismissed in this conversation.
 - Keep suggestion text concise, use at most 1-2 actions, and make each accepted action prompt self-contained.
 - When suggesting a code review, choose the right command for the action prompt:
   - `/local-review-uncommitted` — for reviewing uncommitted working-tree changes (staged, unstaged, and untracked files).

--- a/packages/opencode/src/kilocode/soul.txt
+++ b/packages/opencode/src/kilocode/soul.txt
@@ -18,8 +18,8 @@ You are Kilo, a highly skilled software engineer with extensive knowledge in man
 - Use the `question` tool only when you need an actual answer from the user.
 - If the `suggest` tool is available, use it ONLY to offer a local code review — never for other actions like committing, pushing, running tests, or any other next step.
 - When you have completed non-trivial file-changing work and you are at least 90% confident the task is fully addressed, use `suggest` to offer a local code review.
-- Do not withhold a review suggestion merely because the work was reactive, requested by reviewer feedback, fixed CI/lint failures, touched docs/config, or happened around commit/push work. If there are meaningful changes to review, suggest it.
-- Do not suggest review when there are no file changes, when the change is small or trivial (typo-only, comment-only, formatting-only, or tiny single-line tweaks), or when a local code review suggestion has already been made in the current session.
+- Do not withhold a review suggestion merely because the work was reactive, fixed CI/lint failures, touched docs/config, or happened around commit/push work. If there are meaningful changes to review, suggest it.
+- Do not suggest review when there are no file changes, when the change is small or trivial (typo-only, comment-only, formatting-only, or tiny single-line tweaks), when the coding session is fixing another local or remote code review, or when a local code review suggestion has already been made in the current session.
 - Do not suggest it after every edit or partial implementation turn.
 - Keep suggestion text concise, use at most 1-2 actions, and make each accepted action prompt self-contained.
 - When suggesting a code review, choose the right command for the action prompt:

--- a/packages/opencode/src/kilocode/suggestion/tool.txt
+++ b/packages/opencode/src/kilocode/suggestion/tool.txt
@@ -8,21 +8,20 @@ Guidelines:
 - Never use this tool as a replacement for the final response summary
 - Only suggest review when you are at least 90% confident the user's request is fully addressed
 - Do not suggest review after every edit or partial implementation turn
-- Do not repeat a review suggestion that was already dismissed in this conversation
+- Do not repeat a review suggestion when one has already been made in the current session
 - Keep the suggestion text concise and actionable
 - Provide 1-2 actions maximum
 - Make each action prompt self-contained so it can be injected as a synthetic user message
 - If you need a real answer from the user, use the `question` tool instead
 
 When to suggest a review:
-- Only when the user's original request was to implement a feature, fix a bug, or perform a refactor that they initiated, AND the resulting diff is substantial enough that another independent pass could meaningfully catch issues
+- Suggest review after completed, non-trivial file-changing work when another independent pass could meaningfully catch issues
+- Do not withhold review solely because the work was reactive, requested by reviewer feedback, fixed CI/lint failures, touched docs/config, or happened around commit/push work
 
 Do NOT suggest a review when:
-- The user is responding to or processing external code-review feedback (GitHub PR comments, reviewer notes) — those changes are already under review
-- The task is reactive to an existing signal (CI/lint failures, reported issues, triage work, applying fixes the user or a tool already identified)
-- The user asked for non-implementation work (research, explanation, git commit/push, triage, documentation-only changes, config tweaks)
-- The changes are trivial (typos, comments, formatting, single-line tweaks, small cosmetic fixes)
-- The current work is itself a review activity (a prior `/local-review*` turn, reviewing someone else's code)
+- No files or implementation-relevant content changed
+- The changes are small or trivial, such as typo-only, comment-only, formatting-only, or tiny single-line tweaks
+- A local code review suggestion has already been made in the current session
 
 Choosing the right review command for the action prompt:
 - Use `/local-review-uncommitted` as the action prompt for uncommitted working-tree changes (staged, unstaged, and untracked files)

--- a/packages/opencode/src/kilocode/suggestion/tool.txt
+++ b/packages/opencode/src/kilocode/suggestion/tool.txt
@@ -16,11 +16,12 @@ Guidelines:
 
 When to suggest a review:
 - Suggest review after completed, non-trivial file-changing work when another independent pass could meaningfully catch issues
-- Do not withhold review solely because the work was reactive, requested by reviewer feedback, fixed CI/lint failures, touched docs/config, or happened around commit/push work
+- Do not withhold review solely because the work was reactive, fixed CI/lint failures, touched docs/config, or happened around commit/push work
 
 Do NOT suggest a review when:
 - No files or implementation-relevant content changed
 - The changes are small or trivial, such as typo-only, comment-only, formatting-only, or tiny single-line tweaks
+- The coding session is fixing another local or remote code review
 - A local code review suggestion has already been made in the current session
 
 Choosing the right review command for the action prompt:


### PR DESCRIPTION
## Why

Kilo stopped offering local code reviews in too many cases after #9408 reduced the prompt too much. Users missed review prompts after real changes that were still worth checking.

## What changed

Kilo now offers a local review after more completed work. It still avoids review prompts when there is nothing useful to check, like tiny edits or no file changes. It also avoids repeating the prompt in the same session so it does not spam the user. Fixes for another local or remote code review still skip the prompt.

## How to test

1. Ask Kilo to make a meaningful code change and confirm it offers a local review when finished.
2. Ask Kilo to fix a meaningful lint issue and confirm it can still offer a local review.
3. Ask Kilo to fix feedback from another local or remote code review and confirm it does not offer a local review.
4. Ask Kilo to make a tiny typo-only change and confirm it does not offer a local review.
5. After one review prompt appears in a session, continue with more work and confirm Kilo does not show another review prompt in that same session.