### PR TITLE
feat(vscode): collapsible Agent Manager sidebar

### DIFF
--- a/.changeset/agent-manager-collapsible-sidebar.md
+++ b/.changeset/agent-manager-collapsible-sidebar.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add a collapsible sidebar in the Agent Manager. The toggle button sits left of the tab title and the collapsed state persists across reloads and restarts. Starting a new session or worktree automatically reopens the sidebar so the new entry is visible.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -529,6 +529,10 @@ export class AgentManagerProvider implements Disposable {
       this.state?.setSessionsCollapsed(m.collapsed)
       return null
     }
+    if (m.type === "agentManager.setSidebarCollapsed") {
+      this.state?.setSidebarCollapsed(m.collapsed)
+      return null
+    }
     if (this.handleSection(m)) return null
     if (m.type === "agentManager.setReviewDiffStyle") {
       this.state?.setReviewDiffStyle(m.style)
@@ -855,6 +859,7 @@ export class AgentManagerProvider implements Disposable {
       case "agentManager.setTabOrder":
       case "agentManager.setWorktreeOrder":
       case "agentManager.setSessionsCollapsed":
+      case "agentManager.setSidebarCollapsed":
       case "agentManager.setReviewDiffStyle":
       case "agentManager.setDefaultBaseBranch":
       case "agentManager.createSection":
@@ -1497,6 +1502,7 @@ export class AgentManagerProvider implements Disposable {
       tabOrder: state.getTabOrder(),
       worktreeOrder: state.getWorktreeOrder(),
       sessionsCollapsed: state.getSessionsCollapsed(),
+      sidebarCollapsed: state.getSidebarCollapsed(),
       reviewDiffStyle: state.getReviewDiffStyle(),
       reviewMarkdownRender: getDiffMarkdownRender(),
       isGitRepo: true,

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -71,6 +71,7 @@ interface StateFile {
   tabOrder?: Record<string, string[]>
   worktreeOrder?: string[]
   sessionsCollapsed?: boolean
+  sidebarCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   defaultBaseBranch?: string
 }
@@ -99,6 +100,7 @@ export class WorktreeStateManager {
   private tabOrder: Record<string, string[]> = {}
   private worktreeOrder: string[] = []
   private collapsed = false
+  private sidebar = false
   private reviewDiffStyle: "unified" | "split" = "unified"
   private defaultBase: string | undefined
   private readonly log: (msg: string) => void
@@ -523,6 +525,19 @@ export class WorktreeStateManager {
   }
 
   // ---------------------------------------------------------------------------
+  // Sidebar collapsed
+  // ---------------------------------------------------------------------------
+
+  getSidebarCollapsed(): boolean {
+    return this.sidebar
+  }
+
+  setSidebarCollapsed(value: boolean): void {
+    this.sidebar = value
+    void this.save()
+  }
+
+  // ---------------------------------------------------------------------------
   // Review diff style
   // ---------------------------------------------------------------------------
 
@@ -636,6 +651,7 @@ export class WorktreeStateManager {
     }
     const repaired = this.setNormalizedWorktreeOrder(this.worktreeOrder)
     this.collapsed = data.sessionsCollapsed ?? false
+    this.sidebar = data.sidebarCollapsed ?? false
     if (data.reviewDiffStyle === "split") {
       this.reviewDiffStyle = "split"
     }
@@ -740,6 +756,9 @@ export class WorktreeStateManager {
     }
     if (this.collapsed) {
       data.sessionsCollapsed = true
+    }
+    if (this.sidebar) {
+      data.sidebarCollapsed = true
     }
     if (this.reviewDiffStyle === "split") {
       data.reviewDiffStyle = "split"

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -126,6 +126,7 @@ interface StateMessage {
   tabOrder?: Record<string, string[]>
   worktreeOrder?: string[]
   sessionsCollapsed?: boolean
+  sidebarCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   reviewMarkdownRender?: boolean
   isGitRepo?: boolean
@@ -456,6 +457,11 @@ interface SetSessionsCollapsedIn {
   collapsed: boolean
 }
 
+interface SetSidebarCollapsedIn {
+  type: "agentManager.setSidebarCollapsed"
+  collapsed: boolean
+}
+
 interface SetReviewDiffStyleIn {
   type: "agentManager.setReviewDiffStyle"
   style: "unified" | "split"
@@ -736,6 +742,7 @@ export type AgentManagerInMessage =
   | SetTabOrderIn
   | SetWorktreeOrderIn
   | SetSessionsCollapsedIn
+  | SetSidebarCollapsedIn
   | SetReviewDiffStyleIn
   | SetReviewMarkdownRenderIn
   | SetDefaultBaseBranchIn

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -35,6 +35,7 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/WorktreeItem.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/SectionHeader.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/CurrentTabsMenu.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/SidebarToggleButton.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/tab-rendering.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/terminal/TerminalTab.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/terminal/SortableTerminalTab.tsx"),

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -425,6 +425,40 @@ describe("WorktreeStateManager", () => {
     })
   })
 
+  describe("sidebarCollapsed", () => {
+    it("defaults to false", () => {
+      expect(manager.getSidebarCollapsed()).toBe(false)
+    })
+
+    it("sets and gets collapsed state", () => {
+      manager.setSidebarCollapsed(true)
+      expect(manager.getSidebarCollapsed()).toBe(true)
+
+      manager.setSidebarCollapsed(false)
+      expect(manager.getSidebarCollapsed()).toBe(false)
+    })
+
+    it("persists and loads collapsed state", async () => {
+      manager.setSidebarCollapsed(true)
+      await manager.flush()
+      await manager.save()
+
+      const loaded = new WorktreeStateManager(root, () => {})
+      await loaded.load()
+      expect(loaded.getSidebarCollapsed()).toBe(true)
+    })
+
+    it("does not persist when false", async () => {
+      manager.setSidebarCollapsed(false)
+      await manager.flush()
+      await manager.save()
+
+      const content = fs.readFileSync(path.join(root, ".kilo", "agent-manager.json"), "utf-8")
+      const data = JSON.parse(content)
+      expect(data.sidebarCollapsed).toBeUndefined()
+    })
+  })
+
   describe("validate", () => {
     it("removes worktrees whose directories do not exist and prunes their sessions", async () => {
       const existing = path.join(root, "wt-exists")

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -120,6 +120,8 @@ import { ConstrainDragXAxis } from "./constrain-drag-x"
 import { mergeWorktreeDiffs } from "./diff-state"
 import { initialMessage, seedInitialVariant } from "./initial-message"
 import { createMarkdownRender } from "./review-preferences"
+import { createSidebarCollapse } from "./sidebar-collapse"
+import { SidebarToggleButton } from "./SidebarToggleButton"
 import { setTabWidths } from "./tab-widths"
 import "./agent-manager.css"
 import "./agent-manager-review.css"
@@ -284,6 +286,10 @@ const AgentManagerContent: Component = () => {
     setLocalSessionIDs((prev) => (prev.includes(sid) ? prev.filter((id) => id !== sid) : prev))
   const [sidebarWidth, setSidebarWidth] = createSignal(persisted?.sidebarWidth ?? DEFAULT_SIDEBAR_WIDTH)
   const [sessionsCollapsed, setSessionsCollapsed] = createSignal(false)
+  const sidebar = createSidebarCollapse(vscode)
+  const sidebarCollapsed = sidebar.collapsed
+  const expandSidebar = sidebar.expand
+  const toggleSidebar = sidebar.toggle
   const [sections, setSections] = createSignal<SectionState[]>([])
 
   // rAF coalescing for resize handlers — at most one signal write per frame
@@ -1280,6 +1286,8 @@ const AgentManagerContent: Component = () => {
         if (restored) setLocalSessionIDs(restored)
         // Recover sessions collapsed state from extension-persisted state
         if (state.sessionsCollapsed !== undefined) setSessionsCollapsed(state.sessionsCollapsed)
+        // Recover sidebar collapsed state and mark hydrated so transitions enable
+        sidebar.hydrate(state.sidebarCollapsed)
         // Clear busy state for worktrees that have been removed
         const ids = new Set(state.worktrees.map((wt) => wt.id))
         setBusyWorktrees((prev) => {
@@ -1757,12 +1765,14 @@ const AgentManagerContent: Component = () => {
 
   const handleCreateWorktree = () => {
     if (!loaded()) return
+    expandSidebar()
     vscode.postMessage({ type: "agentManager.createWorktree" })
   }
 
   // Advanced worktree dialog — opens a full dialog with prompt, versions, model, mode
   const showAdvancedWorktreeDialog = () => {
     if (!loaded()) return
+    expandSidebar()
     dialog.show(() => <NewWorktreeDialog onClose={() => dialog.close()} defaultBaseBranch={repoDefaultBranch()} />)
   }
 
@@ -1857,6 +1867,7 @@ const AgentManagerContent: Component = () => {
 
   const openLocally = (sid: string) => {
     saveTabMemory()
+    expandSidebar()
     const pending = activePendingId()
     if (pending) {
       setLocalSessionIDs((prev) => prev.map((id) => (id === pending ? sid : id)))
@@ -1870,6 +1881,7 @@ const AgentManagerContent: Component = () => {
 
   const handleAddSession = () => {
     const sel = selection()
+    expandSidebar()
     if (sel === LOCAL) return addPendingTab()
     if (sel) {
       // Deactivate any focused terminal so the new session is visible.
@@ -2110,8 +2122,17 @@ const AgentManagerContent: Component = () => {
   }
 
   return (
-    <div class="am-layout" onContextMenu={(e) => e.preventDefault()}>
-      <div class="am-sidebar" style={{ width: `${sidebarWidth()}px` }}>
+    <div
+      class="am-layout"
+      classList={{ "am-layout-hydrated": sidebar.hydrated() }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <div
+        class="am-sidebar"
+        classList={{ "am-sidebar-collapsed": sidebarCollapsed() }}
+        style={{ width: sidebarCollapsed() ? "0px" : `${sidebarWidth()}px` }}
+        aria-hidden={sidebarCollapsed()}
+      >
         <ResizeHandle
           direction="horizontal"
           size={sidebarWidth()}
@@ -2635,8 +2656,19 @@ const AgentManagerContent: Component = () => {
       </div>
 
       <div class="am-detail">
-        {/* Tab bar — visible when a section is selected and has tabs or a pending new session */}
-        <Show when={selection() !== null && !contextEmpty()}>
+        {/* Tab bar — full version with tabs renders when a section is selected
+            and has tabs; otherwise a minimal version still renders so the
+            sidebar toggle button stays at a fixed position. */}
+        <Show
+          when={selection() !== null && !contextEmpty()}
+          fallback={
+            <div class="am-tab-bar am-tab-bar-empty">
+              <div class="am-tab-leading">
+                <SidebarToggleButton collapsed={sidebarCollapsed()} onClick={toggleSidebar} />
+              </div>
+            </div>
+          }
+        >
           <DragDropProvider
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
@@ -2647,6 +2679,7 @@ const AgentManagerContent: Component = () => {
             <ConstrainDragYAxis />
             <div class="am-tab-bar" onPointerLeave={releaseTabs}>
               <div class="am-tab-leading">
+                <SidebarToggleButton collapsed={sidebarCollapsed()} onClick={toggleSidebar} />
                 <CurrentTabsMenu
                   items={tabMenuItems}
                   label={t("agentManager.tabsMenu.label")}

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2131,7 +2131,7 @@ const AgentManagerContent: Component = () => {
         class="am-sidebar"
         classList={{ "am-sidebar-collapsed": sidebarCollapsed() }}
         style={{ width: sidebarCollapsed() ? "0px" : `${sidebarWidth()}px` }}
-        aria-hidden={sidebarCollapsed()}
+        inert={sidebarCollapsed() || undefined}
       >
         <ResizeHandle
           direction="horizontal"

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarToggleButton.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarToggleButton.tsx
@@ -1,0 +1,29 @@
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import { useLanguage } from "../src/context/language"
+
+interface Props {
+  collapsed: boolean
+  onClick: () => void
+}
+
+/**
+ * Sidebar collapse/expand toggle rendered inside the tab bar's leading slot.
+ * Same pixel position in both states; only the icon's left-column fill flips
+ * to indicate state.
+ */
+export function SidebarToggleButton(props: Props) {
+  const { t } = useLanguage()
+  const label = () => (props.collapsed ? t("agentManager.sidebar.expand") : t("agentManager.sidebar.collapse"))
+  return (
+    <Tooltip value={label()} placement="bottom">
+      <IconButton
+        icon={props.collapsed ? "layout-left-partial" : "layout-left-full"}
+        size="small"
+        variant="ghost"
+        label={label()}
+        onClick={props.onClick}
+      />
+    </Tooltip>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -23,6 +23,37 @@
   background: var(--surface-interactive-base);
 }
 
+/* Collapsed sidebar: width animates closed; the layout-hydrated class delays
+   the transition until after the first state push so we don't see a flash on
+   initial render when the persisted state is "collapsed". */
+.am-layout-hydrated .am-sidebar {
+  transition:
+    width 180ms ease,
+    min-width 180ms ease,
+    padding 180ms ease,
+    border-right-width 180ms ease;
+}
+
+.am-sidebar-collapsed {
+  min-width: 0;
+  padding-left: 0;
+  padding-right: 0;
+  border-right-width: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.am-sidebar-collapsed > [data-component="resize-handle"] {
+  display: none;
+}
+
+/* Empty tab bar — rendered when no session is selected so the sidebar
+   toggle button sits in the same pixel position regardless of state.
+   Drops the leading slot's border-right because there's nothing after it. */
+.am-tab-bar-empty .am-tab-leading {
+  border-right: none;
+}
+
 /* Fixed local repo item */
 
 .am-local-item {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -40,7 +40,8 @@
   padding-right: 0;
   border-right-width: 0;
   overflow: hidden;
-  pointer-events: none;
+  /* Pointer events, focus, and a11y tree exclusion are all handled by the
+     inert attribute on the element. No need for pointer-events: none. */
 }
 
 .am-sidebar-collapsed > [data-component="resize-handle"] {

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "محلي",
+  "agentManager.sidebar.collapse": "طي الشريط الجانبي",
+  "agentManager.sidebar.expand": "إظهار الشريط الجانبي",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "الجلسات",
   "agentManager.notGitRepo": "ليس مستودع git",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "local",
+  "agentManager.sidebar.collapse": "Recolher barra lateral",
+  "agentManager.sidebar.expand": "Mostrar barra lateral",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESSÕES",
   "agentManager.notGitRepo": "Não é um repositório git",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokalno",
+  "agentManager.sidebar.collapse": "Skupi bočnu traku",
+  "agentManager.sidebar.expand": "Prikaži bočnu traku",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESIJE",
   "agentManager.notGitRepo": "Nije git repozitorij",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokal",
+  "agentManager.sidebar.collapse": "Skjul sidebjælke",
+  "agentManager.sidebar.expand": "Vis sidebjælke",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESSIONER",
   "agentManager.notGitRepo": "Ikke et git-repository",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokal",
+  "agentManager.sidebar.collapse": "Seitenleiste einklappen",
+  "agentManager.sidebar.expand": "Seitenleiste anzeigen",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SITZUNGEN",
   "agentManager.notGitRepo": "Kein Git-Repository",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "local",
+  "agentManager.sidebar.collapse": "Collapse sidebar",
+  "agentManager.sidebar.expand": "Show sidebar",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESSIONS",
   "agentManager.notGitRepo": "Not a git repository",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "local",
+  "agentManager.sidebar.collapse": "Contraer barra lateral",
+  "agentManager.sidebar.expand": "Mostrar barra lateral",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESIONES",
   "agentManager.notGitRepo": "No es un repositorio git",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "local",
+  "agentManager.sidebar.collapse": "Réduire la barre latérale",
+  "agentManager.sidebar.expand": "Afficher la barre latérale",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESSIONS",
   "agentManager.notGitRepo": "Ce n'est pas un dépôt git",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "ローカル",
+  "agentManager.sidebar.collapse": "サイドバーを折りたたむ",
+  "agentManager.sidebar.expand": "サイドバーを表示",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "セッション",
   "agentManager.notGitRepo": "gitリポジトリではありません",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "로컬",
+  "agentManager.sidebar.collapse": "사이드바 접기",
+  "agentManager.sidebar.expand": "사이드바 표시",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "세션",
   "agentManager.notGitRepo": "git 저장소가 아닙니다",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokaal",
+  "agentManager.sidebar.collapse": "Zijbalk inklappen",
+  "agentManager.sidebar.expand": "Zijbalk tonen",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESSIES",
   "agentManager.notGitRepo": "Geen git repository",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokal",
+  "agentManager.sidebar.collapse": "Skjul sidefelt",
+  "agentManager.sidebar.expand": "Vis sidefelt",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "ØKTER",
   "agentManager.notGitRepo": "Ikke et git-repositorium",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "lokalne",
+  "agentManager.sidebar.collapse": "Zwiń pasek boczny",
+  "agentManager.sidebar.expand": "Pokaż pasek boczny",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "SESJE",
   "agentManager.notGitRepo": "Nie jest repozytorium git",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "локальный",
+  "agentManager.sidebar.collapse": "Свернуть боковую панель",
+  "agentManager.sidebar.expand": "Показать боковую панель",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "СЕССИИ",
   "agentManager.notGitRepo": "Не является git-репозиторием",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "ในเครื่อง",
+  "agentManager.sidebar.collapse": "ย่อแถบด้านข้าง",
+  "agentManager.sidebar.expand": "แสดงแถบด้านข้าง",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "เซสชัน",
   "agentManager.notGitRepo": "ไม่ใช่ git repository",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "yerel",
+  "agentManager.sidebar.collapse": "Kenar çubuğunu daralt",
+  "agentManager.sidebar.expand": "Kenar çubuğunu göster",
   "agentManager.section.worktrees": "WORKTREE'LER",
   "agentManager.section.sessions": "OTURUMLAR",
   "agentManager.notGitRepo": "Bir git deposu değil",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "локальний",
+  "agentManager.sidebar.collapse": "Згорнути бічну панель",
+  "agentManager.sidebar.expand": "Показати бічну панель",
   "agentManager.section.worktrees": "РОБОЧІ ДЕРЕВА",
   "agentManager.section.sessions": "СЕСІЇ",
   "agentManager.notGitRepo": "Не є git-репозиторієм",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "本地",
+  "agentManager.sidebar.collapse": "折叠侧边栏",
+  "agentManager.sidebar.expand": "显示侧边栏",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "会话",
   "agentManager.notGitRepo": "不是 git 仓库",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -1,5 +1,7 @@
 export const dict = {
   "agentManager.local": "本機",
+  "agentManager.sidebar.collapse": "收合側邊欄",
+  "agentManager.sidebar.expand": "顯示側邊欄",
   "agentManager.section.worktrees": "WORKTREES",
   "agentManager.section.sessions": "工作階段",
   "agentManager.notGitRepo": "不是 git 儲存庫",

--- a/packages/kilo-vscode/webview-ui/agent-manager/sidebar-collapse.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sidebar-collapse.ts
@@ -1,0 +1,38 @@
+import { createSignal } from "solid-js"
+import type { WebviewMessage } from "../src/types/messages"
+
+export interface VsCodePoster {
+  postMessage: (msg: WebviewMessage) => void
+}
+
+/**
+ * Encapsulates the sidebar collapsed signal, persistence postMessage, and
+ * a single-frame "hydrated" flag that gates the width transition so the
+ * initial render (after restart with a persisted-collapsed state) does not
+ * animate from open to closed.
+ */
+export function createSidebarCollapse(vscode: VsCodePoster) {
+  const [collapsed, setCollapsed] = createSignal(false)
+  const [hydrated, setHydrated] = createSignal(false)
+
+  const persist = (next: boolean) => {
+    setCollapsed(next)
+    vscode.postMessage({ type: "agentManager.setSidebarCollapsed", collapsed: next })
+  }
+
+  return {
+    collapsed,
+    hydrated,
+    /** Apply state from extension push without re-broadcasting. */
+    hydrate: (value: boolean | undefined) => {
+      if (value !== undefined) setCollapsed(value)
+      if (!hydrated()) requestAnimationFrame(() => setHydrated(true))
+    },
+    /** Ensure the sidebar is visible; no-op + no message when already open. */
+    expand: () => {
+      if (collapsed()) persist(false)
+    },
+    /** Toggle and persist. */
+    toggle: () => persist(!collapsed()),
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -512,6 +512,7 @@ export interface AgentManagerStateMessage {
   tabOrder?: Record<string, string[]>
   worktreeOrder?: string[]
   sessionsCollapsed?: boolean
+  sidebarCollapsed?: boolean
   reviewDiffStyle?: "unified" | "split"
   reviewMarkdownRender?: boolean
   isGitRepo?: boolean

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -635,6 +635,12 @@ export interface SetSessionsCollapsedRequest {
   collapsed: boolean
 }
 
+// Persist sidebar collapsed state
+export interface SetSidebarCollapsedRequest {
+  type: "agentManager.setSidebarCollapsed"
+  collapsed: boolean
+}
+
 // Persist review diff style preference
 export interface SetReviewDiffStyleRequest {
   type: "agentManager.setReviewDiffStyle"
@@ -1115,6 +1121,7 @@ export type WebviewMessage =
   | SetTabOrderRequest
   | SetWorktreeOrderRequest
   | SetSessionsCollapsedRequest
+  | SetSidebarCollapsedRequest
   | SetReviewDiffStyleRequest
   | SetReviewMarkdownRenderRequest
   | PersistVariantRequest


### PR DESCRIPTION
The Agent Manager fills the editor pane and its left sidebar (worktrees + sessions) takes a fixed slice of the panel. On narrow editor splits or when focusing on a single chat, that's wasted space, and there's no way to reclaim it.

This adds a toggle button left of the active session/tab title that collapses the sidebar and a clearly labelled affordance to bring it back. The collapsed state is part of `.kilo/agent-manager.json` next to the existing `sessionsCollapsed`, so it survives panel reloads, window reloads, switching workspaces, and VS Code restarts. Each workspace remembers its own preference.

The button stays in a fixed pixel position whether the sidebar is open or closed and whether there's an active session or not, so the affordance is always reachable and the same target the user clicked to collapse is the one they click to expand. To make sure users never lose the panel they just acted on, creating a new session or worktree (via `+`, advanced dialog, or "Open Locally") implicitly expands the sidebar.

The first paint after a restart applies the collapsed state without the width transition, so the panel never flashes from open to closed on startup.