### PR TITLE
feat(cli): show running spinner in subagent footer

### DIFF
--- a/.changeset/subagent-footer-spinner.md
+++ b/.changeset/subagent-footer-spinner.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Show running spinner in subagent footer to indicate when subagent is processing

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -3,6 +3,8 @@ import { useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { SplitBorder } from "@tui/component/border"
+import { Spinner } from "@tui/component/spinner" // kilocode_change
+import { useLocal } from "@tui/context/local" // kilocode_change
 import type { AssistantMessage } from "@kilocode/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
@@ -12,8 +14,23 @@ import { useTerminalDimensions } from "@opentui/solid"
 export function SubagentFooter() {
   const route = useRouteData("session")
   const sync = useSync()
+  const local = useLocal() // kilocode_change
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const session = createMemo(() => sync.session.get(route.sessionID))
+
+  // kilocode_change start
+  const lastAssistant = createMemo(() => messages().findLast((m) => m.role === "assistant"))
+
+  const isRunning = createMemo(() => {
+    const status = sync.data.session_status?.[route.sessionID]
+    if (status?.type === "busy") return true
+    const last = lastAssistant()
+    if (last && !last.time.completed) return true
+    return false
+  })
+
+  const agentColor = createMemo(() => local.agent.color(lastAssistant()?.agent ?? ""))
+  // kilocode_change end
 
   const subagentInfo = createMemo(() => {
     const s = session()
@@ -84,6 +101,11 @@ export function SubagentFooter() {
                 ({subagentInfo().index} of {subagentInfo().total})
               </text>
             </Show>
+            {/* kilocode_change start */}
+            <Show when={isRunning()}>
+              <Spinner color={agentColor()} />
+            </Show>
+            {/* kilocode_change end */}
             <Show when={usage()}>
               {(item) => (
                 <text fg={theme.textMuted} wrapMode="none">


### PR DESCRIPTION
## Context

Subagent sessions in the TUI have no visual indicator showing whether the subagent is currently running or idle. The main session displays an animated spinner in the prompt component when the agent is working, but the subagent footer only shows the label, sibling count, usage stats, and navigation buttons, making it impossible to tell at a glance if a subagent is still processing or has finished.

Closes #10309

## Implementation

Added a running status indicator to the `SubagentFooter` component (`packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx`):

- **`isRunning` memo**: Checks `session_status` store (real-time SSE events) for `"busy"` state, with a fallback to checking if the last assistant message lacks `time.completed`.
- **`agentColor` memo**: Derives the spinner color from the last assistant message's agent field via `local.agent.color()`.
- **Spinner rendering**: Inserts `<Spinner color={agentColor()} />` between the subagent label/count and usage stats when running.

No "esc interrupt" text is included since subagent sessions don't have an input prompt to interrupt, the spinner alone communicates "working" status.

## Screenshots

### Before

https://github.com/user-attachments/assets/8e4109b2-6825-4d83-b7e2-22dad7d468bc

### After

https://github.com/user-attachments/assets/7b41ef3f-253e-477e-a2a1-3551909cf85c

## How to Test

1. Start a Kilo CLI session in the TUI (`kilo`)
2. Send a prompt that spawns a subagent via the `task` tool (e.g., "explore the codebase and find all API endpoints")
3. Navigate into the child subagent session
4. Observe the subagent footer at the bottom. A colored spinner should appear next to the subagent label while the agent is working
5. Wait for the subagent to complete. The spinner should disappear
6. Navigate between sibling subagent sessions. Each should independently show/hide its spinner based on its own running status

## Get in Touch

Discord: @IamCoder18 