### PR TITLE
fix(vscode): stabilize shell command streaming

### DIFF
--- a/.changeset/stable-shell-streaming.md
+++ b/.changeset/stable-shell-streaming.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep shell command blocks stable while output streams so pending animations and expanded state do not reset.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -67,19 +67,26 @@ interface AssistantMessageProps {
   feedback?: MessageFeedbackControls
 }
 
+type ToolStateProps = {
+  input?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+  output?: string
+  status?: string
+}
+
 function TodoToolCard(props: { part: ToolPart }) {
   const render = ToolRegistry.render(props.part.tool)
-  const state = props.part.state as any
+  const state = () => props.part.state as ToolStateProps
   return (
     <Show when={render}>
       {(renderFn) => (
         <Dynamic
           component={renderFn()}
-          input={state?.input ?? {}}
-          metadata={state?.metadata ?? {}}
+          input={state()?.input ?? {}}
+          metadata={state()?.metadata ?? {}}
           tool={props.part.tool}
-          output={state?.output}
-          status={state?.status}
+          output={state()?.output}
+          status={state()?.status}
           defaultOpen
           reveal={false}
         />
@@ -90,23 +97,23 @@ function TodoToolCard(props: { part: ToolPart }) {
 
 function BashToolCard(props: { part: ToolPart; defaultOpen: boolean }) {
   const render = ToolRegistry.render(props.part.tool)
-  const state = props.part.state as any
+  const state = () => props.part.state as ToolStateProps
   return (
     <Show when={render}>
       {(card) => (
         <Dynamic
           component={card() as unknown as Component<Record<string, unknown>>}
-          input={state?.input ?? {}}
-          metadata={state?.metadata ?? {}}
+          input={state()?.input ?? {}}
+          metadata={state()?.metadata ?? {}}
           partMetadata={props.part.metadata ?? {}}
           tool={props.part.tool}
           partID={props.part.id}
           callID={props.part.callID}
-          output={state?.output}
-          status={state?.status}
+          output={state()?.output}
+          status={state()?.status}
           defaultOpen={props.defaultOpen}
           animate
-          reveal={state?.status === "pending" || state?.status === "running"}
+          reveal={state()?.status === "pending" || state()?.status === "running"}
         />
       )}
     </Show>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1192,8 +1192,13 @@ export const SessionProvider: ParentComponent = (props) => {
             // Append text delta to text or reasoning parts
             ;(existing as { text: string }).text += delta.textDelta
           } else {
-            // Replace entire part
-            parts[effectiveMessageID][existingIndex] = part
+            // Preserve the proxy identity so Solid does not remount tool UI
+            // during streaming updates and restart pending animations.
+            const target = existing as unknown as Record<string, unknown>
+            for (const key of Object.keys(target)) {
+              if (!(key in part)) delete target[key]
+            }
+            Object.assign(existing, part)
           }
         } else {
           // Add new part


### PR DESCRIPTION
Fix shell command blocks remounting during streamed tool updates, which restarted pending animations and reset expanded state while output was still arriving.

The webview now preserves the existing reactive part identity for non-text part updates and reads tool state reactively from the shell card so streamed output still updates in place.

To Reproduce: Let the bot run `for i in {1..30}; do printf "stream tick %02d\n" "$i"; sleep 0.2; done`

Before (tool description flickering):
<img width="271" height="105" alt="image" src="https://github.com/user-attachments/assets/53f12ef3-5500-451e-93ee-a66ba4da0aaa" />
After (not flickering):
<img width="634" height="199" alt="image" src="https://github.com/user-attachments/assets/9feb2750-4e4d-44a2-a9c6-0e10794cf170" />
