### PR TITLE
fix(agent-manager): expand reviewable diffs by default

### DIFF
--- a/.changeset/calm-diffs-fold.md
+++ b/.changeset/calm-diffs-fold.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open reviewable Agent Manager diffs by default while keeping generated or extreme files collapsed.

--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test"
 import { mergeWorktreeDiffs } from "../../webview-ui/agent-manager/diff-state"
-import { initialOpenFiles } from "../../webview-ui/agent-manager/diff-open-policy"
+import {
+  EXTREME_DIFF_CHANGED_LINES,
+  expandableOpenFiles,
+  initialOpenFiles,
+} from "../../webview-ui/agent-manager/diff-open-policy"
 import type { WorktreeFileDiff } from "../../webview-ui/src/types/messages"
 
 function diff(overrides: Partial<WorktreeFileDiff>): WorktreeFileDiff {
@@ -48,15 +52,26 @@ describe("agent manager diff state", () => {
     expect(result.stale).toEqual(new Set(["src/app.ts"]))
   })
 
-  it("does not auto-open generated-like files or large diff sets", () => {
+  it("opens reviewable diffs initially", () => {
     expect(
       initialOpenFiles([
         diff({ file: "src/app.ts", generatedLike: false, additions: 3 }),
         diff({ file: "node_modules/pkg/index.js", generatedLike: true, additions: 3 }),
+        diff({ file: "src/huge.ts", additions: EXTREME_DIFF_CHANGED_LINES + 1 }),
       ]),
     ).toEqual(["src/app.ts"])
 
     const many = Array.from({ length: 26 }, (_, i) => diff({ file: `src/${i}.ts` }))
-    expect(initialOpenFiles(many)).toEqual([])
+    expect(initialOpenFiles(many)).toHaveLength(26)
+  })
+
+  it("expands only reviewable files from the bulk action", () => {
+    expect(
+      expandableOpenFiles([
+        diff({ file: "src/app.ts", generatedLike: false, additions: 3 }),
+        diff({ file: "src/generated.ts", generatedLike: true, additions: 3 }),
+        diff({ file: "src/huge.ts", additions: EXTREME_DIFF_CHANGED_LINES + 1 }),
+      ]),
+    ).toEqual(["src/app.ts"])
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -366,22 +366,14 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
         <div class="am-diff-header-actions">
           <Show when={props.diffs.length > 0}>
             <Tooltip
-              value={
-                open().length > 0
-                  ? t("ui.sessionReview.collapseAll")
-                  : t("ui.sessionReview.expandAll")
-              }
+              value={open().length > 0 ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll")}
               placement="bottom"
             >
               <IconButton
                 icon="chevron-grabber-vertical"
                 size="small"
                 variant="ghost"
-                label={
-                  open().length > 0
-                    ? t("ui.sessionReview.collapseAll")
-                    : t("ui.sessionReview.expandAll")
-                }
+                label={open().length > 0 ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll")}
                 onClick={handleExpandAll}
               />
             </Tooltip>

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -21,7 +21,7 @@ import {
   type AnnotationLabels,
   type AnnotationMeta,
 } from "./review-annotations"
-import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
+import { LONG_DIFF_MARKER_FILE_COUNT, expandableOpenFiles, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 import { treeOrder } from "./file-tree-utils"
 import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
@@ -69,8 +69,8 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
   const [draft, setDraft] = createSignal<{ file: string; side: AnnotationSide; line: number } | null>(null)
   const [editing, setEditing] = createSignal<string | null>(null)
   let nextId = 0
-  // Tracks the session key for which auto-open has already run. When the
-  // key changes (different worktree) we re-expand. Within the same key,
+  // Tracks the session key for which initial open state has already run. When the
+  // key changes (different worktree) we expand reviewable files. Within the same key,
   // only pruning happens so the user's manual collapse state is preserved.
   let initializedKey: string | undefined
 
@@ -130,9 +130,9 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     focusRoot()
   }
 
-  // Unified auto-open effect: tracks both sessionKey and diffs in a single effect
+  // Unified open-state effect: tracks both sessionKey and diffs in a single effect
   // to eliminate the race condition between the old separate sessionKey-reset and
-  // diffs-watch effects. Uses the session key to decide when auto-expand is needed
+  // diffs-watch effects. Uses the session key to decide when initialization is needed
   // vs when we just prune stale entries from the open list.
   createEffect(
     on(
@@ -314,8 +314,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
   }
 
   const handleExpandAll = () => {
-    const allOpen = open().length === props.diffs.length
-    setOpen(allOpen ? [] : props.diffs.map((d) => d.file))
+    setOpen(open().length > 0 ? [] : expandableOpenFiles(props.diffs))
   }
 
   const totals = createMemo(() => ({
@@ -368,7 +367,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
           <Show when={props.diffs.length > 0}>
             <Tooltip
               value={
-                open().length === props.diffs.length
+                open().length > 0
                   ? t("ui.sessionReview.collapseAll")
                   : t("ui.sessionReview.expandAll")
               }
@@ -379,7 +378,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                 size="small"
                 variant="ghost"
                 label={
-                  open().length === props.diffs.length
+                  open().length > 0
                     ? t("ui.sessionReview.collapseAll")
                     : t("ui.sessionReview.expandAll")
                 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -29,7 +29,7 @@ import {
   type AnnotationLabels,
   type AnnotationMeta,
 } from "./review-annotations"
-import { LONG_DIFF_MARKER_FILE_COUNT, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
+import { LONG_DIFF_MARKER_FILE_COUNT, expandableOpenFiles, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
 
@@ -82,8 +82,8 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
   const [treeWidth, setTreeWidth] = createSignal(240)
   let nextId = 0
   let draftMeta: AnnotationMeta | null = null
-  // Tracks the session key for which auto-open has already run. When the
-  // key changes (different worktree) we re-expand. Within the same key,
+  // Tracks the session key for which initial open state has already run. When the
+  // key changes (different worktree) we expand reviewable files. Within the same key,
   // only pruning happens so the user's manual collapse state is preserved.
   let initializedKey: string | undefined
   let rootRef: HTMLDivElement | undefined
@@ -133,9 +133,9 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     focusRoot()
   }
 
-  // Unified auto-open effect: tracks both sessionKey and diffs in a single effect
+  // Unified open-state effect: tracks both sessionKey and diffs in a single effect
   // to eliminate the race condition between the old separate sessionKey-reset and
-  // diffs-watch effects. Uses the session key to decide when auto-expand is needed
+  // diffs-watch effects. Uses the session key to decide when initialization is needed
   // vs when we just prune stale entries from the open list.
   createEffect(
     on(
@@ -342,8 +342,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
   }
 
   const handleExpandAll = () => {
-    const allOpen = open().length === props.diffs.length
-    setOpen(allOpen ? [] : props.diffs.map((d) => d.file))
+    setOpen(open().length > 0 ? [] : expandableOpenFiles(props.diffs))
   }
 
   const syncActiveFileFromScroll = () => {
@@ -449,7 +448,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
         <div class="am-review-toolbar-right">
           <Button size="small" variant="ghost" onClick={handleExpandAll}>
             <Icon name="chevron-grabber-vertical" size="small" />
-            {open().length === props.diffs.length ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll")}
+            {open().length > 0 ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll")}
           </Button>
           <Show when={comments().length > 0 && props.canComment !== false}>
             <TooltipKeybind

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
@@ -1,21 +1,16 @@
 import type { WorktreeFileDiff } from "../src/types/messages"
 
 export const LONG_DIFF_MARKER_FILE_COUNT = 50
-const AUTO_OPEN_FILE_COUNT = 25
-const AUTO_OPEN_LIMIT = 8
-const LARGE_FILE_CHANGED_LINES = 400
+export const EXTREME_DIFF_CHANGED_LINES = 2_000
 
 export function isLargeDiffFile(diff: WorktreeFileDiff): boolean {
-  return diff.additions + diff.deletions > LARGE_FILE_CHANGED_LINES
+  return diff.additions + diff.deletions > EXTREME_DIFF_CHANGED_LINES
+}
+
+export function expandableOpenFiles(diffs: WorktreeFileDiff[]): string[] {
+  return diffs.filter((diff) => !isLargeDiffFile(diff) && diff.generatedLike !== true).map((diff) => diff.file)
 }
 
 export function initialOpenFiles(diffs: WorktreeFileDiff[]): string[] {
-  if (diffs.length === 0) return []
-  if (diffs.length > AUTO_OPEN_FILE_COUNT) return []
-
-  const files = diffs
-    .filter((diff) => !isLargeDiffFile(diff) && diff.generatedLike !== true)
-    .slice(0, AUTO_OPEN_LIMIT)
-    .map((diff) => diff.file)
-  return files
+  return expandableOpenFiles(diffs)
 }


### PR DESCRIPTION
## Summary
- Keep normal reviewable Agent Manager diff files expanded when a review opens, including larger reviewable diffs that were previously collapsed by the old 400-line threshold.
- Keep generated-like files and extreme per-file diffs collapsed by default, and also exclude them from the bulk Expand all action.
- Raise the large-diff cutoff to 2,000 changed lines per file so only truly extreme diffs are treated as too large for automatic expansion.

For reference: This also works in the sidebar diff viewer

## Why
The previous policy only auto-opened the first 8 files for small reviews and treated files over 400 changed lines as large. That made ordinary reviewable diffs look collapsed and forced users to click Collapse/Expand controls instead of reading the changes directly.

## Testing
- `bun test ./tests/unit/agent-manager-diff-state.test.ts`
- `bun run lint`
- `bun run typecheck`