### PR TITLE
fix(cli): honor kilocodeignore file patterns

### DIFF
--- a/.changeset/kilocodeignore-single-files.md
+++ b/.changeset/kilocodeignore-single-files.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Honor `.kilocodeignore` single-file patterns for nested files.

--- a/packages/opencode/src/kilocode/ignore-migrator.ts
+++ b/packages/opencode/src/kilocode/ignore-migrator.ts
@@ -64,7 +64,8 @@ export namespace IgnoreMigrator {
    * - `foo/` matches directory and all contents -> `foo/*`
    * - `*.env` matches anywhere in tree -> `*.env` (already works)
    * - `/foo` matches only at root -> `foo` (rooted)
-   * - `foo` matches anywhere -> `*foo*` or just `foo` depending on context
+   * - `foo` matches root `foo`; buildPermissionRules also adds `*/foo`
+   *   so unrooted filename patterns match nested files.
    *
    * Note: Opencode's wildcard `*` already matches any path depth because
    * it's converted to `.*` regex which matches `/` characters.
@@ -98,6 +99,21 @@ export namespace IgnoreMigrator {
     return glob
   }
 
+  // kilocode_change start
+  export function convertToGlobs(pattern: string): string[] {
+    const glob = convertToGlob(pattern)
+
+    // Gitignore treats an unrooted pattern without a slash as matching that
+    // name at any directory depth. Opencode permissions use exact wildcard
+    // patterns, so keep the root match and add an explicit nested match.
+    if (!pattern.startsWith("/") && !glob.includes("/")) {
+      return [glob, `*/${glob}`]
+    }
+
+    return [glob]
+  }
+  // kilocode_change end
+
   /**
    * Load patterns from a .kilocodeignore file
    */
@@ -130,16 +146,22 @@ export namespace IgnoreMigrator {
     // First pass: add deny rules
     for (const p of patterns) {
       if (!p.negated) {
-        const glob = convertToGlob(p.pattern)
-        rules[glob] = "deny"
+        // kilocode_change start
+        for (const glob of convertToGlobs(p.pattern)) {
+          rules[glob] = "deny"
+        }
+        // kilocode_change end
       }
     }
 
     // Second pass: add negated (allow) rules - these override denies
     for (const p of patterns) {
       if (p.negated) {
-        const glob = convertToGlob(p.pattern)
-        rules[glob] = "allow"
+        // kilocode_change start
+        for (const glob of convertToGlobs(p.pattern)) {
+          rules[glob] = "allow"
+        }
+        // kilocode_change end
       }
     }
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -226,12 +226,20 @@ export const ReadTool = Tool.define(
         kind: stat?.type === "Directory" ? "directory" : "file",
       })
 
+      // kilocode_change start - evaluate in-worktree reads against relative paths
+      const permissionPath = path.relative(instance.worktree, filepath)
+      const permissionPattern =
+        permissionPath && !permissionPath.startsWith("..") && !path.isAbsolute(permissionPath)
+          ? permissionPath
+          : filepath
+
       yield* ctx.ask({
         permission: "read",
-        patterns: [filepath],
+        patterns: [permissionPattern],
         always: ["*"],
         metadata: {},
       })
+      // kilocode_change end
 
       if (!stat) return yield* miss(filepath)
 

--- a/packages/opencode/test/kilocode/ignore-migrator.test.ts
+++ b/packages/opencode/test/kilocode/ignore-migrator.test.ts
@@ -101,6 +101,14 @@ pattern2
     test("preserves nested path pattern", () => {
       expect(IgnoreMigrator.convertToGlob("config/secrets.json")).toBe("config/secrets.json")
     })
+
+    test("expands unrooted single-file patterns to nested matches", () => {
+      expect(IgnoreMigrator.convertToGlobs("secret.txt")).toEqual(["secret.txt", "*/secret.txt"])
+    })
+
+    test("does not expand rooted single-file patterns to nested matches", () => {
+      expect(IgnoreMigrator.convertToGlobs("/secret.txt")).toEqual(["secret.txt"])
+    })
   })
 
   describe("buildPermissionRules", () => {
@@ -117,6 +125,14 @@ pattern2
       expect(rules["secrets/*"]).toBe("deny")
     })
 
+    test("creates nested deny rule for unrooted single-file pattern", () => {
+      const patterns = [{ pattern: "secret.txt", negated: false, source: "project" as const }]
+      const rules = IgnoreMigrator.buildPermissionRules(patterns)
+
+      expect(rules["secret.txt"]).toBe("deny")
+      expect(rules["*/secret.txt"]).toBe("deny")
+    })
+
     test("creates allow rules for negated patterns", () => {
       const patterns = [
         { pattern: "*.env", negated: false, source: "project" as const },
@@ -126,6 +142,7 @@ pattern2
 
       expect(rules["*.env"]).toBe("deny")
       expect(rules[".env.example"]).toBe("allow")
+      expect(rules["*/.env.example"]).toBe("allow")
     })
 
     test("handles multiple deny patterns", () => {


### PR DESCRIPTION
## Summary
- expand unrooted `.kilocodeignore` single-file patterns so nested files are denied too
- evaluate in-worktree read permissions using workspace-relative paths
- add regression coverage for `secret.txt` style rules and negations

Fixes #9228.

## Verification
- git diff upstream/main...HEAD --check
- bun run script/check-opencode-annotations.ts --base upstream/main

Full local compile/test was not run to avoid OOM risk.