### PR TITLE
feat(vscode): implement agent model and variant override dropdowns in VSCode settings

### DIFF
--- a/.changeset/agent-variant-override.md
+++ b/.changeset/agent-variant-override.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support choosing agent model and variant overrides from dropdowns.

--- a/packages/kilo-vscode/tests/unit/config-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/config-utils.test.ts
@@ -330,6 +330,29 @@ describe("ConfigState", () => {
     })
   })
 
+  describe("clearing an agent variant override", () => {
+    it("keeps null in the draft so the backend receives a delete sentinel", () => {
+      const s = new ConfigState()
+      s.handleConfigLoaded({
+        agent: {
+          explore: {
+            model: "kilo/anthropic/claude-sonnet-4-6",
+            variant: "high",
+          },
+        },
+      })
+
+      s.updateConfig({ agent: { explore: { variant: null } } })
+
+      expect(s.config.agent?.explore?.variant).toBeUndefined()
+      expect(s.dirty).toBe(true)
+      expect(s.draft.agent?.explore?.variant).toBeNull()
+      expect(JSON.parse(JSON.stringify(s.draft))).toEqual({
+        agent: { explore: { variant: null } },
+      })
+    })
+  })
+
   describe("agent permission patches", () => {
     it("merges nested per-agent permission patches into existing rules", () => {
       const s = new ConfigState()

--- a/packages/kilo-vscode/tests/unit/mode-model.test.ts
+++ b/packages/kilo-vscode/tests/unit/mode-model.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test"
+
+import { modelPatch } from "../../webview-ui/src/components/settings/mode-model"
+
+describe("modelPatch", () => {
+  it("clears model and variant together", () => {
+    expect(modelPatch("", "", [], "high")).toEqual({ model: null, variant: null })
+  })
+
+  it("keeps current variant when next model supports it", () => {
+    expect(modelPatch("kilo", "anthropic/claude-sonnet-4-6", ["low", "high"], "high")).toEqual({
+      model: "kilo/anthropic/claude-sonnet-4-6",
+    })
+  })
+
+  it("clears stale variant when next model does not support it", () => {
+    expect(modelPatch("kilo", "anthropic/claude-sonnet-4-6", ["low", "medium"], "high")).toEqual({
+      model: "kilo/anthropic/claude-sonnet-4-6",
+      variant: null,
+    })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModeEditView.tsx
@@ -6,12 +6,17 @@ import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 
 import { useConfig } from "../../context/config"
+import { useProvider } from "../../context/provider"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { AgentConfig, AgentInfo, PermissionConfig, PermissionRuleItem } from "../../types/messages"
+import { parseModelString } from "../../../../src/shared/provider-model"
 import SettingsRow from "./SettingsRow"
 import { buildExport } from "./mode-io"
+import { modelPatch } from "./mode-model"
 import PermissionEditor from "./PermissionEditor"
+import { ModelSelectorBase } from "../shared/ModelSelector"
+import { ThinkingSelectorBase } from "../shared/ThinkingSelector"
 
 interface Props {
   name: string
@@ -22,6 +27,7 @@ interface Props {
 const ModeEditView: Component<Props> = (props) => {
   const language = useLanguage()
   const { config, updateConfig } = useConfig()
+  const provider = useProvider()
   const session = useSession()
 
   // agent() may be undefined for modes that only exist in the config draft (just
@@ -32,6 +38,13 @@ const ModeEditView: Component<Props> = (props) => {
   const [expanded, setExpanded] = createSignal(false)
 
   const cfg = createMemo<AgentConfig>(() => config().agent?.[props.name] ?? {})
+  const model = createMemo(() => parseModelString(cfg().model ?? undefined))
+  const variants = createMemo(() => {
+    const sel = model()
+    if (!sel) return []
+    return Object.keys(provider.findModel(sel)?.variants ?? {})
+  })
+  const showVariant = () => variants().length > 0 || !!cfg().variant
 
   const update = (partial: Partial<AgentConfig>) => {
     const existing = config().agent ?? {}
@@ -42,6 +55,20 @@ const ModeEditView: Component<Props> = (props) => {
         [props.name]: { ...current, ...partial },
       },
     })
+  }
+
+  const selectModel = (providerID: string, modelID: string) => {
+    const sel = { providerID, modelID }
+    const list = Object.keys(provider.findModel(sel)?.variants ?? {})
+    update(modelPatch(providerID, modelID, list, cfg().variant))
+  }
+
+  const selectVariant = (value: string) => {
+    update({ variant: value })
+  }
+
+  const clearVariant = () => {
+    update({ variant: null })
   }
 
   const updatePermission = (patch: PermissionConfig) => {
@@ -147,12 +174,32 @@ const ModeEditView: Component<Props> = (props) => {
           title={language.t("settings.agentBehaviour.modelOverride.title")}
           description={language.t("settings.agentBehaviour.modelOverride.description")}
         >
-          <TextField
-            value={cfg().model ?? ""}
-            placeholder="e.g. anthropic/claude-sonnet-4-20250514"
-            onChange={(val) => update({ model: val || null })}
+          <ModelSelectorBase
+            value={model()}
+            onSelect={selectModel}
+            placement="bottom-start"
+            allowClear
+            clearLabel={language.t("settings.providers.notSet")}
           />
         </SettingsRow>
+
+        <Show when={showVariant()}>
+          <SettingsRow
+            title={language.t("settings.agentBehaviour.variantOverride.title")}
+            description={language.t("settings.agentBehaviour.variantOverride.description")}
+          >
+            <ThinkingSelectorBase
+              variants={variants()}
+              value={cfg().variant ?? undefined}
+              onSelect={selectVariant}
+              onClear={clearVariant}
+              allowClear
+              clearLabel={language.t("settings.providers.notSet")}
+              placement="bottom-start"
+              globalTrigger={false}
+            />
+          </SettingsRow>
+        </Show>
 
         <SettingsRow
           title={language.t("settings.agentBehaviour.temperature.title")}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/mode-model.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/mode-model.ts
@@ -1,0 +1,17 @@
+import type { AgentConfig } from "../../types/messages"
+
+export function modelPatch(
+  providerID: string,
+  modelID: string,
+  variants: string[],
+  current?: string | null,
+): Partial<AgentConfig> {
+  if (!providerID || !modelID) {
+    return { model: null, variant: null }
+  }
+
+  return {
+    model: `${providerID}/${modelID}`,
+    ...(current && !variants.includes(current) ? { variant: null } : {}),
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -23,14 +23,32 @@ export interface ThinkingSelectorBaseProps {
   value: string | undefined
   /** Called when the user picks a variant */
   onSelect: (value: string) => void
+  /** Called when the user clears selection via default row. */
+  onClear?: () => void
+  /** Include default/unset row at top. */
+  allowClear?: boolean
+  /** Label for default/unset row. */
+  clearLabel?: string
+  /** Popover placement — defaults to top-start. */
+  placement?: "top-start" | "bottom-start" | "bottom-end" | "top-end"
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
+  /** Listen for the global prompt trigger event. Defaults to true. */
+  globalTrigger?: boolean
 }
 
 export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [focused, setFocused] = createSignal(-1)
   let listRef: HTMLDivElement | undefined
+
+  const rows = () => (props.allowClear ? [undefined, ...props.variants] : props.variants)
+  const clearLabel = () => props.clearLabel ?? "Not set"
+
+  function display(value: string | undefined) {
+    if (!value) return clearLabel()
+    return value.charAt(0).toUpperCase() + value.slice(1)
+  }
 
   function focusItem(idx: number) {
     const items = listRef?.querySelectorAll<HTMLElement>("[role=option]")
@@ -47,7 +65,8 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
   function onOpen(val: boolean) {
     setOpen(val)
     if (val) {
-      const idx = props.variants.findIndex((v) => v === props.value)
+      const items = rows()
+      const idx = items.findIndex((v) => v === props.value)
       requestAnimationFrame(() => focusItem(idx >= 0 ? idx : 0))
       return
     }
@@ -55,20 +74,29 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
   }
 
   const onTrigger = () => {
-    if (props.variants.length === 0) return
+    if (rows().length === 0) return
     onOpen(true)
   }
-  window.addEventListener("openVariantPicker", onTrigger)
-  onCleanup(() => window.removeEventListener("openVariantPicker", onTrigger))
+  if (props.globalTrigger ?? true) {
+    window.addEventListener("openVariantPicker", onTrigger)
+    onCleanup(() => window.removeEventListener("openVariantPicker", onTrigger))
+  }
 
-  function pick(value: string) {
+  function pick(value: string | undefined) {
+    if (value === undefined) {
+      props.onClear?.()
+      onOpen(false)
+      return
+    }
     props.onSelect(value)
     onOpen(false)
   }
 
   function onKeyDown(e: KeyboardEvent) {
-    const len = props.variants.length
+    const items = rows()
+    const len = items.length
     const cur = focused()
+    if (len === 0) return
     if (e.key === "ArrowDown") {
       e.preventDefault()
       focusItem((cur + 1) % len)
@@ -91,7 +119,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
     }
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault()
-      if (cur >= 0 && cur < len) pick(props.variants[cur])
+      if (cur >= 0 && cur < len) pick(items[cur])
       return
     }
     if (e.key === "Escape") {
@@ -101,16 +129,11 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
     }
   }
 
-  const label = () => {
-    const v = props.value
-    return v ? v.charAt(0).toUpperCase() + v.slice(1) : ""
-  }
-
   return (
-    <Show when={props.variants.length > 0}>
+    <Show when={rows().length > 0}>
       <PopupSelector
         expanded={false}
-        placement="top-start"
+        placement={props.placement ?? "top-start"}
         preferredWidth={180}
         minHeight={100}
         deferDismiss={props.deferDismiss}
@@ -120,7 +143,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
         triggerProps={{ variant: "ghost", size: "small" }}
         trigger={
           <>
-            <span class="thinking-selector-trigger-label">{label()}</span>
+            <span class="thinking-selector-trigger-label">{display(props.value)}</span>
             <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style={{ "flex-shrink": "0" }}>
               <path d="M8 4l4 5H4l4-5z" />
             </svg>
@@ -135,7 +158,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
             onKeyDown={onKeyDown}
             style={bodyH() !== undefined ? { "max-height": `${bodyH()}px` } : {}}
           >
-            <For each={props.variants}>
+            <For each={rows()}>
               {(v, i) => (
                 <div
                   class={`thinking-selector-item${props.value === v ? " selected" : ""}`}
@@ -145,7 +168,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
                   onClick={() => pick(v)}
                   onFocus={() => setFocused(i())}
                 >
-                  <span class="thinking-selector-item-name">{v.charAt(0).toUpperCase() + v.slice(1)}</span>
+                  <span class="thinking-selector-item-name">{display(v)}</span>
                 </div>
               )}
             </For>

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1228,6 +1228,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "اختر وكيلاً للتهيئة…",
   "settings.agentBehaviour.modelOverride.title": "تجاوز النموذج",
   "settings.agentBehaviour.modelOverride.description": "تجاوز النموذج الافتراضي لهذا الوكيل",
+  "settings.agentBehaviour.variantOverride.title": "تجاوز المتغير",
+  "settings.agentBehaviour.variantOverride.description": "تجاوز متغير النموذج لهذا الوكيل",
   "settings.agentBehaviour.prompt.title": "موجه مخصص",
   "settings.agentBehaviour.prompt.description": "موجه نظام إضافي لهذا الوكيل",
   "settings.agentBehaviour.temperature.title": "الحرارة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1257,6 +1257,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Selecionar um agente para configurar…",
   "settings.agentBehaviour.modelOverride.title": "Substituição de modelo",
   "settings.agentBehaviour.modelOverride.description": "Substituir o modelo padrão para este agente",
+  "settings.agentBehaviour.variantOverride.title": "Substituição de variante",
+  "settings.agentBehaviour.variantOverride.description": "Substituir a variante do modelo para este agente",
   "settings.agentBehaviour.prompt.title": "Prompt personalizado",
   "settings.agentBehaviour.prompt.description": "Prompt de sistema adicional para este agente",
   "settings.agentBehaviour.temperature.title": "Temperatura",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1257,6 +1257,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Odaberi agenta za konfiguraciju…",
   "settings.agentBehaviour.modelOverride.title": "Zamjena modela",
   "settings.agentBehaviour.modelOverride.description": "Zamijeni zadani model za ovog agenta",
+  "settings.agentBehaviour.variantOverride.title": "Zamjena varijante",
+  "settings.agentBehaviour.variantOverride.description": "Zamijeni varijantu modela za ovog agenta",
   "settings.agentBehaviour.prompt.title": "Prilagođeni prompt",
   "settings.agentBehaviour.prompt.description": "Dodatni sistemski prompt za ovog agenta",
   "settings.agentBehaviour.temperature.title": "Temperatura",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1250,6 +1250,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Vælg en agent at konfigurere…",
   "settings.agentBehaviour.modelOverride.title": "Modeloverstyring",
   "settings.agentBehaviour.modelOverride.description": "Tilsidesæt standardmodellen for denne agent",
+  "settings.agentBehaviour.variantOverride.title": "Variantoverstyring",
+  "settings.agentBehaviour.variantOverride.description": "Tilsidesæt modelvarianten for denne agent",
   "settings.agentBehaviour.prompt.title": "Brugerdefineret prompt",
   "settings.agentBehaviour.prompt.description": "Yderligere systemprompt for denne agent",
   "settings.agentBehaviour.temperature.title": "Temperatur",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1273,6 +1273,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Agent zum Konfigurieren auswählen…",
   "settings.agentBehaviour.modelOverride.title": "Modell-Überschreibung",
   "settings.agentBehaviour.modelOverride.description": "Standardmodell für diesen Agent überschreiben",
+  "settings.agentBehaviour.variantOverride.title": "Varianten-Überschreibung",
+  "settings.agentBehaviour.variantOverride.description": "Modellvariante für diesen Agent überschreiben",
   "settings.agentBehaviour.prompt.title": "Benutzerdefinierter Prompt",
   "settings.agentBehaviour.prompt.description": "Zusätzlicher System-Prompt für diesen Agent",
   "settings.agentBehaviour.temperature.title": "Temperatur",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1242,6 +1242,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Select an agent to configure…",
   "settings.agentBehaviour.modelOverride.title": "Model Override",
   "settings.agentBehaviour.modelOverride.description": "Override the default model for this agent",
+  "settings.agentBehaviour.variantOverride.title": "Variant Override",
+  "settings.agentBehaviour.variantOverride.description": "Override the model variant for this agent",
   "settings.agentBehaviour.prompt.title": "Custom Prompt",
   "settings.agentBehaviour.prompt.description": "Additional system prompt for this agent",
   "settings.agentBehaviour.temperature.title": "Temperature",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1264,6 +1264,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Seleccionar un agente para configurar…",
   "settings.agentBehaviour.modelOverride.title": "Anulación de modelo",
   "settings.agentBehaviour.modelOverride.description": "Anular el modelo predeterminado para este agente",
+  "settings.agentBehaviour.variantOverride.title": "Anulación de variante",
+  "settings.agentBehaviour.variantOverride.description": "Anular la variante del modelo para este agente",
   "settings.agentBehaviour.prompt.title": "Prompt personalizado",
   "settings.agentBehaviour.prompt.description": "Prompt de sistema adicional para este agente",
   "settings.agentBehaviour.temperature.title": "Temperatura",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1277,6 +1277,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Sélectionner un agent à configurer…",
   "settings.agentBehaviour.modelOverride.title": "Remplacement du modèle",
   "settings.agentBehaviour.modelOverride.description": "Remplacer le modèle par défaut pour cet agent",
+  "settings.agentBehaviour.variantOverride.title": "Remplacement de la variante",
+  "settings.agentBehaviour.variantOverride.description": "Remplacer la variante du modèle pour cet agent",
   "settings.agentBehaviour.prompt.title": "Prompt personnalisé",
   "settings.agentBehaviour.prompt.description": "Prompt système supplémentaire pour cet agent",
   "settings.agentBehaviour.temperature.title": "Température",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1245,6 +1245,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "設定するエージェントを選択…",
   "settings.agentBehaviour.modelOverride.title": "モデルオーバーライド",
   "settings.agentBehaviour.modelOverride.description": "このエージェントのデフォルトモデルを上書き",
+  "settings.agentBehaviour.variantOverride.title": "バリアントオーバーライド",
+  "settings.agentBehaviour.variantOverride.description": "このエージェントのモデルバリアントを上書き",
   "settings.agentBehaviour.prompt.title": "カスタムプロンプト",
   "settings.agentBehaviour.prompt.description": "このエージェントの追加システムプロンプト",
   "settings.agentBehaviour.temperature.title": "温度",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1239,6 +1239,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "구성할 에이전트를 선택하세요…",
   "settings.agentBehaviour.modelOverride.title": "모델 재정의",
   "settings.agentBehaviour.modelOverride.description": "이 에이전트의 기본 모델 재정의",
+  "settings.agentBehaviour.variantOverride.title": "변형 재정의",
+  "settings.agentBehaviour.variantOverride.description": "이 에이전트의 모델 변형 재정의",
   "settings.agentBehaviour.prompt.title": "사용자 정의 프롬프트",
   "settings.agentBehaviour.prompt.description": "이 에이전트의 추가 시스템 프롬프트",
   "settings.agentBehaviour.temperature.title": "온도",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1258,6 +1258,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Selecteer een agent om te configureren…",
   "settings.agentBehaviour.modelOverride.title": "Model Overschrijven",
   "settings.agentBehaviour.modelOverride.description": "Overschrijf het standaard model voor deze agent",
+  "settings.agentBehaviour.variantOverride.title": "Variant Overschrijven",
+  "settings.agentBehaviour.variantOverride.description": "Overschrijf de modelvariant voor deze agent",
   "settings.agentBehaviour.prompt.title": "Aangepaste Prompt",
   "settings.agentBehaviour.prompt.description": "Aanvullende systeem prompt voor deze agent",
   "settings.agentBehaviour.temperature.title": "Temperatuur",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1250,6 +1250,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Velg en agent å konfigurere…",
   "settings.agentBehaviour.modelOverride.title": "Modelloverstying",
   "settings.agentBehaviour.modelOverride.description": "Overstyr standardmodellen for denne agenten",
+  "settings.agentBehaviour.variantOverride.title": "Variantoverstyring",
+  "settings.agentBehaviour.variantOverride.description": "Overstyr modellvarianten for denne agenten",
   "settings.agentBehaviour.prompt.title": "Egendefinert prompt",
   "settings.agentBehaviour.prompt.description": "Ekstra systemprompt for denne agenten",
   "settings.agentBehaviour.temperature.title": "Temperatur",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1250,6 +1250,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Wybierz agenta do konfiguracji…",
   "settings.agentBehaviour.modelOverride.title": "Nadpisanie modelu",
   "settings.agentBehaviour.modelOverride.description": "Nadpisz domyślny model dla tego agenta",
+  "settings.agentBehaviour.variantOverride.title": "Nadpisanie wariantu",
+  "settings.agentBehaviour.variantOverride.description": "Nadpisz wariant modelu dla tego agenta",
   "settings.agentBehaviour.prompt.title": "Niestandardowy prompt",
   "settings.agentBehaviour.prompt.description": "Dodatkowy prompt systemowy dla tego agenta",
   "settings.agentBehaviour.temperature.title": "Temperatura",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1253,6 +1253,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Выберите агента для настройки…",
   "settings.agentBehaviour.modelOverride.title": "Переопределение модели",
   "settings.agentBehaviour.modelOverride.description": "Переопределить модель по умолчанию для этого агента",
+  "settings.agentBehaviour.variantOverride.title": "Переопределение варианта",
+  "settings.agentBehaviour.variantOverride.description": "Переопределить вариант модели для этого агента",
   "settings.agentBehaviour.prompt.title": "Пользовательский промпт",
   "settings.agentBehaviour.prompt.description": "Дополнительный системный промпт для этого агента",
   "settings.agentBehaviour.temperature.title": "Температура",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1236,6 +1236,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "เลือกเอเจนต์เพื่อกำหนดค่า…",
   "settings.agentBehaviour.modelOverride.title": "แทนที่โมเดล",
   "settings.agentBehaviour.modelOverride.description": "แทนที่โมเดลเริ่มต้นของเอเจนต์นี้",
+  "settings.agentBehaviour.variantOverride.title": "แทนที่ตัวแปรโมเดล",
+  "settings.agentBehaviour.variantOverride.description": "แทนที่ตัวแปรของโมเดลสำหรับเอเจนต์นี้",
   "settings.agentBehaviour.prompt.title": "พรอมต์กำหนดเอง",
   "settings.agentBehaviour.prompt.description": "พรอมต์ระบบเพิ่มเติมสำหรับเอเจนต์นี้",
   "settings.agentBehaviour.temperature.title": "อุณหภูมิ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1250,6 +1250,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Yapılandırmak için bir ajan seçin…",
   "settings.agentBehaviour.modelOverride.title": "Model Geçersiz Kılma",
   "settings.agentBehaviour.modelOverride.description": "Bu ajan için varsayılan modeli geçersiz kıl",
+  "settings.agentBehaviour.variantOverride.title": "Varyant Geçersiz Kılma",
+  "settings.agentBehaviour.variantOverride.description": "Bu ajan için model varyantını geçersiz kıl",
   "settings.agentBehaviour.prompt.title": "Özel Komut",
   "settings.agentBehaviour.prompt.description": "Bu ajan için ek sistem komutu",
   "settings.agentBehaviour.temperature.title": "Sıcaklık",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1250,6 +1250,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "Виберіть агента для налаштування…",
   "settings.agentBehaviour.modelOverride.title": "Перевизначення моделі",
   "settings.agentBehaviour.modelOverride.description": "Перевизначити стандартну модель для цього агента",
+  "settings.agentBehaviour.variantOverride.title": "Перевизначення варіанту",
+  "settings.agentBehaviour.variantOverride.description": "Перевизначити варіант моделі для цього агента",
   "settings.agentBehaviour.prompt.title": "Власний запит",
   "settings.agentBehaviour.prompt.description": "Додатковий системний запит для цього агента",
   "settings.agentBehaviour.temperature.title": "Температура",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1218,6 +1218,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "选择要配置的智能体…",
   "settings.agentBehaviour.modelOverride.title": "模型覆盖",
   "settings.agentBehaviour.modelOverride.description": "覆盖此智能体的默认模型",
+  "settings.agentBehaviour.variantOverride.title": "模型变体覆盖",
+  "settings.agentBehaviour.variantOverride.description": "覆盖此智能体的模型变体",
   "settings.agentBehaviour.prompt.title": "自定义提示词",
   "settings.agentBehaviour.prompt.description": "此智能体的附加系统提示词",
   "settings.agentBehaviour.temperature.title": "温度",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1187,6 +1187,8 @@ export const dict = {
   "settings.agentBehaviour.selectAgent.description": "選擇要設定的 Agent…",
   "settings.agentBehaviour.modelOverride.title": "模型覆寫",
   "settings.agentBehaviour.modelOverride.description": "覆寫此 Agent 的預設模型",
+  "settings.agentBehaviour.variantOverride.title": "模型變體覆寫",
+  "settings.agentBehaviour.variantOverride.description": "覆寫此 Agent 的模型變體",
   "settings.agentBehaviour.prompt.title": "自訂提示詞",
   "settings.agentBehaviour.prompt.description": "此 Agent 的附加系統提示詞",
   "settings.agentBehaviour.temperature.title": "溫度",

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -76,6 +76,11 @@ const MOCK_PROVIDERS = {
         inputPrice: 0.003,
         outputPrice: 0.015,
         limit: { context: 200000, output: 8192 },
+        variants: {
+          low: { reasoningEffort: "low" },
+          medium: { reasoningEffort: "medium" },
+          high: { reasoningEffort: "high" },
+        },
       },
     },
   },

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -126,7 +126,8 @@ export const AgentBehaviourEditCustomMode: Story = {
       reviewer: {
         description: "Review code for quality and best practices",
         prompt: "You are a code reviewer. Focus on code quality, best practices, and potential bugs.",
-        model: "anthropic/claude-sonnet-4-20250514",
+        model: "kilo/anthropic/claude-sonnet-4-6",
+        variant: "high",
         temperature: 0.3,
         permission: {
           read: "allow",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agents.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agents.ts
@@ -30,6 +30,7 @@ export interface AgentInfo {
 
 export interface AgentConfig {
   model?: string | null
+  variant?: string | null
   prompt?: string | null
   description?: string | null
   mode?: "subagent" | "primary" | "all"


### PR DESCRIPTION
## Context

Currently, users cannot configure the model variants in the Agent Behavior settings page, and the model names are a plain text field, not a dropdown.

## Implementation

Reuse the model and variant dropdown components we use in other locations within the Agent Behavior settings, to provide a way for users to change these settings permanently that is consistent with other UX.

## Screenshots

<img width="891" height="465" alt="Screenshot_20260509_011048" src="https://github.com/user-attachments/assets/b9bf5fe8-8ba1-451f-9437-6150c28f59a4" />

<img width="882" height="544" alt="Screenshot_20260509_011108" src="https://github.com/user-attachments/assets/843812af-5816-4eb0-b44d-010875fe171f" />

<img width="882" height="544" alt="Screenshot_20260509_011121" src="https://github.com/user-attachments/assets/6fbafcc7-c210-4234-940f-343e61a10bc5" />


## Get in Touch

ExpedientFalcon on Discord