### PR TITLE
fix(vscode): add custom provider temperature toggle

### DIFF
--- a/.changeset/custom-provider-temperature.md
+++ b/.changeset/custom-provider-temperature.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add a model-level temperature toggle to custom provider configuration.

--- a/packages/kilo-vscode/src/shared/custom-provider.ts
+++ b/packages/kilo-vscode/src/shared/custom-provider.ts
@@ -44,6 +44,7 @@ export const CustomProviderConfigSchema = z
           .object({
             name: z.string().trim().min(1).max(200),
             reasoning: z.boolean().optional(),
+            temperature: z.boolean().optional(),
             variants: z.record(z.string().trim().min(1), VariantConfigSchema).optional(),
           })
           .strict(),
@@ -60,7 +61,7 @@ export type SanitizedProviderConfig = {
     baseURL: string
     headers?: Record<string, string>
   }
-  models: Record<string, { name: string; reasoning?: true; variants?: Record<string, VariantConfig> }>
+  models: Record<string, { name: string; reasoning?: true; temperature?: boolean; variants?: Record<string, VariantConfig> }>
 }
 
 export type CustomProviderAuthChange = { mode: "preserve" } | { mode: "clear" } | { mode: "set"; key: string }
@@ -131,6 +132,7 @@ export function normalizeCustomProviderConfig(
         {
           name: model.name.trim(),
           ...(model.reasoning ? { reasoning: true as const } : {}),
+          ...(model.temperature !== undefined ? { temperature: model.temperature } : {}),
           ...(model.variants && Object.keys(model.variants).length > 0 ? { variants: model.variants } : {}),
         },
       ]),

--- a/packages/kilo-vscode/tests/unit/custom-provider-dialog-validate.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider-dialog-validate.test.ts
@@ -11,7 +11,7 @@ function base(): FormState {
     name: "My Provider",
     baseURL: "https://example.com/v1",
     apiKey: "",
-    models: [{ id: "model-1", name: "Model One", reasoning: false, variants: [] }],
+    models: [{ id: "model-1", name: "Model One", reasoning: false, temperature: false, variants: [] }],
     headers: [],
     saving: false,
   }
@@ -154,5 +154,22 @@ describe("validateCustomProvider – variant name validation", () => {
     expect(out.result).toBeDefined()
     const saved = out.result!.config.models["model-1"] as Record<string, unknown>
     expect(saved.variants).toEqual({ eco: { enable_thinking: true, reasoningEffort: "low" } })
+  })
+
+  it("persists temperature in the saved config when enabled", () => {
+    const form = base()
+    form.models[0].temperature = true
+    const out = validateCustomProvider(args(form))
+    expect(out.result).toBeDefined()
+    const saved = out.result!.config.models["model-1"] as Record<string, unknown>
+    expect(saved.temperature).toBe(true)
+  })
+
+  it("persists temperature false in the saved config when disabled", () => {
+    const form = base()
+    const out = validateCustomProvider(args(form))
+    expect(out.result).toBeDefined()
+    const saved = out.result!.config.models["model-1"] as Record<string, unknown>
+    expect(saved.temperature).toBe(false)
   })
 })

--- a/packages/kilo-vscode/tests/unit/custom-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider.test.ts
@@ -131,6 +131,33 @@ describe("sanitizeCustomProviderConfig", () => {
     })
   })
 
+  it("accepts models with temperature enabled", () => {
+    const result = sanitizeCustomProviderConfig({
+      name: "Temperature Provider",
+      options: { baseURL: "https://example.com/v1" },
+      models: {
+        "model-1": {
+          name: "Model One",
+          temperature: true,
+        },
+      },
+    })
+
+    expect(result).toEqual({
+      value: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Temperature Provider",
+        options: { baseURL: "https://example.com/v1" },
+        models: {
+          "model-1": {
+            name: "Model One",
+            temperature: true,
+          },
+        },
+      },
+    })
+  })
+
   it("rejects unknown fields", () => {
     const result = sanitizeCustomProviderConfig({
       name: "Bad Provider",

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
@@ -65,11 +65,17 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
 
   function initModels(): ModelEntry[] {
     const cfg = props.existing?.config
-    if (!cfg?.models || typeof cfg.models !== "object") return [{ id: "", name: "", reasoning: false, variants: [] }]
+    if (!cfg?.models || typeof cfg.models !== "object")
+      return [{ id: "", name: "", reasoning: false, temperature: false, variants: [] }]
     const entries = Object.entries(cfg.models)
-    if (entries.length === 0) return [{ id: "", name: "", reasoning: false, variants: [] }]
+    if (entries.length === 0) return [{ id: "", name: "", reasoning: false, temperature: false, variants: [] }]
     return entries.map(([id, m]) => {
-      const raw = m as { name?: string; reasoning?: boolean; variants?: Record<string, Record<string, unknown>> }
+      const raw = m as {
+        name?: string
+        reasoning?: boolean
+        temperature?: boolean
+        variants?: Record<string, Record<string, unknown>>
+      }
       const variants: VariantEntry[] = Object.entries(raw?.variants ?? {}).map(([vname, vcfg]) => ({
         name: vname,
         enableThinking: typeof vcfg.enable_thinking === "boolean" ? (vcfg.enable_thinking as boolean) : undefined,
@@ -88,6 +94,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
         id,
         name: raw?.name ?? id,
         reasoning: raw?.reasoning ?? false,
+        temperature: raw?.temperature ?? false,
         variants,
       }
     })
@@ -292,7 +299,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     // Replace the single empty row or append
     const row = form.models[0]
     const empty = form.models.length === 1 && !!row && !row.id.trim() && !row.name.trim()
-    const defaults = (m: FetchedModel): ModelEntry => ({ ...m, reasoning: false, variants: [] })
+    const defaults = (m: FetchedModel): ModelEntry => ({ ...m, reasoning: false, temperature: false, variants: [] })
     const merged = empty ? picked.map(defaults) : [...form.models, ...picked.map(defaults)]
 
     setForm("models", merged)
@@ -321,7 +328,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
   }
 
   function addModel() {
-    setForm("models", (v) => [...v, { id: "", name: "", reasoning: false, variants: [] }])
+    setForm("models", (v) => [...v, { id: "", name: "", reasoning: false, temperature: false, variants: [] }])
     setErrors("models", (v) => [...v, { variants: [] }])
   }
 
@@ -536,6 +543,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
                   onChangeId={(v) => setForm("models", i(), "id", v)}
                   onChangeName={(v) => setForm("models", i(), "name", v)}
                   onChangeReasoning={(v) => setForm("models", i(), "reasoning", v)}
+                  onChangeTemperature={(v) => setForm("models", i(), "temperature", v)}
                   onRemove={() => removeModel(i())}
                   onAddVariant={() => addVariant(i())}
                   onRemoveVariant={(vi) => removeVariant(i(), vi)}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderModelCard.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderModelCard.tsx
@@ -25,6 +25,7 @@ export type ModelEntry = {
   id: string
   name: string
   reasoning: boolean
+  temperature: boolean
   variants: VariantEntry[]
 }
 
@@ -224,6 +225,7 @@ type ModelCardProps = {
   onChangeId: (val: string) => void
   onChangeName: (val: string) => void
   onChangeReasoning: (val: boolean) => void
+  onChangeTemperature: (val: boolean) => void
   onRemove: () => void
   onAddVariant: () => void
   onRemoveVariant: (vi: number) => void
@@ -279,24 +281,42 @@ export function ModelCard(props: ModelCardProps) {
         />
       </div>
 
-      {/* Reasoning toggle */}
-      <label
-        style={{
-          display: "flex",
-          "align-items": "center",
-          gap: "8px",
-          cursor: "pointer",
-          "font-size": "var(--kilo-font-size-13)",
-          color: "var(--vscode-foreground)",
-        }}
-      >
-        <input
-          type="checkbox"
-          checked={props.m.reasoning}
-          onChange={(e) => props.onChangeReasoning(e.currentTarget.checked)}
-        />
-        {props.t("provider.custom.models.reasoning.label")}
-      </label>
+      <div style={{ display: "flex", "flex-wrap": "wrap", gap: "12px" }}>
+        <label
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "8px",
+            cursor: "pointer",
+            "font-size": "var(--kilo-font-size-13)",
+            color: "var(--vscode-foreground)",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={props.m.reasoning}
+            onChange={(e) => props.onChangeReasoning(e.currentTarget.checked)}
+          />
+          {props.t("provider.custom.models.reasoning.label")}
+        </label>
+        <label
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "8px",
+            cursor: "pointer",
+            "font-size": "var(--kilo-font-size-13)",
+            color: "var(--vscode-foreground)",
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={props.m.temperature}
+            onChange={(e) => props.onChangeTemperature(e.currentTarget.checked)}
+          />
+          {props.t("provider.custom.models.temperature.label")}
+        </label>
+      </div>
 
       {/* Variants — only available when reasoning is enabled */}
       <Show when={props.m.reasoning}>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderValidation.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderValidation.ts
@@ -113,7 +113,7 @@ function serializeVariant(v: VariantEntry): [string, Record<string, unknown>] {
 
 function serializeModel(m: ModelEntry): [string, Record<string, unknown>] {
   const ventries = m.reasoning ? m.variants.filter((v) => v.name.trim()).map(serializeVariant) : []
-  const entry: Record<string, unknown> = { name: m.name.trim() }
+  const entry: Record<string, unknown> = { name: m.name.trim(), temperature: m.temperature }
   if (m.reasoning) entry.reasoning = true
   if (ventries.length > 0) entry.variants = Object.fromEntries(ventries)
   return [m.id.trim(), entry]

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -809,6 +809,7 @@ export const dict = {
   "provider.custom.models.name.label": "Name",
   "provider.custom.models.name.placeholder": "Display Name",
   "provider.custom.models.reasoning.label": "Reasoning",
+  "provider.custom.models.temperature.label": "Temperature",
   "provider.custom.models.variants.label": "Variants",
   "provider.custom.models.variants.add": "Add variant",
   "provider.custom.models.variants.remove": "Remove variant",


### PR DESCRIPTION
## Summary
- add a per-model Temperature checkbox to the custom provider dialog
- persist the model `temperature` capability through validation and config sanitization
- include regression coverage for temperature serialization and schema normalization

Partially fixes #10226. This restores the temperature setting only; streaming is intentionally left untouched for a separate focused change.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `bun run script/check-opencode-annotations.ts --base upstream/main`

Full local compile/test was not run to avoid OOM risk, per maintainer workflow constraints.