### PR TITLE
fix(vscode): hide empty task header graph

### DIFF
--- a/.changeset/hide-empty-task-header-graph.md
+++ b/.changeset/hide-empty-task-header-graph.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Hide the task header graph area until timeline data is available.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -78,6 +78,14 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
     return undefined
   })
 
+  const hasTimeline = createMemo(() => {
+    for (const m of session.messages()) {
+      if (m.role !== "assistant") continue
+      if (session.getParts(m.id).some((p) => p.type !== "step-start")) return true
+    }
+    return false
+  })
+
   const fmtNum = (n: number): string => {
     if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
     if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
@@ -166,7 +174,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
         </div>
       </div>
       {/* Expanded graph section: timeline + context bar + token breakdown */}
-      <Show when={expanded() && session.messages().some((m) => m.role === "assistant")}>
+      <Show when={expanded() && hasTimeline()}>
         <div data-component="task-header-graph">
           <TaskTimeline />
           <div data-slot="task-header-graph-row">


### PR DESCRIPTION
Hide the task header graph area until graphable timeline parts are available.
This prevents an empty expanded graph section from appearing while new sessions are still initializing.