### PR TITLE
fix(vscode): collapse terminal output by default

### DIFF
--- a/.changeset/collapse-terminal-command-default.md
+++ b/.changeset/collapse-terminal-command-default.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Collapse terminal command output by default in the VS Code chat UI.

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -59,11 +59,11 @@ Reasoning blocks stay expanded by default in the VS Code chat UI. Enable **Auto-
 
 ### Terminal Command Blocks
 
-Terminal command blocks stay expanded by default in the VS Code chat UI. Choose **Collapsed** for **Terminal Command Blocks** in the Display tab, or set `terminal_command_display` in `kilo.jsonc`, to start them collapsed:
+Terminal command blocks start collapsed by default in the VS Code chat UI. Choose **Expanded** for **Terminal Command Blocks** in the Display tab, or set `terminal_command_display` in `kilo.jsonc`, to keep them expanded:
 
 ```json
 {
-  "terminal_command_display": "collapsed"
+  "terminal_command_display": "expanded"
 }
 ```
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -174,7 +174,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const session = useSession()
   const display = useDisplay()
   const { config } = useConfig()
-  const open = createMemo(() => config().terminal_command_display !== "collapsed")
+  const open = createMemo(() => config().terminal_command_display === "expanded")
 
   const parts = createMemo(() => {
     const stored = data.store.part?.[props.message.id]

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -106,13 +106,13 @@ const DisplayTab: Component = () => {
         >
           <Select
             options={TERMINAL_OPTIONS}
-            current={TERMINAL_OPTIONS.find((o) => o.value === (config().terminal_command_display ?? "expanded"))}
+            current={TERMINAL_OPTIONS.find((o) => o.value === (config().terminal_command_display ?? "collapsed"))}
             value={(o) => o.value}
             label={(o) => language.t(o.labelKey)}
             onSelect={(o) => {
               if (!o) return
               const next = o.value as TerminalCommandDisplay
-              if (next === (config().terminal_command_display ?? "expanded")) return
+              if (next === (config().terminal_command_display ?? "collapsed")) return
               updateConfig({ terminal_command_display: next })
             }}
             variant="secondary"


### PR DESCRIPTION
## Summary

- Collapses terminal command output by default in the VS Code chat UI.
- Keeps explicit `terminal_command_display: "expanded"` settings working for users who prefer expanded output.
- Updates the Display settings fallback and docs to match the new default.

Fixes #9959

## Verification

- git diff --check
- git diff upstream/main...HEAD --check

No local build/typecheck or broader test run per OOM constraint.
