### PR TITLE
fix(cli): resolve packaged tree-sitter wasm paths

### DIFF
--- a/.changeset/tree-sitter-wasm-path.md
+++ b/.changeset/tree-sitter-wasm-path.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Resolve bundled tree-sitter WASM resources from the installed CLI layout so codebase indexing works in packaged CLI and VS Code builds.

--- a/install
+++ b/install
@@ -348,6 +348,10 @@ download_and_install() {
 
     # kilocode_change start
     mv "$tmp_dir/kilo" "$INSTALL_DIR"
+    rm -rf "${INSTALL_DIR}/tree-sitter"
+    if [ -d "$tmp_dir/tree-sitter" ]; then
+        mv "$tmp_dir/tree-sitter" "$INSTALL_DIR"
+    fi
     chmod 755 "${INSTALL_DIR}/kilo"
     # kilocode_change end
     rm -rf "$tmp_dir"

--- a/packages/kilo-indexing/src/tree-sitter/languageParser.ts
+++ b/packages/kilo-indexing/src/tree-sitter/languageParser.ts
@@ -41,7 +41,7 @@ export interface LanguageParser {
   }
 }
 
-function resolveModulePath(specifier: string): string | undefined {
+export function resolveModulePath(specifier: string): string | undefined {
   try {
     return require.resolve(specifier)
   } catch {
@@ -53,7 +53,7 @@ function uniquePaths(paths: Array<string | undefined>): string[] {
   return [...new Set(paths.filter((item): item is string => !!item))]
 }
 
-function wasmDirectories(sourceDirectory?: string): string[] {
+export function wasmDirectories(sourceDirectory?: string): string[] {
   const baseDir = sourceDirectory || __dirname
   const execDir = path.dirname(process.execPath)
   const envDir = process.env.KILO_TREE_SITTER_WASM_DIR
@@ -80,7 +80,7 @@ function resolveFromDirectories(file: string, dirs: string[]): string | undefine
   }
 }
 
-function resolveCoreRuntimeWasmPath(sourceDirectory?: string): string | undefined {
+export function resolveCoreRuntimeWasmPath(sourceDirectory?: string): string | undefined {
   const dirs = wasmDirectories(sourceDirectory)
   const localPath = resolveFromDirectories("tree-sitter.wasm", dirs)
   if (localPath) {
@@ -89,7 +89,7 @@ function resolveCoreRuntimeWasmPath(sourceDirectory?: string): string | undefine
   return resolveModulePath("web-tree-sitter/tree-sitter.wasm")
 }
 
-function resolveLanguageWasmPath(langName: string, sourceDirectory?: string) {
+export function resolveLanguageWasmPath(langName: string, sourceDirectory?: string) {
   const dirs = wasmDirectories(sourceDirectory)
   const fileName = `tree-sitter-${langName}.wasm`
   const wasmPath = resolveFromDirectories(fileName, dirs)

--- a/packages/kilo-indexing/test/kilocode/tree-sitter/wasm-resolution.test.ts
+++ b/packages/kilo-indexing/test/kilocode/tree-sitter/wasm-resolution.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, writeFile } from "fs/promises"
+import { join } from "path"
+import { tmpdir } from "os"
+import { resolveCoreRuntimeWasmPath, resolveLanguageWasmPath } from "../../../src/tree-sitter/languageParser"
+
+const env = "KILO_TREE_SITTER_WASM_DIR"
+const prev = process.env[env]
+
+describe("tree-sitter WASM resolution", () => {
+  afterEach(() => {
+    if (prev === undefined) delete process.env[env]
+    if (prev !== undefined) process.env[env] = prev
+  })
+
+  test("prefers installed CLI tree-sitter resources over module resolution", async () => {
+    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-tree-sitter-wasm-XXXXXX")}`
+      .text()
+      .then((text) => text.trim())
+    try {
+      const dir = join(root, "bin", "tree-sitter")
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, "tree-sitter.wasm"), "runtime")
+      await writeFile(join(dir, "tree-sitter-typescript.wasm"), "language")
+
+      process.env[env] = dir
+
+      expect(resolveCoreRuntimeWasmPath()).toBe(join(dir, "tree-sitter.wasm"))
+      expect(resolveLanguageWasmPath("typescript").wasmPath).toBe(join(dir, "tree-sitter-typescript.wasm"))
+    } finally {
+      await Bun.$`rm -rf ${root}`
+    }
+  })
+})

--- a/packages/kilo-indexing/test/kilocode/tree-sitter/wasm-resolution.test.ts
+++ b/packages/kilo-indexing/test/kilocode/tree-sitter/wasm-resolution.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdir, writeFile } from "fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
 import { join } from "path"
 import { tmpdir } from "os"
 import { resolveCoreRuntimeWasmPath, resolveLanguageWasmPath } from "../../../src/tree-sitter/languageParser"
@@ -14,9 +14,7 @@ describe("tree-sitter WASM resolution", () => {
   })
 
   test("prefers installed CLI tree-sitter resources over module resolution", async () => {
-    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-tree-sitter-wasm-XXXXXX")}`
-      .text()
-      .then((text) => text.trim())
+    const root = await mkdtemp(join(tmpdir(), "kilo-tree-sitter-wasm-"))
     try {
       const dir = join(root, "bin", "tree-sitter")
       await mkdir(dir, { recursive: true })
@@ -28,7 +26,7 @@ describe("tree-sitter WASM resolution", () => {
       expect(resolveCoreRuntimeWasmPath()).toBe(join(dir, "tree-sitter.wasm"))
       expect(resolveLanguageWasmPath("typescript").wasmPath).toBe(join(dir, "tree-sitter-typescript.wasm"))
     } finally {
-      await Bun.$`rm -rf ${root}`
+      await rm(root, { recursive: true, force: true })
     }
   })
 })

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -2,6 +2,7 @@
 import { $ } from "bun"
 import { join } from "node:path"
 import { existsSync, mkdirSync, rmSync, chmodSync } from "node:fs"
+import { copyTreeSitterResources } from "../src/services/cli-backend/cli-resources"
 import { ensureFfmpegForTarget } from "./ffmpeg-helper"
 
 const packageJsonPath = join(import.meta.dir, "..", "package.json")
@@ -75,6 +76,7 @@ for (const config of targets) {
 
   console.log(`  📥 Copying binary from ${config.cliDir}/bin/${config.binary}...`)
   await $`cp ${sourceBinary} ${targetBinary}`
+  await copyTreeSitterResources(sourceBinary, targetBinary)
 
   if (config.binary !== "kilo.exe") {
     chmodSync(targetBinary, 0o755)

--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -2,6 +2,7 @@
 import { $ } from "bun"
 import { join, relative, dirname, basename } from "node:path"
 import { chmodSync, statSync, rmSync, readdirSync, existsSync } from "node:fs"
+import { copyTreeSitterResources, hasTreeSitterResources } from "../src/services/cli-backend/cli-resources"
 import { currentFfmpegTarget, ensureFfmpegForTarget } from "./ffmpeg-helper"
 
 const forceRebuild = process.argv.includes("--force")
@@ -83,6 +84,7 @@ async function findKiloBinaryInOpencodeDist(): Promise<string | null> {
   const preferred = join(distDir, `@kilocode`, tag, "bin", binName)
   try {
     statSync(preferred)
+    if (!hasTreeSitterResources(preferred)) return null
     return preferred
   } catch {
     // fall through to generic search
@@ -108,6 +110,7 @@ async function findKiloBinaryInOpencodeDist(): Promise<string | null> {
         continue
       }
       if (e.isFile() && (e.name === "kilo" || e.name === "kilo.exe") && basename(dirname(p)) === "bin") {
+        if (!hasTreeSitterResources(p)) continue
         return p
       }
     }
@@ -182,6 +185,7 @@ async function main() {
   const sourceBinPath = await ensureBuiltBinary()
   await $`mkdir -p ${targetBinDir}`
   await $`cp ${sourceBinPath} ${targetBinPath}`
+  await copyTreeSitterResources(sourceBinPath, targetBinPath)
   chmodSync(targetBinPath, 0o755)
   await ensureFfmpegForTarget(currentFfmpegTarget(), targetBinDir)
 

--- a/packages/kilo-vscode/script/watch-cli.ts
+++ b/packages/kilo-vscode/script/watch-cli.ts
@@ -9,6 +9,7 @@
 import { watch, chmodSync } from "node:fs"
 import { join, relative } from "node:path"
 import { $ } from "bun"
+import { copyTreeSitterResources } from "../src/services/cli-backend/cli-resources"
 
 const kiloVscodeDir = join(import.meta.dir, "..")
 const packagesDir = join(kiloVscodeDir, "..")
@@ -57,6 +58,7 @@ async function rebuild() {
 
     await $`mkdir -p ${targetBinDir}`
     await $`cp ${source} ${targetBinPath}`
+    await copyTreeSitterResources(source, targetBinPath)
     chmodSync(targetBinPath, 0o755)
 
     const elapsed = ((performance.now() - start) / 1000).toFixed(1)

--- a/packages/kilo-vscode/src/services/cli-backend/cli-resources.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/cli-resources.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs"
+import * as path from "path"
+
+const dir = "tree-sitter"
+const runtime = "tree-sitter.wasm"
+
+function paths(file: string) {
+  if (/^[a-z]:[\\/]/i.test(file) || file.includes("\\")) return path.win32
+  return path
+}
+
+export function treeSitterDirForBinary(file: string): string {
+  const p = paths(file)
+  return p.join(p.dirname(file), dir)
+}
+
+export function treeSitterDirForExtension(root: string): string {
+  return paths(root).join(root, "bin", dir)
+}
+
+export function resolveTreeSitterEnv(root: string): Record<string, string> {
+  return { KILO_TREE_SITTER_WASM_DIR: treeSitterDirForExtension(root) }
+}
+
+export function hasTreeSitterResources(file: string): boolean {
+  return fs.existsSync(path.join(treeSitterDirForBinary(file), runtime))
+}
+
+export async function copyTreeSitterResources(source: string, target: string): Promise<void> {
+  const from = treeSitterDirForBinary(source)
+  const to = treeSitterDirForBinary(target)
+
+  if (!fs.existsSync(path.join(from, runtime))) {
+    throw new Error(`CLI tree-sitter resources not found at ${from}`)
+  }
+
+  await fs.promises.rm(to, { recursive: true, force: true })
+  await fs.promises.cp(from, to, { recursive: true })
+}

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -4,6 +4,7 @@ import * as crypto from "crypto"
 import * as fs from "fs"
 import * as path from "path"
 import * as vscode from "vscode"
+import { resolveTreeSitterEnv } from "./cli-resources"
 import { t } from "./i18n"
 import { parseServerPort } from "./server-utils"
 
@@ -131,6 +132,7 @@ export class ServerManager {
           KILO_VSCODE_VERSION: vscode.version,
           KILOCODE_EDITOR_NAME: `${vscode.env.appName} ${vscode.version}`,
           ...(!claudeCompat && { KILO_DISABLE_CLAUDE_CODE: "true" }),
+          ...resolveTreeSitterEnv(this.context.extensionPath),
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "bun:test"
 import { parseServerPort } from "../../src/services/cli-backend/server-utils"
 import { resolveServerCwd, resolveIndexingEnv, toErrorMessage } from "../../src/services/cli-backend/server-manager"
+import {
+  copyTreeSitterResources,
+  resolveTreeSitterEnv,
+  treeSitterDirForBinary,
+  treeSitterDirForExtension,
+} from "../../src/services/cli-backend/cli-resources"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
 
 describe("parseServerPort", () => {
   it("parses port from standard CLI startup message", () => {
@@ -43,6 +52,53 @@ describe("parseServerPort", () => {
   it("matches only first occurrence when multiple ports present", () => {
     const output = "listening on http://127.0.0.1:3000 and http://127.0.0.1:4000"
     expect(parseServerPort(output)).toBe(3000)
+  })
+})
+
+describe("cli tree-sitter resources", () => {
+  it("resolves resources next to the VS Code bundled CLI", () => {
+    const root = "/Users/test/.vscode/extensions/kilocode.kilo-code-7.2.50-darwin-arm64"
+    const bin = `${root}/bin/kilo`
+
+    expect(treeSitterDirForBinary(bin)).toBe(`${root}/bin/tree-sitter`)
+    expect(treeSitterDirForExtension(root)).toBe(`${root}/bin/tree-sitter`)
+    expect(resolveTreeSitterEnv(root)).toEqual({ KILO_TREE_SITTER_WASM_DIR: `${root}/bin/tree-sitter` })
+  })
+
+  it("resolves resources next to a Windows packaged CLI", () => {
+    const root = String.raw`C:\Users\test\.vscode\extensions\kilocode.kilo-code-7.2.50-win32-x64`
+    const bin = String.raw`${root}\bin\kilo.exe`
+
+    expect(treeSitterDirForBinary(bin)).toBe(String.raw`${root}\bin\tree-sitter`)
+    expect(treeSitterDirForExtension(root)).toBe(String.raw`${root}\bin\tree-sitter`)
+    expect(resolveTreeSitterEnv(root)).toEqual({
+      KILO_TREE_SITTER_WASM_DIR: String.raw`${root}\bin\tree-sitter`,
+    })
+  })
+
+  it("copies runtime and language WASMs with the packaged CLI binary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-vscode-tree-sitter-"))
+    try {
+      const source = path.join(root, "dist", "@kilocode", "cli-darwin-arm64", "bin", "kilo")
+      const target = path.join(root, "extension", "bin", "kilo")
+      const dir = treeSitterDirForBinary(source)
+
+      await fs.mkdir(dir, { recursive: true })
+      await fs.mkdir(path.dirname(target), { recursive: true })
+      await fs.writeFile(source, "binary")
+      await fs.writeFile(target, "binary")
+      await fs.writeFile(path.join(dir, "tree-sitter.wasm"), "runtime")
+      await fs.writeFile(path.join(dir, "tree-sitter-typescript.wasm"), "language")
+
+      await copyTreeSitterResources(source, target)
+
+      expect(await fs.readFile(path.join(treeSitterDirForBinary(target), "tree-sitter.wasm"), "utf8")).toBe("runtime")
+      expect(await fs.readFile(path.join(treeSitterDirForBinary(target), "tree-sitter-typescript.wasm"), "utf8")).toBe(
+        "language",
+      )
+    } finally {
+      await fs.rm(root, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/opencode/bin/kilo
+++ b/packages/opencode/bin/kilo
@@ -5,13 +5,17 @@ const fs = require("fs")
 const path = require("path")
 const os = require("os")
 
-function run(target) {
-  // kilocode_change start - point packaged binaries at co-located tree-sitter WASM resources
+// kilocode_change start - point packaged binaries at co-located tree-sitter WASM resources
+function configureTreeSitterResources(target) {
   const wasmDir = path.join(path.dirname(target), "tree-sitter")
   if (!process.env.KILO_TREE_SITTER_WASM_DIR && fs.existsSync(path.join(wasmDir, "tree-sitter.wasm"))) {
     process.env.KILO_TREE_SITTER_WASM_DIR = wasmDir
   }
-  // kilocode_change end
+}
+// kilocode_change end
+
+function run(target) {
+  configureTreeSitterResources(target) // kilocode_change
   const result = childProcess.spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
   })
@@ -34,6 +38,7 @@ const scriptDir = path.dirname(scriptPath)
 // kilocode_change start - fall through to findBinary() if cached binary fails
 const cached = path.join(scriptDir, ".kilo")
 if (fs.existsSync(cached)) {
+  configureTreeSitterResources(cached)
   const result = childProcess.spawnSync(cached, process.argv.slice(2), {
     stdio: "inherit",
   })

--- a/packages/opencode/bin/kilo
+++ b/packages/opencode/bin/kilo
@@ -6,6 +6,12 @@ const path = require("path")
 const os = require("os")
 
 function run(target) {
+  // kilocode_change start - point packaged binaries at co-located tree-sitter WASM resources
+  const wasmDir = path.join(path.dirname(target), "tree-sitter")
+  if (!process.env.KILO_TREE_SITTER_WASM_DIR && fs.existsSync(path.join(wasmDir, "tree-sitter.wasm"))) {
+    process.env.KILO_TREE_SITTER_WASM_DIR = wasmDir
+  }
+  // kilocode_change end
   const result = childProcess.spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
   })

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -126,6 +126,19 @@ function findBinary() {
 }
 // kilocode_change end
 
+// kilocode_change start - copy tree-sitter WASM resources next to cached binary
+function copyTreeSitterResources(binaryPath) {
+  const source = path.join(path.dirname(binaryPath), "tree-sitter")
+  const target = path.join(__dirname, "bin", "tree-sitter")
+  const runtime = path.join(source, "tree-sitter.wasm")
+
+  if (!fs.existsSync(runtime)) return
+
+  fs.rmSync(target, { recursive: true, force: true })
+  fs.cpSync(source, target, { recursive: true })
+}
+// kilocode_change end
+
 function main() {
   if (os.platform() === "win32") {
     // On Windows, the .exe is already included in the package and bin field points to it
@@ -141,6 +154,7 @@ function main() {
   } catch {
     fs.copyFileSync(binaryPath, target)
   }
+  copyTreeSitterResources(binaryPath) // kilocode_change
   fs.chmodSync(target, 0o755)
 }
 

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -113,7 +113,11 @@ if (!Script.preview) {
     `sha256sums_x86_64=('${x64Sha}')`,
     "",
     "package() {",
-    '  install -Dm755 ./kilo "${pkgdir}/usr/bin/kilo"',
+    '  install -Dm755 ./kilo "${pkgdir}/usr/lib/kilo/kilo"', // kilocode_change
+    '  install -dm755 "${pkgdir}/usr/bin" "${pkgdir}/usr/lib/kilo/tree-sitter"', // kilocode_change
+    '  cp -r ./tree-sitter/. "${pkgdir}/usr/lib/kilo/tree-sitter/"', // kilocode_change
+    "  printf '%s\\n' '#!/bin/sh' 'export KILO_TREE_SITTER_WASM_DIR=/usr/lib/kilo/tree-sitter' 'exec /usr/lib/kilo/kilo \"$@\"' > \"${pkgdir}/usr/bin/kilo\"", // kilocode_change
+    '  chmod 755 "${pkgdir}/usr/bin/kilo"', // kilocode_change
     "}",
     "",
   ].join("\n")
@@ -156,7 +160,8 @@ if (!Script.preview) {
     `      sha256 "${macX64Sha}"`,
     "",
     "      def install",
-    '        bin.install "kilo"',
+    '        libexec.install "kilo", "tree-sitter"', // kilocode_change
+    '        (bin/"kilo").write_env_script libexec/"kilo", KILO_TREE_SITTER_WASM_DIR: libexec/"tree-sitter"', // kilocode_change
     "      end",
     "    end",
     "    if Hardware::CPU.arm?",
@@ -164,7 +169,8 @@ if (!Script.preview) {
     `      sha256 "${macArm64Sha}"`,
     "",
     "      def install",
-    '        bin.install "kilo"',
+    '        libexec.install "kilo", "tree-sitter"', // kilocode_change
+    '        (bin/"kilo").write_env_script libexec/"kilo", KILO_TREE_SITTER_WASM_DIR: libexec/"tree-sitter"', // kilocode_change
     "      end",
     "    end",
     "  end",
@@ -174,14 +180,16 @@ if (!Script.preview) {
     `      url "https://github.com/Kilo-Org/kilocode/releases/download/v${Script.version}/kilo-linux-x64.tar.gz"`,
     `      sha256 "${x64Sha}"`,
     "      def install",
-    '        bin.install "kilo"',
+    '        libexec.install "kilo", "tree-sitter"', // kilocode_change
+    '        (bin/"kilo").write_env_script libexec/"kilo", KILO_TREE_SITTER_WASM_DIR: libexec/"tree-sitter"', // kilocode_change
     "      end",
     "    end",
     "    if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?",
     `      url "https://github.com/Kilo-Org/kilocode/releases/download/v${Script.version}/kilo-linux-arm64.tar.gz"`,
     `      sha256 "${arm64Sha}"`,
     "      def install",
-    '        bin.install "kilo"',
+    '        libexec.install "kilo", "tree-sitter"', // kilocode_change
+    '        (bin/"kilo").write_env_script libexec/"kilo", KILO_TREE_SITTER_WASM_DIR: libexec/"tree-sitter"', // kilocode_change
     "      end",
     "    end",
     "  end",

--- a/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
+++ b/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { mkdir, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+
+const script = join(import.meta.dir, "..", "..", "bin", "kilo")
+
+describe("bin/kilo tree-sitter resources", () => {
+  async function setup(root: string, nested: boolean) {
+    const dir = nested
+      ? join(root, "node_modules", "@kilocode", "cli-darwin-arm64", "bin")
+      : join(root, "node_modules", "@kilocode", "cli", "bin")
+    const wasm = join(dir, "tree-sitter")
+    const bin = join(dir, nested ? "kilo" : ".kilo")
+    const log = join(root, nested ? "nested-env.txt" : "cached-env.txt")
+
+    await mkdir(wasm, { recursive: true })
+    await writeFile(join(wasm, "tree-sitter.wasm"), "wasm")
+    await writeFile(bin, `#!/bin/sh\nprintf '%s' "$KILO_TREE_SITTER_WASM_DIR" > ${JSON.stringify(log)}\n`, {
+      mode: 0o755,
+    })
+
+    return { bin, log, wasm }
+  }
+
+  async function run(root: string, bin: string) {
+    return Bun.spawnSync(["node", "--input-type=commonjs", "--eval", await Bun.file(script).text()], {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH ?? "",
+        KILO_BIN_PATH: bin,
+      },
+    })
+  }
+
+  test("exports co-located tree-sitter WASM dir for optional package binary", async () => {
+    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-bin-tree-sitter-XXXXXX")}`
+      .text()
+      .then((text) => text.trim())
+    try {
+      const item = await setup(root, true)
+      const proc = await run(root, item.bin)
+
+      expect(proc.exitCode).toBe(0)
+      expect(await Bun.file(item.log).text()).toBe(item.wasm)
+    } finally {
+      await Bun.$`rm -rf ${root}`
+    }
+  })
+
+  test("exports co-located tree-sitter WASM dir for cached postinstall binary", async () => {
+    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-bin-tree-sitter-XXXXXX")}`
+      .text()
+      .then((text) => text.trim())
+    try {
+      const item = await setup(root, false)
+      const proc = await run(root, item.bin)
+
+      expect(proc.exitCode).toBe(0)
+      expect(await Bun.file(item.log).text()).toBe(item.wasm)
+    } finally {
+      await Bun.$`rm -rf ${root}`
+    }
+  })
+})

--- a/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
+++ b/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdir, writeFile } from "fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import { join } from "path"
 
@@ -16,15 +16,23 @@ describe("bin/kilo tree-sitter resources", () => {
 
     await mkdir(wasm, { recursive: true })
     await writeFile(join(wasm, "tree-sitter.wasm"), "wasm")
-    await writeFile(bin, `#!/bin/sh\nprintf '%s' "$KILO_TREE_SITTER_WASM_DIR" > ${JSON.stringify(log)}\n`, {
-      mode: 0o755,
-    })
+    await writeFile(bin, "binary")
 
     return { bin, log, wasm }
   }
 
-  async function run(root: string, bin: string) {
-    return Bun.spawnSync(["node", "--input-type=commonjs", "--eval", await Bun.file(script).text()], {
+  async function run(root: string, bin: string, log: string) {
+    const capture = `
+const kiloFs = require("fs")
+const kiloChild = require("child_process")
+const log = process.argv[1]
+kiloChild.spawnSync = () => {
+  kiloFs.writeFileSync(log, process.env.KILO_TREE_SITTER_WASM_DIR || "")
+  return { status: 0 }
+}
+`
+    const source = (await Bun.file(script).text()).replace(/^#!.*\n/, "")
+    return Bun.spawnSync(["node", "--input-type=commonjs", "--eval", capture + source, log], {
       cwd: root,
       env: {
         PATH: process.env.PATH ?? "",
@@ -34,32 +42,28 @@ describe("bin/kilo tree-sitter resources", () => {
   }
 
   test("exports co-located tree-sitter WASM dir for optional package binary", async () => {
-    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-bin-tree-sitter-XXXXXX")}`
-      .text()
-      .then((text) => text.trim())
+    const root = await mkdtemp(join(tmpdir(), "kilo-bin-tree-sitter-"))
     try {
       const item = await setup(root, true)
-      const proc = await run(root, item.bin)
+      const proc = await run(root, item.bin, item.log)
 
       expect(proc.exitCode).toBe(0)
       expect(await Bun.file(item.log).text()).toBe(item.wasm)
     } finally {
-      await Bun.$`rm -rf ${root}`
+      await rm(root, { recursive: true, force: true })
     }
   })
 
   test("exports co-located tree-sitter WASM dir for cached postinstall binary", async () => {
-    const root = await Bun.$`mktemp -d ${join(tmpdir(), "kilo-bin-tree-sitter-XXXXXX")}`
-      .text()
-      .then((text) => text.trim())
+    const root = await mkdtemp(join(tmpdir(), "kilo-bin-tree-sitter-"))
     try {
       const item = await setup(root, false)
-      const proc = await run(root, item.bin)
+      const proc = await run(root, item.bin, item.log)
 
       expect(proc.exitCode).toBe(0)
       expect(await Bun.file(item.log).text()).toBe(item.wasm)
     } finally {
-      await Bun.$`rm -rf ${root}`
+      await rm(root, { recursive: true, force: true })
     }
   })
 })

--- a/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
+++ b/packages/opencode/test/kilocode/bin-tree-sitter-env.test.ts
@@ -18,25 +18,28 @@ describe("bin/kilo tree-sitter resources", () => {
     await writeFile(join(wasm, "tree-sitter.wasm"), "wasm")
     await writeFile(bin, "binary")
 
-    return { bin, log, wasm }
+    return { bin, log, wasm, wrapper: join(dir, "kilo") }
   }
 
-  async function run(root: string, bin: string, log: string) {
+  async function run(root: string, bin: string | undefined, log: string, wrapper?: string) {
     const capture = `
 const kiloFs = require("fs")
 const kiloChild = require("child_process")
 const log = process.argv[1]
+const wrapper = process.argv[2]
+const realpathSync = kiloFs.realpathSync
+kiloFs.realpathSync = (file) => wrapper && file === __filename ? wrapper : realpathSync(file)
 kiloChild.spawnSync = () => {
   kiloFs.writeFileSync(log, process.env.KILO_TREE_SITTER_WASM_DIR || "")
   return { status: 0 }
 }
 `
     const source = (await Bun.file(script).text()).replace(/^#!.*\n/, "")
-    return Bun.spawnSync(["node", "--input-type=commonjs", "--eval", capture + source, log], {
+    return Bun.spawnSync(["node", "--input-type=commonjs", "--eval", capture + source, log, wrapper ?? ""], {
       cwd: root,
       env: {
         PATH: process.env.PATH ?? "",
-        KILO_BIN_PATH: bin,
+        ...(bin ? { KILO_BIN_PATH: bin } : {}),
       },
     })
   }
@@ -58,7 +61,7 @@ kiloChild.spawnSync = () => {
     const root = await mkdtemp(join(tmpdir(), "kilo-bin-tree-sitter-"))
     try {
       const item = await setup(root, false)
-      const proc = await run(root, item.bin, item.log)
+      const proc = await run(root, undefined, item.log, item.wrapper)
 
       expect(proc.exitCode).toBe(0)
       expect(await Bun.file(item.log).text()).toBe(item.wasm)


### PR DESCRIPTION
Fixes #9880
Fixes #10105

- Codebase indexing fails in packaged builds when `web-tree-sitter` falls back to Bun's build-time CI path for `tree-sitter.wasm`.
- Resolve tree-sitter WASM resources from the installed CLI layout instead, so VS Code and CLI installs use their bundled `bin/tree-sitter` files.
- Carry that resource directory through VS Code, npm, Homebrew, and AUR packaging paths so moved binaries still load the correct runtime files.