### PR TITLE
fix(cli): prefer kilo plugin config paths

### DIFF
--- a/.changeset/kilo-plugin-config-paths.md
+++ b/.changeset/kilo-plugin-config-paths.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prefer Kilo-named config files when installing plugins with `kilo plugin`.

--- a/packages/kilo-docs/pages/automate/extending/plugins.md
+++ b/packages/kilo-docs/pages/automate/extending/plugins.md
@@ -86,7 +86,7 @@ kilo plugin my-plugin --global
 kilo plugin my-plugin --force
 ```
 
-The command resolves the package, reads its `package.json` for plugin entrypoints, and writes the entry into the appropriate config file (currently `.opencode/opencode.jsonc` / `.opencode/tui.jsonc` for local installs, or `~/.config/kilo/opencode.jsonc` / `~/.config/kilo/tui.jsonc` for `--global`) while preserving JSONC comments.
+The command resolves the package, reads its `package.json` for plugin entrypoints, and writes the entry into the appropriate config file while preserving JSONC comments. It prefers existing Kilo config paths (`kilo.jsonc`, `.kilo/kilo.jsonc`, and `.kilo/tui.jsonc`) and falls back to the upstream-compatible `.opencode/opencode.jsonc` / `.opencode/tui.jsonc` paths when no Kilo config is present.
 
 ### How plugins are installed
 

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -28,7 +28,7 @@ export type PlugDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode" | "tui") => string[]
+  files: (dir: string, name: "kilo" | "opencode" | "tui") => string[] // kilocode_change
   global: string
 }
 

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -17,6 +17,7 @@ import { parsePluginSpecifier, readPackageThemes, readPluginPackage, resolvePlug
 
 type Mode = "noop" | "add" | "replace"
 type Kind = "server" | "tui"
+type ConfigName = "kilo" | "opencode" | "tui" // kilocode_change
 
 export type Target = {
   kind: Kind
@@ -31,7 +32,7 @@ export type PatchDeps = {
   readText: (file: string) => Promise<string>
   write: (file: string, text: string) => Promise<void>
   exists: (file: string) => Promise<boolean>
-  files: (dir: string, name: "opencode" | "tui") => string[]
+  files: (dir: string, name: ConfigName) => string[] // kilocode_change
 }
 
 export type PatchInput = {
@@ -330,20 +331,73 @@ export async function readPluginManifest(target: string): Promise<ManifestResult
   }
 }
 
-function patchDir(input: PatchInput) {
+// kilocode_change start - split plugin config root selection from Kilo/OpenCode config filename selection.
+function patchRoot(input: PatchInput) {
   if (input.global) return input.config ?? Global.Path.config
   const git = input.vcs === "git" && input.worktree !== "/"
-  const root = git ? input.worktree : input.directory
-  return path.join(root, ".opencode")
+  return git ? input.worktree : input.directory
 }
 
-function patchName(kind: Kind): "opencode" | "tui" {
+function patchName(kind: Kind): ConfigName {
   if (kind === "server") return "opencode"
   return "tui"
 }
 
-async function patchOne(dir: string, target: Target, spec: string, force: boolean, dep: PatchDeps): Promise<PatchOne> {
-  const name = patchName(target.kind)
+function kiloName(kind: Kind): ConfigName {
+  if (kind === "server") return "kilo"
+  return "tui"
+}
+
+async function existingFile(dir: string, name: ConfigName, dep: PatchDeps) {
+  for (const file of dep.files(dir, name)) {
+    if (await dep.exists(file)) return { dir, name }
+  }
+}
+
+async function hasKiloConfig(dir: string, dep: PatchDeps) {
+  return Boolean((await existingFile(dir, "kilo", dep)) ?? (await existingFile(dir, "tui", dep)))
+}
+
+async function patchLocation(input: PatchInput, target: Target, dep: PatchDeps) {
+  const root = patchRoot(input)
+  const legacy = patchName(target.kind)
+  const kilo = kiloName(target.kind)
+
+  if (input.global) {
+    if (await hasKiloConfig(root, dep)) return (await existingFile(root, kilo, dep)) ?? { dir: root, name: kilo }
+    const existing = await existingFile(root, legacy, dep)
+    if (existing) return existing
+    return { dir: root, name: legacy }
+  }
+
+  if (await hasKiloConfig(root, dep)) return (await existingFile(root, kilo, dep)) ?? { dir: root, name: kilo }
+
+  const rootKilo = await existingFile(root, kilo, dep)
+  if (rootKilo) return rootKilo
+
+  const kiloDir = path.join(root, ".kilo")
+  if (await dep.exists(kiloDir)) {
+    return (await existingFile(kiloDir, kilo, dep)) ?? (await existingFile(kiloDir, legacy, dep)) ?? { dir: kiloDir, name: kilo }
+  }
+
+  const rootLegacy = await existingFile(root, legacy, dep)
+  if (rootLegacy) return rootLegacy
+
+  const legacyDir = path.join(root, ".opencode")
+  return (await existingFile(legacyDir, legacy, dep)) ?? { dir: legacyDir, name: legacy }
+}
+// kilocode_change end
+
+// kilocode_change start - pass the selected Kilo/OpenCode config filename into each patch operation.
+async function patchOne(
+  dir: string,
+  name: ConfigName,
+  target: Target,
+  spec: string,
+  force: boolean,
+  dep: PatchDeps,
+): Promise<PatchOne> {
+// kilocode_change end
   await using _ = await Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, name))}`)
 
   const files = dep.files(dir, name)
@@ -419,10 +473,12 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
 }
 
 export async function patchPluginConfig(input: PatchInput, dep: PatchDeps = defaultPatchDeps): Promise<PatchResult> {
-  const dir = patchDir(input)
   const items: PatchItem[] = []
+  let dir = patchRoot(input) // kilocode_change
   for (const target of input.targets) {
-    const hit = await patchOne(dir, target, input.spec, Boolean(input.force), dep)
+    const location = await patchLocation(input, target, dep) // kilocode_change
+    dir = location.dir // kilocode_change
+    const hit = await patchOne(location.dir, location.name, target, input.spec, Boolean(input.force), dep) // kilocode_change
     if (!hit.ok) {
       return {
         ...hit,

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -128,6 +128,49 @@ describe("plugin.install.task", () => {
     expect(tui.plugin).toEqual(["acme@1.2.3"])
   })
 
+  // kilocode_change start
+  test("writes server plugins to existing root kilo config", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["server"])
+    const cfg = path.join(tmp.path, "kilo.jsonc")
+    await Bun.write(cfg, JSON.stringify({ plugin: ["seed@1.0.0"] }, null, 2))
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      deps(path.join(tmp.path, "global"), target),
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+
+    const server = await read(cfg)
+    expect(server.plugin).toEqual(["seed@1.0.0", "acme@1.2.3"])
+    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+  })
+
+  test("writes local plugin config under .kilo when the project uses that directory", async () => {
+    await using tmp = await tmpdir()
+    const target = await plugin(tmp.path, ["server", "tui"])
+    await fs.mkdir(path.join(tmp.path, ".kilo"), { recursive: true })
+    const run = createPlugTask(
+      {
+        mod: "acme@1.2.3",
+      },
+      deps(path.join(tmp.path, "global"), target),
+    )
+
+    const ok = await run(ctx(tmp.path))
+    expect(ok).toBe(true)
+
+    const server = await read(path.join(tmp.path, ".kilo", "kilo.jsonc"))
+    const tui = await read(path.join(tmp.path, ".kilo", "tui.jsonc"))
+    expect(server.plugin).toEqual(["acme@1.2.3"])
+    expect(tui.plugin).toEqual(["acme@1.2.3"])
+    expect(await Filesystem.exists(path.join(tmp.path, ".opencode", "opencode.jsonc"))).toBe(false)
+  })
+  // kilocode_change end
+
   test("writes default options from exports config metadata", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"], {


### PR DESCRIPTION
Fixes #9503.

`kilo plugin` now writes into existing Kilo-named config paths such as `kilo.jsonc` or `.kilo/kilo.jsonc` / `.kilo/tui.jsonc`, while preserving the existing `.opencode` fallback for upstream-style projects.

Verification: lightweight diff and annotation checks only; local compile/typecheck/build intentionally not run per no-local-OOM constraint. GitHub CI should perform full validation.