### PR TITLE
fix(cli): auto-resume session after network restore

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/network.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/network.tsx
@@ -57,7 +57,7 @@ export function NetworkPrompt(props: { request: SessionNetworkWait }) {
         >
           <text fg={theme.success}>Network reconnected</text>
           <text fg={theme.text}>Connection restored.</text>
-          <text fg={theme.textMuted}>Resuming automatically...</text>
+          <text fg={theme.textMuted}>Resuming...</text>
           <text fg={theme.textMuted}>Press Esc to stop.</text>
         </Show>
       </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/network.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/network.tsx
@@ -57,7 +57,7 @@ export function NetworkPrompt(props: { request: SessionNetworkWait }) {
         >
           <text fg={theme.success}>Network reconnected</text>
           <text fg={theme.text}>Connection restored.</text>
-          <text fg={theme.textMuted}>Press Enter to resume this turn.</text>
+          <text fg={theme.textMuted}>Resuming automatically...</text>
           <text fg={theme.textMuted}>Press Esc to stop.</text>
         </Show>
       </box>

--- a/packages/opencode/src/session/network.ts
+++ b/packages/opencode/src/session/network.ts
@@ -240,6 +240,10 @@ export namespace SessionNetwork {
         sessionID: req.info.sessionID,
         requestID: req.info.id,
       })
+      // #9792: the DNS probe already verified the network is back, so resume
+      // automatically instead of waiting for the user to press Enter on a
+      // dialog that was only ever needed for sustained outages.
+      await reply({ requestID })
     },
   )
 

--- a/packages/opencode/test/session/network.test.ts
+++ b/packages/opencode/test/session/network.test.ts
@@ -135,4 +135,97 @@ describe("session.network", () => {
       },
     })
   })
+
+  test("restore auto-resolves pending request and clears the list", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { promise } = await SessionNetwork.ask({
+          sessionID: SessionID.make("ses_test"),
+          message: "Connection reset by server",
+          abort: new AbortController().signal,
+        })
+        const pending = await SessionNetwork.list()
+        expect(pending).toHaveLength(1)
+        const req = pending[0]!
+
+        await SessionNetwork.restore({ requestID: req.id })
+        await expect(promise).resolves.toBeUndefined()
+        expect(await SessionNetwork.list()).toHaveLength(0)
+      },
+    })
+  })
+
+  test("restore publishes both Restored and Replied events", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const seen: string[] = []
+        const offRestored = Bus.subscribe(SessionNetwork.Event.Restored, () => seen.push("restored"))
+        const offReplied = Bus.subscribe(SessionNetwork.Event.Replied, () => seen.push("replied"))
+        try {
+          const { promise } = await SessionNetwork.ask({
+            sessionID: SessionID.make("ses_test"),
+            message: "Connection reset by server",
+            abort: new AbortController().signal,
+          })
+          const pending = await SessionNetwork.list()
+          const req = pending[0]!
+          await SessionNetwork.restore({ requestID: req.id })
+          await promise
+          expect(seen).toStrictEqual(["restored", "replied"])
+        } finally {
+          offRestored()
+          offReplied()
+        }
+      },
+    })
+  })
+
+  test("restore is idempotent after auto-resume", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { promise } = await SessionNetwork.ask({
+          sessionID: SessionID.make("ses_test"),
+          message: "Connection reset by server",
+          abort: new AbortController().signal,
+        })
+        const pending = await SessionNetwork.list()
+        const req = pending[0]!
+        await SessionNetwork.restore({ requestID: req.id })
+        await promise
+
+        // Second restore call lands after auto-resume cleaned up — should be a no-op
+        await SessionNetwork.restore({ requestID: req.id })
+        expect(await SessionNetwork.list()).toHaveLength(0)
+      },
+    })
+  })
+
+  test("manual reply after auto-resume is a no-op", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { promise } = await SessionNetwork.ask({
+          sessionID: SessionID.make("ses_test"),
+          message: "Connection reset by server",
+          abort: new AbortController().signal,
+        })
+        const pending = await SessionNetwork.list()
+        const req = pending[0]!
+        await SessionNetwork.restore({ requestID: req.id })
+        await promise
+
+        // TUI may still POST /reply if the user pressed Enter on the flash —
+        // it should be a clean no-op, not a crash.
+        await SessionNetwork.reply({ requestID: req.id })
+        expect(await SessionNetwork.list()).toHaveLength(0)
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Context

Closes #9792.

Long-running streaming requests against providers with high inference latency (the report cites zai/glm-5.1 around 90s of thinking) regularly hit ECONNRESET when the provider closes the idle TCP connection. The error gets wrapped as `APIError { isRetryable: true }` via `MessageV2.fromError`, but instead of running the normal exponential backoff, the policy routes through `opts.offline` and the user sits on a `Waiting for network… Press Esc to stop this turn.` dialog. After the 3s DNS probe in `SessionNetwork.watch` confirms the network is up, the dialog flips to `Network reconnected / Press Enter to resume`, which still needs a keystroke. For a transient stream reset where the next retry would succeed on its own, that's pure friction.

## Implementation

`SessionNetwork.restore` now calls `reply` after publishing the `Restored` event. The DNS probe already verified the network is back, so the offline handler resolves on its own and the retry policy continues with `result === "retry"`. The `Restored` → `Replied` event pair gives the TUI a brief flash of `Network reconnected` before the prompt clears, which preserves the user-visible signal without blocking on input.

`SessionNetwork.reply` already handles a missing pending entry as a `log.warn` no-op, so a TUI that still POSTs `/reply` after the user pressed Enter on the flash stays safe.

## How to Test

1. Run `bun test test/session/network.test.ts` inside `packages/opencode` — four new cases cover auto-resolve, event ordering, idempotent re-restore, and post-restore manual reply.
2. Manual repro of the original bug: configure an OpenAI-compatible provider with long inference time (or a local proxy that resets the socket after ~30s of idle). Send a complex task that streams >30s without output. The session should auto-retry instead of stopping on the `Press Enter to resume` prompt.

## Get in Touch

GitHub: `@truffle-dev`. Happy to iterate on the shape — for example, hiding the brief `Network reconnected` flash entirely, or gating auto-resume behind a config flag if the team would rather keep manual confirmation as an option.