### PR TITLE
docs: clarify PR review readiness expectations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+## Issue
+
+<!-- Reference an existing issue with `Fixes #123`, `Closes #123`, or equivalent linked issue wording. -->
+
+Fixes #
+
 ## Context
 
 <!-- Brief description of WHAT you’re doing and WHY. -->
@@ -6,11 +12,13 @@
 
 <!--
 
-Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?
+Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to? Keep this focused on context reviewers cannot infer from the diff; skip file-by-file summaries, placeholders, and other filler.
 
 -->
 
-## Screenshots
+## Screenshots / Video
+
+<!-- Required for visual changes. Include the relevant before/after or resulting state. -->
 
 | before | after |
 |---|---|
@@ -52,6 +60,13 @@ Every PR marked ready for review must include testing evidence. A bare "Not test
 
 Docs-only, config-only, and similar changes still need concrete evidence. For examples, see [Testing Evidence for Pull Requests](https://kilo.ai/docs/contributing/development-environment#testing-evidence-for-pull-requests). Draft PRs may be incomplete until marked ready for review.
 -->
+
+## Checklist
+
+- [ ] Issue linked above, or exception explained
+- [ ] Tests/verification described
+- [ ] Screenshots/video included for visual changes, or marked N/A
+- [ ] Changeset considered for user-facing changes
 
 ## Get in Touch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,8 @@ Current required fields by issue type:
 
 ## Pull Request Expectations
 
+Contributor guidance exists to protect maintainer review time and keep reviews focused on work that is ready to evaluate.
+
 - **UI Changes:** Include screenshots or videos (before/after).
 - **Logic Changes:** Explain how you verified it works.
 
@@ -265,11 +267,27 @@ If you cannot complete a relevant command, include all of the following in the P
 
 See [Testing Evidence for Pull Requests](packages/kilo-docs/pages/contributing/development-environment.md#testing-evidence-for-pull-requests) for more examples. Agent limitations, local resource constraints, OOM constraints, or an agent prompt that says to skip tests do not waive this requirement. Draft PRs may be incomplete until they are marked ready for review. Maintainers may still defer or close review at their discretion.
 
-## Issue First Policy
+Our issue-first policy asks contributors to reference an existing issue when opening a PR. This helps reviewers understand the problem statement, discussion, and intended scope before reviewing the code change.
 
-All pull requests must reference an existing issue.
+A review-ready PR description should explain:
 
-This helps reviewers understand the problem statement, discussion, and intended scope before reviewing the code change.
+- What problem is being solved
+- Why the change is needed
+- Important implementation choices or tradeoffs reviewers cannot infer from the diff
+- How the change was tested or verified
+
+Keep the description focused on context reviewers cannot infer from the diff. Skip file-by-file summaries, placeholders, and other filler.
+
+For visual UI changes, include screenshots or video showing the relevant before/after or resulting state.
+
+Maintainers may close or decline review of PRs presented as review-ready at their discretion when they lack:
+
+- Linked issue context
+- A clear what/why explanation
+- Credible testing evidence
+- Relevant UI proof for visual UI changes
+
+When a PR is close to this bar, addresses important work, or would benefit from further shaping, maintainers may ask for specific fixes instead of closing or declining review. Contributors may reopen or resubmit once the PR meets the documented bar.
 
 ## PR Titles
 

--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -107,6 +107,10 @@ Before marking a PR ready for review, include testing evidence in the PR templat
 
 ### Creating a Pull Request
 
+Contributor guidance exists to protect maintainer review time and keep reviews focused on work that is ready to evaluate.
+
+Follow the issue-first policy by linking the relevant issue when you open a PR. Use `Fixes #123`, `Closes #123`, or equivalent linked issue wording so reviewers can see the problem statement, discussion, and intended scope before reviewing the code change.
+
 1. Push your changes to your fork:
 
    ```bash
@@ -120,12 +124,19 @@ Before marking a PR ready for review, include testing evidence in the PR templat
 4. Select your fork and branch
 
 5. Fill out the PR template with:
-   - A clear description of the changes
-   - Any related issues
+   - Related issue link, or an explanation for why there is no existing issue
+   - What problem is being solved and why the change is needed
+   - Important implementation choices or tradeoffs reviewers cannot infer from the diff
    - Testing evidence, including commands run and results
    - Manual/local verification performed
    - Any command blocker plus substitute verification
-   - Screenshots (if applicable)
+   - Screenshots or video for visual UI changes, showing the relevant before/after or resulting state
+
+Keep the description focused on context reviewers cannot infer from the diff. Skip file-by-file summaries, placeholders, and other filler.
+
+Maintainers may close or decline review of PRs presented as review-ready at their discretion when they lack linked issue context, a clear what/why explanation, credible testing evidence, or relevant UI proof for visual UI changes.
+
+When a PR is close to this bar, addresses important work, or would benefit from further shaping, maintainers may ask for specific fixes instead of closing or declining review. Contributors may reopen or resubmit once the PR meets the documented bar.
 
 ## Contributing to the Kilo Marketplace
 


### PR DESCRIPTION
## Context

Improving docs and PR template to make it more clear what is expected from community PRs

## Implementation

- Added checklist for things that are important before we consider an internal review
- Added details of what happens once the expectations are not met