### PR TITLE
fix(vscode): show full command auto-approve option

### DIFF
--- a/.changeset/full-command-auto-approve-rules.md
+++ b/.changeset/full-command-auto-approve-rules.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show short bash commands as exact auto-approve options in the permission dock.

--- a/packages/kilo-vscode/tests/unit/permission-dock-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-dock-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test"
-import { savedRuleStates } from "../../webview-ui/src/components/chat/permission-dock-utils"
+import {
+  MAX_FULL_COMMAND_RULE_LENGTH,
+  commandRuleOptions,
+  displayCommandRule,
+  isFullCommandRule,
+  savedRuleStates,
+} from "../../webview-ui/src/components/chat/permission-dock-utils"
 
 describe("savedRuleStates", () => {
   it("returns empty map when rule is undefined", () => {
@@ -61,5 +67,51 @@ describe("savedRuleStates", () => {
   it("returns empty map for empty config object", () => {
     const result = savedRuleStates(["npm *"], {})
     expect(result).toEqual({})
+  })
+})
+
+describe("commandRuleOptions", () => {
+  it("adds the full command as an exact auto-approve option when it is short enough", () => {
+    expect(commandRuleOptions(["npm *", "npm install *"], "npm install lodash", ["npm install lodash"])).toEqual([
+      "npm *",
+      "npm install *",
+      "npm install lodash",
+    ])
+  })
+
+  it("does not duplicate an existing full command option", () => {
+    expect(commandRuleOptions(["npm *", "npm install lodash"], "npm install lodash", ["npm install lodash"])).toEqual([
+      "npm *",
+      "npm install lodash",
+    ])
+  })
+
+  it("does not add an unreasonably long full command option", () => {
+    const command = "x".repeat(MAX_FULL_COMMAND_RULE_LENGTH + 1)
+    expect(commandRuleOptions(["node *"], command, [command])).toEqual(["node *"])
+  })
+
+  it("keeps empty or missing commands out of the rule options", () => {
+    expect(commandRuleOptions(["git *"], undefined)).toEqual(["git *"])
+    expect(commandRuleOptions(["git *"], "", [""])).toEqual(["git *"])
+  })
+
+  it("does not add a full command option when the request cannot save it as a pattern", () => {
+    expect(commandRuleOptions(["npm *", "git *"], "npm test && git status", ["npm test", "git status"])).toEqual([
+      "npm *",
+      "git *",
+    ])
+  })
+})
+
+describe("displayCommandRule", () => {
+  it("keeps short exact command rules visible in full", () => {
+    expect(displayCommandRule("npm install lodash", "npm install lodash")).toBe("npm install lodash")
+    expect(isFullCommandRule("npm install lodash", "npm install lodash")).toBe(true)
+  })
+
+  it("keeps wildcard command rules compact", () => {
+    expect(displayCommandRule("npm install *", "npm install lodash")).toBe("npm install")
+    expect(isFullCommandRule("npm install *", "npm install lodash")).toBe(false)
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -17,7 +17,15 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import { useConfig } from "../../context/config"
-import { describePatterns, resolveLabel, savedRuleStates, type RuleDecision } from "./permission-dock-utils"
+import {
+  commandRuleOptions,
+  describePatterns,
+  displayCommandRule,
+  isFullCommandRule,
+  resolveLabel,
+  savedRuleStates,
+  type RuleDecision,
+} from "./permission-dock-utils"
 import { PermissionCommand } from "./PermissionCommand"
 import { PermissionDiff } from "./PermissionDiff"
 import { permissionDiffs } from "./permission-diff-utils"
@@ -37,15 +45,23 @@ export const PermissionDock: Component<{
 
   const fromChild = () => props.request.sessionID !== session.currentSessionID()
   // Bash sends fine-grained rules via metadata.rules; other tools use the always array.
-  const rules = () => props.request.args?.rules ?? props.request.always ?? []
-  // Rules like "git *" or "git log *" — strip the trailing wildcard for display.
-  // A bare "*" (global wildcard) becomes empty so only the tool name shows.
-  const label = (rule: string) => (rule === "*" ? "" : rule.replace(/ \*$/, ""))
-  const command = () => {
+  const rawRules = () => props.request.args?.rules ?? props.request.always ?? []
+  const rawCommand = () => {
     const cmd = props.request.args?.command
     if (typeof cmd !== "string") return undefined
+    return cmd
+  }
+  const bashRuleCommand = () => (props.request.toolName === "bash" ? rawCommand() : undefined)
+  const rules = () => commandRuleOptions(rawRules(), bashRuleCommand(), props.request.patterns)
+  const command = () => {
+    const cmd = rawCommand()
+    if (!cmd) return undefined
     // Normalize IDN/Unicode hostnames to punycode ASCII to prevent homograph attacks.
     return normalizeUrls(cmd)
+  }
+  const commandRuleLabel = (rule: string) => {
+    const label = displayCommandRule(rule, bashRuleCommand())
+    return isFullCommandRule(rule, bashRuleCommand()) ? normalizeUrls(label) : label
   }
   const description = createMemo(() =>
     command() ? null : describePatterns(props.request.toolName, props.request.patterns, language.t),
@@ -217,7 +233,11 @@ export const PermissionDock: Component<{
                   <div data-slot="permission-rules">
                     <For each={rules()}>
                       {(rule, index) => (
-                        <div data-slot="permission-rule-row" data-decision={decision(index())}>
+                        <div
+                          data-slot="permission-rule-row"
+                          data-decision={decision(index())}
+                          data-full-command={isFullCommandRule(rule, bashRuleCommand()) ? "" : undefined}
+                        >
                           <div data-slot="permission-rule-actions">
                             <Tooltip value={approveTooltip(index())} placement="top">
                               <button
@@ -244,9 +264,12 @@ export const PermissionDock: Component<{
                               </button>
                             </Tooltip>
                           </div>
-                          <code data-slot="permission-rule">
+                          <code
+                            data-slot="permission-rule"
+                            data-full-command={isFullCommandRule(rule, bashRuleCommand()) ? "" : undefined}
+                          >
                             {command()
-                              ? label(rule)
+                              ? commandRuleLabel(rule)
                               : rule === "*"
                                 ? resolveLabel(props.request.toolName, language.t)
                                 : `${resolveLabel(props.request.toolName, language.t)} ${rule}`}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/permission-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/permission-dock-utils.ts
@@ -2,6 +2,8 @@ import type { PermissionRule } from "../../types/messages"
 
 export type RuleDecision = "approved" | "denied" | "pending"
 
+export const MAX_FULL_COMMAND_RULE_LENGTH = 240
+
 /**
  * Check which rules are already saved in the user's config and return
  * their initial toggle states (approved/denied). Rules not found in
@@ -16,6 +18,23 @@ export function savedRuleStates(rules: string[], saved: PermissionRule | undefin
     if (action === "deny") result[i] = "denied"
   }
   return result
+}
+
+export function commandRuleOptions(rules: string[], command: string | undefined, patterns: string[] = []): string[] {
+  if (!command) return rules
+  if (command.length > MAX_FULL_COMMAND_RULE_LENGTH) return rules
+  if (!patterns.includes(command)) return rules
+  if (rules.includes(command)) return rules
+  return [...rules, command]
+}
+
+export function isFullCommandRule(rule: string, command: string | undefined): boolean {
+  return !!command && command.length <= MAX_FULL_COMMAND_RULE_LENGTH && rule === command
+}
+
+export function displayCommandRule(rule: string, command: string | undefined): string {
+  if (isFullCommandRule(rule, command)) return rule
+  return rule === "*" ? "" : rule.replace(/ \*$/, "")
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -278,6 +278,10 @@
     gap: 6px;
     padding: 3px 0 3px 8px;
     min-width: 0;
+
+    &[data-full-command] {
+      align-items: flex-start;
+    }
   }
 
   [data-slot="permission-rule-type"] {
@@ -296,6 +300,14 @@
     white-space: nowrap;
     min-width: 0;
     flex: 1;
+
+    &[data-full-command] {
+      overflow: visible;
+      text-overflow: clip;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
   }
 
   [data-slot="permission-rule-actions"] {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -384,6 +384,7 @@ export const layer = Layer.effect(
       if (ConfigProtection.isRequest(existing.info)) return true // kilocode_change
 
       const validRules = new Set([
+        ...(existing.info.permission === "bash" ? existing.info.patterns : []),
         ...((existing.info.metadata?.rules as string[] | undefined) ?? []),
         ...existing.info.always,
       ])

--- a/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
+++ b/packages/opencode/test/kilocode/permission/next.always-rules.test.ts
@@ -105,6 +105,40 @@ describe("saveAlwaysRules", () => {
     ),
   )
 
+  it.live("approved current-request patterns auto-allow future exact bash requests", () =>
+    withDir({ git: true }, () =>
+      Effect.gen(function* () {
+        const asking = yield* ask({
+          id: PermissionID.make("permission_exact_pattern"),
+          sessionID: SessionID.make("session_test"),
+          permission: "bash",
+          patterns: ["npm install lodash"],
+          metadata: { command: "npm install lodash", rules: ["npm *", "npm install *"] },
+          always: ["npm install *"],
+          ruleset: [],
+        }).pipe(Effect.forkScoped)
+
+        yield* waitForPending(1)
+        yield* saveAlwaysRules({
+          requestID: PermissionID.make("permission_exact_pattern"),
+          approvedAlways: ["npm install lodash"],
+        })
+        yield* reply({ requestID: PermissionID.make("permission_exact_pattern"), reply: "once" })
+        yield* Fiber.join(asking)
+
+        const result = yield* ask({
+          sessionID: SessionID.make("session_test"),
+          permission: "bash",
+          patterns: ["npm install lodash"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        })
+        expect(result).toBeUndefined()
+      }),
+    ),
+  )
+
   it.live("denied rules auto-deny future requests", () =>
     withDir({ git: true }, () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Adds the current short bash command as an exact auto-approve option in the VS Code permission dock when it is safe to save as a current-request pattern.
- Allows bash current-request patterns to be persisted through saveAlwaysRules so the new exact option actually takes effect.
- Lets exact command rule rows wrap instead of being ellipsized, while long commands remain omitted by the threshold.

Fixes #10383

## Verification

- git diff --check
- git diff upstream/main...HEAD --check
- /root/.bun/bin/bun run script/check-opencode-annotations.ts --base upstream/main

No local build/typecheck or broader test run per OOM constraint.