### PR TITLE
fix(agent-manager): prevent prompt selector clipping

### DIFF
--- a/.changeset/agent-manager-prompt-picker.md
+++ b/.changeset/agent-manager-prompt-picker.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep long New Worktree prompts clear of selector controls and show inline model picker options without clipping.

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2557,9 +2557,9 @@ body.am-wt-dragging-active * {
   overflow-y: auto;
 }
 
-.am-nv-dialog .am-prompt-input-container:has(.model-selector-popover[data-component="popover-content"]),
-.am-nv-dialog-content:has(.model-selector-popover[data-component="popover-content"]),
-[data-component="dialog"]:has(.am-nv-dialog .model-selector-popover[data-component="popover-content"])
+.am-nv-dialog .am-prompt-input-container:has([class~="model-selector-popover"][data-component="popover-content"]),
+.am-nv-dialog-content:has([class~="model-selector-popover"][data-component="popover-content"]),
+[data-component="dialog"]:has(.am-nv-dialog [class~="model-selector-popover"][data-component="popover-content"])
   [data-slot="dialog-body"] {
   overflow: visible;
 }
@@ -2568,7 +2568,7 @@ body.am-wt-dragging-active * {
   height: 100%;
 }
 
-.am-nv-dialog .prompt-input-hint {
+.am-nv-dialog [class~="prompt-input-hint"] {
   flex-shrink: 0;
 }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2553,10 +2553,23 @@ body.am-wt-dragging-active * {
 .am-nv-dialog .am-prompt-input-wrapper {
   flex: 1;
   min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.am-nv-dialog .am-prompt-input-container:has(.model-selector-popover[data-component="popover-content"]),
+.am-nv-dialog-content:has(.model-selector-popover[data-component="popover-content"]),
+[data-component="dialog"]:has(.am-nv-dialog .model-selector-popover[data-component="popover-content"])
+  [data-slot="dialog-body"] {
+  overflow: visible;
 }
 
 .am-nv-dialog .am-prompt-input-ghost-wrapper {
   height: 100%;
+}
+
+.am-nv-dialog .prompt-input-hint {
+  flex-shrink: 0;
 }
 
 .am-nv-dialog .am-prompt-input {


### PR DESCRIPTION
Keep the Agent Manager New Worktree prompt usable when prompts grow and when users select models inside the dialog.

The dialog keeps its inline selector interaction stable while letting model options render fully and keeping long prompt text clear of selector controls.

<img width="590" height="316" alt="image" src="https://github.com/user-attachments/assets/73a3bc64-c1ad-42a9-8912-9b75e93e67bb" />
