### PR TITLE
fix(cli): report unknown tool calls clearly

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -400,11 +400,16 @@ const live: Layer.Layer<
               toolName: lower,
             }
           }
+          const error = repairToolCallError({
+            tool: failed.toolCall.toolName,
+            error: failed.error.message,
+            tools,
+          })
           return {
             ...failed.toolCall,
             input: JSON.stringify({
               tool: failed.toolCall.toolName,
-              error: failed.error.message,
+              error,
             }),
             toolName: "invalid",
           }
@@ -522,6 +527,14 @@ export function hasToolCalls(messages: ModelMessage[]): boolean {
     }
   }
   return false
+}
+
+export function repairToolCallError(input: { tool: string; error: string; tools: Record<string, Tool> }): string {
+  if (input.tools[input.tool]) return input.error
+  const names = Object.keys(input.tools)
+    .filter((name) => name !== "invalid")
+    .sort()
+  return `Unknown tool: ${input.tool}. Available tools: ${names.join(", ") || "none"}`
 }
 
 export * as LLM from "./llm"

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -119,6 +119,45 @@ describe("session.llm.hasToolCalls", () => {
   })
 })
 
+describe("session.llm.repairToolCallError", () => {
+  test("returns a clear error for unknown tool names", () => {
+    const error = LLM.repairToolCallError({
+      tool: "skills_branstrom",
+      error: "tools.skills_branstrom.execute is not a function",
+      tools: {
+        invalid: tool({
+          description: "Invalid tool",
+          inputSchema: z.object({}),
+          execute: async () => ({ output: "" }),
+        }),
+        skill: tool({
+          description: "Load a skill",
+          inputSchema: z.object({}),
+          execute: async () => ({ output: "" }),
+        }),
+      },
+    })
+
+    expect(error).toBe("Unknown tool: skills_branstrom. Available tools: skill")
+  })
+
+  test("keeps the provider error for registered tools", () => {
+    const error = LLM.repairToolCallError({
+      tool: "skill",
+      error: "bad input",
+      tools: {
+        skill: tool({
+          description: "Load a skill",
+          inputSchema: z.object({}),
+          execute: async () => ({ output: "" }),
+        }),
+      },
+    })
+
+    expect(error).toBe("bad input")
+  })
+})
+
 type Capture = {
   url: URL
   headers: Headers


### PR DESCRIPTION
## Summary
- convert unregistered tool repair failures into a clear `Unknown tool` message
- keep the original provider repair error for tools that are registered but fail validation/execution
- add session LLM coverage for unknown and registered tool repair errors

Fixes #10318

## Validation
- `bun test ./test/session/llm.test.ts`
- `bun run typecheck` from `packages/opencode`
- `bun turbo typecheck --filter=@kilocode/cli`
- `bun turbo typecheck`
- `bun run script/check-opencode-annotations.ts`
- `git diff --check`