### PR TITLE
Support comments on rendered Markdown diffs

### DIFF
--- a/.changeset/markdown-line-comments.md
+++ b/.changeset/markdown-line-comments.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support commenting on rendered Markdown lines in diff reviewers.

--- a/bun.lock
+++ b/bun.lock
@@ -251,6 +251,7 @@
         "ignore": "^7.0.3",
         "js-tiktoken": "^1.0.18",
         "lru-cache": "^11.0.2",
+        "marked": "catalog:",
         "openai": "^4.85.4",
         "quick-lru": "^7.0.0",
         "simple-git": "3.35.2",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -946,6 +946,7 @@
     "ignore": "^7.0.3",
     "js-tiktoken": "^1.0.18",
     "lru-cache": "^11.0.2",
+    "marked": "catalog:",
     "openai": "^4.85.4",
     "quick-lru": "^7.0.0",
     "simple-git": "3.35.2",

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -25,6 +25,8 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/DiffPanel.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/FullScreenDiffView.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/MarkdownDiffView.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/MarkdownAnnotationLayer.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/markdown-comment-ranges.ts"),
   path.join(ROOT, "webview-ui/agent-manager/DiffEndMarker.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/FileTree.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/review-annotations.ts"),

--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -7,6 +7,7 @@ import {
   getFilename,
   type ReviewComment,
 } from "../../webview-ui/agent-manager/review-comments"
+import { markdownCommentBlocks } from "../../webview-ui/agent-manager/markdown-comment-ranges"
 import type { WorktreeFileDiff } from "../../webview-ui/src/types/messages"
 
 function diff(file: string, before: string, after: string): WorktreeFileDiff {
@@ -183,6 +184,55 @@ describe("extractLines", () => {
 
   it("handles empty content", () => {
     expect(extractLines("", 1, 1)).toBe("")
+  })
+})
+
+// ── markdownCommentBlocks ───────────────────────────────────────────────────
+
+describe("markdownCommentBlocks", () => {
+  it("keeps fenced code blocks as one selectable range", () => {
+    const result = markdownCommentBlocks("# Demo\n\n```ts\nconst value = 1\nconsole.log(value)\n```\n\nAfter")
+    expect(result).toContainEqual({ type: "block", start: 3, end: 6 })
+  })
+
+  it("maps table comments to rendered rows, not separator lines", () => {
+    const result = markdownCommentBlocks("| Area | Status |\n|---|---|\n| Tables | Pass |\n| Lists | Pass |")
+    expect(result).toEqual([
+      {
+        type: "table",
+        start: 1,
+        end: 4,
+        rows: [
+          { start: 1, end: 1 },
+          { start: 3, end: 3 },
+          { start: 4, end: 4 },
+        ],
+      },
+    ])
+  })
+
+  it("maps list comments to whole list items", () => {
+    const result = markdownCommentBlocks("- First\n  continued\n- [x] Second\n- Third")
+    expect(result).toEqual([
+      {
+        type: "list",
+        start: 1,
+        end: 4,
+        items: [
+          { start: 1, end: 2 },
+          { start: 3, end: 3 },
+          { start: 4, end: 4 },
+        ],
+      },
+    ])
+  })
+
+  it("keeps blockquotes and paragraphs as rendered blocks", () => {
+    const result = markdownCommentBlocks("> Quote\n> Continued\n\nParagraph line one\nparagraph line two")
+    expect(result).toEqual([
+      { type: "block", start: 1, end: 2 },
+      { type: "block", start: 4, end: 5 },
+    ])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -66,7 +66,9 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     delete: t("common.delete"),
   })
   const [open, setOpen] = createSignal<string[]>([])
-  const [draft, setDraft] = createSignal<{ file: string; side: AnnotationSide; line: number } | null>(null)
+  const [draft, setDraft] = createSignal<{ file: string; side: AnnotationSide; line: number; endLine?: number } | null>(
+    null,
+  )
   const [editing, setEditing] = createSignal<string | null>(null)
   let nextId = 0
   // Tracks the session key for which auto-open has already run. When the
@@ -240,6 +242,11 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
         if (currentDraft.line < 1 || currentDraft.line > max) {
           setDraft(null)
           draftMeta = null
+          return
+        }
+        if (currentDraft.endLine !== undefined && currentDraft.endLine > max) {
+          setDraft(null)
+          draftMeta = null
         }
       },
     ),
@@ -287,7 +294,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     if (draft()) return
     const side: AnnotationSide = range.side === "deletions" ? "deletions" : "additions"
     preserveScroll(() => {
-      setDraft({ file, side, line: range.start })
+      setDraft({ file, side, line: range.start, endLine: range.end })
     })
   }
 
@@ -559,7 +566,17 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                               />
                             }
                           >
-                            <MarkdownDiffView diff={diff} />
+                            <MarkdownDiffView
+                              diff={diff}
+                              annotations={annotationsForFile(diff.file)}
+                              renderAnnotation={buildAnnotation}
+                              enableGutterUtility={true}
+                              onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                              onLineNumberClick={(event) => {
+                                if (event.annotationSide === "deletions") return
+                                props.onOpenFile?.(diff.file, event.lineNumber)
+                              }}
+                            />
                           </Show>
                         </Show>
                       </Show>

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -76,7 +76,9 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     delete: t("common.delete"),
   })
   const [open, setOpen] = createSignal<string[]>([])
-  const [draft, setDraft] = createSignal<{ file: string; side: AnnotationSide; line: number } | null>(null)
+  const [draft, setDraft] = createSignal<{ file: string; side: AnnotationSide; line: number; endLine?: number } | null>(
+    null,
+  )
   const [editing, setEditing] = createSignal<string | null>(null)
   const [activeFile, setActiveFile] = createSignal<string | null>(null)
   const [treeWidth, setTreeWidth] = createSignal(240)
@@ -255,6 +257,11 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
         if (currentDraft.line < 1 || currentDraft.line > max) {
           setDraft(null)
           draftMeta = null
+          return
+        }
+        if (currentDraft.endLine !== undefined && currentDraft.endLine > max) {
+          setDraft(null)
+          draftMeta = null
         }
       },
     ),
@@ -296,7 +303,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     if (draft()) return
     const side: AnnotationSide = range.side === "deletions" ? "deletions" : "additions"
     preserveScroll(() => {
-      setDraft({ file, side, line: range.start })
+      setDraft({ file, side, line: range.start, endLine: range.end })
     })
   }
 
@@ -646,7 +653,17 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                                   />
                                 }
                               >
-                                <MarkdownDiffView diff={diff} />
+                                <MarkdownDiffView
+                                  diff={diff}
+                                  annotations={annotationsForFile(diff.file)}
+                                  renderAnnotation={buildAnnotation}
+                                  enableGutterUtility={props.canComment !== false}
+                                  onGutterUtilityClick={(result) => handleGutterClick(diff.file, result)}
+                                  onLineNumberClick={(event) => {
+                                    if (event.annotationSide === "deletions") return
+                                    props.onOpenFile?.(diff.file, event.lineNumber)
+                                  }}
+                                />
                               </Show>
                             </Show>
                           </Show>

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
@@ -1,0 +1,221 @@
+import { type Component, createEffect, createMemo, onCleanup } from "solid-js"
+import type { AnnotationSide, DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs"
+import { markdownCommentBlocks, type MarkdownRange } from "./markdown-comment-ranges"
+import type { AnnotationMeta } from "./review-annotations"
+
+type Insert = "after" | "list" | "table"
+
+type Anchor = MarkdownRange & {
+  line: number
+  element: HTMLElement
+  insert: Insert
+}
+
+export interface MarkdownAnnotationLayerProps {
+  pane: () => HTMLElement | undefined
+  root: () => HTMLElement | undefined
+  text: string
+  side: AnnotationSide
+  annotations: DiffLineAnnotation<AnnotationMeta>[]
+  renderAnnotation: ((annotation: DiffLineAnnotation<AnnotationMeta>) => HTMLElement | undefined) | undefined
+  enableGutterUtility: boolean
+  onGutterUtilityClick: ((range: SelectedLineRange) => void) | undefined
+  onLineNumberClick: ((event: { annotationSide: AnnotationSide; lineNumber: number }) => void) | undefined
+}
+
+function children(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.children).filter((child): child is HTMLElement => {
+    if (!(child instanceof HTMLElement)) return false
+    if (child.classList.contains("am-markdown-inline-annotations")) return false
+    if (child.classList.contains("am-markdown-list-annotation")) return false
+    if (child.classList.contains("am-markdown-table-annotation")) return false
+    return true
+  })
+}
+
+function listItems(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.children).filter((child): child is HTMLElement => {
+    if (!(child instanceof HTMLElement)) return false
+    if (child.tagName !== "LI") return false
+    return !child.classList.contains("am-markdown-list-annotation")
+  })
+}
+
+function tableRows(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll("tr")).filter((row) => {
+    return !row.classList.contains("am-markdown-table-annotation")
+  })
+}
+
+function anchors(root: HTMLElement, source: ReturnType<typeof markdownCommentBlocks>): Anchor[] {
+  const rendered = children(root)
+  const result: Anchor[] = []
+  let index = 0
+
+  for (const block of source) {
+    const element = rendered[index]
+    if (!element) break
+    index += 1
+
+    if (block.type === "table" && element.tagName === "TABLE") {
+      const rows = tableRows(element)
+      for (const [row, range] of block.rows.entries()) {
+        const target = rows[row]
+        if (target) result.push({ ...range, line: range.start, element: target, insert: "table" })
+      }
+      continue
+    }
+
+    if (block.type === "list" && (element.tagName === "UL" || element.tagName === "OL")) {
+      const items = listItems(element)
+      for (const [item, range] of block.items.entries()) {
+        const target = items[item]
+        if (target) result.push({ ...range, line: range.start, element: target, insert: "list" })
+      }
+      continue
+    }
+
+    result.push({ start: block.start, end: block.end, line: block.start, element, insert: "after" })
+  }
+
+  return result
+}
+
+function matches(annotation: DiffLineAnnotation<AnnotationMeta>, anchor: Anchor, side: AnnotationSide): boolean {
+  if (annotation.side !== side) return false
+  if (annotation.lineNumber < anchor.start) return false
+  if (annotation.lineNumber > anchor.end) return false
+  return true
+}
+
+function removeInserted(root: HTMLElement, layer: HTMLElement): void {
+  layer.replaceChildren()
+  root
+    .querySelectorAll(".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation")
+    .forEach((node) => node.remove())
+}
+
+function insertHost(anchor: Anchor, host: HTMLElement): void {
+  if (anchor.insert === "table" && anchor.element instanceof HTMLTableRowElement) {
+    const row = document.createElement("tr")
+    row.className = "am-markdown-table-annotation"
+    const cell = document.createElement("td")
+    cell.colSpan = Math.max(1, anchor.element.cells.length)
+    cell.appendChild(host)
+    row.appendChild(cell)
+    anchor.element.parentNode?.insertBefore(row, anchor.element.nextSibling)
+    return
+  }
+
+  if (anchor.insert === "list") {
+    const item = document.createElement("li")
+    item.className = "am-markdown-list-annotation"
+    item.appendChild(host)
+    anchor.element.parentNode?.insertBefore(item, anchor.element.nextSibling)
+    return
+  }
+
+  anchor.element.parentNode?.insertBefore(host, anchor.element.nextSibling)
+}
+
+export const MarkdownAnnotationLayer: Component<MarkdownAnnotationLayerProps> = (props) => {
+  let layer: HTMLDivElement | undefined
+  let observer: MutationObserver | undefined
+  let frame: number | undefined
+  const ranges = createMemo(() => markdownCommentBlocks(props.text))
+
+  const schedule = () => {
+    if (frame !== undefined) return
+    frame = requestAnimationFrame(render)
+  }
+
+  const render = () => {
+    frame = undefined
+    const pane = props.pane()
+    const root = props.root()
+    if (!pane || !root || !layer) return
+
+    observer?.disconnect()
+    removeInserted(root, layer)
+
+    const list = anchors(root, ranges())
+    for (const anchor of list) {
+      const annotations = props.annotations.filter((annotation) => matches(annotation, anchor, props.side))
+      if (annotations.length > 0) {
+        const host = document.createElement("div")
+        host.className = "am-markdown-inline-annotations"
+        for (const annotation of annotations) {
+          const element = props.renderAnnotation?.(annotation)
+          if (element) host.appendChild(element)
+        }
+        insertHost(anchor, host)
+      }
+    }
+
+    const paneBox = pane.getBoundingClientRect()
+    for (const anchor of list) {
+      const box = anchor.element.getBoundingClientRect()
+      const row = document.createElement("div")
+      row.className = "am-markdown-target"
+      row.style.top = `${box.top - paneBox.top}px`
+      row.style.height = `${Math.max(20, box.height)}px`
+
+      if (props.enableGutterUtility) {
+        const button = document.createElement("button")
+        button.className = "am-markdown-comment-button"
+        button.type = "button"
+        button.title = `Comment on line ${anchor.line}`
+        button.setAttribute("aria-label", `Comment on line ${anchor.line}`)
+        button.textContent = "+"
+        button.addEventListener("click", (event) => {
+          event.stopPropagation()
+          props.onGutterUtilityClick?.({ side: props.side, start: anchor.start, end: anchor.end })
+        })
+        row.appendChild(button)
+      }
+
+      const line = document.createElement("button")
+      line.className = "am-markdown-line-number"
+      line.type = "button"
+      line.textContent = `${anchor.line}`
+      line.setAttribute("aria-label", `Open line ${anchor.line}`)
+      line.addEventListener("click", (event) => {
+        event.stopPropagation()
+        props.onLineNumberClick?.({ annotationSide: props.side, lineNumber: anchor.line })
+      })
+      row.appendChild(line)
+      layer.appendChild(row)
+    }
+
+    observer?.observe(root, { childList: true, subtree: true })
+  }
+
+  createEffect(() => {
+    props.text
+    props.side
+    props.annotations
+    props.enableGutterUtility
+    props.onGutterUtilityClick
+    props.onLineNumberClick
+    props.pane()
+    props.root()
+    schedule()
+  })
+
+  createEffect(() => {
+    const root = props.root()
+    if (!root) return
+    observer?.disconnect()
+    observer = new MutationObserver(schedule)
+    observer.observe(root, { childList: true, subtree: true })
+  })
+
+  onCleanup(() => {
+    if (frame !== undefined) cancelAnimationFrame(frame)
+    observer?.disconnect()
+    const root = props.root()
+    if (root && layer) removeInserted(root, layer)
+  })
+
+  return <div class="am-markdown-gutter-layer" ref={layer} />
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownDiffView.tsx
@@ -1,5 +1,8 @@
 import { type Component, Show } from "solid-js"
+import type { AnnotationSide, DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs"
 import { Markdown } from "@kilocode/kilo-ui/markdown"
+import { MarkdownAnnotationLayer } from "./MarkdownAnnotationLayer"
+import type { AnnotationMeta } from "./review-annotations"
 
 interface MarkdownDiffFile {
   file: string
@@ -10,36 +13,106 @@ interface MarkdownDiffFile {
 
 interface MarkdownDiffViewProps {
   diff: MarkdownDiffFile
+  annotations?: DiffLineAnnotation<AnnotationMeta>[]
+  renderAnnotation?: (annotation: DiffLineAnnotation<AnnotationMeta>) => HTMLElement | undefined
+  enableGutterUtility?: boolean
+  onGutterUtilityClick?: (range: SelectedLineRange) => void
+  onLineNumberClick?: (event: { annotationSide: AnnotationSide; lineNumber: number }) => void
 }
 
 export function isMarkdownFile(file: string): boolean {
   return /\.(md|mdx|markdown)$/i.test(file)
 }
 
+interface PaneProps {
+  title?: string
+  text: string
+  side: AnnotationSide
+  cache: string
+  annotations: DiffLineAnnotation<AnnotationMeta>[]
+  renderAnnotation: ((annotation: DiffLineAnnotation<AnnotationMeta>) => HTMLElement | undefined) | undefined
+  enableGutterUtility: boolean
+  onGutterUtilityClick: ((range: SelectedLineRange) => void) | undefined
+  onLineNumberClick: ((event: { annotationSide: AnnotationSide; lineNumber: number }) => void) | undefined
+}
+
+const MarkdownPane: Component<PaneProps> = (props) => {
+  let pane: HTMLElement | undefined
+  let body: HTMLDivElement | undefined
+  const interactive = () =>
+    props.enableGutterUtility || props.onLineNumberClick !== undefined || props.annotations.length > 0
+  const root = () => body?.querySelector<HTMLElement>('[data-component="markdown"]') ?? undefined
+
+  return (
+    <section class="am-markdown-pane" data-comments={interactive() ? "true" : undefined} ref={pane}>
+      <Show when={props.title}>{(title) => <div class="am-markdown-pane-title">{title()}</div>}</Show>
+      <div class="am-markdown-body" ref={body}>
+        <Markdown text={props.text} cacheKey={props.cache} />
+      </div>
+      <Show when={interactive()}>
+        <MarkdownAnnotationLayer
+          pane={() => pane}
+          root={root}
+          text={props.text}
+          side={props.side}
+          annotations={props.annotations}
+          renderAnnotation={props.renderAnnotation}
+          enableGutterUtility={props.enableGutterUtility}
+          onGutterUtilityClick={props.onGutterUtilityClick}
+          onLineNumberClick={props.onLineNumberClick}
+        />
+      </Show>
+    </section>
+  )
+}
+
 export const MarkdownDiffView: Component<MarkdownDiffViewProps> = (props) => {
   const before = () => (props.diff.status === "added" ? "" : props.diff.before)
   const after = () => (props.diff.status === "deleted" ? "" : props.diff.after)
   const split = () => before().length > 0 && after().length > 0 && before() !== after()
+  const side = () => (after().length > 0 ? "additions" : "deletions") as AnnotationSide
+  const annotations = () => props.annotations ?? []
 
   return (
     <div class="am-markdown-diff" data-split={split() ? "true" : undefined}>
       <Show
         when={split()}
         fallback={
-          <section class="am-markdown-pane">
-            <Markdown text={after() || before()} cacheKey={`${props.diff.file}:rendered`} />
-          </section>
+          <MarkdownPane
+            text={after() || before()}
+            side={side()}
+            cache={`${props.diff.file}:rendered`}
+            annotations={annotations()}
+            renderAnnotation={props.renderAnnotation}
+            enableGutterUtility={props.enableGutterUtility === true}
+            onGutterUtilityClick={props.onGutterUtilityClick}
+            onLineNumberClick={props.onLineNumberClick}
+          />
         }
       >
         <>
-          <section class="am-markdown-pane">
-            <div class="am-markdown-pane-title">Before</div>
-            <Markdown text={before()} cacheKey={`${props.diff.file}:before`} />
-          </section>
-          <section class="am-markdown-pane">
-            <div class="am-markdown-pane-title">After</div>
-            <Markdown text={after()} cacheKey={`${props.diff.file}:after`} />
-          </section>
+          <MarkdownPane
+            title="Before"
+            text={before()}
+            side="deletions"
+            cache={`${props.diff.file}:before`}
+            annotations={annotations()}
+            renderAnnotation={props.renderAnnotation}
+            enableGutterUtility={props.enableGutterUtility === true}
+            onGutterUtilityClick={props.onGutterUtilityClick}
+            onLineNumberClick={props.onLineNumberClick}
+          />
+          <MarkdownPane
+            title="After"
+            text={after()}
+            side="additions"
+            cache={`${props.diff.file}:after`}
+            annotations={annotations()}
+            renderAnnotation={props.renderAnnotation}
+            enableGutterUtility={props.enableGutterUtility === true}
+            onGutterUtilityClick={props.onGutterUtilityClick}
+            onLineNumberClick={props.onLineNumberClick}
+          />
         </>
       </Show>
     </div>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1859,11 +1859,16 @@ body.am-wt-dragging-active * {
 }
 
 .am-markdown-pane {
+  position: relative;
   min-width: 0;
   padding: 16px 20px 24px;
   background: var(--vscode-editor-background, var(--surface-base));
   color: var(--vscode-editor-foreground, var(--text-base));
   overflow-x: auto;
+}
+
+.am-markdown-pane[data-comments="true"] {
+  padding: 12px 20px 20px 64px;
 }
 
 .am-markdown-pane-title {
@@ -1875,8 +1880,94 @@ body.am-wt-dragging-active * {
   letter-spacing: 0.04em;
 }
 
+.am-markdown-pane[data-comments="true"] .am-markdown-pane-title {
+  margin: 0 0 12px;
+}
+
 .am-markdown-pane [data-component="markdown"] {
   max-width: 900px;
+}
+
+.am-markdown-gutter-layer {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 56px;
+  pointer-events: none;
+}
+
+.am-markdown-target {
+  position: absolute;
+  left: 0;
+  width: 56px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  padding-top: 2px;
+  box-sizing: border-box;
+  color: var(--text-weak);
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--font-size-small);
+  user-select: none;
+  pointer-events: auto;
+}
+
+.am-markdown-comment-button,
+.am-markdown-line-number {
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 20px;
+}
+
+.am-markdown-comment-button {
+  width: 18px;
+  padding: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.am-markdown-target:hover .am-markdown-comment-button,
+.am-markdown-comment-button:focus-visible {
+  opacity: 1;
+}
+
+.am-markdown-comment-button:hover,
+.am-markdown-comment-button:focus-visible {
+  color: var(--text-base);
+  background: var(--surface-interactive-base);
+}
+
+.am-markdown-line-number {
+  min-width: 24px;
+  padding: 0 4px;
+  text-align: right;
+  cursor: pointer;
+}
+
+.am-markdown-line-number:hover,
+.am-markdown-line-number:focus-visible {
+  color: var(--text-base);
+}
+
+.am-markdown-body {
+  min-width: 0;
+}
+
+.am-markdown-inline-annotations {
+  min-width: 0;
+}
+
+.am-markdown-list-annotation {
+  list-style: none;
+  margin: 0 0 8px;
+}
+
+.am-markdown-table-annotation td {
+  padding: 0;
+  border: none;
 }
 
 @media (max-width: 840px) {

--- a/packages/kilo-vscode/webview-ui/agent-manager/markdown-comment-ranges.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/markdown-comment-ranges.ts
@@ -1,0 +1,75 @@
+import { marked, type Token, type Tokens } from "marked"
+
+export type MarkdownRange = {
+  start: number
+  end: number
+}
+
+export type MarkdownBlock =
+  | { type: "block"; start: number; end: number }
+  | { type: "list"; start: number; end: number; items: MarkdownRange[] }
+  | { type: "table"; start: number; end: number; rows: MarkdownRange[] }
+
+type Cursor = {
+  line: number
+  offset: number
+}
+
+function advance(pos: Cursor, raw: string): Cursor {
+  const matches = raw.match(/\n/g)
+  return { line: pos.line + (matches?.length ?? 0), offset: pos.offset + raw.length }
+}
+
+function span(pos: Cursor, raw: string): MarkdownRange {
+  const next = advance(pos, raw)
+  const trailing = raw.endsWith("\n") ? 1 : 0
+  return { start: pos.line, end: Math.max(pos.line, next.line - trailing) }
+}
+
+function lineCount(raw: string): number {
+  return Math.max(1, raw.replace(/\n+$/, "").split("\n").length)
+}
+
+function list(token: Tokens.List, range: MarkdownRange): MarkdownBlock {
+  let line = range.start
+  const items = token.items.map((item) => {
+    const size = lineCount(item.raw)
+    const next = { start: line, end: line + size - 1 }
+    line += size
+    return next
+  })
+  return { type: "list", ...range, items }
+}
+
+function table(raw: string, range: MarkdownRange): MarkdownBlock {
+  const rows = raw
+    .replace(/\n+$/, "")
+    .split("\n")
+    .map((_, index) => range.start + index)
+    .filter((line, index) => index !== 1 && line <= range.end)
+    .map((line) => ({ start: line, end: line }))
+  return { type: "table", ...range, rows }
+}
+
+function block(token: Token, range: MarkdownRange): MarkdownBlock {
+  if (token.type === "list") return list(token as Tokens.List, range)
+  if (token.type === "table") return table(token.raw, range)
+  return { type: "block", ...range }
+}
+
+export function markdownCommentBlocks(text: string): MarkdownBlock[] {
+  const tokens = marked.lexer(text)
+  const result: MarkdownBlock[] = []
+  let pos = { line: 1, offset: 0 }
+
+  for (const token of tokens) {
+    const raw = token.raw ?? ""
+    const index = text.indexOf(raw, pos.offset)
+    if (index > pos.offset) pos = advance(pos, text.slice(pos.offset, index))
+    const range = span(pos, raw)
+    if (token.type !== "space") result.push(block(token, range))
+    pos = advance(pos, raw)
+  }
+
+  return result
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
@@ -14,12 +14,15 @@ export interface AnnotationLabels {
   delete: string
 }
 
+// A draft is the active unsaved inline comment composer opened from the gutter.
+// It becomes a normal comment only after the user submits the textarea.
 export interface AnnotationMeta {
   type: "comment" | "draft"
   comment: ReviewComment | null
   file: string
   side: AnnotationSide
   line: number
+  endLine?: number
   editing?: boolean
 }
 
@@ -76,7 +79,7 @@ export function buildFileAnnotations(
   file: string,
   fileComments: ReviewComment[],
   edit: string | null,
-  draft: { file: string; side: AnnotationSide; line: number } | null,
+  draft: { file: string; side: AnnotationSide; line: number; endLine?: number } | null,
   draftMeta: AnnotationMeta | null,
 ): { annotations: DiffLineAnnotation<AnnotationMeta>[]; draftMeta: AnnotationMeta | null } {
   const result: DiffLineAnnotation<AnnotationMeta>[] = fileComments.map((c) => ({
@@ -93,8 +96,21 @@ export function buildFileAnnotations(
   }))
 
   if (draft && draft.file === file) {
-    if (!draftMeta || draftMeta.file !== draft.file || draftMeta.side !== draft.side || draftMeta.line !== draft.line) {
-      draftMeta = { type: "draft", comment: null, file: draft.file, side: draft.side, line: draft.line }
+    if (
+      !draftMeta ||
+      draftMeta.file !== draft.file ||
+      draftMeta.side !== draft.side ||
+      draftMeta.line !== draft.line ||
+      draftMeta.endLine !== draft.endLine
+    ) {
+      draftMeta = {
+        type: "draft",
+        comment: null,
+        file: draft.file,
+        side: draft.side,
+        line: draft.line,
+        endLine: draft.endLine,
+      }
     }
     result.push({ side: draft.side, lineNumber: draft.line, metadata: draftMeta })
   }
@@ -146,7 +162,7 @@ export function buildReviewAnnotation(
       if (!text) return
       const diff = handlers.diffs.find((item) => item.file === meta.file)
       const content = meta.side === "deletions" ? (diff?.before ?? "") : (diff?.after ?? "")
-      const selected = extractLines(content, meta.line, meta.line)
+      const selected = extractLines(content, meta.line, meta.endLine ?? meta.line)
       handlers.addComment(meta.file, meta.side, meta.line, text, selected)
     }
 


### PR DESCRIPTION
## Summary
- Support inline review comments on rendered Markdown diff blocks, list items, and table rows.
- Preserve the existing raw diff comment UI and rendered Markdown structure while capturing useful source ranges for comments.

Why?
- We want to support this to allow the user making plans, view them markdown rendered and then make comments directly on the plan

<img width="363" height="339" alt="image" src="https://github.com/user-attachments/assets/d9feac01-7dd3-400b-86e2-94e78ae2f443" />
<img width="700" height="320" alt="image" src="https://github.com/user-attachments/assets/0b9b0443-b7b4-48a1-8935-deb49ffcbdf4" />
<img width="691" height="589" alt="image" src="https://github.com/user-attachments/assets/722194df-5ce1-4766-b754-d6b7bf03f216" />
