### PR TITLE
fix(cli): use pinned Bun in Nix package builds

### DIFF
--- a/.changeset/nice-nix-build.md
+++ b/.changeset/nice-nix-build.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix the Nix package build to use the pinned Bun version and Nix dynamic linker.

--- a/flake.nix
+++ b/flake.nix
@@ -16,64 +16,66 @@
       ];
       forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       rev = self.shortRev or self.dirtyShortRev or "dirty";
+      bunFor =
+        pkgs:
+        let
+          # Pin bun to the version declared in package.json (packageManager: "bun@1.3.13").
+          # nixpkgs-unstable currently ships 1.3.11, so we fetch the official release directly.
+          sources = {
+            "aarch64-linux" = {
+              name = "bun-linux-aarch64";
+              hash = "sha256-cLrkGzkIsKEg4eWMXIrzDnSvrjuNEbDT/djnh937SyI=";
+            };
+            "x86_64-linux" = {
+              name = "bun-linux-x64";
+              hash = "sha256-ecB3H6i5LDOq5B4VoODTB+qZ0OLwAxfHHGxTI3p44lo=";
+            };
+            "aarch64-darwin" = {
+              name = "bun-darwin-aarch64";
+              hash = "sha256-VGfj9l26Umuf6pjwzOBO+vwMY+Fpcz7Ce4dqOtMtoZA=";
+            };
+            "x86_64-darwin" = {
+              name = "bun-darwin-x64";
+              hash = "sha256-5abItk9BmSUjLREeyxPiXwq/VeVPeSNB+YdiP9B3gAk=";
+            };
+          };
+          source =
+            sources.${pkgs.stdenv.hostPlatform.system}
+              or (throw "Unsupported system for bun: ${pkgs.stdenv.hostPlatform.system}");
+        in
+        pkgs.stdenv.mkDerivation rec {
+          pname = "bun";
+          version = "1.3.13";
+          src = pkgs.fetchurl {
+            url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/${source.name}.zip";
+            inherit (source) hash;
+          };
+          nativeBuildInputs = [
+            pkgs.unzip
+          ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.autoPatchelfHook;
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+          dontConfigure = true;
+          dontBuild = true;
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 bun $out/bin/bun
+            ln -s $out/bin/bun $out/bin/bunx
+            runHook postInstall
+          '';
+          meta = {
+            description = "Fast all-in-one JavaScript runtime";
+            homepage = "https://bun.sh";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "bun";
+            platforms = builtins.attrNames sources;
+          };
+        };
     in
     {
       devShells = forEachSystem (pkgs: {
         default =
           let
-            # Pin bun to the version declared in package.json (packageManager: "bun@1.3.13").
-            # nixpkgs-unstable currently ships 1.3.11, so we fetch the official release directly.
-            bun =
-              let
-                sources = {
-                  "aarch64-linux" = {
-                    name = "bun-linux-aarch64";
-                    hash = "sha256-cLrkGzkIsKEg4eWMXIrzDnSvrjuNEbDT/djnh937SyI=";
-                  };
-                  "x86_64-linux" = {
-                    name = "bun-linux-x64";
-                    hash = "sha256-ecB3H6i5LDOq5B4VoODTB+qZ0OLwAxfHHGxTI3p44lo=";
-                  };
-                  "aarch64-darwin" = {
-                    name = "bun-darwin-aarch64";
-                    hash = "sha256-VGfj9l26Umuf6pjwzOBO+vwMY+Fpcz7Ce4dqOtMtoZA=";
-                  };
-                  "x86_64-darwin" = {
-                    name = "bun-darwin-x64";
-                    hash = "sha256-5abItk9BmSUjLREeyxPiXwq/VeVPeSNB+YdiP9B3gAk=";
-                  };
-                };
-                source =
-                  sources.${pkgs.stdenv.hostPlatform.system}
-                    or (throw "Unsupported system for bun: ${pkgs.stdenv.hostPlatform.system}");
-              in
-              pkgs.stdenv.mkDerivation rec {
-                pname = "bun";
-                version = "1.3.13";
-                src = pkgs.fetchurl {
-                  url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/${source.name}.zip";
-                  inherit (source) hash;
-                };
-                nativeBuildInputs = [
-                  pkgs.unzip
-                ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.autoPatchelfHook;
-                buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
-                dontConfigure = true;
-                dontBuild = true;
-                installPhase = ''
-                  runHook preInstall
-                  install -Dm755 bun $out/bin/bun
-                  ln -s $out/bin/bun $out/bin/bunx
-                  runHook postInstall
-                '';
-                meta = {
-                  description = "Fast all-in-one JavaScript runtime";
-                  homepage = "https://bun.sh";
-                  license = pkgs.lib.licenses.mit;
-                  mainProgram = "bun";
-                  platforms = builtins.attrNames sources;
-                };
-              };
+            bun = bunFor pkgs;
 
             kilo-dev = pkgs.writeShellScriptBin "kilo-dev" ''
                 cd "$KILO_ROOT"
@@ -261,8 +263,9 @@
         default =
           final: _prev:
           let
+            bun = bunFor final;
             node_modules = final.callPackage ./nix/node_modules.nix {
-              inherit rev;
+              inherit bun rev;
             };
             opencode = final.callPackage ./nix/opencode.nix {
               inherit node_modules;
@@ -276,11 +279,12 @@
       packages = forEachSystem (
         pkgs:
         let
+          bun = bunFor pkgs;
           node_modules = pkgs.callPackage ./nix/node_modules.nix {
-            inherit rev;
+            inherit bun rev;
           };
           kilo = pkgs.callPackage ./nix/kilo.nix {
-            inherit node_modules;
+            inherit bun node_modules;
           };
         in
         {

--- a/nix/kilo.nix
+++ b/nix/kilo.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   stdenvNoCC,
   callPackage,
   bun,
@@ -41,6 +42,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   env.KILO_DISABLE_MODELS_FETCH = true;
   env.KILO_VERSION = finalAttrs.version;
   env.KILO_CHANNEL = "local";
+  env.KILO_LINUX_INTERPRETER = lib.optionalString stdenvNoCC.hostPlatform.isLinux stdenv.cc.bintools.dynamicLinker;
 
   buildPhase = ''
     runHook preBuild

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -266,7 +266,7 @@ for (const item of targets) {
       "arm64-musl": "/lib/ld-musl-aarch64.so.1",
     }
     const key = item.abi === "musl" ? `${item.arch}-musl` : item.arch
-    const interpreter = interpreters[key]
+    const interpreter = process.env.KILO_LINUX_INTERPRETER || interpreters[key]
     if (interpreter) {
       try {
         await $`patchelf --set-interpreter ${interpreter} dist/${name}/bin/kilo`


### PR DESCRIPTION
## Summary
- Share the flake-pinned Bun derivation between the dev shell, overlay, and package builds.
- Pass that pinned Bun into `node_modules` and `kilo` package derivations so package builds do not fall back to the older nixpkgs Bun.
- Let Nix package builds provide the Linux dynamic linker used when patching the generated binary.

Closes #10417

## Validation
- PATH="$HOME/.bun/bin:$PATH" bun run typecheck
- PATH="$HOME/.bun/bin:$PATH" bun run script/check-opencode-annotations.ts
- PATH="$HOME/.bun/bin:$PATH" bun run check-kilocode-change (from packages/kilo-vscode)
- git diff --check
- PATH="$HOME/.bun/bin:$PATH" git push -u mturac fix/10417-nix-bun-package-build (pre-push: bun turbo typecheck --filter=!@kilocode/kilo-jetbrains)

Not run: `nix build` is unavailable in this local environment.