### PR TITLE
fix(vscode): load small diff previews immediately

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -5,6 +5,7 @@ import {
   allOpenFiles,
   expandableOpenFiles,
   initialOpenFiles,
+  shouldAutoLoadDiffDetail,
   toggleOpenFiles,
 } from "../../webview-ui/agent-manager/diff-open-policy"
 import type { WorktreeFileDiff } from "../../webview-ui/src/types/messages"
@@ -75,6 +76,14 @@ describe("agent manager diff state", () => {
         diff({ file: "src/huge.ts", additions: EXTREME_DIFF_CHANGED_LINES + 1 }),
       ]),
     ).toEqual(["src/app.ts"])
+  })
+
+  it("auto-loads only reviewable diff details", () => {
+    expect(shouldAutoLoadDiffDetail(diff({ file: "src/app.ts", additions: 3 }))).toBe(true)
+    expect(shouldAutoLoadDiffDetail(diff({ file: "src/generated.ts", generatedLike: true }))).toBe(false)
+    expect(shouldAutoLoadDiffDetail(diff({ file: "src/huge.ts", additions: EXTREME_DIFF_CHANGED_LINES + 1 }))).toBe(
+      false,
+    )
   })
 
   it("toggles reviewable files based on whether every reviewable file is open", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -227,10 +227,13 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
         if (!props.onRequestDiff) return
         const loading = props.loadingFiles ?? new Set<string>()
         for (const file of next) {
-          if (loading.has(file)) continue
           const diff = props.diffs.find((item) => item.file === file)
           if (!diff || diff.summarized !== true) continue
           const value = diffToken(diff)
+          if (loading.has(file)) {
+            requested.set(file, value)
+            continue
+          }
           if (requested.get(file) === value) continue
           requested.set(file, value)
           props.onRequestDiff(file)

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -489,7 +489,8 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                 const isDeleted = () => diff.status === "deleted"
                 const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
                 const isLoadingDetail = () =>
-                  (props.loadingFiles?.has(diff.file) ?? false) || shouldAutoLoadDiffDetail(diff)
+                  (props.loadingFiles?.has(diff.file) ?? false) ||
+                  (shouldAutoLoadDiffDetail(diff) && !requested.has(diff.file))
                 const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                 return (

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -35,6 +35,7 @@ import {
   allOpenFiles,
   initialOpenFiles,
   isLargeDiffFile,
+  shouldAutoLoadDiffDetail,
   toggleOpenFiles,
 } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
@@ -487,7 +488,8 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                 const isAdded = () => diff.status === "added"
                 const isDeleted = () => diff.status === "deleted"
                 const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
-                const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
+                const isLoadingDetail = () =>
+                  (props.loadingFiles?.has(diff.file) ?? false) || shouldAutoLoadDiffDetail(diff)
                 const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                 return (

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -586,7 +586,8 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                     const isDeleted = () => diff.status === "deleted"
                     const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
                     const isLoadingDetail = () =>
-                      (props.loadingFiles?.has(diff.file) ?? false) || shouldAutoLoadDiffDetail(diff)
+                      (props.loadingFiles?.has(diff.file) ?? false) ||
+                      (shouldAutoLoadDiffDetail(diff) && !requested.has(diff.file))
                     const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                     return (

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -237,10 +237,13 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
         if (!props.onRequestDiff) return
         const loading = props.loadingFiles ?? new Set<string>()
         for (const file of next) {
-          if (loading.has(file)) continue
           const diff = props.diffs.find((item) => item.file === file)
           if (!diff || diff.summarized !== true) continue
           const value = diffToken(diff)
+          if (loading.has(file)) {
+            requested.set(file, value)
+            continue
+          }
           if (requested.get(file) === value) continue
           requested.set(file, value)
           props.onRequestDiff(file)

--- a/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/FullScreenDiffView.tsx
@@ -43,6 +43,7 @@ import {
   allOpenFiles,
   initialOpenFiles,
   isLargeDiffFile,
+  shouldAutoLoadDiffDetail,
   toggleOpenFiles,
 } from "./diff-open-policy"
 import { DiffEndMarker } from "./DiffEndMarker"
@@ -584,7 +585,8 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                     const isAdded = () => diff.status === "added"
                     const isDeleted = () => diff.status === "deleted"
                     const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
-                    const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
+                    const isLoadingDetail = () =>
+                      (props.loadingFiles?.has(diff.file) ?? false) || shouldAutoLoadDiffDetail(diff)
                     const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                     return (

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
@@ -7,8 +7,12 @@ export function isLargeDiffFile(diff: WorktreeFileDiff): boolean {
   return diff.additions + diff.deletions > EXTREME_DIFF_CHANGED_LINES
 }
 
+export function shouldAutoLoadDiffDetail(diff: WorktreeFileDiff): boolean {
+  return !isLargeDiffFile(diff) && diff.generatedLike !== true
+}
+
 export function expandableOpenFiles(diffs: WorktreeFileDiff[]): string[] {
-  return diffs.filter((diff) => !isLargeDiffFile(diff) && diff.generatedLike !== true).map((diff) => diff.file)
+  return diffs.filter(shouldAutoLoadDiffDetail).map((diff) => diff.file)
 }
 
 export function initialOpenFiles(diffs: WorktreeFileDiff[]): string[] {


### PR DESCRIPTION
## Context

Fixes #10233. Small Agent Manager diffs could briefly show the "Diff preview loads on demand" placeholder before their detail request entered the loading set.

## Implementation

I added a shared `shouldAutoLoadDiffDetail` policy for reviewable diffs and reused it in both the embedded and full-screen Agent Manager diff views. Small non-generated diffs now show the loading state while their detail request is being scheduled; large/generated diffs still keep the on-demand placeholder.

## Screenshots

| before | after |
|---|---|
| Not captured | Not captured |

## How to Test

- Open Agent Manager review for a worktree with a small changed file.
- Expand the file in the diff view.
- It should go straight into loading/rendering instead of showing "Diff preview loads on demand".

Validation run:

- `bun test tests/unit/agent-manager-diff-state.test.ts` from `packages/kilo-vscode/`
- `bun run format` from `packages/kilo-vscode/`
- `bun run typecheck` from `packages/kilo-vscode/`
- `bun run lint` from `packages/kilo-vscode/`
- `bun turbo typecheck` from repo root via pre-push hook

## Get in Touch

Happy to tune the loading copy if maintainers want a different distinction between small and large diff previews.