### PR TITLE
fix(cli): make bash tool description Windows-aware

### DIFF
--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -85,6 +85,7 @@ function chainGuidance(name: string) {
   return "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
 }
 
+// kilocode_change start
 function bashCommandSection(chain: string, limits: Limits) {
   return `Before executing the command, please follow these steps:
 
@@ -128,6 +129,7 @@ Usage notes:
     cd /foo/bar && pytest tests
     </bad-example>`
 }
+// kilocode_change end
 
 function powershellCommandSection(name: string, chain: string, pathSep: string, limits: Limits) {
   return `${powershellNotes(name)}
@@ -258,8 +260,10 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits) {
     }
   }
   return {
+    // kilocode_change start
     intro:
       "Executes a given command in a persistent shell session with optional timeout, ensuring proper handling and security measures.",
+    // kilocode_change end
     workdirSection:
       "All commands run in the current working directory by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.",
     commandSection: bashCommandSection(chain, limits),
@@ -276,12 +280,10 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits) {
 
 export function render(name: string, platform: NodeJS.Platform, limits: Limits) {
   const selected = profile(name, platform, limits)
-  const os =
-    platform === "win32" ? "Windows" : platform === "darwin" ? "macOS" : "Linux"
   return {
     description: renderPrompt(DESCRIPTION, {
       intro: selected.intro,
-      os,
+      os: platform,
       shell: name,
       tmp: Global.Path.tmp,
       workdirSection: selected.workdirSection,

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -108,7 +108,7 @@ Usage notes:
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${limits.maxLines} lines or ${limits.maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use \`head\`, \`tail\`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
 
-  - Avoid using Bash with the \`find\`, \`grep\`, \`cat\`, \`head\`, \`tail\`, \`sed\`, \`awk\`, or \`echo\` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
+  - Avoid using the shell with the \`find\`, \`grep\`, \`cat\`, \`head\`, \`tail\`, \`sed\`, \`awk\`, or \`echo\` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
     - File search: Use Glob (NOT find or ls)
     - Content search: Use Grep (NOT grep or rg)
     - Read files: Use Read (NOT cat/head/tail)
@@ -259,7 +259,7 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits) {
   }
   return {
     intro:
-      "Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.",
+      "Executes a given command in a persistent shell session with optional timeout, ensuring proper handling and security measures.",
     workdirSection:
       "All commands run in the current working directory by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.",
     commandSection: bashCommandSection(chain, limits),
@@ -276,10 +276,12 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits) {
 
 export function render(name: string, platform: NodeJS.Platform, limits: Limits) {
   const selected = profile(name, platform, limits)
+  const os =
+    platform === "win32" ? "Windows" : platform === "darwin" ? "macOS" : "Linux"
   return {
     description: renderPrompt(DESCRIPTION, {
       intro: selected.intro,
-      os: platform,
+      os,
       shell: name,
       tmp: Global.Path.tmp,
       workdirSection: selected.workdirSection,


### PR DESCRIPTION
Title: fix(cli): make bash tool platform-aware so AI doesn't suggest Linux commands on Windows

Context: On Windows the bash tool previously told the AI to use Linux/bash commands while the actual shell was PowerShell or cmd.exe, causing command failures. Now uses platformName to show the actual platform name (Windows/macOS/Linux) and includes cmd.exe chaining support.

Implementation: Changed bash.txt tool description template to be platform-neutral — the description now interpolates a computed platformName string ("Windows"/"macOS"/"Linux") instead of the raw process.platform value. Added a branch in bash.ts that detects when the spawned shell is cmd (Windows command prompt) and outputs &&-based chaining instructions instead of ;-based. Updated the description's "How to Use" section to reference platform-specific command syntax and path quoting rules.

How to Test: Use Kilo on a Windows machine, observe that the bash tool description in the system prompt shows "Windows" as the platform and references PowerShell/cmd.exe syntax rather than bash. Run a task that chains commands — the AI should use correct Windows chaining (; for PowerShell, && for cmd).