### PR TITLE
fix(indexing): support OpenRouter Gemini embedding dimensions

### DIFF
--- a/.changeset/gentle-indexing-dimensions.md
+++ b/.changeset/gentle-indexing-dimensions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-indexing": patch
+---
+
+Allow OpenRouter Gemini embedding preview models to initialize code indexing without a manual dimension override.

--- a/packages/kilo-indexing/src/indexing/config-manager.ts
+++ b/packages/kilo-indexing/src/indexing/config-manager.ts
@@ -302,10 +302,9 @@ export class CodeIndexConfigManager {
   }
 
   public get currentModelDimension(): number | undefined {
+    if (this.modelDimension && this.modelDimension > 0) return this.modelDimension
     const id = this.modelId ?? getDefaultModelId(this.embedderProvider)
-    const dim = getModelDimension(this.embedderProvider, id)
-    if (!dim && this.modelDimension && this.modelDimension > 0) return this.modelDimension
-    return dim
+    return getModelDimension(this.embedderProvider, id)
   }
 
   public get currentSearchMinScore(): number {

--- a/packages/kilo-indexing/src/indexing/embedding-profile.ts
+++ b/packages/kilo-indexing/src/indexing/embedding-profile.ts
@@ -20,7 +20,7 @@ export function resolveEmbeddingProfile(
   modelDimension?: number,
 ): EmbeddingProfile | undefined {
   const id = modelId ?? getDefaultModelId(provider)
-  const dim = getModelDimension(provider, id) ?? parseDimension(modelDimension)
+  const dim = parseDimension(modelDimension) ?? getModelDimension(provider, id)
   if (!dim) return undefined
   return {
     provider,

--- a/packages/kilo-indexing/src/indexing/model-registry.ts
+++ b/packages/kilo-indexing/src/indexing/model-registry.ts
@@ -48,6 +48,7 @@ const profiles: Record<string, Record<string, ModelProfile>> = {
   openrouter: {
     "openai/text-embedding-3-small": { dimension: 1536, scoreThreshold: 0.4 },
     "openai/text-embedding-3-large": { dimension: 3072, scoreThreshold: 0.4 },
+    "google/gemini-embedding-2-preview": { dimension: 3072, scoreThreshold: 0.35 },
   },
   "openai-compatible": {},
   "vercel-ai-gateway": {

--- a/packages/kilo-indexing/test/kilocode/indexing/config-manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/config-manager.test.ts
@@ -83,6 +83,20 @@ describe("CodeIndexConfigManager", () => {
     expect(cfg.currentModelDimension).toBe(2048)
   })
 
+  test("uses configured dimension before static model metadata", () => {
+    const cfg = new CodeIndexConfigManager(
+      createInput({
+        embedderProvider: "openrouter",
+        openAiKey: undefined,
+        openRouterApiKey: "or-test",
+        modelId: "google/gemini-embedding-2-preview",
+        modelDimension: 1536,
+      }),
+    )
+
+    expect(cfg.currentModelDimension).toBe(1536)
+  })
+
   describe("loadConfiguration restart checks", () => {
     test("requires restart when model changes with same dimension", () => {
       const cfg = new CodeIndexConfigManager(createInput({ modelId: "text-embedding-3-small" }))

--- a/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
@@ -154,6 +154,21 @@ describe("CodeIndexServiceFactory", () => {
     })
   })
 
+  test("creates vector store for OpenRouter Gemini embedding preview", () => {
+    const factory = createFactory({
+      embedderProvider: "openrouter",
+      openAiKey: undefined,
+      openRouterApiKey: "or-test",
+      modelId: "google/gemini-embedding-2-preview",
+      vectorStoreProvider: "lancedb",
+    })
+
+    const store = factory.createVectorStore() as unknown as { vectorSize: number }
+
+    expect(store).toBeDefined()
+    expect(store.vectorSize).toBe(3072)
+  })
+
   test("creates Kilo embedder with Cloud-provided model", async () => {
     const factory = createFactory({
       embedderProvider: "kilo",
@@ -177,6 +192,7 @@ describe("CodeIndexServiceFactory", () => {
       input: ["hello"],
       model: "mistralai/mistral-embed-2312",
       encoding_format: "base64",
+      dimensions: 1024,
     })
   })
 })


### PR DESCRIPTION
## Summary
- add OpenRouter metadata for `google/gemini-embedding-2-preview` so indexing can initialize LanceDB without a manual dimension override
- let explicit `indexing.dimension` override static model metadata for vector-store sizing
- cover the OpenRouter Gemini profile and dimension override behavior in indexing tests

Fixes #10268

## Validation
- `bun test test/kilocode/indexing/service-factory.test.ts test/kilocode/indexing/config-manager.test.ts test/kilocode/indexing/embedders/openrouter.test.ts`
- `bun run typecheck` from `packages/kilo-indexing`
- `bun turbo typecheck --filter=@kilocode/kilo-indexing`
- `bun turbo typecheck`
- `bun run lint` (passes with existing repo warnings)
- `git diff --check`