### PR TITLE
fix(cli): use readable plan filenames

### DIFF
--- a/.changeset/readable-plan-filenames.md
+++ b/.changeset/readable-plan-filenames.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use readable title-based names for new plan files while preserving existing plan file paths.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -6,7 +6,7 @@ import { Cause, Effect, Exit } from "effect"
 import { SessionID, PartID } from "@/session/schema"
 import { MessageV2 } from "@/session/message-v2"
 import { Session } from "@/session/session"
-import { Instance } from "@/project/instance"
+import { Instance, type InstanceContext } from "@/project/instance"
 import type { SessionStatus } from "@/session/status"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { PlanFollowup } from "@/kilocode/plan-followup"
@@ -120,6 +120,26 @@ export namespace KiloSessionPrompt {
     return input.agent.permission
   }
 
+  function userMessageTitle(userMessage: MessageV2.WithParts) {
+    return userMessage.parts
+      .filter((part): part is MessageV2.TextPart => part.type === "text" && !("synthetic" in part && part.synthetic))
+      .map((part) => part.text.trim())
+      .find(Boolean)
+  }
+
+  export function planPath(input: {
+    session: Session.Info
+    userMessage?: MessageV2.WithParts
+    instance: InstanceContext
+  }) {
+    const title = !Session.isDefaultTitle(input.session.title)
+      ? input.session.title
+      : input.userMessage
+        ? userMessageTitle(input.userMessage)
+        : undefined
+    return Session.plan({ ...input.session, title }, input.instance)
+  }
+
   /**
    * Mutable cache for environment details, keyed by user message ID
    * so it recomputes when a new user message arrives.
@@ -212,7 +232,7 @@ export namespace KiloSessionPrompt {
     userMessage: MessageV2.WithParts
   }) {
     if (input.agent.name !== "plan") return
-    const plan = Session.plan(input.session, Instance.current)
+    const plan = planPath({ session: input.session, userMessage: input.userMessage, instance: Instance.current })
     const exists = await Filesystem.exists(plan)
     if (!exists) await ensurePlanDir(path.dirname(plan))
     const info = exists

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -270,7 +270,7 @@ export const layer = Layer.effect(
       const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
       if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
         const ctx = yield* InstanceState.context
-        const plan = Session.plan(input.session, ctx)
+        const plan = KiloSessionPrompt.planPath({ session: input.session, userMessage, instance: ctx }) // kilocode_change
         if (!(yield* fsys.existsSafe(plan))) return input.messages
         const part = yield* sessions.updatePart({
           id: PartID.ascending(),
@@ -287,7 +287,7 @@ export const layer = Layer.effect(
       if (input.agent.name !== "plan" || assistantMessage?.info.agent === "plan") return input.messages
 
       const ctx = yield* InstanceState.context
-      const plan = Session.plan(input.session, ctx)
+      const plan = KiloSessionPrompt.planPath({ session: input.session, userMessage, instance: ctx }) // kilocode_change
       const exists = yield* fsys.existsSafe(plan)
       if (!exists) yield* fsys.ensureDir(path.dirname(plan)).pipe(Effect.catch(Effect.die))
       const part = yield* sessions.updatePart({

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1,5 +1,6 @@
 import { Slug } from "@opencode-ai/core/util/slug"
 import path from "path"
+import { readdirSync } from "fs" // kilocode_change
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { Decimal } from "decimal.js"
@@ -325,12 +326,43 @@ export const Event = {
   // kilocode_change end
 }
 
-export function plan(input: { slug: string; time: { created: number } }, instance: InstanceContext) {
+// kilocode_change start - prefer readable plan filenames while preserving existing paths
+function planFilenameSlug(input: { slug: string; title?: string }) {
+  if (!input.title || isDefaultTitle(input.title)) return input.slug
+  const value = input.title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+    .slice(0, 80)
+    .replace(/-+$/, "")
+  return value || input.slug
+}
+
+function existingPlanFile(base: string, created: number, preferred: string) {
+  try {
+    const prefix = `${created}-`
+    const matches = readdirSync(base, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.startsWith(prefix) && entry.name.endsWith(".md"))
+      .map((entry) => entry.name)
+      .sort()
+    if (matches.includes(preferred)) return path.join(base, preferred)
+    const existing = matches[0]
+    return existing ? path.join(base, existing) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function plan(input: { slug: string; title?: string; time: { created: number } }, instance: InstanceContext) {
   const base = instance.project.vcs
     ? path.join(instance.worktree, ".kilo", "plans") // kilocode_change
     : path.join(Global.Path.data, "plans")
-  return path.join(base, [input.time.created, input.slug].join("-") + ".md")
+  const filename = [input.time.created, planFilenameSlug(input)].join("-") + ".md"
+  return existingPlanFile(base, input.time.created, filename) ?? path.join(base, filename)
 }
+// kilocode_change end
 
 export const getUsage = (input: {
   model: Provider.Model

--- a/packages/opencode/test/kilocode/session/session.test.ts
+++ b/packages/opencode/test/kilocode/session/session.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { Session as SessionNs } from "@/session/session"
+import { KiloSessionPrompt } from "@/kilocode/session/prompt"
+import type { MessageV2 } from "@/session/message-v2"
 import { Bus } from "../../../src/bus"
 import * as Log from "@opencode-ai/core/util/log"
 import { Instance } from "../../../src/project/instance"
@@ -83,6 +86,91 @@ describe("session.created event", () => {
 })
 
 describe("Session", () => {
+  test("plan filename uses a safe slug from the session title", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const plan = await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        SessionNs.plan(
+          {
+            slug: "quiet-otter",
+            title: "Fix OAuth callback: Windows/WSL path?",
+            time: { created: 1234567890 },
+          },
+          Instance.current,
+        ),
+    })
+
+    expect(plan).toBe(path.join(tmp.path, ".kilo", "plans", "1234567890-fix-oauth-callback-windows-wsl-path.md"))
+  })
+
+  test("plan filename falls back to session slug for default titles", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const plan = await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        SessionNs.plan(
+          {
+            slug: "quiet-otter",
+            title: "New session - 2026-05-19T12:34:56.789Z",
+            time: { created: 1234567890 },
+          },
+          Instance.current,
+        ),
+    })
+
+    expect(plan).toBe(path.join(tmp.path, ".kilo", "plans", "1234567890-quiet-otter.md"))
+  })
+
+  test("plan path uses the current user prompt while the session title is still default", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const plan = await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        KiloSessionPrompt.planPath({
+          session: {
+            slug: "quiet-otter",
+            title: "New session - 2026-05-19T12:34:56.789Z",
+            time: { created: 1234567890 },
+          } as SessionNs.Info,
+          userMessage: {
+            parts: [{ type: "text", text: "Create a release checklist for Windows installs" }],
+          } as MessageV2.WithParts,
+          instance: Instance.current,
+        }),
+    })
+
+    expect(plan).toBe(
+      path.join(tmp.path, ".kilo", "plans", "1234567890-create-a-release-checklist-for-windows-installs.md"),
+    )
+  })
+
+  test("plan filename reuses an existing file for the session timestamp", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = path.join(tmp.path, ".kilo", "plans")
+    const existing = path.join(dir, "1234567890-create-login-flow.md")
+    await fs.mkdir(dir, { recursive: true })
+    await Bun.write(existing, "Existing plan")
+
+    const plan = await Instance.provide({
+      directory: tmp.path,
+      fn: () =>
+        SessionNs.plan(
+          {
+            slug: "quiet-otter",
+            title: "Generated conversation title",
+            time: { created: 1234567890 },
+          },
+          Instance.current,
+        ),
+    })
+
+    expect(plan).toBe(existing)
+  })
+
   test("remove works without an instance", async () => {
     await using tmp = await tmpdir({ git: true })
 


### PR DESCRIPTION
Fixes #9584.

Plan files were named from the random session slug, which made `.kilo/plans` hard to scan. This PR uses a safe title-derived slug for plan filenames, while preserving the timestamp prefix for chronological order and reusing any existing plan file for the same session timestamp so title changes do not strand prior plan content.

Changes:
- Use readable title/user-prompt based plan filename slugs.
- Fall back to the existing random session slug for default or empty titles.
- Reuse an already-created plan file for the same session timestamp.
- Add focused coverage for title slugs, default-title fallback, prompt-based initial plan paths, and existing file reuse.

Verification:
- `git diff --cached --check`
- `bun run script/check-opencode-annotations.ts --base upstream/main`

Local compile/typecheck/build and broader tests were intentionally not run to avoid local OOM risk; GitHub CI should perform full validation.