### PR TITLE
fix(tui): handle newlines in DialogAlert messages

### DIFF
--- a/.changeset/dialog-alert-newlines.md
+++ b/.changeset/dialog-alert-newlines.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Handle newlines in DialogAlert messages

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,7 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
-import { For } from "solid-js"
+import { For } from "solid-js" // kilocode_change
 
 export type DialogAlertProps = {
   title: string
@@ -32,11 +32,13 @@ export function DialogAlert(props: DialogAlertProps) {
           esc
         </text>
       </box>
-      <box paddingBottom={1} flexDirection="column">
-        <For each={props.message.replace(/\\n/g, "\n").split("\n")}>
-          {(line) => <text fg={theme.textMuted}>{line}</text>}
-        </For>
-      </box>
+       {/* kilocode_change start */}
+       <box paddingBottom={1} flexDirection="column">
+         <For each={props.message.replace(/\\n/g, "\n").split("\n")}>
+           {(line) => <text fg={theme.textMuted}>{line}</text>}
+         </For>
+       </box>
+       {/* kilocode_change end */}
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box
           paddingLeft={3}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,6 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { For } from "solid-js"
 
 export type DialogAlertProps = {
   title: string
@@ -31,8 +32,10 @@ export function DialogAlert(props: DialogAlertProps) {
           esc
         </text>
       </box>
-      <box paddingBottom={1}>
-        <text fg={theme.textMuted}>{props.message}</text>
+      <box paddingBottom={1} flexDirection="column">
+        <For each={props.message.replace(/\\n/g, "\n").split("\n")}>
+          {(line) => <text fg={theme.textMuted}>{line}</text>}
+        </For>
       </box>
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box


### PR DESCRIPTION
## Context

Fixes a bug where DialogAlert in the CLI TUI renders escaped newlines (`\n`) as literal text instead of actual line breaks. This affects the Teams tab message when users aren't members of any team.

Closes #10192

## Implementation

Modified `packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx`:
- Added import for `For` from `solid-js` for proper list rendering
- Changed message box to use `flexDirection="column"` to stack lines vertically
- Added `.replace(/\\n/g, "\n")` to handle escaped newlines before splitting

This fix applies to all 10 DialogAlert usages throughout the app, making them future-proof for multi-line messages.

## Screenshots

| before | after |
|---|---|
| <img width="600" height="190" alt="WindowsTerminal_JGUQ53y9pA" src="https://github.com/user-attachments/assets/f0aa3e93-a985-44a4-820d-0532581911b4" /> | <img width="600" height="190" alt="WindowsTerminal_meYB56mZRM" src="https://github.com/user-attachments/assets/2d3b9302-6ae5-4995-aecf-287eab4b1525" /> |

## How to Test

1. Run `bun run dev` from `packages/opencode/`
2. Type `/teams` in the TUI
3. If not a member of any team, verify the message shows two lines instead of `\n` as text