### PR TITLE
fix: stabilize code indexing retries

### DIFF
--- a/.changeset/quiet-indexes-retry.md
+++ b/.changeset/quiet-indexes-retry.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-indexing": patch
+---
+
+Reduce indexing embedding request bursts and preserve existing search vectors when incremental replacement work fails.

--- a/packages/kilo-indexing/src/indexing/constants/index.ts
+++ b/packages/kilo-indexing/src/indexing/constants/index.ts
@@ -41,6 +41,7 @@ export const MAX_BATCH_RETRIES = 3
 export const INITIAL_RETRY_DELAY_MS = 500
 export const PARSING_CONCURRENCY = 10
 export const MAX_PENDING_BATCHES = 20 // Maximum number of batches to accumulate before waiting
+export const EMBEDDING_REQUEST_CONCURRENCY = 1
 
 /**Manager Recovery */
 export const MAX_MANAGER_RECOVERY_ATTEMPTS = 3

--- a/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
+++ b/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
@@ -463,6 +463,10 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
       const state = OpenAICompatibleEmbedder.globalRateLimitState
       const now = Date.now()
 
+      if (state.isRateLimited && state.rateLimitResetTime > now) {
+        return
+      }
+
       // Increment consecutive rate limit errors
       if (now - state.lastRateLimitError < 60000) {
         // Within 1 minute

--- a/packages/kilo-indexing/src/indexing/embedders/openrouter.ts
+++ b/packages/kilo-indexing/src/indexing/embedders/openrouter.ts
@@ -382,6 +382,10 @@ export class OpenRouterEmbedder implements IEmbedder {
       const state = OpenRouterEmbedder.globalRateLimitState
       const now = Date.now()
 
+      if (state.isRateLimited && state.rateLimitResetTime > now) {
+        return
+      }
+
       // Increment consecutive rate limit errors
       if (now - state.lastRateLimitError < 60000) {
         // Within 1 minute

--- a/packages/kilo-indexing/src/indexing/orchestrator.ts
+++ b/packages/kilo-indexing/src/indexing/orchestrator.ts
@@ -100,22 +100,23 @@ export class CodeIndexOrchestrator {
             totalInBatch,
             currentFile ? path.basename(currentFile) : undefined,
           )
-          if (processedInBatch === totalInBatch) {
-            log.info("file watcher batch completed", {
-              workspacePath: this.workspacePath,
-              totalInBatch,
-            })
-            if (totalInBatch > 0) {
-              this.stateManager.setSystemState("Indexed", "File changes processed. Index up-to-date.")
-            } else if (this.stateManager.state === "Indexing") {
-              this.stateManager.setSystemState("Indexed", "Index up-to-date. File queue empty.")
-            }
-          }
         }),
         this.fileWatcher.onDidFinishBatchProcessing.on((summary: BatchProcessingSummary) => {
-          if (summary.batchError) {
-            log.error("batch processing failed", { err: summary.batchError })
+          const failed = summary.processedFiles.find(
+            (file) => file.status === "error" || file.status === "local_error",
+          )
+          const err = summary.batchError ?? failed?.error
+          if (err || failed) {
+            log.error("batch processing failed", { err })
+            this.stateManager.setSystemState("Error", "Failed to process file changes.")
+            return
           }
+
+          log.info("file watcher batch completed", {
+            workspacePath: this.workspacePath,
+            totalInBatch: summary.processedFiles.length,
+          })
+          this.stateManager.setSystemState("Indexed", "File changes processed. Index up-to-date.")
         }),
       ]
       this.fileWatcher.setCollecting(false)
@@ -309,6 +310,12 @@ export class CodeIndexOrchestrator {
           )
         }
       }
+    }
+
+    if (mode === "incremental" && batchErrors.length > 0) {
+      const first = batchErrors.at(0)
+      const msg = first ? first.message : "Unknown batch error"
+      throw new Error(`Incremental indexing failed: ${msg}`)
     }
 
     this.fileWatcher.setCollecting(true)

--- a/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
+++ b/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
@@ -4,6 +4,7 @@ import { createHash } from "crypto"
 import path from "path"
 import { v5 as uuidv5 } from "uuid"
 import type { Ignore } from "ignore"
+import pLimit from "p-limit"
 import { Emitter, type Disposable } from "../runtime"
 import {
   QDRANT_CODE_BLOCK_NAMESPACE,
@@ -11,6 +12,7 @@ import {
   BATCH_SEGMENT_THRESHOLD,
   MAX_BATCH_RETRIES,
   INITIAL_RETRY_DELAY_MS,
+  EMBEDDING_REQUEST_CONCURRENCY,
 } from "../constants"
 import { scannerExtensions } from "../shared/supported-extensions"
 import {
@@ -48,6 +50,7 @@ export class FileWatcher implements IFileWatcher {
   private batchProcessDebounceTimer?: NodeJS.Timeout
   private readonly BATCH_DEBOUNCE_DELAY_MS = 500
   private readonly FILE_PROCESSING_CONCURRENCY_LIMIT = 10
+  private readonly embedLimit = pLimit(EMBEDDING_REQUEST_CONCURRENCY)
   private batchSegmentThreshold: number
   private maxBatchRetries: number
   private collecting = true
@@ -242,28 +245,20 @@ export class FileWatcher implements IFileWatcher {
   /**
    * Handles deletion phase of batch processing.
    *
-   * Deletes vector store points for explicitly deleted files and for files
-   * that changed (old points are cleared before re-upserting new ones).
+   * Deletes vector store points for explicitly deleted files. Changed files
+   * are cleared only after their replacement embeddings are ready.
    */
   private async _handleBatchDeletions(
     batchResults: FileProcessingResult[],
     processedCountInBatch: number,
     totalFilesInBatch: number,
     pathsToExplicitlyDelete: string[],
-    filesToUpsertDetails: Array<{ path: string; originalType: "create" | "change" }>,
-  ): Promise<{ overallBatchError?: Error; clearedPaths: Set<string>; processedCount: number }> {
+  ): Promise<{ overallBatchError?: Error; processedCount: number }> {
     let overallBatchError: Error | undefined
-    const allPathsToClearFromDB = new Set<string>(pathsToExplicitlyDelete)
 
-    for (const fileDetail of filesToUpsertDetails) {
-      if (fileDetail.originalType === "change") {
-        allPathsToClearFromDB.add(fileDetail.path)
-      }
-    }
-
-    if (allPathsToClearFromDB.size > 0 && this.vectorStore) {
+    if (pathsToExplicitlyDelete.length > 0 && this.vectorStore) {
       try {
-        await this.vectorStore.deletePointsByMultipleFilePaths(Array.from(allPathsToClearFromDB))
+        await this.vectorStore.deletePointsByMultipleFilePaths(pathsToExplicitlyDelete)
 
         for (const path of pathsToExplicitlyDelete) {
           this.cacheManager.deleteHash(path)
@@ -300,7 +295,29 @@ export class FileWatcher implements IFileWatcher {
       }
     }
 
-    return { overallBatchError, clearedPaths: allPathsToClearFromDB, processedCount: processedCountInBatch }
+    return { overallBatchError, processedCount: processedCountInBatch }
+  }
+
+  private async _clearBatchReplacements(paths: string[]): Promise<Error | undefined> {
+    if (paths.length === 0 || !this.vectorStore) return undefined
+
+    const unique = [...new Set(paths)]
+    try {
+      await this.vectorStore.deletePointsByMultipleFilePaths(unique)
+      return undefined
+    } catch (error: any) {
+      const errorStatus = error?.status || error?.response?.status || error?.statusCode
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      log.error("batch replacement deletion failed", {
+        error: sanitizeErrorMessage(errorMessage),
+        location: "deletePointsByMultipleFilePaths",
+        errorType: "replacement_deletion_error",
+        errorStatus,
+      })
+      this.emitError("file-watcher:deleteReplacementPoints", error)
+      return error as Error
+    }
   }
 
   /**
@@ -522,7 +539,6 @@ export class FileWatcher implements IFileWatcher {
       processedCountInBatch,
       totalFilesInBatch,
       pathsToExplicitlyDelete,
-      filesToUpsertDetails,
     )
     overallBatchError = deletionError
     processedCountInBatch = deletionCount
@@ -541,6 +557,16 @@ export class FileWatcher implements IFileWatcher {
     )
     processedCountInBatch = upsertCount
 
+    if (!overallBatchError) {
+      const changed = new Set(
+        filesToUpsertDetails.filter((file) => file.originalType === "change").map((file) => file.path),
+      )
+      const replacements = successfullyProcessedForUpsert
+        .map((file) => file.path)
+        .filter((path) => changed.has(path))
+      overallBatchError = await this._clearBatchReplacements(replacements)
+    }
+
     // Phase 3: Execute batch upsert
     overallBatchError = await this._executeBatchUpsertOperations(
       pointsForBatchUpsert,
@@ -550,11 +576,6 @@ export class FileWatcher implements IFileWatcher {
     )
 
     // Finalize
-    this.onDidFinishBatchProcessing.fire({
-      processedFiles: batchResults,
-      batchError: overallBatchError,
-    })
-
     const successCount = batchResults.filter((item) => item.status === "success").length
     const skippedCount = batchResults.filter((item) => item.status === "skipped").length
     const errorCount = batchResults.filter((item) => item.status === "error" || item.status === "local_error").length
@@ -580,6 +601,11 @@ export class FileWatcher implements IFileWatcher {
         currentFile: undefined,
       })
     }
+
+    this.onDidFinishBatchProcessing.fire({
+      processedFiles: batchResults,
+      batchError: overallBatchError,
+    })
   }
 
   /**
@@ -647,7 +673,7 @@ export class FileWatcher implements IFileWatcher {
       let pointsToUpsert: PointStruct[] = []
       if (this.embedder && blocks.length > 0) {
         const texts = blocks.map((block) => block.content)
-        const { embeddings } = await this.embedder.createEmbeddings(texts)
+        const { embeddings } = await this.embedLimit(() => this.embedder!.createEmbeddings(texts))
         if (embeddings.length !== blocks.length) {
           return {
             path: filePath,

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -23,6 +23,7 @@ import {
   PARSING_CONCURRENCY,
   BATCH_PROCESSING_CONCURRENCY,
   MAX_PENDING_BATCHES,
+  EMBEDDING_REQUEST_CONCURRENCY,
 } from "../constants"
 import { FileIgnore } from "../../file/ignore"
 import { Log } from "../../util/log"
@@ -33,6 +34,7 @@ const log = Log.create({ service: "indexing-scanner" })
 
 export class DirectoryScanner implements IDirectoryScanner {
   private _cancelled = false
+  private readonly embedLimit = pLimit(EMBEDDING_REQUEST_CONCURRENCY)
   private batchSegmentThreshold: number
   private maxBatchRetries: number
 
@@ -524,12 +526,59 @@ export class DirectoryScanner implements IDirectoryScanner {
     // Respect cooperative cancellation
     if (this._cancelled || batchBlocks.length === 0) return
 
-    if (batchBlocks.length === 0) {
-      log.debug("Skipping empty batch processing")
-      return
-    }
-
     log.debug(`Starting to process batch of ${batchBlocks.length} blocks in workspace ${scanWorkspace}`)
+
+    const points = await (async () => {
+      try {
+        if (this._cancelled) return undefined
+
+        log.debug(`Creating embeddings for ${batchTexts.length} texts`)
+        const { embeddings } = await this.embedLimit(() => this.embedder.createEmbeddings(batchTexts))
+        log.debug(`Successfully created ${embeddings.length} embeddings`)
+
+        log.debug("Preparing points for Qdrant upsert")
+        const ready = batchBlocks.map((block, index) => {
+          const vector = embeddings[index]
+          if (!vector) {
+            throw new Error(`Missing embedding for block at index ${index}`)
+          }
+
+          const normalizedAbsolutePath = generateNormalizedAbsolutePath(block.file_path, scanWorkspace)
+          const pointId = uuidv5(block.segmentHash, QDRANT_CODE_BLOCK_NAMESPACE)
+
+          return {
+            id: pointId,
+            vector,
+            payload: {
+              filePath: generateRelativeFilePath(normalizedAbsolutePath, scanWorkspace),
+              codeChunk: block.content,
+              startLine: block.start_line,
+              endLine: block.end_line,
+              segmentHash: block.segmentHash,
+            },
+          }
+        })
+        log.debug(`Prepared ${ready.length} points for Qdrant`)
+        return ready
+      } catch (error) {
+        const err = error as Error
+        log.error(`Error preparing batch in workspace ${scanWorkspace}`, {
+          error: sanitizeErrorMessage(err.message || String(error)),
+          stack: sanitizeErrorMessage(err.stack || ""),
+          location: "processBatch:prepare",
+          batchSize: batchBlocks.length,
+        })
+        this.emitError(mode, "scanner:processBatch", err)
+        onBatchFailed?.()
+        if (onError) {
+          const message = err.message || "Unknown error"
+          onError(new Error(`Failed to prepare batch: ${message}`))
+        }
+        return undefined
+      }
+    })()
+
+    if (!points) return
 
     let attempts = 0
     let success = false
@@ -582,41 +631,6 @@ export class DirectoryScanner implements IDirectoryScanner {
         }
         // --- End Deletion Step ---
 
-        // Create embeddings for batch
-        if (this._cancelled) return
-
-        log.debug(`Creating embeddings for ${batchTexts.length} texts`)
-
-        const { embeddings } = await this.embedder.createEmbeddings(batchTexts)
-        log.debug(`Successfully created ${embeddings.length} embeddings`)
-
-        // Prepare points for Qdrant
-        log.debug("Preparing points for Qdrant upsert")
-        const points = batchBlocks.map((block, index) => {
-          const vector = embeddings[index]
-          if (!vector) {
-            throw new Error(`Missing embedding for block at index ${index}`)
-          }
-
-          const normalizedAbsolutePath = generateNormalizedAbsolutePath(block.file_path, scanWorkspace)
-
-          // Use segmentHash for unique ID generation to handle multiple segments from same line
-          const pointId = uuidv5(block.segmentHash, QDRANT_CODE_BLOCK_NAMESPACE)
-
-          return {
-            id: pointId,
-            vector,
-            payload: {
-              filePath: generateRelativeFilePath(normalizedAbsolutePath, scanWorkspace),
-              codeChunk: block.content,
-              startLine: block.start_line,
-              endLine: block.end_line,
-              segmentHash: block.segmentHash,
-            },
-          }
-        })
-        log.debug(`Prepared ${points.length} points for Qdrant`)
-
         // Upsert points to Qdrant
         if (this._cancelled) return
 
@@ -652,7 +666,6 @@ export class DirectoryScanner implements IDirectoryScanner {
       this.emitError(mode, "scanner:processBatch", lastError, this.maxBatchRetries)
       onBatchFailed?.()
       if (onError) {
-        // Preserve the original error message from embedders which now have detailed messages
         const errorMessage = lastError.message || "Unknown error"
 
         onError(new Error(`Failed to process batch after ${this.maxBatchRetries} retries: ${errorMessage}`))

--- a/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
@@ -364,6 +364,33 @@ describe("OpenAICompatibleEmbedder", () => {
         })
       })
 
+      test("coalesces overlapping rate-limit cooldown windows", async () => {
+        const error = new Error("Rate limit exceeded") as Error & { status?: number }
+        error.status = 429
+        const data = embedder as unknown as {
+          updateGlobalRateLimitState(error: Error & { status?: number }): Promise<void>
+          constructor: {
+            globalRateLimitState: {
+              consecutiveRateLimitErrors: number
+              rateLimitResetTime: number
+            }
+          }
+        }
+
+        await Promise.all([
+          data.updateGlobalRateLimitState(error),
+          data.updateGlobalRateLimitState(error),
+          data.updateGlobalRateLimitState(error),
+        ])
+
+        const state = data.constructor.globalRateLimitState
+        const reset = state.rateLimitResetTime
+        await data.updateGlobalRateLimitState(error)
+
+        expect(state.consecutiveRateLimitErrors).toBe(1)
+        expect(state.rateLimitResetTime).toBe(reset)
+      })
+
       test("should not retry on non-rate-limit errors", async () => {
         const testTexts = ["Hello world"]
         const authError = new Error("Unauthorized")

--- a/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
@@ -17,6 +17,7 @@ import { Emitter } from "../../../src/indexing/runtime"
 
 class Store {
   public clearCount = 0
+  public completeCount = 0
   public deleteCount = 0
 
   constructor(
@@ -53,7 +54,9 @@ class Store {
   async hasIndexedData(): Promise<boolean> {
     return this.existing
   }
-  async markIndexingComplete(): Promise<void> {}
+  async markIndexingComplete(): Promise<void> {
+    this.completeCount += 1
+  }
   async markIndexingIncomplete(): Promise<void> {}
 }
 
@@ -82,6 +85,30 @@ class Scanner {
         skipped: 0,
       },
       totalBlockCount: this.blocks,
+    }
+  }
+
+  cancel(): void {}
+  updateBatchSegmentThreshold(_newThreshold: number): void {}
+}
+
+class BatchErrorScanner {
+  public readonly isCancelled = false
+
+  async scanDirectory(
+    _directory: string,
+    onError?: (error: Error) => void,
+    _onFilesIndexed?: (indexedCount: number) => void,
+    onFileParsed?: () => void,
+  ): Promise<{ stats: { processed: number; skipped: number }; totalBlockCount: number }> {
+    onFileParsed?.()
+    onError?.(new Error("incremental update batch failed"))
+    return {
+      stats: {
+        processed: 0,
+        skipped: 0,
+      },
+      totalBlockCount: 0,
     }
   }
 
@@ -193,6 +220,63 @@ describe("CodeIndexOrchestrator telemetry", () => {
     expect(completed?.filesDiscovered).toBe(2)
     expect(completed?.filesIndexed).toBe(1)
     expect(completed?.totalBlocks).toBe(2)
+  })
+
+  test("does not complete incremental scans with failed update batches", async () => {
+    const events: IndexingTelemetryEvent[] = []
+    const store = new Store(true)
+    const orchestrator = new CodeIndexOrchestrator(
+      createConfig(),
+      new CodeIndexStateManager(),
+      "/tmp/ws",
+      {
+        async clearCacheFile() {},
+      } as unknown as CacheManager,
+      store as unknown as IVectorStore,
+      new BatchErrorScanner() as unknown as DirectoryScanner,
+      new Watcher() as unknown as IFileWatcher,
+      (event) => events.push(event),
+    )
+
+    await orchestrator.startIndexing("manual")
+
+    expect(orchestrator.state).toBe("Error")
+    expect(store.completeCount).toBe(0)
+    expect(events.some((event) => event.type === "completed")).toBe(false)
+  })
+
+  test("keeps watcher batches in error when file updates fail", async () => {
+    const watcher = new Watcher()
+    const orchestrator = new CodeIndexOrchestrator(
+      createConfig(),
+      new CodeIndexStateManager(),
+      "/tmp/ws",
+      {
+        async clearCacheFile() {},
+      } as unknown as CacheManager,
+      new Store(false) as unknown as IVectorStore,
+      new Scanner(1, 1, 1) as unknown as DirectoryScanner,
+      watcher as unknown as IFileWatcher,
+    )
+
+    await orchestrator.startIndexing("manual")
+    watcher.onDidStartBatchProcessing.fire(["/tmp/ws/main.ts"])
+    watcher.onBatchProgressUpdate.fire({
+      processedInBatch: 1,
+      totalInBatch: 1,
+      currentFile: "/tmp/ws/main.ts",
+    })
+    watcher.onDidFinishBatchProcessing.fire({
+      processedFiles: [
+        {
+          path: "/tmp/ws/main.ts",
+          status: "local_error",
+          error: new Error("watcher update failed"),
+        },
+      ],
+    })
+
+    expect(orchestrator.state).toBe("Error")
   })
 
   test("cancelIndexing prevents scan from running", async () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
@@ -6,6 +6,7 @@ import { v5 as uuidv5 } from "uuid"
 import { CacheManager } from "../../../../src/indexing/cache-manager"
 import { QDRANT_CODE_BLOCK_NAMESPACE } from "../../../../src/indexing/constants"
 import type {
+  BatchProcessingSummary,
   IEmbedder,
   IndexingTelemetryEvent,
   IVectorStore,
@@ -31,7 +32,41 @@ function createEmbedder(): IEmbedder {
   }
 }
 
+function createFailingEmbedder(): IEmbedder {
+  return {
+    ...createEmbedder(),
+    async createEmbeddings() {
+      throw new Error("watcher embedding failed")
+    },
+  }
+}
+
+class TrackEmbedder implements IEmbedder {
+  public active = 0
+  public max = 0
+
+  async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
+    this.active += 1
+    this.max = Math.max(this.max, this.active)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    this.active -= 1
+    return {
+      embeddings: texts.map((_, index) => [index + 1]),
+    }
+  }
+
+  async validateConfiguration(): Promise<{ valid: boolean; error?: string }> {
+    return { valid: true }
+  }
+
+  get embedderInfo() {
+    return { name: "openai" as const }
+  }
+}
+
 class RetryStore implements IVectorStore {
+  public deletes: string[][] = []
+
   constructor(private readonly fail: number) {}
 
   private calls = 0
@@ -57,7 +92,9 @@ class RetryStore implements IVectorStore {
   }
 
   async deletePointsByFilePath(_filePath: string): Promise<void> {}
-  async deletePointsByMultipleFilePaths(_filePaths: string[]): Promise<void> {}
+  async deletePointsByMultipleFilePaths(filePaths: string[]): Promise<void> {
+    this.deletes.push(filePaths)
+  }
   async clearCollection(): Promise<void> {}
   async deleteCollection(): Promise<void> {}
   async collectionExists(): Promise<boolean> {
@@ -103,6 +140,71 @@ describe("FileWatcher", () => {
       expect(point.payload.endLine).toBe(1)
       expect(point.id).toBe(uuidv5(point.payload.segmentHash, QDRANT_CODE_BLOCK_NAMESPACE))
     })
+  })
+
+  test("serializes embedding requests across concurrent file updates", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-test-"))
+    const cacheDir = path.join(root, ".cache")
+    const first = path.join(root, "first.md")
+    const second = path.join(root, "second.md")
+
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(first, "x".repeat(5000))
+    await writeFile(second, "y".repeat(5000))
+
+    const cache = new CacheManager(cacheDir, root)
+    await cache.initialize()
+
+    const emb = new TrackEmbedder()
+    const watcher = new FileWatcher(root, cache, emb, new RetryStore(0))
+    const data = watcher as unknown as {
+      processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+    }
+
+    await data.processBatch(
+      new Map([
+        [first, { path: first, type: "create" }],
+        [second, { path: second, type: "create" }],
+      ]),
+    )
+
+    expect(emb.max).toBe(1)
+  })
+
+  test("keeps changed file vectors when replacement embeddings fail", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-test-"))
+    const cacheDir = path.join(root, ".cache")
+    const file = path.join(root, "oversized.md")
+
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(file, "x".repeat(5000))
+
+    const cache = new CacheManager(cacheDir, root)
+    await cache.initialize()
+    cache.updateHash(file, "old-hash")
+
+    const store = new RetryStore(0)
+    const watcher = new FileWatcher(root, cache, createFailingEmbedder(), store)
+    const summaries: BatchProcessingSummary[] = []
+    watcher.onDidFinishBatchProcessing.on((summary) => summaries.push(summary))
+    const data = watcher as unknown as {
+      processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+    }
+
+    await data.processBatch(
+      new Map([
+        [
+          file,
+          {
+            path: file,
+            type: "change",
+          },
+        ],
+      ]),
+    )
+
+    expect(store.deletes).toEqual([])
+    expect(summaries[0]?.processedFiles).toContainEqual(expect.objectContaining({ path: file, status: "local_error" }))
   })
 
   test("emits retry telemetry for watcher upsert retries", async () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -33,6 +33,35 @@ class Emb implements IEmbedder {
   }
 }
 
+class CountEmb extends Emb {
+  public calls = 0
+
+  public override async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
+    this.calls += 1
+    return super.createEmbeddings(texts)
+  }
+}
+
+class FailEmb extends Emb {
+  public override async createEmbeddings(_texts: string[]): Promise<{ embeddings: number[][] }> {
+    throw new Error("embedding failed")
+  }
+}
+
+class TrackEmb extends Emb {
+  public active = 0
+  public max = 0
+
+  public override async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
+    this.active += 1
+    this.max = Math.max(this.max, this.active)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const result = await super.createEmbeddings(texts)
+    this.active -= 1
+    return result
+  }
+}
+
 class Parser implements ICodeParser {
   public async parseFile(
     filePath: string,
@@ -197,6 +226,46 @@ describe("DirectoryScanner", () => {
     expect(cache.getHash(file)).toBe(hash)
   })
 
+  test("serializes embedding requests across queued scan batches", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const file = join(root, "main.ts")
+    await Bun.write(file, "export const value = 2\n")
+
+    const cache = new CacheManager(cacheDir, root)
+    await cache.initialize()
+
+    const emb = new TrackEmb()
+    const store = new Store()
+    const scan = new DirectoryScanner(emb, store, new ManyParser(), cache, ignore(), 1, 1)
+
+    await scan.scanDirectory(root)
+
+    expect(store.points).toBe(3)
+    expect(emb.max).toBe(1)
+  })
+
+  test("keeps prior vectors when replacement embeddings fail", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const file = join(root, "main.ts")
+    await Bun.write(file, "export const value = 2\n")
+
+    const cache = new CacheManager(cacheDir, root)
+    await cache.initialize()
+    cache.updateHash(file, "old-hash")
+
+    const errors: Error[] = []
+    const store = new Store()
+    const scan = new DirectoryScanner(new FailEmb(), store, new Parser(), cache, ignore(), 1, 2)
+
+    await scan.scanDirectory(root, (error) => errors.push(error))
+
+    expect(errors).toHaveLength(1)
+    expect(store.multi).toEqual([])
+    expect(cache.getHash(file)).toBe("old-hash")
+  })
+
   test("does not mark hash current when a later batch fails for the same file", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
@@ -285,8 +354,9 @@ describe("DirectoryScanner", () => {
     await cache.initialize()
 
     const events: IndexingTelemetryEvent[] = []
+    const emb = new CountEmb()
     const scan = new DirectoryScanner(
-      new Emb(),
+      emb,
       new RetryStore(),
       new Parser(),
       cache,
@@ -310,5 +380,6 @@ describe("DirectoryScanner", () => {
     expect(retry?.attempt).toBe(1)
     expect(retry?.maxRetries).toBe(2)
     expect(retry?.error).toContain("[REDACTED_PATH]")
+    expect(emb.calls).toBe(1)
   })
 })

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -53,7 +53,7 @@ import type { RemoteStatusService } from "./services/RemoteStatusService"
 import { resolveProjectDirectory } from "./project-directory"
 import { getBusySessionCount, seedSessionStatuses } from "./session-status"
 import { normalizeEnhancePromptErrorMessage } from "./enhance-prompt-error"
-import { retry } from "./services/cli-backend/retry"
+import { deadline, retry } from "./services/cli-backend/retry"
 import { slimPart, slimParts } from "./kilo-provider/slim-metadata"
 import { handleSidebarWorktreeMessage } from "./kilo-provider/sidebar-worktree"
 import { parseMessageFiles, type MessageFile } from "./kilo-provider/message-files"
@@ -190,6 +190,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private cachedMcpStatusMessage: unknown = null
   /** Ref-count of in-flight handleUpdateConfig calls; prevents fetchAndSendConfig from sending stale data */
   private pending = 0
+  private refreshWait = 5_000
   private configWarningsShown = false
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: unknown = null
@@ -2425,8 +2426,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const { data: merged } = await retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true }))
-      const { data: global } = await this.client.global.config.get({ throwOnError: true })
+      const refreshed = await deadline(
+        (async () => {
+          const { data: merged } = await retry(() =>
+            this.client!.config.get({ directory: dir }, { throwOnError: true }),
+          )
+          const { data: global } = await this.client!.global.config.get({ throwOnError: true })
+          return { merged, global }
+        })(),
+        this.refreshWait,
+        "Timed out refreshing saved config",
+      )
+      const merged = refreshed.merged
+      const global = refreshed.global
       this.cachedGlobalConfig = global ?? null
       this.cachedConfigMessage = {
         type: "configLoaded",

--- a/packages/kilo-vscode/src/services/cli-backend/retry.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/retry.ts
@@ -1,5 +1,5 @@
-// Replicated from packages/core/src/util/retry.ts to avoid adding @opencode-ai/core
-// as a dependency of the extension. Keep in sync with the original.
+// retry() is replicated from packages/core/src/util/retry.ts to avoid adding @opencode-ai/core
+// as a dependency of the extension. Keep retry() in sync with the original.
 
 const TRANSIENT = [
   "load failed",
@@ -31,4 +31,20 @@ export async function retry<T>(fn: () => Promise<T>, attempts = 3, delay = 500):
     }
   }
   throw last
+}
+
+export function deadline<T>(task: Promise<T>, delay: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), delay)
+    task.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
 }

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -8,9 +8,12 @@ type Internals = {
   connectionState: "connecting" | "connected" | "disconnected" | "error"
   currentSession: { id: string } | null
   cachedIndexingStatusMessage: unknown
+  pending: number
+  refreshWait: number
+  postMessage: (message: unknown) => void
   handleEvent: (event: unknown, directory?: string) => void
   reloadAfterAuthChange: () => Promise<void>
-  handleUpdateConfig: (partial: Partial<Config>) => Promise<void>
+  handleUpdateConfig: (partial: Partial<Config>, project?: Partial<Config>) => Promise<void>
   fetchAndSendConfig: () => Promise<void>
   fetchAndSendProviders: () => Promise<void>
   fetchAndSendAgents: () => Promise<void>
@@ -36,6 +39,7 @@ function createConnection() {
   }
 
   return {
+    client,
     drains: () => drains,
     service: {
       drainPendingPrompts: async () => {
@@ -95,6 +99,23 @@ describe("KiloProvider indexing refresh", () => {
 
     expect(conn.drains()).toBe(1)
     expect(indexing).toBe(0)
+  })
+
+  it("confirms saved config when the post-write refresh stalls", async () => {
+    const conn = createConnection()
+    conn.client.config.get = async () => new Promise<never>(() => {})
+    const provider = new KiloProvider({} as never, conn.service as never)
+    const internal = provider as unknown as Internals
+    const messages: Array<{ type?: string }> = []
+
+    internal.connectionState = "connected"
+    internal.refreshWait = 0
+    internal.postMessage = (message) => messages.push(message as { type?: string })
+
+    await internal.handleUpdateConfig({ indexing: { provider: "kilo" } })
+
+    expect(messages.some((message) => message.type === "configUpdated")).toBe(true)
+    expect(internal.pending).toBe(0)
   })
 
   it("fetchAndSendIndexingStatus uses current session directory header", async () => {


### PR DESCRIPTION
Large code indexing runs can overload embedding providers with bursty requests, then leave incremental updates looking complete even when replacement work failed.
This change bounds indexing embedding pressure, preserves existing vectors until replacements are ready, and keeps failed incremental work retryable and visible instead of reporting a false complete state.
Settings saves also finish their UI acknowledgement when the post-write config refresh stalls during reload churn, so persisted config changes do not leave the settings surface stuck dirty.
Fixes #8311.