### PR TITLE
fix(cli): handle broken symlinks and junctions for config directories on Windows

### DIFF
--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -5,6 +5,7 @@ import os from "os"
 import { Context, Effect, Layer } from "effect"
 import { Flock } from "./util/flock"
 import { markNoIndex } from "./kilocode/spotlight" // kilocode_change
+import { ensureRealDir } from "./kilocode/global" // kilocode_change
 import { Flag } from "./flag/flag"
 
 const app = "kilo" // kilocode_change
@@ -42,12 +43,12 @@ export const Path = paths
 Flock.setGlobal({ state })
 
 await Promise.all([
-  fs.mkdir(Path.data, { recursive: true }),
-  fs.mkdir(Path.config, { recursive: true }),
-  fs.mkdir(Path.state, { recursive: true }),
-  fs.mkdir(Path.tmp, { recursive: true }),
-  fs.mkdir(Path.log, { recursive: true }),
-  fs.mkdir(Path.bin, { recursive: true }),
+  ensureRealDir(Path.data), // kilocode_change
+  ensureRealDir(Path.config), // kilocode_change
+  ensureRealDir(Path.state), // kilocode_change
+  ensureRealDir(Path.tmp), // kilocode_change
+  ensureRealDir(Path.log), // kilocode_change
+  ensureRealDir(Path.bin), // kilocode_change
 ])
 
 // kilocode_change start - keep generated Kilo data out of macOS Spotlight

--- a/packages/core/src/kilocode/global.ts
+++ b/packages/core/src/kilocode/global.ts
@@ -1,0 +1,20 @@
+import fs from "fs/promises"
+
+/**
+ * Like `fs.mkdir({ recursive: true })` but also repairs broken symlinks and
+ * junctions whose target no longer exists (a Windows edge-case where the user
+ * had a junction at e.g. `~/.kilocode` pointing to a deleted directory).
+ *
+ * `fs.mkdir({ recursive: true })` silently no-ops when a junction exists even
+ * if its target is gone, so subsequent writes inside that path fail with ENOENT.
+ * We detect this by calling `fs.stat` (which follows the symlink/junction) after
+ * mkdir: if stat fails the entry is broken and we remove + recreate it.
+ */
+export async function ensureRealDir(p: string) {
+  await fs.mkdir(p, { recursive: true }).catch(() => {})
+  const ok = await fs.stat(p).then(() => true).catch(() => false)
+  if (!ok) {
+    await fs.rm(p, { force: true }).catch(() => {})
+    await fs.mkdir(p, { recursive: true })
+  }
+}

--- a/packages/core/src/kilocode/global.ts
+++ b/packages/core/src/kilocode/global.ts
@@ -11,10 +11,10 @@ import fs from "fs/promises"
  * mkdir: if stat fails the entry is broken and we remove + recreate it.
  */
 export async function ensureRealDir(p: string) {
-  await fs.mkdir(p, { recursive: true }).catch(() => {})
+  await fs.mkdir(p, { recursive: true })
   const ok = await fs.stat(p).then(() => true).catch(() => false)
   if (!ok) {
-    await fs.rm(p, { force: true }).catch(() => {})
+    await fs.rm(p, { force: true })
     await fs.mkdir(p, { recursive: true })
   }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -544,7 +544,7 @@ export const layer = Layer.effect(
           )
           .pipe(
             Effect.catchIf(
-              (e) => e.reason._tag === "PermissionDenied",
+              (e) => e.reason._tag === "PermissionDenied" || e.reason._tag === "NotFound", // kilocode_change - also ignore NotFound (broken symlink/junction on Windows)
               () => Effect.void,
             ),
           )


### PR DESCRIPTION
https://github.com/Kilo-Org/kilocode/issues/9511#issuecomment-4408669972

## Context

On Windows, a user's `~/.kilocode` directory was a junction (directory symlink) pointing to a deleted target. This caused a fatal crash at startup because writing `.gitignore` into the broken junction failed with `ENOENT`, which `Effect.orDie` converted into a process-killing defect.

## Implementation

Two targeted fixes:

**New file `packages/core/src/kilocode/global.ts`** — adds `ensureRealDir()`, a drop-in replacement for `fs.mkdir({ recursive: true })` that also repairs broken junctions. After `mkdir`, it calls `fs.stat()` (which follows symlinks/junctions) to verify the directory is actually accessible. If `stat` fails, the entry is a broken junction or dangling symlink — it is removed with `fs.rm` and recreated as a real directory. The logic lives in a Kilo-owned file to minimize the upstream diff.

**`packages/core/src/global.ts`** — replaces the 6 bare `fs.mkdir` calls with `ensureRealDir` via a single new import and inline `// kilocode_change` markers. The upstream file shape is unchanged apart from those markers.

**`packages/opencode/src/config/config.ts`** — extends the `Effect.catchIf` predicate in `ensureGitignore` to also ignore `NotFound` errors (alongside the existing `PermissionDenied`). This is a belt-and-suspenders guard: user-discovered `.kilocode` dirs are not created by `global.ts`, so a broken junction there would still reach this write.

## Screenshots

| before | after |
|---|---|
| Fatal crash on startup when `~/.kilocode` is a broken Windows junction | Startup succeeds; broken junction is repaired automatically for core dirs, silently skipped for user config dirs |

## How to Test

1. On Windows, create a junction at `%APPDATA%\kilo` or `%USERPROFILE%\.kilocode` pointing to a non-existent directory:
   ```
   mklink /J C:\Users\<user>\.kilocode C:\non\existent\path
   ```
2. Launch Kilo — it should start without crashing; `.kilocode` (or `%APPDATA%\kilo`) will be replaced by a real directory.
3. Previously this produced: `PlatformError message=NotFound: FileSystem.writeFile (...\.gitignore)` and a fatal exit.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->