### PR TITLE
Normalize proxy env for Remote-SSH backend spawns

### DIFF
--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -272,7 +272,7 @@ type EnvMap = Record<string, string | undefined>
 function normalizeProxyUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   if (!trimmed) return undefined
-  return trimmed.replace(/\/$/, "")
+  return trimmed.replace(/\/+$/, "")
 }
 
 /**
@@ -287,7 +287,9 @@ function normalizeProxyUrl(value: string | undefined): string | undefined {
 export function normalizeProxyEnv<T extends EnvMap>(env: T): T {
   const next = { ...env }
   const httpProxy = normalizeProxyUrl(next.http_proxy) ?? normalizeProxyUrl(next.HTTP_PROXY)
-  const httpsProxy = normalizeProxyUrl(next.https_proxy) ?? normalizeProxyUrl(next.HTTPS_PROXY) ?? httpProxy
+  const hasHttpsProxyKey = "https_proxy" in next || "HTTPS_PROXY" in next
+  const httpsProxy =
+    normalizeProxyUrl(next.https_proxy) ?? normalizeProxyUrl(next.HTTPS_PROXY) ?? (hasHttpsProxyKey ? undefined : httpProxy)
   const allProxy = normalizeProxyUrl(next.all_proxy) ?? normalizeProxyUrl(next.ALL_PROXY)
   const noProxy = next.no_proxy?.trim() || next.NO_PROXY?.trim() || undefined
 

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -99,7 +99,7 @@ export class ServerManager {
       const proxyStrictSSL = vscode.workspace.getConfiguration("http").get<boolean>("proxyStrictSSL", true)
       const serverProcess = spawn(cliPath, ["serve", "--port", "0"], {
         cwd: spawnCwd,
-        env: {
+        env: normalizeProxyEnv({
           NODE_USE_SYSTEM_CA: "1",
           ...(extraCaCerts && { NODE_EXTRA_CA_CERTS: extraCaCerts }),
           ...(!proxyStrictSSL && { NODE_TLS_REJECT_UNAUTHORIZED: "0" }),
@@ -110,6 +110,10 @@ export class ServerManager {
           // HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars that Bun's fetch and
           // most HTTP clients already respect.
           ...buildProxyEnv(),
+          // Remote-SSH may provide only one casing or only http_proxy in the
+          // extension host environment. Normalize the final child env after
+          // merging process.env and VS Code settings so HTTPS streaming clients
+          // see the proxy variables they expect.
           // Force mimalloc (the allocator Bun ships with) to return freed pages
           // to the OS immediately instead of retaining them in its arenas.
           // Without this, Bun.spawn's piped stdio accumulates ~2 MB of native
@@ -131,7 +135,7 @@ export class ServerManager {
           KILO_VSCODE_VERSION: vscode.version,
           KILOCODE_EDITOR_NAME: `${vscode.env.appName} ${vscode.version}`,
           ...(!claudeCompat && { KILO_DISABLE_CLAUDE_CODE: "true" }),
-        },
+        }),
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       })
@@ -261,6 +265,50 @@ export class ServerStartupError extends Error {
 
 function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, "")
+}
+
+type EnvMap = Record<string, string | undefined>
+
+function normalizeProxyUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) return undefined
+  return trimmed.replace(/\/$/, "")
+}
+
+/**
+ * Normalize proxy-related environment variables before spawning the CLI backend.
+ *
+ * VS Code Remote-SSH can expose only one proxy casing (for example, lowercase
+ * `http_proxy`) in the extension host environment. HTTPS streaming clients in
+ * the bundled CLI may look for `https_proxy`/`HTTPS_PROXY` instead, so mirror
+ * the non-empty values across common lowercase/uppercase variants after all
+ * process.env and VS Code `http.proxy` settings have been merged.
+ */
+export function normalizeProxyEnv<T extends EnvMap>(env: T): T {
+  const next = { ...env }
+  const httpProxy = normalizeProxyUrl(next.http_proxy) ?? normalizeProxyUrl(next.HTTP_PROXY)
+  const httpsProxy = normalizeProxyUrl(next.https_proxy) ?? normalizeProxyUrl(next.HTTPS_PROXY) ?? httpProxy
+  const allProxy = normalizeProxyUrl(next.all_proxy) ?? normalizeProxyUrl(next.ALL_PROXY)
+  const noProxy = next.no_proxy?.trim() || next.NO_PROXY?.trim() || undefined
+
+  if (httpProxy) {
+    next.http_proxy = httpProxy
+    next.HTTP_PROXY = httpProxy
+  }
+  if (httpsProxy) {
+    next.https_proxy = httpsProxy
+    next.HTTPS_PROXY = httpsProxy
+  }
+  if (allProxy) {
+    next.all_proxy = allProxy
+    next.ALL_PROXY = allProxy
+  }
+  if (noProxy) {
+    next.no_proxy = noProxy
+    next.NO_PROXY = noProxy
+  }
+
+  return next as T
 }
 
 /**

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "bun:test"
 import * as vscode from "vscode"
-import { buildProxyEnv } from "../../src/services/cli-backend/server-manager"
+import { buildProxyEnv, normalizeProxyEnv } from "../../src/services/cli-backend/server-manager"
 
 type Info = { globalValue?: unknown; workspaceValue?: unknown; workspaceFolderValue?: unknown }
 type WorkspaceStub = {
@@ -133,6 +133,54 @@ describe("buildProxyEnv", () => {
       http_proxy: "",
       https_proxy: "",
       no_proxy: "",
+    })
+  })
+})
+
+describe("normalizeProxyEnv", () => {
+  it("mirrors a Remote-SSH lowercase http_proxy into HTTPS and uppercase variants", () => {
+    expect(normalizeProxyEnv({ http_proxy: "http://127.0.0.1:58119/" })).toEqual({
+      HTTP_PROXY: "http://127.0.0.1:58119",
+      HTTPS_PROXY: "http://127.0.0.1:58119",
+      http_proxy: "http://127.0.0.1:58119",
+      https_proxy: "http://127.0.0.1:58119",
+    })
+  })
+
+  it("mirrors uppercase HTTPS and ALL proxy values into lowercase variants", () => {
+    expect(
+      normalizeProxyEnv({
+        HTTPS_PROXY: "http://proxy.corp.example:8443/",
+        ALL_PROXY: "socks5h://127.0.0.1:58120/",
+      }),
+    ).toEqual({
+      HTTPS_PROXY: "http://proxy.corp.example:8443",
+      https_proxy: "http://proxy.corp.example:8443",
+      ALL_PROXY: "socks5h://127.0.0.1:58120",
+      all_proxy: "socks5h://127.0.0.1:58120",
+    })
+  })
+
+  it("mirrors no_proxy casing without URL normalization", () => {
+    expect(normalizeProxyEnv({ no_proxy: "localhost,127.0.0.1,10.0.0.0/8" })).toEqual({
+      NO_PROXY: "localhost,127.0.0.1,10.0.0.0/8",
+      no_proxy: "localhost,127.0.0.1,10.0.0.0/8",
+    })
+  })
+
+  it("preserves explicit empty proxy clears", () => {
+    expect(
+      normalizeProxyEnv({
+        HTTP_PROXY: "",
+        HTTPS_PROXY: "",
+        http_proxy: "",
+        https_proxy: "",
+      }),
+    ).toEqual({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      http_proxy: "",
+      https_proxy: "",
     })
   })
 })

--- a/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-proxy-env.test.ts
@@ -139,7 +139,7 @@ describe("buildProxyEnv", () => {
 
 describe("normalizeProxyEnv", () => {
   it("mirrors a Remote-SSH lowercase http_proxy into HTTPS and uppercase variants", () => {
-    expect(normalizeProxyEnv({ http_proxy: "http://127.0.0.1:58119/" })).toEqual({
+    expect(normalizeProxyEnv({ http_proxy: "http://127.0.0.1:58119//" })).toEqual({
       HTTP_PROXY: "http://127.0.0.1:58119",
       HTTPS_PROXY: "http://127.0.0.1:58119",
       http_proxy: "http://127.0.0.1:58119",
@@ -180,6 +180,21 @@ describe("normalizeProxyEnv", () => {
       HTTP_PROXY: "",
       HTTPS_PROXY: "",
       http_proxy: "",
+      https_proxy: "",
+    })
+  })
+
+  it("does not derive HTTPS from ambient HTTP proxy when HTTPS proxy was explicitly cleared", () => {
+    expect(
+      normalizeProxyEnv({
+        http_proxy: "http://ambient.example:3128",
+        HTTPS_PROXY: "",
+        https_proxy: "",
+      }),
+    ).toEqual({
+      HTTP_PROXY: "http://ambient.example:3128",
+      http_proxy: "http://ambient.example:3128",
+      HTTPS_PROXY: "",
       https_proxy: "",
     })
   })


### PR DESCRIPTION
## Summary

Normalize proxy-related environment variables before spawning the bundled `kilo serve` backend from the VS Code extension.

Remote-SSH extension hosts can expose only one proxy casing/value (for example lowercase `http_proxy`) to `process.env`. If the backend child only receives `http_proxy`, HTTPS streaming clients may miss `https_proxy` / `HTTPS_PROXY` and fail behind local/corporate proxies.

This patch mirrors non-empty proxy values across common lowercase/uppercase variants after merging `process.env` and VS Code `http.proxy` settings:

- `http_proxy` <-> `HTTP_PROXY`
- `https_proxy` <-> `HTTPS_PROXY`, deriving from HTTP proxy when HTTPS proxy is missing
- `all_proxy` <-> `ALL_PROXY`
- `no_proxy` <-> `NO_PROXY`

It also strips a trailing slash from proxy URLs to avoid `http://127.0.0.1:58119/` vs `http://127.0.0.1:58119` inconsistencies.

## Why

Fixes/addresses #10086.

## Testing

- Added unit coverage in `tests/unit/server-manager-proxy-env.test.ts` for:
  - Remote-SSH-style lowercase-only `http_proxy`
  - uppercase HTTPS/ALL proxy mirroring
  - `no_proxy` casing mirroring
  - preserving explicit empty proxy clears
- Locally ran an equivalent JS behavior check for the normalization cases.

Not run: `bun test tests/unit/server-manager-proxy-env.test.ts` because the current container does not have `bun` installed (`/bin/bash: bun: command not found`).
