### PR TITLE
fix(vscode): reset todos on snapshot revert

### DIFF
--- a/.changeset/reset-reverted-todos.md
+++ b/.changeset/reset-reverted-todos.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reset the To-dos tab when reverting a session snapshot.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -670,7 +670,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           await this.handleAbort(message.sessionID)
           break
         case "revertSession":
-          this.handleRevertSession(message.sessionID, message.messageID).catch((e) =>
+          this.handleRevertSession(message.sessionID, message.messageID, message.partID).catch((e) =>
             console.error("[Kilo New] handleRevertSession failed:", e),
           )
           break
@@ -2696,10 +2696,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  private async handleRevertSession(sessionID: string, messageID: string): Promise<void> {
+  private async handleRevertSession(sessionID: string, messageID: string, partID?: string): Promise<void> {
     if (!this.client) return
     const dir = this.getWorkspaceDirectory(sessionID)
-    const { data, error } = await this.client.session.revert({ sessionID, messageID, directory: dir })
+    const { data, error } = await this.client.session.revert({ sessionID, messageID, partID, directory: dir })
     if (error) {
       console.error("[Kilo New] KiloProvider: Failed to revert session:", error)
       this.postMessage({ type: "error", message: "Failed to revert session", sessionID })

--- a/packages/kilo-vscode/tests/unit/todo-revert.test.ts
+++ b/packages/kilo-vscode/tests/unit/todo-revert.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test"
+import { state, target } from "../../webview-ui/src/context/todo-revert"
+import type { Message, Part, TodoItem } from "../../webview-ui/src/types/messages"
+
+const base = {
+  sessionID: "session",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  time: { created: 1 },
+}
+
+const user = (id: string): Message => ({ ...base, id, role: "user" })
+
+const assistant = (id: string, parentID: string): Message => ({ ...base, id, parentID, role: "assistant" })
+
+const todos = (...status: TodoItem["status"][]): TodoItem[] =>
+  status.map((status, index) => ({ id: String(index + 1), content: `todo ${index + 1}`, status }))
+
+const part = (id: string, messageID: string, list: TodoItem[]): Part => ({
+  id,
+  messageID,
+  sessionID: "session",
+  type: "tool",
+  tool: "todowrite",
+  state: {
+    status: "completed",
+    input: { todos: list },
+    output: JSON.stringify(list),
+    title: `${list.length} todos`,
+    metadata: { todos: list },
+  },
+})
+
+describe("todo revert helpers", () => {
+  const messages = [user("message_1"), assistant("message_2", "message_1")]
+  const parts = {
+    message_2: [
+      part("part_1", "message_2", todos("pending", "pending", "pending")),
+      part("part_2", "message_2", todos("completed", "pending", "pending")),
+      part("part_3", "message_2", todos("completed", "completed", "pending")),
+    ],
+  }
+
+  it("restores the todo state before a reverted todowrite part", () => {
+    expect(state({ messages, parts, revert: { messageID: "message_2", partID: "part_3" } })).toEqual(
+      todos("completed", "pending", "pending"),
+    )
+  })
+
+  it("restores the latest todo state on redo", () => {
+    expect(state({ messages, parts })).toEqual(todos("completed", "completed", "pending"))
+  })
+
+  it("targets the todowrite part that first completed the clicked todo", () => {
+    expect(target({ messages, parts }, 0)?.id).toBe("part_2")
+    expect(target({ messages, parts }, 1)?.id).toBe("part_3")
+    expect(target({ messages, parts }, 2)).toBeUndefined()
+  })
+
+  it("uses normal part ordering inside the revert boundary message", () => {
+    expect(state({ messages, parts, revert: { messageID: "message_2", partID: "part_2" } })).toEqual(
+      todos("pending", "pending", "pending"),
+    )
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -19,7 +19,8 @@ import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { TaskTimeline } from "./TaskTimeline"
 import { ContextProgress } from "./ContextProgress"
-import type { TodoItem, ExtensionMessage } from "../../types/messages"
+import { target as todoTarget } from "../../context/todo-revert"
+import type { Part, TodoItem, ExtensionMessage } from "../../types/messages"
 
 interface TaskHeaderProps {
   readonly?: boolean
@@ -124,6 +125,16 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   })
 
   const [todosOpen, setTodosOpen] = createSignal(false)
+
+  const donePart = (idx: number): Part | undefined =>
+    todoTarget({ messages: session.messages(), parts: session.allParts() }, idx)
+
+  const revertTodo = (part: Part | undefined) => {
+    if (session.status() !== "idle") return
+    if (part?.type !== "tool") return
+    if (!part.messageID) return
+    session.revertSession(part.messageID, part.id)
+  }
 
   return (
     <Show when={hasMessages()}>
@@ -234,16 +245,21 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
           <Show when={todosOpen()}>
             <div data-slot="task-header-todos-list">
               <For each={todos()}>
-                {(todo: TodoItem) => (
-                  <Checkbox readOnly checked={todo.status === "completed"}>
-                    <span
-                      data-slot="task-header-todo-content"
-                      data-completed={todo.status === "completed" ? "" : undefined}
-                    >
-                      {todo.content}
-                    </span>
-                  </Checkbox>
-                )}
+                {(todo: TodoItem, idx) => {
+                  const part = createMemo(() => (todo.status === "completed" ? donePart(idx()) : undefined))
+                  return (
+                    <Tooltip value={part() ? language.t("settings.checkpoints.title") : undefined} placement="bottom">
+                      <Checkbox readOnly checked={todo.status === "completed"} onClick={() => revertTodo(part())}>
+                        <span
+                          data-slot="task-header-todo-content"
+                          data-completed={todo.status === "completed" ? "" : undefined}
+                        >
+                          {todo.content}
+                        </span>
+                      </Checkbox>
+                    </Tooltip>
+                  )
+                }}
               </For>
             </div>
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1473,7 +1473,6 @@ export const SessionProvider: ParentComponent = (props) => {
     const next = session.revert ?? undefined
     setStore("sessions", session.id, session)
     if (prev?.messageID === next?.messageID && prev?.partID === next?.partID) return
-    if (!prev && !next) return
     resetTodos(session.id, next)
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -49,6 +49,7 @@ import { resolveModelSelection } from "./model-selection"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs } from "./session-errors"
 import { PartStash } from "./part-stash"
+import { state as todoState } from "./todo-revert"
 import { getVariant, sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
 
@@ -205,7 +206,7 @@ interface SessionContextValue {
   worktreeStats: Accessor<{ files: number; additions: number; deletions: number } | undefined>
 
   // Actions
-  revertSession: (messageID: string) => void
+  revertSession: (messageID: string, partID?: string) => void
   unrevertSession: () => void
   sendMessage: (
     text: string,
@@ -840,7 +841,7 @@ export const SessionProvider: ParentComponent = (props) => {
         break
 
       case "sessionUpdated":
-        setStore("sessions", message.session.id, message.session)
+        handleSessionUpdated(message.session)
         break
 
       case "sessionDeleted":
@@ -1103,6 +1104,8 @@ export const SessionProvider: ParentComponent = (props) => {
         })
       }
 
+      const revert = store.sessions[sessionID]?.revert ?? undefined
+      if (revert) resetTodos(sessionID, revert)
       recoverPrefs(sessionID, merged)
     })
     if (reset) requestAnimationFrame(() => patchPage(sessionID, { lastMutation: undefined }))
@@ -1454,6 +1457,24 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function handleTodoUpdated(sessionID: string, items: TodoItem[]) {
     setStore("todos", sessionID, items)
+  }
+
+  function resetTodos(sessionID: string, revert?: NonNullable<SessionInfo["revert"]>) {
+    const items = todoState({
+      messages: store.messages[sessionID] ?? [],
+      parts: (messageID) => store.parts[messageID] ?? stash.peek(messageID),
+      revert,
+    })
+    setStore("todos", sessionID, items)
+  }
+
+  function handleSessionUpdated(session: SessionInfo) {
+    const prev = store.sessions[session.id]?.revert
+    const next = session.revert ?? undefined
+    setStore("sessions", session.id, session)
+    if (prev?.messageID === next?.messageID && prev?.partID === next?.partID) return
+    if (!prev && !next) return
+    resetTodos(session.id, next)
   }
 
   function handleSessionsLoaded(loaded: SessionInfo[], preserve?: string[]) {
@@ -2155,7 +2176,7 @@ export const SessionProvider: ParentComponent = (props) => {
     return id ? (store.sessions[id]?.summary ?? undefined) : undefined
   })
 
-  function revertSession(messageID: string) {
+  function revertSession(messageID: string, partID?: string) {
     const id = currentSessionID()
     if (!id) return
     // Restore the reverted user message's prompt text into the input.
@@ -2168,7 +2189,7 @@ export const SessionProvider: ParentComponent = (props) => {
         .join("")
       if (text) window.postMessage({ type: "setChatBoxMessage", text }, "*")
     }
-    vscode.postMessage({ type: "revertSession", sessionID: id, messageID })
+    vscode.postMessage({ type: "revertSession", sessionID: id, messageID, partID })
   }
 
   function unrevertSession() {

--- a/packages/kilo-vscode/webview-ui/src/context/todo-revert.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/todo-revert.ts
@@ -1,0 +1,74 @@
+import type { Message, Part, SessionInfo, TodoItem, ToolPart } from "../types/messages"
+
+type Revert = NonNullable<SessionInfo["revert"]>
+type Source = Record<string, Part[]> | ((messageID: string) => Part[] | undefined)
+type TodoPart = ToolPart & { state: { status: "completed"; metadata?: Record<string, unknown> } }
+
+interface Input {
+  messages: Message[]
+  parts: Source
+  revert?: Revert
+}
+
+interface Write {
+  part: TodoPart
+  todos: TodoItem[]
+}
+
+function list(source: Source, messageID: string) {
+  if (typeof source === "function") return source(messageID) ?? []
+  return source[messageID] ?? []
+}
+
+export function isTodo(part: Part): part is TodoPart {
+  if (part.type !== "tool") return false
+  if (part.tool !== "todowrite") return false
+  if (part.state.status !== "completed") return false
+  return true
+}
+
+export function items(part: Part): TodoItem[] | undefined {
+  if (!isTodo(part)) return undefined
+  const todos = part.state.metadata?.todos
+  if (!Array.isArray(todos)) return undefined
+  return todos as TodoItem[]
+}
+
+function active(input: Input, msg: Message) {
+  const parts = list(input.parts, msg.id)
+  const revert = input.revert
+  if (!revert) return parts
+  if (msg.id < revert.messageID) return parts
+  if (msg.id > revert.messageID) return []
+  if (!revert.partID) return []
+  const partID = revert.partID
+  return parts.filter((part) => part.id < partID)
+}
+
+export function writes(input: Input): Write[] {
+  return input.messages.flatMap((msg) =>
+    active(input, msg).flatMap((part) => {
+      const todos = items(part)
+      return todos ? [{ part: part as TodoPart, todos }] : []
+    }),
+  )
+}
+
+export function state(input: Input): TodoItem[] {
+  return writes(input).at(-1)?.todos ?? []
+}
+
+export function target(input: Omit<Input, "revert">, index: number): Part | undefined {
+  const all = writes(input)
+  const done = (item: Write) => item.todos[index]?.status === "completed"
+  const fallback = [...all].reverse().find(done)
+  const entry = all
+    .map((item, idx) => ({ item, idx }))
+    .reverse()
+    .find(({ item, idx }) => {
+      if (!done(item)) return false
+      return all[idx - 1]?.todos[index]?.status !== "completed"
+    })
+
+  return entry?.item.part ?? fallback?.part
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -2,7 +2,13 @@
 export type ToolState =
   | { status: "pending"; input: Record<string, unknown> }
   | { status: "running"; input: Record<string, unknown>; title?: string }
-  | { status: "completed"; input: Record<string, unknown>; output: string; title: string }
+  | {
+      status: "completed"
+      input: Record<string, unknown>
+      output: string
+      title: string
+      metadata?: Record<string, unknown>
+    }
   | { status: "error"; input: Record<string, unknown>; error: string }
 
 // Base part interface - all parts have these fields

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -40,6 +40,7 @@ export interface RevertSessionRequest {
   type: "revertSession"
   sessionID: string
   messageID: string
+  partID?: string
 }
 
 export interface UnrevertSessionRequest {


### PR DESCRIPTION
Fix the To-dos tab so snapshot revert and redo restore the todo state from the active conversation history instead of keeping stale items.

This also lets reverting a completed todo target the specific `todowrite` snapshot part, so reverting the second completed item keeps earlier completed items intact.

<img width="464" height="859" alt="image" src="https://github.com/user-attachments/assets/0209d794-366d-4e0f-b202-7f2f2d62045d" />
