### PR TITLE
fix(vscode): send recorded prompts from send button

### DIFF
--- a/.changeset/swift-voices-send.md
+++ b/.changeset/swift-voices-send.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Send recorded voice prompts directly when the prompt send button is pressed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # kilocode_change start
       - name: Setup Node
-        uses: actions/setup-node@v6 # kilocode_change
+        id: setup-node
+        continue-on-error: ${{ runner.os == 'Windows' }}
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
+
+      - name: Retry Setup Node on Windows
+        if: runner.os == 'Windows' && steps.setup-node.outcome == 'failure'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      # kilocode_change end
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/packages/kilo-vscode/tests/unit/use-speech-to-text.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-speech-to-text.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test"
+import { createRoot } from "solid-js"
+import { useSpeechToText } from "../../webview-ui/src/components/speech-to-text/useSpeechToText"
+import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/types/messages"
+
+function setup() {
+  const sent: WebviewMessage[] = []
+  let handler: ((message: ExtensionMessage) => void) | undefined
+
+  const root = createRoot((dispose) => ({
+    dispose,
+    speech: useSpeechToText(
+      {
+        postMessage: (message) => sent.push(message),
+        onMessage: (next) => {
+          handler = next
+          return () => {
+            handler = undefined
+          }
+        },
+      },
+      { profileData: () => ({}), goToLogin: () => {} },
+      { t: (key) => key },
+    ),
+  }))
+
+  const fire = (message: ExtensionMessage) => handler?.(message)
+  return { ...root, fire, sent }
+}
+
+describe("useSpeechToText", () => {
+  it("runs the stop completion after inserting a transcript", () => {
+    const ctx = setup()
+    const text: string[] = []
+    let done = 0
+
+    ctx.speech.start({ model: "scribe", insert: (value) => text.push(value) })
+    const start = ctx.sent[0]
+    if (start?.type !== "speechToTextStart") throw new Error("speech start message missing")
+
+    ctx.speech.stop({ done: () => done++ })
+    ctx.fire({ type: "speechToTextResult", requestId: start.requestId, text: "Recorded prompt" })
+
+    expect(text).toEqual(["Recorded prompt"])
+    expect(done).toBe(1)
+    expect(ctx.speech.state()).toBe("idle")
+    ctx.dispose()
+  })
+
+  it("drops the stop completion when transcription is cancelled", () => {
+    const ctx = setup()
+    let done = 0
+
+    ctx.speech.start({ model: "scribe", insert: () => {} })
+    const start = ctx.sent[0]
+    if (start?.type !== "speechToTextStart") throw new Error("speech start message missing")
+
+    ctx.speech.stop({ done: () => done++ })
+    ctx.speech.cancel()
+    ctx.fire({ type: "speechToTextResult", requestId: start.requestId, text: "Ignored prompt" })
+
+    expect(done).toBe(0)
+    expect(ctx.speech.state()).toBe("idle")
+    ctx.dispose()
+  })
+
+  it("drops the stop completion when the send context changes", () => {
+    const ctx = setup()
+    const text: string[] = []
+    let done = 0
+
+    ctx.speech.start({ model: "scribe", insert: (value) => text.push(value) })
+    const start = ctx.sent[0]
+    if (start?.type !== "speechToTextStart") throw new Error("speech start message missing")
+
+    ctx.speech.stop({ done: () => done++, ready: () => false })
+    ctx.fire({ type: "speechToTextResult", requestId: start.requestId, text: "Keep as draft" })
+
+    expect(text).toEqual(["Keep as draft"])
+    expect(done).toBe(0)
+    expect(ctx.speech.state()).toBe("idle")
+    ctx.dispose()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -335,8 +335,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const speechModel = () => selectedSpeechToTextModel(settings())
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
   const canSend = () =>
-    hasInput() && !isDisabled() && !speech.active() && !terminal.pending() && !git.pending() && !props.blocked?.()
-  const showStop = () => isBusy() && !hasInput()
+    !isDisabled() &&
+    !terminal.pending() &&
+    !git.pending() &&
+    !props.blocked?.() &&
+    (speech.state() === "recording" || (hasInput() && !speech.active()))
+  const sendLabel = () => {
+    if (props.blocked?.()) return language.t("prompt.action.send.blocked")
+    if (speech.state() === "recording") return language.t("prompt.action.send.recording")
+    return language.t("prompt.action.send")
+  }
+  const showStop = () => isBusy() && !hasInput() && speech.state() !== "recording"
   const isAtEnd = () =>
     textareaRef ? atEnd(textareaRef.selectionStart, textareaRef.selectionEnd, textareaRef.value.length) : false
   const highlightMentions = () => {
@@ -675,6 +684,33 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     speech.start({ model: speechModel(), insert: insertSpeechText })
   }
 
+  const transcribeAndSend = () => {
+    const key = draftKey()
+    const id = sid()
+    const context = ctx()
+    const value = text()
+    const comments = reviewComments()
+    const images = imageAttach.images()
+    speech.stop({
+      done: () => void handleSend(),
+      ready: () =>
+        draftKey() === key &&
+        sid() === id &&
+        ctx() === context &&
+        text() === value &&
+        reviewComments() === comments &&
+        imageAttach.images() === images,
+    })
+  }
+
+  const handleSendClick = () => {
+    if (speech.state() !== "recording" || !canSend()) {
+      void handleSend()
+      return
+    }
+    transcribeAndSend()
+  }
+
   const handleSend = async () => {
     const draft = text().trim()
 
@@ -721,6 +757,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const pendingId = props.pendingSessionID ?? session.draftSessionID()
     const id = sid()
     const sel = session.selected(id)
+    const context = ctx()
+    const key = draftKey()
 
     const terminalFile = await terminal.resolveAttachment(message, id).catch((err: Error) => {
       showToast({ variant: "error", title: "Terminal context unavailable", description: err.message })
@@ -742,15 +780,19 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     ]
     const attachments = allFiles.length > 0 ? allFiles : undefined
 
-    const key = draftKey()
     // Server-side slash command (cmdMatch/matched already computed above)
     if (matched) {
       const rest = draft.slice(cmdMatch![0].length).trim()
       const args = review && rest ? `${review}\n\n${rest}` : rest || review
-      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments, pendingId, ctx())
+      session.sendCommand(matched.name, args, sel?.providerID, sel?.modelID, attachments, pendingId, context)
     } else {
-      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments, pendingId, ctx())
+      session.sendMessage(message, sel?.providerID, sel?.modelID, attachments, pendingId, context)
     }
+
+    drafts.delete(key)
+    reviewDrafts.delete(key)
+    imageDrafts.delete(key)
+    if (draftKey() !== key) return
 
     history.append(draft)
     history.reset()
@@ -759,9 +801,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     imageAttach.clear()
     mention.closeMention()
     slash.close()
-    drafts.delete(key)
-    reviewDrafts.delete(key)
-    imageDrafts.delete(key)
 
     if (textareaRef) textareaRef.style.height = "auto"
   }
@@ -1085,16 +1124,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           <Show
             when={showStop()}
             fallback={
-              <Tooltip
-                value={props.blocked?.() ? language.t("prompt.action.send.blocked") : language.t("prompt.action.send")}
-                placement="top"
-              >
+              <Tooltip value={sendLabel()} placement="top">
                 <Button
                   variant="ghost"
                   size="small"
-                  onClick={() => void handleSend()}
+                  onClick={handleSendClick}
                   aria-disabled={!canSend()}
-                  aria-label={language.t("prompt.action.send")}
+                  aria-label={sendLabel()}
                 >
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M1.5 1.5L14.5 8L1.5 14.5V9L10 8L1.5 7V1.5Z" />

--- a/packages/kilo-vscode/webview-ui/src/components/speech-to-text/useSpeechToText.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/speech-to-text/useSpeechToText.ts
@@ -26,12 +26,17 @@ type StartOptions = {
   insert: InsertTranscript
 }
 
+type StopOptions = {
+  done?: () => void
+  ready?: () => boolean
+}
+
 export type SpeechToText = {
   state: Accessor<SpeechState>
   error: Accessor<string | undefined>
   active: Accessor<boolean>
   start: (opts: StartOptions) => void
-  stop: () => void
+  stop: (opts?: StopOptions) => void
   cancel: () => void
   clear: () => void
 }
@@ -45,6 +50,8 @@ export function useSpeechToText(vscode: VSCode, server: Server, lang: Lang): Spe
   let request = ""
   let counter = 0
   let insert: InsertTranscript | undefined
+  let done: (() => void) | undefined
+  let ready: (() => boolean) | undefined
 
   const unsub = vscode.onMessage((msg) => {
     if (!isSpeechMessage(msg)) return
@@ -73,10 +80,12 @@ export function useSpeechToText(vscode: VSCode, server: Server, lang: Lang): Spe
       return
     }
 
+    const next = ready?.() === false ? undefined : done
     insert?.(text)
     cleanup()
     setState("idle")
     setError(undefined)
+    next?.()
   })
 
   onCleanup(() => {
@@ -113,8 +122,10 @@ export function useSpeechToText(vscode: VSCode, server: Server, lang: Lang): Spe
     })
   }
 
-  function stop() {
+  function stop(opts?: StopOptions) {
     if (state() !== "recording") return
+    done = opts?.done
+    ready = opts?.ready
     setState("transcribing")
     vscode.postMessage({ type: "speechToTextStop", requestId: request })
   }
@@ -143,6 +154,8 @@ export function useSpeechToText(vscode: VSCode, server: Server, lang: Lang): Spe
   function cleanup() {
     request = ""
     insert = undefined
+    done = undefined
+    ready = undefined
   }
 
   return { state, error, active, start, stop, cancel, clear }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -268,6 +268,7 @@ export const dict = {
   "prompt.attachment.remove": "إزالة المرفق",
   "prompt.action.send": "إرسال",
   "prompt.action.send.blocked": "أجب عن السؤال المعلق أو تجاهله أولاً",
+  "prompt.action.send.recording": "تفريغ وإرسال",
   "prompt.action.stop": "توقف",
   "prompt.action.enhance": "تحسين النص",
   "prompt.action.autoApprove.enable": "تفعيل الموافقة التلقائية",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -269,6 +269,7 @@ export const dict = {
   "prompt.attachment.remove": "Remover anexo",
   "prompt.action.send": "Enviar",
   "prompt.action.send.blocked": "Responda ou feche a pergunta pendente primeiro",
+  "prompt.action.send.recording": "Transcrever e enviar",
   "prompt.action.stop": "Parar",
   "prompt.action.enhance": "Melhorar prompt",
   "prompt.action.autoApprove.enable": "Ativar aprovação automática",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -270,6 +270,7 @@ export const dict = {
   "prompt.attachment.remove": "Ukloni prilog",
   "prompt.action.send": "Pošalji",
   "prompt.action.send.blocked": "Prvo odgovorite ili odbacite pitanje na čekanju",
+  "prompt.action.send.recording": "Transkribuj i pošalji",
   "prompt.action.stop": "Zaustavi",
   "prompt.action.enhance": "Poboljšaj prompt",
   "prompt.action.autoApprove.enable": "Uključi automatsko odobravanje",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -269,6 +269,7 @@ export const dict = {
   "prompt.attachment.remove": "Fjern vedhæftning",
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Besvar eller afvis det afventende spørgsmål først",
+  "prompt.action.send.recording": "Transskriber og send",
   "prompt.action.stop": "Stop",
   "prompt.action.enhance": "Forbedr prompt",
   "prompt.action.autoApprove.enable": "Aktiver automatisk godkendelse",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -273,6 +273,7 @@ export const dict = {
   "prompt.attachment.remove": "Anhang entfernen",
   "prompt.action.send": "Senden",
   "prompt.action.send.blocked": "Beantworten oder verwerfen Sie zuerst die ausstehende Frage",
+  "prompt.action.send.recording": "Transkribieren und senden",
   "prompt.action.stop": "Stopp",
   "prompt.action.enhance": "Prompt verbessern",
   "prompt.action.autoApprove.enable": "Automatische Genehmigung aktivieren",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -270,6 +270,7 @@ export const dict = {
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Answer or dismiss the pending question first",
+  "prompt.action.send.recording": "Transcribe and send",
   "prompt.action.stop": "Stop",
   "prompt.action.enhance": "Enhance prompt",
   "prompt.action.indexing": "Indexing settings",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -270,6 +270,7 @@ export const dict = {
   "prompt.attachment.remove": "Eliminar adjunto",
   "prompt.action.send": "Enviar",
   "prompt.action.send.blocked": "Responda o descarte la pregunta pendiente primero",
+  "prompt.action.send.recording": "Transcribir y enviar",
   "prompt.action.stop": "Detener",
   "prompt.action.enhance": "Mejorar prompt",
   "prompt.action.autoApprove.enable": "Activar aprobación automática",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -271,6 +271,7 @@ export const dict = {
   "prompt.attachment.remove": "Supprimer la pièce jointe",
   "prompt.action.send": "Envoyer",
   "prompt.action.send.blocked": "Répondez ou rejetez d'abord la question en attente",
+  "prompt.action.send.recording": "Transcrire et envoyer",
   "prompt.action.stop": "Arrêter",
   "prompt.action.enhance": "Améliorer le prompt",
   "prompt.action.autoApprove.enable": "Activer l'approbation automatique",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -268,6 +268,7 @@ export const dict = {
   "prompt.attachment.remove": "添付ファイルを削除",
   "prompt.action.send": "送信",
   "prompt.action.send.blocked": "最初に保留中の質問に答えるか、閉じてください",
+  "prompt.action.send.recording": "文字起こしして送信",
   "prompt.action.stop": "停止",
   "prompt.action.enhance": "プロンプトを改善",
   "prompt.action.autoApprove.enable": "自動承認を有効化",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -271,6 +271,7 @@ export const dict = {
   "prompt.attachment.remove": "첨부 파일 제거",
   "prompt.action.send": "전송",
   "prompt.action.send.blocked": "먼저 대기 중인 질문에 답하거나 닫아주세요",
+  "prompt.action.send.recording": "텍스트 변환 및 전송",
   "prompt.action.stop": "중지",
   "prompt.action.enhance": "프롬프트 개선",
   "prompt.action.autoApprove.enable": "자동 승인 사용",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -270,6 +270,7 @@ export const dict = {
   "prompt.attachment.remove": "Bijlage verwijderen",
   "prompt.action.send": "Verzenden",
   "prompt.action.send.blocked": "Beantwoord of negeer eerst de openstaande vraag",
+  "prompt.action.send.recording": "Transcriberen en verzenden",
   "prompt.action.stop": "Stop",
   "prompt.action.enhance": "Prompt verbeteren",
   "prompt.action.indexing": "Indexeringsinstellingen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -272,6 +272,7 @@ export const dict = {
   "prompt.attachment.remove": "Fjern vedlegg",
   "prompt.action.send": "Send",
   "prompt.action.send.blocked": "Svar på eller avvis det ventende spørsmålet først",
+  "prompt.action.send.recording": "Transkriber og send",
   "prompt.action.stop": "Stopp",
   "prompt.action.enhance": "Forbedre prompt",
   "prompt.action.autoApprove.enable": "Aktiver automatisk godkjenning",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -269,6 +269,7 @@ export const dict = {
   "prompt.attachment.remove": "Usuń załącznik",
   "prompt.action.send": "Wyślij",
   "prompt.action.send.blocked": "Najpierw odpowiedz na oczekujące pytanie lub je odrzuć",
+  "prompt.action.send.recording": "Transkrybuj i wyślij",
   "prompt.action.stop": "Zatrzymaj",
   "prompt.action.enhance": "Ulepsz prompt",
   "prompt.action.autoApprove.enable": "Włącz automatyczne zatwierdzanie",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -268,6 +268,7 @@ export const dict = {
   "prompt.attachment.remove": "Удалить вложение",
   "prompt.action.send": "Отправить",
   "prompt.action.send.blocked": "Сначала ответьте на ожидающий вопрос или отклоните его",
+  "prompt.action.send.recording": "Расшифровать и отправить",
   "prompt.action.stop": "Остановить",
   "prompt.action.enhance": "Улучшить промпт",
   "prompt.action.autoApprove.enable": "Включить автоодобрение",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -269,6 +269,7 @@ export const dict = {
   "prompt.attachment.remove": "เอาไฟล์แนบออก",
   "prompt.action.send": "ส่ง",
   "prompt.action.send.blocked": "โปรดตอบหรือข้ามคำถามที่รอดำเนินการก่อน",
+  "prompt.action.send.recording": "ถอดเสียงและส่ง",
   "prompt.action.stop": "หยุด",
   "prompt.action.enhance": "ปรับปรุงพรอมต์",
   "prompt.action.autoApprove.enable": "เปิดใช้การอนุมัติอัตโนมัติ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -269,6 +269,7 @@ export const dict = {
   "prompt.attachment.remove": "Eki kaldır",
   "prompt.action.send": "Gönder",
   "prompt.action.send.blocked": "Bekleyen soruyu önce yanıtlayın veya kapatın",
+  "prompt.action.send.recording": "Yazıya dök ve gönder",
   "prompt.action.stop": "Durdur",
   "prompt.action.enhance": "Komutu geliştir",
   "prompt.action.indexing": "İndeksleme ayarları",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -270,6 +270,7 @@ export const dict = {
   "prompt.attachment.remove": "Видалити вкладення",
   "prompt.action.send": "Надіслати",
   "prompt.action.send.blocked": "Спочатку дайте відповідь або закрийте очікуюче питання",
+  "prompt.action.send.recording": "Транскрибувати та надіслати",
   "prompt.action.stop": "Зупинити",
   "prompt.action.enhance": "Покращити запит",
   "prompt.action.indexing": "Налаштування індексування",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -273,6 +273,7 @@ export const dict = {
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "发送",
   "prompt.action.send.blocked": "请先回答或忽略待处理的问题",
+  "prompt.action.send.recording": "转录并发送",
   "prompt.action.stop": "停止",
   "prompt.action.enhance": "优化提示词",
   "prompt.action.resetModel": "重置模型为默认值",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -268,6 +268,7 @@ export const dict = {
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "傳送",
   "prompt.action.send.blocked": "請先回答或忽略待處理的問題",
+  "prompt.action.send.recording": "轉錄並傳送",
   "prompt.action.stop": "停止",
   "prompt.action.enhance": "改善提示詞",
   "prompt.action.autoApprove.enable": "啟用自動核准",


### PR DESCRIPTION
Clicking Send while voice capture is active should complete the user's intended action instead of requiring a second submission step.

This change makes the send affordance transcribe and submit the pending recording, while preserving normal mic insertion behavior and preventing delayed auto-send from firing after the prompt context changes.