### PR TITLE
Remove duplicate busy badge in Agent Manager tab search

### DIFF
--- a/.changeset/quiet-tabs-work.md
+++ b/.changeset/quiet-tabs-work.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the duplicate Work badge from busy Agent Manager tab search results.

--- a/packages/kilo-vscode/webview-ui/agent-manager/CurrentTabsMenu.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/CurrentTabsMenu.tsx
@@ -135,7 +135,6 @@ function buildItem(
 
 function statusLabel(id: string, blocked: boolean, status: SessionStatusInfo | undefined, deps: CurrentTabItemsDeps) {
   if (blocked) return deps.t("agentManager.tabsMenu.status.waiting")
-  if (status?.type === "busy") return deps.t("agentManager.tabsMenu.status.working")
   if (status?.type === "retry") return deps.t("agentManager.tabsMenu.status.retry")
   return undefined
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "البحث في علامات التبويب...",
   "agentManager.tabsMenu.empty": "لا توجد علامات تبويب مطابقة",
   "agentManager.tabsMenu.status.waiting": "انتظار",
-  "agentManager.tabsMenu.status.working": "يعمل",
   "agentManager.tabsMenu.status.retry": "إعادة",
 
   "agentManager.terminal.new": "علامة تبويب جديدة للمحطة الطرفية",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Pesquisar abas...",
   "agentManager.tabsMenu.empty": "Nenhuma aba correspondente",
   "agentManager.tabsMenu.status.waiting": "Espera",
-  "agentManager.tabsMenu.status.working": "Execução",
   "agentManager.tabsMenu.status.retry": "Repetir",
 
   "agentManager.terminal.new": "Nova aba de terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Pretraži kartice...",
   "agentManager.tabsMenu.empty": "Nema podudarnih kartica",
   "agentManager.tabsMenu.status.waiting": "Čeka",
-  "agentManager.tabsMenu.status.working": "Radi",
   "agentManager.tabsMenu.status.retry": "Pokušaj",
 
   "agentManager.terminal.new": "Nova kartica terminala",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Søg faner...",
   "agentManager.tabsMenu.empty": "Ingen matchende faner",
   "agentManager.tabsMenu.status.waiting": "Venter",
-  "agentManager.tabsMenu.status.working": "Arbejder",
   "agentManager.tabsMenu.status.retry": "Igen",
 
   "agentManager.terminal.new": "Ny terminalfane",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Tabs suchen...",
   "agentManager.tabsMenu.empty": "Keine passenden Tabs",
   "agentManager.tabsMenu.status.waiting": "Warten",
-  "agentManager.tabsMenu.status.working": "Läuft",
   "agentManager.tabsMenu.status.retry": "Erneut",
 
   "agentManager.terminal.new": "Neuer Terminal-Tab",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -59,7 +59,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Search tabs...",
   "agentManager.tabsMenu.empty": "No matching tabs",
   "agentManager.tabsMenu.status.waiting": "Wait",
-  "agentManager.tabsMenu.status.working": "Work",
   "agentManager.tabsMenu.status.retry": "Retry",
 
   "agentManager.terminal.new": "New Terminal Tab",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Buscar pestañas...",
   "agentManager.tabsMenu.empty": "No hay pestañas coincidentes",
   "agentManager.tabsMenu.status.waiting": "Espera",
-  "agentManager.tabsMenu.status.working": "En curso",
   "agentManager.tabsMenu.status.retry": "Reintento",
 
   "agentManager.terminal.new": "Nueva pestaña de terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Rechercher des onglets...",
   "agentManager.tabsMenu.empty": "Aucun onglet correspondant",
   "agentManager.tabsMenu.status.waiting": "Attente",
-  "agentManager.tabsMenu.status.working": "En cours",
   "agentManager.tabsMenu.status.retry": "Réessai",
 
   "agentManager.terminal.new": "Nouvel onglet de terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "タブを検索...",
   "agentManager.tabsMenu.empty": "一致するタブがありません",
   "agentManager.tabsMenu.status.waiting": "待機",
-  "agentManager.tabsMenu.status.working": "実行中",
   "agentManager.tabsMenu.status.retry": "再試行",
 
   "agentManager.terminal.new": "新しいターミナルタブ",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "탭 검색...",
   "agentManager.tabsMenu.empty": "일치하는 탭 없음",
   "agentManager.tabsMenu.status.waiting": "대기",
-  "agentManager.tabsMenu.status.working": "작업 중",
   "agentManager.tabsMenu.status.retry": "재시도",
 
   "agentManager.terminal.new": "새 터미널 탭",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -59,7 +59,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Tabbladen zoeken...",
   "agentManager.tabsMenu.empty": "Geen overeenkomende tabbladen",
   "agentManager.tabsMenu.status.waiting": "Wacht",
-  "agentManager.tabsMenu.status.working": "Bezig",
   "agentManager.tabsMenu.status.retry": "Opnieuw",
 
   "agentManager.terminal.new": "Nieuw terminaltabblad",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Søk i faner...",
   "agentManager.tabsMenu.empty": "Ingen treffende faner",
   "agentManager.tabsMenu.status.waiting": "Venter",
-  "agentManager.tabsMenu.status.working": "Jobber",
   "agentManager.tabsMenu.status.retry": "Igjen",
 
   "agentManager.terminal.new": "Ny terminalfane",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Szukaj kart...",
   "agentManager.tabsMenu.empty": "Brak pasujących kart",
   "agentManager.tabsMenu.status.waiting": "Czeka",
-  "agentManager.tabsMenu.status.working": "Pracuje",
   "agentManager.tabsMenu.status.retry": "Ponów",
 
   "agentManager.terminal.new": "Nowa karta terminala",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Поиск вкладок...",
   "agentManager.tabsMenu.empty": "Нет подходящих вкладок",
   "agentManager.tabsMenu.status.waiting": "Ожидание",
-  "agentManager.tabsMenu.status.working": "Работа",
   "agentManager.tabsMenu.status.retry": "Повтор",
 
   "agentManager.terminal.new": "Новая вкладка терминала",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "ค้นหาแท็บ...",
   "agentManager.tabsMenu.empty": "ไม่มีแท็บที่ตรงกัน",
   "agentManager.tabsMenu.status.waiting": "รอ",
-  "agentManager.tabsMenu.status.working": "ทำงาน",
   "agentManager.tabsMenu.status.retry": "ลองใหม่",
 
   "agentManager.terminal.new": "แท็บเทอร์มินัลใหม่",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -59,7 +59,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Sekmelerde ara...",
   "agentManager.tabsMenu.empty": "Eşleşen sekme yok",
   "agentManager.tabsMenu.status.waiting": "Bekliyor",
-  "agentManager.tabsMenu.status.working": "Çalışıyor",
   "agentManager.tabsMenu.status.retry": "Yeniden",
 
   "agentManager.terminal.new": "Yeni Terminal Sekmesi",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -59,7 +59,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "Шукати вкладки...",
   "agentManager.tabsMenu.empty": "Немає відповідних вкладок",
   "agentManager.tabsMenu.status.waiting": "Очікує",
-  "agentManager.tabsMenu.status.working": "Працює",
   "agentManager.tabsMenu.status.retry": "Повтор",
 
   "agentManager.terminal.new": "Нова вкладка термінала",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "搜索标签页...",
   "agentManager.tabsMenu.empty": "无匹配标签页",
   "agentManager.tabsMenu.status.waiting": "等待",
-  "agentManager.tabsMenu.status.working": "工作中",
   "agentManager.tabsMenu.status.retry": "重试",
 
   "agentManager.terminal.new": "新建终端标签页",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -55,7 +55,6 @@ export const dict = {
   "agentManager.tabsMenu.search": "搜尋分頁...",
   "agentManager.tabsMenu.empty": "沒有相符的分頁",
   "agentManager.tabsMenu.status.waiting": "等待",
-  "agentManager.tabsMenu.status.working": "工作中",
   "agentManager.tabsMenu.status.retry": "重試",
 
   "agentManager.terminal.new": "新增終端分頁",


### PR DESCRIPTION
Remove vibe coded work label, that should never have been there.

<img width="668" height="242" alt="image" src="https://github.com/user-attachments/assets/7c26f00b-c041-4988-8931-37c12a555389" />
