### PR TITLE
fix(ui): show dismissed question text

### DIFF
--- a/.changeset/dismissed-question-review.md
+++ b/.changeset/dismissed-question-review.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-ui": patch
+"@opencode-ai/ui": patch
+---
+
+Keep dismissed question tool cards reviewable by showing the original question text with a dismissed status.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2761,20 +2761,23 @@ ToolRegistry.register({
     const i18n = useI18n()
     const questions = createMemo(() => (props.input.questions ?? []) as QuestionInfo[])
     const answers = createMemo(() => (props.metadata.answers ?? []) as QuestionAnswer[])
+    const dismissed = createMemo(() => props.metadata.dismissed === true)
     const completed = createMemo(() => answers().length > 0)
+    const reviewable = createMemo(() => completed() || dismissed())
     const pending = createMemo(() => busy(props.status))
 
     const subtitle = createMemo(() => {
       const count = questions().length
       if (count === 0) return ""
       if (completed()) return i18n.t("ui.question.subtitle.answered", { count })
+      if (dismissed()) return i18n.t("ui.messagePart.questions.dismissed")
       return `${count} ${i18n.t(count > 1 ? "ui.common.question.other" : "ui.common.question.one")}`
     })
 
     return (
       <BasicTool
         {...props}
-        defaultOpen={false}
+        defaultOpen={dismissed()}
         icon="bubble-5"
         trigger={
           <ToolTriggerRow
@@ -2785,7 +2788,7 @@ ToolRegistry.register({
           />
         }
       >
-        <Show when={completed()}>
+        <Show when={reviewable()}>
           <div data-component="question-answers">
             <For each={questions()}>
               {(q, i) => {
@@ -2793,7 +2796,11 @@ ToolRegistry.register({
                 return (
                   <div data-slot="question-answer-item">
                     <div data-slot="question-text">{q.question}</div>
-                    <div data-slot="answer-text">{answer().join(", ") || i18n.t("ui.question.answer.none")}</div>
+                    <div data-slot="answer-text">
+                      {dismissed()
+                        ? i18n.t("ui.messagePart.questions.dismissed")
+                        : answer().join(", ") || i18n.t("ui.question.answer.none")}
+                    </div>
                   </div>
                 )
               }}

--- a/packages/kilo-ui/src/stories/message-part.stories.tsx
+++ b/packages/kilo-ui/src/stories/message-part.stories.tsx
@@ -163,6 +163,34 @@ const errorToolPart: ToolPart = {
   },
 }
 
+const dismissedQuestionPart: ToolPart = {
+  id: "part-question-dismissed",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-question-dismissed",
+  tool: "question",
+  state: {
+    status: "completed",
+    input: {
+      questions: [
+        {
+          question: "Should I continue with the refactor?",
+          header: "Continue?",
+          options: [
+            { label: "Continue", description: "Proceed with the planned refactor" },
+            { label: "Stop", description: "Leave the current code unchanged" },
+          ],
+        },
+      ],
+    },
+    output: "User dismissed the question.",
+    title: "Question dismissed",
+    metadata: { answers: [], dismissed: true },
+    time: { start: now - 6000, end: now - 5500 },
+  },
+}
+
 // Completed edit tool with full filediff metadata — exercises canOpenDiff()
 // so the "Open in Diff Viewer" icon button renders in the trigger.
 const editCompletedPart: ToolPart = {
@@ -264,6 +292,7 @@ const mockData = createMockData([completedToolPart, textPart])
 const mockDataRunning = createMockData([runningToolPart])
 // Only the error edit tool — matches old WithErrorTool single-part intent
 const mockDataError = createMockData([errorToolPart])
+const mockDataDismissedQuestion = createMockData([dismissedQuestionPart])
 // Reasoning + text — matches old WithReasoning single-reasoning intent
 const mockDataReasoning = createMockData([reasoningPart, textPart])
 // Completed bash tool — exercises ShellRollingResults path
@@ -341,6 +370,16 @@ export const WithRunningTool: Story = {
 export const WithErrorTool: Story = {
   render: () => (
     <AllProviders data={mockDataError}>
+      <AssistantParts messages={[mockAssistantMessage]} />
+    </AllProviders>
+  ),
+}
+
+// --- Dismissed question → original question remains reviewable ---
+
+export const WithDismissedQuestion: Story = {
+  render: () => (
+    <AllProviders data={mockDataDismissedQuestion}>
       <AssistantParts messages={[mockAssistantMessage]} />
     </AllProviders>
   ),

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -171,6 +171,28 @@ describe("Write and apply_patch patch rendering contracts (source)", () => {
   })
 })
 
+describe("Question tool dismissed-review contract (source)", () => {
+  const sources = [
+    ["kilo-ui", KILO_MESSAGE_PART_FILE],
+    ["ui", MESSAGE_PART_FILE],
+  ] as const
+
+  for (const [label, file] of sources) {
+    it(`${label} renders dismissed questions with their original text`, () => {
+      const src = fs.readFileSync(file, "utf-8")
+      const block =
+        src.match(/ToolRegistry\.register\(\{\s*name:\s*"question"[\s\S]*?(?=ToolRegistry\.register\(|$)/)?.[0] ??
+        ""
+
+      expect(block).toContain("props.metadata.dismissed === true")
+      expect(block).toContain("completed() || dismissed()")
+      expect(block).toContain("<Show when={reviewable()}>")
+      expect(block).toContain('data-slot="question-text"')
+      expect(block).toContain('i18n.t("ui.messagePart.questions.dismissed")')
+    })
+  }
+})
+
 describe("Bash tool syntax highlighting and section labels (source)", () => {
   const src = fs.readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")
   const block =

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2268,26 +2268,29 @@ ToolRegistry.register({
     const i18n = useI18n()
     const questions = createMemo(() => (props.input.questions ?? []) as QuestionInfo[])
     const answers = createMemo(() => (props.metadata.answers ?? []) as QuestionAnswer[])
+    const dismissed = createMemo(() => props.metadata.dismissed === true)
     const completed = createMemo(() => answers().length > 0)
+    const reviewable = createMemo(() => completed() || dismissed())
 
     const subtitle = createMemo(() => {
       const count = questions().length
       if (count === 0) return ""
       if (completed()) return i18n.t("ui.question.subtitle.answered", { count })
+      if (dismissed()) return i18n.t("ui.messagePart.questions.dismissed")
       return `${count} ${i18n.t(count > 1 ? "ui.common.question.other" : "ui.common.question.one")}`
     })
 
     return (
       <BasicTool
         {...props}
-        defaultOpen={completed()}
+        defaultOpen={reviewable()}
         icon="bubble-5"
         trigger={{
           title: i18n.t("ui.tool.questions"),
           subtitle: subtitle(),
         }}
       >
-        <Show when={completed()}>
+        <Show when={reviewable()}>
           <div data-component="question-answers">
             <For each={questions()}>
               {(q, i) => {
@@ -2295,7 +2298,11 @@ ToolRegistry.register({
                 return (
                   <div data-slot="question-answer-item">
                     <div data-slot="question-text">{q.question}</div>
-                    <div data-slot="answer-text">{answer().join(", ") || i18n.t("ui.question.answer.none")}</div>
+                    <div data-slot="answer-text">
+                      {dismissed()
+                        ? i18n.t("ui.messagePart.questions.dismissed")
+                        : answer().join(", ") || i18n.t("ui.question.answer.none")}
+                    </div>
                   </div>
                 )
               }}


### PR DESCRIPTION
Fixes #10361.\n\n## Summary\n- render dismissed question tool cards as reviewable instead of empty\n- show the original question text with a dismissed status\n- add a story and source contract coverage for the dismissed metadata path\n\n## Verification\n- git diff --check\n- git diff upstream/main...HEAD --check\n\nLocal build/tests not run per OOM constraint; CI should cover broader validation.