### PR TITLE
fix(cli): default edit and bash permissions to ask on fresh installs

### DIFF
--- a/.changeset/fresh-install-ask-permissions.md
+++ b/.changeset/fresh-install-ask-permissions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Default to asking before edits and shell commands on fresh installs so VS Code and JetBrains always receive permission prompts on first use. Existing users with explicit permission config are unaffected.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -498,6 +498,7 @@ export const layer = Layer.effect(
 
     const loadGlobal = Effect.fnUntraced(function* () {
       yield* Effect.promise(() => KilocodeConfig.migrateBashPermission()) // kilocode_change
+      yield* Effect.promise(() => KilocodeConfig.migrateEditPermission()) // kilocode_change
       let result: Info = {}
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "config.json")))
       // kilocode_change start

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -229,7 +229,13 @@ export interface KiloData {
 // Prepare kilo-specific data derived from config. Call once per state initialization.
 export function prepare(cfg: Config.Info): KiloData {
   const mcpRules = getMcpRules(cfg)
-  const defaultsPatch = Permission.fromConfig({ bash, recall: "ask" })
+  // Default ask for edit and bash ensures fresh installs always prompt before
+  // risky actions, so VS Code and JetBrains receive permission.asked events.
+  // User/project config merged after defaults still overrides these.
+  const defaultsPatch = Permission.merge(
+    Permission.fromConfig({ bash, recall: "ask" }),
+    Permission.fromConfig({ edit: "ask", bash: "ask" }),
+  )
   return { mcpRules, defaultsPatch }
 }
 

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -229,9 +229,9 @@ export interface KiloData {
 // Prepare kilo-specific data derived from config. Call once per state initialization.
 export function prepare(cfg: Config.Info): KiloData {
   const mcpRules = getMcpRules(cfg)
-  // Default ask for edit and bash ensures fresh installs always prompt before
-  // risky actions, so VS Code and JetBrains receive permission.asked events.
-  // User/project config merged after defaults still overrides these.
+  // Fresh installs ask before edits and all bash commands, including commands
+  // covered by the safe-bash allowlist, so editor clients always receive
+  // permission.asked events. User/project config still overrides these rules.
   const defaultsPatch = Permission.merge(
     Permission.fromConfig({ bash, recall: "ask" }),
     Permission.fromConfig({ edit: "ask", bash: "ask" }),

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -313,7 +313,7 @@ export namespace KilocodeConfig {
     return { agents: {}, warnings }
   }
 
-  // ── Bash permission migration ────────────────────────────────────────
+  // ── Permission migrations ────────────────────────────────────────────
 
   const GLOBAL_CONFIG_FILES = ["config.json", "kilo.json", "kilo.jsonc", "opencode.json", "opencode.jsonc"]
 
@@ -368,6 +368,59 @@ export namespace KilocodeConfig {
     const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
     await Bun.write(target, JSON.stringify(merged, null, 2))
     log.info("migrated bash permission to allow for existing user", { path: target })
+  }
+
+  /**
+   * Migrate edit permission for existing users before config is consumed.
+   *
+   * Existing users (those with at least one global config file or the legacy TOML
+   * config) who have no explicit `permission.edit` setting get `edit: "allow"`
+   * written to their highest-precedence config file. This preserves their current
+   * behavior now that the new default is `edit: "ask"`.
+   */
+  export async function migrateEditPermission() {
+    const files = GLOBAL_CONFIG_FILES.map((f) => path.join(Global.Path.config, f))
+    const legacy = path.join(Global.Path.config, "config")
+    const existing = files.filter((f) => existsSync(f))
+    const hasLegacy = existsSync(legacy)
+
+    // no global config → new user, they'll get the new edit:ask default
+    if (existing.length === 0 && !hasLegacy) return
+
+    // check if any config file already has an explicit edit permission
+    for (const file of existing) {
+      const text = await Bun.file(file)
+        .text()
+        .catch(() => "")
+      const data = parseJsonc(text) ?? {}
+      if (data.permission?.edit) return
+    }
+
+    // also check legacy TOML config for edit permission
+    if (hasLegacy) {
+      const toml = await import(pathToFileURL(legacy).href, { with: { type: "toml" } }).catch(() => undefined)
+      if (toml?.default?.permission?.edit) return
+    }
+
+    // existing user without edit permission → write edit:allow to highest-precedence file
+    const target = existing.length > 0 ? existing[existing.length - 1] : path.join(Global.Path.config, "config.json")
+    const text = await Bun.file(target)
+      .text()
+      .catch(() => "{}")
+
+    if (target.endsWith(".jsonc")) {
+      const edits = modify(text, ["permission", "edit"], "allow", {
+        formattingOptions: { insertSpaces: true, tabSize: 2 },
+      })
+      await Bun.write(target, applyEdits(text, edits))
+      log.info("migrated edit permission to allow for existing user", { path: target })
+      return
+    }
+
+    const data = parseJsonc(text) ?? {}
+    const merged = { ...data, permission: { ...data.permission, edit: "allow" } }
+    await Bun.write(target, JSON.stringify(merged, null, 2))
+    log.info("migrated edit permission to allow for existing user", { path: target })
   }
 
   // ── Config merge utilities ───────────────────────────────────────────

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -52,7 +52,7 @@ test("code agent has correct default properties", async () => {
       expect(code).toBeDefined()
       expect(code?.mode).toBe("primary")
       expect(code?.native).toBe(true)
-      expect(evalPerm(code, "edit")).toBe("allow")
+      expect(evalPerm(code, "edit")).toBe("ask") // kilocode_change - default is ask on clean config
       expect(evalPerm(code, "bash")).toBe("ask") // kilocode_change - safe-bash default is ask
     },
   })
@@ -322,8 +322,8 @@ test("agent permission config merges with defaults", async () => {
       expect(code).toBeDefined()
       // Specific pattern is denied
       expect(Permission.evaluate("bash", "rm -rf *", code!.permission).action).toBe("deny")
-      // Edit still allowed
-      expect(evalPerm(code, "edit")).toBe("allow")
+      // Edit still asks (default on clean config)
+      expect(evalPerm(code, "edit")).toBe("ask")
       // kilocode_change end
     },
   })

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1777,6 +1777,61 @@ test("Effect config parser preserves permission order while rejecting unknown to
   }
 })
 
+// kilocode_change start
+test("migrates edit permission to allow for existing global config users", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear(true)
+  try {
+    const file = path.join(globalTmp.path, "kilo.json")
+    await fs.mkdir(globalTmp.path, { recursive: true })
+    await fs.writeFile(file, JSON.stringify({ permission: { bash: "allow" } }, null, 2))
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.permission?.edit).toBe("allow")
+        expect(config.permission?.bash).toBe("allow")
+      },
+    })
+
+    const written = JSON.parse(await fs.readFile(file, "utf8"))
+    expect(written.permission.edit).toBe("allow")
+    expect(written.permission.bash).toBe("allow")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear(true)
+  }
+})
+
+test("does not migrate edit permission for fresh users without global config", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await fs.rm(globalTmp.path, { force: true, recursive: true })
+  await clear(true)
+  try {
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.permission?.edit).toBeUndefined()
+      },
+    })
+
+    expect(await Bun.file(path.join(globalTmp.path, "kilo.json")).exists()).toBe(false)
+    expect(await Bun.file(path.join(globalTmp.path, "config.json")).exists()).toBe(false)
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear(true)
+  }
+})
+// kilocode_change end
+
 // MCP config merging tests
 
 test("project config can override MCP server enabled status", async () => {

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -13,6 +13,61 @@ afterEach(async () => {
   await disposeAllInstances()
 })
 
+test("code agent defaults edit and bash to ask on clean config", async () => {
+  await using tmp = await tmpdir()
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const code = await load(tmp.path, (svc) => svc.get("code"))
+      expect(code).toBeDefined()
+      expect(Permission.evaluate("edit", "src/index.ts", code!.permission).action).toBe("ask")
+      expect(Permission.evaluate("bash", "ls -la", code!.permission).action).toBe("ask")
+      // read and search tools remain non-destructive
+      expect(Permission.evaluate("read", "src/index.ts", code!.permission).action).toBe("allow")
+      expect(Permission.evaluate("grep", "*", code!.permission).action).toBe("allow")
+      expect(Permission.evaluate("glob", "*", code!.permission).action).toBe("allow")
+    },
+  })
+})
+
+test("code agent respects explicit edit:allow user override", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      permission: {
+        edit: "allow",
+        bash: "allow",
+      },
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const code = await load(tmp.path, (svc) => svc.get("code"))
+      expect(code).toBeDefined()
+      expect(Permission.evaluate("edit", "src/index.ts", code!.permission).action).toBe("allow")
+      expect(Permission.evaluate("bash", "npm install", code!.permission).action).toBe("allow")
+    },
+  })
+})
+
+test("code agent respects explicit edit:deny user override", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      permission: {
+        edit: "deny",
+      },
+    },
+  })
+  await WithInstance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const code = await load(tmp.path, (svc) => svc.get("code"))
+      expect(code).toBeDefined()
+      expect(Permission.evaluate("edit", "src/index.ts", code!.permission).action).toBe("deny")
+    },
+  })
+})
+
 test("ask agent honors user MCP allow over generated ask rule", async () => {
   await using tmp = await tmpdir({
     config: {


### PR DESCRIPTION
## Context

On a clean Kilo install with no user config, the default `code` agent previously allowed edits without prompting. This meant VS Code and JetBrains never received `permission.asked` events on first run — the CLI had already evaluated the tool call as allowed, so editor UIs had nothing to display.

The fix ensures that on a fresh install (no `permission.edit` or `permission.bash` in user config), the CLI always emits `permission.asked` before edits and shell commands, giving every editor client the event it needs to show a prompt.

## Implementation

A small change to `KiloAgent.prepare()` in `src/kilocode/agent/index.ts` (Kilo-owned) appends explicit ask rules after the existing Kilo defaults:

```ts
const defaultsPatch = Permission.merge(
  Permission.fromConfig({ bash, recall: "ask" }),
  Permission.fromConfig({ edit: "ask", bash: "ask" }),
)
```

`Permission.evaluate` uses `findLast`, so the trailing `bash: "ask"` rule intentionally wins over the safe-bash allowlist on fresh installs: every bash command now prompts unless user/project config explicitly allows it. Merge order is preserved: native agent defaults → `defaultsPatch` → user top-level `permission` → agent-level `permission`, so any explicit override in config still wins.

Existing users are guarded by migrations: `migrateBashPermission()` preserves prior bash behavior by writing `bash: "allow"` when needed, and this PR adds `migrateEditPermission()` to preserve prior edit behavior by writing `edit: "allow"` for existing users without explicit edit permission.

## Screenshots

No UI change — permission prompt behavior is owned by the editor clients. The CLI now reliably emits the events needed for those prompts to appear.

## How to Test

1. Start with no `~/.config/kilo/kilo.json` (or a config with no `permission` key).
2. Start `kilo serve` and open a session in VS Code or JetBrains.
3. Ask the agent to edit a file. You should see a permission prompt.
4. Ask the agent to run any bash command, including `ls -la`. You should see a permission prompt.
5. Add `"permission": { "edit": "allow", "bash": "allow" }` to your config and repeat — prompts should not appear.

## Get in Touch

<!-- Discord handle if applicable -->