### PR TITLE
fix(vscode): preserve in-flight sessions during session list reconcil…

### DIFF
--- a/.changeset/nine-steaks-boil.md
+++ b/.changeset/nine-steaks-boil.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve in-flight sessions during session list reconciliation

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1594,7 +1594,11 @@ export const SessionProvider: ParentComponent = (props) => {
             if (id.startsWith("cloud:")) continue
             if (kept?.has(id)) continue
             if (!ids.has(id)) {
-              if (statusMap[id] && statusMap[id].type !== "idle") continue
+              // Preserve in-flight sessions, but only if they haven't been
+              // busy for too long — prevents stale-lock if the backend never
+              // sends an idle event (e.g. crash, lost SSE).
+              const busySince = busySinceMap[id]
+              if (statusMap[id]?.type !== "idle" && (!busySince || Date.now() - busySince < 300_000)) continue
               delete sessions[id]
             }
           }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1583,6 +1583,9 @@ export const SessionProvider: ParentComponent = (props) => {
       // entries from other projects accumulating in the store.
       // Sessions whose worktree directories failed to list are preserved —
       // their absence is transient, not a real deletion.
+      // Also preserve any session currently in flight (non-idle status) to
+      // avoid clearing an active session when the backend returns an
+      // incomplete list during session creation or other race conditions.
       const ids = new Set(loaded.map((s) => s.id))
       setStore(
         "sessions",
@@ -1590,7 +1593,10 @@ export const SessionProvider: ParentComponent = (props) => {
           for (const id of Object.keys(sessions)) {
             if (id.startsWith("cloud:")) continue
             if (kept?.has(id)) continue
-            if (!ids.has(id)) delete sessions[id]
+            if (!ids.has(id)) {
+              if (statusMap[id] && statusMap[id].type !== "idle") continue
+              delete sessions[id]
+            }
           }
         }),
       )


### PR DESCRIPTION
Title: fix(vscode): preserve in-flight sessions during session list reconciliation

Context: handleSessionsLoaded reconciles the session list by deleting any session not in the loaded set. If the backend returns an incomplete list during a race condition (e.g., during session creation, or when worktree directory listing fails transiently), an active session can be silently cleared, causing the user to lose their current conversation.

Implementation: Modified the reconciliation loop in handleSessionsLoaded to skip deletion for sessions with a non-idle statusMap entry. An in-flight session (type !== "idle") is preserved even if absent from the loaded list. The preserve parameter still works for explicit preservation (used by worktree sessions).

How to Test: Start a session, begin an agent task. While the task is running, trigger a sessionsLoaded event with a list that doesn't include the active session. Verify the session is not deleted. After the task completes (status becomes idle), verify a subsequent sessionsLoaded without the session correctly cleans it u