### PR TITLE
fix(cli): show output context limits

### DIFF
--- a/.changeset/context-output-display.md
+++ b/.changeset/context-output-display.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show model output context limits separately in the TUI.

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -45,6 +45,7 @@ import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-worksp
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
 import { KiloSessionTuiSync } from "@/kilocode/session/tui-sync" // kilocode_change
+import { fmtContext, fmtOutputContext } from "@/kilocode/components/model-info-panel-utils" // kilocode_change
 
 export type PromptProps = {
   sessionID?: string
@@ -237,9 +238,16 @@ export function Prompt(props: PromptProps) {
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    // kilocode_change start - show total context and output context separately in the TUI footer
+    const context = model?.limit.context
+      ? `${Locale.number(tokens)} / ${fmtContext(model.limit.context)} (${pct})`
+      : Locale.number(tokens)
+    const output = model ? fmtOutputContext(model.limit.output) : null
+    // kilocode_change end
     const cost = msg.reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
     return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
+      context, // kilocode_change
+      output: output ? `${output} output` : undefined, // kilocode_change
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })
@@ -1493,7 +1501,9 @@ export function Prompt(props: PromptProps) {
                     <Match when={usage()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
+                          {/* kilocode_change start */}
+                          {[item().context, item().output, item().cost].filter(Boolean).join(" · ")}
+                          {/* kilocode_change end */}
                         </text>
                       )}
                     </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -8,6 +8,7 @@ import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
 import { Locale } from "@/util/locale"
 import { useTerminalDimensions } from "@opentui/solid"
+import { fmtContext, fmtOutputContext } from "@/kilocode/components/model-info-panel-utils" // kilocode_change
 
 export function SubagentFooter() {
   const route = useRouteData("session")
@@ -42,6 +43,12 @@ export function SubagentFooter() {
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    // kilocode_change start - show total context and output context separately in the subagent footer
+    const context = model?.limit.context
+      ? `${Locale.number(tokens)} / ${fmtContext(model.limit.context)} (${pct})`
+      : Locale.number(tokens)
+    const output = model ? fmtOutputContext(model.limit.output) : null
+    // kilocode_change end
     const cost = msg.reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
 
     const money = new Intl.NumberFormat("en-US", {
@@ -50,7 +57,8 @@ export function SubagentFooter() {
     })
 
     return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
+      context, // kilocode_change
+      output: output ? `${output} output` : undefined, // kilocode_change
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })
@@ -87,7 +95,9 @@ export function SubagentFooter() {
             <Show when={usage()}>
               {(item) => (
                 <text fg={theme.textMuted} wrapMode="none">
-                  {[item().context, item().cost].filter(Boolean).join(" · ")}
+                  {/* kilocode_change start */}
+                  {[item().context, item().output, item().cost].filter(Boolean).join(" · ")}
+                  {/* kilocode_change end */}
                 </text>
               )}
             </Show>

--- a/packages/opencode/src/kilocode/components/model-info-panel-utils.ts
+++ b/packages/opencode/src/kilocode/components/model-info-panel-utils.ts
@@ -32,6 +32,11 @@ export function fmtContext(n: number): string {
   return String(n)
 }
 
+export function fmtOutputContext(n: number): string | null {
+  if (n <= 0) return null
+  return fmtContext(n)
+}
+
 export function fmtDate(s: string): string {
   const d = new Date(s)
   if (isNaN(d.getTime())) return s

--- a/packages/opencode/src/kilocode/components/model-info-panel.tsx
+++ b/packages/opencode/src/kilocode/components/model-info-panel.tsx
@@ -3,7 +3,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { createMemo, Show } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import type { Model } from "@kilocode/sdk/v2"
-import { avgPrice, fmtCachedPrice, fmtContext, fmtDate, fmtPrice } from "./model-info-panel-utils"
+import { avgPrice, fmtCachedPrice, fmtContext, fmtDate, fmtOutputContext, fmtPrice } from "./model-info-panel-utils"
 
 interface Props {
   model: Model
@@ -20,6 +20,7 @@ export function ModelInfoPanel(props: Props) {
   const cost = () => m().cost
   const cached = () => (cost() ? fmtCachedPrice(cost()) : null)
   const avg = () => (cost() ? avgPrice(cost()) : undefined)
+  const outputContext = () => fmtOutputContext(m().limit.output)
   const caps = () => m().capabilities
   const inputs = () => caps()?.input
   const outputs = () => caps()?.output
@@ -106,9 +107,17 @@ export function ModelInfoPanel(props: Props) {
               </box>
             </Show>
             <box flexDirection="row" justifyContent="space-between">
-              <text fg={theme.textMuted}>Context</text>
+              <text fg={theme.textMuted}>Total Context</text>
               <text fg={theme.text}>{m() ? fmtContext(m().limit.context) : "—"}</text>
             </box>
+            <Show when={outputContext()}>
+              {(limit) => (
+                <box flexDirection="row" justifyContent="space-between">
+                  <text fg={theme.textMuted}>Max Output</text>
+                  <text fg={theme.text}>{limit()}</text>
+                </box>
+              )}
+            </Show>
           </box>
         </Show>
         <Show when={caps()?.reasoning || inputLine() || outputLine()}>

--- a/packages/opencode/test/kilocode/model-info-panel-utils.test.ts
+++ b/packages/opencode/test/kilocode/model-info-panel-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { avgPrice, fmtCachedPrice, fmtContext, fmtPrice } from "../../src/kilocode/components/model-info-panel-utils"
+import {
+  avgPrice,
+  fmtCachedPrice,
+  fmtContext,
+  fmtOutputContext,
+  fmtPrice,
+} from "../../src/kilocode/components/model-info-panel-utils"
 
 describe("model info panel price formatting", () => {
   test("fmtPrice returns Free for zero", () => {
@@ -48,5 +54,13 @@ describe("model info panel context formatting", () => {
 
   test("returns exact value for small contexts", () => {
     expect(fmtContext(800)).toBe("800")
+  })
+
+  test("formats output context when present", () => {
+    expect(fmtOutputContext(65536)).toBe("65.5K")
+  })
+
+  test("omits zero output context", () => {
+    expect(fmtOutputContext(0)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- Shows model total context and max output limits as separate rows in the TUI model info panel.
- Includes the total context limit and output limit in the TUI footer usage display when model metadata is available.
- Adds focused formatting coverage for output context limits.

Fixes #9906

## Verification

- git diff --check
- git diff upstream/main...HEAD --check
- /root/.bun/bin/bun run script/check-opencode-annotations.ts --base upstream/main

No local build/typecheck or broader test run per OOM constraint.