### PR TITLE
Remove trusted dependencies from package.json

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -574,13 +574,6 @@
       },
     },
   },
-  "trustedDependencies": [
-    "esbuild",
-    "tree-sitter-powershell",
-    "protobufjs",
-    "web-tree-sitter",
-    "tree-sitter-bash",
-  ],
   "patchedDependencies": {
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@npmcli/agent@4.0.0": "patches/@npmcli%2Fagent@4.0.0.patch",

--- a/package.json
+++ b/package.json
@@ -115,13 +115,6 @@
     "printWidth": 120
   },
   "trustedDependencies": [
-    "esbuild",
-    "node-pty",
-    "protobufjs",
-    "tree-sitter",
-    "tree-sitter-bash",
-    "tree-sitter-powershell",
-    "web-tree-sitter",
     "electron"
   ],
   "overrides": {


### PR DESCRIPTION
## Summary

- Trim `trustedDependencies` down to just `electron`, the only one whose postinstall actually does meaningful work (downloads the VS Code test binary).
- The rest (`esbuild`, `tree-sitter-*`, `protobufjs`, `web-tree-sitter`, `node-pty`) ship prebuilt binaries or wasm, so their install hooks are noise.
- Smaller allowlist means faster `bun install` and less postinstall script surface area for supply-chain risk.

## Testing
- Verified clean `bun install`, CLI typecheck/tests, extension `compile`, `test:unit`, and `test` all run successfully on macOS.