### PR TITLE
fix(vscode): show session-cumulative token usage

### DIFF
--- a/.changeset/quick-mice-trade.md
+++ b/.changeset/quick-mice-trade.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix token usage display to show usage for entire session

--- a/packages/kilo-vscode/tests/unit/session-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-utils.test.ts
@@ -3,6 +3,7 @@ import {
   computeStatus,
   calcTotalCost,
   calcContextUsage,
+  calcTokenUsage,
   buildFamilyCosts,
   buildFamilyParents,
   buildFamilyLabels,
@@ -138,6 +139,35 @@ describe("calcContextUsage", () => {
     const result = calcContextUsage({ input: 100, output: 0 }, 1000)
     expect(result.tokens).toBe(100)
     expect(result.percentage).toBe(10)
+  })
+})
+
+describe("calcTokenUsage", () => {
+  it("sums assistant message input, output, and cache read tokens", () => {
+    const result = calcTokenUsage([
+      { role: "assistant", tokens: { input: 100, output: 40, reasoning: 8, cache: { read: 10, write: 5 } } },
+      { role: "assistant", tokens: { input: 25, output: 15, cache: { read: 7, write: 3 } } },
+    ])
+
+    expect(result).toEqual({ input: 125, output: 55, cached: 17 })
+  })
+
+  it("ignores user messages, missing tokens, reasoning tokens, and cache writes", () => {
+    const result = calcTokenUsage([
+      { role: "user", tokens: { input: 999, output: 999, cache: { read: 999, write: 999 } } },
+      { role: "assistant" },
+      { role: "assistant", tokens: { input: 10, output: 4, reasoning: 30, cache: { read: 2, write: 20 } } },
+    ])
+
+    expect(result).toEqual({ input: 10, output: 4, cached: 2 })
+  })
+
+  it("returns undefined when there are no displayed token counts", () => {
+    const result = calcTokenUsage([
+      { role: "assistant", tokens: { input: 0, output: 0, reasoning: 12, cache: { read: 0, write: 6 } } },
+    ])
+
+    expect(result).toBeUndefined()
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -14,7 +14,7 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Checkbox } from "@kilocode/kilo-ui/checkbox"
 import { useSession } from "../../context/session"
-import { collapseCostBreakdown } from "../../context/session-utils"
+import { calcTokenUsage, collapseCostBreakdown } from "../../context/session-utils"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { TaskTimeline } from "./TaskTimeline"
@@ -66,18 +66,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     return { tokens, pct }
   })
 
-  // Token breakdown from the last assistant message — only return if at least one value is > 0
-  const tokens = createMemo(() => {
-    const msgs = session.visibleMessages()
-    for (let i = msgs.length - 1; i >= 0; i--) {
-      const m = msgs[i]
-      if (m.role !== "assistant" || !m.tokens) continue
-      const tk = m.tokens
-      const has = tk.input > 0 || tk.output > 0 || (tk.cache?.write ?? 0) > 0 || (tk.cache?.read ?? 0) > 0
-      if (has) return tk
-    }
-    return undefined
-  })
+  const tokens = createMemo(() => calcTokenUsage(session.visibleMessages()))
 
   const hasTimeline = createMemo(() => {
     for (const m of session.visibleMessages()) {
@@ -207,16 +196,10 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                     {fmtNum(tk().output)}
                   </span>
                 </Show>
-                <Show when={tk().cache?.write && tk().cache!.write > 0}>
-                  <span class="task-header-tokens-value">
-                    <Icon name="arrow-up" size="small" />
-                    cache {fmtNum(tk().cache!.write)}
-                  </span>
-                </Show>
-                <Show when={tk().cache?.read && tk().cache!.read > 0}>
+                <Show when={tk().cached > 0}>
                   <span class="task-header-tokens-value">
                     <Icon name="arrow-down-to-line" size="small" />
-                    cache {fmtNum(tk().cache!.read)}
+                    cache {fmtNum(tk().cached)}
                   </span>
                 </Show>
               </div>

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -98,6 +98,35 @@ export function calcContextUsage(
   return { tokens: total, percentage }
 }
 
+export type TokenUsageMessage = {
+  role: string
+  tokens?: {
+    input: number
+    output: number
+    reasoning?: number
+    cache?: { read: number; write: number }
+  }
+}
+
+export function calcTokenUsage(
+  messages: TokenUsageMessage[],
+): { input: number; output: number; cached: number } | undefined {
+  const total = messages.reduce(
+    (sum, m) => {
+      if (m.role !== "assistant" || !m.tokens) return sum
+      return {
+        input: sum.input + m.tokens.input,
+        output: sum.output + m.tokens.output,
+        cached: sum.cached + (m.tokens.cache?.read ?? 0),
+      }
+    },
+    { input: 0, output: 0, cached: 0 },
+  )
+
+  if (total.input > 0 || total.output > 0 || total.cached > 0) return total
+  return undefined
+}
+
 /**
  * Build a map of session ID → **own cost** for each session in the family
  * that has non-zero own cost.


### PR DESCRIPTION
## Context

The VSCode UI currently shows token usage from only the current turn. This is confusing to users and differs from what the CLI shows.

## Implementation

This change updates the token display to show the total token usage for the full session, equivalent to what the CLI shows.

## Screenshots

CLI:

<img width="544" height="427" alt="image" src="https://github.com/user-attachments/assets/a591729c-b98b-42af-aba0-c4b88bfeab2e" />


VSCode Before:

<img width="365" height="119" alt="image" src="https://github.com/user-attachments/assets/a19b35d2-a43c-461b-aa77-ad88a7cb089c" />


VSCode After (matches CLI):

<img width="344" height="121" alt="image" src="https://github.com/user-attachments/assets/72988f73-7fb6-464c-bda1-3c03aca71464" />

## Get in Touch

ExpedientFalcon on Discord
