### PR TITLE
ux(cli): remove `--dangerously-skip-permissions`

### DIFF
--- a/.changeset/breezy-feet-allow.md
+++ b/.changeset/breezy-feet-allow.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-docs": patch
+"@kilocode/cli": patch
+---
+
+Remove `--dangerously-skip-permissions` CLI flag which did nothing

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
@@ -184,7 +184,6 @@ Options:
       --variant                       model variant (provider-specific reasoning effort, e.g., high, max, minimal)  [string]
       --thinking                      show thinking blocks  [boolean] [default: false]
       --auto                          auto-approve all permissions (for autonomous/pipeline usage)  [boolean] [default: false]
-      --dangerously-skip-permissions  auto-approve permissions that are not explicitly denied (dangerous!)  [boolean] [default: false]
 ```
 
 ## kilo debug

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -295,12 +295,7 @@ export const RunCommand = cmd({
           describe: "auto-approve all permissions (for autonomous/pipeline usage)",
           default: false,
         })
-        // kilocode_change end
-        .option("dangerously-skip-permissions", {
-          type: "boolean",
-          describe: "auto-approve permissions that are not explicitly denied (dangerous!)",
-          default: false,
-        })
+      // kilocode_change end
     )
   },
   handler: async (args) => {


### PR DESCRIPTION
This flag currently does nothing. Presumably, it was recently added by OpenCode upstream, but since Kilo already has the `--auto` flag, the code that would handle `--dangerously-skip-permissions` is wired into `--auto` instead.

Removing this useless flag avoids confusion for users.

## Get in Touch

ExpedientFalcon on Discord
