### PR TITLE
fix(cli): render alert message newlines

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,12 +2,19 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { For } from "solid-js" // kilocode_change
 
 export type DialogAlertProps = {
   title: string
   message: string
   onConfirm?: () => void
 }
+
+// kilocode_change start
+export function lines(message: string) {
+  return message.split("\n")
+}
+// kilocode_change end
 
 export function DialogAlert(props: DialogAlertProps) {
   const dialog = useDialog()
@@ -32,7 +39,9 @@ export function DialogAlert(props: DialogAlertProps) {
         </text>
       </box>
       <box paddingBottom={1}>
-        <text fg={theme.textMuted}>{props.message}</text>
+        {/* kilocode_change start */}
+        <For each={lines(props.message)}>{(line) => <text fg={theme.textMuted}>{line}</text>}</For>
+        {/* kilocode_change end */}
       </box>
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box

--- a/packages/opencode/test/kilocode/dialog-alert.test.ts
+++ b/packages/opencode/test/kilocode/dialog-alert.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+import { lines } from "../../src/cli/cmd/tui/ui/dialog-alert"
+
+test("DialogAlert splits message newlines into renderable lines", () => {
+  expect(lines("You're not a member of any teams.\nVisit https://app.kilo.ai to create or join a team.")).toEqual([
+    "You're not a member of any teams.",
+    "Visit https://app.kilo.ai to create or join a team.",
+  ])
+})


### PR DESCRIPTION
## Summary
- render `DialogAlert` messages as separate text rows for each newline
- add a Kilo regression test for the Teams-dialog message case

Fixes #10192.

## Validation
- `bun test test/kilocode/dialog-alert.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`

## Note
- Repo pre-push `bun turbo typecheck` was attempted, but this machine has no Java runtime and the unrelated `@kilocode/kilo-jetbrains` typecheck fails before completing.