### PR TITLE
Fix: Hide subagent sessions from VsCode Agent Manager sessions view

### DIFF
--- a/.changeset/hide-subagent-sessions.md
+++ b/.changeset/hide-subagent-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Hide Task tool subagent sessions from Agent Manager session lists.

--- a/packages/kilo-vscode/tests/unit/navigate.test.ts
+++ b/packages/kilo-vscode/tests/unit/navigate.test.ts
@@ -5,6 +5,7 @@ import {
   adjacentHint,
   restoreLocalSessions,
   reconcileLocalSessions,
+  filterUnassignedSessions,
   LOCAL,
 } from "../../webview-ui/agent-manager/navigate"
 
@@ -185,6 +186,105 @@ describe("adjacentHint", () => {
   it("works with single-item list", () => {
     expect(adjacentHint("a", "b", ["a", "b"], "prev", "next")).toBe("prev")
     expect(adjacentHint("b", "a", ["a", "b"], "prev", "next")).toBe("next")
+  })
+})
+
+describe("filterUnassignedSessions", () => {
+  const at = (day: number) => `2026-01-${String(day).padStart(2, "0")}T00:00:00.000Z`
+  const info = (id: string, day: number, parentID?: string | null) => ({
+    id,
+    createdAt: at(day),
+    ...(parentID === undefined ? {} : { parentID }),
+  })
+
+  it("keeps root sessions with undefined parent IDs", () => {
+    const result = filterUnassignedSessions([info("old", 1), info("new", 3)], new Set(), new Set())
+
+    expect(result.map((s) => s.id)).toEqual(["new", "old"])
+  })
+
+  it("keeps root sessions with null parent IDs", () => {
+    const result = filterUnassignedSessions([info("root", 1, null)], new Set(), new Set())
+
+    expect(result.map((s) => s.id)).toEqual(["root"])
+  })
+
+  it("filters child sessions with parent IDs", () => {
+    const result = filterUnassignedSessions(
+      [info("parent", 2), info("child", 3, "parent"), info("orphan", 4, "missing")],
+      new Set(),
+      new Set(),
+    )
+
+    expect(result.map((s) => s.id)).toEqual(["parent"])
+  })
+
+  it("filters string parent IDs even when they are empty", () => {
+    const result = filterUnassignedSessions([info("blank", 2, ""), info("root", 1)], new Set(), new Set())
+
+    expect(result.map((s) => s.id)).toEqual(["root"])
+  })
+
+  it("filters worktree sessions while keeping other roots", () => {
+    const result = filterUnassignedSessions(
+      [info("root", 1), info("worktree", 3), info("other", 2)],
+      new Set(["worktree"]),
+      new Set(),
+    )
+
+    expect(result.map((s) => s.id)).toEqual(["other", "root"])
+  })
+
+  it("filters local tab sessions while keeping other roots", () => {
+    const result = filterUnassignedSessions(
+      [info("root", 1), info("local", 3), info("other", 2)],
+      new Set(),
+      new Set(["local"]),
+    )
+
+    expect(result.map((s) => s.id)).toEqual(["other", "root"])
+  })
+
+  it("applies child, worktree, and local filters before sorting", () => {
+    const result = filterUnassignedSessions(
+      [info("old-root", 1), info("child", 6, "old-root"), info("worktree", 5), info("local", 4), info("new-root", 3)],
+      new Set(["worktree"]),
+      new Set(["local"]),
+    )
+
+    expect(result.map((s) => s.id)).toEqual(["new-root", "old-root"])
+  })
+
+  it("returns an empty list when every session is filtered", () => {
+    const result = filterUnassignedSessions(
+      [info("child", 3, "root"), info("worktree", 2), info("local", 1)],
+      new Set(["worktree"]),
+      new Set(["local"]),
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("does not mutate the input order", () => {
+    const sessions = [info("old", 1), info("new", 3), info("mid", 2)]
+
+    filterUnassignedSessions(sessions, new Set(), new Set())
+
+    expect(sessions.map((s) => s.id)).toEqual(["old", "new", "mid"])
+  })
+
+  it("preserves session objects and extra fields", () => {
+    const root = { ...info("root", 1), title: "Existing session" }
+    const result = filterUnassignedSessions([root], new Set(), new Set())
+
+    expect(result[0]).toBe(root)
+    expect(result[0]?.title).toBe("Existing session")
+  })
+
+  it("keeps a parent root when its child is filtered", () => {
+    const result = filterUnassignedSessions([info("root", 1), info("child", 2, "root")], new Set(), new Set())
+
+    expect(result.map((s) => s.id)).toEqual(["root"])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -87,7 +87,14 @@ import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { LanguageBridge, DataBridge, MermaidDownloadBridge } from "../src/App"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
-import { nextSelectionAfterDelete, adjacentHint, restoreLocalSessions, reconcileLocalSessions, LOCAL } from "./navigate"
+import {
+  nextSelectionAfterDelete,
+  adjacentHint,
+  restoreLocalSessions,
+  reconcileLocalSessions,
+  filterUnassignedSessions,
+  LOCAL,
+} from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { createTabOrderSync } from "./tab-order-sync"
 import { ConstrainDragYAxis } from "./sortable-tab"
@@ -717,9 +724,7 @@ const AgentManagerContent: Component = () => {
 
   // Sessions NOT in any worktree and not local
   const unassignedSessions = createMemo(() =>
-    [...session.sessions()]
-      .filter((s) => !worktreeSessionIds().has(s.id) && !localSet().has(s.id))
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    filterUnassignedSessions(session.sessions(), worktreeSessionIds(), localSet()),
   )
 
   // Local sessions (resolved from session list + pending tabs, in insertion order)

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -12,6 +12,18 @@ export const LOCAL = "local" as const
 
 type NavResult = { action: "select"; id: string } | { action: typeof LOCAL } | { action: "none" }
 
+type SessionLike = { id: string; parentID?: string | null; createdAt: string }
+
+export function filterUnassignedSessions<T extends SessionLike>(
+  sessions: T[],
+  worktree: Set<string>,
+  local: Set<string>,
+): T[] {
+  return [...sessions]
+    .filter((s) => (s.parentID === undefined || s.parentID === null) && !worktree.has(s.id) && !local.has(s.id))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+}
+
 export function resolveNavigation(direction: "up" | "down", current: string | undefined, ids: string[]): NavResult {
   // Determine current position: -1 = local, 0..N-1 = session index
   if (!current) {


### PR DESCRIPTION
Task-tool subagents are internal child sessions, but Agent Manager could surface them as normal unassigned sessions when their metadata reached the shared session store.

Via a regression subagents where shown as

`@explore some task`

This keeps the Agent Manager session list focused on root sessions while preserving child sessions for transcript, permission, and task resume flows.