### PR TITLE
Fix misplaced section in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,17 +89,6 @@ Prefer `const`.
 
 Good:
 
-### Naming Enforcement (Read This)
-
-THIS RULE IS MANDATORY FOR AGENT WRITTEN CODE.
-
-- Use single word names by default for new locals, params, and helper functions.
-- Multi-word names are allowed only when a single word would be unclear or ambiguous.
-- Do not introduce new camelCase compounds when a short single-word alternative is clear.
-- Before finishing edits, review touched lines and shorten newly introduced identifiers where possible.
-- Good short names to prefer: `pid`, `cfg`, `err`, `opts`, `dir`, `root`, `child`, `state`, `timeout`.
-- Examples to avoid unless truly required: `inputPID`, `existingClient`, `connectTimeout`, `workerPath`.
-
 ```ts
 const foo = condition ? 1 : 2
 ```
@@ -112,6 +101,17 @@ let foo
 if (condition) foo = 1
 else foo = 2
 ```
+
+### Naming Enforcement (Read This)
+
+THIS RULE IS MANDATORY FOR AGENT WRITTEN CODE.
+
+- Use single word names by default for new locals, params, and helper functions.
+- Multi-word names are allowed only when a single word would be unclear or ambiguous.
+- Do not introduce new camelCase compounds when a short single-word alternative is clear.
+- Before finishing edits, review touched lines and shorten newly introduced identifiers where possible.
+- Good short names to prefer: `pid`, `cfg`, `err`, `opts`, `dir`, `root`, `child`, `state`, `timeout`.
+- Examples to avoid unless truly required: `inputPID`, `existingClient`, `connectTimeout`, `workerPath`.
 
 ### Avoid else statements
 


### PR DESCRIPTION
## Context

A section was inserted in the middle of another section in `AGENTS.md`. This is a very simple change to fix that.

## Implementation

Just moved the relevant part.