### PR TITLE
fix(vscode): keep revert checkpoints accessible

### DIFF
--- a/.changeset/revert-checkpoints-stay.md
+++ b/.changeset/revert-checkpoints-stay.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep older revert checkpoints available after reverting a message in the VS Code extension.

--- a/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
+++ b/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+const TURN_FILE = path.join(ROOT, "webview-ui/src/components/chat/VscodeSessionTurn.tsx")
+
+const src = fs.readFileSync(TURN_FILE, "utf-8")
+
+describe("message revert checkpoints", () => {
+  it("keeps revert actions available after a session is already reverted", () => {
+    expect(src).toMatch(/onRevert=\{\s*assistantMessages\(\)\.length > 0\s*\? \(\) =>/)
+    expect(src).not.toMatch(/onRevert=\{[\s\S]*?&& !session\.revert\(\)[\s\S]*?\? \(\) =>/)
+  })
+
+  it("only marks revert disabled while the agent is busy", () => {
+    expect(src).toMatch(/data-revert-disabled=\{\s*assistantMessages\(\)\.length > 0 && session\.status\(\) !== "idle"/)
+    expect(src).not.toMatch(/data-revert-disabled=\{[\s\S]*?!session\.revert\(\)/)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -123,10 +123,10 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
             <div
               class="vscode-session-turn-user"
               data-revert-disabled={
-                assistantMessages().length > 0 && !session.revert() && session.status() !== "idle" ? "" : undefined
+                assistantMessages().length > 0 && session.status() !== "idle" ? "" : undefined
               }
               title={
-                assistantMessages().length > 0 && !session.revert() && session.status() !== "idle"
+                assistantMessages().length > 0 && session.status() !== "idle"
                   ? language.t("revert.disabled.agentBusy")
                   : undefined
               }
@@ -138,7 +138,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                 queued={props.queued}
                 onFork={props.onForkMessage ? () => props.onForkMessage?.(msg().sessionID, msg().id) : undefined}
                 onRevert={
-                  assistantMessages().length > 0 && !session.revert()
+                  assistantMessages().length > 0
                     ? () => {
                         if (session.status() !== "idle") return
                         session.revertSession(msg().id)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -122,9 +122,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
           <Show when={!props.turn.partial}>
             <div
               class="vscode-session-turn-user"
-              data-revert-disabled={
-                assistantMessages().length > 0 && session.status() !== "idle" ? "" : undefined
-              }
+              data-revert-disabled={assistantMessages().length > 0 && session.status() !== "idle" ? "" : undefined}
               title={
                 assistantMessages().length > 0 && session.status() !== "idle"
                   ? language.t("revert.disabled.agentBusy")


### PR DESCRIPTION
Keep VS Code chat revert checkpoints available after a user reverts a message, so users can move to another checkpoint without sending a dummy prompt first.

This removes the active-revert UI gate while preserving the existing busy-state guard, and adds a focused regression test for the message revert action.

Fixes https://github.com/Kilo-Org/kilocode/issues/10115