### PR TITLE
fix(vscode): stop repeated diff preview loads

### DIFF
--- a/.changeset/flickering-diffs-rest.md
+++ b/.changeset/flickering-diffs-rest.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Stop repeatedly reloading non-renderable Agent Manager diff previews.

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -25,6 +25,7 @@ import { LONG_DIFF_MARKER_FILE_COUNT, expandableOpenFiles, initialOpenFiles, isL
 import { DiffEndMarker } from "./DiffEndMarker"
 import { treeOrder } from "./file-tree-utils"
 import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
+import { diffToken } from "./diff-state"
 
 // --- Data model ---
 
@@ -75,6 +76,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
   // key changes (different worktree) we expand reviewable files. Within the same key,
   // only pruning happens so the user's manual collapse state is preserved.
   let initializedKey: string | undefined
+  const requested = new Map<string, string>()
 
   // Reorder diffs to match the file-tree's depth-first visual order so
   // scrolling through the accordion matches the tree grouping.
@@ -168,14 +170,31 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
 
   createEffect(
     on(
+      () => props.sessionKey,
+      () => {
+        requested.clear()
+      },
+    ),
+  )
+
+  createEffect(
+    on(
       () => [open(), props.diffs] as const,
       ([next]) => {
+        const files = new Set(next)
+        for (const file of requested.keys()) {
+          if (!files.has(file)) requested.delete(file)
+        }
+        if (!props.onRequestDiff) return
         const loading = props.loadingFiles ?? new Set<string>()
         for (const file of next) {
           if (loading.has(file)) continue
           const diff = props.diffs.find((item) => item.file === file)
           if (!diff || diff.summarized !== true) continue
-          props.onRequestDiff?.(file)
+          const value = diffToken(diff)
+          if (requested.get(file) === value) continue
+          requested.set(file, value)
+          props.onRequestDiff(file)
         }
       },
       { defer: true },

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -32,6 +32,7 @@ import {
 import { LONG_DIFF_MARKER_FILE_COUNT, expandableOpenFiles, initialOpenFiles, isLargeDiffFile } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
 import { isMarkdownFile, MarkdownDiffView } from "./MarkdownDiffView"
+import { diffToken } from "./diff-state"
 
 type DiffStyle = "unified" | "split"
 
@@ -88,6 +89,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
   // key changes (different worktree) we expand reviewable files. Within the same key,
   // only pruning happens so the user's manual collapse state is preserved.
   let initializedKey: string | undefined
+  const requested = new Map<string, string>()
   let rootRef: HTMLDivElement | undefined
   let scrollRef: HTMLDivElement | undefined
   let syncFrame: number | undefined
@@ -178,14 +180,31 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
 
   createEffect(
     on(
+      () => props.sessionKey,
+      () => {
+        requested.clear()
+      },
+    ),
+  )
+
+  createEffect(
+    on(
       () => [open(), props.diffs] as const,
       ([next]) => {
+        const files = new Set(next)
+        for (const file of requested.keys()) {
+          if (!files.has(file)) requested.delete(file)
+        }
+        if (!props.onRequestDiff) return
         const loading = props.loadingFiles ?? new Set<string>()
         for (const file of next) {
           if (loading.has(file)) continue
           const diff = props.diffs.find((item) => item.file === file)
           if (!diff || diff.summarized !== true) continue
-          props.onRequestDiff?.(file)
+          const value = diffToken(diff)
+          if (requested.get(file) === value) continue
+          requested.set(file, value)
+          props.onRequestDiff(file)
         }
       },
       { defer: true },

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-state.ts
@@ -13,6 +13,11 @@ export function sameDiffMeta(left: WorktreeFileDiff, right: WorktreeFileDiff) {
   )
 }
 
+export function diffToken(diff: WorktreeFileDiff) {
+  const parts = [diff.status ?? "", diff.additions, diff.deletions, diff.tracked ?? "", diff.generatedLike ?? ""]
+  return diff.stamp ?? parts.join(":")
+}
+
 export interface MergeResult {
   diffs: WorktreeFileDiff[]
   /** Files whose metadata changed while we preserved cached content.


### PR DESCRIPTION
## Summary
- Stop VsCode and agent manager from repeatedly requesting detail for unchanged summarized diff files.
- Keep dynamic updates and manual retries by keying requests on diff metadata and clearing them on collapse or source changes.

This will prevent flickering in the diff viewer for files that don't have a diff