### PR TITLE
fix(cli): vertically center TUI dialogs

### DIFF
--- a/.changeset/tui-dialog-vertical-centering.md
+++ b/.changeset/tui-dialog-vertical-centering.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Vertically center TUI dialogs on screen

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -39,9 +39,9 @@ export function Dialog(
       width={dimensions().width}
       height={dimensions().height}
       alignItems="center"
+      justifyContent="center" // kilocode_change
       position="absolute"
       zIndex={3000}
-      paddingTop={dimensions().height / 4}
       left={0}
       top={0}
       backgroundColor={RGBA.fromInts(0, 0, 0, 150)}


### PR DESCRIPTION
## Context

The `/help` dialog and all other TUI dialogs were not vertically centered on screen. They rendered approximately 3-5 rows too high. The dialog overlay used a hardcoded `paddingTop={dimensions().height / 4}` approximation, which doesn't account for varying terminal heights or dialog content sizes.

Closes #10296

## Implementation

Replaced `paddingTop={dimensions().height / 4}` with `justifyContent="center"` on the dialog overlay `<box>` in `packages/opencode/src/cli/cmd/tui/ui/dialog.tsx`. The overlay already had `alignItems="center"` for horizontal centering and `height={dimensions().height}` for full-screen coverage. Adding `justifyContent="center"` leverages flexbox to properly center the dialog vertically regardless of terminal dimensions or dialog height. This is a one-line change that affects all dialogs uniformly.

## Screenshots

| before | after |
|---|---|
| <img width="1920" height="975" alt="before" src="https://github.com/user-attachments/assets/2df61830-bb4e-4c21-817c-96da8aa47dd3" /> | <img width="1920" height="978" alt="after" src="https://github.com/user-attachments/assets/0dcba2ce-a4bb-4cdf-9cae-d5b5079edf8d" /> |

## How to Test

- Run `bun dev`
- Press `Ctrl+X H` or run `/help` to open the help dialog
- The dialog should be vertically centered on screen

## Get in Touch

Discord: @IamCoder18
