### PR TITLE
fix(cli): trim repaired tool names

### DIFF
--- a/.changeset/tool-name-whitespace.md
+++ b/.changeset/tool-name-whitespace.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Handle tool calls whose tool names include accidental leading or trailing whitespace.

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -9,6 +9,17 @@ const SAFETY = 2048
 const MIN_OUTPUT = 1024
 
 export namespace KiloLLM {
+  export function repairToolName(input: { name: string; tools: Record<string, unknown> }): string | undefined {
+    const trimmed = input.name.trim()
+    if (trimmed !== input.name && input.tools[trimmed]) return trimmed
+
+    const lower = input.name.toLowerCase()
+    if (lower !== input.name && input.tools[lower]) return lower
+
+    const normalized = trimmed.toLowerCase()
+    if (normalized !== input.name && input.tools[normalized]) return normalized
+  }
+
   /**
    * Caps `maxOutputTokens` to fit within the model's context window after
    * accounting for the actual estimated input tokens (messages + tool schemas).

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -389,17 +389,19 @@ const live: Layer.Layer<
           })
         },
         async experimental_repairToolCall(failed) {
-          const lower = failed.toolCall.toolName.toLowerCase()
-          if (lower !== failed.toolCall.toolName && tools[lower]) {
+          // kilocode_change start
+          const repaired = KiloLLM.repairToolName({ name: failed.toolCall.toolName, tools })
+          if (repaired) {
             l.info("repairing tool call", {
               tool: failed.toolCall.toolName,
-              repaired: lower,
+              repaired,
             })
             return {
               ...failed.toolCall,
-              toolName: lower,
+              toolName: repaired,
             }
           }
+          // kilocode_change end
           return {
             ...failed.toolCall,
             input: JSON.stringify({

--- a/packages/opencode/test/kilocode/session/llm.test.ts
+++ b/packages/opencode/test/kilocode/session/llm.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { KiloLLM } from "../../../src/kilocode/session/llm"
+
+describe("KiloLLM.repairToolName", () => {
+  const tools = {
+    read: {},
+    bash: {},
+    customTool: {},
+  }
+
+  test("repairs leading whitespace before known tool names", () => {
+    expect(KiloLLM.repairToolName({ name: " read", tools })).toBe("read")
+  })
+
+  test("repairs case and surrounding whitespace together", () => {
+    expect(KiloLLM.repairToolName({ name: " Bash ", tools })).toBe("bash")
+  })
+
+  test("keeps unknown tool names unknown", () => {
+    expect(KiloLLM.repairToolName({ name: " missing ", tools })).toBeUndefined()
+  })
+
+  test("does not change exact custom tool names", () => {
+    expect(KiloLLM.repairToolName({ name: "customTool", tools })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Normalizes tool names with accidental leading or trailing whitespace before falling back to the invalid-tool repair path.
- Keeps truly unknown tools unknown and preserves exact custom tool names.
- Adds focused helper coverage for whitespace and casing repair.

Fixes #10140

## Verification

- git diff --check
- git diff upstream/main...HEAD --check
- /root/.bun/bin/bun run script/check-opencode-annotations.ts --base upstream/main

No local build/typecheck or broader test run per OOM constraint.