### PR TITLE
fix(tool): clarify semantic_search returns snippets not file paths

### DIFF
--- a/.changeset/semantic-search-snippets.md
+++ b/.changeset/semantic-search-snippets.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Clarify that semantic search returns matching code snippets with paths, line ranges, and relevance scores.

--- a/packages/opencode/src/kilocode/tool/semantic-search.txt
+++ b/packages/opencode/src/kilocode/tool/semantic-search.txt
@@ -1,4 +1,5 @@
-- Find files most relevant to the search query using semantic search.
+- Find code snippets most relevant to the search query using semantic search.
+- Returns matching content with file paths, line ranges, and relevance scores.
 - Searches based on meaning rather than exact text matches.
 - By default searches entire workspace, with capability to filter by path.
 

--- a/packages/opencode/test/kilocode/semantic-search.test.ts
+++ b/packages/opencode/test/kilocode/semantic-search.test.ts
@@ -34,6 +34,14 @@ const baseCtx = {
 } satisfies Tool.Context
 
 describe("tool.semantic_search", () => {
+  test("describes code snippet results", async () => {
+    const tool = await initTool()
+
+    expect(tool.description).toContain("Find code snippets most relevant")
+    expect(tool.description).toContain("Returns matching content with file paths, line ranges, and relevance scores")
+    expect(tool.description).not.toContain("Find files most relevant")
+  })
+
   test("throws when query is empty", async () => {
     const tool = await initTool()
     expect(rt.runPromise(tool.execute({ query: "" }, baseCtx))).rejects.toThrow("query is required")


### PR DESCRIPTION
Clarifies the agent-facing `semantic_search` tool description so models understand it returns code snippets with file paths, line ranges, and relevance scores, not only file names.
Adds a regression test and changeset so release notes capture the corrected behavior.

Closes #9767.