### PR TITLE
fix(gateway): strip transient Responses item ids

### DIFF
--- a/.changeset/tame-responses-items.md
+++ b/.changeset/tame-responses-items.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-gateway": patch
+---
+
+Prevent Kilo Gateway Responses requests from replaying transient provider item IDs when request storage is disabled.

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -8,6 +8,7 @@ import { getApiKey } from "./auth/token.js"
 import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
 import { ANONYMOUS_API_KEY } from "./api/constants.js"
 import { resolveKiloOpenRouterBaseUrl } from "./api/url.js"
+import { sanitizeResponsesBody } from "./responses.js"
 
 /**
  * Create a KiloCode provider instance
@@ -45,6 +46,7 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const originalFetch = options.fetch ?? fetch
   const wrappedFetch = async (input: string | URL | Request, init?: RequestInit) => {
     const headers = new Headers(init?.headers)
+    const body = sanitizeResponsesBody(input, init?.body)
 
     // Add custom headers
     Object.entries(customHeaders).forEach(([key, value]) => {
@@ -59,6 +61,7 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
     return originalFetch(input, {
       ...init,
       headers,
+      body,
     })
   }
 

--- a/packages/kilo-gateway/src/responses.ts
+++ b/packages/kilo-gateway/src/responses.ts
@@ -1,0 +1,36 @@
+function record(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
+function endpoint(input: string | URL | Request) {
+  const raw = input instanceof Request ? input.url : input.toString()
+  return new URL(raw, "https://kilo.local").pathname.endsWith("/responses")
+}
+
+function strip(input: unknown[]) {
+  const kept = input.flatMap((item) => {
+    if (!record(item)) return [item]
+    if (item.type === "item_reference") return []
+    if (!("id" in item)) return [item]
+
+    const next = { ...item }
+    delete next.id
+    return [next]
+  })
+  const changed = kept.length !== input.length || kept.some((item, index) => item !== input[index])
+  return { kept, changed }
+}
+
+export function sanitizeResponsesBody(input: string | URL | Request, body: BodyInit | null | undefined) {
+  if (!endpoint(input)) return body
+  if (typeof body !== "string") return body
+
+  const data = JSON.parse(body) as unknown
+  if (!record(data)) return body
+  if (data.store === true) return body
+  if (!Array.isArray(data.input)) return body
+
+  const result = strip(data.input)
+  if (!result.changed) return body
+  return JSON.stringify({ ...data, input: result.kept })
+}

--- a/packages/kilo-gateway/src/responses.ts
+++ b/packages/kilo-gateway/src/responses.ts
@@ -25,7 +25,13 @@ export function sanitizeResponsesBody(input: string | URL | Request, body: BodyI
   if (!endpoint(input)) return body
   if (typeof body !== "string") return body
 
-  const data = JSON.parse(body) as unknown
+  const data = (() => {
+    try {
+      return JSON.parse(body) as unknown
+    } catch {
+      return undefined
+    }
+  })()
   if (!record(data)) return body
   if (data.store === true) return body
   if (!Array.isArray(data.input)) return body

--- a/packages/kilo-gateway/src/responses.ts
+++ b/packages/kilo-gateway/src/responses.ts
@@ -4,7 +4,14 @@ function record(input: unknown): input is Record<string, unknown> {
 
 function endpoint(input: string | URL | Request) {
   const raw = input instanceof Request ? input.url : input.toString()
-  return new URL(raw, "https://kilo.local").pathname.endsWith("/responses")
+  const path = (() => {
+    try {
+      return new URL(raw).pathname
+    } catch {
+      return raw.split(/[?#]/, 1)[0]
+    }
+  })()
+  return path.endsWith("/responses")
 }
 
 function strip(input: unknown[]) {

--- a/packages/kilo-gateway/test/responses.test.ts
+++ b/packages/kilo-gateway/test/responses.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizeResponsesBody } from "../src/responses"
+
+describe("Responses request sanitization", () => {
+  test("strips item ids when storage is disabled", () => {
+    const body = JSON.stringify({
+      store: false,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_tmp_123",
+          encrypted_content: "encrypted",
+          summary: [{ type: "summary_text", text: "thinking" }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          id: "msg_tmp_123",
+          content: [{ type: "output_text", text: "Hello" }],
+        },
+        {
+          type: "item_reference",
+          id: "rs_tmp_456",
+        },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Continue" }],
+        },
+      ],
+    })
+
+    const result = sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/responses", body)
+    const data = JSON.parse(result as string)
+
+    expect(data.input).toHaveLength(3)
+    expect(data.input[0].id).toBeUndefined()
+    expect(data.input[0].encrypted_content).toBe("encrypted")
+    expect(data.input[0].summary[0].text).toBe("thinking")
+    expect(data.input[1].id).toBeUndefined()
+    expect(data.input[1].content[0].text).toBe("Hello")
+    expect(data.input.some((item: { type?: string }) => item.type === "item_reference")).toBe(false)
+    expect(data.input[2].content[0].text).toBe("Continue")
+  })
+
+  test("keeps item ids when storage is enabled", () => {
+    const body = JSON.stringify({
+      store: true,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_123",
+          encrypted_content: "encrypted",
+          summary: [],
+        },
+        {
+          type: "item_reference",
+          id: "rs_456",
+        },
+      ],
+    })
+
+    expect(sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/responses", body)).toBe(body)
+  })
+
+  test("leaves non-responses requests unchanged", () => {
+    const body = "not json"
+
+    expect(sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/chat/completions", body)).toBe(body)
+  })
+})

--- a/packages/kilo-gateway/test/responses.test.ts
+++ b/packages/kilo-gateway/test/responses.test.ts
@@ -68,4 +68,10 @@ describe("Responses request sanitization", () => {
 
     expect(sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/chat/completions", body)).toBe(body)
   })
+
+  test("leaves invalid responses JSON unchanged", () => {
+    const body = "not json"
+
+    expect(sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/responses", body)).toBe(body)
+  })
 })

--- a/packages/kilo-gateway/test/responses.test.ts
+++ b/packages/kilo-gateway/test/responses.test.ts
@@ -74,4 +74,21 @@ describe("Responses request sanitization", () => {
 
     expect(sanitizeResponsesBody("https://api.kilo.ai/api/openrouter/responses", body)).toBe(body)
   })
+
+  test("matches relative responses paths without a placeholder host", () => {
+    const body = JSON.stringify({
+      input: [
+        {
+          type: "message",
+          role: "assistant",
+          id: "msg_tmp_123",
+          content: [{ type: "output_text", text: "Hello" }],
+        },
+      ],
+    })
+    const result = sanitizeResponsesBody("/api/openrouter/responses?stream=true", body)
+    const data = JSON.parse(result as string)
+
+    expect(data.input[0].id).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Fix Kilo Gateway Responses requests that can fail with provider 400: `Item with id 'rs_*' not found. Items are not persisted when store is false.` The PR intentionally omits the real item ID, user/org IDs, prompts, headers, and routing metadata.

OpenRouter documents `/responses` as stateless, so Kilo must send valid client-managed history instead of replaying server-stored item references. OpenAI and Azure document `reasoning.encrypted_content` as the supported way to carry reasoning across `store:false` turns. This change strips persisted-item references from `store:false` `/responses` inputs while preserving full message content and encrypted reasoning so stateless history remains valid.

Documentation used:
- OpenRouter Responses overview, stateless only: https://openrouter.ai/docs/api/reference/responses/overview
- OpenRouter multi-turn Responses usage, full history required: https://openrouter.ai/docs/api/reference/responses/basic-usage#multiple-turn-conversations
- OpenAI reasoning docs, encrypted reasoning items for `store:false`: https://developers.openai.com/api/docs/guides/reasoning?api-mode=responses#encrypted-reasoning-items
- Azure Responses docs, encrypted reasoning items: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses#encrypted-reasoning-items

The sanitizer is scoped to Kilo Gateway `/responses` requests where storage is not enabled, so `store:true` chaining remains untouched.