### PR TITLE
Fix Agent Manager state showing in Git

### DIFF
--- a/.changeset/agent-manager-state-exclude.md
+++ b/.changeset/agent-manager-state-exclude.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager state hidden from Git before creating local sessions.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -251,6 +251,7 @@ export class AgentManagerProvider implements Disposable {
       return
     }
 
+    await this.ensureGitExclude(manager)
     const loaded = await state.load()
     manager.cleanupOrphanedTempDirs()
 
@@ -289,6 +290,12 @@ export class AgentManagerProvider implements Disposable {
     // are registered with their directory overrides so the recovery queries the
     // correct CLI backend Instances.
     this.panel?.sessions.recoverPendingPrompts()
+  }
+
+  private async ensureGitExclude(manager: WorktreeManager): Promise<void> {
+    await manager.ensureGitExclude().catch((err) => {
+      this.log("Failed to update git exclude:", err)
+    })
   }
 
   private async recoverWorktrees(manager: WorktreeManager, state: WorktreeStateManager): Promise<void> {

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -183,6 +183,16 @@ describe("Agent Manager Provider Messages", () => {
     expect(getMethodBody("onMessage")).toContain("if (this.shouldWaitForState(m)) await this.waitForStateReady(m.type)")
   })
 
+  it("initializeState updates local git exclude before loading persisted state", () => {
+    const body = getMethodBody("initializeState")
+    const exclude = body.indexOf("await this.ensureGitExclude(manager)")
+    const load = body.indexOf("const loaded = await state.load()")
+
+    expect(exclude).toBeGreaterThanOrEqual(0)
+    expect(load).toBeGreaterThanOrEqual(0)
+    expect(exclude).toBeLessThan(load)
+  })
+
   it("async shutdown waits for terminal router cleanup", () => {
     const body = getMethodBody("disposeAsync")
     expect(body).toContain("await this.terminalRouter.dispose()")

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -680,7 +680,7 @@ describe("WorktreeManager.discoverWorktrees", () => {
 // ---------------------------------------------------------------------------
 
 describe("WorktreeManager.ensureGitExclude", () => {
-  it("adds .kilo/worktrees/ to .git/info/exclude", async () => {
+  it("adds Agent Manager state and worktrees to .git/info/exclude", async () => {
     const root = await createTempRepo()
     const mgr = createManager(root)
 
@@ -688,6 +688,7 @@ describe("WorktreeManager.ensureGitExclude", () => {
 
     const content = await fs.readFile(path.join(root, ".git", "info", "exclude"), "utf-8")
     expect(content).toContain(".kilo/worktrees/")
+    expect(content).toContain(".kilo/agent-manager.json")
   })
 
   it("adds only specific legacy Agent Manager paths", async () => {


### PR DESCRIPTION
Agent Manager now installs its local git exclude rules during startup, before loading or writing persisted state.

This keeps .kilo/agent-manager.json out of Source Control for local-only sessions without changing the user's .gitignore.

Similar to `/.kilo/worktrees` it makes only sense to only also ignore `/.kilo/agent-manager.json`. The logic has high cohesion to the existing worktree exclude logic and is at the correct place.