### PR TITLE
fix: honor KILO_API_URL for remaining hardcoded gateway endpoints

### DIFF
--- a/.changeset/local-backend-url-overrides.md
+++ b/.changeset/local-backend-url-overrides.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Honor `KILO_API_URL` for codebase search proxy, GitHub app installation check, OIDC default, and marketplace fetcher so the local-backend launch profile reaches every Kilo gateway request.

--- a/packages/kilo-vscode/src/services/marketplace/api.ts
+++ b/packages/kilo-vscode/src/services/marketplace/api.ts
@@ -1,7 +1,8 @@
 import { parse as parseYaml } from "yaml"
 import type { MarketplaceItem, McpMarketplaceItem, ModeMarketplaceItem, SkillMarketplaceItem, RawSkill } from "./types"
 
-const BASE_URL = "https://api.kilo.ai/api/marketplace"
+const API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai"
+const BASE_URL = `${API_BASE}/api/marketplace`
 const CACHE_TTL = 300_000
 const MAX_RETRIES = 3
 const TIMEOUT = 10_000

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -34,6 +34,7 @@ import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { Effect } from "effect"
+import { KILO_API_BASE } from "@kilocode/kilo-gateway" // kilocode_change - honor KILO_API_URL
 
 type GitHubAuthor = {
   login: string
@@ -365,8 +366,8 @@ export const GithubInstallCommand = cmd({
             s.stop("Installed GitHub app")
 
             async function getInstallation() {
-              // kilocode_change start - updated to new endpoint
-              return await fetch(`https://api.kilo.ai/api/integrations/github/check-installation?owner=${app.owner}`)
+              // kilocode_change start - updated to new endpoint, honor KILO_API_URL
+              return await fetch(`${KILO_API_BASE}/api/integrations/github/check-installation?owner=${app.owner}`)
                 .then((res) => res.json())
                 .then((data) => data.installation)
               // kilocode_change end
@@ -752,7 +753,7 @@ export const GithubRunCommand = cmd({
 
       function normalizeOidcBaseUrl(): string {
         const value = process.env["OIDC_BASE_URL"]
-        if (!value) return "https://api.kilo.ai" // kilocode_change
+        if (!value) return KILO_API_BASE // kilocode_change - honor KILO_API_URL
         return value.replace(/\/+$/, "")
       }
 

--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { WarpGrepClient } from "@morphllm/morphsdk/tools/warp-grep/client" // kilocode_change
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
+import { KILO_API_BASE } from "@kilocode/kilo-gateway" // kilocode_change
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"
 import { TuiEvent } from "../cli/cmd/tui/event"
@@ -10,7 +11,7 @@ import DESCRIPTION from "./warpgrep.txt"
 // FREE_PERIOD_TODO: Remove KILO_WARPGREP_PROXY_URL constant and the proxy
 // fallback below. After the free period ends, require MORPH_API_KEY and
 // return an error when it is missing.
-const KILO_WARPGREP_PROXY_URL = "https://api.kilo.ai/api/gateway"
+const KILO_WARPGREP_PROXY_URL = `${KILO_API_BASE}/api/gateway` // kilocode_change - honor KILO_API_URL
 
 const Parameters = Schema.Struct({
   query: Schema.String.annotate({


### PR DESCRIPTION
## Summary

Make the `KILO_API_URL` env var (and the existing `VSCode - Run Extension (Local Backend)` launch profile) actually point **all** Kilo gateway traffic at a local backend. Today most calls go through the centralized `KILO_API_BASE` constant, but four call sites still hardcoded `https://api.kilo.ai` and bypassed the override:

- `packages/opencode/src/tool/warpgrep.ts` — `codebase_search` proxy fallback
- `packages/opencode/src/cli/cmd/github.ts` — GitHub app installation check
- `packages/opencode/src/cli/cmd/github.ts` — `OIDC_BASE_URL` default
- `packages/kilo-vscode/src/services/marketplace/api.ts` — marketplace fetcher (extension-direct, doesn't go via `kilo serve`)

After this change, setting `KILO_API_URL=http://localhost:3000` (or running the existing launch profile) covers chat completions, FIM, balance, profile, notifications, model listing, embeddings, device-auth, GitHub install, codebase search, and marketplace.

## Why not a `kilo.jsonc` field

That was considered but skipped here. `KILO_API_BASE` is captured at module-load time in `packages/kilo-gateway/src/api/constants.ts`, so a config-driven override would need either a synchronous early config read in the CLI bootstrap or converting the constant to a getter across every interpolation site — both materially larger and touch shared upstream code. The env-var path already works end-to-end and is documented in `CONTRIBUTING.md` and `.vscode/launch.json`. Happy to do the config-field follow-up in a separate PR if desired.

## Testing

- `bun run typecheck` (opencode + kilo-vscode)
- `bun run lint` (kilo-vscode)
- Manually verified the env var still flows from the launch profile into `process.env` for both the spawned `kilo serve` and the extension renderer.
