### PR TITLE
fix(agent-manager): stabilize markdown review capture

### DIFF
--- a/.changeset/markdown-review-voice.md
+++ b/.changeset/markdown-review-voice.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep inline review voice capture stable in rendered Markdown diffs.

--- a/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
+++ b/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "bun:test"
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
+import { isAnnotationMutation } from "../../webview-ui/agent-manager/MarkdownAnnotationLayer"
 
-const file = join(import.meta.dir, "../../webview-ui/agent-manager/MarkdownAnnotationLayer.tsx")
-const src = readFileSync(file, "utf8")
+function mutation(target: Node): Pick<MutationRecord, "target"> {
+  return { target }
+}
 
-describe("MarkdownAnnotationLayer", () => {
-  it("ignores inline annotation DOM mutations while watching rendered Markdown", () => {
-    expect(src).toMatch(/function isAnnotationMutation[\s\S]*target\.closest\(selector\)/)
-    expect(src).toMatch(
-      /new MutationObserver\(\(mutations\) => \{[\s\S]*mutations\.every\(isAnnotationMutation\)[\s\S]*schedule\(\)/,
-    )
+describe("isAnnotationMutation", () => {
+  it("matches nested annotation DOM mutations", () => {
+    const target = { closest: () => ({}) } as unknown as Node
+    expect(isAnnotationMutation(mutation(target))).toBe(true)
+  })
+
+  it("keeps external Markdown DOM mutations observable", () => {
+    const markdown = { closest: () => null } as unknown as Node
+    const plain = {} as Node
+    expect(isAnnotationMutation(mutation(markdown))).toBe(false)
+    expect(isAnnotationMutation(mutation(plain))).toBe(false)
   })
 })

--- a/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
+++ b/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const file = join(import.meta.dir, "../../webview-ui/agent-manager/MarkdownAnnotationLayer.tsx")
+const src = readFileSync(file, "utf8")
+
+describe("MarkdownAnnotationLayer", () => {
+  it("ignores inline annotation DOM mutations while watching rendered Markdown", () => {
+    expect(src).toMatch(/function isAnnotationMutation[\s\S]*target\.closest\(selector\)/)
+    expect(src).toMatch(
+      /new MutationObserver\(\(mutations\) => \{[\s\S]*mutations\.every\(isAnnotationMutation\)[\s\S]*schedule\(\)/,
+    )
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
@@ -88,11 +88,17 @@ function matches(annotation: DiffLineAnnotation<AnnotationMeta>, anchor: Anchor,
   return true
 }
 
+const selector = ".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation"
+
+function isAnnotationMutation(mutation: MutationRecord): boolean {
+  const target = mutation.target
+  if (!(target instanceof Element)) return false
+  return target.closest(selector) !== null
+}
+
 function removeInserted(root: HTMLElement, layer: HTMLElement): void {
   layer.replaceChildren()
-  root
-    .querySelectorAll(".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation")
-    .forEach((node) => node.remove())
+  root.querySelectorAll(selector).forEach((node) => node.remove())
 }
 
 function insertHost(anchor: Anchor, host: HTMLElement): void {
@@ -206,7 +212,10 @@ export const MarkdownAnnotationLayer: Component<MarkdownAnnotationLayerProps> = 
     const root = props.root()
     if (!root) return
     observer?.disconnect()
-    observer = new MutationObserver(schedule)
+    observer = new MutationObserver((mutations) => {
+      if (mutations.length > 0 && mutations.every(isAnnotationMutation)) return
+      schedule()
+    })
     observer.observe(root, { childList: true, subtree: true })
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
@@ -90,9 +90,11 @@ function matches(annotation: DiffLineAnnotation<AnnotationMeta>, anchor: Anchor,
 
 const selector = ".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation"
 
-function isAnnotationMutation(mutation: MutationRecord): boolean {
+// Keep host insertion observable, only nested annotation UI updates are safe to ignore.
+export function isAnnotationMutation(mutation: Pick<MutationRecord, "target">): boolean {
   const target = mutation.target
-  if (!(target instanceof Element)) return false
+  if (!("closest" in target)) return false
+  if (typeof target.closest !== "function") return false
   return target.closest(selector) !== null
 }
 
@@ -213,7 +215,7 @@ export const MarkdownAnnotationLayer: Component<MarkdownAnnotationLayerProps> = 
     if (!root) return
     observer?.disconnect()
     observer = new MutationObserver((mutations) => {
-      if (mutations.length > 0 && mutations.every(isAnnotationMutation)) return
+      if (mutations.every(isAnnotationMutation)) return
       schedule()
     })
     observer.observe(root, { childList: true, subtree: true })


### PR DESCRIPTION
Rendered Markdown review comments can rebuild their injected annotation layer while inline comment UI mutates, which disrupts comment capture in split diff views.

Ignore annotation-owned Markdown DOM mutations so rendered Markdown comment composers and voice capture remain stable during review.

This would cause the edge case that you couldn't actually use speech to text in a markdown rendered diff.

<img width="709" height="545" alt="image" src="https://github.com/user-attachments/assets/e7b30c9e-1fdf-4fb1-8b7d-e2fdd5e82d93" />
