### PR TITLE
feat(vscode): add sign-in nudge banner for signed-out users on Auto Free

### DIFF
--- a/.changeset/auto-free-signin-banner.md
+++ b/.changeset/auto-free-signin-banner.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Show a sign-in nudge above the chat input for signed-out users, letting them know they're using Auto Free and that signing in unlocks 500+ models including Auto Balanced.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/free-tier-sign-in-banner-story-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/free-tier-sign-in-banner-story-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73d1223cea1ef8e10cc56a64929c66d1e1cd0e094c77f7dd24e293a2b46b2fcd
+size 9517

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -17,6 +17,7 @@ import { MessageList } from "./MessageList"
 import { PromptInput } from "./PromptInput"
 import { PermissionDock } from "./PermissionDock"
 import { StartupErrorBanner } from "./StartupErrorBanner"
+import { FreeTierSignInBanner } from "./FreeTierSignInBanner"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
@@ -324,6 +325,9 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
       <Show when={dock()}>
         <div class="chat-input">
+          <Show when={!props.readonly}>
+            <FreeTierSignInBanner />
+          </Show>
           <Show when={server.connectionState() === "error" && server.errorMessage()}>
             <StartupErrorBanner errorMessage={server.errorMessage()!} errorDetails={server.errorDetails()!} />
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/FreeTierSignInBanner.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/FreeTierSignInBanner.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@kilocode/kilo-ui/button"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Show, type Component } from "solid-js"
+import { useLanguage } from "../../context/language"
+import { useNotifications } from "../../context/notifications"
+import { useServer } from "../../context/server"
+
+const BANNER_ID = "free-tier-signin-nudge"
+
+export const FreeTierSignInBanner: Component = () => {
+  const server = useServer()
+  const notifications = useNotifications()
+  const language = useLanguage()
+
+  const signedOut = () => !server.profileData()
+  const dismissed = () => notifications.dismissedIds().includes(BANNER_ID)
+  // Wait until both auth state and dismissed-ids have loaded from the extension
+  // host. Otherwise signed-in users briefly see the banner during webview boot,
+  // and previously-dismissed banners flash back before notifications arrive.
+  const ready = () => server.profileLoaded() && notifications.loaded()
+  const visible = () => ready() && signedOut() && !dismissed()
+
+  const signIn = () => server.goToLogin()
+  const dismiss = () => notifications.dismiss(BANNER_ID)
+
+  return (
+    <Show when={visible()}>
+      <div data-component="free-tier-signin-banner">
+        <div data-slot="free-tier-signin-banner-copy">
+          <span data-slot="free-tier-signin-banner-icon">
+            <Icon name="brain" size="small" />
+          </span>
+          <span data-slot="free-tier-signin-banner-text">{language.t("chat.signInBanner.text")}</span>
+        </div>
+        <div data-slot="free-tier-signin-banner-actions">
+          <Button variant="secondary" size="small" onClick={signIn}>
+            {language.t("common.signIn")}
+          </Button>
+          <IconButton
+            icon="close"
+            variant="ghost"
+            size="small"
+            label={language.t("common.dismiss")}
+            onClick={dismiss}
+          />
+        </div>
+      </div>
+    </Show>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
@@ -14,6 +14,8 @@ import type { KilocodeNotification, ExtensionMessage } from "../types/messages"
 interface NotificationsContextValue {
   notifications: Accessor<KilocodeNotification[]>
   filteredNotifications: Accessor<KilocodeNotification[]>
+  dismissedIds: Accessor<string[]>
+  loaded: Accessor<boolean>
   dismiss: (id: string) => void
 }
 
@@ -23,11 +25,13 @@ export const NotificationsProvider: ParentComponent = (props) => {
   const vscode = useVSCode()
   const [notifications, setNotifications] = createSignal<KilocodeNotification[]>([])
   const [dismissedIds, setDismissedIds] = createSignal<string[]>([])
+  const [loaded, setLoaded] = createSignal(false)
 
   const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "notificationsLoaded") {
       setNotifications(message.notifications)
       setDismissedIds(message.dismissedIds)
+      setLoaded(true)
     }
   })
 
@@ -64,6 +68,8 @@ export const NotificationsProvider: ParentComponent = (props) => {
   const value: NotificationsContextValue = {
     notifications,
     filteredNotifications,
+    dismissedIds,
+    loaded,
     dismiss,
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/server.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/server.tsx
@@ -16,6 +16,7 @@ interface ServerContextValue {
   errorDetails: Accessor<string | undefined>
   isConnected: Accessor<boolean>
   profileData: Accessor<ProfileData | null>
+  profileLoaded: Accessor<boolean>
   deviceAuth: Accessor<DeviceAuthState>
   startLogin: () => void
   goToLogin: () => void
@@ -38,6 +39,7 @@ export const ServerProvider: ParentComponent = (props) => {
   const [errorMessage, setErrorMessage] = createSignal<string | undefined>()
   const [errorDetails, setErrorDetails] = createSignal<string | undefined>()
   const [profileData, setProfileData] = createSignal<ProfileData | null>(null)
+  const [profileLoaded, setProfileLoaded] = createSignal(false)
   const [deviceAuth, setDeviceAuth] = createSignal<DeviceAuthState>(initialDeviceAuth)
   const [vscodeLanguage, setVscodeLanguage] = createSignal<string | undefined>()
   const [languageOverride, setLanguageOverride] = createSignal<string | undefined>()
@@ -103,6 +105,7 @@ export const ServerProvider: ParentComponent = (props) => {
         case "profileData":
           console.log("[Kilo New] Profile data:", message.data ? "received" : "null")
           setProfileData(message.data)
+          setProfileLoaded(true)
           break
 
         case "deviceAuthStarted":
@@ -176,6 +179,7 @@ export const ServerProvider: ParentComponent = (props) => {
     errorDetails,
     isConnected: () => connectionState() === "connected",
     profileData,
+    profileLoaded,
     deviceAuth,
     startLogin,
     goToLogin,

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -598,6 +598,9 @@ export const dict = {
   "terminal.connectionLost.description":
     "The terminal connection was interrupted. This can happen when the server restarts.",
 
+  "chat.signInBanner.text":
+    "You're using Auto Free. Sign in to unlock 500+ models, including Auto Balanced — a great mix of capability and price.",
+
   "common.closeTab": "Close tab",
   "common.signIn": "Sign in",
   "common.signOut": "Sign out",

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -123,6 +123,8 @@ function mockNotificationsValue(items: KilocodeNotification[] = []) {
   return {
     notifications: () => items,
     filteredNotifications: () => items,
+    dismissedIds: () => [],
+    loaded: () => true,
     dismiss: noop,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -13,6 +13,7 @@ import { ChatView } from "../components/chat/ChatView"
 import { TaskHeader } from "../components/chat/TaskHeader"
 import { QuestionDock } from "../components/chat/QuestionDock"
 import { SuggestBar } from "../components/chat/SuggestBar"
+import { FreeTierSignInBanner } from "../components/chat/FreeTierSignInBanner"
 import { MessageList } from "../components/chat/MessageList"
 import { SessionContext } from "../context/session"
 import { ServerContext } from "../context/server"
@@ -229,6 +230,38 @@ export const SuggestBarReview: Story = {
       </div>
     </StoryProviders>
   ),
+}
+
+export const FreeTierSignInBannerStory: Story = {
+  name: "FreeTierSignInBanner — auto free nudge",
+  render: () => {
+    const server = {
+      connectionState: () => "connected" as const,
+      serverInfo: () => undefined,
+      extensionVersion: () => "1.0.0",
+      errorMessage: () => undefined,
+      errorDetails: () => undefined,
+      isConnected: () => true,
+      profileData: () => null,
+      profileLoaded: () => true,
+      deviceAuth: () => ({ status: "idle" as const }),
+      startLogin: () => {},
+      goToLogin: () => {},
+      vscodeLanguage: () => "en",
+      languageOverride: () => undefined,
+      workspaceDirectory: () => "/project",
+      gitInstalled: () => true,
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID}>
+        <ServerContext.Provider value={server as any}>
+          <div style={{ width: "100%" }}>
+            <FreeTierSignInBanner />
+          </div>
+        </ServerContext.Provider>
+      </StoryProviders>
+    )
+  },
 }
 
 const toolUserID = "user-msg-spacing-001"
@@ -674,6 +707,7 @@ const mockServer = {
     balance: { balance: 5.0 },
     currentOrgId: "org-1",
   }),
+  profileLoaded: () => true,
   deviceAuth: () => ({ status: "idle" as const }),
   startLogin: () => {},
   goToLogin: () => {},

--- a/packages/kilo-vscode/webview-ui/src/styles/chat.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat.css
@@ -20,5 +20,6 @@
 @import "./tool-overrides.css";
 @import "./question-dock.css";
 @import "./suggest-bar.css";
+@import "./free-tier-signin-banner.css";
 @import "./settings.css";
 @import "./high-contrast.css";

--- a/packages/kilo-vscode/webview-ui/src/styles/free-tier-signin-banner.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/free-tier-signin-banner.css
@@ -1,0 +1,42 @@
+/* ============================================
+   Free Tier Sign-In Banner
+   ============================================ */
+
+[data-component="free-tier-signin-banner"] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--background-base) 88%, var(--vscode-textLink-foreground) 12%);
+
+  [data-slot="free-tier-signin-banner-copy"] {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  [data-slot="free-tier-signin-banner-icon"] {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-info, var(--vscode-textLink-foreground));
+    flex-shrink: 0;
+  }
+
+  [data-slot="free-tier-signin-banner-text"] {
+    min-width: 0;
+    color: var(--text-base);
+    font-size: var(--kilo-font-size-12);
+    line-height: 1.4;
+  }
+
+  [data-slot="free-tier-signin-banner-actions"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a dismissable banner above the chat input that nudges signed-out users (currently on Auto Free) to sign in and unlock 500+ models including Auto Balanced. Modeled visually on the existing Local Review suggestion bar, with a "Sign In" CTA that routes through the existing device-auth flow and an X to dismiss.

## Why

Signed-out users default to Auto Free without any in-product surface explaining the upgrade path. This banner makes the value prop visible at the natural decision point — right above the prompt where they're about to send a message.

## Notes for review

- Gated on `server.profileLoaded() && notifications.loaded()` so signed-in users don't briefly see it during webview boot.
- Dismiss persistence piggybacks on the existing `dismissNotification` → `globalState["kilo.dismissedNotificationIds"]` pipeline. This works but conceptually couples the banner to the cloud-notifications fetcher; happy to extract a dedicated `dismissedHints` mechanism in a follow-up if reviewers prefer.
- Storybook story added next to `SuggestBarReview` for visual-regression coverage.