### PR TITLE
docs(jetbrains): add RELEASING.md with RC release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ kilo run --auto "run tests and fix any failures"
 We welcome contributions from developers, writers, and enthusiasts!
 To get started, please read our [Contributing Guide](/CONTRIBUTING.md). It includes details on setting up your environment, coding standards, types of contribution and how to submit pull requests.
 
-See [RELEASING.md](RELEASING.md) for the release process.
+See [RELEASING.md](RELEASING.md) for the VS Code extension and CLI release process.
+
+See [packages/kilo-jetbrains/RELEASING.md](packages/kilo-jetbrains/RELEASING.md) for the JetBrains plugin release process.
 
 ## Code of Conduct
 

--- a/packages/kilo-jetbrains/README.md
+++ b/packages/kilo-jetbrains/README.md
@@ -52,26 +52,9 @@ The built plugin archive is at `build/distributions/kilo.jetbrains-<version>.zip
 
 ---
 
-## Publish release candidates
+## Releasing
 
-JetBrains release-candidate builds publish from tags matching `jetbrains/vx.y.z-rc.n`, for example `jetbrains/v7.0.1-rc.1`. The git tag is the source of truth for the Marketplace plugin version; the `v` prefix is stripped before the version is set in the plugin metadata so the Marketplace version remains a plain semver (`x.y.z-rc.n`). Production Gradle builds fail if `HEAD` is not tagged with `jetbrains/v<version>`. Local dev builds use the placeholder `0.0.0-dev` version.
-
-The `publish-jetbrains` workflow publishes RC builds to the JetBrains Marketplace `eap` channel and uploads the same plugin ZIP to a GitHub prerelease for the tag. Stable tags like `jetbrains/vx.y.z` are recognized by the workflow but intentionally rejected until default-channel publishing is enabled.
-
-Testers can install or update EAP builds from this custom plugin repository:
-
-```
-https://plugins.jetbrains.com/plugins/eap/list
-```
-
-Required GitHub Actions secrets:
-
-- `JETBRAINS_MARKETPLACE_TOKEN`
-- `JETBRAINS_CERTIFICATE_CHAIN`
-- `JETBRAINS_PRIVATE_KEY`
-- `JETBRAINS_PRIVATE_KEY_PASSWORD`
-
-Before the first publish, complete `RELEASE_TODO.md`.
+See [RELEASING.md](RELEASING.md) for the full release process, including how to tag and push an RC, where to watch workflow progress, and how to install RC builds via the custom plugin repository.
 
 ---
 

--- a/packages/kilo-jetbrains/RELEASING.md
+++ b/packages/kilo-jetbrains/RELEASING.md
@@ -1,0 +1,62 @@
+# Releasing the JetBrains Plugin
+
+## RC releases (currently the only supported flow)
+
+Stable release tags (`jetbrains/vx.y.z`) are recognized by the workflow but intentionally rejected. Only RC tags are accepted right now.
+
+### 1. Create and push a tag
+
+Tag format: `jetbrains/v<major>.<minor>.<patch>-rc.<n>`
+
+```
+git tag jetbrains/v7.0.1-rc.1
+git push origin jetbrains/v7.0.1-rc.1
+```
+
+### 2. Watch the workflow
+
+The `publish-jetbrains` workflow starts automatically on tag push. Follow progress at:
+
+[https://github.com/Kilo-Org/kilocode/actions/workflows/publish-jetbrains.yml](https://github.com/Kilo-Org/kilocode/actions/workflows/publish-jetbrains.yml)
+
+The workflow:
+1. Validates the tag format and required secrets.
+2. Downloads CLI binaries for all 6 platforms from the matching GitHub Release.
+3. Verifies and signs the plugin with `./gradlew verifyPlugin publishPlugin -Pproduction=true`.
+4. Publishes the signed ZIP to the JetBrains Marketplace `eap` channel.
+5. Uploads the signed ZIP to a GitHub prerelease for the tag.
+
+### 3. Verify on the Marketplace
+
+Once the workflow succeeds, the new version should appear in the plugin's version list:
+
+[https://plugins.jetbrains.com/plugin/28350-kilo-code/edit/versions](https://plugins.jetbrains.com/plugin/28350-kilo-code/edit/versions)
+
+---
+
+## Installing RC builds via the custom plugin repository
+
+RC builds are published to the `eap` channel, not the default channel. To get them in IntelliJ IDEA:
+
+1. Open **Settings > Plugins**.
+2. Click the gear icon and choose **Manage Plugin Repositories**.
+3. Add the following URL:
+
+```
+https://plugins.jetbrains.com/plugins/list?channel=eap&pluginId=28350
+```
+
+4. Search for **Kilo Code** in the Marketplace tab — the latest RC version will appear and update automatically.
+
+---
+
+## Required GitHub Actions secrets
+
+| Secret | Purpose |
+|---|---|
+| `JETBRAINS_MARKETPLACE_TOKEN` | Marketplace API token for publishing |
+| `JETBRAINS_CERTIFICATE_CHAIN` | PEM certificate chain for plugin signing |
+| `JETBRAINS_PRIVATE_KEY` | PEM private key for plugin signing |
+| `JETBRAINS_PRIVATE_KEY_PASSWORD` | Password for the private key |
+
+Before the first publish, complete `RELEASE_TODO.md` to set up these secrets and the Marketplace plugin entry.


### PR DESCRIPTION
Adds `packages/kilo-jetbrains/RELEASING.md` with end-to-end instructions for releasing the JetBrains plugin: tagging and pushing an RC, watching the CI workflow, verifying on the Marketplace, and installing RC builds via the custom plugin repository URL.

The verbose inline publish section in `packages/kilo-jetbrains/README.md` is replaced with a single pointer to RELEASING.md, and the root README links to both release docs files so the JetBrains process is discoverable from the top level.