### PR TITLE
docs: move Kilo CLI origin to FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Our community is built on respect, inclusivity, and collaboration. Please review
 This project is licensed under the MIT License.
 You’re free to use, modify, and distribute this code, including for commercial purposes as long as you include proper attribution and license notices. See [License](/LICENSE).
 
-### Where did Kilo CLI come from?
+## FAQ
+
+<details>
+<summary>Where did Kilo CLI come from?</summary>
 
 Kilo CLI is a fork of [OpenCode](https://github.com/anomalyco/opencode), enhanced to work within the Kilo agentic engineering platform.
+
+</details>


### PR DESCRIPTION
Added FAQ section with details about Kilo CLI's origin.

## Context

I moved the `Where did Kilo CLI come from?` question in `README.md`  to an new FAQ section. This results in a cleaner readme, with an easy way to add more questions later on.

## Implementation

N/A

## Screenshots

N/A

## How to Test

N/A

## Get in Touch

Discord: `@thomasnow`
