### PR TITLE
Fix Add to Kilo when sidebar is hidden

### DIFF
--- a/.changeset/bright-ravens-open.md
+++ b/.changeset/bright-ravens-open.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open the Kilo Code sidebar before adding selected code or terminal output to chat context.

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -10,9 +10,13 @@ export function registerCodeActions(
   agentManager?: AgentManagerProvider,
 ): void {
   const target = () => (agentManager?.isActive() ? agentManager : provider)
+  const reveal = async () => {
+    await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+    await provider.waitForReady()
+  }
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("kilo-code.new.explainCode", () => {
+    vscode.commands.registerCommand("kilo-code.new.explainCode", async () => {
       const ctx = getEditorContext()
       if (!ctx) return
       const prompt = createPrompt("EXPLAIN", {
@@ -22,10 +26,11 @@ export function registerCodeActions(
         selectedText: ctx.selectedText,
         userInput: "",
       })
+      await reveal()
       provider.postMessage({ type: "triggerTask", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.fixCode", () => {
+    vscode.commands.registerCommand("kilo-code.new.fixCode", async () => {
       const ctx = getEditorContext()
       if (!ctx) return
       const prompt = createPrompt("FIX", {
@@ -36,10 +41,11 @@ export function registerCodeActions(
         diagnostics: ctx.diagnostics,
         userInput: "",
       })
+      await reveal()
       provider.postMessage({ type: "triggerTask", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.improveCode", () => {
+    vscode.commands.registerCommand("kilo-code.new.improveCode", async () => {
       const ctx = getEditorContext()
       if (!ctx) return
       const prompt = createPrompt("IMPROVE", {
@@ -49,10 +55,11 @@ export function registerCodeActions(
         selectedText: ctx.selectedText,
         userInput: "",
       })
+      await reveal()
       provider.postMessage({ type: "triggerTask", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.addToContext", () => {
+    vscode.commands.registerCommand("kilo-code.new.addToContext", async () => {
       const ctx = getEditorContext()
       if (!ctx) return
       const prompt = createPrompt("ADD_TO_CONTEXT", {
@@ -61,11 +68,19 @@ export function registerCodeActions(
         endLine: String(ctx.endLine),
         selectedText: ctx.selectedText,
       })
-      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "appendChatBoxMessage", text: prompt })
     }),
 
-    vscode.commands.registerCommand("kilo-code.new.focusChatInput", () => {
-      target().postMessage({ type: "action", action: "focusInput" })
+    vscode.commands.registerCommand("kilo-code.new.focusChatInput", async () => {
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "action", action: "focusInput" })
     }),
   )
 }

--- a/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-terminal-actions.ts
@@ -10,6 +10,10 @@ export function registerTerminalActions(
   agentManager?: AgentManagerProvider,
 ): void {
   const target = () => (agentManager?.isActive() ? agentManager : provider)
+  const reveal = async () => {
+    await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
+    await provider.waitForReady()
+  }
 
   context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.terminalAddToContext", async (args: any) => {
@@ -25,8 +29,12 @@ export function registerTerminalActions(
         terminalContent: content,
         userInput: "",
       })
-      target().postMessage({ type: "appendChatBoxMessage", text: prompt })
-      target().postMessage({ type: "action", action: "focusInput" })
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "appendChatBoxMessage", text: prompt })
+      view.postMessage({ type: "action", action: "focusInput" })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.terminalFixCommand", async (args: any) => {
@@ -42,7 +50,11 @@ export function registerTerminalActions(
         terminalContent: content,
         userInput: "",
       })
-      target().postMessage({ type: "triggerTask", text: prompt })
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "triggerTask", text: prompt })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.terminalExplainCommand", async (args: any) => {
@@ -58,7 +70,11 @@ export function registerTerminalActions(
         terminalContent: content,
         userInput: "",
       })
-      target().postMessage({ type: "triggerTask", text: prompt })
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "triggerTask", text: prompt })
     }),
   )
 }

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -50,7 +50,10 @@ const mockVscode = {
       get: <T>(_key: string, value?: T) => value,
       update: async () => {},
     }),
-    asRelativePath: (pathOrUri: string) => pathOrUri,
+    asRelativePath: (pathOrUri: string | { fsPath?: string }) => {
+      const value = typeof pathOrUri === "string" ? pathOrUri : (pathOrUri.fsPath ?? "")
+      return value.startsWith("/repo/") ? value.slice("/repo/".length) : value
+    },
     fs: {
       createDirectory: async () => {},
       writeFile: async () => {},
@@ -94,6 +97,10 @@ const mockVscode = {
   commands: {
     registerCommand: () => ({ dispose: noop }),
     executeCommand: async () => {},
+  },
+  languages: {
+    getDiagnostics: () => [],
+    registerCodeActionsProvider: () => ({ dispose: noop }),
   },
   CodeAction: class {
     command?: { command: string; title: string }

--- a/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import * as vscode from "vscode"
+import { registerCodeActions } from "../../src/services/code-actions/register-code-actions"
+
+type Command = (...args: unknown[]) => unknown
+
+type Api = typeof vscode & {
+  commands: {
+    registerCommand: (command: string, callback: Command) => { dispose(): void }
+    executeCommand: (...args: unknown[]) => Promise<void>
+  }
+  languages: {
+    getDiagnostics: () => Array<{ range: { intersection: () => unknown } }>
+  }
+  window: typeof vscode.window & { activeTextEditor?: unknown }
+}
+
+const api = vscode as Api
+const original = {
+  register: api.commands.registerCommand,
+  execute: api.commands.executeCommand,
+  editor: api.window.activeTextEditor,
+  diagnostics: api.languages.getDiagnostics,
+}
+
+function setup(active = false) {
+  const commands = new Map<string, Command>()
+  const executed: unknown[][] = []
+  const events: string[] = []
+  const posts: unknown[] = []
+  const waits: string[] = []
+  const context = { subscriptions: [] as Array<{ dispose(): void }> } as vscode.ExtensionContext
+  const provider = {
+    postMessage: (msg: unknown) => {
+      events.push("post")
+      posts.push(msg)
+    },
+    waitForReady: async () => {
+      events.push("wait")
+      waits.push("provider")
+    },
+  }
+  const agent = {
+    isActive: () => active,
+    postMessage: (msg: unknown) => {
+      events.push("post")
+      posts.push(msg)
+    },
+  }
+
+  api.commands.registerCommand = (command, callback) => {
+    commands.set(command, callback)
+    return { dispose: () => undefined }
+  }
+  api.commands.executeCommand = async (...args) => {
+    events.push("focus")
+    executed.push(args)
+  }
+  api.languages.getDiagnostics = () => []
+  api.window.activeTextEditor = {
+    selection: {
+      isEmpty: false,
+      start: { line: 2 },
+      end: { line: 4 },
+    },
+    document: {
+      uri: vscode.Uri.file("/repo/src/file.ts"),
+      getText: () => "const value = 1",
+    },
+  }
+
+  registerCodeActions(context, provider as never, agent as never)
+
+  return { commands, events, executed, posts, waits }
+}
+
+afterEach(() => {
+  api.commands.registerCommand = original.register
+  api.commands.executeCommand = original.execute
+  api.window.activeTextEditor = original.editor
+  api.languages.getDiagnostics = original.diagnostics
+})
+
+describe("registerCodeActions", () => {
+  it("reveals the sidebar before adding selected code to context", async () => {
+    const state = setup()
+
+    await state.commands.get("kilo-code.new.addToContext")?.()
+
+    expect(state.events).toEqual(["focus", "wait", "post"])
+    expect(state.executed).toEqual([["kilo-code.SidebarProvider.focus"]])
+    expect(state.waits).toEqual(["provider"])
+    expect(state.posts).toEqual([
+      {
+        type: "appendChatBoxMessage",
+        text: "src/file.ts:3-5\n```\nconst value = 1\n```",
+      },
+    ])
+  })
+
+  it("adds selected code to the active Agent Manager without revealing the sidebar", async () => {
+    const state = setup(true)
+
+    await state.commands.get("kilo-code.new.addToContext")?.()
+
+    expect(state.events).toEqual(["post"])
+    expect(state.executed).toEqual([])
+    expect(state.waits).toEqual([])
+    expect(state.posts).toEqual([
+      {
+        type: "appendChatBoxMessage",
+        text: "src/file.ts:3-5\n```\nconst value = 1\n```",
+      },
+    ])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/register-terminal-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/register-terminal-actions.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import * as vscode from "vscode"
+import { registerTerminalActions } from "../../src/services/code-actions/register-terminal-actions"
+
+type Command = (...args: unknown[]) => unknown
+
+type Api = typeof vscode & {
+  commands: {
+    registerCommand: (command: string, callback: Command) => { dispose(): void }
+    executeCommand: (...args: unknown[]) => Promise<void>
+  }
+}
+
+const api = vscode as Api
+const original = {
+  register: api.commands.registerCommand,
+  execute: api.commands.executeCommand,
+}
+
+function setup(active = false) {
+  const commands = new Map<string, Command>()
+  const executed: unknown[][] = []
+  const events: string[] = []
+  const posts: unknown[] = []
+  const waits: string[] = []
+  const context = { subscriptions: [] as Array<{ dispose(): void }> } as vscode.ExtensionContext
+  const provider = {
+    postMessage: (msg: unknown) => {
+      events.push("post")
+      posts.push(msg)
+    },
+    waitForReady: async () => {
+      events.push("wait")
+      waits.push("provider")
+    },
+  }
+  const agent = {
+    isActive: () => active,
+    postMessage: (msg: unknown) => {
+      events.push("post")
+      posts.push(msg)
+    },
+  }
+
+  api.commands.registerCommand = (command, callback) => {
+    commands.set(command, callback)
+    return { dispose: () => undefined }
+  }
+  api.commands.executeCommand = async (...args) => {
+    events.push("focus")
+    executed.push(args)
+  }
+
+  registerTerminalActions(context, provider as never, agent as never)
+
+  return { commands, events, executed, posts, waits }
+}
+
+afterEach(() => {
+  api.commands.registerCommand = original.register
+  api.commands.executeCommand = original.execute
+})
+
+describe("registerTerminalActions", () => {
+  it("reveals the sidebar before adding terminal output to context", async () => {
+    const state = setup()
+
+    await state.commands.get("kilo-code.new.terminalAddToContext")?.({ selection: "bun test" })
+
+    expect(state.events).toEqual(["focus", "wait", "post", "post"])
+    expect(state.executed).toEqual([["kilo-code.SidebarProvider.focus"]])
+    expect(state.waits).toEqual(["provider"])
+    expect(state.posts).toEqual([
+      {
+        type: "appendChatBoxMessage",
+        text: "\nTerminal output:\n```\nbun test\n```",
+      },
+      { type: "action", action: "focusInput" },
+    ])
+  })
+
+  it("adds terminal output to the active Agent Manager without revealing the sidebar", async () => {
+    const state = setup(true)
+
+    await state.commands.get("kilo-code.new.terminalAddToContext")?.({ selection: "bun test" })
+
+    expect(state.events).toEqual(["post", "post"])
+    expect(state.executed).toEqual([])
+    expect(state.waits).toEqual([])
+    expect(state.posts).toEqual([
+      {
+        type: "appendChatBoxMessage",
+        text: "\nTerminal output:\n```\nbun test\n```",
+      },
+      { type: "action", action: "focusInput" },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Reveal the Kilo sidebar and wait for the webview before posting editor and terminal context actions.
- Keep active Agent Manager context actions routed to Agent Manager without forcing the sidebar open.
- Add focused unit coverage for hidden-sidebar and active-Agent-Manager routing.

Fixes #10048