### PR TITLE
fix(vscode): keep streamed responses visible after reconcile

### DIFF
--- a/.changeset/calm-responses-stay.md
+++ b/.changeset/calm-responses-stay.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep final streamed responses visible during session reconciliation.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1434,6 +1434,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.loadMessagesAbort = abort
       this.refreshSessionDetails(sessionID, dir, abort.signal)
     }
+    const since = mode === "reconcile" ? Date.now() : undefined
     try {
       const page = await fetchMessagePage(this.client, {
         sessionID,
@@ -1465,6 +1466,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         mode,
         cursor: page.cursor,
         hasMore: Boolean(page.cursor),
+        since,
       })
       // Recover any prompts missed while the webview was loading or during an SSE reconnection.
       this.recoverPendingPrompts()

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -143,9 +143,10 @@ describe("KiloProvider.handleLoadMessages / focus mode freshness", () => {
     // so the webview merges without tearing down existing reactive proxies.
     const loaded = sent.find(
       (msg) => typeof msg === "object" && msg && (msg as { type?: unknown }).type === "messagesLoaded",
-    ) as { mode?: string; messages: { id: string }[] } | undefined
+    ) as { mode?: string; since?: number; messages: { id: string }[] } | undefined
     expect(loaded).toBeDefined()
     expect(loaded!.mode).toBe("reconcile")
+    expect(typeof loaded!.since).toBe("number")
     expect(loaded!.messages.map((m) => m.id)).toContain("m3")
   })
 

--- a/packages/kilo-vscode/tests/unit/session-parts.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-parts.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test"
+import { mergeParts, sameParts } from "../../webview-ui/src/context/session-parts"
+import type { Part } from "../../webview-ui/src/types/messages"
+
+function text(id: string, value: string, time: { start?: number; end?: number } = {}): Part {
+  return { id, messageID: "m1", type: "text", text: value, time: { start: time.start ?? 1, end: time.end } }
+}
+
+function tool(id: string): Part {
+  return { id, messageID: "m1", type: "tool", tool: "bash", state: { status: "pending", input: {} } }
+}
+
+function value(parts: Part[], id: string) {
+  const part = parts.find((item) => item.id === id)
+  if (!part || part.type !== "text") return
+  return part.text
+}
+
+describe("mergeParts", () => {
+  it("keeps a final streamed tail part created after the reconcile snapshot started", () => {
+    const parts = mergeParts(
+      [text("p1", "tool done", { end: 2 }), text("p2", "final summary", { start: 20, end: 30 })],
+      [text("p1", "tool done", { end: 2 })],
+      10,
+    )
+
+    expect(parts.map((part) => part.id)).toEqual(["p1", "p2"])
+    expect(value(parts, "p2")).toBe("final summary")
+  })
+
+  it("drops trailing local text that predates the reconcile snapshot", () => {
+    const parts = mergeParts(
+      [text("p1", "tool done", { end: 2 }), text("p2", "stale tail", { start: 5 })],
+      [text("p1", "tool done", { end: 2 })],
+      10,
+    )
+
+    expect(parts.map((part) => part.id)).toEqual(["p1"])
+  })
+
+  it("drops local-only parts that do not prove they were appended after the snapshot", () => {
+    const parts = mergeParts(
+      [text("p1", "stale", { start: 20 }), text("p3", "live tail", { start: 20 })],
+      [text("p2", "server")],
+      10,
+    )
+
+    expect(parts.map((part) => part.id)).toEqual(["p2", "p3"])
+  })
+
+  it("drops local-only non-stream parts so reconcile can heal removals", () => {
+    const parts = mergeParts([text("p1", "server", { end: 2 }), tool("p2")], [text("p1", "server", { end: 2 })], 10)
+
+    expect(parts.map((part) => part.id)).toEqual(["p1"])
+  })
+
+  it("drops local streamed parts when the snapshot has no part boundary", () => {
+    const parts = mergeParts([text("p1", "stale streamed text", { start: 20 })], [], 10)
+
+    expect(parts).toEqual([])
+  })
+
+  it("keeps longer streaming text when an open snapshot has an older prefix", () => {
+    const parts = mergeParts([text("p1", "Recommendation: approve with notes")], [text("p1", "Recommendation")], 10)
+
+    expect(value(parts, "p1")).toBe("Recommendation: approve with notes")
+  })
+
+  it("uses completed snapshot text even when local text is a longer prefix extension", () => {
+    const parts = mergeParts(
+      [text("p1", "Recommendation: approve with notes")],
+      [text("p1", "Recommendation", { end: 2 })],
+      10,
+    )
+
+    expect(value(parts, "p1")).toBe("Recommendation")
+  })
+
+  it("uses snapshots for mismatched types, non-prefix text, and shorter local text", () => {
+    const types = mergeParts([tool("p1")], [text("p1", "server")], 10)
+    const edited = mergeParts([text("p1", "local rewrite")], [text("p1", "server")], 10)
+    const longer = mergeParts([text("p1", "short")], [text("p1", "longer server")], 10)
+
+    expect(value(types, "p1")).toBe("server")
+    expect(value(edited, "p1")).toBe("server")
+    expect(value(longer, "p1")).toBe("longer server")
+  })
+
+  it("uses snapshot repairs while preserving proven streamed tail parts in ID order", () => {
+    const parts = mergeParts(
+      [text("p3", "live tail", { start: 20 }), text("p1", "partial")],
+      [text("p2", "missed snapshot part"), text("p1", "complete snapshot repair", { end: 2 })],
+      10,
+    )
+
+    expect(parts.map((part) => part.id)).toEqual(["p1", "p2", "p3"])
+    expect(value(parts, "p1")).toBe("complete snapshot repair")
+    expect(value(parts, "p2")).toBe("missed snapshot part")
+    expect(value(parts, "p3")).toBe("live tail")
+  })
+})
+
+describe("sameParts", () => {
+  it("accepts equal hydrated and snapshot parts", () => {
+    expect(sameParts([text("p1", "done", { end: 2 })], [text("p1", "done", { end: 2 })])).toBe(true)
+  })
+
+  it("rejects same-count snapshots with different ids, text, or completion state", () => {
+    expect(sameParts([text("p1", "done", { end: 2 })], [text("p2", "done", { end: 2 })])).toBe(false)
+    expect(sameParts([text("p1", "live")], [text("p1", "server")])).toBe(false)
+    expect(sameParts([text("p1", "done")], [text("p1", "done", { end: 2 })])).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
@@ -1,0 +1,47 @@
+import type { Part } from "../types/messages"
+
+function stream(part: Part): part is Extract<Part, { type: "text" | "reasoning" }> {
+  return part.type === "text" || part.type === "reasoning"
+}
+
+function newer(local: Part, snapshot: Part): Part {
+  if (local.type !== snapshot.type) return snapshot
+  if (!stream(local) || !stream(snapshot)) return snapshot
+  if (snapshot.time?.end !== undefined) return snapshot
+  if (local.text.length <= snapshot.text.length) return snapshot
+  if (!local.text.startsWith(snapshot.text)) return snapshot
+  return local
+}
+
+export function sameParts(local: Part[] = [], snapshot: Part[] = []): boolean {
+  if (local.length !== snapshot.length) return false
+  for (const [i, part] of snapshot.entries()) {
+    const current = local[i]!
+    if (current.id !== part.id || current.type !== part.type) return false
+    if (!stream(current) || !stream(part)) continue
+    if (current.text !== part.text) return false
+    if (current.time?.end !== part.time?.end) return false
+  }
+  return true
+}
+
+/**
+ * Reconcile snapshots may be older than in-flight streaming deltas. Preserve
+ * only appended streamed tail parts and open prefix extensions while still
+ * accepting snapshots that heal older removals and completed corrections.
+ */
+export function mergeParts(local: Part[], snapshot: Part[], since: number): Part[] {
+  const by = new Map(snapshot.map((part) => [part.id, part]))
+  const last = snapshot.reduce<string | undefined>((id, part) => (!id || part.id > id ? part.id : id), undefined)
+  for (const part of local) {
+    const current = by.get(part.id)
+    if (current) {
+      by.set(part.id, newer(part, current))
+      continue
+    }
+    if (!last || !stream(part) || part.id <= last) continue
+    if (part.time?.start === undefined || part.time.start < since) continue
+    by.set(part.id, part)
+  }
+  return [...by.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -49,6 +49,7 @@ import { resolveModelSelection } from "./model-selection"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs } from "./session-errors"
 import { PartStash } from "./part-stash"
+import { mergeParts, sameParts } from "./session-parts"
 import { state as todoState } from "./todo-revert"
 import { getVariant, sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
 import { KILO_AUTO, parseModelString } from "../../../src/shared/provider-model"
@@ -813,6 +814,7 @@ export const SessionProvider: ParentComponent = (props) => {
           mode: message.mode,
           cursor: message.cursor,
           hasMore: message.hasMore,
+          since: message.since,
         })
         break
 
@@ -1030,17 +1032,15 @@ export const SessionProvider: ParentComponent = (props) => {
     return [...messages, ...orphans]
   }
 
-  // Cheap shape check: same ids in same order AND same part counts per message.
-  // Short-circuits reconcile when the server snapshot matches local state
-  // (the common case — SSE didn't actually miss anything), avoiding the
-  // 80 setStore("parts", ...) calls per session switch.
+  // Cheap tail check: same ids in the same order and no visible streamed-part
+  // correction to apply. It skips store churn when SSE already matches the
+  // snapshot, but lets reconcile heal part removals and finalized text.
   function sameReconcileShape(current: Message[], incoming: Message[]): boolean {
     if (current.length !== incoming.length) return false
-    for (let i = 0; i < incoming.length; i++) {
+    for (const [i, n] of incoming.entries()) {
       const c = current[i]!
-      const n = incoming[i]!
       if (c.id !== n.id) return false
-      if ((c.parts?.length ?? 0) !== (n.parts?.length ?? 0)) return false
+      if (!sameParts(store.parts[c.id] ?? c.parts, n.parts)) return false
     }
     return true
   }
@@ -1048,7 +1048,7 @@ export const SessionProvider: ParentComponent = (props) => {
   function handleMessagesLoaded(
     sessionID: string,
     messages: Message[],
-    input: { mode?: Exclude<MessageLoadMode, "focus">; cursor?: string; hasMore?: boolean } = {},
+    input: { mode?: Exclude<MessageLoadMode, "focus">; cursor?: string; hasMore?: boolean; since?: number } = {},
   ) {
     const mode = input.mode ?? "replace"
     const reset = mode === "prepend"
@@ -1086,19 +1086,23 @@ export const SessionProvider: ParentComponent = (props) => {
       }
 
       for (const msg of messages) {
-        if (!msg.parts || msg.parts.length === 0) continue
+        const parts = msg.parts ?? []
         if (mode === "reconcile" && store.parts[msg.id]) {
           // Reconcile on a message already hydrated into the reactive store:
-          // write parts directly so visible turns pick up the server-
-          // authoritative state immediately instead of waiting for the
-          // virtualizer to re-render.
-          setStore("parts", msg.id, reconcile(msg.parts, { key: "id" }))
+          // write parts directly so visible turns pick up server corrections,
+          // but do not erase proven newer streamed text absent from a stale snapshot.
+          const merged = mergeParts(store.parts[msg.id], parts, input.since ?? Number.POSITIVE_INFINITY)
+          setStore("parts", msg.id, reconcile(merged, { key: "id" }))
           stash.remove(msg.id)
-        } else {
-          // Stash parts outside the reactive store — they'll be hydrated
-          // on demand when the virtualizer renders the corresponding turn.
-          stash.put(msg.id, msg.parts)
+          continue
         }
+        if (parts.length > 0) {
+          // Stash parts outside the reactive store. They hydrate on demand
+          // when the virtualizer renders the corresponding turn.
+          stash.put(msg.id, parts)
+          continue
+        }
+        if (mode === "reconcile") stash.remove(msg.id)
       }
 
       // "reconcile" is a background tail refresh, not a page navigation —

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -174,6 +174,7 @@ export interface MessagesLoadedMessage {
   mode?: Exclude<MessageLoadMode, "focus">
   cursor?: string
   hasMore?: boolean
+  since?: number
 }
 
 export interface MessageCreatedMessage {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -23,6 +23,7 @@ export interface TextPart extends BasePart {
   type: "text"
   text: string
   synthetic?: boolean
+  time?: { start: number; end?: number }
 }
 
 export interface FilePartSource {
@@ -52,6 +53,7 @@ export interface ToolPart extends BasePart {
 export interface ReasoningPart extends BasePart {
   type: "reasoning"
   text: string
+  time?: { start: number; end?: number }
 }
 
 // Step parts from the backend


### PR DESCRIPTION
Session focus reconciliation can race with streamed assistant output and temporarily hide the final response in the sidebar or Agent Manager until another session reloads it.
Preserve only streamed parts proven newer than the fetched snapshot, while still allowing reconcile to heal removed or finalized server state.

This would sometimes not show the final summary of the model even though it was there, on reopening the last text reappeared. Often the user therefore assumed the session stopped.