### PR TITLE
Fix Kilo branding in CLI auth flows

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -278,7 +278,7 @@ export const RunCommand = effectCmd({
       })
       .option("attach", {
         type: "string",
-        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
+        describe: "attach to a running kilo server (e.g., http://localhost:4096)", // kilocode_change
       })
       .option("password", {
         alias: ["p"],

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -114,17 +114,17 @@ const TIPS = [
   "Add {highlight}.ts{/highlight} files to {highlight}.opencode/plugin/{/highlight} for event hooks",
   "Use plugins to send OS notifications when sessions complete",
   "Create a plugin to prevent OpenCode from reading sensitive files",
-  "Use {highlight}opencode run{/highlight} for non-interactive scripting",
-  "Use {highlight}opencode --continue{/highlight} to resume the last session",
-  "Use {highlight}opencode run -f file.ts{/highlight} to attach files via CLI",
+  "Use {highlight}kilo run{/highlight} for non-interactive scripting", // kilocode_change
+  "Use {highlight}kilo --continue{/highlight} to resume the last session", // kilocode_change
+  "Use {highlight}kilo run -f file.ts{/highlight} to attach files via CLI", // kilocode_change
   "Use {highlight}--format json{/highlight} for machine-readable output in scripts",
-  "Run {highlight}opencode serve{/highlight} for headless API access to OpenCode",
-  "Use {highlight}opencode run --attach{/highlight} to connect to a running server",
-  "Run {highlight}opencode upgrade{/highlight} to update to the latest version",
-  "Run {highlight}opencode auth list{/highlight} to see all configured providers",
-  "Run {highlight}opencode agent create{/highlight} for guided agent creation",
+  "Run {highlight}kilo serve{/highlight} for headless API access to Kilo", // kilocode_change
+  "Use {highlight}kilo run --attach{/highlight} to connect to a running server", // kilocode_change
+  "Run {highlight}kilo upgrade{/highlight} to update to the latest version", // kilocode_change
+  "Run {highlight}kilo auth list{/highlight} to see all configured providers", // kilocode_change
+  "Run {highlight}kilo agent create{/highlight} for guided agent creation", // kilocode_change
   "Use {highlight}/opencode{/highlight} in GitHub issues/PRs to trigger AI actions",
-  "Run {highlight}opencode github install{/highlight} to set up the GitHub workflow",
+  "Run {highlight}kilo github install{/highlight} to set up the GitHub workflow", // kilocode_change
   "Comment {highlight}/opencode fix this{/highlight} on issues to auto-create PRs",
   "Comment {highlight}/oc{/highlight} on PR code lines for targeted code reviews",
   'Use {highlight}"theme": "system"{/highlight} to match your terminal\'s colors',

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -140,7 +140,7 @@ export const Info = Schema.Struct({
   }),
   logLevel: Schema.optional(LogLevelRef).annotate({ description: "Log level" }),
   server: Schema.optional(ConfigServer.Server).annotate({
-    description: "Server configuration for opencode serve and web commands",
+    description: "Server configuration for the kilo serve command", // kilocode_change
   }),
   command: Schema.optional(Schema.Record(Schema.String, ConfigCommand.Info)).annotate({
     description: "Command configuration, see https://opencode.ai/docs/commands",

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -112,7 +112,7 @@ function buildAuthorizeUrl(redirectUri: string, pkce: PkceCodes, state: string):
     id_token_add_organizations: "true",
     codex_cli_simplified_flow: "true",
     state,
-    originator: "opencode",
+    originator: "kilo", // kilocode_change
   })
   return `${ISSUER}/oauth/authorize?${params.toString()}`
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -92,7 +92,7 @@ const PathParameterSchemas = {
 
 const LegacyComponentDescriptions = {
   LogLevel: "Log level",
-  ServerConfig: "Server configuration for opencode serve and web commands",
+  ServerConfig: "Server configuration for the kilo serve command", // kilocode_change
   LayoutConfig: "@deprecated Always uses stretch layout.",
 } satisfies Record<string, string>
 

--- a/packages/opencode/test/kilocode/command-branding.test.ts
+++ b/packages/opencode/test/kilocode/command-branding.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const root = path.join(__dirname, "..", "..")
+
+const files = [
+  "src/cli/cmd/tui/feature-plugins/home/tips-view.tsx",
+  "src/cli/cmd/run.ts",
+  "src/config/config.ts",
+  "src/server/routes/instance/httpapi/public.ts",
+  "src/mcp/index.ts",
+]
+
+const command = /opencode\s+(--[a-z-]+|run|serve|auth|upgrade|agent|github|mcp)\b/g
+
+describe("Kilo command branding", () => {
+  test("user-facing command help uses the `kilo` binary name", async () => {
+    const results = await Promise.all(
+      files.map(async (file) => ({
+        file,
+        matches: [...(await Bun.file(path.join(root, file)).text()).matchAll(command)].map((match) => match[0]),
+      })),
+    )
+
+    expect(results.filter((result) => result.matches.length > 0)).toEqual([])
+  })
+})

--- a/packages/opencode/test/kilocode/oauth-branding.test.ts
+++ b/packages/opencode/test/kilocode/oauth-branding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const root = path.join(__dirname, "..", "..")
+
+describe("Kilo OAuth branding", () => {
+  test("Codex OAuth browser flow uses Kilo branding", async () => {
+    const src = await Bun.file(path.join(root, "src", "plugin", "codex.ts")).text()
+
+    expect(src).toContain('originator: "kilo"')
+    expect(src).toContain("return to Kilo")
+    expect(src).not.toContain('originator: "opencode"')
+    expect(src).not.toContain("return to OpenCode")
+  })
+
+  test("MCP OAuth callback page uses Kilo branding", async () => {
+    const src = await Bun.file(path.join(root, "src", "mcp", "oauth-callback.ts")).text()
+
+    expect(src).toContain("return to Kilo")
+    expect(src).not.toContain("return to OpenCode")
+  })
+})

--- a/packages/ui/src/components/provider-icons/types.ts
+++ b/packages/ui/src/components/provider-icons/types.ts
@@ -7,12 +7,12 @@ export const iconNames = [
   "zai",
   "zai-coding-plan",
   "xiaomi",
-  "xiaomi-token-plan-sgp", // kilocode_change
-  "xiaomi-token-plan-cn", // kilocode_change
-  "xiaomi-token-plan-ams", // kilocode_change
+  "xiaomi-token-plan-sgp",
+  "xiaomi-token-plan-cn",
+  "xiaomi-token-plan-ams",
   "xai",
   "wandb",
-  "wafer.ai", // kilocode_change
+  "wafer.ai",
   "vultr",
   "vivgrid",
   "vercel",
@@ -20,8 +20,8 @@ export const iconNames = [
   "v0",
   "upstage",
   "togetherai",
-  "the-grid-ai", // kilocode_change
-  "tencent-tokenhub", // kilocode_change
+  "the-grid-ai",
+  "tencent-tokenhub",
   "tencent-coding-plan",
   "synthetic",
   "submodel",
@@ -32,7 +32,7 @@ export const iconNames = [
   "scaleway",
   "sap-ai-core",
   "requesty",
-  "regolo-ai", // kilocode_change
+  "regolo-ai",
   "qiniu-ai",
   "qihang-ai",
   "privatemode-ai",
@@ -48,7 +48,7 @@ export const iconNames = [
   "nvidia",
   "novita-ai",
   "nova",
-  "neuralwatt", // kilocode_change
+  "neuralwatt",
   "nebius",
   "nano-gpt",
   "morph",
@@ -56,7 +56,7 @@ export const iconNames = [
   "moonshotai-cn",
   "modelscope",
   "moark",
-  "mixlayer", // kilocode_change
+  "mixlayer",
   "mistral",
   "minimax",
   "minimax-coding-plan",
@@ -65,10 +65,10 @@ export const iconNames = [
   "meganova",
   "lucidquery",
   "lmstudio",
-  "llmgateway", // kilocode_change
+  "llmgateway",
   "llama",
   "kuae-cloud-coding-plan",
-  "kiro", // kilocode_change
+  "kiro",
   "kimi-for-coding",
   "kilo",
   "jiekou",
@@ -77,7 +77,7 @@ export const iconNames = [
   "inception",
   "iflowcn",
   "huggingface",
-  "hpc-ai", // kilocode_change
+  "hpc-ai",
   "helicone",
   "groq",
   "google",
@@ -86,7 +86,7 @@ export const iconNames = [
   "gitlab",
   "github-models",
   "github-copilot",
-  "frogbot", // kilocode_change
+  "frogbot",
   "friendli",
   "firmware",
   "fireworks-ai",
@@ -94,7 +94,7 @@ export const iconNames = [
   "evroc",
   "drun",
   "dinference",
-  "digitalocean", // kilocode_change
+  "digitalocean",
   "deepseek",
   "deepinfra",
   "cortecs",
@@ -117,7 +117,7 @@ export const iconNames = [
   "alibaba-coding-plan-cn",
   "alibaba-cn",
   "aihubmix",
-  "abliteration-ai", // kilocode_change
+  "abliteration-ai",
   "abacus",
   "302ai",
 ] as const


### PR DESCRIPTION
## Context

Fix user-facing branding drift where Kilo auth and command guidance could still point users at OpenCode/opencode instead of Kilo/kilo.

## Implementation

Updated CLI/TUI help strings, server config descriptions, and the OpenAI/Codex OAuth originator parameter to use Kilo branding. Added Kilo-owned regression tests that scan the affected user-facing command and OAuth callback sources; this branch also includes provider icon marker cleanup from the existing branch history.

## Screenshots

<img width="1649" height="796" alt="image" src="https://github.com/user-attachments/assets/f63d510d-9b2d-40e6-bbe9-711026829136" />

## How to Test

- From `packages/opencode/`, run `bun test test/kilocode/oauth-branding.test.ts test/kilocode/command-branding.test.ts test/kilocode/mcp-branding.test.ts`
- From `packages/opencode/`, run `bun run typecheck`
- From the repo root, run `bun run script/check-opencode-annotations.ts`