### PR TITLE
fix(ui): restore Mermaid node labels stripped by DOMPurify

### DIFF
--- a/.changeset/silent-mermaid-labels.md
+++ b/.changeset/silent-mermaid-labels.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Fix Mermaid diagrams rendering with empty text inside every shape by restoring the `foreignObject` HTML integration point that DOMPurify dropped in 3.1.7.

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1526,12 +1526,8 @@ unix(
           })
 
           yield* llm.tool("bash", {
-            // kilocode_change start - emit a sentinel after the truncating output
-            // so the test can deterministically wait until the bash tool has
-            // already crossed the truncation threshold before cancelling.
             command:
-              'i=0; while [ "$i" -lt 4000 ]; do printf "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx %05d\\n" "$i"; i=$((i + 1)); done; echo READY_TO_CANCEL; sleep 30',
-            // kilocode_change end
+              'i=0; while [ "$i" -lt 4000 ]; do printf "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx %05d\\n" "$i"; i=$((i + 1)); done; sleep 30',
             description: "Print many lines",
             timeout: 30_000,
             workdir: path.resolve(dir),
@@ -1539,29 +1535,7 @@ unix(
 
           const run = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
           yield* llm.wait(1)
-          // kilocode_change start - wait until the bash tool has actually emitted
-          // its full output (including the sentinel) before cancelling. The
-          // running metadata `output` is the tail of stdout, so the sentinel
-          // confirms truncation already triggered server-side. A bare
-          // Effect.sleep was racy on slow Linux CI runners (TODO #8990).
-          yield* waitFor(
-            "bash output past truncation threshold",
-            sessions.messages({ sessionID: chat.id }).pipe(
-              Effect.map((msgs) => {
-                for (const msg of msgs) {
-                  for (const part of msg.parts) {
-                    if (part.type !== "tool") continue
-                    if (part.tool !== "bash") continue
-                    if (part.state.status !== "running") continue
-                    const out = part.state.metadata?.output
-                    if (typeof out === "string" && out.includes("READY_TO_CANCEL")) return part
-                  }
-                }
-                return undefined
-              }),
-            ),
-          )
-          // kilocode_change end
+          yield* Effect.sleep(150)
           yield* prompt.cancel(chat.id)
 
           const exit = yield* Fiber.await(run)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1526,8 +1526,12 @@ unix(
           })
 
           yield* llm.tool("bash", {
+            // kilocode_change start - emit a sentinel after the truncating output
+            // so the test can deterministically wait until the bash tool has
+            // already crossed the truncation threshold before cancelling.
             command:
-              'i=0; while [ "$i" -lt 4000 ]; do printf "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx %05d\\n" "$i"; i=$((i + 1)); done; sleep 30',
+              'i=0; while [ "$i" -lt 4000 ]; do printf "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx %05d\\n" "$i"; i=$((i + 1)); done; echo READY_TO_CANCEL; sleep 30',
+            // kilocode_change end
             description: "Print many lines",
             timeout: 30_000,
             workdir: path.resolve(dir),
@@ -1535,7 +1539,29 @@ unix(
 
           const run = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
           yield* llm.wait(1)
-          yield* Effect.sleep(150)
+          // kilocode_change start - wait until the bash tool has actually emitted
+          // its full output (including the sentinel) before cancelling. The
+          // running metadata `output` is the tail of stdout, so the sentinel
+          // confirms truncation already triggered server-side. A bare
+          // Effect.sleep was racy on slow Linux CI runners (TODO #8990).
+          yield* waitFor(
+            "bash output past truncation threshold",
+            sessions.messages({ sessionID: chat.id }).pipe(
+              Effect.map((msgs) => {
+                for (const msg of msgs) {
+                  for (const part of msg.parts) {
+                    if (part.type !== "tool") continue
+                    if (part.tool !== "bash") continue
+                    if (part.state.status !== "running") continue
+                    const out = part.state.metadata?.output
+                    if (typeof out === "string" && out.includes("READY_TO_CANCEL")) return part
+                  }
+                }
+                return undefined
+              }),
+            ),
+          )
+          // kilocode_change end
           yield* prompt.cancel(chat.id)
 
           const exit = yield* Fiber.await(run)

--- a/packages/ui/src/kilocode/markdown-mermaid.ts
+++ b/packages/ui/src/kilocode/markdown-mermaid.ts
@@ -2,9 +2,15 @@ import DOMPurify from "dompurify"
 import { fnv1a } from "../context/marked"
 import { mountMermaidActions } from "./markdown-mermaid-actions"
 
+// DOMPurify >= 3.1.7 dropped foreignObject from the default HTML integration
+// points, which caused the inner <div> / <span> / <p> labels Mermaid renders
+// inside <foreignObject> to be stripped during sanitization, leaving every
+// shape with empty text. Restoring it via HTML_INTEGRATION_POINTS keeps the
+// labels while still sanitizing untrusted markup.
 const svgConfig = {
   USE_PROFILES: { html: true, svg: true, svgFilters: true },
   ADD_TAGS: ["foreignObject"],
+  HTML_INTEGRATION_POINTS: { foreignobject: true },
   FORBID_TAGS: ["script"],
   FORBID_CONTENTS: ["script"],
 }


### PR DESCRIPTION
DOMPurify 3.1.7 dropped `foreignObject` from its default HTML integration points (cure53/DOMPurify#1002, #1040). Mermaid renders every node label as `<foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel"><p>Text</p></span></div></foreignObject>`, so on our shipped DOMPurify 3.4.2 the foreignObject survived but its inner HTML was stripped, leaving every shape with empty text.

Restoring `HTML_INTEGRATION_POINTS: { foreignobject: true }` in our sanitize config keeps the labels while still sanitizing untrusted markup. This is the same fix mermaid itself adopted upstream.

Before:
<img width="586" height="370" alt="image" src="https://github.com/user-attachments/assets/be263632-0806-43c8-848c-db82a0c2443d" />
After:
<img width="439" height="742" alt="image" src="https://github.com/user-attachments/assets/22bbf5ca-8600-452d-825d-13c13de5524c" />
