### PR TITLE
fix(vscode): keep worktree model search open

### DIFF
--- a/.changeset/model-picker-search-focus.md
+++ b/.changeset/model-picker-search-focus.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the New Worktree model picker open when interacting with its search field.

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -397,6 +397,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                         if (pid && mid) setModel({ providerID: pid, modelID: mid })
                       }}
                       placement="top-start"
+                      portal={false}
                       deferDismiss
                     />
                     <ThinkingSelectorBase
@@ -603,6 +604,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                   placement="top-start"
                   flip={false}
                   sameWidth
+                  portal={false}
                   deferDismiss
                   class="am-compare-popover"
                   trigger={

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -96,6 +96,8 @@ export interface ModelSelectorBaseProps {
   favorites?: boolean
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
+  /** Render inline instead of through a portal when nested in a dialog. */
+  portal?: boolean
 }
 
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
@@ -537,6 +539,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
       minHeight={200}
       placement={props.placement ?? "top-start"}
       deferDismiss={props.deferDismiss}
+      portal={props.portal}
       open={open()}
       onOpenChange={setOpen}
       triggerAs={Button}


### PR DESCRIPTION
Keep the New Worktree model dropdown open while users click and type in its search field.

Render the worktree model selectors inline within the dialog so dialog focus handling does not dismiss the popup as an outside interaction. Add a patch changeset for the user-visible fix.

<img width="541" height="394" alt="image" src="https://github.com/user-attachments/assets/7c38168c-19e6-4c8d-801a-de5dfbb080a5" />
