### PR TITLE
fix(webview-ui): ignore Enter during IME composition

### DIFF
--- a/.changeset/ime-enter-composition-guard.md
+++ b/.changeset/ime-enter-composition-guard.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Ignore Enter while IME composition is active (including Windows virtual-key 229) so composed text is not accidentally submitted from chat and sidebar inputs.

--- a/packages/kilo-vscode/tests/unit/ime-enter-key.test.ts
+++ b/packages/kilo-vscode/tests/unit/ime-enter-key.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "bun:test"
+import { isEnterKeyCommitNotIme } from "../../webview-ui/src/utils/ime-enter"
+
+describe("isEnterKeyCommitNotIme", () => {
+  it("is true for a normal Enter keydown", () => {
+    expect(isEnterKeyCommitNotIme({ key: "Enter", isComposing: false, keyCode: 13 })).toBe(true)
+  })
+
+  it("is false while isComposing is true", () => {
+    expect(isEnterKeyCommitNotIme({ key: "Enter", isComposing: true, keyCode: 13 })).toBe(false)
+  })
+
+  it("is false when keyCode is 229 (IME-processed key on Windows)", () => {
+    expect(isEnterKeyCommitNotIme({ key: "Enter", isComposing: false, keyCode: 229 })).toBe(false)
+  })
+
+  it("is false for non-Enter keys", () => {
+    expect(isEnterKeyCommitNotIme({ key: "a", isComposing: false, keyCode: 65 })).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/ConversationList.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/ConversationList.tsx
@@ -132,7 +132,7 @@ function ConversationItem(props: { conversation: ConversationListItem }) {
   }
 
   const onKey = (e: KeyboardEvent) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       commitRename()
     } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/ConversationList.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/ConversationList.tsx
@@ -5,6 +5,7 @@ import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-j
 import { useClaw } from "../context/claw"
 import { useKiloClawLanguage } from "../context/language"
 import type { ConversationListItem } from "../lib/types"
+import { isEnterKeyCommitNotIme } from "../../src/utils/ime-enter"
 
 type Group = { label: string; items: ConversationListItem[] }
 
@@ -132,7 +133,7 @@ function ConversationItem(props: { conversation: ConversationListItem }) {
   }
 
   const onKey = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e)) {
       e.preventDefault()
       commitRename()
     } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageArea.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageArea.tsx
@@ -150,7 +150,7 @@ export function MessageArea() {
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       submit()
     }

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageArea.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageArea.tsx
@@ -10,6 +10,7 @@ import { useKiloClawLanguage } from "../context/language"
 import { MessageBubble } from "./MessageBubble"
 import { computeBotDisplay, useNowTicker } from "./botStatus"
 import type { Message } from "../lib/types"
+import { isEnterKeyCommitNotIme } from "../../src/utils/ime-enter"
 
 export function MessageArea() {
   const claw = useClaw()
@@ -150,7 +151,7 @@ export function MessageArea() {
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e) && !e.shiftKey) {
       e.preventDefault()
       submit()
     }

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageBubble.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageBubble.tsx
@@ -13,6 +13,7 @@ import { Markdown } from "@kilocode/kilo-ui/markdown"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import type { ContentBlock, ExecApprovalDecision, Message } from "../lib/types"
 import { useKiloClawLanguage } from "../context/language"
+import { isEnterKeyCommitNotIme } from "../../src/utils/ime-enter"
 
 const ULID_TIME_LEN = 10
 const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
@@ -254,7 +255,7 @@ export function MessageBubble(props: MessageBubbleProps) {
                     value={editText()}
                     onInput={(e) => setEditText(e.currentTarget.value)}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
+                      if (isEnterKeyCommitNotIme(e) && !e.shiftKey) {
                         e.preventDefault()
                         saveEdit()
                       } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageBubble.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/MessageBubble.tsx
@@ -254,7 +254,7 @@ export function MessageBubble(props: MessageBubbleProps) {
                     value={editText()}
                     onInput={(e) => setEditText(e.currentTarget.value)}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter" && !e.shiftKey) {
+                      if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
                         e.preventDefault()
                         saveEdit()
                       } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/StatusSidebar.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/StatusSidebar.tsx
@@ -6,6 +6,7 @@
 import { Show, createMemo, createSignal } from "solid-js"
 import { useClaw } from "../context/claw"
 import { useKiloClawLanguage } from "../context/language"
+import { isEnterKeyCommitNotIme } from "../../src/utils/ime-enter"
 
 function dot(status: string | null | undefined): string {
   if (!status) return "kiloclaw-dot-offline"
@@ -77,7 +78,7 @@ export function StatusSidebar() {
   }
 
   const onTitleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e)) {
       e.preventDefault()
       commitTitleRename()
     } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/kiloclaw/components/StatusSidebar.tsx
+++ b/packages/kilo-vscode/webview-ui/kiloclaw/components/StatusSidebar.tsx
@@ -77,7 +77,7 @@ export function StatusSidebar() {
   }
 
   const onTitleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       commitTitleRename()
     } else if (e.key === "Escape") {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -23,6 +23,7 @@ import { PermissionDiff } from "./PermissionDiff"
 import { permissionDiffs } from "./permission-diff-utils"
 import { normalizeUrls } from "../../../../../opencode/src/kilocode/util/url"
 import type { PermissionRequest } from "../../types/messages"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 let rulesExpandedPreference = false
 
@@ -133,7 +134,7 @@ export const PermissionDock: Component<{
     )
 
   const plain = (e: KeyboardEvent) =>
-    e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !e.isComposing && e.keyCode !== 229
+    isEnterKeyCommitNotIme(e) && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey
 
   const skip = (e: KeyboardEvent, target: Element | undefined) => {
     const local = !!target?.closest("[data-component='permission-shortcuts']")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -133,7 +133,7 @@ export const PermissionDock: Component<{
     )
 
   const plain = (e: KeyboardEvent) =>
-    e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !e.isComposing
+    e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && !e.isComposing && e.keyCode !== 229
 
   const skip = (e: KeyboardEvent, target: Element | undefined) => {
     const local = !!target?.closest("[data-component='permission-shortcuts']")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -133,8 +133,7 @@ export const PermissionDock: Component<{
       "button, input, select, textarea, a[href], [contenteditable='true'], [role='button'], [role='menu'], [role='menuitem'], [role='listbox'], [role='option'], [role='combobox'], [role='textbox']",
     )
 
-  const plain = (e: KeyboardEvent) =>
-    isEnterKeyCommitNotIme(e) && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey
+  const plain = (e: KeyboardEvent) => isEnterKeyCommitNotIme(e) && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey
 
   const skip = (e: KeyboardEvent, target: Element | undefined) => {
     const local = !!target?.closest("[data-component='permission-shortcuts']")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -615,7 +615,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       session.abort()
       return
     }
-    if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       handleSend()
     }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -48,6 +48,7 @@ import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdow
 import { pendingDraftKey, scopeDraftKey, sessionDraftKey } from "../../utils/prompt-drafts"
 import { ReviewComments } from "./ReviewComments"
 import { partReview, reviewBody } from "../../../../src/shared/review-comments"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 // Per-session input text storage (module-level so it survives remounts)
 const drafts = new Map<string, string>()
@@ -615,7 +616,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       session.abort()
       return
     }
-    if (e.key === "Enter" && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e) && !e.shiftKey) {
       e.preventDefault()
       handleSend()
     }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -288,7 +288,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       reject()
       return
     }
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       e.stopPropagation()
       if (store.sending) return

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -19,6 +19,7 @@ import {
   toggleAnswer,
   tr,
 } from "./question-dock-utils"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
@@ -288,7 +289,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       reject()
       return
     }
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e) && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
       e.stopPropagation()
       if (store.sending) return

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -13,6 +13,7 @@ import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { AgentInfo } from "../../types/messages"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 /** Format an agent for display. Uses displayName if available, otherwise title-cases the slug. */
 function formatAgentLabel(agent: AgentInfo): string {
@@ -87,7 +88,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
     } else if (e.key === "End") {
       e.preventDefault()
       focusItem(len - 1)
-    } else if (e.key === " " || (e.key === "Enter" && !e.isComposing && e.keyCode !== 229)) {
+    } else if (e.key === " " || isEnterKeyCommitNotIme(e)) {
       e.preventDefault()
       if (cur >= 0 && cur < len) pick(props.agents[cur].name)
     }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -87,7 +87,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
     } else if (e.key === "End") {
       e.preventDefault()
       focusItem(len - 1)
-    } else if (e.key === "Enter" || e.key === " ") {
+    } else if (e.key === " " || (e.key === "Enter" && !e.isComposing && e.keyCode !== 229)) {
       e.preventDefault()
       if (cur >= 0 && cur < len) pick(props.agents[cur].name)
     }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -31,6 +31,7 @@ import type { EnrichedModel } from "../../context/provider"
 import { useSession, SessionContext } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { ModelSelection } from "../../types/messages"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 import {
   KILO_GATEWAY_ID,
   isSmall,
@@ -549,7 +550,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
       return
     }
 
-    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
+    if (isEnterKeyCommitNotIme(e)) {
       e.preventDefault()
       const row = rowMap().get(selectedKey())
       if (row) selectRow(row)

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -549,7 +549,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
       return
     }
 
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       const row = rowMap().get(selectedKey())
       if (row) selectRow(row)

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -11,6 +11,7 @@ import { type Accessor, Component, createSignal, For, onCleanup, Show } from "so
 import { PopupSelector } from "./PopupSelector"
 import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
+import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 // ---------------------------------------------------------------------------
 // Reusable base component
@@ -117,7 +118,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
       focusItem(len - 1)
       return
     }
-    if (e.key === " " || (e.key === "Enter" && !e.isComposing && e.keyCode !== 229)) {
+    if (e.key === " " || isEnterKeyCommitNotIme(e)) {
       e.preventDefault()
       if (cur >= 0 && cur < len) pick(items[cur])
       return

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -117,7 +117,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
       focusItem(len - 1)
       return
     }
-    if (e.key === "Enter" || e.key === " ") {
+    if (e.key === " " || (e.key === "Enter" && !e.isComposing && e.keyCode !== 229)) {
       e.preventDefault()
       if (cur >= 0 && cur < len) pick(items[cur])
       return

--- a/packages/kilo-vscode/webview-ui/src/utils/ime-enter.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/ime-enter.ts
@@ -3,8 +3,6 @@
  * Browsers set `isComposing` while composing; on Windows, `keyCode === 229` often
  * marks IME-handled keys even when `isComposing` is false for a given keydown.
  */
-export function isEnterKeyCommitNotIme(
-  e: Pick<KeyboardEvent, "key" | "isComposing" | "keyCode">,
-): boolean {
+export function isEnterKeyCommitNotIme(e: Pick<KeyboardEvent, "key" | "isComposing" | "keyCode">): boolean {
   return e.key === "Enter" && !e.isComposing && e.keyCode !== 229
 }

--- a/packages/kilo-vscode/webview-ui/src/utils/ime-enter.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/ime-enter.ts
@@ -1,0 +1,10 @@
+/**
+ * IME composition: Enter should confirm glyphs, not trigger chat send / shortcuts.
+ * Browsers set `isComposing` while composing; on Windows, `keyCode === 229` often
+ * marks IME-handled keys even when `isComposing` is false for a given keydown.
+ */
+export function isEnterKeyCommitNotIme(
+  e: Pick<KeyboardEvent, "key" | "isComposing" | "keyCode">,
+): boolean {
+  return e.key === "Enter" && !e.isComposing && e.keyCode !== 229
+}


### PR DESCRIPTION
## Context

Issue #7216: with a Chinese IME active, Enter should confirm composition, not send a chat message, pick a model row, commit a rename, or fire other Enter shortcuts. Some paths already checked `isComposing`; Windows often still reports `keyCode === 229` while the IME is handling the key, so Enter could slip through.

## Implementation

- Chat send (`PromptInput`) and permission / question dock Enter paths now also ignore `keyCode === 229`.
- KiloClaw composer (`MessageArea`), inline message edit (`MessageBubble`), conversation rename (`ConversationList`), and sidebar title rename (`StatusSidebar`) use the same guard.
- Popup selectors (`ModelSelector`, `ModeSwitcher`, `ThinkingSelector`) only treat Enter as confirm when not in an IME composition.

## Screenshots

| before | after |
|---|---|
|  |  |

## How to Test

- On Windows, enable Microsoft Pinyin (or another CJK IME), focus the chat textarea, type a few Latin letters inside composition, press Enter to confirm the composition: the message must not send until you press Enter again in normal typing mode.
- Repeat in KiloClaw message input and when renaming a conversation title.
- Open model selector with keyboard, same IME flow: Enter during composition must not select a row.

## Get in Touch

Discord same as GitHub profile if maintainers need a repro session.

Fixes #7216
