### PR TITLE
fix(cli): chunk oversized compactions

### DIFF
--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -245,18 +245,25 @@ export namespace KiloCompactionChunks {
           ),
         },
       }
-      const result = yield* worker.process({
-        user: input.user,
-        agent,
-        sessionID: input.sessionID,
-        tools: {},
-        system: [],
-        messages: [...input.data, { role: "user", content: [{ type: "text", text: input.text }] }],
-        model: mdl,
-      })
-      const parts = MessageV2.parts(worker.message.id)
-      const output = text(worker.message, parts)
-      yield* input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore)
+      const out = yield* Effect.gen(function* () {
+        const result = yield* worker.process({
+          user: input.user,
+          agent,
+          sessionID: input.sessionID,
+          tools: {},
+          system: [],
+          messages: [...input.data, { role: "user", content: [{ type: "text", text: input.text }] }],
+          model: mdl,
+        })
+        const parts = MessageV2.parts(worker.message.id)
+        return { result, output: text(worker.message, parts) }
+      }).pipe(
+        Effect.ensuring(
+          input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore),
+        ),
+      )
+      const result = out.result
+      const output = out.output
       if (result !== "continue") return { result, output: undefined }
       if (!output) return { result: "stop" as const, output: undefined }
       return { result, output }

--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -253,13 +253,10 @@ export namespace KiloCompactionChunks {
         system: [],
         messages: [...input.data, { role: "user", content: [{ type: "text", text: input.text }] }],
         model: mdl,
-      }).pipe(
-        Effect.ensuring(
-          input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore),
-        ),
-      )
+      })
       const parts = MessageV2.parts(worker.message.id)
       const output = text(worker.message, parts)
+      yield* input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore)
       if (result !== "continue") return { result, output: undefined }
       if (!output) return { result: "stop" as const, output: undefined }
       return { result, output }

--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -1,0 +1,344 @@
+import { Effect } from "effect"
+import type { Agent } from "@/agent/agent"
+import type { Config } from "@/config/config"
+import type { Provider } from "@/provider/provider"
+import type { LLM } from "@/session/llm"
+import { MessageV2 } from "@/session/message-v2"
+import { usable } from "@/session/overflow"
+import type { SessionProcessor } from "@/session/processor"
+import { MessageID, PartID, type SessionID } from "@/session/schema"
+import type { Session } from "@/session/session"
+import { Token } from "@/util/token"
+import * as Log from "@opencode-ai/core/util/log"
+
+type Update = <T extends MessageV2.Part>(part: T) => Effect.Effect<T>
+type UpdateMessage = <T extends MessageV2.Info>(msg: T) => Effect.Effect<T>
+
+const log = Log.create({ service: "kilocode.compaction.chunks" })
+const TOOL_OUTPUT_MAX_CHARS = 2_000
+const TRANSCRIPT_MAX_CHARS = 16_000
+const RATIO = 0.6
+const CONCURRENCY = 3
+const DEPTH = 3
+const OUTPUT = 2_048
+
+export namespace KiloCompactionChunks {
+  type Chunk = {
+    index: number
+    messages: MessageV2.WithParts[]
+  }
+
+  type Output = {
+    result: SessionProcessor.Result
+    output: string | undefined
+  }
+
+  type Deps = {
+    processors: SessionProcessor.Interface
+    session: Pick<Session.Interface, "updateMessage" | "updatePart" | "removeMessage">
+  }
+
+  type Input = Deps & {
+    user: MessageV2.User
+    agent: Agent.Info
+    sessionID: SessionID
+    model: Provider.Model
+    cfg: Config.Info
+    messages: MessageV2.WithParts[]
+    prompt: string
+    target: MessageV2.Assistant
+    updateMessage: UpdateMessage
+    updatePart: Update
+  }
+
+  type Replay = {
+    info: MessageV2.User
+    parts: MessageV2.Part[]
+  }
+
+  export function eligible(input: { result: SessionProcessor.Result; error: MessageV2.Assistant["error"] }) {
+    if (input.result === "compact") return true
+    return input.result === "stop" && input.error?.name === "ContextOverflowError"
+  }
+
+  export function needed(input: { cfg: Config.Info; model: Provider.Model; tokens: number }) {
+    // Apply 1.3x multiplier to token estimate to compensate for Token.estimate
+    // under-counting actual provider tokenizer counts by ~15-30%.
+    return Math.ceil(input.tokens * 1.3) + model(input.model).limit.output > usable({ cfg: input.cfg, model: model(input.model) })
+  }
+
+  export function replay(input: Input & { replay: Replay }) {
+    return Effect.gen(function* () {
+      const chunk: Chunk = {
+        index: 0,
+        messages: [{ info: input.replay.info, parts: input.replay.parts }],
+      }
+      const size = budget({ cfg: input.cfg, model: input.model })
+      if (!(yield* large({ messages: chunk.messages, model: input.model, size }))) return input.replay
+      const result = yield* summarize({ ...input, chunk, total: 1 })
+      if (result.result !== "continue" || !result.output) return input.replay
+      return {
+        info: input.replay.info,
+        parts: [
+          {
+            id: PartID.ascending(),
+            messageID: input.replay.info.id,
+            sessionID: input.sessionID,
+            type: "text" as const,
+            synthetic: true,
+            text: [
+              "The original replayed request was too large to send after compaction.",
+              "Use this compacted representation of that request instead:",
+              result.output,
+            ].join("\n\n"),
+          },
+        ],
+      } satisfies Replay
+    })
+  }
+
+  function budget(input: { cfg: Config.Info; model: Provider.Model }) {
+    return Math.max(1_000, Math.floor(usable({ cfg: input.cfg, model: model(input.model) }) * RATIO))
+  }
+
+  function model(input: Provider.Model) {
+    return {
+      ...input,
+      limit: {
+        ...input.limit,
+        output: Math.min(input.limit.output, OUTPUT),
+      },
+    } satisfies Provider.Model
+  }
+
+  function large(input: { messages: MessageV2.WithParts[]; model: Provider.Model; size: number }) {
+    return estimate({ messages: input.messages, model: input.model }).pipe(Effect.map((count) => count > input.size))
+  }
+
+  function estimate(input: { messages: MessageV2.WithParts[]; model: Provider.Model }) {
+    return Effect.gen(function* () {
+      const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, input.model, {
+        stripMedia: true,
+        toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
+      })
+      return Token.estimate(JSON.stringify(msgs))
+    })
+  }
+
+  export function split(input: { messages: MessageV2.WithParts[]; model: Provider.Model; size: number }) {
+    return Effect.gen(function* () {
+      const chunks: Chunk[] = []
+      let buf: MessageV2.WithParts[] = []
+      for (const msg of input.messages) {
+        const next = [...buf, msg]
+        const size = yield* estimate({ messages: next, model: input.model })
+        if (buf.length && size > input.size) {
+          chunks.push({ index: chunks.length, messages: buf })
+          buf = [msg]
+          continue
+        }
+        buf = next
+      }
+      if (buf.length) chunks.push({ index: chunks.length, messages: buf })
+      return chunks
+    })
+  }
+
+  function text(msg: MessageV2.Assistant, parts: MessageV2.Part[]) {
+    return parts
+      .filter((part): part is MessageV2.TextPart => part.type === "text" && part.messageID === msg.id)
+      .map((part) => part.text.trim())
+      .filter(Boolean)
+      .join("\n\n")
+      .trim()
+  }
+
+  function clip(input: { text: string; chars: number; label: string }) {
+    if (input.text.length <= input.chars) return input.text
+    const cut = input.text.length - input.chars
+    return `${input.text.slice(0, input.chars)}\n[${input.label} truncated for compaction: omitted ${cut} chars]`
+  }
+
+  function part(part: MessageV2.Part) {
+    if (part.type === "text") return clip({ text: part.text, chars: TRANSCRIPT_MAX_CHARS, label: "Text" })
+    if (part.type === "reasoning") return `[Reasoning]: ${clip({ text: part.text, chars: TRANSCRIPT_MAX_CHARS, label: "Reasoning" })}`
+    if (part.type === "file") return `[File attachment]: ${part.filename ?? part.url} (${part.mime})`
+    if (part.type === "agent") return `[Agent]: ${part.name}`
+    if (part.type === "subtask") return `[Subtask ${part.agent}]: ${part.description}\n${clip({ text: part.prompt, chars: TRANSCRIPT_MAX_CHARS, label: "Subtask prompt" })}`
+    if (part.type === "tool") {
+      const head = `[Tool ${part.tool} ${part.state.status}]`
+      if (part.state.status === "completed") {
+        return [
+          head,
+          `input: ${clip({ text: JSON.stringify(part.state.input), chars: TOOL_OUTPUT_MAX_CHARS, label: "Tool input" })}`,
+          `output: ${clip({ text: part.state.output, chars: TOOL_OUTPUT_MAX_CHARS, label: "Tool output" })}`,
+        ].join("\n")
+      }
+      if (part.state.status === "error") return `${head}\n${clip({ text: part.state.error, chars: TOOL_OUTPUT_MAX_CHARS, label: "Tool error" })}`
+      return `${head}\ninput: ${clip({ text: JSON.stringify(part.state.input), chars: TOOL_OUTPUT_MAX_CHARS, label: "Tool input" })}`
+    }
+    if (part.type === "step-finish") return `[Step finished]: ${part.reason}`
+    if (part.type === "compaction") return "[Compaction requested]"
+    return `[${part.type}]`
+  }
+
+  function transcript(input: { messages: MessageV2.WithParts[] }) {
+    return input.messages
+      .map((msg, index) => {
+        const body = msg.parts
+          .map(part)
+          .filter(Boolean)
+          .join("\n\n")
+        return [`<message index=\"${index + 1}\" role=\"${msg.info.role}\">`, body || "[no content]", "</message>"].join("\n")
+      })
+      .join("\n\n")
+  }
+
+  function prompt(input: { chunk: Chunk; total: number }) {
+    return [
+      `Summarize conversation chunk ${input.chunk.index + 1} of ${input.total}.`,
+      "Only summarize facts present in this chunk.",
+      "Preserve concrete file paths, commands, errors, decisions, and unresolved tasks.",
+      "Use terse Markdown bullets. Do not mention chunking or compaction.",
+    ].join("\n")
+  }
+
+  function messages(input: { summaries: string[] }) {
+    return input.summaries.map((summary, index) => ({
+      role: "user" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: [`<partial-summary index=\"${index + 1}\">`, summary, "</partial-summary>"].join("\n"),
+        },
+      ],
+    }))
+  }
+
+  function assistant(input: { base: MessageV2.Assistant; sessionID: SessionID }) {
+    return {
+      ...input.base,
+      id: MessageID.ascending(),
+      parentID: input.base.parentID,
+      sessionID: input.sessionID,
+      cost: 0,
+      tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: Date.now() },
+      finish: undefined,
+      error: undefined,
+    } satisfies MessageV2.Assistant
+  }
+
+  function run(input: Input & { data: LLM.StreamInput["messages"]; text: string }) {
+    return Effect.gen(function* () {
+      const msg = yield* input.session.updateMessage(assistant({ base: input.target, sessionID: input.sessionID }))
+      const mdl = model(input.model)
+      const worker = yield* input.processors.create({ assistantMessage: msg, sessionID: input.sessionID, model: mdl })
+      const opts = input.agent.options
+      input.agent.options = {
+        ...opts,
+        maxOutputTokens: Math.min(
+          OUTPUT,
+          typeof opts?.maxOutputTokens === "number" ? opts.maxOutputTokens : OUTPUT,
+        ),
+      }
+      const result = yield* worker.process({
+        user: input.user,
+        agent: input.agent,
+        sessionID: input.sessionID,
+        tools: {},
+        system: [],
+        messages: [...input.data, { role: "user", content: [{ type: "text", text: input.text }] }],
+        model: mdl,
+      }).pipe(Effect.ensuring(Effect.sync(() => { input.agent.options = opts })))
+      const parts = MessageV2.parts(worker.message.id)
+      const output = text(worker.message, parts)
+      yield* input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore)
+      if (result !== "continue") return { result, output: undefined }
+      if (!output) return { result: "stop" as const, output: undefined }
+      return { result, output }
+    })
+  }
+
+  function summarize(input: Input & { chunk: Chunk; total: number }) {
+    return Effect.gen(function* () {
+      const size = budget({ cfg: input.cfg, model: input.model })
+      const data = (yield* large({ messages: input.chunk.messages, model: input.model, size }))
+        ? [
+            {
+              role: "user" as const,
+              content: [
+                {
+                  type: "text" as const,
+                  text: [
+                    "The following compacted transcript represents an oversized conversation chunk.",
+                    "Summarize only facts present in the transcript.",
+                    "<conversation>",
+                    transcript({ messages: input.chunk.messages }),
+                    "</conversation>",
+                  ].join("\n"),
+                },
+              ],
+            },
+          ]
+        : yield* MessageV2.toModelMessagesEffect(input.chunk.messages, input.model, {
+            stripMedia: true,
+            toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
+          })
+      return yield* run({ ...input, data, text: prompt({ chunk: input.chunk, total: input.total }) })
+    })
+  }
+
+  function reduce(input: Input & { summaries: string[]; depth: number }): Effect.Effect<Output> {
+    return Effect.gen(function* () {
+      const result = yield* run({ ...input, data: messages({ summaries: input.summaries }), text: input.prompt })
+      if (result.result === "continue") return result
+      if (input.depth >= DEPTH || input.summaries.length <= 1) return result
+
+      const size = Math.ceil(input.summaries.length / 2)
+      const groups = Array.from({ length: Math.ceil(input.summaries.length / size) }, (_, index) =>
+        input.summaries.slice(index * size, index * size + size),
+      )
+      const next: Output[] = yield* Effect.forEach(
+        groups,
+        (group) => reduce({ ...input, summaries: group, depth: input.depth + 1 }),
+        { concurrency: 1 },
+      )
+      if (next.some((item) => item.result !== "continue" || !item.output)) return result
+      return yield* reduce({ ...input, summaries: next.map((item) => item.output!), depth: input.depth + 1 })
+    })
+  }
+
+  export function process(input: Input) {
+    return Effect.gen(function* () {
+      const size = budget({ cfg: input.cfg, model: input.model })
+      const chunks = yield* split({ messages: input.messages, model: input.model, size })
+      log.info("fallback", { chunks: chunks.length, concurrency: CONCURRENCY })
+
+      const partial = yield* Effect.forEach(
+        chunks,
+        (chunk) => summarize({ ...input, chunk, total: chunks.length }),
+        { concurrency: Math.min(CONCURRENCY, chunks.length) },
+      )
+      if (partial.some((item) => item.result !== "continue" || !item.output)) return "compact" as const
+
+      const final = chunks.length === 1 && (yield* large({ messages: chunks[0].messages, model: input.model, size }))
+        ? partial[0]
+        : yield* reduce({ ...input, summaries: partial.map((item) => item.output!), depth: 0 })
+      if (!final || final.result !== "continue" || !final.output) return "compact" as const
+
+      yield* input.updatePart({
+        id: PartID.ascending(),
+        messageID: input.target.id,
+        sessionID: input.sessionID,
+        type: "text",
+        text: final.output,
+      })
+      input.target.finish = "stop"
+      input.target.error = undefined
+      input.target.time.completed = Date.now()
+      yield* input.updateMessage(input.target)
+      return "continue" as const
+    })
+  }
+}

--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -235,25 +235,31 @@ export namespace KiloCompactionChunks {
       const mdl = model(input.model)
       const worker = yield* input.processors.create({ assistantMessage: msg, sessionID: input.sessionID, model: mdl })
       const opts = input.agent.options
-      input.agent.options = {
-        ...opts,
-        maxOutputTokens: Math.min(
-          OUTPUT,
-          typeof opts?.maxOutputTokens === "number" ? opts.maxOutputTokens : OUTPUT,
-        ),
+      const agent = {
+        ...input.agent,
+        options: {
+          ...opts,
+          maxOutputTokens: Math.min(
+            OUTPUT,
+            typeof opts?.maxOutputTokens === "number" ? opts.maxOutputTokens : OUTPUT,
+          ),
+        },
       }
       const result = yield* worker.process({
         user: input.user,
-        agent: input.agent,
+        agent,
         sessionID: input.sessionID,
         tools: {},
         system: [],
         messages: [...input.data, { role: "user", content: [{ type: "text", text: input.text }] }],
         model: mdl,
-      }).pipe(Effect.ensuring(Effect.sync(() => { input.agent.options = opts })))
+      }).pipe(
+        Effect.ensuring(
+          input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore),
+        ),
+      )
       const parts = MessageV2.parts(worker.message.id)
       const output = text(worker.message, parts)
-      yield* input.session.removeMessage({ sessionID: input.sessionID, messageID: worker.message.id }).pipe(Effect.ignore)
       if (result !== "continue") return { result, output: undefined }
       if (!output) return { result: "stop" as const, output: undefined }
       return { result, output }
@@ -305,7 +311,7 @@ export namespace KiloCompactionChunks {
         { concurrency: 1 },
       )
       if (next.some((item) => item.result !== "continue" || !item.output)) return result
-      return yield* reduce({ ...input, summaries: next.map((item) => item.output!), depth: input.depth + 1 })
+      return yield* reduce({ ...input, summaries: next.map((item) => item.output!), depth: input.depth + 2 })
     })
   }
 

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -1,0 +1,52 @@
+import type { ModelMessage } from "ai"
+import type { Provider } from "@/provider/provider"
+import { Token } from "@/util/token"
+
+// Token.estimate consistently under-counts by ~15-30% vs. actual provider tokenizers.
+// Multiply all estimates by this factor and add a fixed safety margin to compensate.
+const ESTIMATE_FACTOR = 1.3
+const SAFETY = 2048
+const MIN_OUTPUT = 1024
+
+export namespace KiloLLM {
+  /**
+   * Caps `maxOutputTokens` to fit within the model's context window after
+   * accounting for the actual estimated input tokens (messages + tool schemas).
+   *
+   * Many small models (e.g. qwen 7B, 32K context) ship with a default
+   * max_output of 32K, leaving no room for input once tools are included.
+   * This prevents the provider from rejecting the request with a context
+   * overflow error.
+   */
+  export function capOutputTokens(input: {
+    model: Provider.Model
+    messages: ModelMessage[]
+    tools: Record<string, { description?: string; inputSchema?: unknown }>
+    configured: number | undefined
+  }): number | undefined {
+    if (!input.configured) return input.configured
+    const { context } = input.model.limit
+    if (!context) return input.configured
+
+    const msgTokens = Math.ceil(Token.estimate(JSON.stringify(input.messages)) * ESTIMATE_FACTOR)
+    const toolTokens = Math.ceil(
+      Token.estimate(
+        JSON.stringify(
+          Object.entries(input.tools).map(([name, t]) => ({
+            name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+          })),
+        ),
+      ) * ESTIMATE_FACTOR,
+    )
+
+    const available = context - msgTokens - toolTokens - SAFETY
+    // If available is ≤0 the input alone exceeds context — return the original
+    // value so the provider returns a natural overflow error which triggers
+    // compaction (compactionAttempts guard stops the loop eventually).
+    if (available <= 0) return input.configured
+    if (available >= input.configured) return input.configured
+    return Math.max(MIN_OUTPUT, available)
+  }
+}

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -24,7 +24,8 @@ export namespace KiloLLM {
     tools: Record<string, { description?: string; inputSchema?: unknown }>
     configured: number | undefined
   }): number | undefined {
-    if (!input.configured) return input.configured
+    if (input.configured == null) return input.configured
+    if (input.configured <= 0) return undefined
     const { context } = input.model.limit
     if (!context) return input.configured
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -20,6 +20,7 @@ import { makeRuntime } from "@/effect/run-service"
 import { fn } from "@/util/fn"
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue" // kilocode_change
 import { KiloCompactionPayloadRecovery } from "@/kilocode/session/compaction-payload-recovery" // kilocode_change
+import { KiloCompactionChunks } from "@/kilocode/session/compaction-chunks" // kilocode_change
 
 const log = Log.create({ service: "session.compaction" })
 
@@ -416,6 +417,7 @@ export const layer: Layer.Layer<
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
       })
+      const tokens = Token.estimate(JSON.stringify(modelMessages)) // kilocode_change
       const ctx = yield* InstanceState.context
       const msg: MessageV2.Assistant = {
         id: MessageID.ascending(),
@@ -450,21 +452,41 @@ export const layer: Layer.Layer<
         model,
       })
       // kilocode_change start
-      const result = yield* KiloCompactionPayloadRecovery.process({
-        processor,
-        user: userMessage,
-        agent,
-        sessionID: input.sessionID,
-        model,
-        messages: modelMessages,
-        prompt: nextPrompt,
-        recovery: selected.head,
-        updateMessage: session.updateMessage,
-        updatePart: session.updatePart,
-      })
+      const result = KiloCompactionChunks.needed({ cfg, model, tokens })
+        ? "compact"
+        : yield* KiloCompactionPayloadRecovery.process({
+            processor,
+            user: userMessage,
+            agent,
+            sessionID: input.sessionID,
+            model,
+            messages: modelMessages,
+            prompt: nextPrompt,
+            recovery: selected.head,
+            updateMessage: session.updateMessage,
+            updatePart: session.updatePart,
+          })
       // kilocode_change end
 
-      if (result === "compact") {
+      // kilocode_change start - fallback to chunked compaction when the first summary overflows
+      const fallback = KiloCompactionChunks.eligible({ result, error: processor.message.error ?? processor.compactError?.() })
+        ? yield* KiloCompactionChunks.process({
+            processors,
+            session,
+            user: userMessage,
+            agent,
+            sessionID: input.sessionID,
+            model,
+            cfg,
+            messages: selected.head,
+            prompt: nextPrompt,
+            target: processor.message,
+            updateMessage: session.updateMessage,
+            updatePart: session.updatePart,
+          })
+        : result
+      if (fallback === "compact") {
+        // kilocode_change end
         processor.message.error = new MessageV2.ContextOverflowError({
           message: replay
             ? "Conversation history too large to compact - exceeds model context limit"
@@ -482,8 +504,25 @@ export const layer: Layer.Layer<
         })
       }
 
-      if (result === "continue" && input.auto) {
+      if (fallback === "continue" && input.auto) { // kilocode_change
         if (replay) {
+          // kilocode_change start - compact oversized replay turns instead of looping into replay overflow
+          replay = yield* KiloCompactionChunks.replay({
+            processors,
+            session,
+            user: userMessage,
+            agent,
+            sessionID: input.sessionID,
+            model,
+            cfg,
+            messages: selected.head,
+            prompt: nextPrompt,
+            target: processor.message,
+            updateMessage: session.updateMessage,
+            updatePart: session.updatePart,
+            replay,
+          })
+          // kilocode_change end
           const original = replay.info
           const replayMsg = yield* session.updateMessage({
             id: MessageID.ascending(),
@@ -496,6 +535,7 @@ export const layer: Layer.Layer<
             tools: original.tools,
             system: original.system,
           })
+          KiloSessionPromptQueue.retarget(input.sessionID, replayMsg.id) // kilocode_change - expose replay to scope()
           for (const part of replay.parts) {
             if (part.type === "compaction") continue
             const replayPart =
@@ -539,6 +579,7 @@ export const layer: Layer.Layer<
               agent: userMessage.agent,
               model: userMessage.model,
             })
+            KiloSessionPromptQueue.retarget(input.sessionID, continueMsg.id) // kilocode_change - expose auto-continue to scope()
             const text =
               (input.overflow
                 ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
@@ -566,12 +607,12 @@ export const layer: Layer.Layer<
 
       // kilocode_change start - compaction already invalidates cache, so collapse stale tool outputs too
       if (processor.message.error) return "stop"
-      if (result === "continue") {
+      if (fallback === "continue") { // kilocode_change
         yield* prune({ sessionID: input.sessionID, reason: "post-compaction" })
         yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
       }
       // kilocode_change end
-      return result
+      return fallback // kilocode_change
     })
 
     const create = Effect.fn("SessionCompaction.create")(function* (input: {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -25,6 +25,7 @@ import { getKiloProjectId } from "@/kilocode/project-id"
 import { HEADER_PROJECTID, HEADER_MACHINEID, HEADER_TASKID } from "@kilocode/kilo-gateway"
 import { Identity } from "@kilocode/kilo-telemetry"
 import { makeRuntime } from "@/effect/run-service"
+import { KiloLLM } from "@/kilocode/session/llm"
 // kilocode_change end
 import { Installation } from "@/installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
@@ -223,6 +224,14 @@ const live: Layer.Layer<
       // kilocode_change end
 
       const tools = resolveTools(input)
+      // kilocode_change start - cap maxOutputTokens to fit within context after estimating real input size
+      params.maxOutputTokens = KiloLLM.capOutputTokens({
+        model: input.model,
+        messages,
+        tools,
+        configured: params.maxOutputTokens,
+      })
+      // kilocode_change end
 
       // LiteLLM and some Anthropic proxies require the tools parameter to be present
       // when message history contains tool calls, even if no tools are being used.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1387,6 +1387,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
             if (task && !lastFinished) tasks.push(...task)
           }
+          // kilocode_change end
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 

--- a/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
+++ b/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
@@ -1,0 +1,582 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import * as Stream from "effect/Stream"
+import { Agent } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Instance } from "../../src/project/instance"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Snapshot } from "../../src/snapshot"
+import { KiloCompactionChunks } from "../../src/kilocode/session/compaction-chunks"
+import { LLM } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionCompaction } from "../../src/session/compaction"
+import * as SessionProcessorModule from "../../src/session/processor"
+import type { SessionProcessor } from "../../src/session/processor"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { Session as SessionNs } from "../../src/session/session"
+import { SessionStatus } from "../../src/session/status"
+import { SessionSummary } from "../../src/session/summary"
+import { ProviderTest } from "../fake/provider"
+import { tmpdir } from "../fixture/fixture"
+
+const providerID = ProviderID.make("test")
+const modelID = ModelID.make("test-model")
+const ref = { providerID, modelID }
+
+function run<A, E>(fx: Effect.Effect<A, E, SessionNs.Service>) {
+  return Effect.runPromise(fx.pipe(Effect.provide(SessionNs.defaultLayer)))
+}
+
+const svc = {
+  create(input?: SessionNs.CreateInput) {
+    return run(SessionNs.Service.use((svc) => svc.create(input)))
+  },
+  messages(input: Parameters<SessionNs.Interface["messages"]>[0]) {
+    return run(SessionNs.Service.use((svc) => svc.messages(input)))
+  },
+  updateMessage<T extends MessageV2.Info>(msg: T) {
+    return run(SessionNs.Service.use((svc) => svc.updateMessage(msg)))
+  },
+  updatePart<T extends MessageV2.Part>(part: T) {
+    return run(SessionNs.Service.use((svc) => svc.updatePart(part)))
+  },
+}
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+async function user(sessionID: SessionID, text: string) {
+  const msg = await svc.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  await svc.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return msg
+}
+
+async function assistant(sessionID: SessionID, parentID: MessageID, root: string, text: string) {
+  const msg: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    sessionID,
+    mode: "build",
+    agent: "build",
+    path: { cwd: root, root },
+    cost: 0,
+    tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID,
+    providerID,
+    parentID,
+    time: { created: Date.now() },
+    finish: "stop",
+  }
+  await svc.updateMessage(msg)
+  await svc.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return msg
+}
+
+function llm() {
+  const queue: Array<
+    Stream.Stream<LLM.Event, unknown> | ((input: LLM.StreamInput) => Stream.Stream<LLM.Event, unknown>)
+  > = []
+
+  return {
+    push(stream: Stream.Stream<LLM.Event, unknown> | ((input: LLM.StreamInput) => Stream.Stream<LLM.Event, unknown>)) {
+      queue.push(stream)
+    },
+    layer: Layer.succeed(
+      LLM.Service,
+      LLM.Service.of({
+        stream: (input) => {
+          const item = queue.shift() ?? Stream.empty
+          const stream = typeof item === "function" ? item(input) : item
+          return stream.pipe(Stream.mapEffect((event) => Effect.succeed(event)))
+        },
+        raw: () => Effect.die("raw not implemented in test LLM"),
+      }),
+    ),
+  }
+}
+
+function reply(text: string, capture?: (input: LLM.StreamInput) => void) {
+  return (input: LLM.StreamInput) => {
+    capture?.(input)
+    return Stream.make(
+      { type: "start" } as LLM.Event,
+      { type: "text-start", id: "txt-0" } as LLM.Event,
+      { type: "text-delta", id: "txt-0", delta: text, text } as LLM.Event,
+      { type: "text-end", id: "txt-0" } as LLM.Event,
+      {
+        type: "finish-step",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        response: { id: "res", modelId: "test-model", timestamp: new Date() },
+        providerMetadata: undefined,
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+          outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+        },
+      } as LLM.Event,
+      {
+        type: "finish",
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        totalUsage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+          outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+        },
+      } as LLM.Event,
+    )
+  }
+}
+
+function overflow() {
+  return Stream.make(
+    { type: "start" } as LLM.Event,
+    {
+      type: "finish-step",
+      finishReason: "stop",
+      rawFinishReason: "stop",
+      response: { id: "res", modelId: "test-model", timestamp: new Date() },
+      providerMetadata: undefined,
+      usage: {
+        inputTokens: 20_000,
+        outputTokens: 1,
+        totalTokens: 20_001,
+        inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+      },
+    } as LLM.Event,
+    {
+      type: "finish",
+      finishReason: "stop",
+      rawFinishReason: "stop",
+      totalUsage: {
+        inputTokens: 20_000,
+        outputTokens: 1,
+        totalTokens: 20_001,
+        inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+      },
+    } as LLM.Event,
+  )
+}
+
+function runtime(layer: Layer.Layer<LLM.Service>, context = 7_000) {
+  const bus = Bus.layer
+  const status = SessionStatus.layer.pipe(Layer.provide(bus))
+  const processor = SessionProcessorModule.SessionProcessor.layer.pipe(Layer.provide(summary))
+  const model = ProviderTest.model({ providerID, id: modelID, limit: { context, output: 1_000 } })
+  return ManagedRuntime.make(
+    Layer.mergeAll(SessionCompaction.layer.pipe(Layer.provide(processor)), processor, bus, status).pipe(
+      Layer.provide(ProviderTest.fake({ model }).layer),
+      Layer.provide(SessionNs.defaultLayer),
+      Layer.provide(Snapshot.defaultLayer),
+      Layer.provide(layer),
+      Layer.provide(Permission.defaultLayer),
+      Layer.provide(Agent.defaultLayer),
+      Layer.provide(Plugin.defaultLayer),
+      Layer.provide(status),
+      Layer.provide(bus),
+      Layer.provide(Layer.mock(Config.Service)({ get: () => Effect.succeed({ ...Config.Info.zod.parse({}), compaction: { reserved: 1_000 } }) })),
+    ),
+  )
+}
+
+function fakeRuntime() {
+  const calls: string[] = []
+  const outputs: number[] = []
+  const bus = Bus.layer
+  const processor = Layer.effect(
+    SessionProcessorModule.SessionProcessor.Service,
+    Effect.gen(function* () {
+      const sessions = yield* SessionNs.Service
+      return SessionProcessorModule.SessionProcessor.Service.of({
+        create: Effect.fn("TestSessionProcessor.create")((input) =>
+          Effect.succeed({
+            get message() {
+              return input.assistantMessage
+            },
+            updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
+            completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
+            process: Effect.fn("TestSessionProcessor.process")((stream: LLM.StreamInput) =>
+              Effect.gen(function* () {
+                outputs.push(input.model.limit.output)
+                calls.push(JSON.stringify(stream.messages))
+                const text = stream.messages.some((msg) => JSON.stringify(msg).includes("Create a new anchored summary"))
+                  ? "final summary"
+                  : calls.length === 1
+                    ? "chunk one"
+                    : "chunk two"
+                yield* sessions.updatePart({
+                  id: PartID.ascending(),
+                  messageID: input.assistantMessage.id,
+                  sessionID: input.sessionID,
+                  type: "text",
+                  text,
+                })
+                input.assistantMessage.finish = "stop"
+                return "continue" as const
+              }),
+            ),
+          } satisfies SessionProcessor.Handle),
+        ),
+      })
+    }),
+  )
+  const model = ProviderTest.model({ providerID, id: modelID, limit: { context: 10_000, output: 1_000 } })
+  return {
+    calls,
+    outputs,
+    rt: ManagedRuntime.make(
+      Layer.mergeAll(SessionCompaction.layer.pipe(Layer.provide(processor)), processor, bus).pipe(
+        Layer.provide(ProviderTest.fake({ model }).layer),
+        Layer.provide(SessionNs.defaultLayer),
+        Layer.provide(Agent.defaultLayer),
+        Layer.provide(Plugin.defaultLayer),
+        Layer.provide(bus),
+        Layer.provide(
+          Layer.mock(Config.Service)({
+            get: () => Effect.succeed({ ...Config.Info.zod.parse({}), compaction: { reserved: 1_000 } }),
+          }),
+        ),
+      ),
+    ),
+  }
+}
+
+function liveRuntime(layer: Layer.Layer<LLM.Service>, context = 10_000) {
+  const bus = Bus.layer
+  const status = SessionStatus.layer.pipe(Layer.provide(bus))
+  const processor = SessionProcessorModule.SessionProcessor.layer.pipe(Layer.provide(summary))
+  const model = ProviderTest.model({ providerID, id: modelID, limit: { context, output: 1_000 } })
+  return ManagedRuntime.make(
+    Layer.mergeAll(SessionCompaction.layer.pipe(Layer.provide(processor)), processor, bus, status).pipe(
+      Layer.provide(ProviderTest.fake({ model }).layer),
+      Layer.provide(SessionNs.defaultLayer),
+      Layer.provide(Snapshot.defaultLayer),
+      Layer.provide(layer),
+      Layer.provide(Permission.defaultLayer),
+      Layer.provide(Agent.defaultLayer),
+      Layer.provide(Plugin.defaultLayer),
+      Layer.provide(status),
+      Layer.provide(bus),
+      Layer.provide(
+        Layer.mock(Config.Service)({
+          get: () => Effect.succeed({ ...Config.Info.zod.parse({}), compaction: { reserved: 1_000 } }),
+        }),
+      ),
+    ),
+  )
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("KiloCompactionChunks", () => {
+  test("splits oversized history into chronological chunks", async () => {
+    const model = ProviderTest.model({ providerID, id: modelID, limit: { context: 7_000, output: 1_000 } })
+    const sessionID = SessionID.make("ses_chunks_split")
+    const messages: MessageV2.WithParts[] = Array.from({ length: 4 }, (_, index) => ({
+      info: {
+        id: MessageID.ascending(),
+        role: "user",
+        sessionID,
+        agent: "build",
+        model: ref,
+        time: { created: Date.now() },
+      },
+      parts: [
+        {
+          id: PartID.ascending(),
+          messageID: MessageID.ascending(),
+          sessionID,
+          type: "text",
+          text: `${index}: ${"x".repeat(8_000)}`,
+        },
+      ],
+    }))
+
+    const chunks = await Effect.runPromise(KiloCompactionChunks.split({ messages, model, size: 2_000 }))
+
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.flatMap((chunk) => chunk.messages.map((msg) => msg.info.id))).toEqual(messages.map((msg) => msg.info.id))
+  })
+
+  test("falls back to chunk workers after the first compaction overflows", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const first = await user(session.id, "first " + "a".repeat(10_000))
+        await assistant(session.id, first.id, tmp.path, "reply " + "b".repeat(10_000))
+        const second = await user(session.id, "second " + "c".repeat(10_000))
+        await assistant(session.id, second.id, tmp.path, "reply " + "d".repeat(10_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+
+        const { rt, calls } = fakeRuntime()
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          const all = await svc.messages({ sessionID: session.id })
+          const summaries = all.filter((msg) => msg.info.role === "assistant" && msg.info.summary)
+          const parts = summaries.flatMap((msg) => msg.parts).filter((part): part is MessageV2.TextPart => part.type === "text")
+
+          expect(result).toBe("continue")
+          expect(calls.length).toBeGreaterThanOrEqual(1)
+          expect(calls.at(-1)).toContain("Create a new anchored summary")
+          expect(summaries).toHaveLength(1)
+          expect(parts.map((part) => part.text)).toEqual(["final summary"])
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("uses chunk fallback before sending oversized normal compaction", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const first = await user(session.id, "first " + "a".repeat(10_000))
+        await assistant(session.id, first.id, tmp.path, "reply " + "b".repeat(10_000))
+        const second = await user(session.id, "second " + "c".repeat(10_000))
+        await assistant(session.id, second.id, tmp.path, "reply " + "d".repeat(10_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+
+        const { rt, calls } = fakeRuntime()
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          expect(result).toBe("continue")
+          expect(calls[0]).toContain("Summarize conversation chunk")
+          expect(calls[0]).not.toContain("Create a new anchored summary")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("uses a worker even when fallback selection produces one oversized chunk", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const first = await user(session.id, "first " + "a".repeat(20_000))
+        await assistant(session.id, first.id, tmp.path, "reply " + "b".repeat(20_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+
+        const { rt, calls } = fakeRuntime()
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          const all = await svc.messages({ sessionID: session.id })
+          const summaries = all.filter((msg) => msg.info.role === "assistant" && msg.info.summary)
+          const parts = summaries.flatMap((msg) => msg.parts).filter((part): part is MessageV2.TextPart => part.type === "text")
+
+          expect(result).toBe("continue")
+          expect(calls.length).toBeGreaterThan(0)
+          expect(calls[0]).toContain("Summarize conversation chunk")
+          expect(summaries).toHaveLength(1)
+          expect(parts.map((part) => part.text)).toEqual(["final summary"])
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("serializes oversized fallback chunks before summarizing", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const first = await user(session.id, "single huge request " + "a".repeat(80_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+
+        const { rt, calls } = fakeRuntime()
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          expect(result).toBe("continue")
+          expect(calls[0]).toContain("compacted transcript")
+          expect(calls[0]).toContain("Text truncated for compaction")
+          expect(calls[0]).toContain("Summarize conversation chunk")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("caps worker output budget below oversized model output limit", async () => {
+    const { rt, calls, outputs } = fakeRuntime()
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const first = await user(session.id, "first " + "a".repeat(1_000))
+        await assistant(session.id, first.id, tmp.path, "reply " + "b".repeat(1_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+              }),
+            ),
+          )
+
+          expect(result).toBe("continue")
+          expect(calls.length).toBeGreaterThan(0)
+          expect(outputs.every((value) => value <= 2_048)).toBe(true)
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("compacts oversized replay turns after overflow compaction", async () => {
+    const stub = llm()
+    const calls: string[] = []
+    stub.push(reply("history summary"))
+    stub.push(reply("replay summary", (input) => calls.push(JSON.stringify(input.messages))))
+
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await svc.create({})
+        const old = await user(session.id, "old context")
+        await assistant(session.id, old.id, tmp.path, "old reply")
+        const large = await user(session.id, "large replay " + "x".repeat(40_000))
+        await SessionCompaction.create({ sessionID: session.id, agent: "build", model: ref, auto: true, overflow: true })
+
+        const rt = liveRuntime(stub.layer)
+        try {
+          const msgs = await svc.messages({ sessionID: session.id })
+          const parent = msgs.at(-1)?.info.id
+          expect(parent).toBeTruthy()
+          const result = await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: parent!,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+                overflow: true,
+              }),
+            ),
+          )
+
+          const all = await svc.messages({ sessionID: session.id })
+          const replay = all.findLast((msg) => msg.info.role === "user" && msg.info.id !== large.id)
+          const part = replay?.parts.find((part): part is MessageV2.TextPart => part.type === "text")
+
+          expect(result).toBe("continue")
+          expect(calls).toHaveLength(1)
+          expect(calls[0]).toContain("Summarize conversation chunk 1 of 1")
+          expect(part?.text).toContain("compacted representation")
+          expect(part?.text).toContain("replay summary")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Context

Fix CLI compaction overflow loops when long conversations or replayed turns still exceed the model context after the normal summary pass.

## Implementation

- Add Kilo-specific chunked compaction that splits oversized histories, summarizes chunks with a smaller output budget, then synthesizes a final summary.
- Fall back to chunked compaction when the first compaction overflows, and compact oversized replay requests before auto-continuing.
- Cap LLM `maxOutputTokens` based on estimated input and tool schema tokens so small-context models keep room for prompts.

## Screenshots

https://github.com/user-attachments/assets/69cb8b12-c886-4e9f-aaa3-1d2f74164c23


## How to Test

- From `packages/opencode/`, run `bun test ./test/kilocode/session-compaction-chunks.test.ts`.
- Exercise a long CLI session that triggers compaction; oversized histories should compact through chunk summaries instead of ending in a context overflow loop.