### PR TITLE
docs(kilo-docs): document Pi Gateway integration

### DIFF
--- a/packages/kilo-docs/pages/gateway/sdks-and-frameworks.md
+++ b/packages/kilo-docs/pages/gateway/sdks-and-frameworks.md
@@ -292,6 +292,17 @@ The Kilo AI Gateway works with any framework that supports OpenAI-compatible API
 | [LlamaIndex](https://www.llamaindex.ai) | Use OpenAI-compatible configuration |
 | [Haystack](https://haystack.deepset.ai) | Use OpenAI generator with custom URL |
 | [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/) | Use OpenAI connector with custom endpoint |
+| [Pi](https://pi.dev) | Install the [Kilo provider extension](https://github.com/Kilo-Org/kilo-pi-provider) |
+
+### Pi coding agent
+
+Use the Kilo-maintained [Pi provider extension](https://github.com/Kilo-Org/kilo-pi-provider) to access Kilo Gateway models from the [Pi coding agent](https://pi.dev).
+
+```bash
+pi install git:github.com/Kilo-Org/kilo-pi-provider
+```
+
+Start Pi and run `/login kilo` to connect your Kilo account, or use free models without signing in. The provider also supports organization accounts, Kilo reasoning variants, and responses-only models.
 
 ### LangChain example
 

--- a/packages/kilo-docs/pages/gateway/sdks-and-frameworks.md
+++ b/packages/kilo-docs/pages/gateway/sdks-and-frameworks.md
@@ -302,7 +302,7 @@ Use the Kilo-maintained [Pi provider extension](https://github.com/Kilo-Org/kilo
 pi install git:github.com/Kilo-Org/kilo-pi-provider
 ```
 
-Start Pi and run `/login kilo` to connect your Kilo account, or use free models without signing in. The provider also supports organization accounts, Kilo reasoning variants, and responses-only models.
+Run `/login kilo` in Pi to connect your account, or use supported free models without signing in. See the provider repository for organization configuration and model-specific behavior.
 
 ### LangChain example
 


### PR DESCRIPTION
Document the Kilo-maintained Pi provider on the Gateway SDKs and Frameworks page, including the install command and account connection entry point.

This makes the maintained integration discoverable now that Kilo hosts the BSL-licensed provider with organization account, reasoning variant, and responses-model support.