### PR TITLE
feat: configure task subagent model defaults

### DIFF
--- a/.changeset/clean-subagents-think.md
+++ b/.changeset/clean-subagents-think.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Support configuring the default task subagent model and reasoning effort while safely inheriting the calling agent model when the override is unavailable.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/models-autocomplete-open-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/models-autocomplete-open-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdcac95e7969d021ebce19001f37f86b8ab670bd79e39086385c9419617294df
-size 27177
+oid sha256:e1a5dfe9704a74cbfa2da2a179ed995bcc31def156e798277dcfb568b25db58d
+size 35913

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/settings-panel-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/settings-panel-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73a34a22b24e42731510f9ecd3ea8827a0e39fa9b335294c45c4e8780df9a1f4
-size 35853
+oid sha256:6bcfc6c12f69c5131dcc8f294f480e26ff53f87e0c5943bf525e69c4c894ad21
+size 43744

--- a/packages/kilo-vscode/tests/unit/settings-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/settings-io.test.ts
@@ -167,6 +167,16 @@ describe("parseImport", () => {
     if (result.ok) expect(result.config.model).toBe("test-model")
   })
 
+  it("preserves task subagent model and variant settings", () => {
+    const json = JSON.stringify({ subagent_model: "anthropic/claude-sonnet-4", subagent_variant: "high" })
+    const result = parseImport(json)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.config.subagent_model).toBe("anthropic/claude-sonnet-4")
+      expect(result.config.subagent_variant).toBe("high")
+    }
+  })
+
   it("strips _meta before returning config", () => {
     const json = JSON.stringify({
       _meta: { version: 1, exportedAt: "2026-01-01", secretsStripped: true },

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -38,7 +38,7 @@ const ModelsTab: Component = () => {
     const list = subagentVariants()
     if (list.length === 0) return undefined
     const value = config().subagent_variant ?? undefined
-    return value && list.includes(value) ? value : list[0]
+    return value && list.includes(value) ? value : undefined
   })
 
   function handleSubagentModelSelect(providerID: string, modelID: string) {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -2,16 +2,19 @@ import { Component, For, createMemo } from "solid-js"
 import { Card } from "@kilocode/kilo-ui/card"
 import { useConfig } from "../../context/config"
 import { useLanguage } from "../../context/language"
+import { useProvider } from "../../context/provider"
 import { useSession } from "../../context/session"
 import { parseModelString } from "../../../../src/shared/provider-model"
 import { DEFAULT_AUTOCOMPLETE_MODEL } from "../../../../src/shared/autocomplete-models"
 import { ModelSelectorBase } from "../shared/ModelSelector"
+import { ThinkingSelectorBase } from "../shared/ThinkingSelector"
 import SettingsRow from "./SettingsRow"
 import { AUTOCOMPLETE_PROVIDER_ID, AUTOCOMPLETE_SELECTOR_MODELS } from "./autocomplete-model-selector"
 
 const ModelsTab: Component = () => {
   const { config, settings, updateConfig, updateSetting } = useConfig()
   const language = useLanguage()
+  const provider = useProvider()
   const session = useSession()
 
   const autocompleteModel = () => String(settings()["autocomplete.model"] ?? DEFAULT_AUTOCOMPLETE_MODEL.id)
@@ -24,6 +27,35 @@ const ModelsTab: Component = () => {
       }
       updateConfig({ [configKey]: `${providerID}/${modelID}` })
     }
+  }
+
+  const subagentModel = createMemo(() => parseModelString(config().subagent_model ?? undefined))
+  const subagentVariants = createMemo(() => {
+    const model = provider.findModel(subagentModel())
+    return model?.variants ? Object.keys(model.variants) : []
+  })
+  const subagentVariant = createMemo(() => {
+    const list = subagentVariants()
+    if (list.length === 0) return undefined
+    const value = config().subagent_variant ?? undefined
+    return value && list.includes(value) ? value : list[0]
+  })
+
+  function handleSubagentModelSelect(providerID: string, modelID: string) {
+    if (!providerID || !modelID) {
+      updateConfig({ subagent_model: null, subagent_variant: null })
+      return
+    }
+    const model = { providerID, modelID }
+    const variants = provider.findModel(model)?.variants
+    const list = variants ? Object.keys(variants) : []
+    const value = config().subagent_model === `${providerID}/${modelID}` ? config().subagent_variant : undefined
+    const variant = value && list.includes(value) ? value : list[0]
+    updateConfig({ subagent_model: `${providerID}/${modelID}`, subagent_variant: variant ?? null })
+  }
+
+  function handleSubagentVariantSelect(value: string) {
+    updateConfig({ subagent_variant: value })
   }
 
   const allAgents = createMemo(() => session.agents())
@@ -70,6 +102,26 @@ const ModelsTab: Component = () => {
             clearLabel={language.t("settings.providers.notSet")}
             includeAutoSmall
           />
+        </SettingsRow>
+        <SettingsRow
+          title={language.t("settings.providers.subagentModel.title")}
+          description={language.t("settings.providers.subagentModel.description")}
+        >
+          <div style={{ display: "flex", "align-items": "center", gap: "8px", "flex-wrap": "wrap" }}>
+            <ModelSelectorBase
+              value={subagentModel()}
+              onSelect={handleSubagentModelSelect}
+              placement="bottom-start"
+              allowClear
+              clearLabel={language.t("settings.providers.notSet")}
+            />
+            <ThinkingSelectorBase
+              variants={subagentVariants()}
+              value={subagentVariant()}
+              onSelect={handleSubagentVariantSelect}
+              placement="bottom-start"
+            />
+          </div>
         </SettingsRow>
         <SettingsRow
           title={language.t("settings.autocomplete.model.title")}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -12,6 +12,8 @@ export const KNOWN_KEYS: ReadonlyArray<string> = [
   "permission",
   "model",
   "small_model",
+  "subagent_model",
+  "subagent_variant",
   "default_agent",
   "agent",
   "provider",

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -25,6 +25,8 @@ export interface ThinkingSelectorBaseProps {
   onSelect: (value: string) => void
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
+  /** Popover placement — defaults to "top-start". */
+  placement?: "top-start" | "bottom-start" | "bottom-end" | "top-end"
 }
 
 export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props) => {
@@ -110,7 +112,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
     <Show when={props.variants.length > 0}>
       <PopupSelector
         expanded={false}
-        placement="top-start"
+        placement={props.placement ?? "top-start"}
         preferredWidth={180}
         minHeight={100}
         deferDismiss={props.deferDismiss}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -807,6 +807,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "متصل من متغيرات البيئة الخاصة بك",
   "settings.providers.action.signInChatGPT": "تسجيل الدخول باستخدام ChatGPT",
   "settings.providers.custom.description": "أضف مزوداً متوافقاً مع OpenAI عبر عنوان URL الأساسي.",
+  "settings.providers.subagentModel.title": "نموذج الوكيل الفرعي",
+  "settings.providers.subagentModel.description":
+    "النموذج الافتراضي وجهد التفكير للوكلاء الفرعيين لـ task-tool. اتركه فارغًا ليرث نموذج الوكيل المستدعي.",
   "settings.providers.modeModels": "نموذج لكل وضع",
   "settings.providers.custom.note": "أضف موفرًا متوافقًا مع OpenAI عبر عنوان URL الأساسي.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -819,6 +819,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Conectado a partir das suas variáveis de ambiente",
   "settings.providers.action.signInChatGPT": "Entrar com ChatGPT",
   "settings.providers.custom.description": "Adicione um provedor compatível com OpenAI pela URL base.",
+  "settings.providers.subagentModel.title": "Modelo de Subagente",
+  "settings.providers.subagentModel.description":
+    "Modelo padrão e esforço de raciocínio para subagentes do task-tool. Deixe em branco para herdar o modelo do agente chamador.",
   "settings.providers.modeModels": "Modelo por Modo",
   "settings.providers.custom.note": "Adicione um provedor compatível com OpenAI por URL base.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -860,6 +860,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Povezano iz vaših varijabli okruženja",
   "settings.providers.action.signInChatGPT": "Prijavi se putem ChatGPT",
   "settings.providers.custom.description": "Dodaj OpenAI-kompatibilan provajder putem osnovnog URL-a.",
+  "settings.providers.subagentModel.title": "Model podagenta",
+  "settings.providers.subagentModel.description":
+    "Zadani model i napor zaključivanja za podagente task-tool-a. Ostavite nepodešeno da naslijedi model pozivnog agenta.",
   "settings.providers.modeModels": "Model po režimu",
   "settings.providers.custom.note": "Dodajte provajdera kompatibilnog s OpenAI putem osnovnog URL-a.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -854,6 +854,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Forbundet fra dine miljøvariabler",
   "settings.providers.action.signInChatGPT": "Log ind med ChatGPT",
   "settings.providers.custom.description": "Tilføj en OpenAI-kompatibel udbyder via basis-URL.",
+  "settings.providers.subagentModel.title": "Underagentmodel",
+  "settings.providers.subagentModel.description":
+    "Standardmodel og ræsonnementsindsats for task-tool-underagenter. Lad den være tom for at nedarve den kaldende agents model.",
   "settings.providers.modeModels": "Model pr. tilstand",
   "settings.providers.custom.note": "Tilføj en OpenAI-kompatibel udbyder via basis-URL.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -866,6 +866,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Verbunden über Ihre Umgebungsvariablen",
   "settings.providers.action.signInChatGPT": "Mit ChatGPT anmelden",
   "settings.providers.custom.description": "Fügen Sie einen OpenAI-kompatiblen Anbieter über die Basis-URL hinzu.",
+  "settings.providers.subagentModel.title": "Subagenten-Modell",
+  "settings.providers.subagentModel.description":
+    "Standardmodell und Aufwand für Schlussfolgerungen für task-tool-Subagenten. Leer lassen, um das Modell des aufrufenden Agenten zu übernehmen.",
   "settings.providers.modeModels": "Modell pro Modus",
   "settings.providers.custom.note": "Fügen Sie einen OpenAI-kompatiblen Anbieter per Basis-URL hinzu.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1460,6 +1460,9 @@ export const dict = {
   "settings.providers.smallModel.title": "Small Model",
   "settings.providers.smallModel.description":
     "Lightweight model for title generation, commit message generation, prompt enhancement, and other quick tasks",
+  "settings.providers.subagentModel.title": "Subagent Model",
+  "settings.providers.subagentModel.description":
+    "Default model and reasoning effort for task-tool subagents. Leave unset to inherit the calling agent's model.",
   "settings.providers.modeModels": "Model per Mode",
   "settings.providers.modeModels.description":
     "Override the default model for specific modes. If not set, the global default model is used.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -862,6 +862,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Conectado desde tus variables de entorno",
   "settings.providers.action.signInChatGPT": "Iniciar sesión con ChatGPT",
   "settings.providers.custom.description": "Añade un proveedor compatible con OpenAI por URL base.",
+  "settings.providers.subagentModel.title": "Modelo de subagente",
+  "settings.providers.subagentModel.description":
+    "Modelo predeterminado y esfuerzo de razonamiento para los subagentes de task-tool. Déjelo sin configurar para heredar el modelo del agente invocador.",
   "settings.providers.modeModels": "Modelo por modo",
   "settings.providers.custom.note": "Agrega un proveedor compatible con OpenAI mediante URL base.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -868,6 +868,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Connecté depuis vos variables d'environnement",
   "settings.providers.action.signInChatGPT": "Se connecter avec ChatGPT",
   "settings.providers.custom.description": "Ajoutez un fournisseur compatible OpenAI par URL de base.",
+  "settings.providers.subagentModel.title": "Modèle de sous-agent",
+  "settings.providers.subagentModel.description":
+    "Modèle par défaut et effort de raisonnement pour les sous-agents du task-tool. Laissez vide pour hériter du modèle de l'agent appelant.",
   "settings.providers.modeModels": "Modèle par mode",
   "settings.providers.custom.note": "Ajoutez un fournisseur compatible OpenAI par URL de base.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -850,6 +850,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "環境変数から接続されています",
   "settings.providers.action.signInChatGPT": "ChatGPT でサインイン",
   "settings.providers.custom.description": "ベースURLでOpenAI互換プロバイダーを追加します。",
+  "settings.providers.subagentModel.title": "サブエージェントモデル",
+  "settings.providers.subagentModel.description":
+    "task-tool サブエージェントのデフォルトモデルと推論の労力。呼び出し元のエージェントのモデルを継承する場合は未設定のままにしてください。",
   "settings.providers.modeModels": "モードごとのモデル",
   "settings.providers.custom.note": "Base URL で OpenAI 互換プロバイダーを追加します。",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -812,6 +812,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "환경 변수에서 연결됨",
   "settings.providers.action.signInChatGPT": "ChatGPT로 로그인",
   "settings.providers.custom.description": "기본 URL로 OpenAI 호환 공급자를 추가합니다.",
+  "settings.providers.subagentModel.title": "하위 에이전트 모델",
+  "settings.providers.subagentModel.description":
+    "task-tool 하위 에이전트의 기본 모델 및 추론 수준입니다. 호출하는 에이전트의 모델을 상속하려면 비워 두세요.",
   "settings.providers.modeModels": "모드별 모델",
   "settings.providers.custom.note": "Base URL로 OpenAI 호환 공급자를 추가합니다.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1450,6 +1450,9 @@ export const dict = {
   "settings.providers.smallModel.title": "Klein Model",
   "settings.providers.smallModel.description":
     "Lichtgewicht model voor het genereren van titels, commit-berichten, promptverbetering en andere snelle taken",
+  "settings.providers.subagentModel.title": "Subagentmodel",
+  "settings.providers.subagentModel.description":
+    "Standaardmodel en redeneerinspanning voor task-tool subagenten. Laat leeg om het model van de aanroepende agent over te nemen.",
   "settings.providers.modeModels": "Model per Modus",
   "settings.providers.modeModels.description":
     "Overschrijf het standaard model voor specifieke modi. Indien niet ingesteld, wordt het globale standaard model gebruikt.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -821,6 +821,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Koblet til fra dine miljøvariabler",
   "settings.providers.action.signInChatGPT": "Logg inn med ChatGPT",
   "settings.providers.custom.description": "Legg til en OpenAI-kompatibel leverandør via basis-URL.",
+  "settings.providers.subagentModel.title": "Underagentmodell",
+  "settings.providers.subagentModel.description":
+    "Standardmodell og resonneringsinnsats for task-tool-underagenter. La stå tom for å arve den kallende agentens modell.",
   "settings.providers.modeModels": "Modell per modus",
   "settings.providers.custom.note": "Legg til en OpenAI-kompatibel leverandør via basis-URL.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -819,6 +819,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Połączony z twoich zmiennych środowiskowych",
   "settings.providers.action.signInChatGPT": "Zaloguj przez ChatGPT",
   "settings.providers.custom.description": "Dodaj dostawcę kompatybilnego z OpenAI przez bazowy URL.",
+  "settings.providers.subagentModel.title": "Model podagenta",
+  "settings.providers.subagentModel.description":
+    "Domyślny model i wysiłek wnioskowania dla podagentów task-tool. Pozostaw puste, aby odziedziczyć model agenta wywołującego.",
   "settings.providers.modeModels": "Model na tryb",
   "settings.providers.custom.note": "Dodaj dostawcę kompatybilnego z OpenAI przez bazowy URL.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -857,6 +857,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "Подключён из ваших переменных окружения",
   "settings.providers.action.signInChatGPT": "Войти через ChatGPT",
   "settings.providers.custom.description": "Добавьте OpenAI-совместимый провайдер по базовому URL.",
+  "settings.providers.subagentModel.title": "Модель субагента",
+  "settings.providers.subagentModel.description":
+    "Модель по умолчанию и уровень рассуждения для субагентов task-tool. Оставьте пустым, чтобы унаследовать модель вызывающего агента.",
   "settings.providers.modeModels": "Модель для режима",
   "settings.providers.custom.note": "Добавьте OpenAI-совместимого провайдера по базовому URL.",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -846,6 +846,9 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "เชื่อมต่อจากตัวแปรสภาพแวดล้อมของคุณ",
   "settings.providers.action.signInChatGPT": "ลงชื่อเข้าใช้ด้วย ChatGPT",
   "settings.providers.custom.description": "เพิ่มผู้ให้บริการที่เข้ากันได้กับ OpenAI ด้วย URL พื้นฐาน",
+  "settings.providers.subagentModel.title": "โมเดลตัวแทนย่อย",
+  "settings.providers.subagentModel.description":
+    "โมเดลเริ่มต้นและระดับการใช้เหตุผลสำหรับตัวแทนย่อยของ task-tool ปล่อยว่างไว้เพื่อรับค่าโมเดลจากตัวแทนที่เรียก",
   "settings.providers.modeModels": "โมเดลต่อโหมด",
   "settings.providers.custom.note": "เพิ่มผู้ให้บริการที่รองรับ OpenAI ด้วย Base URL",
   "settings.providers.modeModels.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1439,6 +1439,9 @@ export const dict = {
   "settings.providers.smallModel.title": "Küçük Model",
   "settings.providers.smallModel.description":
     "Başlık oluşturma, commit mesajı oluşturma, komut istemi iyileştirme ve diğer hızlı görevler için hafif model",
+  "settings.providers.subagentModel.title": "Alt Aracı Modeli",
+  "settings.providers.subagentModel.description":
+    "task-tool alt aracıları için varsayılan model ve akıl yürütme çabası. Çağıran aracının modelini devralmak için boş bırakın.",
   "settings.providers.modeModels": "Mod Başına Model",
   "settings.providers.modeModels.description":
     "Belirli modlar için varsayılan modeli geçersiz kılın. Ayarlanmadıysa genel varsayılan model kullanılır.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1439,6 +1439,9 @@ export const dict = {
   "settings.providers.smallModel.title": "Мала модель",
   "settings.providers.smallModel.description":
     "Легка модель для генерації заголовків, повідомлень комітів, покращення запитів та інших швидких завдань",
+  "settings.providers.subagentModel.title": "Модель субагента",
+  "settings.providers.subagentModel.description":
+    "Модель за замовчуванням та рівень міркування для субагентів task-tool. Залиште порожнім, щоб успадкувати модель агента, що викликає.",
   "settings.providers.modeModels": "Модель для кожного режиму",
   "settings.providers.modeModels.description":
     "Перевизначити стандартну модель для певних режимів. Якщо не встановлено, використовується загальна стандартна модель.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -834,6 +834,8 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "从您的环境变量连接",
   "settings.providers.action.signInChatGPT": "使用 ChatGPT 登录",
   "settings.providers.custom.description": "通过基础 URL 添加 OpenAI 兼容的提供商。",
+  "settings.providers.subagentModel.title": "子代理模型",
+  "settings.providers.subagentModel.description": "task-tool 子代理的默认模型和推理工作量。留空以继承调用代理的模型。",
   "settings.providers.modeModels": "按模式选择模型",
   "settings.providers.custom.note": "通过 Base URL 添加 OpenAI 兼容提供商。",
   "settings.providers.modeModels.description": "为特定模式覆盖默认模型。如果未设置，将使用全局默认模型。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -802,6 +802,8 @@ export const dict = {
   "settings.providers.connected.environmentDescription": "從您的環境變數連線",
   "settings.providers.action.signInChatGPT": "使用 ChatGPT 登入",
   "settings.providers.custom.description": "透過基礎 URL 新增 OpenAI 相容的提供商。",
+  "settings.providers.subagentModel.title": "子代理模型",
+  "settings.providers.subagentModel.description": "task-tool 子代理的預設模型和推理工作量。留空以繼承呼叫代理的模型。",
   "settings.providers.modeModels": "按模式選擇模型",
   "settings.providers.custom.note": "透過 Base URL 新增 OpenAI 相容供應商。",
   "settings.providers.modeModels.description": "為特定模式覆寫預設模型。如果未設定，將使用全域預設模型。",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -116,6 +116,8 @@ export interface Config {
   permission?: PermissionConfig
   model?: string | null
   small_model?: string | null
+  subagent_model?: string | null
+  subagent_variant?: string | null
   default_agent?: string | null
   agent?: Record<string, AgentConfig>
   provider?: Record<string, ProviderConfig>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -196,6 +196,13 @@ export const Info = Schema.Struct({
   small_model: Schema.optional(Schema.NullOr(ConfigModelID)).annotate({
     description: "Small model to use for tasks like title generation in the format of provider/model",
   }),
+  subagent_model: Schema.optional(Schema.NullOr(ConfigModelID)).annotate({
+    description:
+      "Default model for task-tool subagents in the format of provider/model. If unset or unavailable, subagents inherit the calling agent model.",
+  }),
+  subagent_variant: Schema.optional(Schema.NullOr(Schema.String)).annotate({
+    description: "Default model variant for task-tool subagents when subagent_model is configured.",
+  }),
   // kilocode_change end
   // kilocode_change start - renamed from "build" to "code" + nullable for delete sentinel
   default_agent: Schema.optional(Schema.NullOr(Schema.String)).annotate({

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -61,7 +61,7 @@ export namespace KiloTask {
 
   type Model = { providerID: ProviderID; modelID: ModelID }
   type Saved = Model & { variant?: string }
-  type Choice = { model: Model; variant?: string; sticky?: boolean }
+  type Choice = { model: Model; variant?: string; sticky?: boolean; direct?: boolean }
 
   function parse(value: string | null | undefined): Model | undefined {
     if (!value) return undefined
@@ -109,12 +109,13 @@ export namespace KiloTask {
             sticky: true,
           }
         : undefined,
-      input.agent.model ? { model: input.agent.model, variant: input.agent.variant } : undefined,
+      input.agent.model ? { model: input.agent.model, variant: input.agent.variant, direct: true } : undefined,
       cfg ? { model: cfg, variant: input.config.subagent_variant ?? undefined } : undefined,
     ]
 
     for (const choice of choices) {
       if (!choice) continue
+      if (choice.direct) return { model: choice.model, variant: choice.variant }
       const full = yield* Effect.tryPromise(() =>
         Provider.getModel(choice.model.providerID, choice.model.modelID),
       ).pipe(

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -4,11 +4,15 @@ import path from "path"
 import { Permission } from "@/permission"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
+import * as Log from "@opencode-ai/core/util/log"
 import { ModelID, ProviderID } from "@/provider/schema"
 import type { Session } from "../../session/session"
 import type { Agent } from "../../agent/agent"
 import type { Config } from "../../config/config"
+import { Provider } from "../../provider/provider"
 import z from "zod"
+
+const log = Log.create({ service: "kilocode-task-model" })
 
 // RATIONALE: Mirror narrow state slice Task tool consumes and ignore unrelated TUI fields.
 const ModelState = z
@@ -55,8 +59,20 @@ export namespace KiloTask {
     return [{ permission: "task", pattern: "*", action: "deny" }, ...rules]
   }
 
-  /** Return saved CLI model for agent, if any. */
-  export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (name: string) {
+  type Model = { providerID: ProviderID; modelID: ModelID }
+  type Saved = Model & { variant?: string }
+  type Choice = { model: Model; variant?: string; sticky?: boolean }
+
+  function parse(value: string | null | undefined): Model | undefined {
+    if (!value) return undefined
+    const [providerID, ...parts] = value.split("/")
+    return {
+      providerID: ProviderID.make(providerID),
+      modelID: ModelID.make(parts.join("/")),
+    }
+  }
+
+  const saved = Effect.fn("KiloTask.savedModel")(function* (name: string) {
     if (Flag.KILO_CLIENT !== "cli") return undefined
     const file = path.join(Global.Path.state, "model.json")
     const state = yield* Effect.tryPromise({
@@ -74,5 +90,53 @@ export namespace KiloTask {
       ...model,
       variant: state?.variant?.[`${model.providerID}/${model.modelID}`],
     }
+  })
+
+  /** Resolve the task subagent model while discarding stale unavailable overrides. */
+  export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (input: {
+    name: string
+    agent: Pick<Agent.Info, "model" | "variant">
+    config: Pick<Config.Info, "subagent_model" | "subagent_variant">
+    parent: Model
+  }) {
+    const state = yield* saved(input.name)
+    const cfg = parse(input.config.subagent_model)
+    const choices: Array<Choice | undefined> = [
+      state
+        ? {
+            model: { providerID: state.providerID, modelID: state.modelID },
+            variant: state.variant,
+            sticky: true,
+          }
+        : undefined,
+      input.agent.model ? { model: input.agent.model, variant: input.agent.variant } : undefined,
+      cfg ? { model: cfg, variant: input.config.subagent_variant ?? undefined } : undefined,
+    ]
+
+    for (const choice of choices) {
+      if (!choice) continue
+      const full = yield* Effect.tryPromise(() =>
+        Provider.getModel(choice.model.providerID, choice.model.modelID),
+      ).pipe(
+        Effect.catch((err) =>
+          Effect.sync(() => {
+            log.debug("skipping unavailable task subagent model", {
+              providerID: choice.model.providerID,
+              modelID: choice.model.modelID,
+              err,
+            })
+            return undefined
+          }),
+        ),
+      )
+      if (!full) continue
+      const variant = choice.variant && full.variants?.[choice.variant] ? choice.variant : undefined
+      return {
+        model: choice.sticky && variant ? { ...choice.model, variant } : choice.model,
+        variant,
+      }
+    }
+
+    return { model: input.parent, variant: undefined }
   })
 }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -117,14 +117,18 @@ export const TaskTool = Tool.define(
       const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
 
-      // kilocode_change start — prefer user's CLI-saved pick for this subagent
-      const saved = yield* KiloTask.resolveModel(next.name)
-      const model = saved ??
-        next.model ?? {
+      // kilocode_change start — prefer valid subagent overrides, safely inheriting when overrides go stale
+      const selected = yield* KiloTask.resolveModel({
+        name: next.name,
+        agent: next,
+        config: cfg,
+        parent: {
           modelID: msg.info.modelID,
           providerID: msg.info.providerID,
-        }
-      const variant = saved?.variant ?? (saved ? undefined : next.variant)
+        },
+      })
+      const model = selected.model
+      const variant = selected.variant
       // kilocode_change end
 
       yield* ctx.metadata({

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -48,6 +48,44 @@ const cfg = {
 
 const savedVariant = "fast"
 const cfgVariant = "balanced"
+const sub = {
+  providerID: ProviderID.make("sub-provider"),
+  modelID: ModelID.make("sub-model"),
+}
+const subVariant = "deep"
+
+function custom(id: string, model: string, variants: string[] = []) {
+  return {
+    name: id,
+    id,
+    env: [],
+    npm: "@ai-sdk/openai-compatible",
+    models: {
+      [model]: {
+        id: model,
+        name: model,
+        attachment: false,
+        reasoning: variants.length > 0,
+        temperature: false,
+        tool_call: true,
+        release_date: "2025-01-01",
+        limit: { context: 100_000, output: 10_000 },
+        cost: { input: 0, output: 0 },
+        options: {},
+        variants: Object.fromEntries(variants.map((variant) => [variant, {}])),
+      },
+    },
+    options: { apiKey: "test-key", baseURL: "http://localhost:1/v1" },
+  }
+}
+
+const catalog = {
+  provider: {
+    "saved-provider": custom("saved-provider", "saved-model", [savedVariant]),
+    "config-provider": custom("config-provider", "config-model", [cfgVariant]),
+    "sub-provider": custom("sub-provider", "sub-model", [subVariant]),
+  },
+}
 
 const it = testEffect(
   Layer.mergeAll(
@@ -138,7 +176,12 @@ function writeState(input: unknown) {
   })
 }
 
-function run(input: { agent: "pinned" | "worker"; state?: unknown; client?: string }) {
+function run(input: {
+  agent: "pinned" | "worker"
+  state?: unknown
+  client?: string
+  config?: Pick<Config.Info, "subagent_model" | "subagent_variant">
+}) {
   return provideTmpdirInstance(
     () =>
       Effect.gen(function* () {
@@ -178,6 +221,8 @@ function run(input: { agent: "pinned" | "worker"; state?: unknown; client?: stri
       }),
     {
       config: {
+        ...catalog,
+        ...input.config,
         agent: {
           worker: { mode: "subagent" },
           pinned: { mode: "subagent", model: "config-provider/config-model", variant: cfgVariant },
@@ -268,6 +313,70 @@ describe("tool.task model resolution", () => {
     ),
   )
 
+  it.live("configured subagent default model and variant apply to task workers", () =>
+    run({
+      agent: "worker",
+      config: { subagent_model: "sub-provider/sub-model", subagent_variant: subVariant },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(sub)
+          expect(result.variant).toEqual(subVariant)
+          expect(result.model).toEqual(sub)
+          expect(result.metadataVariant).toEqual(subVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("per-agent task model remains above the configured subagent default", () =>
+    run({
+      agent: "pinned",
+      config: { subagent_model: "sub-provider/sub-model", subagent_variant: subVariant },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(cfg)
+          expect(result.variant).toEqual(cfgVariant)
+          expect(result.model).toEqual(cfg)
+          expect(result.metadataVariant).toEqual(cfgVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("unavailable configured subagent model falls back to the parent model", () =>
+    run({
+      agent: "worker",
+      config: { subagent_model: "missing-provider/missing-model", subagent_variant: subVariant },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.variant).toBeUndefined()
+          expect(result.model).toEqual(parent)
+          expect(result.metadataVariant).toBeUndefined()
+        }),
+      ),
+    ),
+  )
+
+  it.live("stale configured subagent variant is ignored without dropping its model", () =>
+    run({
+      agent: "worker",
+      config: { subagent_model: "sub-provider/sub-model", subagent_variant: "gone" },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(sub)
+          expect(result.variant).toBeUndefined()
+          expect(result.model).toEqual(sub)
+          expect(result.metadataVariant).toBeUndefined()
+        }),
+      ),
+    ),
+  )
+
   it.live("no file and no agent config falls back to parent for worker", () =>
     run({
       agent: "worker",
@@ -324,6 +433,7 @@ describe("tool.task model resolution", () => {
         }),
       {
         config: {
+          ...catalog,
           agent: {
             worker: { mode: "subagent" },
             pinned: { mode: "subagent", model: "config-provider/config-model", variant: cfgVariant },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1307,6 +1307,8 @@ export type Config = {
   terminal_command_display?: "expanded" | "collapsed"
   model?: string
   small_model?: string
+  subagent_model?: string
+  subagent_variant?: string
   default_agent?: string
   username?: string
   mode?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15778,6 +15778,12 @@
           "small_model": {
             "type": "string"
           },
+          "subagent_model": {
+            "type": "string"
+          },
+          "subagent_variant": {
+            "type": "string"
+          },
           "default_agent": {
             "type": "string"
           },


### PR DESCRIPTION
Task-tool subagents currently inherit the calling agent model, which prevents users from steering delegated work toward a separate model and reasoning profile. This adds a configurable default subagent model and reasoning effort while preserving inherited behavior whenever the override is unset or unavailable.

Addresses #7459. Related context: #8784. Supersedes #8630.

<img width="852" height="254" alt="image" src="https://github.com/user-attachments/assets/1fe38aa3-8d77-42f2-bb92-5a71e85a319e" />
<img width="455" height="635" alt="image" src="https://github.com/user-attachments/assets/0f9a3e10-5625-420b-8c51-7cd01cce48de" />
