### PR TITLE
fix(vscode): support PipeWire speech input

### DIFF
--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -29,6 +29,11 @@ type Audio = {
   language?: string
 }
 
+type Args = {
+  pipe?: string[]
+  input: string[]
+}
+
 let active: Recording | undefined
 let starting: string | undefined
 
@@ -119,13 +124,15 @@ async function waitForStart(state: Recording): Promise<void> {
   })
 }
 
-async function startWithArgs(bin: string, file: string, input: Input, args: string[][]): Promise<Recording> {
+async function startWithArgs(bin: string, file: string, input: Input, args: Args[]): Promise<Recording> {
   const [first, ...rest] = args
   if (!first) throw new Error(`Unsupported platform for speech input: ${process.platform}`)
 
-  const proc = spawn(bin, ["-y", ...first, "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-f", "wav", file], {
-    stdio: ["pipe", "ignore", "pipe"],
-  })
+  const proc = first.pipe
+    ? pipeProcess(first.pipe, bin, file)
+    : spawn(bin, ["-y", ...first.input, "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-f", "wav", file], {
+        stdio: ["pipe", "ignore", "pipe"],
+      })
   const state: Recording = { ...input, file, proc, stderr: [], stopped: false }
   active = state
 
@@ -149,6 +156,21 @@ async function startWithArgs(bin: string, file: string, input: Input, args: stri
     if (rest.length === 0) throw err
     return startWithArgs(bin, file, input, rest)
   }
+}
+
+function pipeProcess(pipe: string[], bin: string, file: string): ChildProcess {
+  const source = spawn("pw-record", pipe, { stdio: ["ignore", "pipe", "pipe"] })
+  const proc = spawn(bin, ["-y", "-f", "s16le", "-ar", "16000", "-ac", "1", "-i", "pipe:0", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-f", "wav", file], {
+    stdio: ["pipe", "ignore", "pipe"],
+  })
+
+  if (source.stdout && proc.stdin) source.stdout.pipe(proc.stdin)
+  source.stderr?.on("data", (data: Buffer) => proc.stderr?.emit("data", data))
+  proc.once("exit", () => {
+    if (!source.killed) source.kill("SIGTERM")
+  })
+
+  return proc
 }
 
 async function stopProcess(state: Recording): Promise<void> {
@@ -226,24 +248,33 @@ function platformPaths(): string[] {
   return ["/usr/bin/ffmpeg", "/usr/local/bin/ffmpeg", "/snap/bin/ffmpeg", "/home/linuxbrew/.linuxbrew/bin/ffmpeg"]
 }
 
-async function inputArgSets(bin: string): Promise<string[][]> {
-  if (process.platform === "darwin") return [["-f", "avfoundation", "-i", ":default"]]
-  if (process.platform === "linux")
+async function inputArgSets(bin: string): Promise<Args[]> {
+  if (process.platform === "darwin") return [{ input: ["-f", "avfoundation", "-i", ":default"] }]
+  if (process.platform === "linux") {
+    const device = process.env.KILO_FFMPEG_AUDIO_DEVICE
+    if (device)
+      return [
+        { pipe: ["--target", device, "--format", "s16", "--rate", "16000", "--channels", "1", "-"], input: [] },
+        { input: ["-f", "pulse", "-i", device] },
+        { input: ["-f", "alsa", "-i", device] },
+      ]
     return [
-      ["-f", "pulse", "-i", "default"],
-      ["-f", "alsa", "-i", "default"],
+      { pipe: ["--format", "s16", "--rate", "16000", "--channels", "1", "-"], input: [] },
+      { input: ["-f", "pulse", "-i", "default"] },
+      { input: ["-f", "alsa", "-i", "default"] },
     ]
+  }
   if (process.platform === "win32") return await windowsInputArgSets(bin)
   return []
 }
 
-async function windowsInputArgSets(bin: string): Promise<string[][]> {
+async function windowsInputArgSets(bin: string): Promise<Args[]> {
   const configured = process.env.KILO_FFMPEG_AUDIO_DEVICE
-  if (configured) return [["-f", "dshow", "-i", `audio=${configured}`]]
+  if (configured) return [{ input: ["-f", "dshow", "-i", `audio=${configured}`] }]
 
   const devices = await listDshowAudioDevices(bin)
   if (devices.length === 0) throw new Error("No Windows audio input devices found for speech input")
-  return devices.map((device) => ["-f", "dshow", "-i", `audio=${device}`])
+  return devices.map((device) => ({ input: ["-f", "dshow", "-i", `audio=${device}`] }))
 }
 
 async function listDshowAudioDevices(bin: string): Promise<string[]> {
@@ -266,9 +297,18 @@ function processOutput(err: unknown): string {
 }
 
 function summary(state: Recording, fallback: string): string {
-  const stderr = state.stderr.join("\n").trim()
+  const stderr = cleanOutput(state.stderr.join("\n"))
   if (!stderr) return fallback
   return `${fallback}: ${stderr.slice(-800)}`
+}
+
+export function cleanOutput(raw: string): string {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^(ffmpeg version|built with|configuration:|lib[a-z]+\s+\d)/i.test(line))
+  return lines.join("\n").trim()
 }
 
 async function removeFile(file: string): Promise<void> {

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -165,7 +165,11 @@ function pipeProcess(pipe: string[], bin: string, file: string): ChildProcess {
   })
 
   if (source.stdout && proc.stdin) source.stdout.pipe(proc.stdin)
+  source.on("error", (err) => proc.emit("error", err))
   source.stderr?.on("data", (data: Buffer) => proc.stderr?.emit("data", data))
+  source.once("exit", () => {
+    if (proc.stdin?.writable) proc.stdin.end()
+  })
   proc.once("exit", () => {
     if (!source.killed) source.kill("SIGTERM")
   })

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -160,9 +160,32 @@ async function startWithArgs(bin: string, file: string, input: Input, args: Args
 
 function pipeProcess(pipe: string[], bin: string, file: string): ChildProcess {
   const source = spawn("pw-record", pipe, { stdio: ["ignore", "pipe", "pipe"] })
-  const proc = spawn(bin, ["-y", "-f", "s16le", "-ar", "16000", "-ac", "1", "-i", "pipe:0", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-f", "wav", file], {
-    stdio: ["pipe", "ignore", "pipe"],
-  })
+  const proc = spawn(
+    bin,
+    [
+      "-y",
+      "-f",
+      "s16le",
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      "-i",
+      "pipe:0",
+      "-acodec",
+      "pcm_s16le",
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      "-f",
+      "wav",
+      file,
+    ],
+    {
+      stdio: ["pipe", "ignore", "pipe"],
+    },
+  )
 
   if (source.stdout && proc.stdin) source.stdout.pipe(proc.stdin)
   source.on("error", (err) => proc.emit("error", err))

--- a/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
+++ b/packages/kilo-vscode/tests/unit/markdown-annotation-layer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { isAnnotationMutation } from "../../webview-ui/agent-manager/MarkdownAnnotationLayer"
+import { isAnnotationMutation } from "../../webview-ui/agent-manager/markdown-annotation-mutation"
 
 function mutation(target: Node): Pick<MutationRecord, "target"> {
   return { target }

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { parseDshowAudioDevices } from "../../src/speech-to-text/capture"
+import { cleanOutput, parseDshowAudioDevices } from "../../src/speech-to-text/capture"
 
 describe("parseDshowAudioDevices", () => {
   it("extracts Windows dshow audio device names", () => {
@@ -18,5 +18,22 @@ describe("parseDshowAudioDevices", () => {
     const raw = `"Microphone" (audio)\n"Microphone" (audio)`
 
     expect(parseDshowAudioDevices(raw)).toEqual(["Microphone"])
+  })
+})
+
+describe("cleanOutput", () => {
+  it("removes ffmpeg build noise from capture errors", () => {
+    const raw = `
+ffmpeg version 4.2.7 Copyright (c) 2000-2022 the FFmpeg developers
+built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.2)
+configuration: --enable-libopus --enable-libx264
+libavutil      56. 31.100 / 56. 31.100
+ALSA lib ../../../src/pcm/pcm.c:2477:(snd_pcm_open_conf) Unknown field libs
+default: Input/output error
+`
+
+    expect(cleanOutput(raw)).toBe(
+      "ALSA lib ../../../src/pcm/pcm.c:2477:(snd_pcm_open_conf) Unknown field libs\ndefault: Input/output error",
+    )
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MarkdownAnnotationLayer.tsx
@@ -2,6 +2,7 @@ import { type Component, createEffect, createMemo, onCleanup } from "solid-js"
 import type { AnnotationSide, DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs"
 import { markdownCommentBlocks, type MarkdownRange } from "./markdown-comment-ranges"
 import type { AnnotationMeta } from "./review-annotations"
+import { annotationSelector, isAnnotationMutation } from "./markdown-annotation-mutation"
 
 type Insert = "after" | "list" | "table"
 
@@ -88,15 +89,7 @@ function matches(annotation: DiffLineAnnotation<AnnotationMeta>, anchor: Anchor,
   return true
 }
 
-const selector = ".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation"
-
-// Keep host insertion observable, only nested annotation UI updates are safe to ignore.
-export function isAnnotationMutation(mutation: Pick<MutationRecord, "target">): boolean {
-  const target = mutation.target
-  if (!("closest" in target)) return false
-  if (typeof target.closest !== "function") return false
-  return target.closest(selector) !== null
-}
+const selector = annotationSelector()
 
 function removeInserted(root: HTMLElement, layer: HTMLElement): void {
   layer.replaceChildren()

--- a/packages/kilo-vscode/webview-ui/agent-manager/markdown-annotation-mutation.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/markdown-annotation-mutation.ts
@@ -1,0 +1,13 @@
+const selector = ".am-markdown-inline-annotations, .am-markdown-list-annotation, .am-markdown-table-annotation"
+
+// Keep host insertion observable, only nested annotation UI updates are safe to ignore.
+export function isAnnotationMutation(mutation: Pick<MutationRecord, "target">): boolean {
+  const target = mutation.target
+  if (!("closest" in target)) return false
+  if (typeof target.closest !== "function") return false
+  return target.closest(selector) !== null
+}
+
+export function annotationSelector(): string {
+  return selector
+}


### PR DESCRIPTION
## Context

Linux speech input could fail on systems without PulseAudio or a usable ALSA default device. This adds a PipeWire-first recording path so speech-to-text works on PipeWire-only setups while preserving existing Linux fallbacks.

## Implementation

The Linux capture flow now tries `pw-record` first and pipes raw PCM into ffmpeg to keep the existing WAV encoding path. If PipeWire capture fails or is unavailable, the extension still falls back to ffmpeg PulseAudio and ALSA inputs. The error summary also removes ffmpeg version/build noise so microphone failures show the actionable device error.

## Screenshots

https://github.com/user-attachments/assets/bb521c34-51de-446e-848d-be2b26d0cfd2

## How to Test

- On a Linux machine with PipeWire and `pw-record` installed, enable speech-to-text in the Kilo Code extension.
- Start speech input from the prompt box and speak into the microphone.
- Stop recording and verify the transcript is inserted without a microphone startup error.
- Optional: set `KILO_FFMPEG_AUDIO_DEVICE` to a PipeWire target and verify capture uses that target.
