### PR TITLE
Show reasoning titles in block headers

### DIFF
--- a/.changeset/bright-brains-title.md
+++ b/.changeset/bright-brains-title.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-ui": patch
+---
+
+Show the first leading reasoning title in each block header without repeating it in the expanded body, while keeping untitled blocks unchanged.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -421,9 +421,17 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   }
 
   [data-slot="reasoning-label"] {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  [data-slot="reasoning-title"] {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    color: var(--text-weak);
+    font-weight: var(--font-weight-regular);
   }
 
   [data-slot="reasoning-content"] {

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -53,6 +53,7 @@ import { busy, createThrottledValue, useToolFade, useContextToolPending } from "
 import { readToolOpen, toolOpenKey } from "./tool-open-state"
 import { ContextToolGroupHeader, ContextToolExpandedList, ContextToolRollingResults } from "./context-tool-results"
 import { ShellRollingResults } from "./shell-rolling-results"
+import { reasoningHeading } from "./reasoning-heading"
 import { extractFilePathFromHref } from "../file-path"
 import { normalize } from "./session-diff"
 import { deferredHighlight } from "../context/marked"
@@ -1487,6 +1488,7 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
 
   // Throttle markdown re-renders during streaming
   const display = createThrottledValue(text)
+  const view = createMemo(() => reasoningHeading(display()))
 
   // time.end is set by the processor on reasoning-end.
   // v1 parts lack time entirely → treat as historical.
@@ -1567,12 +1569,13 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
             <div data-slot="reasoning-header">
               <Icon name="brain" size="small" />
               <span data-slot="reasoning-label">{i18n.t("ui.reasoning.label" as never)}</span>
+              <Show when={view().title}>{(title) => <span data-slot="reasoning-title">{title()}</span>}</Show>
             </div>
             <Collapsible.Arrow />
           </Collapsible.Trigger>
           <Collapsible.Content>
             <div data-slot="reasoning-content" ref={ref} onScroll={onScroll} onWheel={onWheel}>
-              <Markdown text={display()} cacheKey={id} />
+              <Markdown text={view().body} cacheKey={id} />
             </div>
           </Collapsible.Content>
         </Collapsible>

--- a/packages/kilo-ui/src/components/reasoning-heading.test.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { reasoningHeading } from "./reasoning-heading"
+
+describe("reasoning heading", () => {
+  test("promotes a leading strong line into the title", () => {
+    expect(reasoningHeading("**Counting distinct users**\n\nI should aggregate the fixed version first.")).toEqual({
+      title: "Counting distinct users",
+      body: "I should aggregate the fixed version first.",
+    })
+  })
+
+  test("promotes heading syntax and keeps the remaining markdown", () => {
+    expect(reasoningHeading("## Check `Slack` [requests](https://example.com) ##\n\n- Inspect the command")).toEqual({
+      title: "Check Slack requests",
+      body: "- Inspect the command",
+    })
+  })
+
+  test("keeps plain lead-in text instead of lifting a later heading", () => {
+    const text = "First inspect the query.\n\n**Then summarize it**\n\nKeep working."
+    expect(reasoningHeading(text)).toEqual({ body: text })
+  })
+
+  test("supports setext headings after normalizing line endings", () => {
+    expect(reasoningHeading("Review the plan\r\n---------------\r\n\r\nCompare the tradeoffs.")).toEqual({
+      title: "Review the plan",
+      body: "Compare the tradeoffs.",
+    })
+  })
+
+  test("promotes HTML headings while flattening inline tags", () => {
+    expect(reasoningHeading('<h3 class="step">Check <em>provider</em> status</h3>\n\nContinue with the next item.')).toEqual({
+      title: "Check provider status",
+      body: "Continue with the next item.",
+    })
+  })
+
+  test("keeps strong lead-in prose in the body", () => {
+    const text = "**Important** because the result can change.\n\nKeep analyzing."
+    expect(reasoningHeading(text)).toEqual({ body: text })
+  })
+
+  test("promotes an underscore strong title without body text", () => {
+    expect(reasoningHeading("__Summarize constraints__")).toEqual({
+      title: "Summarize constraints",
+      body: "",
+    })
+  })
+})

--- a/packages/kilo-ui/src/components/reasoning-heading.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.ts
@@ -1,0 +1,40 @@
+export type ReasoningHeading = {
+  title?: string
+  body: string
+}
+
+function clean(value: string) {
+  return value
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/[*_~]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function pick(src: string, expr: RegExp, group = 1): ReasoningHeading | undefined {
+  const found = src.match(expr)
+  const raw = found?.[group]
+  if (!found || !raw) return
+
+  const title = clean(raw)
+  if (!title) return
+
+  return {
+    title,
+    body: src.slice(found[0].length).trimStart(),
+  }
+}
+
+export function reasoningHeading(text: string): ReasoningHeading {
+  const src = text.replace(/\r\n?/g, "\n").trim()
+  return (
+    pick(src, /^<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>[ \t]*(?:\n|$)?/i) ??
+    pick(src, /^#{1,6}[ \t]+([^\n]+?)(?:[ \t]+#+[ \t]*)?(?:\n|$)/) ??
+    pick(src, /^([^\n]+)\n(?:=+|-+)[ \t]*(?:\n|$)/) ??
+    pick(src, /^(\*\*|__)([^\n]+?)\1[ \t]*(?:\n|$)/, 2) ?? {
+      body: src,
+    }
+  )
+}

--- a/packages/kilo-ui/src/stories/message-part.stories.tsx
+++ b/packages/kilo-ui/src/stories/message-part.stories.tsx
@@ -232,7 +232,7 @@ const reasoningPart: ReasoningPart = {
   sessionID: SESSION_ID,
   messageID: ASST_MSG_ID,
   type: "reasoning",
-  text: "Let me think about this carefully. The user wants code improvements.\n\n1. First, I should check for error boundaries — they prevent cascading failures\n2. The dependencies could be updated to newer minor versions\n3. Unit tests would improve confidence in refactoring later\n\nI'll structure my response to address each point clearly.",
+  text: "**Reviewing code improvements**\n\nLet me think about this carefully. The user wants code improvements.\n\n1. First, I should check for error boundaries - they prevent cascading failures\n2. The dependencies could be updated to newer minor versions\n3. Unit tests would improve confidence in refactoring later\n\nI'll structure my response to address each point clearly.",
   time: { start: now - 9000, end: now - 8500 },
 }
 


### PR DESCRIPTION
Lift only the first leading title from each reasoning block into its header and remove that lifted title from the expanded content.
This applies when model reasoning begins with a title, as GPT blocks often do across multiple blocks; untitled reasoning such as Opus output keeps the generic header.

<img width="505" height="230" alt="image" src="https://github.com/user-attachments/assets/ae574613-5af7-4f05-a01d-d5415b9e0908" />
<img width="524" height="325" alt="image" src="https://github.com/user-attachments/assets/b681fa8a-6b04-42cb-84a8-c0158460670d" />
<img width="419" height="76" alt="image" src="https://github.com/user-attachments/assets/e12cab67-96e8-44a5-9ec2-1cf9f2ea7b83" />
