### PR TITLE
feat(vscode): add voice input to inline review comments

### DIFF
--- a/.changeset/inline-review-speech.md
+++ b/.changeset/inline-review-speech.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support speech-to-text voice input in Agent Manager inline review comments.

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -30,6 +30,7 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/DiffEndMarker.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/FileTree.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/review-annotations.ts"),
+  path.join(ROOT, "webview-ui/agent-manager/review-annotation-speech.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/MultiModelSelector.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/ApplyDialog.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/WorktreeItem.tsx"),

--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -8,6 +8,11 @@ import {
   type ReviewComment,
 } from "../../webview-ui/agent-manager/review-comments"
 import { markdownCommentBlocks } from "../../webview-ui/agent-manager/markdown-comment-ranges"
+import {
+  reviewAnnotationSpeechKey,
+  reviewDraftSpeechKey,
+  reviewEditSpeechKey,
+} from "../../webview-ui/agent-manager/review-annotations"
 import type { WorktreeFileDiff } from "../../webview-ui/src/types/messages"
 
 function diff(file: string, before: string, after: string): WorktreeFileDiff {
@@ -233,6 +238,55 @@ describe("markdownCommentBlocks", () => {
       { type: "block", start: 1, end: 2 },
       { type: "block", start: 4, end: 5 },
     ])
+  })
+})
+
+// ── review annotation speech keys ───────────────────────────────────────────
+
+describe("review annotation speech keys", () => {
+  it("keeps draft keys scoped to the selected review location", () => {
+    expect(reviewDraftSpeechKey({ file: "src/a.ts", side: "additions", line: 4 })).toBe(
+      "draft:src/a.ts:additions:4:4",
+    )
+    expect(reviewDraftSpeechKey({ file: "src/a.ts", side: "deletions", line: 4, endLine: 8 })).toBe(
+      "draft:src/a.ts:deletions:4:8",
+    )
+  })
+
+  it("keeps edit keys scoped to the review comment id", () => {
+    expect(reviewEditSpeechKey("c-123")).toBe("edit:c-123")
+  })
+
+  it("only exposes annotation speech keys for active draft and edit composers", () => {
+    const current = comment({ file: "src/a.ts", line: 7 })
+    expect(
+      reviewAnnotationSpeechKey({
+        type: "draft",
+        comment: null,
+        file: "src/a.ts",
+        side: "additions",
+        line: 7,
+      }),
+    ).toBe("draft:src/a.ts:additions:7:7")
+    expect(
+      reviewAnnotationSpeechKey({
+        type: "comment",
+        comment: current,
+        file: current.file,
+        side: current.side,
+        line: current.line,
+        editing: true,
+      }),
+    ).toBe(`edit:${current.id}`)
+    expect(
+      reviewAnnotationSpeechKey({
+        type: "comment",
+        comment: current,
+        file: current.file,
+        side: current.side,
+        line: current.line,
+      }),
+    ).toBeUndefined()
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -245,9 +245,7 @@ describe("markdownCommentBlocks", () => {
 
 describe("review annotation speech keys", () => {
   it("keeps draft keys scoped to the selected review location", () => {
-    expect(reviewDraftSpeechKey({ file: "src/a.ts", side: "additions", line: 4 })).toBe(
-      "draft:src/a.ts:additions:4:4",
-    )
+    expect(reviewDraftSpeechKey({ file: "src/a.ts", side: "additions", line: 4 })).toBe("draft:src/a.ts:additions:4:4")
     expect(reviewDraftSpeechKey({ file: "src/a.ts", side: "deletions", line: 4, endLine: 8 })).toBe(
       "draft:src/a.ts:deletions:4:8",
     )

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -14,13 +14,22 @@ import type { DiffLineAnnotation, AnnotationSide, SelectedLineRange } from "@pie
 import type { WorktreeFileDiff } from "../src/types/messages"
 import { KILO_FILE_PATH_MIME } from "../src/utils/path-mentions"
 import { useLanguage } from "../src/context/language"
+import { useVSCode } from "../src/context/vscode"
+import { useServer } from "../src/context/server"
+import { useProvider } from "../src/context/provider"
+import { useConfig } from "../src/context/config"
+import { canUseSpeechToText, selectedSpeechToTextModel } from "../src/components/speech-to-text/availability"
+import { useSpeechToText } from "../src/components/speech-to-text/useSpeechToText"
 import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
 import {
   buildFileAnnotations,
   buildReviewAnnotation,
+  reviewDraftSpeechKey,
+  reviewEditSpeechKey,
   type AnnotationLabels,
   type AnnotationMeta,
 } from "./review-annotations"
+import { createReviewAnnotationSpeechRenderer } from "./review-annotation-speech"
 import {
   LONG_DIFF_MARKER_FILE_COUNT,
   allOpenFiles,
@@ -59,6 +68,13 @@ interface DiffPanelProps {
 
 export const DiffPanel: Component<DiffPanelProps> = (props) => {
   const { t } = useLanguage()
+  const vscode = useVSCode()
+  const server = useServer()
+  const provider = useProvider()
+  const { config, settings } = useConfig()
+  const speech = useSpeechToText(vscode, server, { t })
+  const canUseSpeech = () => canUseSpeechToText(settings(), config(), provider.connected(), server.profileData())
+  const speechModel = () => selectedSpeechToTextModel(settings())
   const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
   const sendAllKeybind = () =>
     isMac ? t("agentManager.review.sendAllShortcut.mac") : t("agentManager.review.sendAllShortcut.other")
@@ -78,6 +94,21 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     null,
   )
   const [editing, setEditing] = createSignal<string | null>(null)
+  const speechKeys = createMemo(() => {
+    const keys = new Set<string>()
+    const current = draft()
+    const edit = editing()
+    if (current) keys.add(reviewDraftSpeechKey(current))
+    if (edit) keys.add(reviewEditSpeechKey(edit))
+    return keys
+  })
+  const reviewSpeech = createReviewAnnotationSpeechRenderer({
+    speech,
+    enabled: canUseSpeech,
+    model: speechModel,
+    label: t,
+    keys: speechKeys,
+  })
   let nextId = 0
   // Tracks the session key for which initial open state has already run. When the
   // key changes (different worktree) we expand reviewable files. Within the same key,
@@ -307,6 +338,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
       cancelDraft,
       labels: labels(),
       activeTerminalId: props.activeTerminalId,
+      speech: reviewSpeech,
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -20,15 +20,24 @@ import type { DiffLineAnnotation, AnnotationSide, SelectedLineRange } from "@pie
 import type { WorktreeFileDiff } from "../src/types/messages"
 import { KILO_FILE_PATH_MIME } from "../src/utils/path-mentions"
 import { useLanguage } from "../src/context/language"
+import { useVSCode } from "../src/context/vscode"
+import { useServer } from "../src/context/server"
+import { useProvider } from "../src/context/provider"
+import { useConfig } from "../src/context/config"
+import { canUseSpeechToText, selectedSpeechToTextModel } from "../src/components/speech-to-text/availability"
+import { useSpeechToText } from "../src/components/speech-to-text/useSpeechToText"
 import { FileTree } from "./FileTree"
 import { treeOrder } from "./file-tree-utils"
 import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
 import {
   buildFileAnnotations,
   buildReviewAnnotation,
+  reviewDraftSpeechKey,
+  reviewEditSpeechKey,
   type AnnotationLabels,
   type AnnotationMeta,
 } from "./review-annotations"
+import { createReviewAnnotationSpeechRenderer } from "./review-annotation-speech"
 import {
   LONG_DIFF_MARKER_FILE_COUNT,
   allOpenFiles,
@@ -69,6 +78,13 @@ interface FullScreenDiffViewProps {
 
 export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) => {
   const { t } = useLanguage()
+  const vscode = useVSCode()
+  const server = useServer()
+  const provider = useProvider()
+  const { config, settings } = useConfig()
+  const speech = useSpeechToText(vscode, server, { t })
+  const canUseSpeech = () => canUseSpeechToText(settings(), config(), provider.connected(), server.profileData())
+  const speechModel = () => selectedSpeechToTextModel(settings())
   const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
   const sendAllKeybind = () =>
     isMac ? t("agentManager.review.sendAllShortcut.mac") : t("agentManager.review.sendAllShortcut.other")
@@ -88,6 +104,21 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     null,
   )
   const [editing, setEditing] = createSignal<string | null>(null)
+  const speechKeys = createMemo(() => {
+    const keys = new Set<string>()
+    const current = draft()
+    const edit = editing()
+    if (current) keys.add(reviewDraftSpeechKey(current))
+    if (edit) keys.add(reviewEditSpeechKey(edit))
+    return keys
+  })
+  const reviewSpeech = createReviewAnnotationSpeechRenderer({
+    speech,
+    enabled: canUseSpeech,
+    model: speechModel,
+    label: t,
+    keys: speechKeys,
+  })
   const [activeFile, setActiveFile] = createSignal<string | null>(null)
   const [treeWidth, setTreeWidth] = createSignal(240)
   let nextId = 0
@@ -322,6 +353,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
       cancelDraft,
       labels: labels(),
       activeTerminalId: props.activeTerminalId,
+      speech: reviewSpeech,
     })
   }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2146,6 +2146,11 @@ body.am-wt-dragging-active * {
   gap: 6px;
 }
 
+.am-annotation-speech {
+  display: flex;
+  align-items: center;
+}
+
 .am-annotation-btn {
   padding: 2px 10px;
   font-size: inherit;

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotation-speech.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotation-speech.tsx
@@ -1,0 +1,129 @@
+import { createEffect, createSignal, onCleanup, Show, type Accessor } from "solid-js"
+import { render as renderSolid } from "solid-js/web"
+import { SpeechToTextButton } from "../src/components/speech-to-text/SpeechToTextButton"
+import { insertSpacedText } from "../src/components/chat/prompt-input-utils"
+import type { SpeechState, SpeechToText } from "../src/components/speech-to-text/useSpeechToText"
+import { reviewAnnotationSpeechKey, type AnnotationMeta } from "./review-annotations"
+
+type Props = {
+  speech: SpeechToText
+  enabled: Accessor<boolean>
+  model: Accessor<string>
+  label: (key: string) => string
+  keys: Accessor<Set<string>>
+}
+
+type Node = {
+  host: HTMLDivElement
+  dispose: VoidFunction
+  setTextarea: (textarea: HTMLTextAreaElement) => void
+}
+
+export function insertReviewSpeechText(textarea: HTMLTextAreaElement, value: string): void {
+  const text = textarea.value
+  const start = textarea.selectionStart ?? text.length
+  const end = textarea.selectionEnd ?? start
+  const result = insertSpacedText(text, value, start, end)
+
+  textarea.value = result.text
+  textarea.setSelectionRange(result.pos, result.pos)
+  textarea.focus()
+}
+
+export function createReviewAnnotationSpeechRenderer(props: Props) {
+  const nodes = new Map<string, Node>()
+  const [owner, setOwner] = createSignal<string | undefined>()
+
+  const mount = (key: string, textarea: HTMLTextAreaElement): Node | undefined => {
+    if (typeof document === "undefined") return undefined
+
+    const host = document.createElement("div")
+    host.className = "am-annotation-speech"
+    let field = textarea
+    const mine = () => owner() === key
+    const state = (): SpeechState => (mine() ? props.speech.state() : "idle")
+    const speech: SpeechToText = {
+      state,
+      error: () => (mine() ? props.speech.error() : undefined),
+      active: () => mine() && props.speech.active(),
+      start: props.speech.start,
+      stop: () => {
+        if (!mine()) return
+        props.speech.stop()
+      },
+      cancel: () => {
+        if (!mine()) return
+        props.speech.cancel()
+        setOwner(undefined)
+      },
+      clear: () => {
+        if (!mine()) return
+        props.speech.clear()
+        setOwner(undefined)
+      },
+    }
+    const blocked = () => props.speech.active() && !mine()
+    const start = () => {
+      setOwner(key)
+      props.speech.start({
+        model: props.model(),
+        insert: (value) => insertReviewSpeechText(field, value),
+      })
+    }
+
+    const dispose = renderSolid(
+      () => (
+        <Show when={props.enabled()}>
+          <SpeechToTextButton speech={speech} disabled={blocked()} start={start} label={props.label} />
+        </Show>
+      ),
+      host,
+    )
+
+    const node = {
+      host,
+      dispose,
+      setTextarea: (next: HTMLTextAreaElement) => {
+        field = next
+      },
+    }
+    nodes.set(key, node)
+    return node
+  }
+
+  const render = (meta: AnnotationMeta, textarea: HTMLTextAreaElement): HTMLElement | undefined => {
+    const key = reviewAnnotationSpeechKey(meta)
+    if (!key) return undefined
+    const node = nodes.get(key) ?? mount(key, textarea)
+    if (!node) return undefined
+    node.setTextarea(textarea)
+    return node.host
+  }
+
+  createEffect(() => {
+    const keys = props.keys()
+    const current = owner()
+    if (current && !keys.has(current)) {
+      if (props.speech.active()) props.speech.cancel()
+      if (props.speech.state() === "error") props.speech.clear()
+      setOwner(undefined)
+    }
+
+    for (const [key, node] of nodes) {
+      if (keys.has(key)) continue
+      node.dispose()
+      nodes.delete(key)
+    }
+  })
+
+  onCleanup(() => {
+    if (owner() && props.speech.active()) props.speech.cancel()
+    for (const [, node] of nodes) node.dispose()
+    nodes.clear()
+  })
+
+  return {
+    active: props.speech.active,
+    render,
+  }
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotation-speech.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotation-speech.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createSignal, onCleanup, Show, type Accessor } from "solid-js"
+import { createEffect, createRoot, createSignal, onCleanup, Show, type Accessor } from "solid-js"
 import { render as renderSolid } from "solid-js/web"
 import { SpeechToTextButton } from "../src/components/speech-to-text/SpeechToTextButton"
 import { insertSpacedText } from "../src/components/chat/prompt-input-utils"
@@ -19,7 +19,7 @@ type Node = {
   setTextarea: (textarea: HTMLTextAreaElement) => void
 }
 
-export function insertReviewSpeechText(textarea: HTMLTextAreaElement, value: string): void {
+function insertReviewSpeechText(textarea: HTMLTextAreaElement, value: string): void {
   const text = textarea.value
   const start = textarea.selectionStart ?? text.length
   const end = textarea.selectionEnd ?? start
@@ -42,11 +42,18 @@ export function createReviewAnnotationSpeechRenderer(props: Props) {
     let field = textarea
     const mine = () => owner() === key
     const state = (): SpeechState => (mine() ? props.speech.state() : "idle")
+    const start = (model: string) => {
+      setOwner(key)
+      props.speech.start({
+        model,
+        insert: (value) => insertReviewSpeechText(field, value),
+      })
+    }
     const speech: SpeechToText = {
       state,
       error: () => (mine() ? props.speech.error() : undefined),
       active: () => mine() && props.speech.active(),
-      start: props.speech.start,
+      start: (opts) => start(opts.model),
       stop: () => {
         if (!mine()) return
         props.speech.stop()
@@ -63,22 +70,24 @@ export function createReviewAnnotationSpeechRenderer(props: Props) {
       },
     }
     const blocked = () => props.speech.active() && !mine()
-    const start = () => {
-      setOwner(key)
-      props.speech.start({
-        model: props.model(),
-        insert: (value) => insertReviewSpeechText(field, value),
-      })
-    }
 
-    const dispose = renderSolid(
-      () => (
-        <Show when={props.enabled()}>
-          <SpeechToTextButton speech={speech} disabled={blocked()} start={start} label={props.label} />
-        </Show>
-      ),
-      host,
-    )
+    const dispose = createRoot((root) => {
+      const view = renderSolid(
+        () => (
+          <Show when={props.enabled()}>
+            <SpeechToTextButton
+              speech={speech}
+              disabled={blocked()}
+              start={() => start(props.model())}
+              label={props.label}
+            />
+          </Show>
+        ),
+        host,
+      )
+      onCleanup(view)
+      return root
+    })
 
     const node = {
       host,

--- a/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/review-annotations.ts
@@ -26,6 +26,22 @@ export interface AnnotationMeta {
   editing?: boolean
 }
 
+type SpeechDraft = Pick<AnnotationMeta, "file" | "side" | "line" | "endLine">
+
+export function reviewDraftSpeechKey(draft: SpeechDraft): string {
+  return `draft:${draft.file}:${draft.side}:${draft.line}:${draft.endLine ?? draft.line}`
+}
+
+export function reviewEditSpeechKey(id: string): string {
+  return `edit:${id}`
+}
+
+export function reviewAnnotationSpeechKey(meta: AnnotationMeta): string | undefined {
+  if (meta.type === "draft") return reviewDraftSpeechKey(meta)
+  if (!meta.editing || !meta.comment) return undefined
+  return reviewEditSpeechKey(meta.comment.id)
+}
+
 interface AnnotationHandlers {
   diffs: WorktreeFileDiff[]
   editing: string | null
@@ -36,6 +52,10 @@ interface AnnotationHandlers {
   cancelDraft: () => void
   labels: AnnotationLabels
   activeTerminalId?: string
+  speech?: {
+    active: () => boolean
+    render: (meta: AnnotationMeta, textarea: HTMLTextAreaElement) => HTMLElement | undefined
+  }
 }
 
 function focusWhenConnected(el: HTMLTextAreaElement): void {
@@ -150,6 +170,8 @@ export function buildReviewAnnotation(
     submitButton.className = "am-annotation-btn am-annotation-btn-submit"
     submitButton.textContent = handlers.labels.comment
 
+    const speech = handlers.speech?.render(meta, textarea)
+    if (speech) actions.appendChild(speech)
     actions.appendChild(cancelButton)
     actions.appendChild(submitButton)
     wrapper.appendChild(header)
@@ -159,6 +181,7 @@ export function buildReviewAnnotation(
     focusWhenConnected(textarea)
 
     const submit = () => {
+      if (handlers.speech?.active()) return
       const text = textarea.value.trim()
       if (!text) return
       const diff = handlers.diffs.find((item) => item.file === meta.file)
@@ -216,6 +239,8 @@ export function buildReviewAnnotation(
     saveButton.className = "am-annotation-btn am-annotation-btn-submit"
     saveButton.textContent = handlers.labels.save
 
+    const speech = handlers.speech?.render(meta, textarea)
+    if (speech) actions.appendChild(speech)
     actions.appendChild(cancelButton)
     actions.appendChild(saveButton)
     wrapper.appendChild(header)
@@ -231,6 +256,7 @@ export function buildReviewAnnotation(
 
     saveButton.addEventListener("click", (event) => {
       event.stopPropagation()
+      if (handlers.speech?.active()) return
       const text = textarea.value.trim()
       if (!text) return
       handlers.updateComment(comment.id, text)
@@ -244,6 +270,7 @@ export function buildReviewAnnotation(
       }
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault()
+        if (handlers.speech?.active()) return
         const text = textarea.value.trim()
         if (!text) return
         handlers.updateComment(comment.id, text)


### PR DESCRIPTION
Agent Manager/VsCode inline review comments currently require keyboard input even though voice input is available elsewhere in the extension.
This adds speech-to-text recording for new and edited inline comments, preserving recorder cleanup as review composers appear, switch, or close.

<img width="441" height="304" alt="image" src="https://github.com/user-attachments/assets/5f51df10-e903-433f-8f53-a541d07f8281" />
