### PR TITLE
fix: allow autocomplete for external files

### DIFF
--- a/.changeset/external-file-autocomplete.md
+++ b/.changeset/external-file-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow autocomplete for standalone files opened outside the current VS Code workspace.

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -393,7 +393,7 @@ export class AutocompleteInlineCompletionProvider implements vscode.InlineComple
             return []
           }
 
-          const isAccessible = controller.validateAccess(document.fileName)
+          const isAccessible = controller.validateDocumentAccess(document.fileName)
           if (!isAccessible) {
             return []
           }

--- a/packages/kilo-vscode/src/services/autocomplete/shims/FileIgnoreController.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/shims/FileIgnoreController.ts
@@ -20,6 +20,11 @@ function toPosix(filePath: string): string {
   return filePath.replace(/\\/g, "/")
 }
 
+function isSensitiveFileName(filePath: string): boolean {
+  const basename = path.basename(toPosix(filePath))
+  return basename === ".env" || basename.startsWith(".env.")
+}
+
 export class FileIgnoreController {
   private workspacePath: string
   private ignoreInstance: Ignore = ignore()
@@ -125,6 +130,24 @@ export class FileIgnoreController {
     }
 
     return !this.ignoreInstance.ignores(relative)
+  }
+
+  /**
+   * Returns true if the active editor document can be used for autocomplete.
+   * Workspace files still honor ignore rules; standalone files are allowed so
+   * VS Code tabs outside the workspace can receive completions.
+   */
+  validateDocumentAccess(filePath: string): boolean {
+    if (!filePath) {
+      return false
+    }
+
+    const relative = this.workspacePath ? this.toRelativePath(filePath) : null
+    if (relative) {
+      return !this.ignoreInstance.ignores(relative)
+    }
+
+    return !isSensitiveFileName(filePath)
   }
 
   /**

--- a/packages/kilo-vscode/tests/unit/file-ignore-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/file-ignore-controller.test.ts
@@ -168,11 +168,44 @@ describe("FileIgnoreController", () => {
       expect(controller.validateAccess("relative/file.ts")).toBe(false)
     })
 
+    it("allows standalone editor documents except sensitive env files", async () => {
+      const controller = new FileIgnoreController("")
+      await controller.initialize()
+
+      expect(controller.validateDocumentAccess("/some/file.ts")).toBe(true)
+      expect(controller.validateDocumentAccess("/some/.env")).toBe(false)
+      expect(controller.validateDocumentAccess("/some/.env.local")).toBe(false)
+    })
+
     it("filterPaths returns empty array", async () => {
       const controller = new FileIgnoreController("")
       await controller.initialize()
 
       expect(controller.filterPaths(["/some/file.ts", "other.ts"])).toEqual([])
+    })
+  })
+
+  describe("active editor document access", () => {
+    it("keeps workspace ignore rules while allowing external source files", async () => {
+      const workspace = await createTempWorkspace()
+      await fs.writeFile(path.join(workspace, ".gitignore"), "node_modules/\n")
+
+      const controller = new FileIgnoreController(workspace)
+      await controller.initialize()
+
+      expect(controller.validateDocumentAccess(path.join(workspace, "node_modules", "foo.js"))).toBe(false)
+      expect(controller.validateDocumentAccess(path.join(workspace, "src", "main.ts"))).toBe(true)
+      expect(controller.validateDocumentAccess("/outside/project/file.ts")).toBe(true)
+    })
+
+    it("blocks sensitive standalone env documents", async () => {
+      const workspace = await createTempWorkspace()
+
+      const controller = new FileIgnoreController(workspace)
+      await controller.initialize()
+
+      expect(controller.validateDocumentAccess("/outside/project/.env")).toBe(false)
+      expect(controller.validateDocumentAccess("/outside/project/.env.production")).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Allow autocomplete to run for standalone files opened outside the current VS Code workspace while keeping workspace ignore filtering in place.

Fixes #10205.