### PR TITLE
fix(vscode): preserve masked custom provider key

### DIFF
--- a/.changeset/custom-provider-masked-key.md
+++ b/.changeset/custom-provider-masked-key.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent custom provider saves from storing the masked API key placeholder.

--- a/packages/kilo-vscode/src/shared/custom-provider.ts
+++ b/packages/kilo-vscode/src/shared/custom-provider.ts
@@ -97,6 +97,7 @@ export function parseCustomProviderSecret(raw: string): { value: { apiKey?: stri
 export function resolveCustomProviderAuth(apiKey: string | undefined, changed: boolean): CustomProviderAuthChange {
   const key = apiKey?.trim()
   if (!changed) return { mode: "preserve" }
+  if (key === MASKED_CUSTOM_PROVIDER_KEY) return { mode: "preserve" }
   if (key) return { mode: "set", key }
   return { mode: "clear" }
 }
@@ -104,6 +105,12 @@ export function resolveCustomProviderAuth(apiKey: string | undefined, changed: b
 export function resolveCustomProviderKey(auth: "api" | "oauth" | "wellknown" | undefined) {
   if (auth !== "api") return ""
   return MASKED_CUSTOM_PROVIDER_KEY
+}
+
+export function resolveCustomProviderKeyInput(current: string, next: string, touched: boolean) {
+  if (next === current) return { key: next, touched }
+  if (touched || current !== MASKED_CUSTOM_PROVIDER_KEY) return { key: next, touched: true }
+  return { key: next.replace(/^\*+/, ""), touched: true }
 }
 
 export function normalizeCustomProviderConfig(

--- a/packages/kilo-vscode/tests/unit/custom-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider.test.ts
@@ -3,6 +3,7 @@ import {
   MASKED_CUSTOM_PROVIDER_KEY,
   parseCustomProviderSecret,
   resolveCustomProviderKey,
+  resolveCustomProviderKeyInput,
   resolveCustomProviderAuth,
   sanitizeCustomProviderConfig,
   validateProviderID,
@@ -44,6 +45,10 @@ describe("resolveCustomProviderAuth", () => {
     expect(resolveCustomProviderAuth(" sk-test ", true)).toEqual({ mode: "set", key: "sk-test" })
   })
 
+  it("preserves auth when the masked api key placeholder is submitted", () => {
+    expect(resolveCustomProviderAuth(MASKED_CUSTOM_PROVIDER_KEY, true)).toEqual({ mode: "preserve" })
+  })
+
   it("clears auth when the field was changed to empty", () => {
     expect(resolveCustomProviderAuth(undefined, true)).toEqual({ mode: "clear" })
   })
@@ -60,6 +65,28 @@ describe("resolveCustomProviderKey", () => {
 
   it("returns empty when there is no saved key", () => {
     expect(resolveCustomProviderKey(undefined)).toBe("")
+  })
+})
+
+describe("resolveCustomProviderKeyInput", () => {
+  it("does not mark unchanged empty input as touched", () => {
+    expect(resolveCustomProviderKeyInput("", "", false)).toEqual({ key: "", touched: false })
+  })
+
+  it("does not mark the masked placeholder as touched when it stays unchanged", () => {
+    expect(resolveCustomProviderKeyInput(MASKED_CUSTOM_PROVIDER_KEY, MASKED_CUSTOM_PROVIDER_KEY, false)).toEqual({
+      key: MASKED_CUSTOM_PROVIDER_KEY,
+      touched: false,
+    })
+  })
+
+  it("strips the masked placeholder prefix when the user enters a new key", () => {
+    expect(
+      resolveCustomProviderKeyInput(MASKED_CUSTOM_PROVIDER_KEY, `${MASKED_CUSTOM_PROVIDER_KEY}sk-test`, false),
+    ).toEqual({
+      key: "sk-test",
+      touched: true,
+    })
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { connectProvider, disconnectProvider, fetchProviderData, saveCustomProvider } from "../../src/provider-actions"
+import { MASKED_CUSTOM_PROVIDER_KEY } from "../../src/shared/custom-provider"
 
 type ExistingGlobal = { disabled_providers?: string[]; provider?: Record<string, unknown> }
 
@@ -195,6 +196,24 @@ describe("saveCustomProvider", () => {
 
     expect(calls.remove).toHaveLength(0)
     expect(calls.set).toEqual([{ providerID: "myprovider", auth: { type: "api", key: "sk-test" } }])
+  })
+
+  it("does not store the masked api key placeholder", async () => {
+    const { ctx, calls, setCachedConfig } = createCtx()
+
+    await saveCustomProvider(
+      ctx,
+      "req",
+      "myprovider",
+      createProvider(),
+      MASKED_CUSTOM_PROVIDER_KEY,
+      true,
+      null,
+      setCachedConfig,
+    )
+
+    expect(calls.set).toHaveLength(0)
+    expect(calls.remove).toHaveLength(0)
   })
 
   // Regression tests for https://github.com/Kilo-Org/kilocode/issues/9186

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
@@ -14,7 +14,7 @@ import { useProvider } from "../../context/provider"
 import { useVSCode } from "../../context/vscode"
 import type { ExtensionMessage, ProviderConfig } from "../../types/messages"
 import { createProviderAction } from "../../utils/provider-action"
-import { MASKED_CUSTOM_PROVIDER_KEY, resolveCustomProviderKey } from "../../../../src/shared/custom-provider"
+import { resolveCustomProviderKey, resolveCustomProviderKeyInput } from "../../../../src/shared/custom-provider"
 import { ModelCard } from "./CustomProviderModelCard"
 import type {
   ChatTemplateArgsValue,
@@ -501,10 +501,11 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
               description={language.t("provider.custom.field.apiKey.description")}
               value={form.apiKey}
               onChange={(v) => {
-                const key = !apiTouched() && form.apiKey === MASKED_CUSTOM_PROVIDER_KEY ? v.replace(/^\*+/, "") : v
-                setApiTouched(true)
+                const next = resolveCustomProviderKeyInput(form.apiKey, v, apiTouched())
+                const key = next.key
+                setApiTouched(next.touched)
                 setForm("apiKey", key)
-                setFetchKey(key)
+                if (next.touched) setFetchKey(key)
               }}
             />
           </div>


### PR DESCRIPTION
## Summary
- avoid marking an unchanged masked custom provider API key as edited
- prevent `********` from being saved as the real API key if it reaches the backend
- add regression coverage for the input helper and save path

Fixes #9931.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `bun run script/check-opencode-annotations.ts --base upstream/main`

Full local compile/test was not run to avoid OOM risk, per workflow constraints.