### PR TITLE
fix(vscode): add DOM.Iterable lib to fix SDK Headers.entries() typecheck

### DIFF
--- a/packages/kilo-vscode/tsconfig.json
+++ b/packages/kilo-vscode/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
## Quick summary

- Followup from #10049

- The publish build fails on `../sdk/js/src/gen/client/utils.gen.ts(172,57): Property 'entries' does not exist on type 'Headers'`
- `Headers.entries()` is defined in the `DOM.Iterable` lib, which we weren't including. Added it now.
- Mirrors upstream

## Testing

- `bun run check-types` from `packages/kilo-vscode/` now passes
- `bun run typecheck` (the filtered variant) still passes
- Failed run for reference: https://github.com/Kilo-Org/kilocode/actions/runs/25545266090/job/74980510505