### PR TITLE
fix(serve): add orphan PID detection to prevent zombie kilo serve pro…

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -4,6 +4,9 @@ import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { InstanceRuntime } from "../../project/instance-runtime" // kilocode_change
+import * as Log from "@opencode-ai/core/util/log" // kilocode_change
+
+const log = Log.create({ service: "serve" }) // kilocode_change
 
 export const ServeCommand = effectCmd({
   command: "serve",
@@ -20,24 +23,48 @@ export const ServeCommand = effectCmd({
     const server = yield* Effect.promise(() => Server.listen(opts))
     console.log(`kilo server listening on http://${server.hostname}:${server.port}`) // kilocode_change
 
-    // kilocode_change start - graceful signal shutdown
-    // yield* Effect.never
-    yield* Effect.promise(
-      () =>
-        new Promise<void>((resolve) => {
-          const shutdown = async () => {
-            try {
-              await InstanceRuntime.disposeAllInstances()
-              await server.stop(true)
-            } finally {
-              resolve()
-            }
+    // kilocode_change start
+    const abort = new AbortController()
+    const shutdown = async (reason: string) => {
+      if (abort.signal.aborted) return
+      log.info("shutting down", { reason })
+      try {
+        await InstanceRuntime.disposeAllInstances()
+        await server.stop(true)
+      } finally {
+        abort.abort()
+      }
+    }
+    process.on("SIGTERM", () => shutdown("sigterm"))
+    process.on("SIGINT", () => shutdown("sigint"))
+    process.on("SIGHUP", () => shutdown("sighup"))
+
+    // Orphan detection: exit if parent dies without sending a signal
+    const parentPid = process.ppid
+    const orphanWatch = setInterval(() => {
+      if (abort.signal.aborted) return
+      const orphaned = (() => {
+        if (process.ppid !== parentPid) return true
+        if (parentPid === 1) return false
+        try {
+          process.kill(parentPid, 0)
+          return false
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code
+          if (code !== "ESRCH") {
+            log.debug("parent liveness check failed", { parentPid, code, error: err })
+            return false
           }
-          process.once("SIGTERM", shutdown)
-          process.once("SIGINT", shutdown)
-          process.once("SIGHUP", shutdown)
-        }),
-    )
+          log.debug("detected dead parent", { parentPid, error: err })
+          return true
+        }
+      })()
+      if (!orphaned) return
+      shutdown("parent-exit")
+    }, 1000)
+    orphanWatch.unref()
     // kilocode_change end
+
+    yield* Effect.promise(() => new Promise<void>((resolve) => abort.signal.addEventListener("abort", resolve)))
   }),
 })

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -35,9 +35,13 @@ export const ServeCommand = effectCmd({
         abort.abort()
       }
     }
-    process.on("SIGTERM", () => shutdown("sigterm"))
-    process.on("SIGINT", () => shutdown("sigint"))
-    process.on("SIGHUP", () => shutdown("sighup"))
+    const onSignal = (reason: string) => shutdown(reason).catch((err) => {
+      log.error("signal shutdown failed", { err })
+      process.exit(1)
+    })
+    process.on("SIGTERM", () => onSignal("sigterm"))
+    process.on("SIGINT", () => onSignal("sigint"))
+    process.on("SIGHUP", () => onSignal("sighup"))
 
     // Orphan detection: exit if parent dies without sending a signal
     const parentPid = process.ppid
@@ -60,7 +64,9 @@ export const ServeCommand = effectCmd({
         }
       })()
       if (!orphaned) return
-      shutdown("parent-exit")
+      shutdown("parent-exit").catch((err) => {
+        log.error("orphan shutdown failed", { err })
+      })
     }, 1000)
     orphanWatch.unref()
     // kilocode_change end

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -48,8 +48,7 @@ export const ServeCommand = effectCmd({
     const orphanWatch = setInterval(() => {
       if (abort.signal.aborted) return
       const orphaned = (() => {
-        if (process.ppid !== parentPid) return true
-        if (parentPid === 1) return false
+        if (process.ppid !== parentPid) return process.ppid !== 1
         try {
           process.kill(parentPid, 0)
           return false


### PR DESCRIPTION
## Summary
Adds parent-process liveness detection to `kilo serve` so orphaned child processes self-terminate instead of consuming 100% CPU indefinitely when VS Code crashes or is killed without a clean shutdown.

## Context
Users report that when VS Code exits without a clean shutdown — e.g. extension host OOM kill, `kill -9`, or a crash — the detached `kilo serve` child process is left running as a zombie. `ServerManager.dispose()` never fires, no SIGTERM is sent to the child, and the TUI worker's 250 ms event-stream retry loop burns a full CPU core. There was no mechanism to detect that the parent had died and exit voluntarily.

## Implementation

### Orphan detection (`packages/opencode/src/cli/cmd/serve.ts`, `23fe8cfe19`)
- **`parentPid = process.ppid`** captured once on startup so we can distinguish intentional reparenting from a dead parent.
- **`setInterval` at 1 s** checks two conditions every tick:
  1. `process.ppid !== parentPid` — the parent PID changed so the process was re-parented; treated as orphaned *unless* the new PPID is `1` (init reparent, which is normal on Linux when a session leader detaches).
  2. `process.kill(parentPid, 0)` — zero-signal liveness probe; `ESRCH` means the parent process is gone.
- **`orphanWatch.unref()`** keeps the interval from blocking the Node.js event-loop from exiting. Self-termination is clean on the graceful-shutdown path regardless.
- **Idempotent `shutdown()`** — `if (abort.signal.aborted) return` prevents the orphan watcher and a signal handler from racing into a double-dispose.

## How to Test
```powershell
# 1. Start kilo serve in a terminal
kilo serve --port 3536
# → "kilo server listening on http://localhost:3536"
# 2. In another terminal, find and kill the parent process:
# (simulates VS Code extension host being killed / OOM kill)
$parent = (Get-Process -Name node | Where-Object { $_.Id -ne (Get-Process -Id $PPID).Id } | Select-Object -First 1)
taskkill /F /PID $parent.Id
# 3. Within ~1 second the orphaned serve process should log "shutting down"

#    (reason: "parent-exit") and exit with code 0 — no lingering CPU burn.

Similarly for the other PR bodies — if you'd like PR descriptions for #8607 and #8637 I can produce those too from the same working-tree reads approach.