### PR TITLE
fix(cli): skip empty assistant history turns

### DIFF
--- a/.changeset/silent-wolves-think.md
+++ b/.changeset/silent-wolves-think.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Skip empty assistant history turns before sending Kilo gateway requests.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -100,6 +100,30 @@ function normalizeMessages(
       .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
+  // kilocode_change start - Kilo gateway/OpenRouter reject assistant history turns with no sendable content.
+  if (model.api.npm === "@kilocode/kilo-gateway" || model.api.npm === "@openrouter/ai-sdk-provider") {
+    msgs = msgs
+      .map((msg) => {
+        if (msg.role !== "assistant") return msg
+        if (typeof msg.content === "string") {
+          if (msg.content === "") return undefined
+          return msg
+        }
+        if (!Array.isArray(msg.content)) return msg
+        const filtered = msg.content.filter((part) => {
+          if (part.type === "text" || part.type === "reasoning") {
+            return part.text !== ""
+          }
+          return true
+        })
+        const sendable = filtered.some((part) => part.type !== "reasoning")
+        if (!sendable) return undefined
+        return { ...msg, content: filtered }
+      })
+      .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
+  }
+  // kilocode_change end
+
   if (model.api.id.includes("claude")) {
     const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
     msgs = msgs.map((msg) => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1432,6 +1432,50 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[1].content).toHaveLength(1)
   })
 
+  // kilocode_change start - Kilo gateway/OpenRouter should not send empty assistant turns.
+  test.each([
+    ["Kilo gateway", "@kilocode/kilo-gateway"],
+    ["OpenRouter", "@openrouter/ai-sdk-provider"],
+  ])("filters empty assistant messages for %s", (_name, npm) => {
+    const model = {
+      ...anthropicModel,
+      id: "kilo/test-model",
+      name: "Test Model",
+      providerID: "kilo",
+      api: {
+        id: "test-model",
+        url: "https://api.kilo.ai/api/openrouter",
+        npm,
+      },
+    }
+
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "" },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "Thinking" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "" },
+          { type: "reasoning", text: "" },
+          { type: "tool-call", toolCallId: "call_1", toolName: "read", input: { filePath: "README.md" } },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {})
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toBe("Hello")
+    expect(result[1].content).toEqual([
+      { type: "tool-call", toolCallId: "call_1", toolName: "read", input: { filePath: "README.md" } },
+    ])
+  })
+  // kilocode_change end
+
   test("splits anthropic assistant messages when text trails tool calls", () => {
     const msgs = [
       {


### PR DESCRIPTION
Fixes #10276.

Drop assistant history turns that have no sendable text or tool content before gateway requests, while preserving valid tool-call turns. This prevents stored empty/reasoning-only turns from causing chat completion 400s.