### PR TITLE
fix(vscode): package tree-sitter wasm assets

### DIFF
--- a/.changeset/tidy-wasms-serve.md
+++ b/.changeset/tidy-wasms-serve.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Package tree-sitter WASM sidecar assets with the VS Code CLI binary.

--- a/packages/kilo-vscode/script/build.ts
+++ b/packages/kilo-vscode/script/build.ts
@@ -2,6 +2,7 @@
 import { $ } from "bun"
 import { join } from "node:path"
 import { existsSync, mkdirSync, rmSync, chmodSync } from "node:fs"
+import { copyCliSidecarAssets } from "./cli-sidecars"
 import { ensureFfmpegForTarget } from "./ffmpeg-helper"
 
 const packageJsonPath = join(import.meta.dir, "..", "package.json")
@@ -78,6 +79,12 @@ for (const config of targets) {
 
   if (config.binary !== "kilo.exe") {
     chmodSync(targetBinary, 0o755)
+  }
+
+  if (copyCliSidecarAssets(sourceBinary, binDir)) {
+    console.log(`  ✅ Tree-sitter WASM assets copied from ${config.cliDir}/bin/tree-sitter`)
+  } else {
+    console.warn(`  ⚠️ Tree-sitter WASM assets not found in ${config.cliDir}/bin/tree-sitter`)
   }
 
   console.log(`  ✅ Binary ready at ${targetBinary}`)

--- a/packages/kilo-vscode/script/cli-sidecars.ts
+++ b/packages/kilo-vscode/script/cli-sidecars.ts
@@ -1,0 +1,18 @@
+import { cpSync, existsSync, rmSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+export const TREE_SITTER_WASM_DIR = "tree-sitter"
+
+export function copyCliSidecarAssets(sourceBinaryPath: string, targetBinDir: string): boolean {
+  const sourceTreeSitterDir = join(dirname(sourceBinaryPath), TREE_SITTER_WASM_DIR)
+  if (!existsSync(sourceTreeSitterDir)) {
+    return false
+  }
+
+  const targetTreeSitterDir = join(targetBinDir, TREE_SITTER_WASM_DIR)
+  if (existsSync(targetTreeSitterDir)) {
+    rmSync(targetTreeSitterDir, { recursive: true, force: true })
+  }
+  cpSync(sourceTreeSitterDir, targetTreeSitterDir, { recursive: true })
+  return true
+}

--- a/packages/kilo-vscode/script/local-bin.ts
+++ b/packages/kilo-vscode/script/local-bin.ts
@@ -2,6 +2,7 @@
 import { $ } from "bun"
 import { join, relative, dirname, basename } from "node:path"
 import { chmodSync, statSync, rmSync, readdirSync, existsSync } from "node:fs"
+import { copyCliSidecarAssets } from "./cli-sidecars"
 import { currentFfmpegTarget, ensureFfmpegForTarget } from "./ffmpeg-helper"
 
 const forceRebuild = process.argv.includes("--force")
@@ -183,6 +184,13 @@ async function main() {
   await $`mkdir -p ${targetBinDir}`
   await $`cp ${sourceBinPath} ${targetBinPath}`
   chmodSync(targetBinPath, 0o755)
+
+  if (copyCliSidecarAssets(sourceBinPath, targetBinDir)) {
+    log(`Copied tree-sitter WASM assets -> ${relative(kiloVscodeDir, join(targetBinDir, "tree-sitter"))}`)
+  } else {
+    log(`Tree-sitter WASM assets not found next to CLI binary at ${relative(packagesDir, dirname(sourceBinPath))}`)
+  }
+
   await ensureFfmpegForTarget(currentFfmpegTarget(), targetBinDir)
 
   // Record the CLI source version so future runs detect when a rebuild is needed

--- a/packages/kilo-vscode/tests/unit/cli-sidecars.test.ts
+++ b/packages/kilo-vscode/tests/unit/cli-sidecars.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { copyCliSidecarAssets } from "../../script/cli-sidecars"
+
+let tmp: string | undefined
+
+afterEach(() => {
+  if (tmp) {
+    rmSync(tmp, { recursive: true, force: true })
+    tmp = undefined
+  }
+})
+
+function setup() {
+  tmp = mkdtempSync(join(tmpdir(), "kilo-cli-sidecars-"))
+  const sourceBin = join(tmp, "source", "bin")
+  const targetBin = join(tmp, "target", "bin")
+  mkdirSync(join(sourceBin, "tree-sitter"), { recursive: true })
+  mkdirSync(targetBin, { recursive: true })
+  const binary = join(sourceBin, process.platform === "win32" ? "kilo.exe" : "kilo")
+  writeFileSync(binary, "binary")
+  writeFileSync(join(sourceBin, "tree-sitter", "tree-sitter.wasm"), "runtime")
+  writeFileSync(join(sourceBin, "tree-sitter", "tree-sitter-typescript.wasm"), "language")
+  return { binary, targetBin }
+}
+
+describe("copyCliSidecarAssets", () => {
+  it("copies tree-sitter WASM assets next to the VS Code CLI binary", () => {
+    const { binary, targetBin } = setup()
+
+    expect(copyCliSidecarAssets(binary, targetBin)).toBe(true)
+
+    expect(readFileSync(join(targetBin, "tree-sitter", "tree-sitter.wasm"), "utf8")).toBe("runtime")
+    expect(readFileSync(join(targetBin, "tree-sitter", "tree-sitter-typescript.wasm"), "utf8")).toBe("language")
+  })
+
+  it("reports missing sidecar assets without creating an empty target directory", () => {
+    tmp = mkdtempSync(join(tmpdir(), "kilo-cli-sidecars-"))
+    const sourceBin = join(tmp, "source", "bin")
+    const targetBin = join(tmp, "target", "bin")
+    mkdirSync(sourceBin, { recursive: true })
+    mkdirSync(targetBin, { recursive: true })
+    const binary = join(sourceBin, "kilo")
+    writeFileSync(binary, "binary")
+
+    expect(copyCliSidecarAssets(binary, targetBin)).toBe(false)
+    expect(existsSync(join(targetBin, "tree-sitter"))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- copy the CLI tree-sitter WASM sidecar directory into VS Code extension packages alongside the CLI binary
- apply the same sidecar copy path for local binary preparation
- add a focused unit test for the sidecar asset copy behavior

Closes #10436

## Validation
- bun test tests/unit/cli-sidecars.test.ts
- git diff --check
- bun run check-kilocode-change
- bun run typecheck