### PR TITLE
fix(cli): allow questions for custom agents

### DIFF
--- a/.changeset/quiet-agents-ask.md
+++ b/.changeset/quiet-agents-ask.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow custom agents to use the question tool by default while preserving explicit permission overrides.

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -267,7 +267,7 @@ export const layer = Layer.effect(
             item = agents[key] = {
               name: key,
               mode: "all",
-              permission: Permission.merge(defaults, user),
+              permission: Permission.merge(defaults, Permission.fromConfig({ question: "allow" }), user),
               options: {},
               native: false,
             }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -242,6 +242,28 @@ test("custom agent from config creates new agent", async () => {
       expect(custom?.topP).toBe(0.9)
       expect(custom?.native).toBe(false)
       expect(custom?.mode).toBe("all")
+      expect(evalPerm(custom, "question")).toBe("allow")
+    },
+  })
+})
+
+test("custom agent config can explicitly deny question tool", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        my_custom_agent: {
+          permission: {
+            question: "deny",
+          },
+        },
+      },
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const custom = await load(tmp.path, (svc) => svc.get("my_custom_agent"))
+      expect(evalPerm(custom, "question")).toBe("deny")
     },
   })
 })


### PR DESCRIPTION
## Summary
- allow newly defined custom agents to use the question tool by default
- preserve explicit per-agent and global permission overrides
- cover the default and explicit-deny cases in agent tests

Closes #10315

## Validation
- `bun test test/agent/agent.test.ts`
- `git diff --check`
- `bun run typecheck`
- `bun run script/check-opencode-annotations.ts`
- `bun run check-kilocode-change`