### PR TITLE
Retry extension network failures

### DIFF
--- a/packages/kilo-vscode/src/util/retry.ts
+++ b/packages/kilo-vscode/src/util/retry.ts
@@ -15,6 +15,9 @@ const MAX_MS = 300_000
 /** Maximum number of retry attempts */
 const MAX_RETRIES = BACKOFF_DELAYS_MS.length
 
+/** Synthetic status used when an SDK request fails before an HTTP response exists. */
+const NETWORK_ERROR_STATUS = 0
+
 /** HTTP status codes that are safe to retry */
 const RETRYABLE = new Set([408, 409, 425, 429, 500, 502, 503, 504])
 
@@ -22,6 +25,7 @@ const RETRYABLE = new Set([408, 409, 425, 429, 500, 502, 503, 504])
  * Whether an HTTP status code is retryable.
  */
 export function retryable(status: number): boolean {
+  if (status === NETWORK_ERROR_STATUS) return true
   if (RETRYABLE.has(status)) return true
   return status >= 500
 }

--- a/packages/kilo-vscode/tests/unit/retry-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/retry-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test"
+import { backoff, headerDelay, retryable } from "../../src/util/retry"
+
+describe("retry utilities", () => {
+  it("retries SDK failures that do not include an HTTP response", () => {
+    expect(retryable(0)).toBe(true)
+  })
+
+  it("retries transient HTTP statuses", () => {
+    expect(retryable(429)).toBe(true)
+    expect(retryable(503)).toBe(true)
+  })
+
+  it("does not retry regular client errors", () => {
+    expect(retryable(400)).toBe(false)
+  })
+
+  it("uses retry-after-ms before the fallback schedule", () => {
+    expect(backoff(3, new Headers({ "retry-after-ms": "1500" }))).toBe(1500)
+  })
+
+  it("returns null for invalid retry headers", () => {
+    expect(headerDelay(new Headers({ "retry-after": "not-a-date" }))).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Treat SDK failures without an HTTP response as retryable extension request failures
- Keep existing retry behavior for 429 and server errors unchanged
- Add focused unit coverage for response-less failures and retry headers

Fixes #10323

## Validation

- `bun test tests/unit/retry-utils.test.ts` from `packages/kilo-vscode`
- `bun run typecheck` from `packages/kilo-vscode`
- `bun run lint` from `packages/kilo-vscode`
- `bun turbo typecheck --filter=kilo-code`
- `bun run check-kilocode-change` from `packages/kilo-vscode`
- `git diff --check`
