### PR TITLE
fix(cli): keep subagent permission prompts visible

### DIFF
--- a/.changeset/quiet-owls-approve.md
+++ b/.changeset/quiet-owls-approve.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep permission prompts visible while viewing subagent sessions.

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { QuestionPrompt } from "./question"
 import { Suggest } from "@/kilocode/suggestion/tui/render" // kilocode_change
 import { SuggestPrompt } from "@/kilocode/suggestion/tui/prompt" // kilocode_change
 import { NetworkPrompt } from "./network" // kilocode_change
+import { requestsForSession } from "./requests" // kilocode_change
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import * as Model from "../../util/model"
 import { formatTranscript } from "../../util/transcript"
@@ -139,23 +140,22 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  // kilocode_change start - child sessions should keep their own blocking prompts visible
   const permissions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+    return requestsForSession(session(), children(), sync.data.permission)
   })
   const questions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
+    return requestsForSession(session(), children(), sync.data.question)
   })
+  // kilocode_change end
   // kilocode_change start
   const suggestions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.suggestion[x.id] ?? [])
+    return requestsForSession(session(), children(), sync.data.suggestion)
   })
   const network = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.network[x.id] ?? [])
+    return requestsForSession(session(), children(), sync.data.network)
   })
+  // kilocode_change end
   const blockingQuestions = createMemo(() => questions().filter((q) => q.blocking !== false))
   const nonBlockingQuestions = createMemo(() => questions().filter((q) => q.blocking === false))
   const question = createMemo(() => blockingQuestions()[0] ?? nonBlockingQuestions()[0])

--- a/packages/opencode/src/cli/cmd/tui/routes/session/requests.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/requests.ts
@@ -1,0 +1,11 @@
+// kilocode_change start - keep blocking requests visible when focused on a child session
+export function requestsForSession<T extends { sessionID: string }>(
+  session: { id: string; parentID?: string } | undefined,
+  children: readonly { id: string }[],
+  requests: Record<string, T[] | undefined>,
+) {
+  if (!session) return []
+  if (session.parentID) return requests[session.id] ?? []
+  return children.flatMap((child) => requests[child.id] ?? [])
+}
+// kilocode_change end

--- a/packages/opencode/test/cli/cmd/tui/session-requests.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/session-requests.test.ts
@@ -1,0 +1,26 @@
+// kilocode_change - new file
+import { describe, expect, test } from "bun:test"
+import { requestsForSession } from "@/cli/cmd/tui/routes/session/requests"
+
+describe("session request visibility", () => {
+  test("shows child requests while viewing the child session", () => {
+    const result = requestsForSession({ id: "child", parentID: "parent" }, [{ id: "child" }], {
+      child: [{ sessionID: "child", id: "request" }],
+    })
+
+    expect(result.map((item) => item.id)).toEqual(["request"])
+  })
+
+  test("shows all child requests while viewing the parent session", () => {
+    const result = requestsForSession(
+      { id: "parent" },
+      [{ id: "parent" }, { id: "child-a" }, { id: "child-b" }],
+      {
+        parent: [{ sessionID: "parent", id: "parent-request" }],
+        "child-a": [{ sessionID: "child-a", id: "child-request" }],
+      },
+    )
+
+    expect(result.map((item) => item.id)).toEqual(["parent-request", "child-request"])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #10311.

- Keep pending permission, question, suggestion, and network prompts visible when the focused session is a subagent.
- Preserve the existing parent-session behavior that aggregates pending requests from parent and child sessions.
- Add focused coverage for parent and child request visibility.

## Validation

- bun test ./test/cli/cmd/tui/session-requests.test.ts
- bun run typecheck
- bun turbo typecheck --filter=@kilocode/cli
- bun run script/check-opencode-annotations.ts
- git diff --check
