### PR TITLE
fix(cli): show startup migration scan progress

### DIFF
--- a/.changeset/startup-scan-progress.md
+++ b/.changeset/startup-scan-progress.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show startup migration scan progress for large legacy storage.

--- a/packages/opencode/src/kilocode/storage/json-migration-progress.ts
+++ b/packages/opencode/src/kilocode/storage/json-migration-progress.ts
@@ -1,0 +1,12 @@
+type Progress = {
+  current: number
+  total: number
+  label: string
+}
+
+export function reportScanProgress(
+  options: { progress?: (event: Progress) => void } | undefined,
+  label: string,
+) {
+  options?.progress?.({ current: 0, total: 1, label })
+}

--- a/packages/opencode/src/storage/json-migration.ts
+++ b/packages/opencode/src/storage/json-migration.ts
@@ -9,6 +9,9 @@ import path from "path"
 import { existsSync } from "fs"
 import { Filesystem } from "@/util/filesystem"
 import { Glob } from "@opencode-ai/core/util/glob"
+// kilocode_change start - report legacy storage scan progress during startup migration
+import { reportScanProgress } from "@/kilocode/storage/json-migration-progress"
+// kilocode_change end
 
 const log = Log.create({ service: "json-migration" })
 
@@ -74,6 +77,13 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
     return Glob.scan(pattern, { cwd: storageDir, absolute: true })
   }
 
+  // kilocode_change start - report legacy storage scan progress during startup migration
+  async function scan(label: string, pattern: string) {
+    reportScanProgress(options, label)
+    return list(pattern)
+  }
+  // kilocode_change end
+
   async function read(files: string[], start: number, end: number) {
     const count = end - start
     // oxlint-disable-next-line unicorn/no-new-array -- pre-allocated for index-based batch fill
@@ -108,15 +118,15 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
 
   // Pre-scan all files upfront to avoid repeated glob operations
   log.info("scanning files...")
-  const [projectFiles, sessionFiles, messageFiles, partFiles, todoFiles, permFiles, shareFiles] = await Promise.all([
-    list("project/*.json"),
-    list("session/*/*.json"),
-    list("message/*/*.json"),
-    list("part/*/*.json"),
-    list("todo/*.json"),
-    list("permission/*.json"),
-    list("session_share/*.json"),
-  ])
+  // kilocode_change start - scan sequentially so large legacy stores do not look frozen at startup
+  const projectFiles = await scan("scan-projects", "project/*.json")
+  const sessionFiles = await scan("scan-sessions", "session/*/*.json")
+  const messageFiles = await scan("scan-messages", "message/*/*.json")
+  const partFiles = await scan("scan-parts", "part/*/*.json")
+  const todoFiles = await scan("scan-todos", "todo/*.json")
+  const permFiles = await scan("scan-permissions", "permission/*.json")
+  const shareFiles = await scan("scan-shares", "session_share/*.json")
+  // kilocode_change end
 
   log.info("file scan complete", {
     projects: projectFiles.length,

--- a/packages/opencode/test/kilocode/storage/json-migration-progress.test.ts
+++ b/packages/opencode/test/kilocode/storage/json-migration-progress.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { drizzle } from "drizzle-orm/bun-sqlite"
+import { migrate } from "drizzle-orm/bun-sqlite/migrator"
+import fs from "fs/promises"
+import { readFileSync, readdirSync } from "fs"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { JsonMigration } from "@/storage/json-migration"
+
+function db() {
+  const sqlite = new Database(":memory:")
+  sqlite.exec("PRAGMA foreign_keys = ON")
+
+  const dir = path.join(import.meta.dirname, "../../../migration")
+  const entries = readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      sql: readFileSync(path.join(dir, entry.name, "migration.sql"), "utf-8"),
+      timestamp: Number(entry.name.split("_")[0]),
+      name: entry.name,
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+
+  const client = drizzle({ client: sqlite })
+  migrate(client, entries)
+  return { client, sqlite }
+}
+
+describe("json migration progress", () => {
+  test("reports scan progress before migrating legacy files", async () => {
+    const storage = path.join(Global.Path.data, "storage")
+    await fs.rm(storage, { recursive: true, force: true })
+    await fs.mkdir(path.join(storage, "project"), { recursive: true })
+    await fs.mkdir(path.join(storage, "session"), { recursive: true })
+    await fs.mkdir(path.join(storage, "message"), { recursive: true })
+    await fs.mkdir(path.join(storage, "part"), { recursive: true })
+    await fs.mkdir(path.join(storage, "todo"), { recursive: true })
+    await fs.mkdir(path.join(storage, "permission"), { recursive: true })
+    await fs.mkdir(path.join(storage, "session_share"), { recursive: true })
+
+    const events: string[] = []
+    const { client, sqlite } = db()
+
+    try {
+      await JsonMigration.run(client, {
+        progress: (event) => events.push(event.label),
+      })
+    } finally {
+      sqlite.close()
+      await fs.rm(storage, { recursive: true, force: true })
+    }
+
+    expect(events.slice(0, 7)).toEqual([
+      "scan-projects",
+      "scan-sessions",
+      "scan-messages",
+      "scan-parts",
+      "scan-todos",
+      "scan-permissions",
+      "scan-shares",
+    ])
+    expect(events).toContain("starting")
+    expect(events.at(-1)).toBe("complete")
+  })
+})


### PR DESCRIPTION
## Context

Fixes #10314.

On first launch with legacy JSON storage, the CLI can spend time scanning files before migration progress starts, which makes startup look frozen on large histories.

## Implementation

Report each legacy storage scan phase before the glob runs, and scan the buckets sequentially so users see visible movement during startup migration.

## Screenshots

| before | after |
|---|---|
|  |  |

## How to Test

- `XDG_DATA_HOME="$tmp/data" XDG_CACHE_HOME="$tmp/cache" XDG_CONFIG_HOME="$tmp/config" XDG_STATE_HOME="$tmp/state" bun test test/kilocode/storage/json-migration-progress.test.ts`
- `bun run typecheck`
- `bun run script/check-opencode-annotations.ts`

## Get in Touch

