### PR TITLE
chore(cli): track codebase search usage

### DIFF
--- a/.changeset/bright-searches-count.md
+++ b/.changeset/bright-searches-count.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Capture aggregate usage telemetry for experimental Morph-backed codebase search.

--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { WarpGrepClient } from "@morphllm/morphsdk/tools/warp-grep/client" // kilocode_change
+import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"
 import { TuiEvent } from "../cli/cmd/tui/event"
@@ -31,6 +32,7 @@ export const CodebaseSearchTool = Tool.define(
             always: ["*"],
             metadata: { query: params.query },
           })
+          Telemetry.trackToolUsed("codebase_search", ctx.sessionID) // kilocode_change
 
           const apiKey = process.env["MORPH_API_KEY"]
 


### PR DESCRIPTION
Track Morph-backed `codebase_search` invocations through the existing tool telemetry event, preserving session attribution without recording search content.
This gives product a simple way to compare distinct users and total usage before deciding whether the experimental integration should remain.