### PR TITLE
ci: exclude jetbrains from root typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev-setup": "bun run --cwd packages/opencode --conditions=browser src/index.ts dev-setup",
     "dev:storybook": "bun --cwd packages/storybook storybook",
     "lint": "oxlint",
-    "typecheck": "bun turbo typecheck",
+    "typecheck": "bun turbo typecheck --filter=!@kilocode/kilo-jetbrains",
     "postinstall": "bun run --cwd packages/opencode fix-node-pty && bun run script/setup-git.ts",
     "prepare": "husky",
     "random": "echo 'Random script'",


### PR DESCRIPTION
Fixes #10396

Excludes `@kilocode/kilo-jetbrains` from the root `bun typecheck` so the OpenAPI client breakage tracked in #10395 doesn't block the rest of the monorepo. The plugin's gradle typecheck still runs as part of `test:ci` via Turbo's task graph.