### PR TITLE
fix(vscode): improve review comment icon contrast

### DIFF
--- a/.changeset/review-plus-contrast.md
+++ b/.changeset/review-plus-contrast.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+---
+
+Improve review comment plus icon contrast in diff viewers.

--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -256,10 +256,7 @@ export function Diff<T>(props: DiffProps<T>) {
     host.removeAttribute("data-color-scheme")
   }
 
-  // Patch a bug in @pierre/diffs where `grid-template-columns: 100% auto` is set
-  // for `line-info-basic` separators under `@media (pointer: fine)`, causing the
-  // expand button to consume 100% of the gutter width and overlap the separator
-  // content text. We inject into `@layer unsafe` which overrides `@layer base`.
+  // Patch Pierre shadow styles for Kilo-specific layout and contrast tweaks.
   let separatorPatchSheet: CSSStyleSheet | null = null
   const patchSeparatorLayout = () => {
     const root = getRoot()
@@ -267,7 +264,7 @@ export function Diff<T>(props: DiffProps<T>) {
     if (!separatorPatchSheet) {
       separatorPatchSheet = new CSSStyleSheet()
       separatorPatchSheet.replaceSync(
-        `@layer unsafe { @media (pointer: fine) { [data-separator='line-info-basic'][data-expand-index] [data-separator-wrapper] { grid-template-columns: 34px auto; } } }`,
+        `@layer unsafe { @media (pointer: fine) { [data-separator='line-info-basic'][data-expand-index] [data-separator-wrapper] { grid-template-columns: 34px auto; } } [data-utility-button] { background-color: var(--vscode-button-background, var(--button-primary-base, var(--icon-interactive-base))); color: var(--vscode-button-foreground, var(--icon-invert-base, #fff)); } }`,
       )
     }
     if (!root.adoptedStyleSheets.includes(separatorPatchSheet))

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1936,8 +1936,8 @@ body.am-wt-dragging-active * {
 
 .am-markdown-comment-button:hover,
 .am-markdown-comment-button:focus-visible {
-  color: var(--text-base);
-  background: var(--surface-interactive-base);
+  color: var(--vscode-button-foreground, var(--icon-invert-base, #fff));
+  background: var(--vscode-button-background, var(--button-primary-base, var(--icon-interactive-base)));
 }
 
 .am-markdown-line-number {


### PR DESCRIPTION
Improve the review comment plus icon contrast in  diff viewer and the standalone diff viewer so the control remains visible over red/deleted diff rows.

This updates both rendered Markdown review gutters and the Pierre diff gutter utility styling to use VS Code button foreground/background tokens with existing Kilo fallbacks.
Before:
4bd3-921a-5b2b68ea442c" />
<img width="358" height="136" alt="image" src="https://github.com/user-attachments/assets/e76224ab-b16a-4bfe-9baf-7bca0ac56e9a" />
After:
<img width="298" height="161" alt="image" src="https://github.com/user-attachments/assets/e08f6c4b-64dd-426c-88b6-1a99977d6556" />
<img width="332" height="167" alt="image" src="https://github.com/user-attachments/assets/669816dc-9fa1-4d79-86f4-7a7eb47d2301" />
<img width="309" height="188" alt="image" src="https://github.com/user-attachments/assets/fc1ebcc4-928d-
<img width="244" height="128" alt="image" src="https://github.com/user-attachments/assets/879a012e-0ac8-4cac-a1e7-256f59e556ef" />
