### PR TITLE
fix(vscode): clear stale diff preview loading

### DIFF
--- a/.changeset/clear-diffs-settle.md
+++ b/.changeset/clear-diffs-settle.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Clear Agent Manager file diff previews stuck on `Loading diff...` when the active diff source stops or changes.

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -181,8 +181,12 @@ export class SourceController {
       return
     }
     const diff = await source.fetchFile(file).catch(() => null)
-    // Drop the response if the source has been disposed/swapped while we waited.
-    if (this.epoch !== epoch) return
+    // Discard stale content after disposal/swap, but still complete the request
+    // so consumers can clear per-file loading state.
+    if (this.epoch !== epoch) {
+      this.send(this.messages.diffFile(source, file, null))
+      return
+    }
     this.send(this.messages.diffFile(source, file, diff))
   }
 

--- a/packages/kilo-vscode/tests/unit/source-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/source-controller.test.ts
@@ -345,6 +345,40 @@ describe("SourceController.requestFile", () => {
 
     controller.stop()
   })
+
+  it("posts null when a pending fetchFile result is invalidated by stop", async () => {
+    let release: () => void = () => {}
+    const workspace: DiffSource = {
+      descriptor: WORKSPACE_DESC,
+      async fetch() {
+        return { diffs: [] }
+      },
+      async fetchFile() {
+        await new Promise<void>((resolve) => (release = resolve))
+        return {
+          file: "foo.ts",
+          before: "a",
+          after: "b",
+          additions: 1,
+          deletions: 1,
+        }
+      },
+    }
+    const { controller, posted } = make({ workspace })
+
+    controller.setContext({ workspaceRoot: "/repo" })
+    await controller.activate("workspace")
+    posted.length = 0
+    const request = controller.requestFile("foo.ts")
+    controller.stop()
+    release()
+    await request
+
+    const files = byType(posted, "diffViewer.diffFile")
+    expect(files).toHaveLength(1)
+    expect(files[0]!.file).toBe("foo.ts")
+    expect(files[0]!.diff).toBeNull()
+  })
 })
 
 describe("SourceController.reactivate", () => {


### PR DESCRIPTION
Agent Manager/Extension review panes can leave file diff previews stuck on `Loading diff...` when an in-flight preview load is invalidated by diff source teardown or switching.
This makes stale detail requests complete cleanly so pending file previews clear deterministically, with regression coverage for that lifecycle edge case.

Fixes:

<img width="611" height="643" alt="image" src="https://github.com/user-attachments/assets/8ebc4f1b-ebac-4cd4-914e-337b79325d30" />
