### PR TITLE
Update auto-docs workflow for PR handling

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -1,35 +1,117 @@
-name: Trigger webhook for feat PRs
+name: Auto-docs dry-run intake
 
+# Trigger on merged feature PRs, or manually with a specific PR number.
+# IMPORTANT: This workflow intentionally does NOT check out PR code and does NOT
+# execute any code from the PR branch. It only reads PR metadata and forwards it
+# to a webhook. This is required for safe use of pull_request_target on a public repo.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to test"
+        required: true
+
+# Minimal permissions: read repo contents (for gh api) and PR metadata only.
+permissions:
+  contents: read
+  pull-requests: read
+
+# One run per PR at a time. Does not cancel in progress — let the current run
+# finish so we don't drop events when a PR is quickly closed/reopened/closed.
+concurrency:
+  group: auto-docs-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
 
 jobs:
-  call-webhook:
+  call-valtown:
     if: >
-      github.event.pull_request.merged == true &&
-      (startsWith(github.event.pull_request.title, 'feat:') ||
-       startsWith(github.event.pull_request.title, 'feat('))
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        (
+          startsWith(github.event.pull_request.title, 'feat:') ||
+          startsWith(github.event.pull_request.title, 'feat(')
+        )
+      )
+
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - name: Send webhook safely
+      # On manual dispatch, fetch real PR metadata via the GitHub API so that
+      # manual runs are full end-to-end tests rather than "ping only" runs.
+      # The fetched fields are written to GITHUB_ENV and picked up by the next
+      # step via the `env.TITLE` etc. fallbacks in its `env:` block.
+      - name: Fetch PR metadata (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/pulls/$PR_NUMBER" > pr.json
+          {
+            echo "TITLE=$(jq -r .title pr.json)"
+            echo "BODY<<__EOF__"
+            jq -r '.body // ""' pr.json
+            echo "__EOF__"
+            echo "AUTHOR=$(jq -r .user.login pr.json)"
+            echo "MERGED_AT=$(jq -r '.merged_at // ""' pr.json)"
+            echo "PR_URL=$(jq -r .html_url pr.json)"
+          } >> "$GITHUB_ENV"
+
+      - name: Build webhook payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          # For pull_request_target the left-hand side is populated by the event.
+          # For workflow_dispatch it evaluates to empty, so we fall back to the
+          # values written to GITHUB_ENV by the "Fetch PR metadata" step above.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          TITLE: ${{ github.event.pull_request.title || env.TITLE }}
+          BODY: ${{ github.event.pull_request.body || env.BODY }}
+          AUTHOR: ${{ github.event.pull_request.user.login || env.AUTHOR }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at || env.MERGED_AT }}
+          PR_URL: ${{ github.event.pull_request.html_url || env.PR_URL }}
         run: |
           payload=$(jq -n \
-            --arg repo "${GITHUB_REPOSITORY}" \
-            --arg pr_number "${{ github.event.pull_request.number }}" \
-            --arg title "${{ github.event.pull_request.title }}" \
-            --arg body "${{ github.event.pull_request.body }}" \
-            --arg author "${{ github.event.pull_request.user.login }}" \
-            --arg merged_at "${{ github.event.pull_request.merged_at }}" \
+            --arg event_name "$EVENT_NAME" \
+            --arg repo "$REPO" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg title "$TITLE" \
+            --arg body "$BODY" \
+            --arg author "$AUTHOR" \
+            --arg merged_at "$MERGED_AT" \
+            --arg pr_url "$PR_URL" \
             '{
+              event_name: $event_name,
               repo: $repo,
               pr_number: $pr_number,
               title: $title,
               description: $body,
               author: $author,
-              merged_at: $merged_at
+              merged_at: $merged_at,
+              pr_url: $pr_url
             }'
           )
-          curl --fail-with-body -X POST "${{ secrets.DOC_WEBHOOK_URL }}" \
+
+          echo "$payload" > payload.json
+          echo "Payload:"
+          cat payload.json
+
+      - name: Send webhook to Val Town
+        env:
+          DOC_WEBHOOK_URL: ${{ secrets.DOC_WEBHOOK_URL }}
+          DOC_WEBHOOK_SECRET: ${{ secrets.DOC_WEBHOOK_SECRET }}
+        run: |
+          if [ -z "$DOC_WEBHOOK_URL" ]; then
+            echo "DOC_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+
+          curl --fail-with-body -sS -X POST "$DOC_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            --data-raw "$payload"
+            -H "X-Docs-Webhook-Secret: $DOC_WEBHOOK_SECRET" \
+            --data-binary @payload.json

--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -13,7 +13,7 @@ on:
         description: "PR number to test"
         required: true
 
-# Minimal permissions: read repo contents (for gh api) and PR metadata only.
+# Minimal permissions: read repo contents and PR metadata only.
 permissions:
   contents: read
   pull-requests: read
@@ -40,74 +40,70 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # On manual dispatch, fetch real PR metadata via the GitHub API so that
-      # manual runs are full end-to-end tests rather than "ping only" runs.
-      # The fetched fields are written to GITHUB_ENV and picked up by the next
-      # step via the `env.TITLE` etc. fallbacks in its `env:` block.
-      - name: Fetch PR metadata (manual dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh api "repos/$REPO/pulls/$PR_NUMBER" > pr.json
-          {
-            echo "TITLE=$(jq -r .title pr.json)"
-            echo "BODY<<__EOF__"
-            jq -r '.body // ""' pr.json
-            echo "__EOF__"
-            echo "AUTHOR=$(jq -r .user.login pr.json)"
-            echo "MERGED_AT=$(jq -r '.merged_at // ""' pr.json)"
-            echo "PR_URL=$(jq -r .html_url pr.json)"
-          } >> "$GITHUB_ENV"
-
       - name: Build webhook payload
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
-          # For pull_request_target the left-hand side is populated by the event.
-          # For workflow_dispatch it evaluates to empty, so we fall back to the
-          # values written to GITHUB_ENV by the "Fetch PR metadata" step above.
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-          TITLE: ${{ github.event.pull_request.title || env.TITLE }}
-          BODY: ${{ github.event.pull_request.body || env.BODY }}
-          AUTHOR: ${{ github.event.pull_request.user.login || env.AUTHOR }}
-          MERGED_AT: ${{ github.event.pull_request.merged_at || env.MERGED_AT }}
-          PR_URL: ${{ github.event.pull_request.html_url || env.PR_URL }}
+          PR_NUMBER_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_NUMBER_FROM_INPUT: ${{ inputs.pr_number }}
         run: |
-          payload=$(jq -n \
+          set -euo pipefail
+
+          PR_NUMBER="${PR_NUMBER_FROM_EVENT:-$PR_NUMBER_FROM_INPUT}"
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Missing PR number"
+            exit 1
+          fi
+
+          gh api "repos/$REPO/pulls/$PR_NUMBER" > pr.json
+
+          jq -n \
             --arg event_name "$EVENT_NAME" \
             --arg repo "$REPO" \
             --arg pr_number "$PR_NUMBER" \
-            --arg title "$TITLE" \
-            --arg body "$BODY" \
-            --arg author "$AUTHOR" \
-            --arg merged_at "$MERGED_AT" \
-            --arg pr_url "$PR_URL" \
+            --slurpfile pr pr.json \
             '{
               event_name: $event_name,
               repo: $repo,
               pr_number: $pr_number,
-              title: $title,
-              description: $body,
-              author: $author,
-              merged_at: $merged_at,
-              pr_url: $pr_url
-            }'
-          )
+              title: $pr[0].title,
+              description: ($pr[0].body // ""),
+              author: $pr[0].user.login,
+              merged_at: ($pr[0].merged_at // ""),
+              pr_url: $pr[0].html_url,
+              base_branch: $pr[0].base.ref,
+              head_branch: $pr[0].head.ref
+            }' > payload.json
 
-          echo "$payload" > payload.json
-          echo "Payload:"
-          cat payload.json
+          echo "Payload created:"
+          jq '{
+            event_name,
+            repo,
+            pr_number,
+            title,
+            author,
+            merged_at,
+            pr_url,
+            base_branch,
+            head_branch
+          }' payload.json
 
       - name: Send webhook to Val Town
         env:
           DOC_WEBHOOK_URL: ${{ secrets.DOC_WEBHOOK_URL }}
           DOC_WEBHOOK_SECRET: ${{ secrets.DOC_WEBHOOK_SECRET }}
         run: |
-          if [ -z "$DOC_WEBHOOK_URL" ]; then
+          set -euo pipefail
+
+          if [ -z "${DOC_WEBHOOK_URL:-}" ]; then
             echo "DOC_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+
+          if [ -z "${DOC_WEBHOOK_SECRET:-}" ]; then
+            echo "DOC_WEBHOOK_SECRET secret is not set"
             exit 1
           fi
 


### PR DESCRIPTION
## Context

We want to start validating an auto-documentation workflow without creating noise for the team.

Customer-facing feature PRs can be merged without an easy follow-up signal for whether the docs also need to change. This PR adds a low-noise dry-run intake for merged `feat:` / `feat(...)` PRs so we can test that signal before enabling any visible documentation automation.

## Summary

This updates the `auto-docs` workflow to send safe PR metadata to the configured docs webhook when a feature PR is merged. It also keeps a manual `workflow_dispatch` path so we can test the flow with a specific PR number.

The workflow follows the existing webhook-based automation pattern, but keeps this first phase intentionally conservative: it does not create comments, labels, issues, docs PRs, reviewer assignments, or team notifications.

<details>
<summary>Implementation details</summary>

The workflow:

- triggers on merged `feat:` / `feat(...)` PRs
- supports manual testing with a PR number
- fetches PR metadata through the GitHub API
- builds a webhook payload with repository, PR number, title, description, author, merged timestamp, and PR URL
- sends the payload to the configured Val Town webhook
- authenticates the request with `DOC_WEBHOOK_SECRET`

Because this repo accepts public contributions and the workflow needs secrets, it uses `pull_request_target`. The workflow does not check out PR code or execute code from the PR branch; it only reads PR metadata and forwards it to the webhook.

</details>

<details>
<summary>Safety notes</summary>

This version keeps the workflow read-only from GitHub’s side:

- `contents: read`
- `pull-requests: read`

</details>

## How to test

1. Add the required repository secrets:
   - `DOC_WEBHOOK_URL`
   - `DOC_WEBHOOK_SECRET`

2. Run the workflow manually from the Actions tab with a test PR number.

3. Confirm the Val Town webhook receives the payload.

4. Confirm the workflow does not create GitHub comments, labels, PRs, reviewer assignments, or team notifications.