### PR TITLE
fix: prevent memory leak in KiloSessionPromptQueue.cancel for sessions without active tails

### DIFF
--- a/.changeset/session-prompt-queue-memory-leak.md
+++ b/.changeset/session-prompt-queue-memory-leak.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent memory leak in KiloSessionPromptQueue.cancel for sessions without active tails

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -27,6 +27,10 @@ export namespace KiloSessionPromptQueue {
   const activeSince = new Map<SessionID, number>()
   let seq = 0
 
+  export function _hasInternalState(sessionID: SessionID): boolean {
+    return versions.has(sessionID) || targets.has(sessionID) || latest.has(sessionID) || activeSince.has(sessionID)
+  }
+
   const version = (sessionID: SessionID) => versions.get(sessionID) ?? 0
   const settle = (promise: Promise<void>) =>
     promise.then(

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -27,6 +27,7 @@ export namespace KiloSessionPromptQueue {
   const activeSince = new Map<SessionID, number>()
   let seq = 0
 
+  /** @internal - test-only helper */
   export function _hasInternalState(sessionID: SessionID): boolean {
     return versions.has(sessionID) || targets.has(sessionID) || latest.has(sessionID) || activeSince.has(sessionID)
   }

--- a/packages/opencode/src/kilocode/session/prompt-queue.ts
+++ b/packages/opencode/src/kilocode/session/prompt-queue.ts
@@ -36,6 +36,13 @@ export namespace KiloSessionPromptQueue {
 
   export function cancel(sessionID: SessionID) {
     return Effect.sync(() => {
+      if (!tails.has(sessionID)) {
+        versions.delete(sessionID)
+        targets.delete(sessionID)
+        latest.delete(sessionID)
+        activeSince.delete(sessionID)
+        return
+      }
       versions.set(sessionID, version(sessionID) + 1)
     })
   }

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -491,6 +491,25 @@ describe("session prompt queue", () => {
     }
   })
 
+  test("cancel on a session with no active tail is a no-op and does not leak state", async () => {
+    const sessionID = SessionID.make("session_cancel_noop")
+
+    await Effect.runPromise(KiloSessionPromptQueue.cancel(sessionID))
+
+    expect(KiloSessionPromptQueue._hasInternalState(sessionID)).toBe(false)
+
+    const result = await Effect.runPromise(
+      KiloSessionPromptQueue.enqueue(
+        sessionID,
+        MessageID.make("message_probe"),
+        Effect.succeed("work executed"),
+        Effect.succeed("cancelled returned"),
+      ),
+    )
+
+    expect(result).toBe("work executed")
+  })
+
   test("cancel drops queued prompts and resets internal state", async () => {
     const ready = Promise.withResolvers<void>()
     const calls: number[] = []


### PR DESCRIPTION
## Context

Fix a memory leak in `KiloSessionPromptQueue.cancel()` where calling cancel on a session with no queued prompts would leave permanent entries in the module-level `versions`, `targets`, `latest`, and `activeSince` maps. This occurred because `cancel()` always incremented and stored a version, but cleanup only happens in `enqueue`'s release phase.

Closes #9211

## Implementation

Modified `cancel()` to check if the session has an active tail before modifying state. If `tails.has(sessionID)` is false, the function now cleans up any existing entries in `versions`, `targets`, `latest`, and `activeSince` maps instead of creating new ones.

```ts
export function cancel(sessionID: SessionID) {
  return Effect.sync(() => {
    if (!tails.has(sessionID)) {
      versions.delete(sessionID)
      targets.delete(sessionID)
      latest.delete(sessionID)
      activeSince.delete(sessionID)
      return
    }
    versions.set(sessionID, version(sessionID) + 1)
  })
}
```

## Get in Touch

Discord: @IamCoder18