### PR TITLE
fix(cli): render alert message newlines

### DIFF
--- a/.changeset/dialog-alert-newlines.md
+++ b/.changeset/dialog-alert-newlines.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Render multi-line TUI alert messages on separate lines.

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,12 +2,19 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { For } from "solid-js" // kilocode_change
 
 export type DialogAlertProps = {
   title: string
   message: string
   onConfirm?: () => void
 }
+
+// kilocode_change start
+export function dialogAlertMessageLines(message: string) {
+  return message.split(/\r\n|\r|\n/)
+}
+// kilocode_change end
 
 export function DialogAlert(props: DialogAlertProps) {
   const dialog = useDialog()
@@ -32,7 +39,11 @@ export function DialogAlert(props: DialogAlertProps) {
         </text>
       </box>
       <box paddingBottom={1}>
-        <text fg={theme.textMuted}>{props.message}</text>
+        {/* kilocode_change start */}
+        <For each={dialogAlertMessageLines(props.message)}>
+          {(line) => <text fg={theme.textMuted}>{line}</text>}
+        </For>
+        {/* kilocode_change end */}
       </box>
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box

--- a/packages/opencode/test/kilocode/dialog-alert-message-lines.test.ts
+++ b/packages/opencode/test/kilocode/dialog-alert-message-lines.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { dialogAlertMessageLines } from "../../src/cli/cmd/tui/ui/dialog-alert"
+
+describe("dialogAlertMessageLines", () => {
+  test("splits newline-delimited alert messages into renderable lines", () => {
+    expect(dialogAlertMessageLines("You're not a member of any teams.\nVisit https://app.kilo.ai")).toEqual([
+      "You're not a member of any teams.",
+      "Visit https://app.kilo.ai",
+    ])
+  })
+
+  test("handles CRLF alert messages", () => {
+    expect(dialogAlertMessageLines("first\r\nsecond\rthird")).toEqual(["first", "second", "third"])
+  })
+})


### PR DESCRIPTION
## Summary
- split TUI alert messages on newline boundaries
- render each alert message line separately
- add regression coverage for newline and CRLF alert messages

Fixes #10192.

## Verification
- git diff upstream/main...HEAD --check
- bun run script/check-opencode-annotations.ts --base upstream/main

Full local compile/test was not run to avoid OOM risk.