### PR TITLE
fix(vscode): rebuild CLI for snapshot installs

### DIFF
--- a/.changeset/fresh-snapshot-cli.md
+++ b/.changeset/fresh-snapshot-cli.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Ensure snapshot installs package a fresh CLI backend so new extension features are available in local VSIX builds.

--- a/packages/kilo-vscode/script/dev-snapshot.ts
+++ b/packages/kilo-vscode/script/dev-snapshot.ts
@@ -41,7 +41,7 @@ console.log("\n📦 Rebuilding SDK...")
 await $`bun run --cwd ../sdk/js build`.cwd(root)
 
 console.log("\n🔧 Preparing CLI binary...")
-await $`bun script/local-bin.ts`.cwd(root)
+await $`bun script/local-bin.ts --force`.cwd(root)
 
 console.log("\n✅ Type-checking...")
 await $`bun run typecheck`.cwd(root)


### PR DESCRIPTION
Snapshot installs could package a stale CLI backend from a previous local dist build, leaving new extension UI wired to backend routes that were not present in the installed VSIX.

This forces snapshot packaging to rebuild the bundled CLI and adds a patch changeset so local snapshot installs include the backend changes they are testing.