### PR TITLE
fix(vscode): allow xhigh custom reasoning effort

### DIFF
--- a/packages/kilo-vscode/src/shared/custom-provider.ts
+++ b/packages/kilo-vscode/src/shared/custom-provider.ts
@@ -14,7 +14,7 @@ export const EnvSchema = z
 const VariantConfigSchema = z.object({
   enable_thinking: z.boolean().optional(),
   thinking: z.object({ type: z.enum(["enabled", "disabled"]) }).optional(),
-  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
   chat_template_args: z.object({ enable_thinking: z.boolean() }).optional(),
 })
 

--- a/packages/kilo-vscode/tests/unit/custom-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider.test.ts
@@ -131,6 +131,39 @@ describe("sanitizeCustomProviderConfig", () => {
     })
   })
 
+  it("accepts xhigh reasoning effort variants", () => {
+    const result = sanitizeCustomProviderConfig({
+      name: "Reasoning Provider",
+      options: { baseURL: "https://example.com/v1" },
+      models: {
+        "model-xhigh": {
+          name: "Reasoning Model",
+          reasoning: true,
+          variants: {
+            xhigh: { reasoningEffort: "xhigh" },
+          },
+        },
+      },
+    })
+
+    expect(result).toEqual({
+      value: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Reasoning Provider",
+        options: { baseURL: "https://example.com/v1" },
+        models: {
+          "model-xhigh": {
+            name: "Reasoning Model",
+            reasoning: true,
+            variants: {
+              xhigh: { reasoningEffort: "xhigh" },
+            },
+          },
+        },
+      },
+    })
+  })
+
   it("rejects unknown fields", () => {
     const result = sanitizeCustomProviderConfig({
       name: "Bad Provider",


### PR DESCRIPTION
Fixes #10312.

## Summary
- allow custom provider configs to save `xhigh` reasoning effort variants
- add regression coverage for sanitizing an `xhigh` custom variant

## Validation
- bun test tests/unit/custom-provider.test.ts
- bun run format
- bun run typecheck
- bun run lint
- bun turbo typecheck