### PR TITLE
fix(kilo-vscode): missing xhigh option in VariantConfigSchema

### DIFF
--- a/packages/kilo-vscode/src/shared/custom-provider.ts
+++ b/packages/kilo-vscode/src/shared/custom-provider.ts
@@ -14,7 +14,7 @@ export const EnvSchema = z
 const VariantConfigSchema = z.object({
   enable_thinking: z.boolean().optional(),
   thinking: z.object({ type: z.enum(["enabled", "disabled"]) }).optional(),
-  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
   chat_template_args: z.object({ enable_thinking: z.boolean() }).optional(),
 })
 


### PR DESCRIPTION
This pull request introduces a minor update to the validation schema for environment configuration in the custom provider module. The main change is the addition of a new value to the `reasoningEffort` enum.

Schema update:

* Added `"xhigh"` as an additional valid option to the `reasoningEffort` enum in the `VariantConfigSchema` within `custom-provider.ts` to fix below error.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/abfec600-029b-4525-ae73-6aaabc9a9636" />