### PR TITLE
feat: track accepted review suggestions

### DIFF
--- a/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
+++ b/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
@@ -50,6 +50,7 @@ describe("TelemetryEvent", () => {
     expect(TelemetryEvent.COMMAND_USED).toBeDefined()
     expect(TelemetryEvent.TOOL_USED).toBeDefined()
     expect(TelemetryEvent.AGENT_USED).toBeDefined()
+    expect(TelemetryEvent.SUGGESTION_SHOWN).toBeDefined()
     expect(TelemetryEvent.SUGGESTION_ACCEPTED).toBeDefined()
   })
 
@@ -91,6 +92,7 @@ describe("Telemetry", () => {
   })
 
   test("suggestion helper is exposed", () => {
+    expect(typeof Telemetry.trackSuggestionShown).toBe("function")
     expect(typeof Telemetry.trackSuggestionAccepted).toBe("function")
   })
 })

--- a/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
+++ b/packages/kilo-telemetry/src/__tests__/telemetry.test.ts
@@ -50,6 +50,7 @@ describe("TelemetryEvent", () => {
     expect(TelemetryEvent.COMMAND_USED).toBeDefined()
     expect(TelemetryEvent.TOOL_USED).toBeDefined()
     expect(TelemetryEvent.AGENT_USED).toBeDefined()
+    expect(TelemetryEvent.SUGGESTION_ACCEPTED).toBeDefined()
   })
 
   test("indexing events are defined", () => {
@@ -87,5 +88,9 @@ describe("Telemetry", () => {
     expect(typeof Telemetry.trackIndexingFileCount).toBe("function")
     expect(typeof Telemetry.trackIndexingBatchRetry).toBe("function")
     expect(typeof Telemetry.trackIndexingError).toBe("function")
+  })
+
+  test("suggestion helper is exposed", () => {
+    expect(typeof Telemetry.trackSuggestionAccepted).toBe("function")
   })
 })

--- a/packages/kilo-telemetry/src/events.ts
+++ b/packages/kilo-telemetry/src/events.ts
@@ -16,6 +16,7 @@ export enum TelemetryEvent {
   TOOL_USED = "Tool Used",
   AGENT_USED = "Agent Used",
   PLAN_FOLLOWUP = "Plan Followup",
+  SUGGESTION_SHOWN = "Suggestion Shown",
   SUGGESTION_ACCEPTED = "Suggestion Accepted",
 
   // Code Indexing

--- a/packages/kilo-telemetry/src/events.ts
+++ b/packages/kilo-telemetry/src/events.ts
@@ -16,6 +16,7 @@ export enum TelemetryEvent {
   TOOL_USED = "Tool Used",
   AGENT_USED = "Agent Used",
   PLAN_FOLLOWUP = "Plan Followup",
+  SUGGESTION_ACCEPTED = "Suggestion Accepted",
 
   // Code Indexing
   INDEXING_STARTED = "Indexing Started",

--- a/packages/kilo-telemetry/src/index.ts
+++ b/packages/kilo-telemetry/src/index.ts
@@ -1,4 +1,4 @@
 export { Telemetry } from "./telemetry.js"
 export { TelemetryEvent } from "./events.js"
 export { Identity } from "./identity.js"
-export type { TelemetryProperties } from "./telemetry.js"
+export type { ReviewCommand, TelemetryProperties } from "./telemetry.js"

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -10,6 +10,8 @@ export interface TelemetryProperties {
   vscodeVersion?: string
 }
 
+export type ReviewCommand = "review" | "local-review" | "local-review-uncommitted"
+
 export interface IndexingTelemetryProperties extends Record<string, unknown> {
   source: "scan" | "watcher"
   provider: string
@@ -156,7 +158,7 @@ export namespace Telemetry {
     taskId?: string
     mode?: "review"
     feature?: "code_reviews"
-    command?: "review" | "local-review" | "local-review-uncommitted"
+    command?: ReviewCommand
     tool?: "suggest"
     apiProvider: string
     modelId: string
@@ -193,9 +195,21 @@ export namespace Telemetry {
     requestId: string
     index: number
     tool: "suggest"
-    command: "review" | "local-review" | "local-review-uncommitted"
+    command: ReviewCommand
+    actionCount?: number
   }) {
     track(TelemetryEvent.SUGGESTION_ACCEPTED, properties)
+  }
+
+  export function trackSuggestionShown(properties: {
+    sessionId: string
+    requestId: string
+    index: number
+    tool: "suggest"
+    command: ReviewCommand
+    actionCount?: number
+  }) {
+    track(TelemetryEvent.SUGGESTION_SHOWN, properties)
   }
 
   export function trackIndexingStarted(properties: IndexingTelemetryProperties) {

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -157,6 +157,7 @@ export namespace Telemetry {
     mode?: "review"
     feature?: "code_reviews"
     command?: "review" | "local-review" | "local-review-uncommitted"
+    tool?: "suggest"
     apiProvider: string
     modelId: string
     inputTokens?: number
@@ -185,6 +186,16 @@ export namespace Telemetry {
 
   export function trackPlanFollowup(sessionId: string, choice: "new_session" | "continue" | "custom" | "dismissed") {
     track(TelemetryEvent.PLAN_FOLLOWUP, { sessionId, choice })
+  }
+
+  export function trackSuggestionAccepted(properties: {
+    sessionId: string
+    requestId: string
+    index: number
+    tool: "suggest"
+    command: "review" | "local-review" | "local-review-uncommitted"
+  }) {
+    track(TelemetryEvent.SUGGESTION_ACCEPTED, properties)
   }
 
   export function trackIndexingStarted(properties: IndexingTelemetryProperties) {

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -4,6 +4,7 @@ import { SessionNetwork } from "@/session/network"
 import type { SessionID } from "@/session/schema"
 import type { SessionStatus } from "@/session/status"
 import { MessageV2 } from "@/session/message-v2"
+import { isRecord } from "@/util/record"
 import * as Log from "@opencode-ai/core/util/log"
 import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -12,6 +13,7 @@ export type ReviewTelemetry = {
   mode: "review"
   feature: "code_reviews"
   command: "review" | "local-review" | "local-review-uncommitted"
+  tool?: "suggest"
 }
 
 export namespace KiloSessionProcessor {
@@ -26,6 +28,13 @@ export namespace KiloSessionProcessor {
     if (command === "review" || command === "local-review" || command === "local-review-uncommitted") {
       return { mode: "review", feature: "code_reviews", command }
     }
+  }
+
+  function command(prompt: string | undefined) {
+    if (!prompt?.startsWith("/")) return
+    const name = prompt.slice(1).split(/\s/, 1)[0]
+    if (!name) return
+    return name
   }
 
   /**
@@ -55,6 +64,25 @@ export namespace KiloSessionProcessor {
       if (meta.mode !== "review") continue
       if (meta.feature !== "code_reviews") continue
       const tel = reviewTelemetry(typeof meta.command === "string" ? meta.command : undefined)
+      if (tel) return tel
+    }
+  }
+
+  export function suggestionReviewTelemetry(metadata: unknown): ReviewTelemetry | undefined {
+    if (!isRecord(metadata)) return
+    if (!isRecord(metadata.accepted)) return
+    const prompt = typeof metadata.accepted.prompt === "string" ? metadata.accepted.prompt : undefined
+    const tel = reviewTelemetry(command(prompt))
+    if (!tel) return
+    return { ...tel, tool: "suggest" }
+  }
+
+  export function extractSuggestionReviewTelemetry(parts: MessageV2.Part[]): ReviewTelemetry | undefined {
+    for (const part of parts) {
+      if (part.type !== "tool") continue
+      if (part.tool !== "suggest") continue
+      if (part.state.status !== "completed") continue
+      const tel = suggestionReviewTelemetry(part.state.metadata)
       if (tel) return tel
     }
   }

--- a/packages/opencode/src/kilocode/suggestion/index.ts
+++ b/packages/opencode/src/kilocode/suggestion/index.ts
@@ -4,12 +4,19 @@ import { Identifier } from "../../id/id"
 import { SessionID } from "../../session/schema"
 import { ZodOverride } from "../../util/effect-zod"
 import * as Log from "@opencode-ai/core/util/log"
+import { Telemetry } from "@kilocode/kilo-telemetry"
 import z from "zod"
 import { Schema } from "effect"
 import { KiloSessionPromptQueue } from "../session/prompt-queue"
 
 export namespace Suggestion {
   const log = Log.create({ service: "suggestion" })
+
+  function command(prompt: string): "review" | "local-review" | "local-review-uncommitted" | undefined {
+    if (!prompt.startsWith("/")) return
+    const name = prompt.slice(1).split(/\s/, 1)[0]
+    if (name === "review" || name === "local-review" || name === "local-review-uncommitted") return name
+  }
 
   export const Action = z
     .object({
@@ -175,6 +182,17 @@ export namespace Suggestion {
     delete s.pending[input.requestID]
 
     log.info("accepted", { requestID: input.requestID, index: input.index, label: action.label })
+
+    const cmd = command(action.prompt)
+    if (cmd) {
+      Telemetry.trackSuggestionAccepted({
+        sessionId: existing.info.sessionID,
+        requestId: existing.info.id,
+        index: input.index,
+        tool: "suggest",
+        command: cmd,
+      })
+    }
 
     Bus.publish(Event.Accepted, {
       sessionID: SessionID.make(existing.info.sessionID),

--- a/packages/opencode/src/kilocode/suggestion/index.ts
+++ b/packages/opencode/src/kilocode/suggestion/index.ts
@@ -4,7 +4,7 @@ import { Identifier } from "../../id/id"
 import { SessionID } from "../../session/schema"
 import { ZodOverride } from "../../util/effect-zod"
 import * as Log from "@opencode-ai/core/util/log"
-import { Telemetry } from "@kilocode/kilo-telemetry"
+import { Telemetry, type ReviewCommand } from "@kilocode/kilo-telemetry"
 import z from "zod"
 import { Schema } from "effect"
 import { KiloSessionPromptQueue } from "../session/prompt-queue"
@@ -12,7 +12,7 @@ import { KiloSessionPromptQueue } from "../session/prompt-queue"
 export namespace Suggestion {
   const log = Log.create({ service: "suggestion" })
 
-  function command(prompt: string): "review" | "local-review" | "local-review-uncommitted" | undefined {
+  function command(prompt: string): ReviewCommand | undefined {
     if (!prompt.startsWith("/")) return
     const name = prompt.slice(1).split(/\s/, 1)[0]
     if (name === "review" || name === "local-review" || name === "local-review-uncommitted") return name
@@ -159,6 +159,18 @@ export namespace Suggestion {
         resolve,
         reject,
       }
+      info.actions.forEach((action, index) => {
+        const cmd = command(action.prompt)
+        if (!cmd) return
+        Telemetry.trackSuggestionShown({
+          sessionId: info.sessionID,
+          requestId: info.id,
+          index,
+          tool: "suggest",
+          command: cmd,
+          actionCount: info.actions.length,
+        })
+      })
       Bus.publish(Event.Shown, { ...info, sessionID: SessionID.make(info.sessionID) })
     })
   }
@@ -191,6 +203,7 @@ export namespace Suggestion {
         index: input.index,
         tool: "suggest",
         command: cmd,
+        actionCount: existing.info.actions.length,
       })
     }
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -228,6 +228,11 @@ export const layer: Layer.Layer<
             attachments: output.attachments,
           },
         })
+        // kilocode_change start - accepted suggest review actions tag following LLM completion telemetry
+        if (match.part.tool === "suggest") {
+          ctx.telemetry = KiloSessionProcessor.suggestionReviewTelemetry(output.metadata) ?? ctx.telemetry
+        }
+        // kilocode_change end
         yield* settleToolCall(toolCallID)
       })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1505,15 +1505,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
-          // kilocode_change start - carry local review command marker into LLM telemetry
-          const telemetry = KiloSessionProcessor.extractReviewTelemetry(
-            msgs.findLast((m) => m.info.role === "user" && m.info.id === lastUser.id)?.parts ?? [],
-          )
-          // kilocode_change end
-
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
           )
+          // kilocode_change start - carry local review command marker into LLM telemetry
+          const telemetry =
+            KiloSessionProcessor.extractReviewTelemetry(
+              msgs.findLast((m) => m.info.role === "user" && m.info.id === lastUser.id)?.parts ?? [],
+            ) ?? KiloSessionProcessor.extractSuggestionReviewTelemetry(lastAssistantMsg?.parts ?? [])
+          // kilocode_change end
+
           // kilocode_change start - keep provider-executed tools from forcing a re-loop
           // Some providers return "stop" even when the assistant message contains tool calls.
           // Keep the loop running so tool results can be sent back to the model.

--- a/packages/opencode/test/kilocode/session-processor-review-telemetry.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-review-telemetry.test.ts
@@ -81,3 +81,45 @@ describe("KiloSessionProcessor.extractReviewTelemetry", () => {
     expect(KiloSessionProcessor.extractReviewTelemetry(parts as unknown as MessageV2.Part[])).toBeUndefined()
   })
 })
+
+describe("KiloSessionProcessor.suggestionReviewTelemetry", () => {
+  test("returns suggest-sourced telemetry for accepted review commands", () => {
+    expect(
+      KiloSessionProcessor.suggestionReviewTelemetry({
+        accepted: { prompt: "/local-review-uncommitted --focus telemetry" },
+      }),
+    ).toEqual({ ...expected("local-review-uncommitted"), tool: "suggest" })
+  })
+
+  test("returns undefined for accepted non-review commands", () => {
+    expect(KiloSessionProcessor.suggestionReviewTelemetry({ accepted: { prompt: "/test" } })).toBeUndefined()
+  })
+
+  test("returns undefined when accepted prompt is not a slash command", () => {
+    expect(KiloSessionProcessor.suggestionReviewTelemetry({ accepted: { prompt: "Run tests" } })).toBeUndefined()
+  })
+
+  test("returns undefined when accepted metadata is missing", () => {
+    expect(KiloSessionProcessor.suggestionReviewTelemetry({ dismissed: true })).toBeUndefined()
+  })
+})
+
+describe("KiloSessionProcessor.extractSuggestionReviewTelemetry", () => {
+  test("recovers review telemetry from completed suggest tool metadata", () => {
+    const parts = [
+      {
+        type: "tool",
+        tool: "suggest",
+        state: {
+          status: "completed",
+          metadata: { accepted: { prompt: "/local-review" } },
+        },
+      },
+    ]
+
+    expect(KiloSessionProcessor.extractSuggestionReviewTelemetry(parts as unknown as MessageV2.Part[])).toEqual({
+      ...expected("local-review"),
+      tool: "suggest",
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
+++ b/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { Telemetry } from "@kilocode/kilo-telemetry"
 import { WithInstance } from "../../../src/project/with-instance"
 import { Suggestion } from "../../../src/kilocode/suggestion"
 import { tmpdir } from "../../fixture/fixture"
+
+afterEach(() => {
+  mock.restore()
+})
 
 describe("suggestion", () => {
   test("show adds pending request with blocking flag", async () => {
@@ -50,6 +55,97 @@ describe("suggestion", () => {
           prompt: "Run the relevant tests now.",
         })
         await expect(Suggestion.list()).resolves.toEqual([])
+      },
+    })
+  })
+
+  test("accept tracks suggestion telemetry with parsed slash command", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review changes?",
+          actions: [{ label: "Review", prompt: "/local-review-uncommitted --focus tests" }],
+        })
+
+        const list = await Suggestion.list()
+        await Suggestion.accept({ requestID: list[0]!.id, index: 0 })
+
+        expect(track).toHaveBeenCalledTimes(1)
+        expect(track).toHaveBeenCalledWith({
+          sessionId: "ses_test",
+          requestId: list[0]!.id,
+          index: 0,
+          tool: "suggest",
+          command: "local-review-uncommitted",
+        })
+        await expect(ask).resolves.toEqual({ label: "Review", prompt: "/local-review-uncommitted --focus tests" })
+      },
+    })
+  })
+
+  test("accept does not track non-review suggestion telemetry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Run tests?",
+          actions: [{ label: "Test", prompt: "/custom-project-command" }],
+        })
+
+        const list = await Suggestion.list()
+        await Suggestion.accept({ requestID: list[0]!.id, index: 0 })
+
+        expect(track).toHaveBeenCalledTimes(0)
+        await expect(ask).resolves.toEqual({ label: "Test", prompt: "/custom-project-command" })
+      },
+    })
+  })
+
+  test("dismiss does not track suggestion telemetry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review changes?",
+          actions: [{ label: "Review", prompt: "/local-review" }],
+        })
+
+        const list = await Suggestion.list()
+        await Suggestion.dismiss(list[0]!.id)
+
+        expect(track).toHaveBeenCalledTimes(0)
+        await expect(ask).rejects.toBeInstanceOf(Suggestion.DismissedError)
+      },
+    })
+  })
+
+  test("invalid action index does not track suggestion telemetry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review changes?",
+          actions: [{ label: "Review", prompt: "/local-review" }],
+        })
+
+        const list = await Suggestion.list()
+        await expect(Suggestion.accept({ requestID: list[0]!.id, index: 1 })).resolves.toBe(false)
+
+        expect(track).toHaveBeenCalledTimes(0)
+        await expect(ask).rejects.toThrow("Invalid action index: 1")
       },
     })
   })

--- a/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
+++ b/packages/opencode/test/kilocode/suggestion/suggestion.test.ts
@@ -81,18 +81,94 @@ describe("suggestion", () => {
           index: 0,
           tool: "suggest",
           command: "local-review-uncommitted",
+          actionCount: 1,
         })
         await expect(ask).resolves.toEqual({ label: "Review", prompt: "/local-review-uncommitted --focus tests" })
       },
     })
   })
 
-  test("accept does not track non-review suggestion telemetry", async () => {
+  test("show tracks review suggestion telemetry with parsed slash command", async () => {
     await using tmp = await tmpdir({ git: true })
     await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
-        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const track = spyOn(Telemetry, "trackSuggestionShown")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review changes?",
+          actions: [{ label: "Review", prompt: "/local-review-uncommitted --focus tests" }],
+        })
+
+        const list = await Suggestion.list()
+
+        expect(track).toHaveBeenCalledTimes(1)
+        expect(track).toHaveBeenCalledWith({
+          sessionId: "ses_test",
+          requestId: list[0]!.id,
+          index: 0,
+          tool: "suggest",
+          command: "local-review-uncommitted",
+          actionCount: 1,
+        })
+
+        await Suggestion.dismiss(list[0]!.id)
+        await expect(ask).rejects.toBeInstanceOf(Suggestion.DismissedError)
+      },
+    })
+  })
+
+  test("show and accept parse local review arguments as local-review", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shown = spyOn(Telemetry, "trackSuggestionShown")
+        const accepted = spyOn(Telemetry, "trackSuggestionAccepted")
+        const ask = Suggestion.show({
+          sessionID: "ses_test",
+          text: "Review release?",
+          actions: [
+            { label: "Review", prompt: "/local-review release -- focus on tests" },
+            { label: "Skip", prompt: "Skip this review." },
+          ],
+        })
+
+        const list = await Suggestion.list()
+
+        expect(shown).toHaveBeenCalledTimes(1)
+        expect(shown).toHaveBeenCalledWith({
+          sessionId: "ses_test",
+          requestId: list[0]!.id,
+          index: 0,
+          tool: "suggest",
+          command: "local-review",
+          actionCount: 2,
+        })
+
+        await Suggestion.accept({ requestID: list[0]!.id, index: 0 })
+
+        expect(accepted).toHaveBeenCalledTimes(1)
+        expect(accepted).toHaveBeenCalledWith({
+          sessionId: "ses_test",
+          requestId: list[0]!.id,
+          index: 0,
+          tool: "suggest",
+          command: "local-review",
+          actionCount: 2,
+        })
+        await expect(ask).resolves.toEqual({ label: "Review", prompt: "/local-review release -- focus on tests" })
+      },
+    })
+  })
+
+  test("non-review commands do not track suggestion telemetry", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shown = spyOn(Telemetry, "trackSuggestionShown")
+        const accepted = spyOn(Telemetry, "trackSuggestionAccepted")
         const ask = Suggestion.show({
           sessionID: "ses_test",
           text: "Run tests?",
@@ -102,18 +178,20 @@ describe("suggestion", () => {
         const list = await Suggestion.list()
         await Suggestion.accept({ requestID: list[0]!.id, index: 0 })
 
-        expect(track).toHaveBeenCalledTimes(0)
+        expect(shown).toHaveBeenCalledTimes(0)
+        expect(accepted).toHaveBeenCalledTimes(0)
         await expect(ask).resolves.toEqual({ label: "Test", prompt: "/custom-project-command" })
       },
     })
   })
 
-  test("dismiss does not track suggestion telemetry", async () => {
+  test("dismiss does not track accepted suggestion telemetry", async () => {
     await using tmp = await tmpdir({ git: true })
     await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
-        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const shown = spyOn(Telemetry, "trackSuggestionShown")
+        const accepted = spyOn(Telemetry, "trackSuggestionAccepted")
         const ask = Suggestion.show({
           sessionID: "ses_test",
           text: "Review changes?",
@@ -123,18 +201,20 @@ describe("suggestion", () => {
         const list = await Suggestion.list()
         await Suggestion.dismiss(list[0]!.id)
 
-        expect(track).toHaveBeenCalledTimes(0)
+        expect(shown).toHaveBeenCalledTimes(1)
+        expect(accepted).toHaveBeenCalledTimes(0)
         await expect(ask).rejects.toBeInstanceOf(Suggestion.DismissedError)
       },
     })
   })
 
-  test("invalid action index does not track suggestion telemetry", async () => {
+  test("invalid action index does not track accepted suggestion telemetry", async () => {
     await using tmp = await tmpdir({ git: true })
     await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
-        const track = spyOn(Telemetry, "trackSuggestionAccepted")
+        const shown = spyOn(Telemetry, "trackSuggestionShown")
+        const accepted = spyOn(Telemetry, "trackSuggestionAccepted")
         const ask = Suggestion.show({
           sessionID: "ses_test",
           text: "Review changes?",
@@ -144,7 +224,8 @@ describe("suggestion", () => {
         const list = await Suggestion.list()
         await expect(Suggestion.accept({ requestID: list[0]!.id, index: 1 })).resolves.toBe(false)
 
-        expect(track).toHaveBeenCalledTimes(0)
+        expect(shown).toHaveBeenCalledTimes(1)
+        expect(accepted).toHaveBeenCalledTimes(0)
         await expect(ask).rejects.toThrow("Invalid action index: 1")
       },
     })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -31,6 +31,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
+import { Suggestion } from "../../src/kilocode/suggestion" // kilocode_change - accept suggestion in telemetry test
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionV2 } from "../../src/v2/session"
@@ -2100,6 +2101,59 @@ it.live(
         const tagged = trackSpy.mock.calls
           .map((args) => args[0] as Parameters<typeof Telemetry.trackLlmCompletion>[0])
           .find((p) => p.mode === "review" && p.feature === "code_reviews" && p.command === "review")
+        expect(tagged).toBeDefined()
+      }),
+      { git: true, config: providerCfg },
+    ),
+  30_000,
+)
+
+it.live(
+  "accepted suggest tool marks following completion with review telemetry",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const trackSpy = spyOn(Telemetry, "trackLlmCompletion")
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "Suggest telemetry",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.tool("suggest", {
+          suggest: "Run a local review?",
+          actions: [{ label: "Review", prompt: "/local-review-uncommitted --focus telemetry" }],
+        })
+        yield* llm.text("review done", { usage: { input: 100, output: 50 } })
+
+        const fiber = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "Suggest a review action." }],
+          })
+          .pipe(Effect.forkChild)
+        const request = yield* waitFor(
+          "suggestion request",
+          Effect.promise(() => Suggestion.list()).pipe(
+            Effect.map((items) => items.find((item) => item.sessionID === chat.id)),
+          ),
+        )
+
+        yield* Effect.promise(() => Suggestion.accept({ requestID: request.id, index: 0 }))
+        yield* Fiber.join(fiber)
+
+        const tagged = trackSpy.mock.calls
+          .map((args) => args[0] as Parameters<typeof Telemetry.trackLlmCompletion>[0])
+          .find(
+            (p) =>
+              p.mode === "review" &&
+              p.feature === "code_reviews" &&
+              p.command === "local-review-uncommitted" &&
+              p.tool === "suggest",
+          )
         expect(tagged).toBeDefined()
       }),
       { git: true, config: providerCfg },


### PR DESCRIPTION
## Why

We want to understand how often review suggestions are shown and accepted without recording arbitrary suggested text or custom slash commands.

## What changed

This adds privacy-safe telemetry for review suggestions at the action level. Known review actions are tracked when shown and when accepted with matching metadata, so acceptance rate can be measured as `Suggestion Accepted / Suggestion Shown` and broken down by review command.

Accepted review suggestions also continue to mark the following model response as coming from the suggest tool. Dismissed, invalid, non-review, and custom-command suggestions are not counted.

## How to test

- `bun test` and `bun run typecheck` from `packages/kilo-telemetry/`
- Suggestion and review telemetry tests from `packages/opencode/`
- `bun run typecheck` from `packages/opencode/`