### PR TITLE
fix(vscode): use VS Code placeholder color for input fields

### DIFF
--- a/.changeset/placeholder-vscode-token.md
+++ b/.changeset/placeholder-vscode-token.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use the VS Code-native placeholder color for input fields so placeholder text is consistently distinct from values you have typed (Settings, Agent Manager, prompt input, model search, etc.).

--- a/packages/kilo-ui/src/components/text-field.css
+++ b/packages/kilo-ui/src/components/text-field.css
@@ -44,7 +44,7 @@
     color: var(--text-base);
 
     &::placeholder {
-      color: var(--icon-weak-base);
+      color: var(--vscode-input-placeholderForeground, var(--text-weaker));
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1403,7 +1403,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-tabs-menu-search-input::placeholder {
-  color: var(--text-weaker);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 .am-tabs-menu-list {
@@ -2482,7 +2482,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-nv-name-input::placeholder {
-  color: var(--text-weaker);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 /* Dialog overrides for prompt-input-container — resizable from bottom edge */
@@ -2665,7 +2665,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-mm-search-input::placeholder {
-  color: var(--text-weaker);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 .am-mm-list {
@@ -2808,7 +2808,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-advanced-input::placeholder {
-  color: var(--text-weaker);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 /* Branch selector */

--- a/packages/kilo-vscode/webview-ui/kiloclaw/kiloclaw.css
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/kiloclaw.css
@@ -170,7 +170,7 @@
 }
 
 .kiloclaw-input::placeholder {
-  color: var(--vscode-input-placeholderForeground);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 /* Status sidebar */

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -234,7 +234,7 @@
 }
 
 .model-selector-search::placeholder {
-  color: var(--vscode-input-placeholderForeground);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 .model-selector-list {

--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
@@ -327,7 +327,7 @@
 }
 
 .prompt-input::placeholder {
-  color: var(--vscode-input-placeholderForeground);
+  color: var(--vscode-input-placeholderForeground, var(--text-weaker));
 }
 
 /* Input overlay (highlight + ghost text) */

--- a/packages/kilo-vscode/webview-ui/src/styles/question-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/question-dock.css
@@ -298,7 +298,7 @@
     line-height: var(--line-height-large);
 
     &::placeholder {
-      color: var(--text-weak);
+      color: var(--vscode-input-placeholderForeground, var(--text-weaker));
     }
 
     &:disabled {


### PR DESCRIPTION
Supersedes #10085 by @sylwester-liljegren — same intent (make placeholders visually distinct from typed values), but uses the VS Code-native `--vscode-input-placeholderForeground` token instead of `--text-weaker` so placeholders match VS Code's own input styling, with `--text-weaker` kept as the fallback.

While here, brings the rest of the webview placeholders onto the same token so the Settings indexing fields, Agent Manager search/name/PR/dropdown inputs, prompt input, model search, kiloclaw input, and question dock custom input all render their placeholder consistently.