### PR TITLE
fix(vscode): reset diff preview scroll

### DIFF
--- a/.changeset/quiet-diffs-scroll.md
+++ b/.changeset/quiet-diffs-scroll.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reset the lightweight diff panel scroll position when opening a different diff.

--- a/packages/kilo-vscode/tests/unit/diff-virtual-scroll.test.ts
+++ b/packages/kilo-vscode/tests/unit/diff-virtual-scroll.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { resetScroll } from "../../webview-ui/diff-virtual/scroll"
+
+describe("diff virtual scroll", () => {
+  test("resets the scroll position immediately and across render frames", () => {
+    const el = { scrollTop: 250, scrollLeft: 30 }
+    const frames: FrameRequestCallback[] = []
+    const frame = (cb: FrameRequestCallback) => {
+      frames.push(cb)
+      return frames.length
+    }
+
+    resetScroll(el, frame)
+
+    expect(el).toEqual({ scrollTop: 0, scrollLeft: 0 })
+
+    el.scrollTop = 180
+    el.scrollLeft = 12
+    frames.shift()?.(0)
+    expect(el).toEqual({ scrollTop: 0, scrollLeft: 0 })
+
+    el.scrollTop = 90
+    el.scrollLeft = 6
+    frames.shift()?.(0)
+    expect(el).toEqual({ scrollTop: 0, scrollLeft: 0 })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -17,6 +17,7 @@ import { LanguageProvider, useLanguage } from "../src/context/language"
 import { ServerProvider, useServer } from "../src/context/server"
 import { getVSCodeAPI, VSCodeProvider } from "../src/context/vscode"
 import { isMarkdownFile, MarkdownDiffView } from "../agent-manager/MarkdownDiffView"
+import { resetScroll } from "./scroll"
 
 type DiffStyle = "unified" | "split"
 
@@ -32,6 +33,7 @@ const DiffVirtualContent: Component = () => {
   const [diff, setDiff] = createSignal<DiffVirtualFile | null>(null)
   const [style, setStyle] = createSignal<DiffStyle>("unified")
   const [markdown, setMarkdown] = createSignal(false)
+  let scroller: HTMLDivElement | undefined
 
   const handler = (event: MessageEvent) => {
     const msg = event.data as {
@@ -44,6 +46,7 @@ const DiffVirtualContent: Component = () => {
       setDiff(msg.diff)
       setStyle(msg.initialDiffStyle ?? "unified")
       setMarkdown(msg.markdownRender === true)
+      resetScroll(scroller)
     }
   }
 
@@ -112,7 +115,7 @@ const DiffVirtualContent: Component = () => {
                 </Tooltip>
               </Show>
             </div>
-            <div class="am-review-diff" style={{ width: "100%" }}>
+            <div ref={scroller} class="am-review-diff" style={{ width: "100%" }}>
               <Show when={view()}>
                 {(v) => (
                   <Show

--- a/packages/kilo-vscode/webview-ui/diff-virtual/scroll.ts
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/scroll.ts
@@ -1,0 +1,21 @@
+type Frame = (cb: FrameRequestCallback) => number
+
+type Scroller = {
+  scrollTop: number
+  scrollLeft: number
+}
+
+export function resetScroll(el: Scroller | undefined, frame: Frame = requestAnimationFrame): void {
+  if (!el) return
+
+  const reset = () => {
+    el.scrollTop = 0
+    el.scrollLeft = 0
+  }
+
+  reset()
+  frame(() => {
+    reset()
+    frame(reset)
+  })
+}


### PR DESCRIPTION
Fixes #10231.

## Summary
- reset the lightweight diff panel scroll position when a different diff opens
- keep the reset across render frames so async diff rendering cannot restore the old position
- add patch release note coverage

## Validation
- bun test tests/unit/diff-virtual-scroll.test.ts
- bun run format
- bun run lint
- bun run typecheck
- bun run check-kilocode-change
- bun turbo typecheck