### PR TITLE
feat: add NEAR AI Cloud provider

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -48,6 +48,7 @@ export const AiProvidersNav: NavSection[] = [
       { href: "/ai-providers/groq", children: "Groq" },
       { href: "/ai-providers/cerebras", children: "Cerebras" },
       { href: "/ai-providers/fireworks", children: "Fireworks AI" },
+      { href: "/ai-providers/nearai", children: "NEAR AI Cloud" },
     ],
   },
   {

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -28,6 +28,7 @@ Major AI companies offering powerful models via API:
 - **[Cloudflare](/docs/ai-providers/cloudflare)** - Workers AI and Cloudflare AI Gateway
 - **[DeepSeek](/docs/ai-providers/deepseek)** - DeepSeek V3., R1
 - **[Mistral](/docs/ai-providers/mistral)** - Mistral Large, Codestral
+- **[NEAR AI Cloud](/docs/ai-providers/nearai)** - TEE-backed private inference through an OpenAI-compatible API
 
 ### Local & Self-Hosted
 

--- a/packages/kilo-docs/pages/ai-providers/nearai.md
+++ b/packages/kilo-docs/pages/ai-providers/nearai.md
@@ -1,0 +1,89 @@
+---
+title: "Using NEAR AI Cloud With Kilo Code"
+description: "Connect NEAR AI Cloud TEE inference to Kilo Code with your NEARAI_API_KEY."
+sidebar_label: NEAR AI Cloud
+---
+
+# Using NEAR AI Cloud With Kilo Code
+
+Kilo Code supports NEAR AI Cloud as a native OpenAI-compatible provider. NEAR AI Cloud provides TEE-backed private inference for supported models and exposes a public model catalog that Kilo uses to keep the available model list current.
+
+**Website:** [https://cloud.near.ai](https://cloud.near.ai)
+
+## Getting an API Key
+
+1. Sign in to NEAR AI Cloud.
+2. Create an API key from your account.
+3. Copy the key immediately and store it securely.
+
+## Configuration in Kilo Code
+
+{% tabs %}
+{% tab label="VSCode (Legacy)" %}
+
+Use the **OpenAI Compatible** provider if the legacy provider list does not include NEAR AI Cloud.
+
+- **Base URL:** `https://cloud-api.near.ai/v1`
+- **API key:** your NEAR AI Cloud API key
+- **Model ID:** use a model ID from the NEAR AI Cloud catalog, such as `zai-org/GLM-5.1-FP8`
+
+{% /tab %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon), go to the **Providers** tab, choose **NEAR AI Cloud**, and enter your API key.
+
+The extension stores your key locally through the Kilo backend auth store. You can also use the environment variable shown in the **CLI** tab.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable:
+
+```bash
+export NEARAI_API_KEY="your-api-key"
+```
+
+Kilo uses `https://cloud-api.near.ai/v1` by default. To override the endpoint, set:
+
+```bash
+export NEARAI_BASE_URL="https://cloud-api.near.ai/v1"
+```
+
+Then select a NEAR AI Cloud model from the model picker, or set a default model in `kilo.json`:
+
+```jsonc
+{
+  "model": "nearai/zai-org/GLM-5.1-FP8"
+}
+```
+
+You can also configure the provider explicitly:
+
+```jsonc
+{
+  "provider": {
+    "nearai": {
+      "env": ["NEARAI_API_KEY"],
+      "options": {
+        "baseURL": "https://cloud-api.near.ai/v1"
+      }
+    }
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Tips and Notes
+
+- **Native provider:** Kilo uses the OpenAI-compatible NEAR AI Cloud endpoint.
+- **Model catalog:** Kilo fetches models from NEAR AI Cloud's public model list and filters to chat-capable text models.
+- **TEE inference:** Some NEAR AI Cloud models are verifiable and support TEE attestation. Check the NEAR AI Cloud catalog for per-model attestation support.
+- **Compatibility:** Kilo avoids sending OpenAI-only reasoning controls to NEAR AI Cloud.
+
+## Troubleshooting
+
+- **Invalid API key:** Verify `NEARAI_API_KEY` is set in the same environment that launches Kilo, or reconnect the provider in Settings.
+- **Model not available:** Refresh providers or pick a current model from the model picker.
+- **Custom endpoint issues:** Confirm `NEARAI_BASE_URL` is the full versioned base URL of your catalog (for example, `https://cloud-api.near.ai/v1`). Kilo appends `/model/list` to it; the URL should not end with a trailing slash.

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -47,6 +47,9 @@
   <!-- packages/opencode/src/provider/error.ts -->
 - <https://cli.github.com/>
   <!-- packages/kilo-vscode/src/agent-manager/WorktreeManager.ts -->
+- <https://cloud-api.near.ai/v1>
+  <!-- packages/opencode/src/provider/model-cache.ts -->
+  <!-- packages/opencode/src/provider/models.ts -->
 - <https://cloud.digitalocean.com/v1/oauth/authorize>
   <!-- packages/opencode/src/plugin/digitalocean.ts -->
 - <https://cloudflare.com/cdn-cgi/trace>

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -51,6 +51,91 @@ const ApertisItem = Schema.Struct({ id: Schema.String, owned_by: Schema.optional
 const ApertisResponse = Schema.Struct({ data: Schema.optional(Schema.Array(ApertisItem)) })
 type ApertisItem = Schema.Schema.Type<typeof ApertisItem>
 
+// kilocode_change start - NEAR AI Cloud model catalog
+const NEARAI_BASE_URL = "https://cloud-api.near.ai/v1"
+const NEARAI_OUTPUT_LIMIT = 32_768
+const KILO_MODALITIES = ["text", "audio", "image", "video", "pdf"] as const
+const KILO_MODALITY_SET: ReadonlySet<string> = new Set(KILO_MODALITIES)
+const NearAIResponse = Schema.Struct({ models: Schema.optional(Schema.Array(Schema.Unknown)) })
+
+type KiloModality = (typeof KILO_MODALITIES)[number]
+type NearAIPrice = {
+  amount?: number
+  scale?: number
+}
+type NearAIModel = {
+  modelId?: string
+  inputCostPerToken?: NearAIPrice
+  outputCostPerToken?: NearAIPrice
+  cacheReadCostPerToken?: NearAIPrice
+  metadata?: {
+    contextLength?: number
+    modelDisplayName?: string
+    ownedBy?: string
+    supportedFeatures?: string[]
+    architecture?: {
+      inputModalities?: unknown
+      outputModalities?: unknown
+    }
+  }
+}
+
+function isKiloModality(value: string): value is KiloModality {
+  return KILO_MODALITY_SET.has(value)
+}
+
+function nearaiModelListURL(baseURL: string) {
+  const url = baseURL.replace(/\/+$/, "")
+  return `${url}/model/list`
+}
+
+function nearaiPrice(value: NearAIPrice | undefined) {
+  const amount = value?.amount
+  if (typeof amount !== "number" || !Number.isFinite(amount)) return 0
+  const scale = typeof value?.scale === "number" && Number.isFinite(value.scale) ? value.scale : 9
+  return amount * 10 ** (6 - scale)
+}
+
+function nearaiModalities(value: unknown, fallback: string[]) {
+  if (!Array.isArray(value)) return fallback
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+function nearaiModel(model: NearAIModel): Models[string] | undefined {
+  const id = model.modelId?.trim()
+  if (!id) return undefined
+  const key = id.toLowerCase()
+  if (key.includes("privacy-filter") || key.includes("reranker")) return undefined
+
+  const meta = model.metadata ?? {}
+  const arch = meta.architecture
+  const input = nearaiModalities(arch?.inputModalities, ["text"]).filter(isKiloModality)
+  const output = nearaiModalities(arch?.outputModalities, ["text"]).filter(isKiloModality)
+  if (!input.includes("text") || !output.includes("text")) return undefined
+
+  const context =
+    typeof meta.contextLength === "number" && Number.isFinite(meta.contextLength) ? meta.contextLength : 128_000
+
+  return {
+    id,
+    name: meta.modelDisplayName?.trim() || id,
+    family: meta.ownedBy ?? id.split("/")[0] ?? "",
+    release_date: "",
+    attachment: input.some((item) => item !== "text"),
+    reasoning: false,
+    temperature: true,
+    tool_call: Array.isArray(meta.supportedFeatures) ? meta.supportedFeatures.includes("tools") : true,
+    cost: {
+      input: nearaiPrice(model.inputCostPerToken),
+      output: nearaiPrice(model.outputCostPerToken),
+      cache_read: nearaiPrice(model.cacheReadCostPerToken),
+    },
+    limit: { context, output: Math.min(context, NEARAI_OUTPUT_LIMIT) },
+    modalities: { input, output },
+  }
+}
+// kilocode_change end
+
 export const layer: Layer.Layer<
   Service,
   never,
@@ -112,8 +197,31 @@ export const layer: Layer.Layer<
       return Object.fromEntries((json.data ?? []).map((item) => [item.id, aperture(item)]))
     })
 
+    // kilocode_change start - NEAR AI Cloud model catalog
+    const fetchNearAIModels = Effect.fn("ModelCache.fetchNearAIModels")(function* (options: Options) {
+      const baseURL = options.baseURL || NEARAI_BASE_URL
+      const request = HttpClientRequest.get(nearaiModelListURL(baseURL)).pipe(HttpClientRequest.acceptJson)
+      const response = yield* (options.apiKey ? HttpClientRequest.bearerToken(request, options.apiKey) : request).pipe(
+        http.execute,
+        Effect.timeout("10 seconds"),
+      )
+      if (response.status < 200 || response.status >= 300) {
+        log.error("nearai model fetch failed", { status: response.status })
+        return {}
+      }
+
+      const json = yield* HttpClientResponse.schemaBodyJson(NearAIResponse)(response)
+      const models: Record<string, Models[string]> = {}
+      for (const item of json.models ?? []) {
+        const entry = nearaiModel(item as NearAIModel)
+        if (entry) models[entry.id] = entry
+      }
+      return models as Models
+    })
+    // kilocode_change end
+
     const authOptions = Effect.fn("ModelCache.authOptions")(function* (providerID: string) {
-      if (providerID !== "kilo" && providerID !== "apertis") return {}
+      if (providerID !== "kilo" && providerID !== "apertis" && providerID !== "nearai") return {}
       const config = yield* cfg.get()
       const options: Options = {}
 
@@ -154,12 +262,33 @@ export const layer: Layer.Layer<
         })
       }
 
+      // kilocode_change start - NEAR AI Cloud auth options
+      if (providerID === "nearai") {
+        const item = config.provider?.[providerID]
+        if (item?.options?.apiKey) options.apiKey = item.options.apiKey
+        if (item?.options?.baseURL) options.baseURL = item.options.baseURL
+
+        const info = yield* auth.get(providerID)
+        if (info?.type === "api") options.apiKey = info.key
+        if (process.env.NEARAI_API_KEY) options.apiKey = process.env.NEARAI_API_KEY
+        if (process.env.NEARAI_BASE_URL) options.baseURL = process.env.NEARAI_BASE_URL
+        log.debug("nearai auth options resolved", {
+          providerID,
+          hasKey: !!options.apiKey,
+          hasBaseURL: !!options.baseURL,
+        })
+      }
+      // kilocode_change end
+
       return options
     })
 
     const fetchModels = (providerID: string, options: Options): Effect.Effect<Result, unknown> => {
       if (providerID === "kilo") return kilo.fetch(options)
       if (providerID === "apertis") return fetchApertisModels(options).pipe(Effect.map((models) => ({ models })))
+      // kilocode_change start - NEAR AI Cloud model catalog
+      if (providerID === "nearai") return fetchNearAIModels(options).pipe(Effect.map((models) => ({ models })))
+      // kilocode_change end
       log.debug("provider not implemented", { providerID })
       return Effect.succeed({ models: {} })
     }
@@ -180,7 +309,9 @@ export const layer: Layer.Layer<
       if (providerID === "kilo") {
         return JSON.stringify([providerID, options?.baseURL, options?.kilocodeOrganizationId, options?.kilocodeToken])
       }
-      if (providerID === "apertis") return JSON.stringify([providerID, options?.baseURL, options?.apiKey])
+      if (providerID === "apertis" || providerID === "nearai") {
+        return JSON.stringify([providerID, options?.baseURL, options?.apiKey])
+      }
       return providerID
     }
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -30,6 +30,13 @@ function baseURL(url: string | undefined, org: string | undefined) {
   return `${base}/api/openrouter`
 }
 
+// kilocode_change start - NEAR AI Cloud provider
+const normalizeOptionalBaseURL = (url: string | undefined): string | undefined => {
+  const trimmed = url?.trim().replace(/\/+$/, "")
+  return trimmed || undefined
+}
+// kilocode_change end
+
 export const layer: Layer.Layer<Service, never, Core.Service | Config.Service | Auth.Service | ModelCache.Service> =
   Layer.effect(
     Service,
@@ -66,8 +73,31 @@ export const layer: Layer.Layer<Service, never, Core.Service | Config.Service | 
             yield* cache.refresh("apertis", aptOpts).pipe(Effect.ignore, Effect.forkDetach)
         })
 
+        // kilocode_change start - NEAR AI Cloud provider
+        const near = cfg.provider?.nearai?.options
+        const nearConfiguredBase = normalizeOptionalBaseURL(near?.baseURL ?? process.env.NEARAI_BASE_URL)
+        const nearURL = nearConfiguredBase ?? "https://cloud-api.near.ai/v1"
+        const nearOpts = nearConfiguredBase ? { baseURL: nearConfiguredBase } : {}
+
+        const addNearAI = Effect.fnUntraced(function* () {
+          if (providers.nearai) return
+          const models = yield* cache.fetch("nearai", nearOpts).pipe(Effect.catch(() => Effect.succeed({})))
+          providers.nearai = {
+            id: "nearai",
+            name: "NEAR AI Cloud",
+            env: ["NEARAI_API_KEY"],
+            api: nearURL,
+            npm: "@ai-sdk/openai-compatible",
+            models,
+          }
+          if (Object.keys(models).length === 0)
+            yield* cache.refresh("nearai", nearOpts).pipe(Effect.ignore, Effect.forkDetach)
+        })
+        // kilocode_change end
+
         if (!allowed) {
           yield* addApertis()
+          yield* addNearAI() // kilocode_change
           return providers
         }
 
@@ -90,6 +120,7 @@ export const layer: Layer.Layer<Service, never, Core.Service | Config.Service | 
         }
         if (Object.keys(models).length === 0) yield* cache.refresh("kilo", fetch).pipe(Effect.ignore, Effect.forkDetach)
         yield* addApertis()
+        yield* addNearAI() // kilocode_change
         return providers
       })
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1235,6 +1235,15 @@ export function options(input: {
     result["promptCacheKey"] = input.sessionID
   }
 
+  // kilocode_change start - NEAR AI Cloud does not support OpenAI reasoning controls
+  if (input.model.providerID === "nearai") {
+    delete result["reasoningEffort"]
+    delete result["reasoningSummary"]
+    delete result["include"]
+    delete result["textVerbosity"]
+  }
+  // kilocode_change end
+
   if (input.model.providerID === "openrouter") {
     result["prompt_cache_key"] = input.sessionID
   }

--- a/packages/opencode/test/kilocode/nearai-provider.test.ts
+++ b/packages/opencode/test/kilocode/nearai-provider.test.ts
@@ -1,0 +1,158 @@
+// kilocode_change - new file
+import { afterEach, expect } from "bun:test"
+import { Effect, Layer, Ref } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { Auth } from "../../src/auth"
+import { ModelCache } from "../../src/provider/model-cache"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+type Hit = { readonly url: string; readonly auth: string | null }
+
+const originalKey = process.env.NEARAI_API_KEY
+const originalURL = process.env.NEARAI_BASE_URL
+
+const auth = Layer.mock(Auth.Service)({
+  get: () => Effect.succeed(undefined),
+})
+
+const it = testEffect(Layer.empty)
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
+afterEach(() => {
+  restoreEnv("NEARAI_API_KEY", originalKey)
+  restoreEnv("NEARAI_BASE_URL", originalURL)
+})
+
+function nearaiBody() {
+  return {
+    models: [
+      {
+        modelId: "zai-org/GLM-5.1-FP8",
+        inputCostPerToken: { amount: 600, scale: 9, currency: "USD" },
+        outputCostPerToken: { amount: 2600, scale: 9, currency: "USD" },
+        cacheReadCostPerToken: { amount: 200, scale: 9, currency: "USD" },
+        metadata: {
+          contextLength: 200000,
+          modelDisplayName: "GLM 5.1 FP8",
+          ownedBy: "zai-org",
+          architecture: {
+            inputModalities: ["text", "image"],
+            outputModalities: ["text"],
+          },
+        },
+      },
+      {
+        modelId: "Qwen/Qwen3-Embedding-0.6B",
+        metadata: {
+          architecture: {
+            inputModalities: ["text"],
+            outputModalities: ["embedding"],
+          },
+        },
+      },
+      {
+        modelId: "black-forest-labs/FLUX.2-klein-4B",
+        metadata: {
+          architecture: {
+            inputModalities: ["text"],
+            outputModalities: ["image"],
+          },
+        },
+      },
+      {
+        modelId: "Qwen/Qwen3-Reranker-0.6B",
+        metadata: {
+          architecture: {
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+          },
+        },
+      },
+      {
+        modelId: "openai/privacy-filter",
+        metadata: {
+          architecture: {
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+          },
+        },
+      },
+    ],
+  }
+}
+
+function layer(hits: Ref.Ref<Hit[]>) {
+  const http = HttpClient.make((request) =>
+    Effect.gen(function* () {
+      yield* Ref.update(hits, (list) => [
+        ...list,
+        { url: request.url, auth: request.headers["authorization"] ?? null },
+      ])
+      return HttpClientResponse.fromWeb(request, Response.json(nearaiBody()))
+    }),
+  )
+
+  return Layer.fresh(ModelCache.layer).pipe(
+    Layer.provide(Layer.succeed(HttpClient.HttpClient, http)),
+    Layer.provide(TestConfig.layer()),
+    Layer.provide(auth),
+    Layer.provide(ModelCache.kiloModelsLayer),
+  )
+}
+
+it.live("nearai model cache fetches chat models and maps metadata", () =>
+  Effect.gen(function* () {
+    delete process.env.NEARAI_API_KEY
+    delete process.env.NEARAI_BASE_URL
+    const hits = yield* Ref.make<Hit[]>([])
+    const models = yield* ModelCache.Service.use((cache) => cache.fetch("nearai")).pipe(Effect.provide(layer(hits)))
+
+    expect(yield* Ref.get(hits)).toEqual([{ url: "https://cloud-api.near.ai/v1/model/list", auth: null }])
+    expect(Object.keys(models)).toEqual(["zai-org/GLM-5.1-FP8"])
+    expect(models["zai-org/GLM-5.1-FP8"]).toMatchObject({
+      id: "zai-org/GLM-5.1-FP8",
+      name: "GLM 5.1 FP8",
+      family: "zai-org",
+      attachment: true,
+      reasoning: false,
+      temperature: true,
+      tool_call: true,
+      cost: { input: 0.6, output: 2.6, cache_read: 0.2 },
+      limit: { context: 200000, output: 32768 },
+      modalities: {
+        input: ["text", "image"],
+        output: ["text"],
+      },
+    })
+  }),
+)
+
+it.live("nearai model cache honors env key and base URL overrides", () =>
+  Effect.gen(function* () {
+    process.env.NEARAI_API_KEY = "test-key"
+    process.env.NEARAI_BASE_URL = "https://example.test/v1/"
+    const hits = yield* Ref.make<Hit[]>([])
+    yield* ModelCache.Service.use((cache) => cache.fetch("nearai")).pipe(Effect.provide(layer(hits)))
+
+    expect(yield* Ref.get(hits)).toEqual([{ url: "https://example.test/v1/model/list", auth: "Bearer test-key" }])
+  }),
+)
+
+it.live("nearai model cache treats NEARAI_BASE_URL as the versioned catalog base", () =>
+  Effect.gen(function* () {
+    delete process.env.NEARAI_API_KEY
+    process.env.NEARAI_BASE_URL = "https://example.test/api/"
+    const hits = yield* Ref.make<Hit[]>([])
+    yield* ModelCache.Service.use((cache) => cache.fetch("nearai")).pipe(Effect.provide(layer(hits)))
+
+    expect(yield* Ref.get(hits)).toEqual([{ url: "https://example.test/api/model/list", auth: null }])
+  }),
+)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4164,6 +4164,17 @@ describe("ProviderTransform.options - OpenAI Responses API params guard", () => 
     expect(result.reasoningEffort).toBe("medium")
   })
 
+  test("excludes OpenAI reasoning controls for NEAR AI Cloud", () => {
+    const result = ProviderTransform.options({
+      model: gpt5Model("@ai-sdk/openai-compatible", "nearai"),
+      sessionID,
+    })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.include).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+  })
+
   test("excludes reasoningSummary for unknown SDK packages", () => {
     const result = ProviderTransform.options({
       model: gpt5Model("@ai-sdk/xai", "xai"),


### PR DESCRIPTION
## Context

Closes #10491.

Adds NEAR AI Cloud as a native OpenAI-compatible provider so users can connect with `NEARAI_API_KEY`, browse the current NEAR AI Cloud model catalog, and use supported TEE inference models from the Kilo provider picker.

## Implementation

The provider registry now injects a `nearai` provider backed by `https://cloud-api.near.ai/v1`, fetches dynamic models from `/model/list`, maps NEAR pricing and modality metadata into Kilo model metadata, and avoids forwarding OpenAI-only reasoning controls to NEAR AI Cloud. The docs add NEAR AI Cloud to the AI provider guide and provider navigation.

## Screenshots

N/A - provider list entries are data-driven and no static UI layout changed.

## How to Test

- `bun run --cwd packages/opencode typecheck`
- `bun --cwd packages/opencode test test/kilocode/nearai-provider.test.ts`
- `bun --cwd packages/opencode test test/provider/transform.test.ts`
- `bun run script/check-opencode-annotations.ts`
- `bun run script/check-md-table-padding.ts`

## Get in Touch

GitHub works best for follow-up questions.