### PR TITLE
fix(core): always deny tool calls for system agents

### DIFF
--- a/.changeset/fast-monkeys-smoke.md
+++ b/.changeset/fast-monkeys-smoke.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Always deny tool calls for title, summarize, and compaction

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -410,6 +410,8 @@ export const layer = Layer.effect(
           )
         }
 
+        KiloAgent.hardenSystemAgents(agents) // kilocode_change - keep system utility agents deny-only after config merges
+
         const get = Effect.fnUntraced(function* (agent: string) {
           return agents[KiloAgent.resolveKey(agent)] // kilocode_change - treat "build" as "code"
         })

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -268,6 +268,32 @@ export function processConfigItem(item: {
   }
 }
 
+const locked = new Set(["compaction", "title", "summary"])
+
+function hardRules() {
+  return Permission.fromConfig({
+    "*": "deny",
+  })
+}
+
+export function harden(item?: { name: string; permission: Permission.Ruleset }) {
+  if (!item) return
+  if (!locked.has(item.name)) return
+  item.permission = hardRules()
+}
+
+export function hardenSystemAgents<T extends { name: string; permission: Permission.Ruleset }>(
+  agents: Record<string, T>,
+) {
+  for (const [key, item] of Object.entries(agents)) {
+    if (locked.has(key)) {
+      item.permission = hardRules()
+      continue
+    }
+    harden(item)
+  }
+}
+
 // Returns experimental_telemetry config for generate calls.
 // AI SDK span recording (ai.* / gen_ai.*) is disabled.
 export function telemetryOptions(_cfg: Config.Info) {
@@ -445,6 +471,8 @@ export function patchAgents(
     mode: "primary",
     native: true,
   }
+
+  hardenSystemAgents(agents)
 }
 
 export const RemoveError = NamedError.create(

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -73,3 +73,71 @@ test("plan agent still hard-denies non-plan edits after user edit allow", async 
     },
   })
 })
+
+test("system utility agents ignore per-agent permission allows", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        title: {
+          permission: {
+            bash: "allow",
+          },
+        },
+        summary: {
+          permission: {
+            read: "allow",
+          },
+        },
+        compaction: {
+          permission: {
+            skill: "allow",
+          },
+        },
+      },
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const title = await load(tmp.path, (svc) => svc.get("title"))
+      const summary = await load(tmp.path, (svc) => svc.get("summary"))
+      const compaction = await load(tmp.path, (svc) => svc.get("compaction"))
+      expect(title).toBeDefined()
+      expect(summary).toBeDefined()
+      expect(compaction).toBeDefined()
+      expect(Permission.evaluate("bash", "*", title!.permission).action).toBe("deny")
+      expect(Permission.evaluate("read", "*", summary!.permission).action).toBe("deny")
+      expect(Permission.evaluate("skill", "using-superpowers", compaction!.permission).action).toBe("deny")
+    },
+  })
+})
+
+test("system utility agents deny tools after configured name override", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        title: {
+          name: "custom-title",
+          permission: {
+            bash: "allow",
+            read: "allow",
+            skill: "allow",
+          },
+        },
+      },
+    },
+  })
+
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const title = await load(tmp.path, (svc) => svc.get("title"))
+      expect(title).toBeDefined()
+      expect(title?.name).toBe("custom-title")
+      expect(Permission.evaluate("bash", "*", title!.permission).action).toBe("deny")
+      expect(Permission.evaluate("read", "README.md", title!.permission).action).toBe("deny")
+      expect(Permission.evaluate("skill", "using-superpowers", title!.permission).action).toBe("deny")
+    },
+  })
+})


### PR DESCRIPTION
## Context

The Title agent would frequently attempt to make tool calls, even though its system prompt tells it not to do so. This resulted in a broken title generation. This was traced back to top-level user allow rules overriding the `deny: "*"` rule for these agents.

## Implementation

Hardcode `deny: "*"` for the Title, Summarize, and Compaction agents. Although this issue was most noticeable for the Title agent, it's possible it was impacting Summarize and Compaction as well, and it seems reasonable to deny tools to those agents as well, since they have no reason to be making tool calls in any situation.

## Get in Touch

ExpedientFalcon on Discord
