### PR TITLE
fix: prefetch initial diff details

### DIFF
--- a/.changeset/diff-detail-prefetch.md
+++ b/.changeset/diff-detail-prefetch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prefetch initially open diff details in the diff viewer and Agent Manager to reduce the visible delay before content appears.

--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-state.test.ts
@@ -4,6 +4,7 @@ import {
   EXTREME_DIFF_CHANGED_LINES,
   allOpenFiles,
   expandableOpenFiles,
+  initialDetailFiles,
   initialOpenFiles,
   toggleOpenFiles,
 } from "../../webview-ui/agent-manager/diff-open-policy"
@@ -65,6 +66,17 @@ describe("agent manager diff state", () => {
 
     const many = Array.from({ length: 26 }, (_, i) => diff({ file: `src/${i}.ts` }))
     expect(initialOpenFiles(many)).toHaveLength(26)
+  })
+
+  it("preloads detail only for summarized files that open initially", () => {
+    expect(
+      initialDetailFiles([
+        diff({ file: "src/summary.ts", summarized: true }),
+        diff({ file: "src/loaded.ts", summarized: false, before: "old\n", after: "new\n" }),
+        diff({ file: "src/generated.ts", generatedLike: true, summarized: true }),
+        diff({ file: "src/huge.ts", additions: EXTREME_DIFF_CHANGED_LINES + 1, summarized: true }),
+      ]),
+    ).toEqual(["src/summary.ts"])
   })
 
   it("expands only reviewable files from the bulk action", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -125,6 +125,7 @@ import {
 import { sectionAwareDetector } from "./section-dnd"
 import { ConstrainDragXAxis } from "./constrain-drag-x"
 import { mergeWorktreeDiffs } from "./diff-state"
+import { initialDetailFiles } from "./diff-open-policy"
 import { initialMessage, seedInitialVariant } from "./initial-message"
 import { createMarkdownRender } from "./review-preferences"
 import { createSidebarCollapse } from "./sidebar-collapse"
@@ -1329,16 +1330,19 @@ const AgentManagerContent: Component = () => {
       if (msg.type === "agentManager.worktreeDiff") {
         const ev = msg as AgentManagerWorktreeDiffMessage
         let staleFiles: Set<string> | undefined
+        let preloadFiles: string[] = []
         setDiffDatas((prev) => {
           const existing = prev[ev.sessionId]
           const merged = existing
             ? mergeWorktreeDiffs(existing, ev.diffs)
             : { diffs: ev.diffs, stale: new Set<string>() }
           staleFiles = merged.stale
+          preloadFiles = initialDetailFiles(merged.diffs)
           const next = merged.diffs
           if (existing && existing.length === next.length && existing.every((old, i) => old === next[i])) return prev
           return { ...prev, [ev.sessionId]: next }
         })
+        preloadInitialDiffDetails(ev.sessionId, preloadFiles)
         if (staleFiles) refreshStaleDiffs(ev.sessionId, staleFiles)
       }
 
@@ -1573,6 +1577,15 @@ const AgentManagerContent: Component = () => {
   }
 
   const refreshStaleDiffs = (sessionId: string, files: Set<string>) => {
+    const loading = diffFileLoading()[sessionId] ?? {}
+    for (const file of files) {
+      if (loading[file]) continue
+      setDiffFilePending(sessionId, file, true)
+      vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
+    }
+  }
+
+  const preloadInitialDiffDetails = (sessionId: string, files: string[]) => {
     const loading = diffFileLoading()[sessionId] ?? {}
     for (const file of files) {
       if (loading[file]) continue

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1328,22 +1328,7 @@ const AgentManagerContent: Component = () => {
       }
 
       if (msg.type === "agentManager.worktreeDiff") {
-        const ev = msg as AgentManagerWorktreeDiffMessage
-        let staleFiles: Set<string> | undefined
-        let preloadFiles: string[] = []
-        setDiffDatas((prev) => {
-          const existing = prev[ev.sessionId]
-          const merged = existing
-            ? mergeWorktreeDiffs(existing, ev.diffs)
-            : { diffs: ev.diffs, stale: new Set<string>() }
-          staleFiles = merged.stale
-          preloadFiles = initialDetailFiles(merged.diffs)
-          const next = merged.diffs
-          if (existing && existing.length === next.length && existing.every((old, i) => old === next[i])) return prev
-          return { ...prev, [ev.sessionId]: next }
-        })
-        preloadInitialDiffDetails(ev.sessionId, preloadFiles)
-        if (staleFiles) refreshStaleDiffs(ev.sessionId, staleFiles)
+        handleWorktreeDiffMessage(msg as AgentManagerWorktreeDiffMessage)
       }
 
       if (msg.type === "agentManager.worktreeDiffFile") {
@@ -1576,7 +1561,7 @@ const AgentManagerContent: Component = () => {
     vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
   }
 
-  const refreshStaleDiffs = (sessionId: string, files: Set<string>) => {
+  const requestDiffDetails = (sessionId: string, files: Iterable<string>) => {
     const loading = diffFileLoading()[sessionId] ?? {}
     for (const file of files) {
       if (loading[file]) continue
@@ -1585,13 +1570,15 @@ const AgentManagerContent: Component = () => {
     }
   }
 
-  const preloadInitialDiffDetails = (sessionId: string, files: string[]) => {
-    const loading = diffFileLoading()[sessionId] ?? {}
-    for (const file of files) {
-      if (loading[file]) continue
-      setDiffFilePending(sessionId, file, true)
-      vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", sessionId, file })
+  const handleWorktreeDiffMessage = (ev: AgentManagerWorktreeDiffMessage) => {
+    const existing = diffDatas()[ev.sessionId]
+    const merged = existing ? mergeWorktreeDiffs(existing, ev.diffs) : { diffs: ev.diffs, stale: new Set<string>() }
+    const next = merged.diffs
+    if (!existing || existing.length !== next.length || !existing.every((old, i) => old === next[i])) {
+      setDiffDatas((prev) => ({ ...prev, [ev.sessionId]: next }))
     }
+    requestDiffDetails(ev.sessionId, initialDetailFiles(next))
+    requestDiffDetails(ev.sessionId, merged.stale)
   }
 
   const diffFileLoadingForCurrent = createMemo(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-open-policy.ts
@@ -15,6 +15,11 @@ export function initialOpenFiles(diffs: WorktreeFileDiff[]): string[] {
   return expandableOpenFiles(diffs)
 }
 
+export function initialDetailFiles(diffs: WorktreeFileDiff[]): string[] {
+  const open = new Set(initialOpenFiles(diffs))
+  return diffs.filter((diff) => open.has(diff.file) && diff.summarized === true).map((diff) => diff.file)
+}
+
 export function allOpenFiles(diffs: WorktreeFileDiff[], open: string[]): boolean {
   const targets = expandableOpenFiles(diffs)
   if (targets.length === 0) return false

--- a/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/DiffViewerApp.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from "@kilocode/kilo-ui/theme"
 import { Toast } from "@kilocode/kilo-ui/toast"
 import { FullScreenDiffView } from "../agent-manager/FullScreenDiffView"
 import { mergeWorktreeDiffs } from "../agent-manager/diff-state"
+import { initialDetailFiles } from "../agent-manager/diff-open-policy"
 import { LanguageProvider, useLanguage } from "../src/context/language"
 import { ServerProvider, useServer } from "../src/context/server"
 import { getVSCodeAPI, VSCodeProvider, useVSCode } from "../src/context/vscode"
@@ -99,6 +100,10 @@ const DiffViewerContent: Component = () => {
     }
   }
 
+  const preloadInitialDiffDetails = (next: WorktreeFileDiff[]) => {
+    for (const file of initialDetailFiles(next)) requestDiffFile(file)
+  }
+
   const unsubscribe = vscode.onMessage((msg) => {
     if (msg.type === "diffViewer.diffs") {
       // Preserve cached `before`/`after` across polls so summarized polling
@@ -106,6 +111,7 @@ const DiffViewerContent: Component = () => {
       // worktree diff merge — see worktree-diff-controller.ts.
       const merged = mergeWorktreeDiffs(diffs(), msg.diffs)
       setDiffs(merged.diffs)
+      preloadInitialDiffDetails(merged.diffs)
       if (merged.stale.size > 0) refreshStaleDiffs(merged.stale)
       return
     }


### PR DESCRIPTION
## Context

Fixes #10234. The diff viewer and Agent Manager could briefly show an on-demand placeholder before initially open diff content was requested.

## Implementation

- Added a shared initial-detail selection helper that only targets summarized files already opened by the review policy.
- Prefetch those details when diff summaries arrive in both the standalone diff viewer and Agent Manager.
- Kept large and generated-like files lazy.

## Screenshots

| before | after |
|---|---|
| Not captured | Not captured |

## How to Test

- Open the extension diff viewer or Agent Manager on a worktree with small summarized diffs.
- Confirm initially open files request their details immediately and render without waiting for a manual expand.
- Confirm large/generated-like files still remain lazy.

Validation run:
- bun test tests/unit/agent-manager-diff-state.test.ts
- bun run check-types:webview
- bun run lint -- webview-ui/agent-manager/diff-open-policy.ts webview-ui/diff-viewer/DiffViewerApp.tsx webview-ui/agent-manager/AgentManagerApp.tsx tests/unit/agent-manager-diff-state.test.ts
- git diff --check

## Get in Touch

GitHub is best.