### PR TITLE
fix(cli): toggle export dialog checkboxes on mouse click

### DIFF
--- a/.changeset/export-dialog-checkbox-click.md
+++ b/.changeset/export-dialog-checkbox-click.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Toggle export dialog checkboxes on mouse click

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -120,7 +120,10 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "thinking" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "thinking")}
+          onMouseUp={() => { // kilocode_change start
+            setStore("active", "thinking")
+            setStore("thinking", !store.thinking)
+          } /* kilocode_change end */}
         >
           <text fg={store.active === "thinking" ? theme.primary : theme.textMuted}>
             {store.thinking ? "[x]" : "[ ]"}
@@ -132,7 +135,10 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "toolDetails" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "toolDetails")}
+          onMouseUp={() => { // kilocode_change start
+            setStore("active", "toolDetails")
+            setStore("toolDetails", !store.toolDetails)
+          } /* kilocode_change end */}
         >
           <text fg={store.active === "toolDetails" ? theme.primary : theme.textMuted}>
             {store.toolDetails ? "[x]" : "[ ]"}
@@ -144,7 +150,10 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "assistantMetadata" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "assistantMetadata")}
+          onMouseUp={() => { // kilocode_change start
+            setStore("active", "assistantMetadata")
+            setStore("assistantMetadata", !store.assistantMetadata)
+          } /* kilocode_change end */}
         >
           <text fg={store.active === "assistantMetadata" ? theme.primary : theme.textMuted}>
             {store.assistantMetadata ? "[x]" : "[ ]"}
@@ -156,7 +165,10 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "openWithoutSaving" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "openWithoutSaving")}
+          onMouseUp={() => { // kilocode_change start
+            setStore("active", "openWithoutSaving")
+            setStore("openWithoutSaving", !store.openWithoutSaving)
+          } /* kilocode_change end */}
         >
           <text fg={store.active === "openWithoutSaving" ? theme.primary : theme.textMuted}>
             {store.openWithoutSaving ? "[x]" : "[ ]"}


### PR DESCRIPTION
## Context

In the TUI export options dialog, clicking on checkbox rows only highlights/focuses them but does not toggle the checkbox value. Users must use keyboard navigation (Tab + Space) to toggle options, which is inconsistent with expected mouse interaction patterns.

Closes #10305

## Implementation

Updated the 4 checkbox row `onMouseUp` handlers in `dialog-export-options.tsx` to both set visual focus (`active`) AND toggle the corresponding boolean value (`thinking`, `toolDetails`, `assistantMetadata`, `openWithoutSaving`). Keyboard shortcuts (Tab for navigation, Space for toggle, Return for confirm) remain unaffected.

## Screenshots

### Before

https://github.com/user-attachments/assets/4dd29dbf-192a-432c-bf65-f3ac535f5013

### After

https://github.com/user-attachments/assets/23566bc8-8731-44ef-ad3a-d1b4ff4d65f5

## How To Test

- Run `bun dev` and open a session
- Trigger "Export session transcript" command
- Click on any checkbox option with mouse. It should now toggle on click
- Verify keyboard navigation (Tab/Space) still works correctly

## Get in Touch

Discord: @IamCoder18