### PR TITLE
fix(vscode): pass vscode.env.shell as SHELL to CLI server process

### DIFF
--- a/.changeset/beige-poets-breathe.md
+++ b/.changeset/beige-poets-breathe.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Pass VS Code's detected shell as SHELL env var to the CLI server

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -134,6 +134,7 @@ export class ServerManager {
           KILO_MACHINE_ID: vscode.env.machineId,
           KILO_APP_VERSION: this.context.extension.packageJSON.version,
           KILO_VSCODE_VERSION: vscode.version,
+          SHELL: vscode.env.shell,
           KILOCODE_EDITOR_NAME: `${vscode.env.appName} ${vscode.version}`,
           ...(!claudeCompat && { KILO_DISABLE_CLAUDE_CODE: "true" }),
           ...resolveTreeSitterEnv(this.context.extensionPath),

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -134,7 +134,7 @@ export class ServerManager {
           KILO_MACHINE_ID: vscode.env.machineId,
           KILO_APP_VERSION: this.context.extension.packageJSON.version,
           KILO_VSCODE_VERSION: vscode.version,
-          SHELL: vscode.env.shell,
+          ...(vscode.env.shell ? { SHELL: vscode.env.shell } : {}),
           KILOCODE_EDITOR_NAME: `${vscode.env.appName} ${vscode.version}`,
           ...(!claudeCompat && { KILO_DISABLE_CLAUDE_CODE: "true" }),
           ...resolveTreeSitterEnv(this.context.extensionPath),


### PR DESCRIPTION
Context

Forward VS Code's authoritative vscode.env.shell as the SHELL environment variable so the CLI always sees the user's correct shell, even when process.env.SHELL is unset (Windows) or mismatched (desktop-launched VS Code on macOS/Linux).

Implementation
Added SHELL: vscode.env.shell to the spawn env object in server-manager.ts after KILO_VSCODE_VERSION. This overrides process.env.SHELL (spread earlier in the object) with VS Code's detected value, which Shell.preferred() / Shell.acceptable() read via process.env.SHELL.

How to Test
On Windows: verify SHELL is set in the kilo serve child process env (e.g. via Get-ChildItem Env:SHELL in a task or inspect CLI logs)
On macOS/Linux: launch VS Code from Finder/Spotify (not terminal), verify the CLI uses the shell from vscode.env.shell rather than whatever the desktop launch inherited**