### PR TITLE
fix(vscode): stop local CLI SSE reconnect flapping

### DIFF
--- a/.changeset/calm-streams-reconnect.md
+++ b/.changeset/calm-streams-reconnect.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent VS Code local CLI reconnect flapping while the event stream is unavailable.

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -584,7 +584,8 @@ export class KiloConnectionService {
 
     this.sseClient = new SdkSSEAdapter(this.client)
 
-    // Wait until SSE actually reaches a terminal state before resolving connect().
+    // Wait until SSE yields its first server event before resolving connect().
+    // Initial stream failures are handled by the adapter reconnect loop.
     let resolveConnected: (() => void) | null = null
     let rejectConnected: ((error: Error) => void) | null = null
     const connectedPromise = new Promise<void>((resolve, reject) => {
@@ -601,11 +602,8 @@ export class KiloConnectionService {
       }
     })
 
-    this.sseClient.onError((error) => {
+    this.sseClient.onError(() => {
       this.setState("error")
-      rejectConnected?.(error)
-      resolveConnected = null
-      rejectConnected = null
     })
 
     // Wire SSE state → broadcast to all registered state listeners

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -210,9 +210,7 @@ export class SdkSSEAdapter {
       }
 
       const wait = delay
-      delay = ready
-        ? SdkSSEAdapter.RECONNECT_DELAY_MS
-        : Math.min(delay * 2, SdkSSEAdapter.MAX_RECONNECT_DELAY_MS)
+      delay = ready ? SdkSSEAdapter.RECONNECT_DELAY_MS : Math.min(delay * 2, SdkSSEAdapter.MAX_RECONNECT_DELAY_MS)
       console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${wait}ms...`)
       this.notifyState("connecting")
       await new Promise((resolve) => setTimeout(resolve, wait))

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -15,9 +15,8 @@ export type SSEStateHandler = (state: "connecting" | "connected" | "disconnected
  *
  * In this VS Code extension context the connection is localhost (extension ↔
  * child-process server), so zombie-connection scenarios are less likely than in
- * a browser client (which goes through proxies/CDNs). We keep the heartbeat for
- * consistency with the original strategy but use a generous 90 s timeout to
- * avoid false-positive reconnections during idle periods.
+ * a browser client (which goes through proxies/CDNs). We still keep a heartbeat
+ * grace window so dead local streams recover without waiting indefinitely.
  *
  * NOTE on event coalescing:
  * The app batches rapid events into 16 ms windows before flushing to the UI.
@@ -37,6 +36,7 @@ export class SdkSSEAdapter {
   // Reduced from 90s: with 90s a dead connection could linger for ~1.5 minutes.
   private static readonly HEARTBEAT_TIMEOUT_MS = 15_000
   private static readonly RECONNECT_DELAY_MS = 250
+  private static readonly MAX_RECONNECT_DELAY_MS = 5_000
 
   constructor(private readonly client: KiloClient) {}
 
@@ -126,8 +126,11 @@ export class SdkSSEAdapter {
    * Main reconnection loop — mirrors the pattern in `global-sdk.tsx`.
    */
   private async consumeLoop(signal: AbortSignal): Promise<void> {
+    let delay = SdkSSEAdapter.RECONNECT_DELAY_MS
+
     while (!signal.aborted) {
       const attempt = new AbortController()
+      let ready = false
 
       // Forward the outer abort to the per-attempt controller so
       // `disconnect()` cancels the current fetch immediately.
@@ -159,8 +162,7 @@ export class SdkSSEAdapter {
           },
         })
 
-        console.log("[Kilo New] SSE: ✅ Stream opened successfully")
-        this.notifyState("connected")
+        console.log("[Kilo New] SSE: ⏳ Waiting for first stream event")
         this.resetHeartbeat(attempt)
 
         for await (const event of events.stream) {
@@ -169,6 +171,13 @@ export class SdkSSEAdapter {
           }
 
           this.resetHeartbeat(attempt)
+
+          if (!ready) {
+            ready = true
+            delay = SdkSSEAdapter.RECONNECT_DELAY_MS
+            console.log("[Kilo New] SSE: ✅ Stream opened successfully")
+            this.notifyState("connected")
+          }
 
           // The SDK yields GlobalEvent = { directory, payload: Event }.
           const globalEvent = event as GlobalEvent
@@ -179,7 +188,9 @@ export class SdkSSEAdapter {
           this.notifyEvent(globalEvent.payload as Event, globalEvent.directory)
         }
 
-        console.log("[Kilo New] SSE: 📭 Stream ended normally")
+        console.log(
+          ready ? "[Kilo New] SSE: 📭 Stream ended normally" : "[Kilo New] SSE: 📭 Stream ended before first event",
+        )
       } catch (error) {
         // Suppress AbortErrors — they are expected when the heartbeat timer
         // or reconnect() aborts the per-attempt controller.
@@ -198,9 +209,13 @@ export class SdkSSEAdapter {
         break
       }
 
-      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${SdkSSEAdapter.RECONNECT_DELAY_MS}ms...`)
+      const wait = delay
+      delay = ready
+        ? SdkSSEAdapter.RECONNECT_DELAY_MS
+        : Math.min(delay * 2, SdkSSEAdapter.MAX_RECONNECT_DELAY_MS)
+      console.log(`[Kilo New] SSE: 🔄 Reconnecting in ${wait}ms...`)
       this.notifyState("connecting")
-      await new Promise((resolve) => setTimeout(resolve, SdkSSEAdapter.RECONNECT_DELAY_MS))
+      await new Promise((resolve) => setTimeout(resolve, wait))
     }
 
     this.notifyState("disconnected")

--- a/packages/kilo-vscode/tests/unit/sdk-sse-adapter.test.ts
+++ b/packages/kilo-vscode/tests/unit/sdk-sse-adapter.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test"
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import { KiloConnectionService } from "../../src/services/cli-backend/connection-service"
+import { SdkSSEAdapter } from "../../src/services/cli-backend/sdk-sse-adapter"
+
+type Opts = {
+  onSseError?: (error: unknown) => void
+  signal?: AbortSignal
+}
+
+type Stream = AsyncGenerator<unknown, void, unknown>
+
+function client(open: (opts: Opts) => Stream): KiloClient {
+  return {
+    global: {
+      event: async (opts: Opts) => ({ stream: open(opts) }),
+    },
+  } as unknown as KiloClient
+}
+
+function event() {
+  return {
+    directory: "/repo",
+    payload: {
+      id: "evt_connected",
+      type: "server.connected",
+      properties: {},
+    },
+  }
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+function aborted(signal?: AbortSignal) {
+  if (!signal || signal.aborted) return Promise.resolve()
+  return new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }))
+}
+
+describe("SdkSSEAdapter", () => {
+  it("reports connected only after the first SSE event arrives", async () => {
+    let release = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const adapter = new SdkSSEAdapter(
+      client(async function* (opts) {
+        await gate
+        yield event()
+        await aborted(opts.signal)
+      }),
+    )
+    const states: string[] = []
+    const connected = new Promise<void>((resolve) => {
+      adapter.onStateChange((state) => {
+        states.push(state)
+        if (state === "connected") resolve()
+      })
+    })
+
+    adapter.connect()
+    await wait(10)
+
+    expect(states).toEqual(["connecting"])
+
+    release()
+    await connected
+
+    expect(states).toEqual(["connecting", "connected"])
+    adapter.disconnect()
+  })
+
+  it("backs off reconnects when an SSE fetch fails before opening", async () => {
+    const timer = globalThis.setTimeout
+    const delays: number[] = []
+    let count = 0
+    let finish = () => {}
+    const reached = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      if (typeof timeout === "number" && timeout <= 5_000) {
+        delays.push(timeout)
+        return timer(handler, 0, ...args)
+      }
+      return timer(handler, timeout, ...args)
+    }) as typeof setTimeout
+
+    const failing = new SdkSSEAdapter(
+      client((opts) => {
+        count += 1
+        if (count === 3) finish()
+        return (async function* () {
+          opts.onSseError?.(new TypeError("fetch failed"))
+        })()
+      }),
+    )
+
+    try {
+      failing.connect()
+      await reached
+      failing.disconnect()
+
+      expect(delays.slice(0, 2)).toEqual([250, 500])
+    } finally {
+      failing.disconnect()
+      globalThis.setTimeout = timer
+    }
+  })
+})
+
+describe("KiloConnectionService SSE startup", () => {
+  it("waits through an initial SSE fetch failure until the stream opens", async () => {
+    const original = globalThis.fetch
+    const chunk = new TextEncoder().encode(
+      'data: {"payload":{"id":"evt_connected","type":"server.connected","properties":{}}}\n\n',
+    )
+    let calls = 0
+    globalThis.fetch = (async () => {
+      calls += 1
+      if (calls === 1) throw new TypeError("fetch failed")
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(chunk)
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        },
+      )
+    }) as typeof fetch
+
+    const service = new KiloConnectionService({} as any)
+    ;(service as any).serverManager.getServer = async () => ({ port: 52512, password: "secret", process: {} })
+
+    try {
+      await expect(service.connect("/tmp/workspace")).resolves.toBeUndefined()
+      expect(calls).toBe(2)
+      expect(service.getConnectionState()).toBe("connected")
+    } finally {
+      service.dispose()
+      globalThis.fetch = original
+    }
+  })
+})


### PR DESCRIPTION
Prevent the VS Code extension from flipping through false connected/reconnecting states when its local CLI SSE stream fails before it is actually open.

The connection now becomes ready only after the server sends its first event, keeps startup inside the normal transient reconnect path, and backs off unopened stream retries so local transport failures do not amplify into repeated sync churn.