### PR TITLE
fix(vscode): preserve legacy custom mode yaml

### DIFF
--- a/.changeset/legacy-custom-modes-yaml.md
+++ b/.changeset/legacy-custom-modes-yaml.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve multiline legacy custom mode instructions and restricted edit groups during migration.

--- a/packages/kilo-vscode/src/legacy-migration/migration-service.ts
+++ b/packages/kilo-vscode/src/legacy-migration/migration-service.ts
@@ -6,6 +6,7 @@
  */
 
 import * as vscode from "vscode"
+import { parse as parseYaml } from "yaml"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import type {
   McpLocalConfig,
@@ -844,6 +845,25 @@ const GROUP_TO_PERMISSION: Record<string, string> = {
 }
 const ALL_MODE_PERMISSIONS = ["read", "edit", "bash", "skill"]
 
+function fileRegexToGlobs(fileRegex: string): string[] {
+  const alternatives = fileRegex.match(/\\\.\((?:\?:)?([^()]+)\)\$$/)
+  if (alternatives) {
+    return alternatives[1]!
+      .split("|")
+      .filter((item) => /^[a-zA-Z0-9_-]+$/.test(item))
+      .map((ext) => `*.${ext}`)
+  }
+
+  const extension = fileRegex.match(/\\\.([a-zA-Z0-9_-]+)\$$/)
+  return extension ? [`*.${extension[1]}`] : []
+}
+
+function fileRegexPermission(fileRegex: string): PermissionObjectConfig {
+  const globs = fileRegexToGlobs(fileRegex)
+  const patterns = globs.length > 0 ? globs : [fileRegex]
+  return Object.fromEntries([["*", "deny"], ...patterns.map((pattern) => [pattern, "allow"])]) as PermissionObjectConfig
+}
+
 function convertCustomModePermissions(groups: LegacyCustomMode["groups"]): PermissionConfig {
   const permission: Record<string, unknown> = {}
   const allowed = new Set<string>()
@@ -854,7 +874,7 @@ function convertCustomModePermissions(groups: LegacyCustomMode["groups"]): Permi
     const permKey = GROUP_TO_PERMISSION[groupName] ?? groupName
     allowed.add(permKey)
 
-    const newValue = groupConfig?.fileRegex ? { [groupConfig.fileRegex]: "allow", "*": "deny" } : "allow"
+    const newValue = groupConfig?.fileRegex ? fileRegexPermission(groupConfig.fileRegex) : "allow"
 
     // Multiple legacy groups can map to the same permission key (browser + command → bash).
     // Merge rules so neither overwrites the other:
@@ -882,7 +902,8 @@ function convertCustomModePermissions(groups: LegacyCustomMode["groups"]): Permi
   return permission as PermissionConfig
 }
 
-function convertCustomMode(mode: LegacyCustomMode): AgentConfig {
+/** @internal - exported for testing only */
+export function convertCustomMode(mode: LegacyCustomMode): AgentConfig {
   const parts = [mode.roleDefinition]
   if (mode.customInstructions?.trim()) {
     parts.push(
@@ -897,7 +918,7 @@ function convertCustomMode(mode: LegacyCustomMode): AgentConfig {
   }
   return {
     mode: "primary",
-    description: mode.description ?? mode.whenToUse ?? mode.roleDefinition?.slice(0, 120),
+    description: mode.description ?? mode.whenToUse ?? mode.name,
     prompt: parts.filter(Boolean).join("\n\n"),
     permission: convertCustomModePermissions(mode.groups),
   }
@@ -1026,17 +1047,29 @@ function stripYamlQuotes(value: string): string {
   return value.replace(/^(['"])(.*)\1$/, "$2")
 }
 
-function parseCustomModesYaml(text: string): LegacyCustomMode[] | null {
+/** @internal - exported for testing only */
+export function parseCustomModesYaml(text: string): LegacyCustomMode[] | null {
   // Try JSON first
   const jsonResult = (() => {
     try {
-      const parsed = JSON.parse(text) as { customModes?: LegacyCustomMode[] }
-      return parsed.customModes ?? null
+      const parsed = JSON.parse(text) as LegacyCustomMode[] | { customModes?: LegacyCustomMode[] }
+      return Array.isArray(parsed) ? parsed : (parsed.customModes ?? null)
     } catch {
       return null
     }
   })()
   if (jsonResult) return jsonResult
+
+  const yamlResult = (() => {
+    try {
+      const parsed = parseYaml(text) as LegacyCustomMode[] | { customModes?: LegacyCustomMode[] } | null
+      if (Array.isArray(parsed)) return parsed
+      return parsed?.customModes ?? null
+    } catch {
+      return null
+    }
+  })()
+  if (yamlResult) return yamlResult
 
   // Parse the simple YAML shape:
   //   customModes:

--- a/packages/kilo-vscode/tests/unit/legacy-migration/native-modes.test.ts
+++ b/packages/kilo-vscode/tests/unit/legacy-migration/native-modes.test.ts
@@ -1,11 +1,68 @@
 import { describe, expect, it } from "bun:test"
 import {
   buildCustomModeList,
+  convertCustomMode,
   isNativeModeModified,
   buildMergedNativeMode,
+  parseCustomModesYaml,
 } from "../../../src/legacy-migration/migration-service"
 import { NATIVE_MODE_DEFAULTS } from "../../../src/legacy-migration/native-mode-defaults"
 import type { LegacyCustomMode, LegacyPromptComponent } from "../../../src/legacy-migration/legacy-types"
+
+// ---------------------------------------------------------------------------
+// legacy custom_modes.yaml parsing and conversion
+// ---------------------------------------------------------------------------
+
+describe("legacy custom mode YAML migration", () => {
+  it("preserves multiline custom instructions and restricted edit groups", () => {
+    const modes = parseCustomModesYaml(`- slug: my-mode
+  name: My Mode
+  roleDefinition: One-sentence role definition for this mode that is long enough to be visibly truncated when copied into the description field.
+  customInstructions: |-
+    First line of instructions.
+
+    ### Section A
+    - bullet a1
+    - bullet a2
+
+    ### Section B
+    - bullet b1
+    - bullet b2
+  groups:
+    - read
+    - - edit
+      - fileRegex: \\.(md|tex)$
+        description: Markdown and LaTeX files only
+    - browser
+    - mcp
+    - command
+  source: global
+`)
+
+    expect(modes).toHaveLength(1)
+    const mode = modes![0]!
+    expect(mode.customInstructions).toContain("### Section A")
+    expect(mode.customInstructions).toContain("### Section B")
+    expect(mode.groups[1]).toEqual([
+      "edit",
+      { fileRegex: "\\.(md|tex)$", description: "Markdown and LaTeX files only" },
+    ])
+
+    const agent = convertCustomMode(mode)
+    expect(agent.prompt).toContain("First line of instructions.")
+    expect(agent.prompt).toContain("### Section A")
+    expect(agent.prompt).toContain("### Section B")
+    expect(agent.description).toBe("My Mode")
+
+    const permission = agent.permission as Record<string, unknown>
+    expect(permission["- edit"]).toBeUndefined()
+    expect(permission.edit).toEqual({
+      "*": "deny",
+      "*.md": "allow",
+      "*.tex": "allow",
+    })
+  })
+})
 
 // ---------------------------------------------------------------------------
 // isNativeModeModified


### PR DESCRIPTION
Fixes #10171.

Legacy `custom_modes.yaml` migration used a limited hand parser, which truncated block-scalar `customInstructions` at blank lines and parsed nested `[edit, { fileRegex }]` groups incorrectly. This PR uses the existing `yaml` dependency for legacy custom mode parsing and keeps a fallback to the old simple parser.

Changes:
- Preserve multiline `customInstructions` block scalars during migration.
- Parse nested restricted edit groups instead of producing invalid `"- edit"` permission keys.
- Convert common extension regexes like `\.(md|tex)$` into effective wildcard edit rules.
- Use the mode name as the description fallback instead of truncating `roleDefinition`.
- Add focused coverage for the issue YAML shape.

Verification:
- `git diff --cached --check`
- `bun run script/check-opencode-annotations.ts --base upstream/main`

Local compile/typecheck/build and broader tests were intentionally not run to avoid local OOM risk; GitHub CI should perform full validation.