### PR TITLE
chore: reduce upstream merge conflicts

### DIFF
--- a/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
+++ b/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
@@ -23,6 +23,7 @@
 - Marked the recurring Kilo-owned workflow conflicts as `keepOurs` in `script/upstream/utils/config.ts`.
 - Marked `.opencode/opencode.jsonc` as `keepOurs`; it points at the Kilo schema and includes Kilo provider defaults.
 - Auto-resolved `.opencode-version` by accepting the transformed upstream branch version, which is written by the merge script immediately before merging.
+- Made `merge.ts` pull the explicit base branch from origin, so retrying from an untracked audit branch does not fail at branch setup.
 
 ## Expected Effect
 

--- a/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
+++ b/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
@@ -1,0 +1,41 @@
+# Upstream Conflict Audit v1.15.5
+
+## Target
+
+- Base branch: `main` at `54d98857`
+- Current recorded upstream: `v1.14.33`
+- Target upstream: `v1.15.5` at `d7a6e1da`
+- Analysis command: `bun run script/upstream/analyze.ts --version v1.15.5 --output /var/folders/dz/q66gh6gs1jbc15k738ynwvf00000gn/T/kilo/upstream-conflicts-before-v1.15.5.md`
+- Merge command: `bun run script/upstream/merge.ts --version v1.15.5 --no-push`
+
+## Before
+
+- Upstream changed files: 1907
+- Initial merge conflicts before post-processing: 164
+- Rerere auto-resolved conflicts: 136
+- Keep-ours auto-resolved conflicts: 10
+- Mergiraf fully resolved conflicts: 26
+- Mergiraf partially resolved files: 99
+- Remaining manual conflicts after automation: 124
+
+## Low-Risk Improvements Applied
+
+- Marked the recurring Kilo-owned workflow conflicts as `keepOurs` in `script/upstream/utils/config.ts`.
+- Marked `.opencode/opencode.jsonc` as `keepOurs`; it points at the Kilo schema and includes Kilo provider defaults.
+- Auto-resolved `.opencode-version` by accepting the transformed upstream branch version, which is written by the merge script immediately before merging.
+
+## Expected Effect
+
+- The exact v1.15.5 retry should remove these manual conflicts from the final list: `.github/workflows/beta.yml`, `.github/workflows/close-issues.yml`, `.github/workflows/containers.yml`, `.github/workflows/disabled/daily-issues-recap.yml.disabled`, `.github/workflows/disabled/daily-pr-recap.yml.disabled`, `.github/workflows/duplicate-issues.yml`, `.github/workflows/generate.yml`, `.github/workflows/nix-hashes.yml`, `.github/workflows/test.yml`, `.github/workflows/triage.yml`, `.github/workflows/typecheck.yml`, `.opencode/opencode.jsonc`, and `.opencode-version`.
+- Expected manual conflict reduction: 124 to 111 if no additional rerere or mergiraf behavior changes.
+
+## Deferred Suggestions
+
+- Keep `bunfig.toml` manual for now because Kilo and upstream changed different dependency-age and exclusion policies that need semantic review.
+- Keep `.gitignore`, `flake.nix`, `packages/core/**`, `packages/opencode/src/**`, and tests manual because those are shared-code or behavior-bearing conflicts.
+- Consider a future workflow policy that treats all existing Kilo workflow files as keep-ours while continuing to skip upstream-only workflows through `skipFiles` and `script/check-workflows.ts`.
+- Consider moving Kilo-specific test expectations from shared upstream tests into `packages/opencode/test/kilocode/**` where the behavior is purely Kilo-owned.
+
+## Retry Result
+
+- Pending.

--- a/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
+++ b/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
@@ -23,7 +23,7 @@
 - Marked the recurring Kilo-owned workflow conflicts as `keepOurs` in `script/upstream/utils/config.ts`.
 - Marked `.opencode/opencode.jsonc` as `keepOurs`; it points at the Kilo schema and includes Kilo provider defaults.
 - Auto-resolved `.opencode-version` by accepting the transformed upstream branch version, which is written by the merge script immediately before merging.
-- Made `merge.ts` pull the explicit base branch from origin, so retrying from an untracked audit branch does not fail at branch setup.
+- Made `merge.ts` pull the explicit base branch from origin when it exists, while allowing local-only audit branches to be used as merge bases.
 
 ## Expected Effect
 

--- a/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
+++ b/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
@@ -42,4 +42,6 @@
 - First retry reached 115 remaining manual conflicts, down from 124.
 - The retry exposed a shadowing bug that prevented `.opencode-version` from auto-resolving; fixed by keeping the imported repository-relative `versionFile` constant distinct from the absolute path returned by `writeVersion`.
 - The retry also hit a transient `.git/index.lock` while staging three keep-ours files, leaving `.github/workflows/nix-hashes.yml`, `.github/workflows/publish.yml`, and `packages/opencode/AGENTS.md` unresolved in that run.
-- Expected clean retry result after the shadowing fix and without the transient lock: 111 remaining manual conflicts.
+- Final retry reached 111 remaining manual conflicts, down from 124.
+- Final retry auto-resolved 22 keep-ours conflicts and `.opencode-version`.
+- Mergiraf fully resolved 26 conflicts, partially resolved 90 files, and skipped 22 non-textual conflicts.

--- a/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
+++ b/script/upstream/UPSTREAM_CONFLICT_AUDIT_1.15.5.md
@@ -39,4 +39,7 @@
 
 ## Retry Result
 
-- Pending.
+- First retry reached 115 remaining manual conflicts, down from 124.
+- The retry exposed a shadowing bug that prevented `.opencode-version` from auto-resolving; fixed by keeping the imported repository-relative `versionFile` constant distinct from the absolute path returned by `writeVersion`.
+- The retry also hit a transient `.git/index.lock` while staging three keep-ours files, leaving `.github/workflows/nix-hashes.yml`, `.github/workflows/publish.yml`, and `packages/opencode/AGENTS.md` unresolved in that run.
+- Expected clean retry result after the shadowing fix and without the transient lock: 111 remaining manual conflicts.

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -398,7 +398,12 @@ async function main() {
 
   // Create backup branch
   await git.checkout(config.baseBranch)
-  await git.pull(config.originRemote, config.baseBranch)
+  const remote = await $`git ls-remote --exit-code --heads ${config.originRemote} ${config.baseBranch}`.quiet().nothrow()
+  if (remote.exitCode === 0) {
+    await git.pull(config.originRemote, config.baseBranch)
+  } else {
+    logger.warn(`Remote branch ${config.originRemote}/${config.baseBranch} not found; using local base branch as-is`)
+  }
   const baseSha = await git.getCommitHash("HEAD")
   const backupBranch = await createBackupBranch(config.baseBranch)
   logger.info(`Created backup branch: ${backupBranch}`)

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -42,7 +42,7 @@ import { transformConflictedScripts, transformAllScripts } from "./transforms/tr
 import { transformConflictedExtensions, transformAllExtensions } from "./transforms/transform-extensions"
 import { transformConflictedWeb, transformAllWeb } from "./transforms/transform-web"
 import { resolveLockFileConflicts, regenerateLockFiles } from "./transforms/lock-files"
-import { writeVersion } from "./utils/upstream"
+import { versionFile, writeVersion } from "./utils/upstream"
 
 interface MergeOptions {
   version?: string
@@ -578,6 +578,13 @@ async function main() {
     const autoResolved = resolved.filter((r) => r.action === "kept")
     if (autoResolved.length > 0) {
       logger.success(`Auto-resolved ${autoResolved.length} conflicts (kept Kilo's version)`)
+    }
+
+    const versionConflicted = (await git.getConflictedFiles()).includes(versionFile)
+    if (versionConflicted) {
+      await git.checkoutTheirs([versionFile])
+      await git.stageFiles([versionFile])
+      logger.success(`Auto-resolved ${versionFile} conflict (accepted recorded upstream tag)`)
     }
 
     // Step 7c: Try to auto-resolve remaining conflicts with post-merge transforms

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -398,7 +398,7 @@ async function main() {
 
   // Create backup branch
   await git.checkout(config.baseBranch)
-  await git.pull(config.originRemote)
+  await git.pull(config.originRemote, config.baseBranch)
   const baseSha = await git.getCommitHash("HEAD")
   const backupBranch = await createBackupBranch(config.baseBranch)
   logger.info(`Created backup branch: ${backupBranch}`)

--- a/script/upstream/merge.ts
+++ b/script/upstream/merge.ts
@@ -520,8 +520,8 @@ async function main() {
 
   // 6k. Record the last merged upstream tag so future automation can find it
   // without walking ls-remote + isAncestor for every tag.
-  const versionFile = await writeVersion(targetVersion.tag)
-  logger.success(`Recorded ${targetVersion.tag} in ${versionFile.split("/").pop()}`)
+  const written = await writeVersion(targetVersion.tag)
+  logger.success(`Recorded ${targetVersion.tag} in ${written.split("/").pop()}`)
 
   // Clean untracked build artifacts from Kilo-specific directories.
   // These packages don't exist in upstream, so their .gitignore files are absent

--- a/script/upstream/utils/config.ts
+++ b/script/upstream/utils/config.ts
@@ -71,9 +71,22 @@ export const defaultConfig: MergeConfig = {
     "SECURITY.md",
     "AGENTS.md",
     // GitHub workflows - MANUAL REVIEW (can break CI/CD)
+    ".github/workflows/beta.yml",
+    ".github/workflows/close-issues.yml",
+    ".github/workflows/containers.yml",
+    ".github/workflows/disabled/daily-issues-recap.yml.disabled",
+    ".github/workflows/disabled/daily-pr-recap.yml.disabled",
+    ".github/workflows/duplicate-issues.yml",
+    ".github/workflows/generate.yml",
+    ".github/workflows/nix-hashes.yml",
     ".github/workflows/publish.yml",
     ".github/workflows/close-stale-prs.yml",
+    ".github/workflows/test.yml",
+    ".github/workflows/triage.yml",
+    ".github/workflows/typecheck.yml",
     ".github/pull_request_template.md",
+    // Kilo root agent config
+    ".opencode/opencode.jsonc",
     // Kilo-specific command files
     ".opencode/command/commit.md",
     // Kilo-specific publish scripts


### PR DESCRIPTION
## Summary
- Reduce the v1.15.5 upstream merge manual conflict set by treating recurring Kilo-owned workflow/config files as keep-ours.
- Auto-resolve `.opencode-version` after the merge script records the target upstream tag.
- Document the conflict audit and verified retry result: 124 remaining manual conflicts down to 111.

## Verification
- `bun test utils/config.test.ts utils/report.test.ts transforms/keep-ours.test.ts transforms/skip-files.test.ts` from `script/upstream/`
- `bun run script/check-md-table-padding.ts`
