### PR TITLE
fix(ui): avoid fetching provider icons during checks

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -36,9 +36,11 @@ function providerIconsPlugin() {
   return {
     name: "provider-icons-plugin",
     configureServer() {
+      if (!process.env.KILO_FETCH_PROVIDER_ICONS) return // kilocode_change
       void fetchProviderIcons()
     },
     buildStart() {
+      if (!process.env.KILO_FETCH_PROVIDER_ICONS) return // kilocode_change
       void fetchProviderIcons()
     },
   }


### PR DESCRIPTION
## Context

Prevent normal UI checks/builds from leaving the worktree dirty by fetching live provider logos from models.dev.

## Implementation

Make the provider icon fetch step opt-in with `KILO_FETCH_PROVIDER_ICONS`, while preserving the existing fetch path for intentional provider logo refreshes.

## Screenshots

| before | after |
|---|---|
| N/A | N/A |

## How to Test

- Run `bun run typecheck` from `packages/ui`
- Run a Vite-backed UI check/build without `KILO_FETCH_PROVIDER_ICONS`
- Confirm provider icon assets and generated provider icon files are not modified

## Get in Touch