### PR TITLE
fix(cli): keep child session prompts visible

### DIFF
--- a/.changeset/fair-ants-respond.md
+++ b/.changeset/fair-ants-respond.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep permission and other blocking prompts visible while viewing a child session in the TUI.

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -96,6 +96,7 @@ import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 import { DialogGoUpsell } from "../../component/dialog-go-upsell"
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
+import { sessionInputQueue } from "./session-input-queue" // kilocode_change
 
 addDefaultParsers(parsers.parsers)
 
@@ -141,28 +142,24 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  // kilocode_change start
   const permissions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+    return sessionInputQueue(session(), children(), sync.data.permission)
   })
   const questions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
+    return sessionInputQueue(session(), children(), sync.data.question)
   })
-  // kilocode_change start
   const suggestions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.suggestion[x.id] ?? [])
+    return sessionInputQueue(session(), children(), sync.data.suggestion)
   })
   const network = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.network[x.id] ?? [])
+    return sessionInputQueue(session(), children(), sync.data.network)
   })
   const blockingQuestions = createMemo(() => questions().filter((q) => q.blocking !== false))
   const nonBlockingQuestions = createMemo(() => questions().filter((q) => q.blocking === false))
   const question = createMemo(() => blockingQuestions()[0] ?? nonBlockingQuestions()[0])
   const blockingSuggestions = createMemo(() => suggestions().filter((s) => s.blocking !== false))
-  // kilocode_change start - footer overlay only hosts blocking suggestions now;
+  // Footer overlay only hosts blocking suggestions now;
   // non-blocking ones render inline at the tool-part slot via `SuggestBar`.
   const blockingSuggestion = createMemo(() => blockingSuggestions()[0])
   // kilocode_change end

--- a/packages/opencode/src/cli/cmd/tui/routes/session/session-input-queue.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/session-input-queue.ts
@@ -1,0 +1,17 @@
+// kilocode_change - new file
+
+type SessionRef = {
+  id: string
+  parentID?: string | null
+}
+
+type QueueMap<T> = Record<string, readonly T[] | undefined>
+
+export function sessionInputQueue<T>(
+  current: SessionRef | undefined,
+  children: readonly Pick<SessionRef, "id">[],
+  bySession: QueueMap<T>,
+): T[] {
+  if (current?.parentID) return [...(bySession[current.id] ?? [])]
+  return children.flatMap((session) => [...(bySession[session.id] ?? [])])
+}

--- a/packages/opencode/test/kilocode/tui-child-input-prompts.test.ts
+++ b/packages/opencode/test/kilocode/tui-child-input-prompts.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { sessionInputQueue } from "../../src/cli/cmd/tui/routes/session/session-input-queue"
+
+describe("TUI child session input prompts", () => {
+  test("child sessions use their own input queue", () => {
+    const queue = sessionInputQueue(
+      { id: "child-1", parentID: "parent" },
+      [{ id: "parent" }, { id: "child-1" }, { id: "child-2" }],
+      {
+        parent: ["parent-permission"],
+        "child-1": ["child-permission"],
+        "child-2": ["sibling-permission"],
+      },
+    )
+
+    expect(queue).toEqual(["child-permission"])
+  })
+
+  test("parent sessions still aggregate child input queues", () => {
+    const queue = sessionInputQueue(
+      { id: "parent" },
+      [{ id: "parent" }, { id: "child-1" }, { id: "child-2" }],
+      {
+        parent: ["parent-permission"],
+        "child-1": ["child-permission"],
+        "child-2": ["sibling-permission"],
+      },
+    )
+
+    expect(queue).toEqual(["parent-permission", "child-permission", "sibling-permission"])
+  })
+})


### PR DESCRIPTION
## Summary
- keep child-session permission prompts visible when viewing the child session
- apply the same current-child lookup to question, suggestion, and network prompts
- add a TUI source regression for child-session input prompts

Closes #10311

## Validation
- `bun test test/kilocode/tui-child-input-prompts.test.ts`
- `git diff --check`
- `bun run typecheck`
- `bun run script/check-opencode-annotations.ts`
- `bun run check-kilocode-change`