### PR TITLE
feat(cli): add Kilo-native MCP server management commands

### DIFF
--- a/.changeset/mcp-cli-management-commands.md
+++ b/.changeset/mcp-cli-management-commands.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support Kilo-native MCP server management commands in the CLI.

--- a/packages/kilo-docs/pages/automate/mcp/using-in-cli.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-cli.md
@@ -107,10 +107,32 @@ You can manage MCP servers from the CLI:
 | Command | Description |
 |---|---|
 | `kilo mcp list` | List all configured MCP servers |
-| `kilo mcp add` | Add an MCP server |
-| `kilo mcp auth` | Authenticate with an MCP server |
+| `kilo mcp add` | Add an MCP server interactively or from arguments |
+| `kilo mcp add-json <name> <json>` | Add an MCP server from a JSON string |
+| `kilo mcp get <name>` | Show details for a configured MCP server |
+| `kilo mcp remove <name>` | Remove an MCP server from config |
+| `kilo mcp auth [name]` | Authenticate with an OAuth-enabled MCP server |
+| `kilo mcp logout [name]` | Remove OAuth credentials for an MCP server |
+| `kilo mcp debug <name>` | Debug OAuth connection details for an MCP server |
 
 Inside the interactive TUI, use the `/mcps` slash command to toggle MCP servers on or off.
+
+`kilo mcp add` also supports Kilo-native arguments:
+
+```bash
+# Add remote server
+kilo mcp add --type=remote sentry https://mcp.sentry.dev/mcp
+
+# Add remote server with headers
+kilo mcp add --type=remote corridor https://app.corridor.dev/api/mcp -H "Authorization: Bearer ..."
+
+# Add local server (local is the default type)
+kilo mcp add my-server -e API_KEY=xxx -- npx my-mcp-server
+```
+
+For scope flags, `local` and `project` write project config; `user` and `global` write global config.
+`kilo mcp add-json` accepts the same Kilo MCP server object used under `mcp.<name>` in config; `type` must be `"local"` or `"remote"`.
+Transport names used by other MCP clients, such as `stdio`, `sse`, or `http`, are not valid Kilo config types.
 
 ## Examples
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
@@ -29,11 +29,14 @@ Options:
 manage MCP (Model Context Protocol) servers
 
 Commands:
-  kilo mcp add            add an MCP server
-  kilo mcp list           list MCP servers and their status  [aliases: ls]
-  kilo mcp auth [name]    authenticate with an OAuth-enabled MCP server
-  kilo mcp logout [name]  remove OAuth credentials for an MCP server
-  kilo mcp debug <name>   debug OAuth connection for an MCP server
+  kilo mcp add [name] [commandOrUrl] [args..]  add an MCP server
+  kilo mcp add-json <name> <json>              add an MCP server from a JSON string
+  kilo mcp get <name>                          get details about an MCP server
+  kilo mcp list                                list MCP servers and their status  [aliases: ls]
+  kilo mcp remove <name>                       remove an MCP server  [aliases: rm]
+  kilo mcp auth [name]                         authenticate with an OAuth-enabled MCP server
+  kilo mcp logout [name]                       remove OAuth credentials for an MCP server
+  kilo mcp debug <name>                        debug OAuth connection for an MCP server
 
 Options:
   --help     Show help  [boolean]
@@ -44,6 +47,47 @@ Options:
 
 ```
 add an MCP server
+
+Positionals:
+  name          name of the MCP server  [string]
+  commandOrUrl  command or URL for the MCP server  [string]
+  args          arguments for local MCP servers  [string]
+
+Options:
+      --help           Show help  [boolean]
+      --version        Show version number  [boolean]
+      --callback-port  fixed port for OAuth callback  [number]
+      --client-id      OAuth client ID for remote servers  [string]
+      --client-secret  prompt for OAuth client secret or read MCP_CLIENT_SECRET  [boolean]
+  -e, --env            set environment variables, e.g. -e KEY=value  [array]
+  -H, --header         set HTTP headers, e.g. -H "Authorization: Bearer ..."  [array]
+  -s, --scope          configuration scope (local, user, or project)  [string] [choices: "local", "user", "project", "global"] [default: "local"]
+  -t, --type           MCP server type (local or remote)  [string] [choices: "local", "remote"] [default: "local"]
+```
+
+### kilo mcp add-json
+
+```
+add an MCP server from a JSON string
+
+Positionals:
+  name  name of the MCP server  [string]
+  json  Kilo MCP server JSON  [string]
+
+Options:
+      --help           Show help  [boolean]
+      --version        Show version number  [boolean]
+  -s, --scope          configuration scope (local, user, or project)  [string] [choices: "local", "user", "project", "global"] [default: "local"]
+      --client-secret  prompt for OAuth client secret or read MCP_CLIENT_SECRET  [boolean]
+```
+
+### kilo mcp get
+
+```
+get details about an MCP server
+
+Positionals:
+  name  name of the MCP server  [string]
 
 Options:
   --help     Show help  [boolean]
@@ -58,6 +102,20 @@ list MCP servers and their status
 Options:
   --help     Show help  [boolean]
   --version  Show version number  [boolean]
+```
+
+### kilo mcp remove
+
+```
+remove an MCP server
+
+Positionals:
+  name  name of the MCP server  [string]
+
+Options:
+      --help     Show help  [boolean]
+      --version  Show version number  [boolean]
+  -s, --scope    configuration scope (local, user, or project)  [string] [choices: "local", "user", "project", "global"]
 ```
 
 ### kilo mcp auth

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -19,6 +19,15 @@ import { Filesystem } from "@/util/filesystem"
 import { Bus } from "../../bus"
 import { AppRuntime } from "../../effect/app-runtime"
 import { Effect } from "effect"
+// kilocode_change start
+import {
+  handleMcpAddArgs,
+  McpAddJsonCommand,
+  McpGetCommand,
+  McpRemoveCommand,
+  resolveConfigTarget,
+} from "../../kilocode/cli/cmd/mcp"
+// kilocode_change end
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
   switch (status) {
@@ -101,7 +110,12 @@ export const McpCommand = cmd({
   builder: (yargs) =>
     yargs
       .command(McpAddCommand)
+      // kilocode_change start
+      .command(McpAddJsonCommand)
+      .command(McpGetCommand)
+      // kilocode_change end
       .command(McpListCommand)
+      .command(McpRemoveCommand) // kilocode_change
       .command(McpAuthCommand)
       .command(McpLogoutCommand)
       .command(McpDebugCommand)
@@ -409,37 +423,11 @@ export const McpLogoutCommand = cmd({
   },
 })
 
-async function resolveConfigPath(baseDir: string, global = false) {
-  // kilocode_change start - prefer kilo.json/.kilo over opencode.json/.opencode
-  // Check for existing config files (prefer .jsonc over .json, check .kilo/ and .opencode/ subdirectory too)
-  const candidates = [
-    path.join(baseDir, "kilo.json"),
-    path.join(baseDir, "kilo.jsonc"),
-    path.join(baseDir, "opencode.json"),
-    path.join(baseDir, "opencode.jsonc"),
-  ]
-
-  if (!global) {
-    candidates.push(
-      path.join(baseDir, ".kilo", "kilo.json"),
-      path.join(baseDir, ".kilo", "kilo.jsonc"),
-      path.join(baseDir, ".kilo", "opencode.json"),
-      path.join(baseDir, ".kilo", "opencode.jsonc"),
-      path.join(baseDir, ".opencode", "opencode.json"),
-      path.join(baseDir, ".opencode", "opencode.jsonc"),
-    )
-  }
-
-  for (const candidate of candidates) {
-    if (await Filesystem.exists(candidate)) {
-      return candidate
-    }
-  }
-
-  // Default to kilo.json if none exist
-  return path.join(baseDir, "kilo.json")
-  // kilocode_change end
+// kilocode_change start - delegate to shared resolveConfigTarget for canonical path resolution
+async function resolveConfigPath(_baseDir: string, global = false) {
+  return resolveConfigTarget(global ? "global" : "project")
 }
+// kilocode_change end
 
 async function addMcpToConfig(name: string, mcpConfig: ConfigMCP.Info, configPath: string) {
   let text = "{}"
@@ -459,12 +447,72 @@ async function addMcpToConfig(name: string, mcpConfig: ConfigMCP.Info, configPat
 }
 
 export const McpAddCommand = cmd({
-  command: "add",
+  command: "add [name] [commandOrUrl] [args..]", // kilocode_change
   describe: "add an MCP server",
-  async handler() {
+  // kilocode_change start
+  builder: (yargs) =>
+    yargs
+      .positional("name", {
+        describe: "name of the MCP server",
+        type: "string",
+      })
+      .positional("commandOrUrl", {
+        describe: "command or URL for the MCP server",
+        type: "string",
+      })
+      .positional("args", {
+        describe: "arguments for local MCP servers",
+        type: "string",
+        array: true,
+      })
+      .option("callback-port", {
+        describe: "fixed port for OAuth callback",
+        type: "number",
+      })
+      .option("client-id", {
+        describe: "OAuth client ID for remote servers",
+        type: "string",
+      })
+      .option("client-secret", {
+        describe: "prompt for OAuth client secret or read MCP_CLIENT_SECRET",
+        type: "boolean",
+      })
+      .option("env", {
+        alias: "e",
+        describe: "set environment variables, e.g. -e KEY=value",
+        type: "string",
+        array: true,
+      })
+      .option("header", {
+        alias: "H",
+        describe: 'set HTTP headers, e.g. -H "Authorization: Bearer ..."',
+        type: "string",
+        array: true,
+      })
+      .option("scope", {
+        alias: "s",
+        describe: "configuration scope (local, user, or project)",
+        type: "string",
+        choices: ["local", "user", "project", "global"],
+        default: "local",
+      })
+      .option("type", {
+        alias: "t",
+        describe: "MCP server type (local or remote, defaults to local)",
+        type: "string",
+        choices: ["local", "remote"],
+      }),
+  // kilocode_change end
+  async handler(args) { // kilocode_change
     await Instance.provide({
       directory: process.cwd(),
       async fn() {
+        // kilocode_change start
+        if (args.name || args.commandOrUrl || args["--"]?.length) {
+          await handleMcpAddArgs(args)
+          return
+        }
+        // kilocode_change end
         UI.empty()
         prompts.intro("Add MCP server")
 

--- a/packages/opencode/src/kilocode/cli/cmd/mcp.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/mcp.ts
@@ -1,0 +1,435 @@
+import { EOL } from "os"
+import path from "path"
+import * as prompts from "@clack/prompts"
+import { applyEdits, modify, parse as parseJsonc, type ParseError } from "jsonc-parser"
+import { Global } from "@opencode-ai/core/global"
+import { cmd } from "../../../cli/cmd/cmd"
+import { UI } from "../../../cli/ui"
+import { Config } from "@/config/config"
+import { ConfigMCP } from "@/config/mcp"
+import { AppRuntime } from "@/effect/app-runtime"
+import { MCP } from "@/mcp"
+import { Instance } from "@/project/instance"
+import { Filesystem } from "@/util/filesystem"
+
+type Scope = "project" | "global"
+
+type AddArgs = {
+  name?: string
+  commandOrUrl?: string
+  args?: string[]
+  type?: string
+  env?: string | string[]
+  header?: string | string[]
+  scope?: string
+  clientId?: string
+  clientSecret?: boolean
+  callbackPort?: number
+  "--"?: string[]
+}
+
+const opts = { formattingOptions: { tabSize: 2, insertSpaces: true } }
+const secret = /secret|token|authorization|api[_-]?key|password/i
+
+// Canonical config file names and directory suffixes (mirrors KilocodeConfig constants)
+const FILES = ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"] as const
+const GLOBAL_FILES = [...FILES, "config.json"] as const
+const DIRS = [".kilo", ".kilocode", ".opencode"] as const
+
+function record(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
+function list(input: unknown) {
+  if (input === undefined) return []
+  if (typeof input === "string") return [input]
+  if (Array.isArray(input)) {
+    return input.map((item) => {
+      if (typeof item !== "string") throw new Error(`Expected string, got ${typeof item}`)
+      return item
+    })
+  }
+  throw new Error(`Expected string, got ${typeof input}`)
+}
+
+function strings(input: unknown) {
+  if (!Array.isArray(input)) return undefined
+  const result = input.filter((item): item is string => typeof item === "string")
+  if (result.length !== input.length) return undefined
+  return result
+}
+
+function text(input: unknown) {
+  return typeof input === "string" && input.length > 0 ? input : undefined
+}
+
+function bool(input: unknown) {
+  return typeof input === "boolean" ? input : undefined
+}
+
+function num(input: unknown) {
+  return typeof input === "number" && Number.isInteger(input) && input > 0 ? input : undefined
+}
+
+function map(input: unknown) {
+  if (!record(input)) return undefined
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value !== "string") return undefined
+    result[key] = value
+  }
+  return result
+}
+
+function fields(input: Record<string, unknown>, allowed: string[]) {
+  for (const key of Object.keys(input)) {
+    if (!allowed.includes(key)) throw new Error(`Unsupported MCP JSON field: ${key}`)
+  }
+}
+
+function split(input: string, sep: string) {
+  const index = input.indexOf(sep)
+  if (index === -1) return undefined
+  const key = input.slice(0, index).trim()
+  const value = input.slice(index + sep.length).trim()
+  if (!key) return undefined
+  return [key, value] as const
+}
+
+function pairs(input: unknown, mode: "env" | "header") {
+  const result: Record<string, string> = {}
+  for (const item of list(input)) {
+    const pair = mode === "header" ? split(item, ":") : split(item, "=")
+    if (!pair) throw new Error(`Invalid ${mode}: ${item}`)
+    result[pair[0]] = pair[1]
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+function scope(input: unknown, fallback?: Scope): Scope | undefined {
+  if (input === undefined) return fallback
+  if (input === "user" || input === "global") return "global"
+  if (input === "local" || input === "project") return "project"
+  throw new Error(`Invalid scope: ${JSON.stringify(input)}`)
+}
+
+/**
+ * Walk from `start` up to `stop` (inclusive), returning directories that
+ * contain any of `targets`. Mirrors `AppFileSystem.up()` without Effect.
+ */
+async function up(targets: readonly string[], start: string, stop?: string) {
+  const found: string[] = []
+  const limit = stop ? path.resolve(stop) : undefined
+  let dir = path.resolve(start)
+  for (;;) {
+    for (const name of targets) {
+      if (await Filesystem.exists(path.join(dir, name))) {
+        found.push(path.join(dir, name))
+        break
+      }
+    }
+    if (limit && dir === limit) break
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return found
+}
+
+/**
+ * Resolve the config file to write MCP entries into.
+ * Mirrors `KilocodeConfig.projectConfigUpdateTarget()` for project scope
+ * and `globalConfigFile()` for global scope.
+ */
+export async function resolveConfigTarget(type: Scope) {
+  if (type === "global") {
+    const base = Global.Path.config
+    for (const file of GLOBAL_FILES) {
+      if (await Filesystem.exists(path.join(base, file))) return path.join(base, file)
+    }
+    return path.join(base, GLOBAL_FILES[0])
+  }
+  const dir = process.cwd()
+  const stop = Instance.worktree
+  const dirs = await up(DIRS, dir, stop)
+  const roots = await up(FILES, dir, stop)
+  const candidates = [...dirs.flatMap((d) => FILES.map((f) => path.join(d, f))), ...roots]
+  for (const file of candidates) {
+    if (await Filesystem.exists(file)) return file
+  }
+  return path.join(dir, ".kilo", "kilo.json")
+}
+
+function parse(raw: string, file: string) {
+  const errors: ParseError[] = []
+  const value = parseJsonc(raw, errors, { allowTrailingComma: true })
+  if (errors.length > 0) throw new Error(`Invalid JSON in ${file}`)
+  return value
+}
+
+async function data(file: string) {
+  if (!(await Filesystem.exists(file))) return {}
+  return parse(await Filesystem.readText(file), file)
+}
+
+async function write(file: string, name: string, cfg: ConfigMCP.Info) {
+  const before = (await Filesystem.exists(file)) ? await Filesystem.readText(file) : "{}"
+  const edits = modify(before, ["mcp", name], cfg, opts)
+  await Filesystem.write(file, applyEdits(before, edits))
+  return file
+}
+
+async function remove(file: string, name: string) {
+  const before = (await Filesystem.exists(file)) ? await Filesystem.readText(file) : "{}"
+  const value = parse(before, file)
+  if (!record(value) || !record(value.mcp) || !(name in value.mcp)) return false
+  const edits = modify(before, ["mcp", name], undefined, opts)
+  await Filesystem.write(file, applyEdits(before, edits))
+  return true
+}
+
+function check(cfg: ConfigMCP.Info) {
+  const result = ConfigMCP.Info.zod.safeParse(cfg)
+  if (result.success) return result.data
+  throw new Error(result.error.issues.map((issue) => issue.message).join("\n"))
+}
+
+function oauth(input: {
+  clientId?: string
+  token?: string
+  port?: number
+  base?: unknown
+}): ConfigMCP.Remote["oauth"] | undefined {
+  const base = input.base === false ? false : record(input.base) ? input.base : undefined
+  if (base === false) return false
+  const result: ConfigMCP.OAuth = {
+    ...base,
+    ...(input.clientId && { clientId: input.clientId }),
+    ...(input.token && { clientSecret: input.token }),
+    ...(input.port && { redirectUri: `http://127.0.0.1:${input.port}/mcp/oauth/callback` }),
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+export function configFromJson(input: unknown, token?: string): ConfigMCP.Info {
+  if (!record(input)) throw new Error("MCP JSON must be an object")
+
+  const kind = text(input.type)
+  const enabled = bool(input.enabled)
+  const timeout = num(input.timeout)
+
+  if (kind === "local") {
+    fields(input, ["type", "command", "environment", "enabled", "timeout"])
+    const command = strings(input.command)
+    const env = map(input.environment)
+    if (!command) throw new Error("local MCP JSON requires command array")
+    return check({
+      type: "local",
+      command,
+      ...(env && { environment: env }),
+      ...(enabled !== undefined && { enabled }),
+      ...(timeout && { timeout }),
+    })
+  }
+
+  if (kind === "remote") {
+    fields(input, ["type", "url", "headers", "oauth", "enabled", "timeout"])
+    const url = text(input.url)
+    const auth = oauth({ token, base: input.oauth })
+    const headers = map(input.headers)
+    if (!url) throw new Error("remote MCP JSON requires url")
+    if (!URL.canParse(url) || !/^https?:$/.test(new URL(url).protocol)) throw new Error(`Invalid MCP server URL: ${url}`)
+    return check({
+      type: "remote",
+      url,
+      ...(headers && { headers }),
+      ...(auth !== undefined && { oauth: auth }),
+      ...(enabled !== undefined && { enabled }),
+      ...(timeout && { timeout }),
+    })
+  }
+
+  throw new Error('MCP JSON type must be "local" or "remote"')
+}
+
+export function configFromAdd(args: AddArgs, token?: string): ConfigMCP.Info {
+  const dash = (args["--"] ?? []).map(String)
+  const head = args.commandOrUrl ? [args.commandOrUrl] : []
+  const tail = [...(args.args ?? []).map(String), ...dash]
+  const command = [...head, ...tail]
+  const type = args.type ?? "local"
+  if (type !== "local" && type !== "remote") {
+    throw new Error(`Invalid MCP server type: ${type}`)
+  }
+
+  if (command.length === 0) throw new Error("MCP command or URL is required")
+
+  if (type === "local") {
+    if (args.header !== undefined) throw new Error("Headers are only supported for remote MCP servers")
+    if (args.clientId !== undefined || args.clientSecret !== undefined || args.callbackPort !== undefined) {
+      throw new Error("OAuth options are only supported for remote MCP servers")
+    }
+    const env = pairs(args.env, "env")
+    return check({
+      type: "local",
+      command,
+      ...(env && { environment: env }),
+    })
+  }
+
+  if (args.env !== undefined) throw new Error("Environment variables are only supported for local MCP servers")
+  if (command.length !== 1) throw new Error("Remote MCP servers require exactly one URL")
+
+  const url = command[0]
+  const auth = oauth({ clientId: args.clientId, token, port: args.callbackPort })
+  const headers = pairs(args.header, "header")
+  if (!URL.canParse(url) || !/^https?:$/.test(new URL(url).protocol)) throw new Error(`Invalid MCP server URL: ${url}`)
+  return check({
+    type: "remote",
+    url,
+    ...(headers && { headers }),
+    ...(auth !== undefined && { oauth: auth }),
+  })
+}
+
+async function token(flag?: boolean) {
+  if (!flag) return undefined
+  if (process.env.MCP_CLIENT_SECRET) return process.env.MCP_CLIENT_SECRET
+  const value = await prompts.password({ message: "Enter client secret" })
+  if (prompts.isCancel(value)) throw new UI.CancelledError()
+  return value
+}
+
+async function save(name: string, cfg: ConfigMCP.Info, raw?: string) {
+  const file = await resolveConfigTarget(scope(raw, "project") ?? "project")
+  await write(file, name, cfg)
+  process.stdout.write(`MCP server "${name}" saved to ${file}${EOL}`)
+}
+
+export async function handleMcpAddArgs(args: AddArgs) {
+  if (!args.name) throw new Error("MCP server name is required")
+  const type = args.type ?? "local"
+  await save(args.name, configFromAdd(args, type === "remote" ? await token(args.clientSecret) : undefined), args.scope)
+}
+
+function redact(input: unknown, key = ""): unknown {
+  if (typeof input === "string") return secret.test(key) ? "<redacted>" : input
+  if (Array.isArray(input)) return input.map((item) => redact(item, key))
+  if (!record(input)) return input
+  return Object.fromEntries(Object.entries(input).map(([name, value]) => [name, redact(value, name)]))
+}
+
+async function sources(name: string, raw?: string) {
+  const wanted = scope(raw)
+  const types: Scope[] = wanted ? [wanted] : ["project", "global"]
+  const seen = new Set<string>()
+  const found: string[] = []
+  for (const type of types) {
+    const base = type === "global" ? Global.Path.config : Instance.worktree
+    const list =
+      type === "global"
+        ? GLOBAL_FILES.map((f) => path.join(base, f))
+        : [
+            ...(await up(DIRS, process.cwd(), base)).flatMap((d) => FILES.map((f) => path.join(d, f))),
+            ...(await up(FILES, process.cwd(), base)),
+          ]
+    for (const file of list) {
+      if (seen.has(file)) continue
+      seen.add(file)
+      if (!(await Filesystem.exists(file))) continue
+      const value = await data(file)
+      if (record(value) && record(value.mcp) && name in value.mcp) found.push(file)
+    }
+  }
+  return found
+}
+
+export const McpAddJsonCommand = cmd({
+  command: "add-json <name> <json>",
+  describe: "add an MCP server from a JSON string",
+  builder: (yargs) =>
+    yargs
+      .positional("name", { describe: "name of the MCP server", type: "string", demandOption: true })
+      .positional("json", { describe: "Kilo MCP server JSON", type: "string", demandOption: true })
+      .option("scope", {
+        alias: "s",
+        describe: "configuration scope (local, user, or project)",
+        type: "string",
+        choices: ["local", "user", "project", "global"],
+        default: "local",
+      })
+      .option("client-secret", {
+        describe: "prompt for OAuth client secret or read MCP_CLIENT_SECRET",
+        type: "boolean",
+      }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        const cfg = configFromJson(parse(args.json, "<mcp-json>"), await token(args.clientSecret))
+        await save(args.name, cfg, args.scope)
+      },
+    })
+  },
+})
+
+export const McpGetCommand = cmd({
+  command: "get <name>",
+  describe: "get details about an MCP server",
+  builder: (yargs) => yargs.positional("name", { describe: "name of the MCP server", type: "string" }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        const name = args.name
+        if (!name) {
+          UI.error("MCP server name is required")
+          process.exit(1)
+        }
+        const cfg = await AppRuntime.runPromise(Config.Service.use((svc) => svc.get()))
+        const value = cfg.mcp?.[name]
+        if (!value) {
+          UI.error(`MCP server not found: ${name}`)
+          process.exit(1)
+        }
+        const status = await AppRuntime.runPromise(MCP.Service.use((mcp) => mcp.status()))
+        process.stdout.write(JSON.stringify(redact({ name, config: value, status: status[name] }), null, 2) + EOL)
+      },
+    })
+  },
+})
+
+export const McpRemoveCommand = cmd({
+  command: "remove <name>",
+  aliases: ["rm"],
+  describe: "remove an MCP server",
+  builder: (yargs) =>
+    yargs
+      .positional("name", { describe: "name of the MCP server", type: "string" })
+      .option("scope", {
+        alias: "s",
+        describe: "configuration scope (local, user, or project)",
+        type: "string",
+        choices: ["local", "user", "project", "global"],
+      }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        const name = args.name
+        if (!name) {
+          UI.error("MCP server name is required")
+          process.exit(1)
+        }
+        const files = await sources(name, args.scope)
+        if (files.length === 0) {
+          UI.error(`MCP server not found in config: ${name}`)
+          process.exit(1)
+        }
+        for (const file of files) await remove(file, name)
+        process.stdout.write(`Removed MCP server "${name}" from ${files.join(", ")}${EOL}`)
+      },
+    })
+  },
+})
+

--- a/packages/opencode/test/kilocode/cli/mcp.test.ts
+++ b/packages/opencode/test/kilocode/cli/mcp.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test"
+import { configFromAdd, configFromJson } from "../../../src/kilocode/cli/cmd/mcp"
+
+describe("mcp cli config helpers", () => {
+  test("builds local config from add args after dash", () => {
+    const cfg = configFromAdd({
+      name: "demo",
+      type: "local",
+      "--": ["npx", "my-mcp-server"],
+      env: ["API_KEY=secret"],
+    })
+
+    expect(cfg).toEqual({
+      type: "local",
+      command: ["npx", "my-mcp-server"],
+      environment: {
+        API_KEY: "secret",
+      },
+    })
+  })
+
+  test("coerces numeric args after dash to strings", () => {
+    const cfg = configFromAdd({
+      name: "demo",
+      type: "local",
+      // yargs parses `-- npx server --port 3000` with 3000 as a number
+      "--": ["npx", "server", "--port", 3000 as unknown as string],
+    })
+
+    expect(cfg).toEqual({
+      type: "local",
+      command: ["npx", "server", "--port", "3000"],
+    })
+  })
+
+  test("builds remote config from add args", () => {
+    const cfg = configFromAdd({
+      name: "sentry",
+      commandOrUrl: "https://mcp.sentry.dev/mcp",
+      type: "remote",
+      header: ["Authorization: Bearer token"],
+      clientId: "client-id",
+      callbackPort: 19876,
+    })
+
+    expect(cfg).toEqual({
+      type: "remote",
+      url: "https://mcp.sentry.dev/mcp",
+      headers: {
+        Authorization: "Bearer token",
+      },
+      oauth: {
+        clientId: "client-id",
+        redirectUri: "http://127.0.0.1:19876/mcp/oauth/callback",
+      },
+    })
+  })
+
+  test("accepts Kilo local JSON", () => {
+    const cfg = configFromJson({
+      type: "local",
+      command: ["node", "server.js"],
+      environment: {
+        API_KEY: "secret",
+      },
+      enabled: false,
+    })
+
+    expect(cfg).toEqual({
+      type: "local",
+      command: ["node", "server.js"],
+      environment: {
+        API_KEY: "secret",
+      },
+      enabled: false,
+    })
+  })
+
+  test("accepts Kilo remote JSON", () => {
+    const cfg = configFromJson(
+      {
+        type: "remote",
+        url: "https://example.com/mcp",
+        headers: {
+          "X-Api-Key": "secret",
+        },
+      },
+      "oauth-secret",
+    )
+
+    expect(cfg).toEqual({
+      type: "remote",
+      url: "https://example.com/mcp",
+      headers: {
+        "X-Api-Key": "secret",
+      },
+      oauth: {
+        clientSecret: "oauth-secret",
+      },
+    })
+  })
+
+  test("rejects non-Kilo MCP types", () => {
+    expect(() =>
+      configFromJson({
+        type: "stdio",
+        command: "node",
+        args: ["server.js"],
+      }),
+    ).toThrow('MCP JSON type must be "local" or "remote"')
+
+    expect(() =>
+      configFromAdd({
+        name: "bad",
+        commandOrUrl: "https://example.com/mcp",
+        type: "http",
+      }),
+    ).toThrow("Invalid MCP server type")
+  })
+
+  test("rejects non-Kilo JSON fields", () => {
+    expect(() =>
+      configFromJson({
+        type: "local",
+        command: ["node", "server.js"],
+        env: {
+          API_KEY: "secret",
+        },
+      }),
+    ).toThrow("Unsupported MCP JSON field: env")
+
+    expect(() =>
+      configFromJson({
+        type: "remote",
+        url: "https://example.com/mcp",
+        args: ["unused"],
+      }),
+    ).toThrow("Unsupported MCP JSON field: args")
+  })
+
+  test("rejects options unsupported by server type", () => {
+    expect(() =>
+      configFromAdd({
+        name: "bad-local",
+        commandOrUrl: "node",
+        type: "local",
+        header: ["Authorization: Bearer token"],
+      }),
+    ).toThrow("Headers are only supported for remote MCP servers")
+
+    expect(() =>
+      configFromAdd({
+        name: "bad-remote",
+        commandOrUrl: "https://example.com/mcp",
+        type: "remote",
+        args: ["extra"],
+      }),
+    ).toThrow("Remote MCP servers require exactly one URL")
+  })
+
+  test("rejects malformed header args", () => {
+    expect(() =>
+      configFromAdd({
+        name: "bad",
+        commandOrUrl: "https://example.com/mcp",
+        type: "remote",
+        header: ["not-a-header"],
+      }),
+    ).toThrow("Invalid header")
+
+    expect(() =>
+      configFromAdd({
+        name: "bad",
+        commandOrUrl: "https://example.com/mcp",
+        type: "remote",
+        header: ["Key=value"],
+      }),
+    ).toThrow("Invalid header")
+  })
+
+  test("rejects non-http(s) URLs", () => {
+    expect(() =>
+      configFromAdd({
+        name: "bad",
+        commandOrUrl: "file:///etc/passwd",
+        type: "remote",
+      }),
+    ).toThrow("Invalid MCP server URL")
+
+    expect(() =>
+      configFromAdd({
+        name: "bad",
+        commandOrUrl: "javascript:alert(1)",
+        type: "remote",
+      }),
+    ).toThrow("Invalid MCP server URL")
+
+    expect(() =>
+      configFromJson({
+        type: "remote",
+        url: "data:text/plain,hello",
+      }),
+    ).toThrow("Invalid MCP server URL")
+  })
+})


### PR DESCRIPTION
Support Kilo-native MCP server management with new commands for adding, retrieving, and removing MCP servers. The implementation includes:

- `kilo mcp add [name] [commandOrUrl] [args..]` - Add MCP servers with support for local commands and remote URLs, including environment variables and HTTP headers
- `kilo mcp add-json <name> <json>` - Add MCP servers from JSON configuration strings
- `kilo mcp get <name>` - Display details for a configured MCP server
- `kilo mcp remove <name>` - Remove MCP servers from configuration

New commands support configuration scopes (local, user, project, global) and OAuth options (client ID, client secret, callback port). The implementation delegates config path resolution to a shared utility function for canonical path handling across both local and global configurations.

Documentation updated with command syntax, positional arguments, options, and usage examples for both interactive and argument-based server configuration.

## Context

The CLI's `kilo mcp` surface only had an interactive `add` flow and `list`/`auth`/`logout`/`debug`. There was no way to add, inspect, or remove MCP servers non-interactively, which blocked scripting and CI/CD usage. This PR adds the missing management commands using Kilo-native config semantics (`type: "local" | "remote"`), rejecting transport names from other MCP clients (`stdio`, `sse`, `http`).

## Implementation

All new command logic lives in `packages/opencode/src/kilocode/cli/cmd/mcp.ts` to minimize upstream merge surface. The shared `mcp.ts` only wires the new commands and delegates the non-interactive `add` path behind `kilocode_change` markers.

Key design decisions:

- **`resolveConfigTarget()`** replaces the old `resolveConfigPath()` for both interactive and non-interactive flows. It mirrors `KilocodeConfig.projectConfigUpdateTarget()` — walks from CWD up to worktree root, checks config dirs (`.kilo/`, `.kilocode/`, `.opencode/`) before root files, and falls back to `.kilo/kilo.json`. This fixes a pre-existing inconsistency where the interactive `add` would create `kilo.json` at the project root instead of `.kilo/kilo.json`.
- **`configFromJson()`** validates that the JSON uses only Kilo-native fields (`type`, `command`, `environment`, `url`, `headers`, `oauth`, `enabled`, `timeout`) and rejects anything else with a clear error.
- **`configFromAdd()`** enforces type-appropriate options — headers/OAuth only for remote, env vars only for local.
- **`--type` flag** defaults to `local` in code (not in yargs) to avoid a yargs positional parsing issue when `--type local` (space-separated) precedes positional arguments.

## Screenshots

N/A — CLI-only changes, no UI.

## How to Test

```bash
# Add a local MCP server
kilo mcp add my-server -e API_KEY=xxx -- npx my-mcp-server

# Add a remote MCP server
kilo mcp add --type=remote sentry https://mcp.sentry.dev/mcp

# Add from JSON
kilo mcp add-json my-server '{"type":"local","command":["npx","my-server"]}'

# Inspect a server
kilo mcp get my-server

# List all servers
kilo mcp list

# Remove a server
kilo mcp remove my-server

# Verify invalid types are rejected
kilo mcp add-json bad '{"type":"stdio","command":"node"}'
# → Error: MCP JSON type must be "local" or "remote"