### PR TITLE
fix(vscode): keep permission dock actions visible

### DIFF
--- a/.changeset/permission-dock-scroll.md
+++ b/.changeset/permission-dock-scroll.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep permission action buttons visible when edit approvals include many file diffs.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -261,26 +261,28 @@ export const PermissionDock: Component<{
           </Show>
         }
       >
-        <Show when={command()}>{(cmd) => <PermissionCommand command={cmd()} />}</Show>
+        <div data-slot="permission-scroll">
+          <Show when={command()}>{(cmd) => <PermissionCommand command={cmd()} />}</Show>
 
-        {(() => {
-          const desc = description()
-          if (!desc)
-            return !command() && toolDescription() ? <div data-slot="permission-hint">{toolDescription()}</div> : null
-          if (desc.kind === "single") return <div data-slot="permission-hint">{desc.text}</div>
-          return (
-            <div data-slot="permission-patterns">
-              <span data-slot="permission-patterns-title">{desc.title}</span>
-              <For each={desc.paths}>{(path) => <code data-slot="permission-pattern">{path}</code>}</For>
+          {(() => {
+            const desc = description()
+            if (!desc)
+              return !command() && toolDescription() ? <div data-slot="permission-hint">{toolDescription()}</div> : null
+            if (desc.kind === "single") return <div data-slot="permission-hint">{desc.text}</div>
+            return (
+              <div data-slot="permission-patterns">
+                <span data-slot="permission-patterns-title">{desc.title}</span>
+                <For each={desc.paths}>{(path) => <code data-slot="permission-pattern">{path}</code>}</For>
+              </div>
+            )
+          })()}
+
+          <Show when={diffs().length > 0}>
+            <div data-slot="permission-diffs" data-count={diffs().length}>
+              <For each={diffs()}>{(diff) => <PermissionDiff filediff={diff} />}</For>
             </div>
-          )
-        })()}
-
-        <Show when={diffs().length > 0}>
-          <div data-slot="permission-diffs" data-count={diffs().length}>
-            <For each={diffs()}>{(diff) => <PermissionDiff filediff={diff} />}</For>
-          </div>
-        </Show>
+          </Show>
+        </div>
 
         <div data-slot="permission-actions">
           <Button

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -5,6 +5,7 @@
 [data-component="dock-prompt"][data-kind="permission"] {
   animation: permission-slide-in 0.3s ease-out;
   margin: 12px;
+  max-height: min(72dvh, calc(100dvh - 96px));
   border: 1px solid
     color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 40%, var(--vscode-panel-border, transparent));
   border-radius: 0.25rem;
@@ -28,6 +29,10 @@
   [data-slot="permission-body"] {
     padding: 10px 16px 0;
     gap: 8px;
+  }
+
+  [data-slot="permission-content"] {
+    overflow: hidden;
   }
 
   [data-slot="permission-header-title"] {
@@ -110,13 +115,17 @@
     word-break: break-all;
   }
 
+  [data-slot="permission-scroll"] {
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 2px;
+  }
+
   [data-slot="permission-diffs"] {
     display: flex;
     flex-direction: column;
     gap: 8px;
     margin: 8px 0;
-    max-height: 420px;
-    overflow: auto;
   }
 
   [data-slot="permission-diff"] {
@@ -352,6 +361,7 @@
   [data-slot="permission-actions"] {
     display: flex;
     align-items: center;
+    flex-shrink: 0;
     flex-wrap: wrap;
     gap: 8px;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- keep permission approval actions outside the scrollable diff area
- cap the permission dock height so long multi-file edit prompts scroll internally
- add a patch changeset for the VS Code extension

Fixes #10351

## Validation
- bunx prettier --check packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx packages/kilo-vscode/webview-ui/src/styles/permission-dock.css .changeset/permission-dock-scroll.md
- git diff --check
- bun run typecheck
- pre-push bun turbo typecheck