### PR TITLE
fix(cli): show recent models in provider picker

### DIFF
--- a/.changeset/openai-recent-models.md
+++ b/.changeset/openai-recent-models.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show recent and favorited models in provider-specific model lists.

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -135,11 +135,14 @@ export function DialogModel(props: { providerID?: string }) {
             },
           })),
           filter((x) => {
-            // kilocode_change: always dedupe favorites/recents (upstream only did this when showSections was true)
-            if (favorites.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
-              return false
-            if (recents.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
-              return false
+            // kilocode_change start - only dedupe favorites/recents when those sections are visible
+            if (showExtra()) {
+              if (favorites.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
+                return false
+              if (recents.some((item) => item.providerID === x.value.providerID && item.modelID === x.value.modelID))
+                return false
+            }
+            // kilocode_change end
             return true
           }),
           sortBy(


### PR DESCRIPTION
## Context

Fix the provider-specific model picker so models that are already recent or favorited still appear after connecting a provider. This addresses cases like OpenAI GPT-5.5 being selectable from `/models` but missing from the OpenAI provider list.

## Implementation

The model picker now only removes recent and favorited models from the main provider list when the Recent/Favorites sections are visible. Provider-specific dialogs hide those sections, so they keep showing the full provider model list.

A patch changeset was added for the CLI release notes.

## Screenshots

<img width="2364" height="1162" alt="image" src="https://github.com/user-attachments/assets/aadcf353-0778-4809-9d5a-b5cdc6040409" />


## How to Test

- Select an OpenAI model such as GPT-5.5 so it appears in Recents.
- Open the OpenAI provider-specific model picker after connecting OpenAI.
- Confirm GPT-5.5 still appears in the OpenAI list and can be selected.
- Run `bun run typecheck` from `packages/opencode/`.

## Get in Touch