### PR TITLE
Remove electron trusted dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,6 @@
     "semi": false,
     "printWidth": 120
   },
-  "trustedDependencies": [
-    "electron"
-  ],
   "overrides": {
     "@types/bun": "catalog:",
     "@types/node": "catalog:",


### PR DESCRIPTION
## Summary

- Drop `electron` from `trustedDependencies`. No package in the workspace depends on `electron`, so its `postinstall` never runs and the entry was dead config.
- `@vscode/test-electron` (the only electron-adjacent dep we use) downloads its own VS Code binary at test time and does not require the `electron` package to be installed.

## Testing
- Verified clean `bun install` reinstalls without changes and without re-adding electron.