### PR TITLE
feat(vscode): export session transcripts as markdown

### DIFF
--- a/.changeset/shiny-sessions-export.md
+++ b/.changeset/shiny-sessions-export.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Export full VS Code session transcripts as Markdown files.

--- a/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
@@ -76,6 +76,12 @@ Find the Kilo Code icon ({% kiloCodeIcon /%}) in VS Code's Primary Side Bar. Cli
 
 The extension automatically passes context from your editor, including your open tabs and active file. You can type `@` in the chat input to get file and terminal autocomplete suggestions — use `@filename` to attach a file or `@terminal` to include your active terminal output. You can also mention file paths naturally in your message (e.g., "update src/utils.ts to add a helper function"). The agent can also discover files on its own using its built-in tools.
 
+**Exporting local transcripts:**
+
+Run `/export` in chat, or open a local session's **History** context menu and choose **Export session transcript**. The save dialog lets you choose the Markdown (`.md`) destination.
+
+Kilo builds the export from the complete local session history, not only the messages currently loaded in the chat view.
+
 {% /tab %}
 {% tab label="CLI" %}
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
@@ -33,6 +33,7 @@ Key features include:
 - **[Skills](/docs/customize/skills)** — Load specialized domain knowledge from SKILL.md files
 - **[Custom Subagents](/docs/customize/custom-subagents)** — Define specialized sub-agents for the `task` tool
 - **Open in Tab** — Pop the chat out into a full editor tab
+- **Transcript export:** Save complete local session transcripts as Markdown files
 - **Sub-Agent Viewer** — Read-only panels for viewing child agent sessions
 - **Legacy Migration** — Automatic migration wizard for VSCode extension settings
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -17,6 +17,7 @@ import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreCo
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
 import { buildWebviewHtml, getWebviewFontSize } from "./utils"
 import { saveImage } from "./kilo-provider/save-image"
+import { exportTranscript } from "./kilo-provider/export-transcript"
 import {
   TelemetryProxy,
   type TelemetryPropertiesProvider,
@@ -617,6 +618,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           connection: this.connectionService,
           dir: this.getWorkspaceDirectory(this.currentSession?.id),
           post: (msg) => this.postMessage(msg),
+          exportTranscript: (sessionID) => this.handleExportSessionTranscript(sessionID),
         })
       ) {
         return
@@ -1656,6 +1658,30 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.postMessage({
         type: "error",
         message: getErrorMessage(error) || "Failed to rename session",
+      })
+    }
+  }
+
+  /**
+   * Export a full session transcript as Markdown.
+   */
+  private async handleExportSessionTranscript(sessionID: string): Promise<void> {
+    if (!this.client) {
+      this.postMessage({ type: "error", message: "Not connected to CLI backend" })
+      return
+    }
+
+    try {
+      const saved = await exportTranscript(this.client, {
+        sessionID,
+        dir: this.getWorkspaceDirectory(sessionID),
+      })
+      if (saved) void vscode.window.showInformationMessage("Session transcript exported as Markdown.")
+    } catch (error) {
+      console.error("[Kilo New] KiloProvider: Failed to export session transcript:", error)
+      this.postMessage({
+        type: "error",
+        message: getErrorMessage(error) || "Failed to export session transcript",
       })
     }
   }

--- a/packages/kilo-vscode/src/kilo-provider/early-message.ts
+++ b/packages/kilo-vscode/src/kilo-provider/early-message.ts
@@ -11,10 +11,16 @@ type Ctx = {
   connection: KiloConnectionService
   dir: string
   post: (msg: unknown) => void
+  exportTranscript: (sessionID: string) => Promise<void>
 }
 
 export async function routeEarlyMessage(message: { type: string }, ctx: Ctx): Promise<boolean> {
   await routeSuggestionWebviewMessage(ctx.question, message)
   if (await ModelState.handleMessage(message.type, message, ctx.client, ctx.post)) return true
+  if (message.type === "exportSessionTranscript") {
+    const input = message as { sessionID?: unknown }
+    if (typeof input.sessionID === "string") await ctx.exportTranscript(input.sessionID)
+    return true
+  }
   return await routeInputToolMessage(message, { connection: ctx.connection, dir: ctx.dir, post: ctx.post })
 }

--- a/packages/kilo-vscode/src/kilo-provider/export-transcript.ts
+++ b/packages/kilo-vscode/src/kilo-provider/export-transcript.ts
@@ -1,0 +1,58 @@
+import * as path from "path"
+import * as vscode from "vscode"
+import type { KiloClient, Message, Part, Session } from "@kilocode/sdk/v2/client"
+import { fetchMessagePage } from "./message-page"
+
+type Item = {
+  info: Message
+  parts: Part[]
+}
+
+export async function exportTranscript(
+  client: KiloClient,
+  input: {
+    sessionID: string
+    dir: string
+  },
+) {
+  const [{ data: session }, page] = await Promise.all([
+    client.session.get({ sessionID: input.sessionID, directory: input.dir }, { throwOnError: true }),
+    fetchMessagePage(client, { sessionID: input.sessionID, workspaceDir: input.dir, limit: 0 }),
+  ])
+  const text = formatTranscript(session, page.items)
+  const uri = await vscode.window.showSaveDialog({
+    defaultUri: vscode.Uri.file(path.join(input.dir, `session-${session.id.slice(0, 8)}.md`)),
+    filters: { Markdown: ["md", "markdown"] },
+    saveLabel: "Export",
+  })
+  if (!uri) return false
+  await vscode.workspace.fs.writeFile(uri, Buffer.from(text, "utf8"))
+  return true
+}
+
+export function formatTranscript(session: Session, items: Item[]): string {
+  const head = [
+    `# ${session.title}`,
+    "",
+    `**Session ID:** ${session.id}`,
+    `**Created:** ${new Date(session.time.created).toLocaleString()}`,
+    `**Updated:** ${new Date(session.time.updated).toLocaleString()}`,
+    "",
+    "---",
+    "",
+    "",
+  ].join("\n")
+  const body = items.map((item) => formatMessage(item)).join("---\n\n")
+  return `${head}${body}${items.length > 0 ? "---\n\n" : ""}`
+}
+
+function formatMessage(item: Item): string {
+  const head = item.info.role === "user" ? "## User\n\n" : "## Assistant\n\n"
+  return `${head}${item.parts.map((part) => formatPart(part)).join("")}`
+}
+
+function formatPart(part: Part): string {
+  if (part.type === "text" && !part.synthetic) return `${part.text}\n\n`
+  if (part.type === "tool") return `**Tool: ${part.tool}**\n\n`
+  return ""
+}

--- a/packages/kilo-vscode/tests/unit/export-transcript.test.ts
+++ b/packages/kilo-vscode/tests/unit/export-transcript.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test"
+import { formatTranscript } from "../../src/kilo-provider/export-transcript"
+
+describe("formatTranscript", () => {
+  it("formats complete Markdown session exports and skips hidden text", () => {
+    const text = formatTranscript(
+      {
+        id: "ses_123456789",
+        slug: "export-test",
+        projectID: "project",
+        directory: "/repo",
+        title: "Export test",
+        version: "1",
+        time: { created: 1_000, updated: 2_000 },
+      } as never,
+      [
+        {
+          info: { role: "user" },
+          parts: [
+            { type: "text", text: "Please export this." },
+            { type: "text", text: "hidden", synthetic: true },
+          ],
+        },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "tool", tool: "read" },
+            { type: "text", text: "Saved as Markdown." },
+          ],
+        },
+      ] as never,
+    )
+
+    expect(text).toContain("# Export test")
+    expect(text).toContain("**Session ID:** ses_123456789")
+    expect(text).toContain("## User\n\nPlease export this.")
+    expect(text).toContain("## Assistant\n\n**Tool: read**\n\nSaved as Markdown.")
+    expect(text).not.toContain("hidden")
+  })
+
+  it("keeps an empty session export readable", () => {
+    const text = formatTranscript(
+      {
+        id: "ses_empty",
+        slug: "empty",
+        projectID: "project",
+        directory: "/repo",
+        title: "Empty",
+        version: "1",
+        time: { created: 1_000, updated: 2_000 },
+      } as never,
+      [],
+    )
+
+    expect(text).toContain("# Empty")
+    expect(text).toEndWith("---\n\n")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -329,6 +329,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   window.addEventListener("compactSession", onCompact)
   onCleanup(() => window.removeEventListener("compactSession", onCompact))
 
+  const onExport = () => {
+    const id = session.currentSessionID()
+    if (id) session.exportSessionTranscript(id)
+  }
+  window.addEventListener("exportSessionTranscript", onExport)
+  onCleanup(() => window.removeEventListener("exportSessionTranscript", onExport))
+
   const isBusy = () => isPromptBusy(session.status(), !!props.suggesting?.(), !!props.questioning?.())
   const isDisabled = () => !server.isConnected()
   const canUseSpeech = () => canUseSpeechToText(settings(), config(), provider.connected(), server.profileData())

--- a/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
@@ -119,6 +119,9 @@ const SessionList: Component<SessionListProps> = (props) => {
             <ContextMenu.Item onSelect={() => startRename(item)}>
               <ContextMenu.ItemLabel>{language.t("common.rename")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
+            <ContextMenu.Item onSelect={() => session.exportSessionTranscript(item.id)}>
+              <ContextMenu.ItemLabel>{language.t("command.session.export")}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
             <ContextMenu.Separator />
             <ContextMenu.Item onSelect={() => confirmDelete(item)}>
               <ContextMenu.ItemLabel>{language.t("common.delete")}</ContextMenu.ItemLabel>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -248,6 +248,7 @@ interface SessionContextValue {
   selectSession: (id: string) => void
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
+  exportSessionTranscript: (id: string) => void
   syncSession: (sessionID: string) => void
 
   // Cloud session preview
@@ -2141,6 +2142,18 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "renameSession", sessionID: id, title })
   }
 
+  function exportSessionTranscript(id: string) {
+    if (!server.isConnected()) {
+      console.warn("[Kilo New] Cannot export session transcript: not connected")
+      return
+    }
+    if (id.startsWith("cloud:")) {
+      console.warn("[Kilo New] Cannot export cloud session transcript")
+      return
+    }
+    vscode.postMessage({ type: "exportSessionTranscript", sessionID: id })
+  }
+
   // Computed values
   const currentSession = () => {
     const id = currentSessionID()
@@ -2429,6 +2442,7 @@ export const SessionProvider: ParentComponent = (props) => {
     selectSession,
     deleteSession,
     renameSession,
+    exportSessionTranscript,
     syncSession,
     cloudPreviewId,
     selectCloudSession,

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -100,6 +100,14 @@ export function useSlashCommand(vscode: VSCodeContext, exclude?: Set<string> | A
       },
     },
     {
+      name: "export",
+      description: "Export the current session transcript as Markdown",
+      hints: ["markdown", "transcript"],
+      action: () => {
+        window.dispatchEvent(new CustomEvent("exportSessionTranscript"))
+      },
+    },
+    {
       name: "settings",
       description: "Open settings",
       hints: [],

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "مشاركة هذه الجلسة ونسخ الرابط إلى الحافظة",
   "command.session.unshare": "إلغاء مشاركة الجلسة",
   "command.session.unshare.description": "إيقاف مشاركة هذه الجلسة",
+  "command.session.export": "تصدير سجل الجلسة",
 
   "palette.search.placeholder": "البحث في الملفات والأوامر والجلسات",
   "palette.empty": "لا توجد نتائج",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Compartilhar esta sessão e copiar a URL para a área de transferência",
   "command.session.unshare": "Parar de compartilhar sessão",
   "command.session.unshare.description": "Parar de compartilhar esta sessão",
+  "command.session.export": "Exportar transcrição da sessão",
 
   "palette.search.placeholder": "Buscar arquivos, comandos e sessões",
   "palette.empty": "Nenhum resultado encontrado",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Podijeli ovu sesiju i kopiraj URL u međuspremnik",
   "command.session.unshare": "Ukini dijeljenje sesije",
   "command.session.unshare.description": "Zaustavi dijeljenje ove sesije",
+  "command.session.export": "Izvezi transkript sesije",
 
   "palette.search.placeholder": "Pretraži datoteke, komande i sesije",
   "palette.empty": "Nema rezultata",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Del denne session og kopier URL'en til udklipsholderen",
   "command.session.unshare": "Stop deling af session",
   "command.session.unshare.description": "Stop med at dele denne session",
+  "command.session.export": "Eksporter sessionsudskrift",
 
   "palette.search.placeholder": "Søg i filer, kommandoer og sessioner",
   "palette.empty": "Ingen resultater fundet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -96,6 +96,7 @@ export const dict = {
   "command.session.share.description": "Diese Sitzung teilen und URL in die Zwischenablage kopieren",
   "command.session.unshare": "Teilen der Sitzung aufheben",
   "command.session.unshare.description": "Teilen dieser Sitzung beenden",
+  "command.session.export": "Sitzungsprotokoll exportieren",
 
   "palette.search.placeholder": "Dateien, Befehle und Sitzungen durchsuchen",
   "palette.empty": "Keine Ergebnisse gefunden",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Share this session and copy the URL to clipboard",
   "command.session.unshare": "Unshare session",
   "command.session.unshare.description": "Stop sharing this session",
+  "command.session.export": "Export session transcript",
 
   "palette.search.placeholder": "Search files, commands, and sessions",
   "palette.empty": "No results found",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Compartir esta sesión y copiar la URL al portapapeles",
   "command.session.unshare": "Dejar de compartir sesión",
   "command.session.unshare.description": "Dejar de compartir esta sesión",
+  "command.session.export": "Exportar transcripción de la sesión",
 
   "palette.search.placeholder": "Buscar archivos, comandos y sesiones",
   "palette.empty": "No se encontraron resultados",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -93,6 +93,7 @@ export const dict = {
   "command.session.share.description": "Partager cette session et copier l'URL dans le presse-papiers",
   "command.session.unshare": "Ne plus partager la session",
   "command.session.unshare.description": "Arrêter de partager cette session",
+  "command.session.export": "Exporter la transcription de la session",
 
   "palette.search.placeholder": "Rechercher des fichiers, des commandes et des sessions",
   "palette.empty": "Aucun résultat trouvé",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "このセッションを共有しURLをクリップボードにコピー",
   "command.session.unshare": "セッションの共有を停止",
   "command.session.unshare.description": "このセッションの共有を停止",
+  "command.session.export": "セッション記録をエクスポート",
 
   "palette.search.placeholder": "ファイル、コマンド、セッションを検索",
   "palette.empty": "結果が見つかりません",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -96,6 +96,7 @@ export const dict = {
   "command.session.share.description": "이 세션을 공유하고 URL을 클립보드에 복사",
   "command.session.unshare": "세션 공유 중지",
   "command.session.unshare.description": "이 세션 공유 중지",
+  "command.session.export": "세션 기록 내보내기",
 
   "palette.search.placeholder": "파일, 명령어 및 세션 검색",
   "palette.empty": "결과 없음",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Deel deze sessie en kopieer de URL naar het klembord",
   "command.session.unshare": "Delen van sessie stoppen",
   "command.session.unshare.description": "Stop met het delen van deze sessie",
+  "command.session.export": "Sessietranscript exporteren",
 
   "palette.search.placeholder": "Zoeken naar bestanden, commando's en sessies",
   "palette.empty": "Geen resultaten gevonden",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -95,6 +95,7 @@ export const dict = {
   "command.session.share.description": "Del denne sesjonen og kopier URL-en til utklippstavlen",
   "command.session.unshare": "Slutt å dele sesjon",
   "command.session.unshare.description": "Slutt å dele denne sesjonen",
+  "command.session.export": "Eksporter sesjonsutskrift",
 
   "palette.search.placeholder": "Søk i filer, kommandoer og sesjoner",
   "palette.empty": "Ingen resultater funnet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Udostępnij tę sesję i skopiuj URL do schowka",
   "command.session.unshare": "Przestań udostępniać sesję",
   "command.session.unshare.description": "Zatrzymaj udostępnianie tej sesji",
+  "command.session.export": "Eksportuj transkrypcję sesji",
 
   "palette.search.placeholder": "Szukaj plików, poleceń i sesji",
   "palette.empty": "Brak wyników",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Поделиться сессией и скопировать URL в буфер обмена",
   "command.session.unshare": "Отменить публикацию",
   "command.session.unshare.description": "Прекратить публикацию сессии",
+  "command.session.export": "Экспортировать запись сеанса",
 
   "palette.search.placeholder": "Поиск файлов, команд и сессий",
   "palette.empty": "Ничего не найдено",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "แชร์เซสชันนี้และคัดลอก URL ไปยังคลิปบอร์ด",
   "command.session.unshare": "ยกเลิกการแชร์เซสชัน",
   "command.session.unshare.description": "หยุดการแชร์เซสชันนี้",
+  "command.session.export": "ส่งออกบันทึกเซสชัน",
 
   "palette.search.placeholder": "ค้นหาไฟล์ คำสั่ง และเซสชัน",
   "palette.empty": "ไม่พบผลลัพธ์",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Bu oturumu paylaş ve URL'yi panoya kopyala",
   "command.session.unshare": "Paylaşımı kaldır",
   "command.session.unshare.description": "Bu oturumun paylaşımını durdur",
+  "command.session.export": "Oturum dökümünü dışa aktar",
 
   "palette.search.placeholder": "Dosya, komut ve oturum ara",
   "palette.empty": "Sonuç bulunamadı",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -92,6 +92,7 @@ export const dict = {
   "command.session.share.description": "Відкрити доступ до цієї сесії та скопіювати URL до буфера обміну",
   "command.session.unshare": "Закрити доступ до сесії",
   "command.session.unshare.description": "Закрити доступ до цієї сесії",
+  "command.session.export": "Експортувати запис сеансу",
 
   "palette.search.placeholder": "Пошук файлів, команд і сесій",
   "palette.empty": "Результатів не знайдено",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -96,6 +96,7 @@ export const dict = {
   "command.session.share.description": "分享此会话并将链接复制到剪贴板",
   "command.session.unshare": "取消分享会话",
   "command.session.unshare.description": "停止分享此会话",
+  "command.session.export": "导出会话记录",
 
   "palette.search.placeholder": "搜索文件、命令和会话",
   "palette.empty": "未找到结果",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -96,6 +96,7 @@ export const dict = {
   "command.session.share.description": "分享此工作階段並將連結複製到剪貼簿",
   "command.session.unshare": "取消分享工作階段",
   "command.session.unshare.description": "停止分享此工作階段",
+  "command.session.export": "匯出會話紀錄",
 
   "palette.search.placeholder": "搜尋檔案、命令和工作階段",
   "palette.empty": "找不到結果",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -320,6 +320,11 @@ export interface RenameSessionRequest {
   title: string
 }
 
+export interface ExportSessionTranscriptRequest {
+  type: "exportSessionTranscript"
+  sessionID: string
+}
+
 export interface RequestAutocompleteSettingsMessage {
   type: "requestAutocompleteSettings"
 }
@@ -1100,6 +1105,7 @@ export type WebviewMessage =
   | SuggestionDismissRequest
   | DeleteSessionRequest
   | RenameSessionRequest
+  | ExportSessionTranscriptRequest
   | RequestAutocompleteSettingsMessage
   | RequestSpeechToTextSettingsMessage
   | RequestChatCompletionMessage


### PR DESCRIPTION
Restore VS Code per-session Markdown transcript export so users can save complete local chat history for debugging, postmortems, and archiving. Users can run `/export` in chat or choose `Export session transcript` from a local History entry.

Reuse the extension's full-history message fetch (`fetchMessagePage` with `limit: 0`), existing webview-to-provider request flow, and VS Code save dialog pattern so both triggers share one exporter instead of relying on paged chat state. This includes docs, localized History menu text, unit coverage, and a release changeset.

Refs #8395