### PR TITLE
feat(jetbrains): add profile editor tab foundation

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/KiloToolWindowFactory.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/KiloToolWindowFactory.kt
@@ -1,12 +1,11 @@
 package ai.kilocode.client
 
-import ai.kilocode.client.actions.HistoryAction
-import ai.kilocode.client.actions.NewSessionAction
 import ai.kilocode.client.app.KiloWorkspaceService
 import ai.kilocode.client.app.Workspace
 import ai.kilocode.client.session.SessionSidePanelManager
 import ai.kilocode.log.KiloLog
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -65,9 +64,9 @@ class KiloToolWindowFactory : ToolWindowFactory, DumbAware {
             toolWindow.contentManager.setSelectedContent(content)
             manager.newSession()
 
-            ActionManager.getInstance().getAction("Kilo.Settings")?.let { settings ->
-                toolWindow.setTitleActions(listOf(NewSessionAction(), HistoryAction(), settings))
-            }
+            val actions = ActionManager.getInstance()
+            val group = actions.getAction("Kilo.ToolWindow.TitleActions") as? DefaultActionGroup
+            toolWindow.setTitleActions(group?.getChildren(actions)?.toList().orEmpty())
         } catch (e: Exception) {
             LOG.error("Failed to set up Kilo tool window content", e)
         }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/ShowProfileAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/ShowProfileAction.kt
@@ -1,0 +1,17 @@
+package ai.kilocode.client.actions
+
+import ai.kilocode.client.fs.KiloEditorService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+
+class ShowProfileAction : AnAction(), DumbAware {
+    override fun actionPerformed(e: AnActionEvent) {
+        e.project?.service<KiloEditorService>()?.openProfile()
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorProvider.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorProvider.kt
@@ -1,0 +1,31 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+class KiloEditorProvider : FileEditorProvider, DumbAware {
+    companion object {
+        const val ID = "kilo-editor"
+    }
+
+    override fun accept(project: Project, file: VirtualFile): Boolean {
+        if (file.fileSystem.protocol != KiloVirtualFileSystem.PROTOCOL) return false
+        return KiloEditorTarget.parse(file.path) != null
+    }
+
+    override fun acceptRequiresReadAction(): Boolean = false
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+        val target = KiloEditorTarget.parse(file.path)
+            ?: error("Unsupported Kilo editor path: ${file.path}")
+        return KiloEmptyEditor(target, file)
+    }
+
+    override fun getEditorTypeId(): String = ID
+
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorService.kt
@@ -1,0 +1,33 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+
+@Service(Service.Level.PROJECT)
+class KiloEditorService(
+    private val project: Project,
+) {
+    fun openProfile() {
+        open(KiloEditorTarget.Profile)
+    }
+
+    fun open(target: KiloEditorTarget) {
+        val file = KiloVirtualFileSystem.getInstance().file(target)
+        val app = ApplicationManager.getApplication()
+        if (app.isDispatchThread) {
+            open(file)
+            return
+        }
+        app.invokeLater({ open(file) }, ModalityState.defaultModalityState())
+    }
+
+    private fun open(file: KiloVirtualFile) {
+        if (project.isDisposed) return
+        val manager = FileEditorManager.getInstance(project)
+        manager.openFile(file, true, true)
+        manager.setSelectedEditor(file, KiloEditorProvider.ID)
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorTarget.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEditorTarget.kt
@@ -1,0 +1,20 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.vfs.VirtualFileManager
+
+sealed class KiloEditorTarget(
+    val path: String,
+    val title: String,
+) {
+    data object Profile : KiloEditorTarget("profile", "Kilo Profile")
+
+    val url: String get() = VirtualFileManager.constructUrl(KiloVirtualFileSystem.PROTOCOL, path)
+
+    companion object {
+        fun parse(path: String): KiloEditorTarget? {
+            val normalized = path.trim('/')
+            if (normalized == Profile.path) return Profile
+            return null
+        }
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEmptyEditor.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloEmptyEditor.kt
@@ -1,0 +1,44 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorLocation
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class KiloEmptyEditor(
+    private val target: KiloEditorTarget,
+    private val file: VirtualFile,
+) : UserDataHolderBase(), FileEditor {
+    private val component = JPanel(BorderLayout()).apply {
+        isOpaque = true
+        background = UIUtil.getPanelBackground()
+    }
+
+    override fun getComponent(): JComponent = component
+
+    override fun getPreferredFocusedComponent(): JComponent? = component
+
+    override fun getName(): String = target.title
+
+    override fun getFile(): VirtualFile = file
+
+    override fun setState(state: FileEditorState) = Unit
+
+    override fun isModified(): Boolean = false
+
+    override fun isValid(): Boolean = true
+
+    override fun addPropertyChangeListener(listener: PropertyChangeListener) = Unit
+
+    override fun removePropertyChangeListener(listener: PropertyChangeListener) = Unit
+
+    override fun getCurrentLocation(): FileEditorLocation? = null
+
+    override fun dispose() = Unit
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloFileType.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloFileType.kt
@@ -1,0 +1,19 @@
+package ai.kilocode.client.fs
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.fileTypes.FileType
+import javax.swing.Icon
+
+object KiloFileType : FileType {
+    override fun getName(): String = "Kilo"
+
+    override fun getDescription(): String = "Kilo virtual editor"
+
+    override fun getDefaultExtension(): String = ""
+
+    override fun getIcon(): Icon = AllIcons.General.User
+
+    override fun isBinary(): Boolean = false
+
+    override fun isReadOnly(): Boolean = true
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloVirtualFile.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloVirtualFile.kt
@@ -1,0 +1,52 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileSystem
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+class KiloVirtualFile(
+    private val fs: KiloVirtualFileSystem,
+    val target: KiloEditorTarget,
+) : VirtualFile() {
+    override fun getName(): String = target.title
+
+    override fun getFileSystem(): VirtualFileSystem = fs
+
+    override fun getPath(): String = target.path
+
+    override fun getPresentableName(): String = target.title
+
+    override fun getPresentableUrl(): String = target.title
+
+    override fun getFileType(): FileType = KiloFileType
+
+    override fun isWritable(): Boolean = false
+
+    override fun isDirectory(): Boolean = false
+
+    override fun isValid(): Boolean = true
+
+    override fun getParent(): VirtualFile? = null
+
+    override fun getChildren(): Array<VirtualFile> = VirtualFile.EMPTY_ARRAY
+
+    override fun getOutputStream(requestor: Any?, newModificationStamp: Long, newTimeStamp: Long): OutputStream {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    override fun contentsToByteArray(): ByteArray = ByteArray(0)
+
+    override fun getModificationStamp(): Long = 0
+
+    override fun getTimeStamp(): Long = 0
+
+    override fun getLength(): Long = 0
+
+    override fun refresh(asynchronous: Boolean, recursive: Boolean, postRunnable: Runnable?) = Unit
+
+    override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloVirtualFileSystem.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/fs/KiloVirtualFileSystem.kt
@@ -1,0 +1,69 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.vfs.DeprecatedVirtualFileSystem
+import com.intellij.openapi.vfs.NonPhysicalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+
+class KiloVirtualFileSystem : DeprecatedVirtualFileSystem(), NonPhysicalFileSystem {
+    companion object {
+        const val PROTOCOL = "kilo"
+
+        private val local = KiloVirtualFileSystem()
+
+        fun getInstance(): KiloVirtualFileSystem {
+            val fs = VirtualFileManager.getInstance().getFileSystem(PROTOCOL)
+            if (fs is KiloVirtualFileSystem) return fs
+            return local
+        }
+    }
+
+    private val files = ConcurrentHashMap<String, KiloVirtualFile>()
+
+    override fun getProtocol(): String = PROTOCOL
+
+    fun file(target: KiloEditorTarget): KiloVirtualFile {
+        return files.computeIfAbsent(target.path) { KiloVirtualFile(this, target) }
+    }
+
+    override fun findFileByPath(path: String): VirtualFile? {
+        val target = KiloEditorTarget.parse(path) ?: return null
+        return file(target)
+    }
+
+    override fun refreshAndFindFileByPath(path: String): VirtualFile? = findFileByPath(path)
+
+    override fun refresh(asynchronous: Boolean) = Unit
+
+    @Throws(IOException::class)
+    override fun deleteFile(requestor: Any?, vFile: VirtualFile) {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    @Throws(IOException::class)
+    override fun moveFile(requestor: Any?, vFile: VirtualFile, newParent: VirtualFile) {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    @Throws(IOException::class)
+    override fun renameFile(requestor: Any?, vFile: VirtualFile, newName: String) {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    @Throws(IOException::class)
+    override fun createChildFile(requestor: Any?, vDir: VirtualFile, fileName: String): VirtualFile {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    @Throws(IOException::class)
+    override fun createChildDirectory(requestor: Any?, vDir: VirtualFile, dirName: String): VirtualFile {
+        throw IOException("Kilo virtual files are read-only")
+    }
+
+    @Throws(IOException::class)
+    override fun copyFile(requestor: Any?, vFile: VirtualFile, newParent: VirtualFile, copyName: String): VirtualFile {
+        throw IOException("Kilo virtual files are read-only")
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptEditorTextField.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptEditorTextField.kt
@@ -1,6 +1,7 @@
 package ai.kilocode.client.session.ui.prompt
 
 import com.intellij.openapi.actionSystem.DataSink
+import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.project.Project
 import com.intellij.ui.EditorTextField
@@ -8,7 +9,7 @@ import com.intellij.ui.EditorTextField
 internal class PromptEditorTextField(
     project: Project,
     private val ctx: SendPromptContext,
-) : EditorTextField(project, PlainTextFileType.INSTANCE) {
+) : EditorTextField(EditorFactory.getInstance().createDocument(""), project, PlainTextFileType.INSTANCE) {
     override fun uiDataSnapshot(sink: DataSink) {
         super.uiDataSnapshot(sink)
         sink.set(PromptDataKeys.SEND, ctx)

--- a/packages/kilo-jetbrains/frontend/src/main/resources/kilo.jetbrains.frontend.xml
+++ b/packages/kilo-jetbrains/frontend/src/main/resources/kilo.jetbrains.frontend.xml
@@ -12,6 +12,12 @@
                     icon="/icons/kilo.svg"
                     factoryClass="ai.kilocode.client.KiloToolWindowFactory"/>
 
+        <virtualFileSystem key="kilo"
+                           implementationClass="ai.kilocode.client.fs.KiloVirtualFileSystem"/>
+
+        <fileEditorProvider id="kilo-editor"
+                            implementation="ai.kilocode.client.fs.KiloEditorProvider"/>
+
         <registryKey key="kilo.session.condense"
                      description="Enable event condensing in the session update queue (merges redundant snapshots before model delivery)."
                      defaultValue="true"
@@ -25,6 +31,15 @@
     </extensions>
 
     <actions>
+        <action id="Kilo.NewSession"
+                class="ai.kilocode.client.actions.NewSessionAction"/>
+
+        <action id="Kilo.ShowProfile"
+                class="ai.kilocode.client.actions.ShowProfileAction"
+                text="Show profile"
+                description="Open the Kilo profile editor"
+                icon="AllIcons.General.User"/>
+
         <action id="Kilo.Restart"
                 class="ai.kilocode.client.actions.RestartKiloAction"/>
 
@@ -32,6 +47,8 @@
                 class="ai.kilocode.client.actions.ReinstallKiloAction"/>
 
         <group id="Kilo.SettingsGroup">
+            <reference ref="Kilo.ShowProfile"/>
+            <separator/>
             <reference ref="Kilo.Restart"/>
             <reference ref="Kilo.Reinstall"/>
         </group>
@@ -42,6 +59,13 @@
 
         <action id="Kilo.History"
                 class="ai.kilocode.client.actions.HistoryAction"/>
+
+        <group id="Kilo.ToolWindow.TitleActions">
+            <reference ref="Kilo.NewSession"/>
+            <reference ref="Kilo.History"/>
+            <reference ref="Kilo.ShowProfile"/>
+            <reference ref="Kilo.Settings"/>
+        </group>
 
         <action id="Kilo.SendPrompt"
                 class="ai.kilocode.client.actions.SendPromptAction"

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloEditorProviderTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloEditorProviderTest.kt
@@ -1,0 +1,54 @@
+package ai.kilocode.client.fs
+
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+@Suppress("UnstableApiUsage")
+class KiloEditorProviderTest : BasePlatformTestCase() {
+
+    fun `test accepts profile virtual file`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile")!!
+        assertTrue(KiloEditorProvider().accept(project, file))
+    }
+
+    fun `test filesystem instance falls back when extension lookup is unavailable`() {
+        val fs = KiloVirtualFileSystem.getInstance()
+        val file = fs.findFileByPath("profile")
+        assertNotNull(file)
+        assertEquals("profile", file!!.path)
+    }
+
+    fun `test rejects unknown path`() {
+        val fs = KiloVirtualFileSystem()
+        val unknown = fs.findFileByPath("settings")
+        assertNull(unknown)
+    }
+
+    fun `test uses hidden default editor policy`() {
+        assertEquals(FileEditorPolicy.HIDE_DEFAULT_EDITOR, KiloEditorProvider().policy)
+    }
+
+    fun `test editor type id is kilo-editor`() {
+        assertEquals("kilo-editor", KiloEditorProvider().editorTypeId)
+    }
+
+    fun `test creates empty profile editor`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile")!!
+        val editor = KiloEditorProvider().createEditor(project, file)
+        try {
+            assertEquals("Kilo Profile", editor.name)
+            assertFalse(editor.isModified)
+            assertTrue(editor.isValid)
+            assertNotNull(editor.component)
+            assertSame(file, editor.file)
+        } finally {
+            editor.dispose()
+        }
+    }
+
+    fun `test accept requires no read action`() {
+        assertFalse(KiloEditorProvider().acceptRequiresReadAction())
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloEditorTargetTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloEditorTargetTest.kt
@@ -1,0 +1,24 @@
+package ai.kilocode.client.fs
+
+import junit.framework.TestCase
+
+class KiloEditorTargetTest : TestCase() {
+
+    fun `test profile target has stable path and url`() {
+        assertEquals("profile", KiloEditorTarget.Profile.path)
+        assertEquals("Kilo Profile", KiloEditorTarget.Profile.title)
+        assertEquals("kilo://profile", KiloEditorTarget.Profile.url)
+    }
+
+    fun `test parse profile path`() {
+        assertSame(KiloEditorTarget.Profile, KiloEditorTarget.parse("profile"))
+        assertSame(KiloEditorTarget.Profile, KiloEditorTarget.parse("/profile"))
+    }
+
+    fun `test reject unknown path`() {
+        assertNull(KiloEditorTarget.parse("account"))
+        assertNull(KiloEditorTarget.parse("settings"))
+        assertNull(KiloEditorTarget.parse("worktree/foo/agent-manager"))
+        assertNull(KiloEditorTarget.parse(""))
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloVirtualFileSystemTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/fs/KiloVirtualFileSystemTest.kt
@@ -1,0 +1,58 @@
+package ai.kilocode.client.fs
+
+import com.intellij.icons.AllIcons
+import junit.framework.TestCase
+
+class KiloVirtualFileSystemTest : TestCase() {
+
+    fun `test find profile file`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile")
+        assertNotNull(file)
+        assertEquals("kilo", file!!.fileSystem.protocol)
+        assertEquals("profile", file.path)
+        assertEquals("Kilo Profile", file.name)
+    }
+
+    fun `test profile file url`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile") as KiloVirtualFile
+        assertEquals("kilo://profile", file.target.url)
+    }
+
+    fun `test profile file is cached`() {
+        val fs = KiloVirtualFileSystem()
+        assertSame(fs.findFileByPath("profile"), fs.findFileByPath("profile"))
+    }
+
+    fun `test profile file is empty read only non directory`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile")!!
+        assertFalse(file.isDirectory)
+        assertFalse(file.isWritable)
+        assertTrue(file.isValid)
+        assertEquals(0, file.modificationStamp)
+        assertEquals(0, file.contentsToByteArray().size)
+    }
+
+    fun `test profile file has user file type icon`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.findFileByPath("profile")!!
+        assertSame(KiloFileType, file.fileType)
+        assertSame(AllIcons.General.User, file.fileType.icon)
+    }
+
+    fun `test unknown paths are not supported`() {
+        val fs = KiloVirtualFileSystem()
+        assertNull(fs.findFileByPath("account"))
+        assertNull(fs.findFileByPath("settings"))
+        assertNull(fs.findFileByPath("missing"))
+    }
+
+    fun `test refresh and find delegates to find`() {
+        val fs = KiloVirtualFileSystem()
+        val file = fs.refreshAndFindFileByPath("profile")
+        assertNotNull(file)
+        assertEquals("profile", file!!.path)
+    }
+}


### PR DESCRIPTION
## Context

This draft PR lays the editor-tab foundation for the JetBrains Account UI. The goal of this PR is to support the future Account UI by proving a singleton non-physical `kilo://profile` editor tab and wiring it into the existing JetBrains UI entry points.

## Implementation

Adds a frontend-owned `kilo://` VFS with a stable `profile` target, a custom `FileEditorProvider`, and an empty Swing editor tab for `Kilo Profile`. The profile action is exposed in the gear menu and the tool window title toolbar via XML action groups, using the same account-style user icon as VS Code.

Also adjusts the prompt editor field to use an in-memory document so split-mode frontend startup does not trip read-action assertions.

## Screenshots

| before | after |
|---|---|
|  |  |

## How to Test

- Run `./gradlew :frontend:test --tests '*KiloEditorProvider*' --tests '*KiloVirtualFileSystem*' --tests '*KiloEditorTarget*' :frontend:compileKotlin` from `packages/kilo-jetbrains/`.
- Run `./gradlew buildPlugin` from `packages/kilo-jetbrains/`.
- Run `./gradlew runIdeFrontend -Pkilo.dev.log.level=debug`, open the Kilo tool window, and click the profile/user icon.
- Confirm a single empty `Kilo Profile` editor tab opens and repeated clicks reveal the existing tab.

## Get in Touch