### PR TITLE
Fix permission dock scrolling for large file edits

### DIFF
--- a/.changeset/permission-dock-scroll.md
+++ b/.changeset/permission-dock-scroll.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep permission actions reachable when reviewing many file diffs.

--- a/packages/kilo-vscode/tests/permission-dock-scroll.spec.ts
+++ b/packages/kilo-vscode/tests/permission-dock-scroll.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+
+function storyUrl(story: string) {
+  return `/iframe.html?id=${story}&viewMode=story&globals=${GLOBALS}`
+}
+
+async function disableAnimations(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  })
+}
+
+test("permission actions stay reachable with many file diffs", async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 720 })
+  await page.goto(storyUrl("composite-webview--permission-dock-many-files"), { waitUntil: "load" })
+  await disableAnimations(page)
+  await page.waitForSelector("#storybook-root *", { state: "attached" })
+
+  const root = page.locator("#storybook-root")
+  const diffs = page.locator('[data-slot="permission-diffs"]')
+  const actions = page.locator('[data-slot="permission-actions"]')
+
+  await expect(diffs).toBeVisible()
+  await expect(actions).toBeVisible()
+
+  const rootBox = await root.boundingBox()
+  const actionsBox = await actions.boundingBox()
+
+  expect(rootBox).not.toBeNull()
+  expect(actionsBox).not.toBeNull()
+  expect(actionsBox!.y + actionsBox!.height).toBeLessThanOrEqual(rootBox!.y + rootBox!.height)
+
+  await diffs.evaluate((element) => {
+    element.scrollTop = element.scrollHeight
+  })
+
+  await expect(actions).toBeVisible()
+})

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -762,10 +762,57 @@ const applyPatchPermission: PermissionRequest = {
   tool: { messageID: ASST_MSG_ID, callID: "call-patch-001" },
 }
 
+const bulkPermission: PermissionRequest = {
+  id: "perm-bulk-001",
+  sessionID: SESSION_ID,
+  toolName: "edit",
+  patterns: ["src/**/*"],
+  always: ["*"],
+  args: {
+    filepath: "src/features",
+    files: Array.from({ length: 14 }, (_, index) => ({
+      relativePath: `src/features/bulk-edit/file-${index + 1}.tsx`,
+      type: "update",
+      patch:
+        "===================================================================\n" +
+        `--- src/features/bulk-edit/file-${index + 1}.tsx\n` +
+        `+++ src/features/bulk-edit/file-${index + 1}.tsx\n` +
+        "@@ -1,3 +1,3 @@\n" +
+        " export function Item() {\n" +
+        "-  return null\n" +
+        "+  return <span>Updated</span>\n" +
+        " }\n",
+      additions: 1,
+      deletions: 1,
+    })),
+  },
+  tool: { messageID: ASST_MSG_ID, callID: "call-bulk-001" },
+}
+
 export const PermissionDockEdit: Story = {
   name: "Permission Dock — edit",
   render: () => {
     const perms = [editPermission]
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID, status: "busy", permissions: perms }),
+      messages: () => [{ id: "msg-001" }] as any[],
+    }
+    return (
+      <StoryProviders permissions={perms} sessionID={SESSION_ID} status="busy" noPadding>
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "100%", height: "350px", display: "flex", "flex-direction": "column" }}>
+            <ChatView />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+export const PermissionDockManyFiles: Story = {
+  name: "Permission Dock - many file diffs",
+  render: () => {
+    const perms = [bulkPermission]
     const session = {
       ...mockSessionValue({ id: SESSION_ID, status: "busy", permissions: perms }),
       messages: () => [{ id: "msg-001" }] as any[],

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -26,8 +26,18 @@
   }
 
   [data-slot="permission-body"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
     padding: 10px 16px 0;
     gap: 8px;
+  }
+
+  [data-slot="permission-content"] {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
   }
 
   [data-slot="permission-header-title"] {
@@ -113,10 +123,16 @@
   [data-slot="permission-diffs"] {
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
     gap: 8px;
     margin: 8px 0;
-    max-height: 420px;
+    max-height: clamp(160px, 32vh, 320px);
+    min-height: 0;
     overflow: auto;
+  }
+
+  [data-slot="permission-diffs"]:not([data-count="1"]) {
+    max-height: clamp(96px, 16vh, 220px);
   }
 
   [data-slot="permission-diff"] {
@@ -352,6 +368,7 @@
   [data-slot="permission-actions"] {
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
     flex-wrap: wrap;
     gap: 8px;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- Keep the permission action buttons reachable when many file diffs are shown
- Add a Storybook regression case and Playwright check for the overflowing dock state

## Validation
- `bun run typecheck`
- `bun run lint`
- `bunx playwright test tests/permission-dock-scroll.spec.ts`
- `bun run check-kilocode-change`
- `bunx prettier --check webview-ui/src/stories/composite.stories.tsx webview-ui/src/styles/permission-dock.css tests/permission-dock-scroll.spec.ts ../../.changeset/permission-dock-scroll.md`
- `git diff --check`

Fixes #10351