### PR TITLE
fix(cli): allow question tool for custom agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -267,7 +267,9 @@ export const layer = Layer.effect(
             item = agents[key] = {
               name: key,
               mode: "all",
-              permission: Permission.merge(defaults, user),
+              // kilocode_change start - custom agents should be able to ask the user by default
+              permission: Permission.merge(defaults, Permission.fromConfig({ question: "allow" }), user),
+              // kilocode_change end
               options: {},
               native: false,
             }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -242,6 +242,7 @@ test("custom agent from config creates new agent", async () => {
       expect(custom?.topP).toBe(0.9)
       expect(custom?.native).toBe(false)
       expect(custom?.mode).toBe("all")
+      expect(evalPerm(custom, "question")).toBe("allow") // kilocode_change
     },
   })
 })


### PR DESCRIPTION
## Context

Fixes #10315. Custom agents inherited the default permission set where the `question` tool is denied unless explicitly enabled, so a newly configured mode could not ask the user follow-up questions.

## Implementation

Custom agents created from config now add a default `question: allow` rule before user/global permissions are merged. Explicit user permission config can still override it. I also added coverage to the existing agent config test.

## Screenshots

| before | after |
|---|---|
| Not applicable | Not applicable |

## How to Test

- Create a custom agent without a `question` permission override.
- Ask it to use the `question` tool.
- The tool should be available by default.

Validation run:

- `bun test ./test/agent/agent.test.ts` from `packages/opencode/`
- `bun run typecheck` from `packages/opencode/`
- `bun run script/check-opencode-annotations.ts` from repo root
- `bun turbo typecheck` from repo root via pre-push hook

## Get in Touch

Happy to adjust the default behavior if maintainers prefer a different permission shape.