### PR TITLE
fix(cli): toggle export checkboxes on click

### DIFF
--- a/.changeset/export-checkbox-click.md
+++ b/.changeset/export-checkbox-click.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Toggle export dialog checkbox options when their rows are clicked.

--- a/packages/kilo-vscode/tests/unit/export-dialog-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/export-dialog-contract.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "../../../..")
+const FILE = path.join(ROOT, "packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx")
+
+describe("TUI export dialog checkbox click contract", () => {
+  const source = fs.readFileSync(FILE, "utf-8")
+
+  it("toggles checkbox state when a checkbox row is clicked", () => {
+    expect(source).toContain("const toggleOption =")
+    expect(source).toContain('setStore("active", option)')
+    expect(source).toContain("setStore(option, !store[option])")
+    expect(source).toContain('onMouseUp={() => toggleOption("thinking")}')
+    expect(source).toContain('onMouseUp={() => toggleOption("toolDetails")}')
+    expect(source).toContain('onMouseUp={() => toggleOption("assistantMetadata")}')
+    expect(source).toContain('onMouseUp={() => toggleOption("openWithoutSaving")}')
+  })
+})

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -33,6 +33,11 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
     active: "filename" as "filename" | "thinking" | "toolDetails" | "assistantMetadata" | "openWithoutSaving",
   })
 
+  const toggleOption = (option: "thinking" | "toolDetails" | "assistantMetadata" | "openWithoutSaving") => {
+    setStore("active", option)
+    setStore(option, !store[option])
+  }
+
   useKeyboard((evt) => {
     if (evt.name === "return") {
       evt.preventDefault()
@@ -120,7 +125,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "thinking" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "thinking")}
+          onMouseUp={() => toggleOption("thinking")}
         >
           <text fg={store.active === "thinking" ? theme.primary : theme.textMuted}>
             {store.thinking ? "[x]" : "[ ]"}
@@ -132,7 +137,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "toolDetails" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "toolDetails")}
+          onMouseUp={() => toggleOption("toolDetails")}
         >
           <text fg={store.active === "toolDetails" ? theme.primary : theme.textMuted}>
             {store.toolDetails ? "[x]" : "[ ]"}
@@ -144,7 +149,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "assistantMetadata" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "assistantMetadata")}
+          onMouseUp={() => toggleOption("assistantMetadata")}
         >
           <text fg={store.active === "assistantMetadata" ? theme.primary : theme.textMuted}>
             {store.assistantMetadata ? "[x]" : "[ ]"}
@@ -156,7 +161,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           gap={2}
           paddingLeft={1}
           backgroundColor={store.active === "openWithoutSaving" ? theme.backgroundElement : undefined}
-          onMouseUp={() => setStore("active", "openWithoutSaving")}
+          onMouseUp={() => toggleOption("openWithoutSaving")}
         >
           <text fg={store.active === "openWithoutSaving" ? theme.primary : theme.textMuted}>
             {store.openWithoutSaving ? "[x]" : "[ ]"}


### PR DESCRIPTION
## Summary
- toggle export dialog checkbox values when their rows are clicked
- keep keyboard space toggling behavior unchanged
- add a source contract test for the row-click wiring

Fixes #10305

## Validation
- bun test tests/unit/export-dialog-contract.test.ts
- bunx prettier --check packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx packages/kilo-vscode/tests/unit/export-dialog-contract.test.ts .changeset/export-checkbox-click.md
- git diff --check
- bun run typecheck
- pre-push bun turbo typecheck