### PR TITLE
fix(tool): snap Read truncation back when it would split a surrogate pair

### DIFF
--- a/.changeset/surrogate-safe-truncate.md
+++ b/.changeset/surrogate-safe-truncate.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Read tool truncation now snaps back when a UTF-16 surrogate pair would be split, so prior file reads no longer leave a lone surrogate in compacted tool output. Downstream JSON encoders (e.g. llama-server) previously rejected the resulting payload with a `surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF` error that was unrecoverable for the session.

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -283,8 +283,14 @@ export type ToolStateCompleted = Types.DeepMutable<Schema.Schema.Type<typeof Too
 
 function truncateToolOutput(text: string, maxChars?: number) {
   if (!maxChars || text.length <= maxChars) return text
-  const omitted = text.length - maxChars
-  return `${text.slice(0, maxChars)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
+  // Snap back if the cut would land between a surrogate pair; JS strings are
+  // UTF-16 and a lone high surrogate at the end gets rejected by downstream
+  // JSON encoders (e.g. llama-server).
+  let cut = maxChars
+  const last = text.charCodeAt(cut - 1)
+  if (last >= 0xd800 && last <= 0xdbff) cut -= 1
+  const omitted = text.length - cut
+  return `${text.slice(0, cut)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
 }
 
 export const ToolStateError = Schema.Struct({

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -283,6 +283,7 @@ export type ToolStateCompleted = Types.DeepMutable<Schema.Schema.Type<typeof Too
 
 function truncateToolOutput(text: string, maxChars?: number) {
   if (!maxChars || text.length <= maxChars) return text
+  // kilocode_change start
   // Snap back if the cut would land between a surrogate pair; JS strings are
   // UTF-16 and a lone high surrogate at the end gets rejected by downstream
   // JSON encoders (e.g. llama-server).
@@ -291,6 +292,7 @@ function truncateToolOutput(text: string, maxChars?: number) {
   if (last >= 0xd800 && last <= 0xdbff) cut -= 1
   const omitted = text.length - cut
   return `${text.slice(0, cut)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
+  // kilocode_change end
 }
 
 export const ToolStateError = Schema.Struct({

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -286,10 +286,13 @@ function truncateToolOutput(text: string, maxChars?: number) {
   // kilocode_change start
   // Snap back if the cut would land between a surrogate pair; JS strings are
   // UTF-16 and a lone high surrogate at the end gets rejected by downstream
-  // JSON encoders (e.g. llama-server).
+  // JSON encoders (e.g. llama-server). Mirrors surrogateSafeSlice in
+  // tool/read.ts.
   let cut = maxChars
-  const last = text.charCodeAt(cut - 1)
-  if (last >= 0xd800 && last <= 0xdbff) cut -= 1
+  if (cut > 0) {
+    const last = text.charCodeAt(cut - 1)
+    if (last >= 0xd800 && last <= 0xdbff) cut -= 1
+  }
   const omitted = text.length - cut
   return `${text.slice(0, cut)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
   // kilocode_change end

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -415,7 +415,7 @@ async function collect(stream: Readable, opts: { limit: number; offset: number }
         more = true
         continue
       }
-      const line = text.length > MAX_LINE_LENGTH ? surrogateSafeSlice(text, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+      const line = text.length > MAX_LINE_LENGTH ? surrogateSafeSlice(text, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text // kilocode_change
       const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
       if (bytes + size > MAX_BYTES) {
         cut = true

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -381,6 +381,22 @@ export const ReadTool = Tool.define(
   }),
 )
 
+// kilocode_change start - JS strings are UTF-16. `String.prototype.substring` cuts on
+// code-unit boundaries, which can split a surrogate pair when the slice ends inside
+// one — leaving a lone high surrogate that JSON encoders downstream reject (e.g.
+// llama-server's "surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF").
+// Snap the end back by one so we always end on a complete code point.
+function surrogateSafeSlice(text: string, end: number): string {
+  if (end <= 0) return ""
+  if (end >= text.length) return text
+  const last = text.charCodeAt(end - 1)
+  if (last >= 0xd800 && last <= 0xdbff) {
+    return text.slice(0, end - 1)
+  }
+  return text.slice(0, end)
+}
+// kilocode_change end
+
 // kilocode_change start - extracted formats use native readers; ordinary text is supplied by AppFileSystem above
 async function collect(stream: Readable, opts: { limit: number; offset: number }) {
   // kilocode_change end
@@ -399,7 +415,7 @@ async function collect(stream: Readable, opts: { limit: number; offset: number }
         more = true
         continue
       }
-      const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+      const line = text.length > MAX_LINE_LENGTH ? surrogateSafeSlice(text, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
       const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
       if (bytes + size > MAX_BYTES) {
         cut = true

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -19,7 +19,12 @@ import * as Extract from "../kilocode/tool/read-extract"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
-const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
+// kilocode_change start
+// Dynamic so the suffix reflects the actual slice length when
+// surrogateSafeSlice snaps the cut back by one to avoid splitting a
+// surrogate pair.
+const lineTruncatedSuffix = (n: number) => `... (line truncated to ${n} chars)`
+// kilocode_change end
 const MAX_BYTES = 50 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
 const SAMPLE_BYTES = 4096
@@ -415,7 +420,13 @@ async function collect(stream: Readable, opts: { limit: number; offset: number }
         more = true
         continue
       }
-      const line = text.length > MAX_LINE_LENGTH ? surrogateSafeSlice(text, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text // kilocode_change
+      // kilocode_change start
+      let line = text
+      if (text.length > MAX_LINE_LENGTH) {
+        const sliced = surrogateSafeSlice(text, MAX_LINE_LENGTH)
+        line = `${sliced}${lineTruncatedSuffix(sliced.length)}`
+      }
+      // kilocode_change end
       const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
       if (bytes + size > MAX_BYTES) {
         cut = true

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -504,6 +504,7 @@ describe("tool.read truncation", () => {
     }),
   )
 
+  // kilocode_change start
   it.live("long-line truncation does not split a surrogate pair", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()
@@ -523,6 +524,7 @@ describe("tool.read truncation", () => {
       expect(result.output).toContain("(line truncated to 2000 chars)")
     }),
   )
+  // kilocode_change end
 
   it.live("image files set truncated to false", () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -504,6 +504,26 @@ describe("tool.read truncation", () => {
     }),
   )
 
+  it.live("long-line truncation does not split a surrogate pair", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // 📁 (U+1F4C1) is two UTF-16 code units. Placing it at code-unit
+      // index 1999 means the naive `substring(0, 2000)` cut lands between
+      // the high and low surrogate.
+      const emoji = "\u{1F4C1}"
+      const line = "x".repeat(1999) + emoji + "x".repeat(1500)
+      yield* put(path.join(dir, "emoji-line.txt"), line)
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "emoji-line.txt") })
+      // Output must be encodable as JSON; a lone surrogate would throw.
+      expect(() => JSON.stringify(result.output)).not.toThrow()
+      // And it must not actually contain one.
+      const isolated = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+      expect(isolated.test(result.output)).toBe(false)
+      expect(result.output).toContain("(line truncated to 2000 chars)")
+    }),
+  )
+
   it.live("image files set truncated to false", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -521,7 +521,9 @@ describe("tool.read truncation", () => {
       // And it must not actually contain one.
       const isolated = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
       expect(isolated.test(result.output)).toBe(false)
-      expect(result.output).toContain("(line truncated to 2000 chars)")
+      // Suffix reports the actual slice length: 1999 here because the
+      // surrogate snap-back drops the high half of the boundary emoji.
+      expect(result.output).toContain("(line truncated to 1999 chars)")
     }),
   )
   // kilocode_change end


### PR DESCRIPTION
## Context

Closes #10467. The Read tool was producing tool outputs containing a lone UTF-16 surrogate when a long line or a compacted tool output happened to be cut between the two halves of a surrogate pair. Downstream JSON encoders reject this — the reporter hit `[json.exception.parse_error.101] ... surrogate U+D800..U+DBFF must be followed by U+DC00..U+DFFF` from llama-server, which is then unrecoverable for the session because every subsequent prompt re-sends the broken payload.

JavaScript strings are UTF-16, so `text.substring(0, 2000)` (and `text.slice(0, 2000)`) cuts on code-unit boundaries, not code points. A 4-byte UTF-8 character like `📁` (U+1F4C1) is two UTF-16 code units; if it sits on the cut, the high surrogate stays and the low one is dropped.

## Implementation

Two slice sites in the read path can split a pair:

- `tool/read.ts` truncates a single line to `MAX_LINE_LENGTH` (2000 chars) before pushing it.
- `session/message-v2.ts` `truncateToolOutput` trims prior tool outputs to 2000 chars during compaction; this is the one most likely to bite reporters with non-trivial sessions, because every prior file read in history runs through it.

Both now check whether the last code unit in the slice is a high surrogate (`0xD800..0xDBFF`) and, if so, back the cut up by one. The result is at most one character shorter than the requested limit, ends on a complete code point, and round-trips through `JSON.stringify`. No grapheme-cluster work — that would help with ZWJ-joined emoji and combining marks too, but it's a separate (correctness-upgrade) change.

The same pattern lives at `tool/grep.ts:124` (match-text truncation). Same fix would apply there; left out of this PR to keep scope tight to the Read path the issue calls out.

## How to Test

Run the read tool tests; the new case "long-line truncation does not split a surrogate pair" places `📁` exactly on the 2000-char boundary and asserts the output is JSON-encodable and contains no lone surrogate:

```
cd packages/opencode
bun test test/tool/read.test.ts
```

To see the bug without the fix, temporarily revert the `surrogateSafeSlice` call in `tool/read.ts` and re-run — the new test fails with the regex matching a lone high surrogate in the output.

## Get in Touch

Happy to expand to the grep-tool site or add an `Intl.Segmenter`-based variant for grapheme clusters if you'd like that in the same PR.