### PR TITLE
fix(vscode): preserve patch file diff status

### DIFF
--- a/.changeset/quiet-patches-diff.md
+++ b/.changeset/quiet-patches-diff.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+---
+
+Preserve apply_patch file status metadata so added and deleted files render with the correct diff context.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2454,6 +2454,14 @@ interface ApplyPatchFile {
   movePath?: string
 }
 
+type ApplyPatchFileStatus = "added" | "modified" | "deleted"
+
+function applyPatchStatus(type: ApplyPatchFile["type"]): ApplyPatchFileStatus {
+  if (type === "add") return "added"
+  if (type === "delete") return "deleted"
+  return "modified"
+}
+
 ToolRegistry.register({
   name: "apply_patch",
   render(props) {
@@ -2469,6 +2477,7 @@ ToolRegistry.register({
         patch,
         additions: file.additions,
         deletions: file.deletions,
+        status: applyPatchStatus(file.type),
       })
     }
     const pending = createMemo(() => busy(props.status))

--- a/packages/kilo-vscode/src/DiffVirtualProvider.ts
+++ b/packages/kilo-vscode/src/DiffVirtualProvider.ts
@@ -9,6 +9,7 @@ export interface DiffVirtualFile {
   patch?: string
   additions: number
   deletions: number
+  status?: "added" | "modified" | "deleted"
   initialDiffStyle: "unified" | "split"
 }
 

--- a/packages/kilo-vscode/tests/unit/permission-diff-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-diff-utils.test.ts
@@ -28,13 +28,15 @@ describe("permissionDiffs", () => {
         files: [
           { relativePath: "src/a.ts", type: "update", patch: "a", additions: 1, deletions: 1 },
           { relativePath: "src/b.ts", type: "add", patch: "b", additions: 2, deletions: 0 },
+          { relativePath: "src/c.ts", type: "delete", patch: "c", additions: 0, deletions: 3 },
         ],
       }),
     )
 
     expect(diffs).toEqual([
-      { file: "src/a.ts", patch: "a", additions: 1, deletions: 1 },
-      { file: "src/b.ts", patch: "b", additions: 2, deletions: 0 },
+      { file: "src/a.ts", patch: "a", additions: 1, deletions: 1, status: "modified" },
+      { file: "src/b.ts", patch: "b", additions: 2, deletions: 0, status: "added" },
+      { file: "src/c.ts", patch: "c", additions: 0, deletions: 3, status: "deleted" },
     ])
   })
 

--- a/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-virtual/DiffVirtualApp.tsx
@@ -25,6 +25,7 @@ interface DiffVirtualFile {
   patch?: string
   additions: number
   deletions: number
+  status?: "added" | "modified" | "deleted"
 }
 
 const DiffVirtualContent: Component = () => {
@@ -119,7 +120,9 @@ const DiffVirtualContent: Component = () => {
                     when={markdown() && isMarkdownFile(d().file)}
                     fallback={<Diff fileDiff={v().fileDiff} diffStyle={style()} hunkSeparators="simple" />}
                   >
-                    <MarkdownDiffView diff={{ file: d().file, before: v().before, after: v().after }} />
+                    <MarkdownDiffView
+                      diff={{ file: d().file, before: v().before, after: v().after, status: d().status }}
+                    />
                   </Show>
                 )}
               </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/permission-diff-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/permission-diff-utils.ts
@@ -1,4 +1,4 @@
-import type { PermissionFileDiff, PermissionRequest } from "../../types/messages"
+import type { PermissionFileDiff, PermissionFileStatus, PermissionRequest } from "../../types/messages"
 
 type File = {
   filePath?: unknown
@@ -17,27 +17,39 @@ function text(value: unknown) {
   return typeof value === "string" ? value : undefined
 }
 
+function status(value: unknown): PermissionFileStatus | undefined {
+  if (value === "added" || value === "modified" || value === "deleted") return value
+  if (value === "add") return "added"
+  if (value === "delete") return "deleted"
+  if (value === "update" || value === "move") return "modified"
+  return undefined
+}
+
 function clean(diff: unknown): PermissionFileDiff | undefined {
   if (!diff || typeof diff !== "object") return
   const item = diff as Record<string, unknown>
   const file = text(item.file)
   if (!file) return
+  const fileStatus = status(item.status)
   return {
     file,
     ...(text(item.patch) !== undefined ? { patch: text(item.patch) } : {}),
     additions: num(item.additions),
     deletions: num(item.deletions),
+    ...(fileStatus !== undefined ? { status: fileStatus } : {}),
   }
 }
 
 function file(item: File): PermissionFileDiff | undefined {
   const name = text(item.relativePath) ?? text(item.filePath)
   if (!name) return
+  const fileStatus = status(item.type)
   return {
     file: name,
     ...(text(item.patch) !== undefined ? { patch: text(item.patch) } : {}),
     additions: num(item.additions),
     deletions: num(item.deletions),
+    ...(fileStatus !== undefined ? { status: fileStatus } : {}),
   }
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/permissions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/permissions.ts
@@ -13,11 +13,14 @@ export interface PermissionRuleItem {
 }
 
 // Permission request
+export type PermissionFileStatus = "added" | "modified" | "deleted"
+
 export interface PermissionFileDiff {
   file: string
   patch?: string
   additions: number
   deletions: number
+  status?: PermissionFileStatus
 }
 
 export interface PermissionPatchFile {


### PR DESCRIPTION
Fixes #10010.

Summary:
- Preserve apply_patch per-file status metadata in permission diffs.
- Pass add/delete/update metadata through apply_patch result diffs and the virtual diff viewer.
- Keep Markdown virtual diffs aware of added/deleted status so one-sided file changes render correctly.

Checks:
- git diff --check
- git diff upstream/main...HEAD --check
- git diff --cached --check

Not run: local compile/build/broad tests due OOM-risk constraint.