### PR TITLE
fix: skip live model fetches offline

### DIFF
--- a/.changeset/offline-model-fetch.md
+++ b/.changeset/offline-model-fetch.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Honor disabled model fetching for live gateway model catalogs in offline CLI environments.

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -8,6 +8,11 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 export namespace ModelCache {
   const log = Log.create({ service: "model-cache" })
 
+  function modelsFetchDisabled() {
+    const value = process.env.KILO_DISABLE_MODELS_FETCH?.toLowerCase()
+    return Flag.KILO_DISABLE_MODELS_FETCH || value === "true" || value === "1"
+  }
+
   // Cache structure
   const cache = new Map<
     string,
@@ -76,7 +81,7 @@ export namespace ModelCache {
       return cached
     }
 
-    if (Flag.KILO_DISABLE_MODELS_FETCH) {
+    if (modelsFetchDisabled()) {
       log.debug("model fetch disabled", { providerID })
       return {}
     }
@@ -118,9 +123,9 @@ export namespace ModelCache {
    * @returns Freshly fetched models
    */
   export async function refresh(providerID: string, options?: any): Promise<Record<string, any>> {
-    if (Flag.KILO_DISABLE_MODELS_FETCH) {
+    if (modelsFetchDisabled()) {
       log.debug("model refresh disabled", { providerID })
-      return get(providerID) ?? {}
+      return {}
     }
 
     // Check if refresh already in progress

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -3,6 +3,7 @@ import { fetchKiloModels, type KiloModelsResult } from "@kilocode/kilo-gateway"
 import { Config } from "../config/config"
 import { Auth } from "../auth"
 import * as Log from "@opencode-ai/core/util/log"
+import { Flag } from "@opencode-ai/core/flag/flag"
 
 export namespace ModelCache {
   const log = Log.create({ service: "model-cache" })
@@ -75,6 +76,11 @@ export namespace ModelCache {
       return cached
     }
 
+    if (Flag.KILO_DISABLE_MODELS_FETCH) {
+      log.debug("model fetch disabled", { providerID })
+      return {}
+    }
+
     // Cache miss - fetch models
     log.info("fetching models", { providerID })
 
@@ -112,6 +118,11 @@ export namespace ModelCache {
    * @returns Freshly fetched models
    */
   export async function refresh(providerID: string, options?: any): Promise<Record<string, any>> {
+    if (Flag.KILO_DISABLE_MODELS_FETCH) {
+      log.debug("model refresh disabled", { providerID })
+      return get(providerID) ?? {}
+    }
+
     // Check if refresh already in progress
     const existing = inFlightRefresh.get(providerID)
     if (existing) {

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -39,6 +39,7 @@ import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Auth } from "../../src/auth"
 import { ModelCache } from "../../src/provider/model-cache"
+import { Flag } from "@opencode-ai/core/flag/flag"
 
 test("model fetch uses accountId from OAuth auth as kilocodeOrganizationId", async () => {
   await using tmp = await tmpdir({
@@ -161,4 +162,40 @@ test("ModelCache.clear removes cached entry so next fetch hits the network", asy
       expect(captured).toBeDefined()
     },
   })
+})
+
+test("KILO_DISABLE_MODELS_FETCH skips live model fetches", async () => {
+  const original = Flag.KILO_DISABLE_MODELS_FETCH
+
+  try {
+    Flag.KILO_DISABLE_MODELS_FETCH = true
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://app.kilo.ai/config.json",
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        captured = undefined
+        ModelCache.clear("kilo")
+
+        const models = await ModelCache.fetch("kilo")
+        const refreshed = await ModelCache.refresh("kilo")
+
+        expect(models).toEqual({})
+        expect(refreshed).toEqual({})
+        expect(captured).toBeUndefined()
+      },
+    })
+  } finally {
+    Flag.KILO_DISABLE_MODELS_FETCH = original
+    ModelCache.clear("kilo")
+  }
 })

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -39,7 +39,6 @@ import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Auth } from "../../src/auth"
 import { ModelCache } from "../../src/provider/model-cache"
-import { Flag } from "@opencode-ai/core/flag/flag"
 
 test("model fetch uses accountId from OAuth auth as kilocodeOrganizationId", async () => {
   await using tmp = await tmpdir({
@@ -165,10 +164,10 @@ test("ModelCache.clear removes cached entry so next fetch hits the network", asy
 })
 
 test("KILO_DISABLE_MODELS_FETCH skips live model fetches", async () => {
-  const original = Flag.KILO_DISABLE_MODELS_FETCH
+  const original = process.env.KILO_DISABLE_MODELS_FETCH
 
   try {
-    Flag.KILO_DISABLE_MODELS_FETCH = true
+    process.env.KILO_DISABLE_MODELS_FETCH = "true"
 
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -195,7 +194,11 @@ test("KILO_DISABLE_MODELS_FETCH skips live model fetches", async () => {
       },
     })
   } finally {
-    Flag.KILO_DISABLE_MODELS_FETCH = original
+    if (original === undefined) {
+      delete process.env.KILO_DISABLE_MODELS_FETCH
+    } else {
+      process.env.KILO_DISABLE_MODELS_FETCH = original
+    }
     ModelCache.clear("kilo")
   }
 })


### PR DESCRIPTION
Honor KILO_DISABLE_MODELS_FETCH for live gateway model catalogs so offline CLI runs do not leave background fetches active.

Fixes #9825.