### PR TITLE
fix(cli): enable image input for custom attachments

### DIFF
--- a/.changeset/custom-provider-image-input.md
+++ b/.changeset/custom-provider-image-input.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Send pasted images to custom OpenAI-compatible models when attachment support is enabled.

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1044,7 +1044,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
       input: {
         text: model.modalities?.input?.includes("text") ?? false,
         audio: model.modalities?.input?.includes("audio") ?? false,
-        image: model.modalities?.input?.includes("image") ?? false,
+        image: model.modalities?.input?.includes("image") ?? model.attachment ?? false, // kilocode_change - attachment implies image input for config-only vision models
         video: model.modalities?.input?.includes("video") ?? false,
         pdf: model.modalities?.input?.includes("pdf") ?? false,
       },
@@ -1245,7 +1245,13 @@ const layer: Layer.Layer<
                 input: {
                   text: model.modalities?.input?.includes("text") ?? existingModel?.capabilities.input.text ?? true,
                   audio: model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
-                  image: model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
+                  // kilocode_change start - attachment implies image input for config-only vision models
+                  image:
+                    model.modalities?.input?.includes("image") ??
+                    existingModel?.capabilities.input.image ??
+                    model.attachment ??
+                    false,
+                  // kilocode_change end
                   video: model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
                   pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,
                 },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1043,6 +1043,45 @@ test("model modalities default correctly", async () => {
   })
 })
 
+// kilocode_change start
+test("custom provider attachment enables image input without modalities", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://app.kilo.ai/config.json",
+          provider: {
+            "test-provider": {
+              name: "Test",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "vision-model": {
+                  name: "Vision Model",
+                  attachment: true,
+                  limit: { context: 8000, output: 2000 },
+                },
+              },
+              options: { apiKey: "test" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("test-provider")].models["vision-model"]
+      expect(model.capabilities.attachment).toBe(true)
+      expect(model.capabilities.input.image).toBe(true)
+    },
+  })
+})
+// kilocode_change end
+
 test("model with custom cost values", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
Fixes #10102.

Custom OpenAI-compatible models that set `attachment: true` now also advertise image input support when modalities are omitted, so pasted images are sent instead of being replaced with an unsupported-input message.

Verification: targeted provider regression test and `packages/opencode` typecheck were run before the no-local-compile constraint was added; further validation should run in GitHub CI.