### PR TITLE
Add minimum release age to bun install config

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,6 @@
 [install]
 exact = true
-minimumReleaseAge = 410520 # seconds (equivalent to 6842 minutes)
+minimumReleaseAge = 410520 # seconds (~4.75 days / ~114 hours)
 
 [test]
 root = "./do-not-run-tests-from-root"

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,6 @@
 [install]
 exact = true
+minimumReleaseAge = 410520 # seconds (equivalent to 6842 minutes)
 
 [test]
 root = "./do-not-run-tests-from-root"


### PR DESCRIPTION


## Context

Set `minimumReleaseAge` to 410520 seconds (~4.75 days) to avoid installing recently published package versions that may be unstable or malicious.
