### PR TITLE
fix(vscode): hide sub-agent sessions from recents

### DIFF
--- a/.changeset/rapid-recents-hide.md
+++ b/.changeset/rapid-recents-hide.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Hide sub-agent sessions from recent session shortcuts in the extension.

--- a/packages/kilo-vscode/tests/unit/session-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-utils.test.ts
@@ -9,6 +9,7 @@ import {
   buildCostBreakdown,
   collapseCostBreakdown,
   childID,
+  recentSessions,
 } from "../../webview-ui/src/context/session-utils"
 import type { Part } from "../../webview-ui/src/types/messages"
 
@@ -81,6 +82,36 @@ describe("computeStatus", () => {
   it("maps synthetic snapshot progress to snapshot status", () => {
     const part: Part = { type: "text", id: "p1", text: "⠋ Initializing snapshot…", synthetic: true }
     expect(computeStatus(part, t)).toBe("Initializing snapshot...")
+  })
+})
+
+describe("recentSessions", () => {
+  const at = (day: number) => `2026-01-${String(day).padStart(2, "0")}T00:00:00.000Z`
+  const info = (id: string, day: number, parentID?: string | null) => ({
+    id,
+    updatedAt: at(day),
+    ...(parentID === undefined ? {} : { parentID }),
+  })
+
+  it("keeps the newest root sessions after removing sub-agents", () => {
+    const result = recentSessions([
+      info("old-root", 1),
+      info("child", 6, "old-root"),
+      info("new-root", 5),
+      info("blank-parent", 4, ""),
+      info("mid-root", 3, null),
+      info("fourth-root", 2),
+    ])
+
+    expect(result.map((session) => session.id)).toEqual(["new-root", "mid-root", "fourth-root"])
+  })
+
+  it("does not mutate the session list while sorting recents", () => {
+    const sessions = [info("old", 1), info("new", 3), info("mid", 2)]
+
+    recentSessions(sessions)
+
+    expect(sessions.map((session) => session.id)).toEqual(["old", "new", "mid"])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -7,6 +7,8 @@
  * Returns the action to take: select a session by ID, go to local, or do nothing.
  */
 
+import { isRootSession } from "../src/context/session-utils"
+
 /** Sentinel value for the local repo selection. */
 export const LOCAL = "local" as const
 
@@ -20,7 +22,7 @@ export function filterUnassignedSessions<T extends SessionLike>(
   local: Set<string>,
 ): T[] {
   return [...sessions]
-    .filter((s) => (s.parentID === undefined || s.parentID === null) && !worktree.has(s.id) && !local.has(s.id))
+    .filter((s) => isRootSession(s) && !worktree.has(s.id) && !local.has(s.id))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -17,6 +17,7 @@ import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
+import { recentSessions } from "../../context/session-utils"
 import { formatRelativeDate } from "../../utils/date"
 import { FeedbackDialog } from "./FeedbackDialog"
 import { VscodeSessionTurn } from "./VscodeSessionTurn"
@@ -93,11 +94,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
   )
   const isEmpty = () => turns().length === 0 && !session.loading() && !boundary()
 
-  const recent = createMemo(() =>
-    [...session.sessions()]
-      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-      .slice(0, 3),
-  )
+  const recent = createMemo(() => recentSessions(session.sessions()))
 
   const activeUserID = createMemo(() => getActiveUserMessageID(session.messages(), session.statusInfo()))
   const queuedIDs = createMemo(() => new Set(queuedUserMessageIDs(session.messages(), session.statusInfo())))

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -14,6 +14,21 @@ export function snapshotProgress(part: SnapshotPart | undefined): boolean {
   return (part.text ?? "").includes("Initializing snapshot")
 }
 
+type ParentSession = { parentID?: string | null }
+
+type RecentSession = ParentSession & { updatedAt: string }
+
+export function isRootSession(session: ParentSession): boolean {
+  return session.parentID === undefined || session.parentID === null
+}
+
+export function recentSessions<T extends RecentSession>(sessions: T[]): T[] {
+  return [...sessions]
+    .filter(isRootSession)
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 3)
+}
+
 /** Minimal message shape for cost breakdown helpers. */
 export type CostMessage = { id: string; role: string; cost?: number }
 


### PR DESCRIPTION
Recent session shortcuts could surface task-created sub-agent sessions even though they are not useful continuation targets.
Hide child sessions from Recent wherever the shared welcome view appears, and keep that root-session rule aligned with Agent Manager session filtering.

<img width="732" height="635" alt="image" src="https://github.com/user-attachments/assets/f7758553-119a-40e9-8347-66a7945a2b43" />
