### PR TITLE
fix(cli): respect startup model overrides

### DIFF
--- a/.changeset/cli-model-startup.md
+++ b/.changeset/cli-model-startup.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Respect the startup `--model` flag over cached model state and avoid silently falling back when the requested model is invalid.

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -192,6 +192,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         // kilocode_change end
       }
 
+      const args = useArgs()
+      // kilocode_change start - explicit CLI models beat cached state and do not silently fall back
+      const argsModel = createMemo(() => {
+        if (!args.model) return { present: false as const }
+        const { providerID, modelID } = parseModel(args.model)
+        if (!providerID || !modelID) return { present: true as const, value: undefined }
+        return { present: true as const, value: { providerID, modelID } }
+      })
+      // kilocode_change end
+
       Filesystem.readJson(filePath)
         .then((x: any) => {
           if (Array.isArray(x.recent)) setModelStore("recent", x.recent)
@@ -202,21 +212,21 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         .catch(() => {})
         .finally(() => {
           setModelStore("ready", true)
-          if (state.pending) save()
-        })
-
-      const args = useArgs()
-      const fallbackModel = createMemo(() => {
-        if (args.model) {
-          const { providerID, modelID } = parseModel(args.model)
-          if (isModelValid({ providerID, modelID })) {
-            return {
-              providerID,
-              modelID,
+          // kilocode_change start - re-apply --model after async state load so stale picks are not restored
+          const explicit = argsModel()
+          let appliedExplicit = false
+          if (explicit.value && isModelValid(explicit.value)) {
+            const a = agent.current()
+            if (a) {
+              apply(a.name, explicit.value, !a.model)
+              appliedExplicit = true
             }
           }
-        }
+          // kilocode_change end
+          if (state.pending || appliedExplicit) save()
+        })
 
+      const fallbackModel = createMemo(() => {
         if (sync.data.config.model) {
           const { providerID, modelID } = parseModel(sync.data.config.model)
           if (isModelValid({ providerID, modelID })) {
@@ -246,6 +256,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
 
       const currentModel = createMemo(() => {
+        // kilocode_change start - a requested --model must never be hidden by persisted fallback state
+        const explicit = argsModel()
+        if (explicit.present) {
+          return explicit.value && isModelValid(explicit.value) ? explicit.value : undefined
+        }
+        // kilocode_change end
         const a = agent.current()
         if (!a) return fallbackModel() // kilocode_change - guard against empty agent list
         // kilocode_change start - configured models beat stale persisted picks

--- a/packages/opencode/test/kilocode/local-model.test.ts
+++ b/packages/opencode/test/kilocode/local-model.test.ts
@@ -505,6 +505,49 @@ describe("edge cases and error handling", () => {
   })
 })
 
+// ── Regression tests for #9980 ──────────────────────────────────────────────
+// CLI --model must win over cached model.json state and invalid explicit values
+// must not silently fall back to the last persisted model.
+
+describe("#9980: CLI model overrides persisted startup state", () => {
+  test("13: --model beats stale persisted model and rewrites model.json", async () => {
+    mockArgs = { model: "anthropic/claude-opus" }
+    const { local, dispose } = await initLocal({
+      prewrite: {
+        recent: [SONNET],
+        model: { code: SONNET },
+        favorite: [],
+        variant: {},
+      },
+    })
+    try {
+      expect(local.model.current()).toEqual(OPUS)
+      await local.model.flush()
+      const data = await readModelJson()
+      expect(data.model.code).toEqual(OPUS)
+    } finally {
+      dispose()
+    }
+  })
+
+  test("14: invalid --model blocks fallback to cached model", async () => {
+    mockArgs = { model: "anthropic/not-real" }
+    const { local, dispose } = await initLocal({
+      prewrite: {
+        recent: [SONNET],
+        model: { code: SONNET },
+        favorite: [],
+        variant: {},
+      },
+    })
+    try {
+      expect(local.model.current()).toBeUndefined()
+    } finally {
+      dispose()
+    }
+  })
+})
+
 // ── Regression tests for #9050 follow-up ────────────────────────────────────
 // Configured agent defaults should win on restart/project switch, while manual
 // selections for those agents remain active only in the current process.


### PR DESCRIPTION
Fixes #9980.

Makes startup `--model` win over cached `model.json` after async state load, and keeps invalid explicit models from silently falling back to the last persisted selection.