### PR TITLE
fix(cli): respect disabled paste summaries

### DIFF
--- a/.changeset/quiet-paste-summary.md
+++ b/.changeset/quiet-paste-summary.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Respect the disable paste summary setting even when a previous local toggle enabled paste summaries.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,5 +1,6 @@
 import { render, TimeToFirstDraw, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as Clipboard from "@tui/util/clipboard"
+import { isPasteSummaryEnabled, PASTE_SUMMARY_ENABLED_KEY } from "@tui/util/paste-summary"
 import * as Selection from "@tui/util/selection"
 import { createCliRenderer, MouseButton, TextAttributes, type CliRendererConfig } from "@opentui/core" // kilocode_change
 import { RouteProvider, useRoute } from "@tui/context/route"
@@ -312,9 +313,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
-  const [pasteSummaryEnabled, setPasteSummaryEnabled] = createSignal(
-    kv.get("paste_summary_enabled", !sync.data.config.experimental?.disable_paste_summary),
-  )
+  const [pasteSummaryEnabled, setPasteSummaryEnabled] = createSignal(isPasteSummaryEnabled(kv, sync.data.config))
 
   KiloApp.useSessionEffects({ route, sdk, sync }) // kilocode_change
 
@@ -775,8 +774,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       onSelect: (dialog) => {
         setPasteSummaryEnabled((prev) => {
           const next = !prev
-          kv.set("paste_summary_enabled", next)
-          return next
+          kv.set(PASTE_SUMMARY_ENABLED_KEY, next)
+          return isPasteSummaryEnabled(kv, sync.data.config)
         })
         dialog.clear()
       },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -27,6 +27,7 @@ import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import * as Editor from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import * as Clipboard from "../../util/clipboard"
+import { isPasteSummaryEnabled } from "../../util/paste-summary"
 import type { AssistantMessage, FilePart, UserMessage } from "@kilocode/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
@@ -1280,7 +1281,7 @@ export function Prompt(props: PromptProps) {
                 const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
                 if (
                   (lineCount >= 5 || pastedContent.length > 800) && // kilocode_change #7252 delay paste summary
-                  kv.get("paste_summary_enabled", !sync.data.config.experimental?.disable_paste_summary)
+                  isPasteSummaryEnabled(kv, sync.data.config)
                 ) {
                   pasteText(pastedContent, `[Pasted ~${lineCount} lines]`)
                   return

--- a/packages/opencode/src/cli/cmd/tui/util/paste-summary.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/paste-summary.ts
@@ -1,0 +1,16 @@
+export const PASTE_SUMMARY_ENABLED_KEY = "paste_summary_enabled"
+
+type PasteSummaryKV = {
+  get(key: string, defaultValue?: boolean): boolean
+}
+
+type PasteSummaryConfig = {
+  experimental?: {
+    disable_paste_summary?: boolean
+  }
+}
+
+export function isPasteSummaryEnabled(kv: PasteSummaryKV, config: PasteSummaryConfig) {
+  if (config.experimental?.disable_paste_summary) return false
+  return kv.get(PASTE_SUMMARY_ENABLED_KEY, true)
+}

--- a/packages/opencode/src/cli/cmd/tui/util/paste-summary.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/paste-summary.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 export const PASTE_SUMMARY_ENABLED_KEY = "paste_summary_enabled"
 
 type PasteSummaryKV = {

--- a/packages/opencode/test/cli/tui/paste-summary.test.ts
+++ b/packages/opencode/test/cli/tui/paste-summary.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { isPasteSummaryEnabled, PASTE_SUMMARY_ENABLED_KEY } from "../../../src/cli/cmd/tui/util/paste-summary"
+
+function kv(value: boolean | undefined) {
+  return {
+    get: (_key: string, defaultValue?: boolean) => value ?? defaultValue ?? false,
+  }
+}
+
+describe("paste summary setting", () => {
+  test("uses the stored toggle when config allows paste summaries", () => {
+    expect(isPasteSummaryEnabled(kv(true), {})).toBe(true)
+    expect(isPasteSummaryEnabled(kv(false), {})).toBe(false)
+    expect(isPasteSummaryEnabled(kv(undefined), {})).toBe(true)
+  })
+
+  test("config disable overrides a previously enabled stored toggle", () => {
+    expect(
+      isPasteSummaryEnabled(kv(true), {
+        experimental: {
+          disable_paste_summary: true,
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("exports the persisted toggle key used by the command menu", () => {
+    expect(PASTE_SUMMARY_ENABLED_KEY).toBe("paste_summary_enabled")
+  })
+})

--- a/packages/opencode/test/cli/tui/paste-summary.test.ts
+++ b/packages/opencode/test/cli/tui/paste-summary.test.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 import { describe, expect, test } from "bun:test"
 import { isPasteSummaryEnabled, PASTE_SUMMARY_ENABLED_KEY } from "../../../src/cli/cmd/tui/util/paste-summary"
 


### PR DESCRIPTION
Fixes #10146.

Respect the disable paste summary setting as a hard off switch, even if a previous local TUI toggle enabled paste summaries. Long pasted content now stays expanded inline when the setting is enabled.