### PR TITLE
fix(cli): prevent nested subagent delegation

### DIFF
--- a/.changeset/deny-nested-subagents.md
+++ b/.changeset/deny-nested-subagents.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent subagents from spawning nested subagents.

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -24,6 +24,11 @@ export namespace KiloTask {
     if (info.mode === "primary") throw new Error(`Agent "${name}" is a primary agent and cannot be used as a subagent`)
   }
 
+  /** Kilo keeps delegation one level deep to avoid recursive subagent chains. */
+  export function nestedTask(): false {
+    return false
+  }
+
   /**
    * Build inherited permission rules from the calling agent.
    * Merges the static agent definition with the session's accumulated permissions

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -62,7 +62,7 @@ export const TaskTool = Tool.define(
       KiloTask.validate(next, params.subagent_type)
       // kilocode_change end
 
-      const canTask = next.permission.some((rule) => rule.permission === id)
+      const canTask = KiloTask.nestedTask() // kilocode_change - Kilo disallows subagents spawning subagents
       const canTodo = next.permission.some((rule) => rule.permission === "todowrite")
 
       const parent = yield* sessions.get(ctx.sessionID)

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config/config"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Session } from "../../src/session/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, PartID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
+import { Truncate } from "../../src/tool/truncate"
+import { ToolRegistry } from "../../src/tool/registry"
+import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    Config.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Session.defaultLayer,
+    Truncate.defaultLayer,
+    ToolRegistry.defaultLayer,
+  ),
+)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const seed = Effect.fn("NestedTaskToolTest.seed")(function* () {
+  const sessions = yield* Session.Service
+  const chat = yield* sessions.create({ title: "Parent" })
+  const user = yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  const assistant: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+  }
+  yield* sessions.updateMessage(assistant)
+  return { chat, assistant }
+})
+
+function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void }): TaskPromptOps {
+  return {
+    cancel() {},
+    resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+    prompt: (input) =>
+      Effect.sync(() => {
+        opts?.onPrompt?.(input)
+        const id = MessageID.ascending()
+        return {
+          info: {
+            id,
+            role: "assistant",
+            parentID: input.messageID ?? MessageID.ascending(),
+            sessionID: input.sessionID,
+            mode: input.agent ?? "general",
+            agent: input.agent ?? "general",
+            cost: 0,
+            path: { cwd: "/tmp", root: "/tmp" },
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+            finish: "stop",
+          },
+          parts: [
+            {
+              id: PartID.ascending(),
+              messageID: id,
+              sessionID: input.sessionID,
+              type: "text",
+              text: "done",
+            },
+          ],
+        } satisfies MessageV2.WithParts
+      }),
+  }
+}
+
+describe("Kilo task nesting", () => {
+  it.live("disables nested task tool even when global task permission allows it", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const { chat, assistant } = yield* seed()
+          const tool = yield* TaskTool
+          const def = yield* tool.init()
+          let seen: SessionPrompt.PromptInput | undefined
+          const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+          const result = yield* def.execute(
+            {
+              description: "inspect bug",
+              prompt: "look into the cache key path",
+              subagent_type: "explore",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          const child = yield* sessions.get(result.metadata.sessionId)
+          expect(seen?.tools?.task).toBe(false)
+          expect(child.permission).toEqual(
+            expect.arrayContaining([
+              {
+                permission: "task",
+                pattern: "*",
+                action: "deny",
+              },
+            ]),
+          )
+        }),
+      {
+        config: {
+          permission: {
+            task: "allow",
+          },
+        },
+      },
+    ),
+  )
+})

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -102,6 +102,44 @@ function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void 
 }
 
 describe("Kilo task nesting", () => {
+  it.live("allows primary agents to delegate one level to a subagent", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "explore",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const kids = yield* sessions.children(chat.id)
+        expect(kids).toHaveLength(1)
+        expect(kids[0]?.id).toBe(result.metadata.sessionId)
+        expect(kids[0]?.parentID).toBe(chat.id)
+        expect(seen?.sessionID).toBe(result.metadata.sessionId)
+        expect(seen?.agent).toBe("explore")
+      }),
+    ),
+  )
+
   it.live("disables nested task tool even when global task permission allows it", () =>
     provideTmpdirInstance(
       () =>

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -383,6 +383,7 @@ describe("tool.task", () => {
           // kilocode_change end
           expect(seen?.tools).toEqual({
             todowrite: false,
+            task: false, // kilocode_change - Kilo disallows nested subagents
             bash: false,
             read: false,
           })


### PR DESCRIPTION
Fixes the nested-subagent regression that made cost breakdowns explode when a subagent recursively spawned more subagents.

Root cause: #8644 intentionally restored Kilo's flat delegation model by preventing subagents from calling `task`, after #8637 showed recursive delegation could create unbounded chains. That protection was weakened again by the upstream behavior from anomalyco/opencode#8111, where agent/user `task` permissions could make `canTask` true and re-add the task tool to subagent prompts. In practice, a global `task: allow` rule could let `explore` spawn another `explore`, producing a deep nested chain instead of a flat set of sibling subagents.

Why this made the cost UI wrong: backend session costs are propagated upward, so every ancestor stores the total cost of its whole subtree, not just its own LLM usage. For example, with own costs `root=$1`, `A=$2`, `B=$3`, `C=$4` in a chain `root -> A -> B -> C`, the real cost is `$10`. But the stored propagated rows are `root=$10`, `A=$9`, `B=$7`, `C=$4`. A UI that sums those rows displays `$30`, counting `C` four times, `B` three times, and `A` twice.

The reproduced shape was the same failure mode at larger depth: 27 nested subagents with about `$11.79` of actual recorded usage. The visible tooltip rows around `$6.xx` were not individual `explore` costs. They were cumulative subtree totals at successive depths:

- shallow `explore`: includes many descendants below it, around `$6.5`
- next nested `explore`: includes slightly fewer descendants, around `$6.3`
- next nested `explore`: includes slightly fewer again, around `$6.0`
- and so on down the chain

Then the tooltip collapsed 19 older rows into one line. That high collapsed value was the sum of 19 subtree totals, not the sum of 19 own costs. This is why a modest-cost nested chain could display as a much larger total.

The correct breakdown is to subtract child totals from parent totals:

```text
root own = root stored - child stored
A own = A stored - B stored
B own = B stored - C stored
C own = C stored
```

#10134 fixes that webview aggregation after reload by deriving missing parent links and subtracting child totals. This PR prevents the recursive session shape from being created again by ensuring Kilo subagents never receive the `task` tool, even when user or agent config globally allows `task`.

Implementation: keep the shared task-tool diff minimal by routing the Kilo-specific policy through `KiloTask.nestedTask()`. Regression coverage lives in Kilo-owned tests and verifies that `task` remains disabled for subagents even when global config allows it.