### PR TITLE
Retry provider rate limit responses

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -62,14 +62,13 @@ export function retryable(error: Err) {
     if (isKiloError(error)) return undefined
     // kilocode_change end
 
-    // 5xx errors are transient server failures and should always be retried,
-    // even when the provider SDK doesn't explicitly mark them as retryable.
-    if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
-
     // kilocode_change start - FreeUsageLimitError is not retryable: retrying the same
     // capped model is futile and the backoff loop cannot be broken by switching
     // models in the chat selector (the retry loop holds a stale model ref).
     if (error.data.responseBody?.includes("FreeUsageLimitError")) return undefined
+    // 429 and 5xx errors are transient provider failures and should be retried,
+    // even when the provider SDK doesn't explicitly mark them as retryable.
+    if (!error.data.isRetryable && !(status === 429 || (status !== undefined && status >= 500))) return undefined
     // kilocode_change end
     return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
   }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -183,6 +183,18 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Internal server error")
   })
 
+  test("retries 429 errors even when isRetryable is false", () => {
+    const error = MessageV2.APIError.Schema.parse(
+      new MessageV2.APIError({
+        message: "Too Many Requests",
+        isRetryable: false,
+        statusCode: 429,
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
+  })
+
   test("retries 502 bad gateway errors", () => {
     const error = MessageV2.APIError.Schema.parse(
       new MessageV2.APIError({


### PR DESCRIPTION
## Summary

- Retry provider 429 responses even when the SDK marks them as non-retryable
- Keep Kilo-specific usage-limit errors non-retryable so users can switch models or sign in
- Add regression coverage for non-retryable 429 API errors

Fixes #10210

## Validation

- `bun test ./test/session/retry.test.ts ./test/kilocode/kilo-errors.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- `bun turbo typecheck --filter=@kilocode/cli`
- `bun turbo typecheck`
- `bun run script/check-opencode-annotations.ts`
- `bun run lint` (passes with existing warnings)
- `git diff --check`
