### PR TITLE
fix(cli): expose DeepSeek V4 reasoning variants

### DIFF
--- a/.changeset/deepseek-v4-reasoning.md
+++ b/.changeset/deepseek-v4-reasoning.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Expose reasoning effort variants for DeepSeek V4 models routed through OpenRouter.
+Expose reasoning effort variants for DeepSeek V4 models routed through OpenRouter and Kilo Gateway.

--- a/.changeset/deepseek-v4-reasoning.md
+++ b/.changeset/deepseek-v4-reasoning.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Expose reasoning effort variants for DeepSeek V4 models routed through OpenRouter.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -509,7 +509,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         !model.id.includes("gpt") &&
         !model.id.includes("gemini-3") &&
         !model.id.includes("claude") &&
-        !model.id.includes("mercury") // kilocode_change
+        !model.id.includes("mercury") && // kilocode_change
+        !id.includes("deepseek-v4") // kilocode_change
       )
         return {}
       return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -513,6 +513,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         !model.id.includes("deepseek-v4") // kilocode_change
       )
         return {}
+      if (model.id.includes("deepseek-v4")) {
+        const efforts = [...WIDELY_SUPPORTED_EFFORTS, "max"]
+        return Object.fromEntries(efforts.map((effort) => [effort, { reasoning: { effort } }]))
+      }
       return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))
 
     case "@ai-sdk/gateway":

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -510,7 +510,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         !model.id.includes("gemini-3") &&
         !model.id.includes("claude") &&
         !model.id.includes("mercury") && // kilocode_change
-        !id.includes("deepseek-v4") // kilocode_change
+        !model.id.includes("deepseek-v4") // kilocode_change
       )
         return {}
       return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoning: { effort } }]))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2229,6 +2229,21 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("openrouter deepseek v4 exposes reasoning effort variants", () => {
+    const model = createMockModel({
+      id: "deepseek/deepseek-v4-pro",
+      providerID: "openrouter",
+      api: {
+        id: "deepseek/deepseek-v4-pro",
+        url: "https://openrouter.ai/api/v1",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result.low).toEqual({ reasoning: { effort: "low" } })
+    expect(result.high).toEqual({ reasoning: { effort: "high" } })
+  })
+
   test("minimax returns empty object", () => {
     const model = createMockModel({
       id: "minimax/minimax-model",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2240,8 +2240,10 @@ describe("ProviderTransform.variants", () => {
       },
     })
     const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
     expect(result.low).toEqual({ reasoning: { effort: "low" } })
     expect(result.high).toEqual({ reasoning: { effort: "high" } })
+    expect(result.max).toEqual({ reasoning: { effort: "max" } })
   })
 
   test("minimax returns empty object", () => {
@@ -2533,8 +2535,10 @@ describe("ProviderTransform.variants", () => {
         },
       })
       const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
       expect(result.low).toEqual({ reasoning: { effort: "low" } })
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
+      expect(result.max).toEqual({ reasoning: { effort: "max" } })
     })
 
     test("codex models return OPENAI_EFFORTS with object-based reasoning format", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2522,6 +2522,21 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
 
+    test("deepseek v4 exposes reasoning effort variants", () => {
+      const model = createMockModel({
+        id: "kilo/deepseek/deepseek-v4-pro",
+        providerID: "kilo",
+        api: {
+          id: "deepseek/deepseek-v4-pro",
+          url: "https://gateway.kilo.ai",
+          npm: "@kilocode/kilo-gateway",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result.low).toEqual({ reasoning: { effort: "low" } })
+      expect(result.high).toEqual({ reasoning: { effort: "high" } })
+    })
+
     test("codex models return OPENAI_EFFORTS with object-based reasoning format", () => {
       const model = createMockModel({
         id: "kilo/openai/gpt-5.2-codex",


### PR DESCRIPTION
Fixes #10176.

Expose reasoning effort variants for DeepSeek V4 models routed through OpenRouter, matching the existing compatible-provider behavior. This makes reasoning controls available instead of hiding them for the selected model.