### PR TITLE
fix(cli): add "reasoning" interleaved field for Cerebras Zai-GLM compatibility

### DIFF
--- a/.changeset/cerebras-zai-glm-reasoning.md
+++ b/.changeset/cerebras-zai-glm-reasoning.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"@kilocode/sdk": patch
+---
+
+Fix Cerebras Zai-GLM compatibility by adding "reasoning" as a valid interleaved content field

--- a/packages/opencode/src/config/provider.ts
+++ b/packages/opencode/src/config/provider.ts
@@ -17,7 +17,7 @@ export const Model = Schema.Struct({
     Schema.Union([
       Schema.Literal(true),
       Schema.Struct({
-        field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+        field: Schema.Literals(["reasoning_content", "reasoning_details", "reasoning"]),
       }),
     ]),
   ),

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -58,7 +58,7 @@ export const Model = Schema.Struct({
     Schema.Union([
       Schema.Literal(true),
       Schema.Struct({
-        field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+        field: Schema.Literals(["reasoning_content", "reasoning_details", "reasoning"]),
       }),
     ]),
   ),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -880,7 +880,7 @@ const ProviderModalities = Schema.Struct({
 const ProviderInterleaved = Schema.Union([
   Schema.Boolean,
   Schema.Struct({
-    field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+    field: Schema.Literals(["reasoning_content", "reasoning_details", "reasoning"]),
   }),
 ])
 
@@ -1055,7 +1055,11 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
         video: model.modalities?.output?.includes("video") ?? false,
         pdf: model.modalities?.output?.includes("pdf") ?? false,
       },
-      interleaved: model.interleaved ?? false,
+      interleaved:
+        model.interleaved ??
+        (provider.id === "cerebras" && model.id.toLowerCase().startsWith("zai-glm")
+          ? { field: "reasoning" }
+          : false),
     },
     release_date: model.release_date ?? "",
     variants: {},

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1706,7 +1706,7 @@ export type ProviderConfig = {
       interleaved?:
         | true
         | {
-            field: "reasoning_content" | "reasoning_details"
+            field: "reasoning_content" | "reasoning_details" | "reasoning"
           }
       cost?: {
         input: number
@@ -2190,7 +2190,7 @@ export type Model = {
     interleaved:
       | boolean
       | {
-          field: "reasoning_content" | "reasoning_details"
+          field: "reasoning_content" | "reasoning_details" | "reasoning"
         }
   }
   cost: {


### PR DESCRIPTION
Cerebras API rejects reasoning_content as a top-level message property and only supports reasoning text inline in the content field. Add "reasoning" as a valid interleaved.field value and default Cerebras zai-glm models to use it.

 #10375 