### PR TITLE
feat: customizable webview font family via Display settings

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -690,6 +690,11 @@
     "configuration": {
       "title": "Kilo Code",
       "properties": {
+        "kilo-code.new.fontFamily": {
+          "type": "string",
+          "default": "",
+          "description": "Font family for Kilo Code webview UI. Overrides the default VS Code font. Leave empty to use the VS Code editor font."
+        },
         "kilo-code.new.language": {
           "type": "string",
           "default": "",

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import { buildWebviewHtml, getWebviewFontSize } from "./utils"
+import { buildWebviewHtml, getFontFamilyConfig, getWebviewFontSize } from "./utils"
 import { watchFontSizeConfig } from "./kilo-provider/font-size"
 import { appendOutput, getWorkspaceRoot } from "./review-utils"
 import { getDiffMarkdownRender, setDiffMarkdownRender } from "./review-settings"
@@ -114,6 +114,7 @@ export class DiffVirtualProvider implements vscode.Disposable {
       styleUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "diff-virtual.css")),
       iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
       title: "Diff Virtual",
+      fontFamily: getFontFamilyConfig(),
       extraStyles: "#root { display: flex; flex-direction: column; height: 100%; }",
     })
   }

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { buildWebviewHtml, getFontFamilyConfig, getWebviewFontSize } from "./utils"
 import { watchFontSizeConfig } from "./kilo-provider/font-size"
+import { watchFontFamilyConfig } from "./kilo-provider/font-family"
 import { appendOutput, getWorkspaceRoot } from "./review-utils"
 import { getDiffMarkdownRender, setDiffMarkdownRender } from "./review-settings"
 
@@ -57,7 +58,9 @@ export class DiffVirtualProvider implements vscode.Disposable {
     panel.webview.html = this.getHtml(panel.webview)
     panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg))
     this.fontConfigDisposable?.dispose()
-    this.fontConfigDisposable = watchFontSizeConfig((msg) => this.post(msg))
+    const font = watchFontSizeConfig((msg) => this.post(msg))
+    const fontFamily = watchFontFamilyConfig((msg) => this.post(msg))
+    this.fontConfigDisposable = vscode.Disposable.from(font, fontFamily)
     panel.onDidDispose(() => {
       this.log("Panel disposed")
       this.fontConfigDisposable?.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -15,7 +15,7 @@ import { type KiloConnectionService, ServerStartupError } from "./services/cli-b
 import type { EditorContext, IndexingStatus } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
-import { buildWebviewHtml, getWebviewFontSize } from "./utils"
+import { buildWebviewHtml, getFontFamilyConfig, getWebviewFontSize } from "./utils"
 import { saveImage } from "./kilo-provider/save-image"
 import {
   TelemetryProxy,
@@ -57,6 +57,7 @@ import { handleSidebarWorktreeMessage } from "./kilo-provider/sidebar-worktree"
 import { parseMessageFiles, type MessageFile } from "./kilo-provider/message-files"
 import { handleFileSearch } from "./kilo-provider/file-search"
 import { watchFontSizeConfig } from "./kilo-provider/font-size"
+import { watchFontFamilyConfig } from "./kilo-provider/font-family"
 import { getTerminalContents } from "./services/terminal/context"
 import { disposeGitChangesTarget } from "./kilo-provider/git-changes-target"
 import { interceptMessage } from "./kilo-provider/git-changes-request"
@@ -1114,6 +1115,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
     })
     this.webviewMessageDisposable = watchFontSizeConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
+    this.webviewMessageDisposable = watchFontFamilyConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
   }
 
   private openExternal(url: unknown): void {
@@ -1270,6 +1272,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           vscodeLanguage: vscode.env.language,
           languageOverride: langConfig.get<string>("language"),
           fontSize: getWebviewFontSize(),
+          fontFamily: langConfig.get<string>("fontFamily") ?? "",
           workspaceDirectory: this.getProjectDirectory(this.currentSession?.id),
         })
       }
@@ -3370,6 +3373,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       iconsBaseUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
       title: "Kilo Code",
       port: this.connectionService.getServerInfo()?.port,
+      fontFamily: getFontFamilyConfig(),
       extraStyles: `.container { height: 100%; display: flex; flex-direction: column; height: 100vh; border-right: 1px solid var(--border-weak-base); }`,
     })
   }

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -10,7 +10,7 @@ import type { Host, PanelContext, OutputHandle, SessionProvider, Disposable } fr
 import type { KiloConnectionService } from "../services/cli-backend"
 import { KiloProvider } from "../KiloProvider"
 import { DiffVirtualProvider } from "../DiffVirtualProvider"
-import { buildWebviewHtml } from "../utils"
+import { buildWebviewHtml, getFontFamilyConfig } from "../utils"
 import { openFileInEditor, getWorkspaceRoot } from "../review-utils"
 import { TelemetryProxy, type TelemetryEventName } from "../services/telemetry"
 import type { AutoApproveController } from "../commands/toggle-auto-approve"
@@ -82,6 +82,7 @@ export class VscodeHost implements Host {
       iconsBaseUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "assets", "icons")),
       title: "Agent Manager",
       port,
+      fontFamily: getFontFamilyConfig(),
     })
 
     const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {

--- a/packages/kilo-vscode/src/kilo-provider/font-family.ts
+++ b/packages/kilo-vscode/src/kilo-provider/font-family.ts
@@ -1,0 +1,13 @@
+import * as vscode from "vscode"
+import { getFontFamilyConfig } from "../utils"
+
+export function watchFontFamilyConfig(
+  post: (msg: { type: "fontFamilyChanged"; fontFamily: string }) => void,
+  next?: vscode.Disposable,
+) {
+  const font = vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration("kilo-code.new.fontFamily"))
+      post({ type: "fontFamilyChanged", fontFamily: getFontFamilyConfig() })
+  })
+  return next ? vscode.Disposable.from(font, next) : font
+}

--- a/packages/kilo-vscode/src/kiloclaw/KiloClawProvider.ts
+++ b/packages/kilo-vscode/src/kiloclaw/KiloClawProvider.ts
@@ -14,7 +14,7 @@ import * as vscode from "vscode"
 import { homedir } from "os"
 import type { KiloConnectionService } from "../services/cli-backend"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
-import { buildWebviewHtml } from "../utils"
+import { buildWebviewHtml, getFontFamilyConfig } from "../utils"
 import { watchFontSizeConfig } from "../kilo-provider/font-size"
 import { TokenManager } from "./token-manager"
 import { KiloChatApiError, KiloChatClient } from "./kilo-chat-client"
@@ -145,6 +145,7 @@ export class KiloClawProvider implements vscode.Disposable {
       styleUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.uri, "dist", "kiloclaw.css")),
       iconsBaseUri: panel.webview.asWebviewUri(vscode.Uri.joinPath(this.uri, "assets", "icons")),
       title: "KiloClaw",
+      fontFamily: getFontFamilyConfig(),
     })
 
     const msgSub = panel.webview.onDidReceiveMessage((msg: KiloClawInMessage) => this.onMessage(msg))

--- a/packages/kilo-vscode/src/kiloclaw/KiloClawProvider.ts
+++ b/packages/kilo-vscode/src/kiloclaw/KiloClawProvider.ts
@@ -16,6 +16,7 @@ import type { KiloConnectionService } from "../services/cli-backend"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import { buildWebviewHtml, getFontFamilyConfig } from "../utils"
 import { watchFontSizeConfig } from "../kilo-provider/font-size"
+import { watchFontFamilyConfig } from "../kilo-provider/font-family"
 import { TokenManager } from "./token-manager"
 import { KiloChatApiError, KiloChatClient } from "./kilo-chat-client"
 import { EventServiceClient, WebSocketAuthError } from "./event-service-client"
@@ -174,6 +175,8 @@ export class KiloClawProvider implements vscode.Disposable {
     this.subs.push(unsub)
     const font = watchFontSizeConfig((msg) => this.post(msg))
     this.subs.push(() => font.dispose())
+    const fontFamily = watchFontFamilyConfig((msg) => this.post(msg))
+    this.subs.push(() => fontFamily.dispose())
   }
 
   private post(msg: KiloClawOutMessage): void {

--- a/packages/kilo-vscode/src/kiloclaw/types.ts
+++ b/packages/kilo-vscode/src/kiloclaw/types.ts
@@ -308,3 +308,4 @@ export type KiloClawOutMessage =
   | { type: "kiloclaw.typing"; conversationId: string; memberId: string }
   | { type: "kiloclaw.typingStop"; conversationId: string; memberId: string }
   | { type: "fontSizeChanged"; fontSize: number }
+  | { type: "fontFamilyChanged"; fontFamily: string }

--- a/packages/kilo-vscode/src/utils.ts
+++ b/packages/kilo-vscode/src/utils.ts
@@ -11,6 +11,11 @@ export function getFontFamilyConfig(): string {
   return vscode.workspace.getConfiguration("kilo-code.new").get<string>("fontFamily") ?? ""
 }
 
+/** Escapes a font family name for safe CSS injection (single quotes, angle brackets, backslashes). */
+function sanitizeFontFamily(name: string): string {
+  return name.replace(/\\/g, "\\\\").replace(/'/g, "\\'").replace(/</g, "\\3c ")
+}
+
 const SIZES = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 
 function clamp(size: number) {
@@ -51,7 +56,7 @@ export function buildWebviewHtml(
   const nonce = getNonce()
   const csp = buildCspString(webview.cspSource, nonce, opts.port)
   const fontFamilyCss = opts.fontFamily
-    ? `\n    :root { --vscode-font-family: '${opts.fontFamily}', sans-serif; }`
+    ? `\n    :root { --vscode-font-family: '${sanitizeFontFamily(opts.fontFamily)}', sans-serif; }`
     : ""
   const extraStyles = [opts.extraStyles, fontFamilyCss].filter(Boolean).join("\n")
 

--- a/packages/kilo-vscode/src/utils.ts
+++ b/packages/kilo-vscode/src/utils.ts
@@ -6,6 +6,11 @@ function getNonce(): string {
   return crypto.randomBytes(16).toString("hex")
 }
 
+/** Reads the kilo-code.new.fontFamily VS Code setting and returns it, or empty string if not set. */
+export function getFontFamilyConfig(): string {
+  return vscode.workspace.getConfiguration("kilo-code.new").get<string>("fontFamily") ?? ""
+}
+
 const SIZES = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 
 function clamp(size: number) {
@@ -40,10 +45,15 @@ export function buildWebviewHtml(
     title: string
     port?: number
     extraStyles?: string
+    fontFamily?: string
   },
 ): string {
   const nonce = getNonce()
   const csp = buildCspString(webview.cspSource, nonce, opts.port)
+  const fontFamilyCss = opts.fontFamily
+    ? `\n    :root { --vscode-font-family: '${opts.fontFamily}', sans-serif; }`
+    : ""
+  const extraStyles = [opts.extraStyles, fontFamilyCss].filter(Boolean).join("\n")
 
   return `<!DOCTYPE html>
 <html lang="en" data-theme="kilo-vscode">
@@ -76,7 +86,7 @@ export function buildWebviewHtml(
     }
     #root {
       height: 100%;
-    }${opts.extraStyles ? `\n    ${opts.extraStyles}` : ""}
+    }${extraStyles ? `\n    ${extraStyles}` : ""}
   </style>
 </head>
 <body>

--- a/packages/kilo-vscode/webview-ui/kiloclaw/context/claw.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/context/claw.tsx
@@ -181,6 +181,15 @@ export function ClawProvider(props: { children: JSX.Element }) {
       applyFontSize(msg.fontSize)
       return
     }
+    if (msg?.type === "fontFamilyChanged") {
+      const root = document.documentElement
+      if (msg.fontFamily) {
+        root.style.setProperty("--vscode-font-family", `'${msg.fontFamily.replace(/'/g, "\\'")}', sans-serif`)
+      } else {
+        root.style.removeProperty("--vscode-font-family")
+      }
+      return
+    }
     if (!msg?.type?.startsWith("kiloclaw.")) return
     const active = activeConversationId()
     if (handleConversationMessage(msg, active)) return

--- a/packages/kilo-vscode/webview-ui/kiloclaw/lib/types.ts
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/lib/types.ts
@@ -154,6 +154,7 @@ export type KiloClawOutMessage =
   | { type: "kiloclaw.typing"; conversationId: string; memberId: string }
   | { type: "kiloclaw.typingStop"; conversationId: string; memberId: string }
   | { type: "fontSizeChanged"; fontSize: number }
+  | { type: "fontFamilyChanged"; fontFamily: string }
 
 // Note: messages sent from the webview to the extension host are typed in
 // src/kiloclaw/types.ts (KiloClawInMessage). The webview dispatches them

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -85,6 +85,19 @@ const DisplayTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.display.fontFamily.title")}
+          description={language.t("settings.display.fontFamily.description")}
+        >
+          <div style={{ width: "200px" }}>
+            <TextField
+              value={display.fontFamily()}
+              placeholder="Editor Font"
+              onChange={(val) => display.setFontFamily(val.trim())}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.display.reasoningAutoCollapse.title")}
           description={language.t("settings.display.reasoningAutoCollapse.description")}
         >

--- a/packages/kilo-vscode/webview-ui/src/context/display.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/display.tsx
@@ -16,7 +16,8 @@ import { applyFontSize, clampFontSize, readFontSize } from "../font-size"
 function applyFontFamily(family: string) {
   const root = document.documentElement
   if (family) {
-    root.style.setProperty("--vscode-font-family", `'${family}', sans-serif`)
+    const escaped = family.replace(/'/g, "\\'")
+    root.style.setProperty("--vscode-font-family", `'${escaped}', sans-serif`)
   } else {
     root.style.removeProperty("--vscode-font-family")
   }

--- a/packages/kilo-vscode/webview-ui/src/context/display.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/display.tsx
@@ -13,11 +13,22 @@ import { useVSCode } from "./vscode"
 import type { ExtensionMessage } from "../types/messages"
 import { applyFontSize, clampFontSize, readFontSize } from "../font-size"
 
+function applyFontFamily(family: string) {
+  const root = document.documentElement
+  if (family) {
+    root.style.setProperty("--vscode-font-family", `'${family}', sans-serif`)
+  } else {
+    root.style.removeProperty("--vscode-font-family")
+  }
+}
+
 interface DisplayContextValue {
   reasoningAutoCollapse: Accessor<boolean>
   setReasoningAutoCollapse: (collapse: boolean) => void
   fontSize: Accessor<number>
   setFontSize: (size: number) => void
+  fontFamily: Accessor<string>
+  setFontFamily: (family: string) => void
 }
 
 export const DisplayContext = createContext<DisplayContextValue>()
@@ -27,14 +38,21 @@ export const DisplayProvider: ParentComponent = (props) => {
   const vscode = useVSCode()
   const reasoningAutoCollapse = createMemo(() => config().auto_collapse_reasoning ?? false)
   const [fontSize, setFontSizeSignal] = createSignal(readFontSize())
+  const [fontFamily, setFontFamilySignal] = createSignal("")
 
   const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "ready" && message.fontSize !== undefined) setFontSizeSignal(clampFontSize(message.fontSize))
     if (message.type === "fontSizeChanged") setFontSizeSignal(clampFontSize(message.fontSize))
+    if (message.type === "ready" && message.fontFamily !== undefined) setFontFamilySignal(message.fontFamily)
+    if (message.type === "fontFamilyChanged") setFontFamilySignal(message.fontFamily)
   })
 
   createEffect(() => {
     applyFontSize(fontSize())
+  })
+
+  createEffect(() => {
+    applyFontFamily(fontFamily())
   })
 
   onCleanup(unsubscribe)
@@ -49,6 +67,11 @@ export const DisplayProvider: ParentComponent = (props) => {
           const next = clampFontSize(size)
           setFontSizeSignal(next)
           vscode.postMessage({ type: "updateSetting", key: "fontSize", value: next })
+        },
+        fontFamily,
+        setFontFamily: (family) => {
+          setFontFamilySignal(family)
+          vscode.postMessage({ type: "updateSetting", key: "fontFamily", value: family })
         },
       }}
     >

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1415,6 +1415,8 @@ export const dict = {
   "settings.display.layout.stretch": "Stretch",
   "settings.display.fontSize.title": "Font Size",
   "settings.display.fontSize.description": "Adjust the Kilo webview UI font size independently from VS Code.",
+  "settings.display.fontFamily.title": "Font Family",
+  "settings.display.fontFamily.description": "Override the webview font family. Leave empty to use the VS Code editor font.",
   "settings.display.reasoningAutoCollapse.title": "Auto-Collapse Reasoning",
   "settings.display.reasoningAutoCollapse.description":
     "Collapse reasoning blocks after the agent finishes writing them. Leave off to keep reasoning expanded unless you collapse it manually.",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -48,12 +48,18 @@ export interface ReadyMessage {
   vscodeLanguage?: string
   languageOverride?: string
   fontSize?: number
+  fontFamily?: string
   workspaceDirectory?: string
 }
 
 export interface FontSizeChangedMessage {
   type: "fontSizeChanged"
   fontSize: number
+}
+
+export interface FontFamilyChangedMessage {
+  type: "fontFamilyChanged"
+  fontFamily: string
 }
 
 export interface GitStatusMessage {
@@ -884,6 +890,7 @@ export interface RemoteStatusMessage {
 export type ExtensionMessage =
   | ReadyMessage
   | FontSizeChangedMessage
+  | FontFamilyChangedMessage
   | GitStatusMessage
   | ConnectionStateMessage
   | ErrorMessage


### PR DESCRIPTION
## Summary

Adds a **Font Family** text field to the Kilo Code Settings > Display tab, so users can customize the webview font without editing VS Code settings.json.

![Display tab with Font Family field]

## Changes

- **Display tab** — new TextField for font family, placeholder "Editor Font"
- **Reactive apply** — font changes take effect immediately via `createEffect` setting `--vscode-font-family` on `:root`
- **Cross-webview sync** — changing the setting broadcasts to all open webviews
- **Extension** — `watchFontFamilyConfig` for config change detection, included in `ready` message
- **Webview HTML** — `buildWebviewHtml` accepts optional `fontFamily` param for initial render
- **package.json** — `kilo-code.new.fontFamily` config contribution (type: string, default: empty)

## Behavior

- Empty (default) → uses the VS Code editor font
- Filled (e.g. "Fira Code") → overrides webview font family

## Related

Follow-up to the initial `fontFamily` config contribution.