### PR TITLE
fix(cli): enable Mistral Medium reasoning variants

### DIFF
--- a/.changeset/neat-mistrals-reason.md
+++ b/.changeset/neat-mistrals-reason.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Enable Mistral Medium 3.5 reasoning variants for the direct Mistral provider.

--- a/packages/kilo-docs/pages/ai-providers/mistral.md
+++ b/packages/kilo-docs/pages/ai-providers/mistral.md
@@ -70,7 +70,7 @@ Then set your default model:
 
 ## Reasoning Variants
 
-Mistral's adjustable reasoning support is exposed only for reasoning-capable Mistral Small 4 models: `mistral-small-2603` and `mistral-small-latest`. When one of these models is selected, Kilo offers a `high` variant that sends `reasoningEffort: "high"` to the Mistral provider.
+Mistral's adjustable reasoning support is exposed only for reasoning-capable Mistral Small 4 and Medium 3.5 models: `mistral-small-2603`, `mistral-small-latest`, `mistral-medium-3-5`, and `mistral-medium-latest`. When one of these models is selected, Kilo offers a `high` variant that sends `reasoningEffort: "high"` to the Mistral provider.
 
 Other Mistral models do not get automatic reasoning variants, even if they appear in the same provider. See Mistral's [adjustable reasoning documentation](https://docs.mistral.ai/capabilities/reasoning/adjustable) for provider-level details.
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -447,6 +447,15 @@ function anthropicAdaptiveEfforts(apiId: string): string[] | null {
   return null
 }
 
+// kilocode_change start
+function isMistralAdjustableReasoningModel(apiId: string): boolean {
+  const id = apiId.toLowerCase()
+  return ["mistral-small-2603", "mistral-small-latest", "mistral-medium-3-5", "mistral-medium-latest"].some(
+    (candidate) => id.includes(candidate),
+  )
+}
+// kilocode_change end
+
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   // kilocode_change start
   if (
@@ -458,7 +467,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   // kilocode_change end
 
-  if (!model.capabilities.reasoning) return {}
+  // kilocode_change start - Mistral's catalog metadata can lag behind newly adjustable models.
+  if (
+    !model.capabilities.reasoning &&
+    !(model.api.npm === "@ai-sdk/mistral" && isMistralAdjustableReasoningModel(model.api.id))
+  )
+    return {}
+  // kilocode_change end
 
   const id = model.id.toLowerCase()
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
@@ -802,11 +817,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/mistral":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
       // https://docs.mistral.ai/capabilities/reasoning/adjustable
-      if (!model.capabilities.reasoning) return {}
       // Only Mistral Small 4 and Medium 3.5 support reasoning
-      const MISTRAL_REASONING_IDS = ["mistral-small-2603", "mistral-small-latest", "mistral-medium-3.5"]
-      const mistralId = model.api.id.toLowerCase()
-      if (!MISTRAL_REASONING_IDS.some((id) => mistralId.includes(id))) return {}
+      if (!isMistralAdjustableReasoningModel(model.api.id)) return {} // kilocode_change
       return {
         high: { reasoningEffort: "high" },
       }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2275,12 +2275,13 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
-  test("mistral-medium-3.5 with reasoning returns variants", () => {
+  // kilocode_change start
+  test("mistral-medium-3-5 with reasoning returns variants", () => {
     const model = createMockModel({
-      id: "mistral/mistral-medium-3.5",
+      id: "mistral/mistral-medium-3-5",
       providerID: "mistral",
       api: {
-        id: "mistral-medium-3.5",
+        id: "mistral-medium-3-5",
         url: "https://api.mistral.com",
         npm: "@ai-sdk/mistral",
       },
@@ -2291,6 +2292,39 @@ describe("ProviderTransform.variants", () => {
       high: { reasoningEffort: "high" },
     })
   })
+
+  test("mistral-medium-latest returns variants when metadata lags", () => {
+    const model = createMockModel({
+      id: "mistral/mistral-medium-latest",
+      providerID: "mistral",
+      api: {
+        id: "mistral-medium-latest",
+        url: "https://api.mistral.com",
+        npm: "@ai-sdk/mistral",
+      },
+      capabilities: { reasoning: false },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      high: { reasoningEffort: "high" },
+    })
+  })
+
+  test("older mistral medium aliases without reasoning stay disabled", () => {
+    const model = createMockModel({
+      id: "mistral/mistral-medium-2508",
+      providerID: "mistral",
+      api: {
+        id: "mistral-medium-2508",
+        url: "https://api.mistral.com",
+        npm: "@ai-sdk/mistral",
+      },
+      capabilities: { reasoning: false },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({})
+  })
+  // kilocode_change end
 
   test("mistral without reasoning returns empty object", () => {
     const model = createMockModel({


### PR DESCRIPTION
## Context

Fixes #10289.

Mistral Medium 3.5 supports adjustable reasoning, but the direct Mistral provider check was matching `mistral-medium-3.5` instead of the current API id `mistral-medium-3-5`, so Kilo did not expose its reasoning variant.

## Implementation

- Updated the Mistral reasoning-capable model id list to match `mistral-medium-3-5`.
- Updated the provider transform coverage for that model id.
- Updated the Mistral provider docs and added a patch changeset.

## Screenshots

| before | after |
|---|---|
| N/A | N/A |

## How to Test

- Select a direct Mistral provider model whose API id is `mistral-medium-3-5`.
- Confirm Kilo exposes the `high` reasoning variant and sends `reasoningEffort: "high"`.

Validated locally:

- `bun test test/provider/transform.test.ts`
- `bun run typecheck` from `packages/opencode`
- `bun run script/check-opencode-annotations.ts`
- `git diff --check`
- pre-push `bun turbo typecheck` with Bun 1.3.13

## Get in Touch

GitHub is best for follow-up.
