### PR TITLE
fix(vscode): report real mcp removals

### DIFF
--- a/.changeset/mcp-remove-real-result.md
+++ b/.changeset/mcp-remove-real-result.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MCP and marketplace removals so missing entries are not reported as successfully deleted.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1121,6 +1121,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             success: result.success,
             slug: result.slug,
             error: result.error,
+            removed: result.removed,
           })
           break
         }
@@ -1972,11 +1973,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async handleRemoveMcp(name: string): Promise<void> {
     // Remove from legacy files first so that the subsequent invalidation
     // causes the CLI to re-read config without the legacy entry.
-    await this.removeLegacyMcp(name)
+    const legacyRemoved = await this.removeLegacyMcp(name)
 
     const stub = { id: name, type: "mcp" as const, name, description: "", url: "", content: "" }
     const removed = await this.removeMarketplaceItemFromAllScopes(stub)
-    if (!removed) {
+    if (!removed && (legacyRemoved.project || legacyRemoved.global)) {
+      await this.invalidateAfterMarketplaceChange(legacyRemoved.global ? "global" : "project")
+    }
+    if (!removed && !legacyRemoved.project && !legacyRemoved.global) {
       console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name)
     }
   }
@@ -1985,26 +1989,26 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Remove an MCP server from legacy config files (.kilo/mcp.json, .kilocode/mcp.json,
    * and the VS Code global storage mcp_settings.json). These files are read by the
    * CLI-side McpMigrator and merged into config at the lowest precedence level.
-   * Returns true if the entry was found and removed from at least one file.
+   * Returns which config scope had at least one removed entry.
    */
-  private async removeLegacyMcp(name: string): Promise<boolean> {
+  private async removeLegacyMcp(name: string): Promise<{ project: boolean; global: boolean }> {
     const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const files: vscode.Uri[] = []
+    const files: Array<{ uri: vscode.Uri; scope: "project" | "global" }> = []
 
     // Project-level legacy files
     if (workspace) {
-      files.push(vscode.Uri.file(path.join(workspace, ".kilo", "mcp.json")))
-      files.push(vscode.Uri.file(path.join(workspace, ".kilocode", "mcp.json")))
+      files.push({ uri: vscode.Uri.file(path.join(workspace, ".kilo", "mcp.json")), scope: "project" })
+      files.push({ uri: vscode.Uri.file(path.join(workspace, ".kilocode", "mcp.json")), scope: "project" })
     }
 
     // Global legacy file (VS Code extension global storage)
     const storage = this.extensionContext?.globalStorageUri
     if (storage) {
-      files.push(vscode.Uri.joinPath(storage, "settings", "mcp_settings.json"))
+      files.push({ uri: vscode.Uri.joinPath(storage, "settings", "mcp_settings.json"), scope: "global" })
     }
 
-    let removed = false
-    for (const uri of files) {
+    const removed = { project: false, global: false }
+    for (const { uri, scope } of files) {
       const bytes = await vscode.workspace.fs.readFile(uri).then(
         (b) => b,
         () => null,
@@ -2019,7 +2023,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         delete servers[name]
         const content = Buffer.from(JSON.stringify(parsed, null, 2), "utf8")
         await vscode.workspace.fs.writeFile(uri, content)
-        removed = true
+        removed[scope] = true
       } catch (err) {
         console.warn("[Kilo New] KiloProvider: Failed to remove legacy MCP from", uri.fsPath, err)
       }
@@ -2055,7 +2059,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async removeMarketplaceItem(item: MarketplaceItem, scope: "project" | "global"): Promise<RemoveResult> {
     const workspace = this.getProjectDirectory(this.currentSession?.id)
     const result = await this.getMarketplace().remove(item, scope, workspace)
-    if (result.success) {
+    if (result.success && result.removed !== false) {
       await this.invalidateAfterMarketplaceChange(scope)
     }
     return result
@@ -2073,8 +2077,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const project = await mp.remove(item, "project", workspace)
     const global = await mp.remove(item, "global", workspace)
 
-    if (project.success || global.success) {
-      const scope = global.success ? "global" : "project"
+    const removed = item.type === "mcp" ? project.removed || global.removed : project.success || global.success
+    if (removed) {
+      const scope =
+        item.type === "mcp" ? (global.removed ? "global" : "project") : global.success ? "global" : "project"
       await this.invalidateAfterMarketplaceChange(scope)
       return true
     }

--- a/packages/kilo-vscode/src/services/marketplace/index.ts
+++ b/packages/kilo-vscode/src/services/marketplace/index.ts
@@ -51,7 +51,7 @@ export class MarketplaceService {
   async remove(item: MarketplaceItem, scope: "project" | "global", workspace?: string): Promise<RemoveResult> {
     const result = await this.installer.remove(item, scope, workspace)
 
-    if (result.success) {
+    if (result.success && result.removed !== false) {
       vscode.window.showInformationMessage(`Successfully removed ${item.name}`)
     }
 

--- a/packages/kilo-vscode/src/services/marketplace/installer.ts
+++ b/packages/kilo-vscode/src/services/marketplace/installer.ts
@@ -195,14 +195,17 @@ export class MarketplaceInstaller {
   }
 
   async removeMcp(item: McpMarketplaceItem, scope: "project" | "global", workspace?: string): Promise<RemoveResult> {
+    if (scope === "project" && !workspace) {
+      return { success: false, slug: item.id, error: "No workspace directory for project-scope remove" }
+    }
     const config = await this.readConfig(scope, workspace)
     if (!config.mcp?.[item.id]) {
-      return { success: true, slug: item.id }
+      return { success: true, slug: item.id, removed: false, error: "MCP server is not installed in this scope" }
     }
     delete config.mcp[item.id]
     if (Object.keys(config.mcp).length === 0) delete config.mcp
     await this.writeConfig(scope, workspace, config)
-    return { success: true, slug: item.id }
+    return { success: true, slug: item.id, removed: true }
   }
 
   async removeMode(item: ModeMarketplaceItem, scope: "project" | "global", workspace?: string): Promise<RemoveResult> {

--- a/packages/kilo-vscode/src/services/marketplace/types.ts
+++ b/packages/kilo-vscode/src/services/marketplace/types.ts
@@ -81,4 +81,5 @@ export interface RemoveResult {
   success: boolean
   slug: string
   error?: string
+  removed?: boolean
 }

--- a/packages/kilo-vscode/tests/unit/marketplace-installer.test.ts
+++ b/packages/kilo-vscode/tests/unit/marketplace-installer.test.ts
@@ -93,4 +93,68 @@ describe("MarketplaceInstaller MCP format normalization", () => {
     const mcp = written.mcp?.already
     expect(mcp).toEqual({ type: "local", command: ["npx", "-y", "someserver"], environment: { KEY: "val" } })
   })
+
+  it("reports when an MCP entry was actually removed", async () => {
+    const paths = new TestPaths()
+    const installer = new MarketplaceInstaller(paths)
+    await fs.mkdir(path.dirname(paths.configPath("global")), { recursive: true })
+    await fs.writeFile(
+      paths.configPath("global"),
+      JSON.stringify({
+        mcp: {
+          memory: { type: "local", command: ["npx", "-y", "@modelcontextprotocol/server-memory"] },
+          github: { type: "remote", url: "https://example.com/mcp" },
+        },
+      }),
+    )
+
+    const result = await installer.remove(
+      {
+        type: "mcp",
+        id: "memory",
+        name: "Memory",
+        description: "test",
+        url: "https://example.com",
+        content: "{}",
+      },
+      "global",
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.removed).toBe(true)
+    const written = JSON.parse(await fs.readFile(paths.configPath("global"), "utf-8"))
+    expect(written.mcp.memory).toBeUndefined()
+    expect(written.mcp.github).toEqual({ type: "remote", url: "https://example.com/mcp" })
+  })
+
+  it("does not report success as a real MCP removal when the entry is absent", async () => {
+    const paths = new TestPaths()
+    const installer = new MarketplaceInstaller(paths)
+    await fs.mkdir(path.dirname(paths.configPath("global")), { recursive: true })
+    await fs.writeFile(
+      paths.configPath("global"),
+      JSON.stringify({
+        mcp: {
+          github: { type: "remote", url: "https://example.com/mcp" },
+        },
+      }),
+    )
+
+    const result = await installer.remove(
+      {
+        type: "mcp",
+        id: "memory",
+        name: "Memory",
+        description: "test",
+        url: "https://example.com",
+        content: "{}",
+      },
+      "global",
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.removed).toBe(false)
+    const written = JSON.parse(await fs.readFile(paths.configPath("global"), "utf-8"))
+    expect(written.mcp.github).toEqual({ type: "remote", url: "https://example.com/mcp" })
+  })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/marketplace/MarketplaceView.tsx
@@ -55,7 +55,7 @@ export const MarketplaceView = () => {
       if (msg.type === "marketplaceRemoveResult") {
         const removed = pending()
         setPending(null)
-        if (msg.success) {
+        if (msg.success && msg.removed !== false) {
           if (removed) {
             telemetry(TelemetryEventName.MARKETPLACE_ITEM_REMOVED, {
               itemId: removed.item.id,

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -858,6 +858,7 @@ export interface MarketplaceRemoveResultMessage {
   success: boolean
   slug: string
   error?: string
+  removed?: boolean
 }
 
 export interface ProviderOAuthReadyMessage {


### PR DESCRIPTION
Fixes #9926.\n\n## Summary\n- track whether MCP marketplace removal actually deleted a config entry\n- avoid reporting missing MCP entries as successful removals\n- refresh the correct legacy MCP scope after removing legacy config entries\n\n## Verification\n- git diff --check\n- git diff upstream/main...HEAD --check\n\nLocal build/tests not run per OOM constraint; CI should cover broader validation.