### PR TITLE
feat(cli): configure plan follow-up

### DIFF
--- a/.changeset/plan-followup-setting.md
+++ b/.changeset/plan-followup-setting.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Support configuring plan mode to continue automatically or start a new implementation session without asking.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -185,6 +185,10 @@ export const Info = Schema.Struct({
   terminal_command_display: Schema.optional(Schema.Literals(["expanded", "collapsed"])).annotate({
     description: "Controls whether terminal command blocks are expanded or collapsed by default in the VS Code chat UI",
   }),
+  plan_followup: Schema.optional(Schema.Literals(["ask", "current", "new"])).annotate({
+    description:
+      "Controls what happens after plan mode finishes: ask for confirmation, continue in the current session, or start a new session.",
+  }),
   // kilocode_change end
   // kilocode_change start - nullable for delete sentinel
   model: Schema.optional(Schema.NullOr(ConfigModelID)).annotate({

--- a/packages/opencode/src/kilocode/plan-followup.ts
+++ b/packages/opencode/src/kilocode/plan-followup.ts
@@ -15,6 +15,7 @@ import { LLM } from "@/session/llm"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionStatus } from "@/session/status"
 import { Todo } from "@/session/todo"
+import { Config } from "@/config/config"
 import { makeRuntime } from "@/effect/run-service"
 import * as Log from "@opencode-ai/core/util/log"
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
@@ -161,6 +162,10 @@ export namespace PlanFollowup {
   export const PLAN_PREFIX = "Implement the following plan:"
   export const ANSWER_NEW_SESSION = "Start new session"
   export const ANSWER_CONTINUE = "Continue here"
+  const ConfigAnswer = {
+    new: ANSWER_NEW_SESSION,
+    current: ANSWER_CONTINUE,
+  }
 
   export function abort(sessionID: SessionID) {
     const ctl = pending.get(sessionID)
@@ -465,13 +470,14 @@ export namespace PlanFollowup {
     const user = latest.find((msg) => msg.info.role === "user")?.info
     if (!user || user.role !== "user" || !user.model) return "break"
 
-    const answers = await prompt({ sessionID: input.sessionID, abort: input.abort })
-    if (!answers) {
-      Telemetry.trackPlanFollowup(input.sessionID, "dismissed")
-      return "break"
-    }
+    const cfg = await Config.get()
+    const answer =
+      cfg.plan_followup === "new" || cfg.plan_followup === "current"
+        ? ConfigAnswer[cfg.plan_followup]
+        : (await prompt({ sessionID: input.sessionID, abort: input.abort }))?.[0]?.[0]?.trim()
 
-    const answer = answers[0]?.[0]?.trim()
+    if (input.abort.aborted) return "break"
+
     if (!answer) {
       Telemetry.trackPlanFollowup(input.sessionID, "dismissed")
       return "break"

--- a/packages/opencode/test/kilocode/plan-followup.test.ts
+++ b/packages/opencode/test/kilocode/plan-followup.test.ts
@@ -11,6 +11,7 @@ import { Provider } from "../../src/provider/provider"
 import { Question } from "../../src/question"
 import { Session } from "../../src/session/session"
 import { LLM } from "../../src/session/llm"
+import { Config } from "../../src/config/config"
 import { MessageV2 } from "../../src/session/message-v2"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { SessionStatus } from "../../src/session/status"
@@ -68,8 +69,8 @@ const planVar = "medium"
 const statePath = path.join(Global.Path.state, "model.json")
 const savedKey = `${saved.providerID}/${saved.modelID}`
 
-async function withInstance(fn: () => Promise<void>) {
-  await using tmp = await tmpdir({ git: true })
+async function withInstance(fn: () => Promise<void>, opts?: { config?: Partial<Config.Info> }) {
+  await using tmp = await tmpdir({ git: true, config: opts?.config })
   await fs.rm(statePath, { force: true }).catch(() => {})
   await Instance.provide({
     directory: tmp.path,
@@ -444,6 +445,52 @@ describe("plan follow-up", () => {
       expect(part.synthetic).toBe(true)
     }))
 
+  test("ask - auto continues when plan_followup is current", () =>
+    withInstance(
+      async () => {
+        const get = spyOn(PlanFollowupRuntime, "agent").mockImplementation(async (name: string) => {
+          if (name === "code") {
+            return {
+              name: "code",
+              mode: "primary",
+              permission: [],
+              options: {},
+              model: saved,
+              variant: configVar,
+            } as any
+          }
+          return undefined as any
+        })
+        const modelSpy = spyOn(PlanFollowupRuntime, "model").mockResolvedValue(savedConfigFull)
+        using _ = {
+          [Symbol.dispose]() {
+            get.mockRestore()
+            modelSpy.mockRestore()
+          },
+        }
+        const seeded = await seed({ text: "1. Build\n2. Test" })
+
+        await expect(
+          PlanFollowup.ask({
+            sessionID: seeded.sessionID,
+            messages: seeded.messages,
+            abort: AbortSignal.any([]),
+          }),
+        ).resolves.toBe("continue")
+
+        expect(await question.list()).toHaveLength(0)
+        const user = await latestUser(seeded.sessionID)
+        expect(user?.info.role).toBe("user")
+        if (!user || user.info.role !== "user") return
+        expect(user.info.agent).toBe("code")
+        expect(user.info.model).toEqual({ ...saved, variant: configVar })
+
+        const part = user.parts.find((item) => item.type === "text")
+        expect(part?.type === "text" && part.text).toBe("Implement the plan above.")
+      },
+      { config: { plan_followup: "current" } },
+    ))
+
   test("ask - returns continue and creates plan message for custom text", () =>
     withInstance(async () => {
       const seeded = await seed({ text: "1. Build\n2. Test" })
@@ -474,6 +521,64 @@ describe("plan follow-up", () => {
       expect(part.text).toBe("Add rollback support too")
       expect(part.synthetic).toBe(true)
     }))
+
+  test("ask - starts a new session when plan_followup is new", () =>
+    withInstance(
+      async () => {
+        const get = spyOn(PlanFollowupRuntime, "agent").mockResolvedValue(fakeAgent as any)
+        const modelSpy = spyOn(PlanFollowupRuntime, "model").mockResolvedValue(fakeModel)
+        const llmSpy = spyOn(LLM, "stream").mockResolvedValue({ text: Promise.resolve("") } as any)
+        const loop = spyOn(PlanFollowupRuntime, "loop").mockResolvedValue({
+          info: {
+            id: MessageID.make("msg_test"),
+            role: "assistant",
+            sessionID: SessionID.make("ses_test"),
+            time: { created: Date.now() },
+            parentID: MessageID.make("msg_parent"),
+            modelID: ModelID.make("test"),
+            providerID: ProviderID.make("test"),
+            mode: "code",
+            agent: "code",
+            path: { cwd: "/tmp", root: "/tmp" },
+            cost: 0,
+            tokens: {
+              total: 0,
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+          parts: [],
+        } as MessageV2.WithParts)
+        using _ = {
+          [Symbol.dispose]() {
+            get.mockRestore()
+            modelSpy.mockRestore()
+            llmSpy.mockRestore()
+            loop.mockRestore()
+          },
+        }
+        const seeded = await seed({ text: "1. Build\n2. Test" })
+        const before = await sessions()
+
+        await expect(
+          PlanFollowup.ask({
+            sessionID: seeded.sessionID,
+            messages: seeded.messages,
+            abort: AbortSignal.any([]),
+          }),
+        ).resolves.toBe("break")
+
+        expect(await question.list()).toHaveLength(0)
+        const after = await sessions()
+        const prev = new Set(before.map((item) => item.id))
+        const added = after.filter((item) => !prev.has(item.id))
+        expect(added).toHaveLength(1)
+        expect(loop).toHaveBeenCalledTimes(1)
+      },
+      { config: { plan_followup: "new" } },
+    ))
 
   test("ask - retargets prompt queue so injected message is visible in scope", () =>
     withInstance(async () => {


### PR DESCRIPTION
## Summary

- Adds a `plan_followup` config option with `ask`, `current`, and `new` modes.
- Reuses the existing continue-here and new-session handoff paths when the setting skips the confirmation question.
- Keeps the default behavior unchanged by asking when no setting is configured.

Fixes #10300

## Verification

- git diff --check
- git diff upstream/main...HEAD --check
- /root/.bun/bin/bun run script/check-opencode-annotations.ts --base upstream/main

No local build/typecheck or broader test run per OOM constraint.