### PR TITLE
fix(agent-manager): reuse shared diff source lifecycle

### DIFF
--- a/.changeset/unified-diff-watch.md
+++ b/.changeset/unified-diff-watch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager review diffs responsive during worktree diff refreshes.

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -268,7 +268,7 @@ export class WorktreeDiffController {
 
   private async revertFile(sessionId: string, file: string): Promise<{ ok: boolean; message: string }> {
     await this.ready("stateReady rejected, continuing revert resolve:")
-    const target = await this.ensureTarget(sessionId)
+    const target = await this.resolveTarget(sessionId)
     if (!target) return { ok: false, message: "Could not resolve diff target" }
 
     try {
@@ -284,6 +284,10 @@ export class WorktreeDiffController {
   private async ensureTarget(sessionId: string): Promise<Target | undefined> {
     if (this.controller.currentId !== sessionId) return undefined
     if (this.target?.sessionId === sessionId) return this.target
+    return await this.resolveTarget(sessionId)
+  }
+
+  private async resolveTarget(sessionId: string): Promise<Target | undefined> {
     const target = await this.resolve(sessionId)
     if (!target) return undefined
     this.target = { sessionId, ...target }

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -1,8 +1,9 @@
 import type { KiloClient } from "@kilocode/sdk/v2/client"
-import { hashFileDiffs } from "../diff/shared/hash"
+import { SourceController } from "../diff/SourceController"
 import { resolveLocalDiffTarget } from "../diff/shared/target"
-import { DIFF_POLL_INTERVAL_MS } from "../diff/polling"
 import { WorktreeDiffClient } from "../diff/shared/client"
+import type { DiffFile } from "../diff/types"
+import type { DiffSource, DiffSourceDescriptor, DiffSourceFetch } from "../diff/sources/types"
 import type { ApplyConflict, GitOps } from "./GitOps"
 import { shouldStopDiffPolling } from "./delete-worktree"
 import { remoteRef, type ManagedSession, type WorktreeStateManager } from "./WorktreeStateManager"
@@ -12,13 +13,15 @@ const LOCAL_DIFF_ID = "local" as const
 
 type Target = { sessionId: string; directory: string; baseBranch: string }
 
+type AgentManagerDiffFile = DiffFile & WorktreeDiffEntry
+
 export interface WorktreeDiffControllerContext {
   getState: () => WorktreeStateManager | undefined
   getRoot: () => string | undefined
   getStateReady: () => Promise<void> | undefined
   /**
    * SDK client — used by `revert()` via `WorktreeDiffClient` for the one-shot
-   * file-status lookup. Hot polling paths (`request`, `requestFile`, `poll`)
+   * file-status lookup. Hot polling paths (`request`, `requestFile`, polling)
    * deliberately bypass the client and go through `localDiff`/`localDiffFile`
    * to keep git spawns out of the Bun `kilo serve` process (see oven-sh/bun#18265).
    */
@@ -33,18 +36,53 @@ export interface WorktreeDiffControllerContext {
 }
 
 export class WorktreeDiffController {
-  private interval: ReturnType<typeof setInterval> | undefined
-  private session: string | undefined
-  private hash: string | undefined
+  private readonly controller: SourceController
   private target: Target | undefined
-  /** Monotonic token for the active diff watch. Async work drops results when this changes. */
-  private epoch = 0
   private applying: string | undefined
 
-  constructor(private readonly ctx: WorktreeDiffControllerContext) {}
+  constructor(private readonly ctx: WorktreeDiffControllerContext) {
+    this.controller = new SourceController(
+      (id) => this.source(id),
+      () => [],
+      (msg) => this.ctx.post(msg as AgentManagerOutMessage),
+      {
+        loading: (source, loading) => ({
+          type: "agentManager.worktreeDiffLoading",
+          sessionId: source.descriptor.id,
+          loading,
+        }),
+        diffs: (source, diffs) => ({
+          type: "agentManager.worktreeDiff",
+          sessionId: source.descriptor.id,
+          diffs: diffs as AgentManagerDiffFile[],
+        }),
+        diffFile: (source, file, diff) => ({
+          type: "agentManager.worktreeDiffFile",
+          sessionId: source?.descriptor.id ?? "",
+          file,
+          diff: diff as AgentManagerDiffFile | null,
+        }),
+        revertFileResult: (source, file, result) => ({
+          type: "agentManager.revertWorktreeFileResult",
+          sessionId: source?.descriptor.id ?? "",
+          file,
+          status: result.ok ? "success" : "error",
+          message: result.message,
+        }),
+        unsupportedRevert: (source, file) => ({
+          type: "agentManager.revertWorktreeFileResult",
+          sessionId: source?.descriptor.id ?? "",
+          file,
+          status: "error",
+          message: "Revert is not supported for the current source",
+        }),
+      },
+    )
+    this.controller.setContext({ workspaceRoot: this.ctx.getRoot() })
+  }
 
   public shouldStopForWorktree(path: string, sessions: ManagedSession[]): boolean {
-    return shouldStopDiffPolling(path, sessions, this.target, this.session)
+    return shouldStopDiffPolling(path, sessions, this.target, this.controller.currentId)
   }
 
   public async apply(worktreeId: string, value?: unknown): Promise<void> {
@@ -110,149 +148,47 @@ export class WorktreeDiffController {
 
   public async revert(sessionId: string, file: string): Promise<void> {
     if (!file) return
-    await this.ready("stateReady rejected, continuing revert resolve:")
-
-    const target = this.target?.sessionId === sessionId ? this.target : await this.resolve(sessionId)
-    if (!target) {
-      this.ctx.post({
-        type: "agentManager.revertWorktreeFileResult",
-        sessionId,
-        file,
-        status: "error",
-        message: "Could not resolve diff target",
-      })
+    if (this.controller.currentId !== sessionId) {
+      const result = await this.revertFile(sessionId, file)
+      this.postRevertResult(sessionId, file, result)
       return
     }
-
-    try {
-      const diff = new WorktreeDiffClient(this.ctx.getClient(), this.ctx.git, (...args) => this.ctx.log(...args))
-      const result = await diff.revertFile(target, file)
-      this.ctx.post({
-        type: "agentManager.revertWorktreeFileResult",
-        sessionId,
-        file,
-        status: result.ok ? "success" : "error",
-        message: result.message,
-      })
-
-      if (result.ok) void this.request(sessionId)
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error)
-      this.ctx.log("Failed to revert worktree file:", msg)
-      this.ctx.post({
-        type: "agentManager.revertWorktreeFileResult",
-        sessionId,
-        file,
-        status: "error",
-        message: msg,
-      })
-    }
+    await this.controller.revertFile(file)
   }
 
   public async request(sessionId: string): Promise<void> {
-    const epoch = this.session === sessionId ? this.epoch : ++this.epoch
-    this.session = sessionId
-    this.target = undefined
-    await this.ready("stateReady rejected, continuing diff resolve:")
-    if (!this.current(epoch, sessionId)) return
-
-    const target = await this.resolve(sessionId)
-    if (!target) return
-    if (!this.current(epoch, sessionId)) return
-
-    this.target = { sessionId, ...target }
-    this.ctx.post({ type: "agentManager.worktreeDiffLoading", sessionId, loading: true })
-
-    try {
-      const files = await this.ctx.localDiff(target.directory, target.baseBranch)
-      if (!this.current(epoch, sessionId)) return
-      this.ctx.log(`Worktree diff returned ${files.length} file(s) for session ${sessionId}`)
-      this.hash = hashFileDiffs(files)
-      this.session = sessionId
-      this.ctx.post({ type: "agentManager.worktreeDiff", sessionId, diffs: files })
-    } catch (error) {
-      this.ctx.log("Failed to fetch worktree diff:", error)
-    } finally {
-      if (this.current(epoch, sessionId)) {
-        this.ctx.post({ type: "agentManager.worktreeDiffLoading", sessionId, loading: false })
-      }
+    if (this.controller.currentId !== sessionId) {
+      await this.activate(sessionId, false, true)
+      return
     }
+    this.target = undefined
+    await this.controller.refresh()
   }
 
   public async requestFile(sessionId: string, file: string): Promise<void> {
     if (!file) return
-    const epoch = this.epoch
-    await this.ready("stateReady rejected, continuing diff detail resolve:")
-    if (!this.current(epoch, sessionId)) return
-
-    const target = this.target?.sessionId === sessionId ? this.target : await this.resolve(sessionId)
-    if (!target) return
-    if (!this.current(epoch, sessionId)) return
-
-    this.target = { sessionId, directory: target.directory, baseBranch: target.baseBranch }
-
-    try {
-      const data = await this.ctx.localDiffFile(target.directory, target.baseBranch, file)
-      if (!this.current(epoch, sessionId)) return
-      this.ctx.post({ type: "agentManager.worktreeDiffFile", sessionId, file, diff: data })
-    } catch (error) {
-      if (!this.current(epoch, sessionId)) return
-      this.ctx.log("Failed to fetch worktree diff file:", error)
+    if (this.controller.currentId !== sessionId) {
       this.ctx.post({ type: "agentManager.worktreeDiffFile", sessionId, file, diff: null })
+      return
     }
+    await this.controller.requestFile(file)
   }
 
   public start(sessionId: string): void {
-    if (this.session === sessionId && this.interval) {
-      this.ctx.log(`Already polling session ${sessionId}, skipping restart`)
-      return
-    }
-
-    this.stop()
-    this.session = sessionId
-    this.hash = undefined
-    const epoch = this.epoch
+    if (this.controller.isPolling && this.controller.currentId === sessionId) return
     this.ctx.log(`Starting diff polling for session ${sessionId}`)
-
-    void this.request(sessionId).then(() => {
-      if (!this.current(epoch, sessionId)) return
-      this.interval = setInterval(() => {
-        void this.poll(sessionId)
-      }, DIFF_POLL_INTERVAL_MS)
-    })
+    void this.activate(sessionId, true, true)
   }
 
   public stop(): void {
-    this.epoch++
-    if (this.interval) {
-      clearInterval(this.interval)
-      this.interval = undefined
-    }
-    this.session = undefined
-    this.hash = undefined
+    this.controller.stop()
     this.target = undefined
   }
 
-  private async poll(sessionId: string): Promise<void> {
-    const epoch = this.epoch
-    const target = this.target?.sessionId === sessionId ? this.target : undefined
-    if (!target) return
-
-    try {
-      const files = await this.ctx.localDiff(target.directory, target.baseBranch)
-      if (!this.current(epoch, sessionId)) return
-      const hash = hashFileDiffs(files)
-      if (hash === this.hash && this.session === sessionId) return
-      this.hash = hash
-      this.session = sessionId
-      this.ctx.post({ type: "agentManager.worktreeDiff", sessionId, diffs: files })
-    } catch (error) {
-      this.ctx.log("Failed to poll worktree diff:", error)
-    }
-  }
-
-  private current(epoch: number, sessionId: string): boolean {
-    return this.epoch === epoch && this.session === sessionId
+  private async activate(sessionId: string, poll: boolean, fetch: boolean): Promise<void> {
+    this.target = undefined
+    this.controller.setContext({ workspaceRoot: this.ctx.getRoot() })
+    await this.controller.activate(sessionId, { poll, fetch })
   }
 
   private async resolve(sessionId: string): Promise<{ directory: string; baseBranch: string } | undefined> {
@@ -289,6 +225,79 @@ export class WorktreeDiffController {
 
   private async ready(msg: string): Promise<void> {
     await this.ctx.getStateReady()?.catch((err) => this.ctx.log(msg, err))
+  }
+
+  private source(sessionId: string): DiffSource {
+    const descriptor: DiffSourceDescriptor = {
+      id: sessionId,
+      type: "workspace",
+      group: "Git",
+      capabilities: { revert: true, comments: true },
+    }
+
+    return {
+      descriptor,
+      fetch: () => this.fetch(sessionId),
+      fetchFile: (file) => this.fetchFile(sessionId, file),
+      revert: (file) => this.revertFile(sessionId, file),
+    }
+  }
+
+  private async fetch(sessionId: string): Promise<DiffSourceFetch> {
+    await this.ready("stateReady rejected, continuing diff resolve:")
+    const target = await this.ensureTarget(sessionId)
+    if (!target) return { diffs: [], stopPolling: true }
+
+    const files = await this.ctx.localDiff(target.directory, target.baseBranch)
+    this.ctx.log(`Worktree diff returned ${files.length} file(s) for session ${sessionId}`)
+    return { diffs: files as AgentManagerDiffFile[] }
+  }
+
+  private async fetchFile(sessionId: string, file: string): Promise<DiffFile | null> {
+    await this.ready("stateReady rejected, continuing diff detail resolve:")
+    const target = await this.ensureTarget(sessionId)
+    if (!target) return null
+
+    try {
+      return (await this.ctx.localDiffFile(target.directory, target.baseBranch, file)) as AgentManagerDiffFile | null
+    } catch (error) {
+      this.ctx.log("Failed to fetch worktree diff file:", error)
+      return null
+    }
+  }
+
+  private async revertFile(sessionId: string, file: string): Promise<{ ok: boolean; message: string }> {
+    await this.ready("stateReady rejected, continuing revert resolve:")
+    const target = await this.ensureTarget(sessionId)
+    if (!target) return { ok: false, message: "Could not resolve diff target" }
+
+    try {
+      const diff = new WorktreeDiffClient(this.ctx.getClient(), this.ctx.git, (...args) => this.ctx.log(...args))
+      return await diff.revertFile(target, file)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      this.ctx.log("Failed to revert worktree file:", msg)
+      return { ok: false, message: msg }
+    }
+  }
+
+  private async ensureTarget(sessionId: string): Promise<Target | undefined> {
+    if (this.controller.currentId !== sessionId) return undefined
+    if (this.target?.sessionId === sessionId) return this.target
+    const target = await this.resolve(sessionId)
+    if (!target) return undefined
+    this.target = { sessionId, ...target }
+    return this.target
+  }
+
+  private postRevertResult(sessionId: string, file: string, result: { ok: boolean; message: string }): void {
+    this.ctx.post({
+      type: "agentManager.revertWorktreeFileResult",
+      sessionId,
+      file,
+      status: result.ok ? "success" : "error",
+      message: result.message,
+    })
   }
 
   private postApplyResult(

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -1,7 +1,49 @@
 import { hashFileDiffs } from "./shared/hash"
 import { DIFF_POLL_INTERVAL_MS } from "./polling"
-import type { DiffSource, DiffSourceDescriptor } from "./sources/types"
+import type { DiffSource, DiffSourceCapabilities, DiffSourceDescriptor, DiffSourceNotice } from "./sources/types"
+import type { DiffFile } from "./types"
 import type { PanelContext } from "./types"
+
+type Messages = {
+  available?: (descriptors: DiffSourceDescriptor[], id: string) => unknown
+  capabilities?: (capabilities: DiffSourceCapabilities) => unknown
+  loading?: (source: DiffSource, loading: boolean) => unknown
+  diffs: (source: DiffSource, diffs: DiffFile[]) => unknown
+  notice?: (source: DiffSource, notice: DiffSourceNotice | undefined) => unknown
+  diffFile: (source: DiffSource | undefined, file: string, diff: DiffFile | null) => unknown
+  revertFileResult: (source: DiffSource | undefined, file: string, result: { ok: boolean; message: string }) => unknown
+  unsupportedRevert: (source: DiffSource | undefined, file: string) => unknown
+}
+
+type ActivateOptions = { poll?: boolean; fetch?: boolean }
+
+const viewerMessages: Messages = {
+  available: (descriptors, id) => ({
+    type: "setAvailableSources",
+    descriptors,
+    currentId: id,
+  }),
+  capabilities: (capabilities) => ({
+    type: "diffViewer.capabilities",
+    capabilities,
+  }),
+  loading: (_source, loading) => ({ type: "diffViewer.loading", loading }),
+  diffs: (_source, diffs) => ({ type: "diffViewer.diffs", diffs }),
+  notice: (_source, notice) => ({ type: "diffViewer.notice", notice }),
+  diffFile: (_source, file, diff) => ({ type: "diffViewer.diffFile", file, diff }),
+  revertFileResult: (_source, file, result) => ({
+    type: "diffViewer.revertFileResult",
+    file,
+    status: result.ok ? "success" : "error",
+    message: result.message,
+  }),
+  unsupportedRevert: (_source, file) => ({
+    type: "diffViewer.revertFileResult",
+    file,
+    status: "error",
+    message: "Revert is not supported for the current source",
+  }),
+}
 
 /**
  * Owns the active DiffSource for a panel: builds it via the injected `build`
@@ -30,6 +72,7 @@ export class SourceController {
     private readonly build: (id: string, ctx: PanelContext) => DiffSource,
     private readonly listAvailable: (ctx: PanelContext) => DiffSourceDescriptor[],
     private readonly post: (msg: unknown) => void,
+    private readonly messages: Messages = viewerMessages,
   ) {}
 
   setContext(ctx: PanelContext): void {
@@ -38,6 +81,10 @@ export class SourceController {
 
   get currentId(): string | undefined {
     return this.activeId
+  }
+
+  get isPolling(): boolean {
+    return this.interval !== undefined
   }
 
   /** Dispose the active source and bump the epoch so in-flight fetches are dropped. */
@@ -55,7 +102,7 @@ export class SourceController {
    * Disposes any previously active source. Throws if the catalog can't build
    * the id — callers should catch and log.
    */
-  async activate(id: string): Promise<void> {
+  async activate(id: string, opts: ActivateOptions = {}): Promise<void> {
     const ctx = this.ctx
     if (!ctx) return
     this.stop()
@@ -65,31 +112,21 @@ export class SourceController {
     const source = this.build(id, ctx)
     this.active = source
 
-    this.post({
-      type: "setAvailableSources",
-      descriptors: this.listAvailable(ctx),
-      currentId: id,
-    })
-    this.post({
-      type: "diffViewer.capabilities",
-      capabilities: source.descriptor.capabilities,
-    })
+    this.send(this.messages.available?.(this.listAvailable(ctx), id))
+    this.send(this.messages.capabilities?.(source.descriptor.capabilities))
+
+    if (opts.fetch === false) return
 
     const keepPolling = await this.runFetch(source, epoch, true)
     // Prevents the polling interval from starting after teardown or swap.
     if (this.epoch !== epoch || this.activeId !== id) return
-    if (keepPolling) this.startPolling(source, epoch)
+    if (opts.poll !== false && keepPolling) this.startPolling(source, epoch)
   }
 
   async revertFile(file: string): Promise<void> {
     const source = this.active
     if (!source?.revert) {
-      this.post({
-        type: "diffViewer.revertFileResult",
-        file,
-        status: "error",
-        message: "Revert is not supported for the current source",
-      })
+      this.send(this.messages.unsupportedRevert(source, file))
       return
     }
 
@@ -98,17 +135,20 @@ export class SourceController {
       const message = err instanceof Error ? err.message : String(err)
       return { ok: false, message }
     })
-    this.post({
-      type: "diffViewer.revertFileResult",
-      file,
-      status: result.ok ? "success" : "error",
-      message: result.message,
-    })
+    this.send(this.messages.revertFileResult(source, file, result))
     // Push fresh diffs immediately after a successful revert so the webview
     // doesn't have to wait for the next polling tick.
     if (result.ok && this.epoch === epoch && this.active === source) {
       await this.runFetch(source, epoch, false)
     }
+  }
+
+  /** Run an immediate fetch against the active source without changing polling state. */
+  async refresh(): Promise<void> {
+    const source = this.active
+    if (!source) return
+    const epoch = this.epoch
+    await this.runFetch(source, epoch, true)
   }
 
   /**
@@ -120,14 +160,18 @@ export class SourceController {
   async requestFile(file: string): Promise<void> {
     const source = this.active
     const epoch = this.epoch
-    if (!source?.fetchFile) {
-      this.post({ type: "diffViewer.diffFile", file, diff: null })
+    if (!source) {
+      this.send(this.messages.diffFile(undefined, file, null))
+      return
+    }
+    if (!source.fetchFile) {
+      this.send(this.messages.diffFile(source, file, null))
       return
     }
     const diff = await source.fetchFile(file).catch(() => null)
     // Drop the response if the source has been disposed/swapped while we waited.
     if (this.epoch !== epoch) return
-    this.post({ type: "diffViewer.diffFile", file, diff })
+    this.send(this.messages.diffFile(source, file, diff))
   }
 
   dispose(): void {
@@ -140,20 +184,20 @@ export class SourceController {
    * requests a stop or the epoch has moved on.
    */
   private async runFetch(source: DiffSource, epoch: number, initial: boolean): Promise<boolean> {
-    if (initial) this.post({ type: "diffViewer.loading", loading: true })
+    if (initial) this.send(this.messages.loading?.(source, true))
 
     try {
       const result = await source.fetch()
       if (this.epoch !== epoch) return false
 
       if (result.notice !== undefined) {
-        this.post({ type: "diffViewer.notice", notice: result.notice })
+        this.send(this.messages.notice?.(source, result.notice))
       }
 
       const hash = hashFileDiffs(result.diffs as never)
       if (initial || hash !== this.lastHash) {
         this.lastHash = hash
-        this.post({ type: "diffViewer.diffs", diffs: result.diffs })
+        this.send(this.messages.diffs(source, result.diffs))
       }
 
       return !result.stopPolling
@@ -167,9 +211,14 @@ export class SourceController {
       return true
     } finally {
       if (initial && this.epoch === epoch) {
-        this.post({ type: "diffViewer.loading", loading: false })
+        this.send(this.messages.loading?.(source, false))
       }
     }
+  }
+
+  private send(msg: unknown): void {
+    if (msg === undefined) return
+    this.post(msg)
   }
 
   private startPolling(source: DiffSource, epoch: number): void {

--- a/packages/kilo-vscode/tests/unit/source-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/source-controller.test.ts
@@ -346,3 +346,31 @@ describe("SourceController.requestFile", () => {
     controller.stop()
   })
 })
+
+describe("SourceController.refresh", () => {
+  it("runs a one-shot active source fetch without restarting polling", async () => {
+    let fetches = 0
+    const source: DiffSource = {
+      descriptor: SESSION_DESC,
+      async fetch() {
+        fetches++
+        return { diffs: [{ file: `file-${fetches}.ts` } as never] }
+      },
+    }
+    const { controller, posted } = make({ "session:s1": source })
+
+    controller.setContext({ workspaceRoot: "/repo", sessionId: "s1" })
+    await controller.activate("session:s1", { poll: false })
+    posted.length = 0
+
+    await controller.refresh()
+
+    expect(fetches).toBe(2)
+    const diffs = byType(posted, "diffViewer.diffs")
+    expect(diffs).toHaveLength(1)
+    expect(diffs[0]!.diffs).toEqual([{ file: "file-2.ts" }])
+    expect(byType(posted, "diffViewer.loading").map((m) => m.loading)).toEqual([true, false])
+
+    controller.stop()
+  })
+})


### PR DESCRIPTION
## Summary
- Reuse the unified diff SourceController for Agent Manager diff watching, one-shot refreshes, file detail loads, and revert refreshes.
- Preserve the shared kilo-ui diff rendering optimizations while keeping Agent Manager target resolution and extension-host git diff fetching scoped to Agent Manager.
- Keep review expansion policy untouched so reviewable files still expand by default.

## Validation
- bun test tests/unit/source-controller.test.ts tests/unit/agent-manager-diff-state.test.ts
- bun run lint
- Touched-file type check grep for SourceController/worktree-diff-controller