### PR TITLE
docs(cli): add Windows Terminal Shift+Enter configuration guide

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -346,6 +346,43 @@ Both keys also accept object configuration for specific tools or language server
 
 The TUI gives `Ctrl+Z` to input undo on Windows because native Windows terminals do not support POSIX terminal suspend. On Windows, `input_undo` defaults to `ctrl+z,ctrl+-,super+z` and `terminal_suspend` is disabled. On macOS and Linux, `terminal_suspend` defaults to `ctrl+z`.
 
+#### Enabling Shift+Enter in Windows Terminal
+
+Some terminals don't send modifier keys with Enter by default. Windows Terminal requires a one-time configuration to forward `Shift+Enter` as an escape sequence that Kilo can read.
+
+Open your `settings.json` at:
+
+```
+%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json
+```
+
+Add this entry to the root-level `actions` array:
+
+```json
+"actions": [
+  {
+    "command": {
+      "action": "sendInput",
+      "input": "\u001b[13;2u"
+    },
+    "id": "User.sendInput.ShiftEnterCustom"
+  }
+]
+```
+
+Add this entry to the root-level `keybindings` array:
+
+```json
+"keybindings": [
+  {
+    "keys": "shift+enter",
+    "id": "User.sendInput.ShiftEnterCustom"
+  }
+]
+```
+
+Save the file and restart Windows Terminal or open a new tab. `Shift+Enter` will now insert a newline in the Kilo prompt instead of submitting the message.
+
 ### OpenTelemetry Export
 
 Kilo telemetry is enabled by default and can be disabled with `experimental.openTelemetry = false`:


### PR DESCRIPTION
Add a new subsection under **TUI Keybindings on Windows** in the CLI docs explaining how to configure Windows Terminal to forward `Shift+Enter` as an escape sequence.

Without this configuration, Windows Terminal does not pass modifier keys with Enter to the TUI, so users cannot insert newlines in the prompt. The steps (adding entries to `actions` and `keybindings` in `settings.json`) are sourced from the upstream OpenCode docs.