### PR TITLE
fix(opencode): avoid dot ripgrep targets on Windows

### DIFF
--- a/.changeset/windows-ripgrep-search.md
+++ b/.changeset/windows-ripgrep-search.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix file search failures on Windows when ripgrep runs from a project directory.

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -195,6 +195,7 @@ function fail(queue: Queue.Queue<string, PlatformError | Error | Cause.Done>, er
 }
 
 function filesArgs(input: FilesInput) {
+  // kilocode_change start - let ripgrep use cwd implicitly so Windows CI does not duplicate the root path
   const args = ["--no-config", "--files", "--glob=!.git/*"]
   if (input.follow) args.push("--follow")
   if (input.hidden !== false) args.push("--hidden")
@@ -203,19 +204,21 @@ function filesArgs(input: FilesInput) {
   if (input.glob) {
     for (const glob of input.glob) args.push(`--glob=${glob}`)
   }
-  args.push(".")
   return args
+  // kilocode_change end
 }
 
 function searchArgs(input: SearchInput) {
+  // kilocode_change start - omit the fallback "." target; ripgrep already searches cwd
   const args = ["--no-config", "--json", "--hidden", "--glob=!.git/*", "--no-messages"]
   if (input.follow) args.push("--follow")
   if (input.glob) {
     for (const glob of input.glob) args.push(`--glob=${glob}`)
   }
   if (input.limit) args.push(`--max-count=${input.limit}`)
-  args.push("--", input.pattern, ...(input.file ?? ["."]))
+  args.push("--", input.pattern, ...(input.file ?? []))
   return args
+  // kilocode_change end
 }
 
 function raceAbort<A, E, R>(effect: Effect.Effect<A, E, R>, signal?: AbortSignal) {

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -677,8 +677,8 @@ describe("file/index Filesystem patterns", () => {
     })
   })
 
-  // kilocode_change - skip on windows: address windows ci failures #9496
-  describe.skipIf(process.platform === "win32")("search()", () => {
+  // kilocode_change - keep Windows ripgrep coverage enabled for #9496
+  describe("search()", () => {
     async function setupSearchableRepo() {
       const tmp = await tmpdir({ git: true })
       await fs.writeFile(path.join(tmp.path, "index.ts"), "code", "utf-8")
@@ -895,8 +895,8 @@ describe("file/index Filesystem patterns", () => {
     })
   })
 
-  // kilocode_change - skip on windows: address windows ci failures #9496
-  describe.skipIf(process.platform === "win32")("InstanceState isolation", () => {
+  // kilocode_change - keep Windows ripgrep coverage enabled for #9496
+  describe("InstanceState isolation", () => {
     test("two directories get independent file caches", async () => {
       await using one = await tmpdir({ git: true })
       await using two = await tmpdir({ git: true })

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -9,8 +9,8 @@ import { Ripgrep } from "../../src/file/ripgrep"
 const run = <A>(effect: Effect.Effect<A, unknown, Ripgrep.Service>) =>
   effect.pipe(Effect.provide(Ripgrep.defaultLayer), Effect.runPromise)
 
-// kilocode_change - skip on windows: address windows ci failures #9496
-describe.skipIf(process.platform === "win32")("file.ripgrep", () => {
+// kilocode_change - keep Windows ripgrep coverage enabled for #9496
+describe("file.ripgrep", () => {
   test("defaults to include hidden", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## Summary

Fixes the Windows ripgrep test failure by letting ripgrep use the current working directory implicitly instead of passing `.` as an explicit search target. This avoids the `rg: .: IO error ... Function not implemented` path while keeping explicit file targets unchanged.

The skipped Windows test blocks are re-enabled so CI covers the behavior again.

Fixes #9496.

## Testing

- `PATH="/Users/mehmet.turac/.bun/bin:$PATH" bun test test/file/ripgrep.test.ts test/file/index.test.ts` from `packages/opencode`
- pre-push `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains`