### PR TITLE
fix(cli): skip cerebras reasoning replay

### DIFF
--- a/.changeset/cerebras-reasoning-history.md
+++ b/.changeset/cerebras-reasoning-history.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Avoid sending replayed reasoning content to Cerebras models that reject it.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -221,11 +221,11 @@ function normalizeMessages(
     })
   }
 
-  if (
-    typeof model.capabilities.interleaved === "object" &&
-    model.capabilities.interleaved.field &&
-    model.api.npm !== "@openrouter/ai-sdk-provider"
-  ) {
+  // kilocode_change start - Cerebras rejects replayed reasoning_content fields in assistant history.
+  const replay = model.api.npm !== "@openrouter/ai-sdk-provider" && model.api.npm !== "@ai-sdk/cerebras"
+  // kilocode_change end
+
+  if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field && replay) { // kilocode_change
     const field = model.capabilities.interleaved.field
     return msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1067,6 +1067,61 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
   })
 
+  // kilocode_change start
+  test("Cerebras leaves reasoning parts out of openai-compatible provider options", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Cerebras should not receive this as reasoning_content." },
+          { type: "text", text: "Answer" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(
+      msgs,
+      {
+        id: ModelID.make("cerebras/zai-glm-4.7"),
+        providerID: ProviderID.make("cerebras"),
+        api: {
+          id: "zai-glm-4.7",
+          url: "https://api.cerebras.ai/v1",
+          npm: "@ai-sdk/cerebras",
+        },
+        name: "Z.AI GLM 4.7",
+        capabilities: {
+          temperature: true,
+          reasoning: true,
+          attachment: false,
+          toolcall: true,
+          input: { text: true, audio: false, image: false, video: false, pdf: false },
+          output: { text: true, audio: false, image: false, video: false, pdf: false },
+          interleaved: {
+            field: "reasoning_content",
+          },
+        },
+        cost: {
+          input: 0.001,
+          output: 0.002,
+          cache: { read: 0.0001, write: 0.0002 },
+        },
+        limit: {
+          context: 128000,
+          output: 8192,
+        },
+        status: "active",
+        options: {},
+        headers: {},
+        release_date: "2026-05-01",
+      },
+      {},
+    )
+
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+  // kilocode_change end
+
   test("Non-DeepSeek providers leave reasoning content unchanged", () => {
     const msgs = [
       {


### PR DESCRIPTION
Fixes #10375.

Cerebras models no longer receive replayed `reasoning_content` in assistant history, avoiding the unsupported-field 400 while preserving the existing replay behavior for OpenAI-compatible reasoning models that require it.

Verification: lightweight diff/annotation checks only; local compile/typecheck/build intentionally not run per no-local-OOM constraint. GitHub CI should perform full validation.