### PR TITLE
fix(cli): accept stringified todowrite todos

### DIFF
--- a/.changeset/todowrite-string-todos.md
+++ b/.changeset/todowrite-string-todos.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Accept JSON-stringified todo arrays in the todowrite tool.

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION_WRITE from "./todowrite.txt"
 import { Todo } from "../session/todo"
+import { zod, ZodOverride } from "../util/effect-zod" // kilocode_change
 // kilocode_change start
 import { TodoView } from "../kilocode/todo-view"
 // kilocode_change end
@@ -17,8 +18,18 @@ const TodoItem = Schema.Struct({
   priority: Schema.String.annotate({ description: "Priority level of the task: high, medium, low" }),
 })
 
+// kilocode_change start
+const TodoList = Schema.mutable(Schema.Array(TodoItem))
+const TodoListParameter = Schema.Union([TodoList, Schema.fromJsonString(TodoList)]).pipe(
+  Schema.annotate({
+    description: "The updated todo list",
+    [ZodOverride]: zod(TodoList).describe("The updated todo list"),
+  }),
+)
+// kilocode_change end
+
 export const Parameters = Schema.Struct({
-  todos: Schema.mutable(Schema.Array(TodoItem)).annotate({ description: "The updated todo list" }),
+  todos: TodoListParameter, // kilocode_change
 })
 
 type Metadata = {

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -217,6 +217,19 @@ describe("tool parameters", () => {
       })
       expect(parsed.todos.length).toBe(1)
     })
+    // kilocode_change start
+    test("accepts JSON-stringified todos array", () => {
+      const todos = [{ content: "do x", status: "pending", priority: "medium" }]
+      const parsed = parse(Todo, { todos: JSON.stringify(todos) })
+      expect(parsed.todos).toEqual(todos)
+    })
+
+    test("rejects JSON-stringified non-array todos", () => {
+      expect(accepts(Todo, { todos: JSON.stringify({ content: "do x", status: "pending", priority: "medium" }) })).toBe(
+        false,
+      )
+    })
+    // kilocode_change end
     test("rejects missing todos", () => {
       expect(accepts(Todo, {})).toBe(false)
     })


### PR DESCRIPTION
## Summary

- Allows the todowrite tool to accept a JSON-stringified todos array when a model sends the array as a string.
- Keeps the public/LLM-visible tool schema as an array via a Zod override, so the preferred contract does not change.
- Adds parameter parsing coverage for valid stringified arrays and rejects stringified non-arrays.

Fixes #10168

## Verification

- git diff --check
- git diff upstream/main...HEAD --check
- /root/.bun/bin/bun run script/check-opencode-annotations.ts --base upstream/main

No local build/typecheck or broader test run per OOM constraint.