### PR TITLE
fix(vscode): explain disabled speech input requirement

### DIFF
--- a/.changeset/speech-to-text-kilo-sign-in-tooltip.md
+++ b/.changeset/speech-to-text-kilo-sign-in-tooltip.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Explain in disabled Speech to Text controls that voice input currently requires the Kilo provider.

--- a/.changeset/speech-to-text-kilo-sign-in-tooltip.md
+++ b/.changeset/speech-to-text-kilo-sign-in-tooltip.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Explain in disabled Speech to Text controls that voice input currently requires the Kilo provider.
+Explain in disabled Speech to Text controls that voice input currently requires Kilo Gateway access.

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -1,5 +1,6 @@
 import { Component, For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { Switch } from "@kilocode/kilo-ui/switch"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Select } from "@kilocode/kilo-ui/select"
 import { TextField } from "@kilocode/kilo-ui/text-field"
 import { Card } from "@kilocode/kilo-ui/card"
@@ -210,14 +211,20 @@ const ExperimentalTab: Component = () => {
               : language.t("settings.experimental.speechToText.disabledDescription")
           }
         >
-          <Switch
-            checked={experimental().speech_to_text ?? false}
-            onChange={(checked) => updateExperimental("speech_to_text", checked)}
-            disabled={!kiloReady()}
-            hideLabel
+          <Tooltip
+            value={language.t("settings.experimental.speechToText.disabledDescription")}
+            placement="top"
+            inactive={kiloReady()}
           >
-            {language.t("settings.experimental.speechToText.title")}
-          </Switch>
+            <Switch
+              checked={experimental().speech_to_text ?? false}
+              onChange={(checked) => updateExperimental("speech_to_text", checked)}
+              disabled={!kiloReady()}
+              hideLabel
+            >
+              {language.t("settings.experimental.speechToText.title")}
+            </Switch>
+          </Tooltip>
         </SettingsRow>
 
         <SettingsRow

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1234,7 +1234,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "تمكين الإدخال الصوتي في حقول المطالبة باستخدام حساب Kilo الخاص بك من خلال Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "قم بتمكين مزود Kilo وتسجيل الدخول إليه لاستخدام Speech to Text. ميزة Speech to Text مدعومة حاليًا مع Kilo فقط.",
+    "قم بتمكين وتسجيل الدخول إلى مزود Kilo لاستخدام Speech to Text. ميزة Speech to Text مدعومة حاليًا فقط مع Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "نموذج تحويل الصوت إلى نص",
   "settings.experimental.speechToTextModel.description": "اختر نموذج نسخ Kilo Gateway للإدخال الصوتي.",
   "settings.experimental.continueOnDeny.title": "المتابعة عند الرفض",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1234,7 +1234,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "تمكين الإدخال الصوتي في حقول المطالبة باستخدام حساب Kilo الخاص بك من خلال Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "قم بتمكين وتسجيل الدخول إلى Kilo provider لاستخدام الإدخال الصوتي في حقول المطالبة.",
+    "قم بتمكين مزود Kilo وتسجيل الدخول إليه لاستخدام Speech to Text. ميزة Speech to Text مدعومة حاليًا مع Kilo فقط.",
   "settings.experimental.speechToTextModel.title": "نموذج تحويل الصوت إلى نص",
   "settings.experimental.speechToTextModel.description": "اختر نموذج نسخ Kilo Gateway للإدخال الصوتي.",
   "settings.experimental.continueOnDeny.title": "المتابعة عند الرفض",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1263,7 +1263,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Ative a entrada de voz nos campos de prompt usando sua conta do Kilo por meio do Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Ative e faça login no Kilo provider para usar a entrada de voz nos campos de prompt.",
+    "Ative e faça login no provedor Kilo para usar o Speech to Text. Atualmente, o Speech to Text é suportado apenas com Kilo.",
   "settings.experimental.speechToTextModel.title": "Modelo de fala para texto",
   "settings.experimental.speechToTextModel.description":
     "Escolha o modelo de transcrição do Kilo Gateway para entrada de voz.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1263,7 +1263,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Ative a entrada de voz nos campos de prompt usando sua conta do Kilo por meio do Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Ative e faça login no provedor Kilo para usar o Speech to Text. Atualmente, o Speech to Text é suportado apenas com Kilo.",
+    "Ative e faça login no provedor Kilo para usar o Speech to Text. Atualmente, o Speech to Text é compatível apenas com o Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Modelo de fala para texto",
   "settings.experimental.speechToTextModel.description":
     "Escolha o modelo de transcrição do Kilo Gateway para entrada de voz.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1263,7 +1263,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Omogućite glasovni unos u poljima za promptove koristeći vaš Kilo račun preko Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Omogućite i prijavite se na Kilo provider da koristite glasovni unos u poljima za promptove.",
+    "Omogućite Kilo provajder i prijavite se da koristite Speech to Text. Speech to Text je trenutno podržan samo uz Kilo.",
   "settings.experimental.speechToTextModel.title": "Model govora u tekst",
   "settings.experimental.speechToTextModel.description":
     "Odaberite Kilo Gateway model za transkripciju za glasovni unos.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1263,7 +1263,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Omogućite glasovni unos u poljima za promptove koristeći vaš Kilo račun preko Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Omogućite Kilo provajder i prijavite se da koristite Speech to Text. Speech to Text je trenutno podržan samo uz Kilo.",
+    "Omogućite i prijavite se na Kilo provajder da biste koristili Speech to Text. Speech to Text je trenutno podržan samo uz Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Model govora u tekst",
   "settings.experimental.speechToTextModel.description":
     "Odaberite Kilo Gateway model za transkripciju za glasovni unos.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1256,7 +1256,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktivér stemmeinput i prompt-felter ved hjælp af din Kilo-konto gennem Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktivér og log ind på Kilo provider for at bruge stemmeinput i prompt-felter.",
+    "Aktivér Kilo-udbyderen, og log ind for at bruge Speech to Text. Speech to Text understøttes i øjeblikket kun med Kilo.",
   "settings.experimental.speechToTextModel.title": "Model til tale til tekst",
   "settings.experimental.speechToTextModel.description": "Vælg Kilo Gateway-transskriptionsmodellen til stemmeinput.",
   "settings.experimental.continueOnDeny.title": "Fortsæt ved afvisning",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1256,7 +1256,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktivér stemmeinput i prompt-felter ved hjælp af din Kilo-konto gennem Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktivér Kilo-udbyderen, og log ind for at bruge Speech to Text. Speech to Text understøttes i øjeblikket kun med Kilo.",
+    "Aktivér og log ind på Kilo-udbyderen for at bruge Speech to Text. Speech to Text understøttes i øjeblikket kun med Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Model til tale til tekst",
   "settings.experimental.speechToTextModel.description": "Vælg Kilo Gateway-transskriptionsmodellen til stemmeinput.",
   "settings.experimental.continueOnDeny.title": "Fortsæt ved afvisning",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1278,7 +1278,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktivieren Sie die Spracheingabe in Prompt-Feldern mit Ihrem Kilo-Konto über Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktivieren Sie Kilo provider und melden Sie sich an, um die Spracheingabe in Prompt-Feldern zu verwenden.",
+    "Aktivieren Sie den Kilo-Anbieter und melden Sie sich an, um Speech to Text zu verwenden. Speech to Text wird derzeit nur mit Kilo unterstützt.",
   "settings.experimental.speechToTextModel.title": "Sprache-zu-Text-Modell",
   "settings.experimental.speechToTextModel.description":
     "Wählen Sie das Kilo Gateway-Transkriptionsmodell für die Spracheingabe.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1278,7 +1278,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktivieren Sie die Spracheingabe in Prompt-Feldern mit Ihrem Kilo-Konto über Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktivieren Sie den Kilo-Anbieter und melden Sie sich an, um Speech to Text zu verwenden. Speech to Text wird derzeit nur mit Kilo unterstützt.",
+    "Aktivieren Sie den Kilo-Anbieter und melden Sie sich an, um Speech to Text zu verwenden. Speech to Text wird derzeit nur mit Kilo Gateway unterstützt.",
   "settings.experimental.speechToTextModel.title": "Sprache-zu-Text-Modell",
   "settings.experimental.speechToTextModel.description":
     "Wählen Sie das Kilo Gateway-Transkriptionsmodell für die Spracheingabe.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1246,7 +1246,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Enable voice input in prompt fields using your Kilo account through Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Enable and sign in to the Kilo provider to use voice input in prompt fields.",
+    "Enable and sign in to the Kilo provider to use Speech to Text. Speech to Text is currently only supported with Kilo.",
   "settings.experimental.speechToTextModel.title": "Speech to Text Model",
   "settings.experimental.speechToTextModel.description": "Choose the Kilo Gateway transcription model for voice input.",
   "settings.experimental.continueOnDeny.title": "Continue on Deny",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1246,7 +1246,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Enable voice input in prompt fields using your Kilo account through Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Enable and sign in to the Kilo provider to use Speech to Text. Speech to Text is currently only supported with Kilo.",
+    "Enable and sign in to the Kilo provider to use Speech to Text. Speech to Text is currently only supported through Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Speech to Text Model",
   "settings.experimental.speechToTextModel.description": "Choose the Kilo Gateway transcription model for voice input.",
   "settings.experimental.continueOnDeny.title": "Continue on Deny",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1270,7 +1270,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Habilita la entrada de voz en los campos de prompt usando tu cuenta de Kilo a través de Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Habilita el proveedor Kilo e inicia sesión para usar Speech to Text. Actualmente, Speech to Text solo es compatible con Kilo.",
+    "Habilita e inicia sesión en el proveedor Kilo para usar Speech to Text. Actualmente, Speech to Text solo es compatible con Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Modelo de voz a texto",
   "settings.experimental.speechToTextModel.description":
     "Elige el modelo de transcripción de Kilo Gateway para la entrada de voz.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1270,7 +1270,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Habilita la entrada de voz en los campos de prompt usando tu cuenta de Kilo a través de Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Habilita e inicia sesión en Kilo provider para usar la entrada de voz en los campos de prompt.",
+    "Habilita el proveedor Kilo e inicia sesión para usar Speech to Text. Actualmente, Speech to Text solo es compatible con Kilo.",
   "settings.experimental.speechToTextModel.title": "Modelo de voz a texto",
   "settings.experimental.speechToTextModel.description":
     "Elige el modelo de transcripción de Kilo Gateway para la entrada de voz.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1282,7 +1282,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Activez la saisie vocale dans les champs de prompt en utilisant votre compte Kilo via Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Activez Kilo provider et connectez-vous pour utiliser la saisie vocale dans les champs de prompt.",
+    "Activez le fournisseur Kilo et connectez-vous pour utiliser Speech to Text. Speech to Text n'est actuellement pris en charge qu'avec Kilo.",
   "settings.experimental.speechToTextModel.title": "Modèle de transcription vocale",
   "settings.experimental.speechToTextModel.description":
     "Choisissez le modèle de transcription Kilo Gateway pour la saisie vocale.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1282,7 +1282,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Activez la saisie vocale dans les champs de prompt en utilisant votre compte Kilo via Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Activez le fournisseur Kilo et connectez-vous pour utiliser Speech to Text. Speech to Text n'est actuellement pris en charge qu'avec Kilo.",
+    "Activez et connectez-vous au fournisseur Kilo pour utiliser Speech to Text. Speech to Text n'est actuellement pris en charge qu'avec Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Modèle de transcription vocale",
   "settings.experimental.speechToTextModel.description":
     "Choisissez le modèle de transcription Kilo Gateway pour la saisie vocale.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1251,7 +1251,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway経由でKiloアカウントを使用して、プロンプトフィールドでの音声入力を有効にします。",
   "settings.experimental.speechToText.disabledDescription":
-    "プロンプトフィールドで音声入力を使用するには、Kilo providerを有効にしてサインインしてください。",
+    "Speech to Text を使用するには、Kilo プロバイダーを有効にしてサインインしてください。現在、Speech to Text は Kilo でのみサポートされています。",
   "settings.experimental.speechToTextModel.title": "音声認識モデル",
   "settings.experimental.speechToTextModel.description": "音声入力に使用するKilo Gateway文字起こしモデルを選択します。",
   "settings.experimental.continueOnDeny.title": "拒否時に続行",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1251,7 +1251,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway経由でKiloアカウントを使用して、プロンプトフィールドでの音声入力を有効にします。",
   "settings.experimental.speechToText.disabledDescription":
-    "Speech to Text を使用するには、Kilo プロバイダーを有効にしてサインインしてください。現在、Speech to Text は Kilo でのみサポートされています。",
+    "Speech to Text を使用するには、Kilo プロバイダーを有効にしてサインインしてください。現在、Speech to Text は Kilo Gateway でのみサポートされています。",
   "settings.experimental.speechToTextModel.title": "音声認識モデル",
   "settings.experimental.speechToTextModel.description": "音声入力に使用するKilo Gateway文字起こしモデルを選択します。",
   "settings.experimental.continueOnDeny.title": "拒否時に続行",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1245,7 +1245,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway를 통해 Kilo 계정을 사용하여 프롬프트 필드에서 음성 입력을 활성화합니다.",
   "settings.experimental.speechToText.disabledDescription":
-    "Speech to Text를 사용하려면 Kilo 제공자를 활성화하고 로그인하세요. 현재 Speech to Text는 Kilo에서만 지원됩니다.",
+    "Speech to Text를 사용하려면 Kilo 제공자를 활성화하고 로그인하세요. 현재 Speech to Text는 Kilo Gateway에서만 지원됩니다.",
   "settings.experimental.speechToTextModel.title": "음성 텍스트 변환 모델",
   "settings.experimental.speechToTextModel.description": "음성 입력에 사용할 Kilo Gateway 변환 모델을 선택하세요.",
   "settings.experimental.continueOnDeny.title": "거부 시 계속",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1245,7 +1245,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway를 통해 Kilo 계정을 사용하여 프롬프트 필드에서 음성 입력을 활성화합니다.",
   "settings.experimental.speechToText.disabledDescription":
-    "프롬프트 필드에서 음성 입력을 사용하려면 Kilo provider를 활성화하고 로그인하세요.",
+    "Speech to Text를 사용하려면 Kilo 제공자를 활성화하고 로그인하세요. 현재 Speech to Text는 Kilo에서만 지원됩니다.",
   "settings.experimental.speechToTextModel.title": "음성 텍스트 변환 모델",
   "settings.experimental.speechToTextModel.description": "음성 입력에 사용할 Kilo Gateway 변환 모델을 선택하세요.",
   "settings.experimental.continueOnDeny.title": "거부 시 계속",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1262,7 +1262,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Schakel spraakinvoer in promptvelden in met uw Kilo-account via Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Schakel Kilo provider in en meld u aan om spraakinvoer in promptvelden te gebruiken.",
+    "Schakel de Kilo-provider in en meld u aan om Speech to Text te gebruiken. Speech to Text wordt momenteel alleen ondersteund door Kilo.",
   "settings.experimental.speechToTextModel.title": "Spraak-naar-tekst-model",
   "settings.experimental.speechToTextModel.description": "Kies het Kilo Gateway-transcriptiemodel voor spraakinvoer.",
   "settings.experimental.continueOnDeny.title": "Doorgaan bij weigering",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1262,7 +1262,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Schakel spraakinvoer in promptvelden in met uw Kilo-account via Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Schakel de Kilo-provider in en meld u aan om Speech to Text te gebruiken. Speech to Text wordt momenteel alleen ondersteund door Kilo.",
+    "Schakel de Kilo-provider in en meld u aan om Speech to Text te gebruiken. Speech to Text wordt momenteel alleen ondersteund met Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Spraak-naar-tekst-model",
   "settings.experimental.speechToTextModel.description": "Kies het Kilo Gateway-transcriptiemodel voor spraakinvoer.",
   "settings.experimental.continueOnDeny.title": "Doorgaan bij weigering",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1222,7 +1222,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktiver taleinndata i prompt-felt ved å bruke din Kilo-konto gjennom Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktiver Kilo provider og logg på for å bruke taleinndata i prompt-felt.",
+    "Aktiver Kilo-leverandøren og logg inn for å bruke Speech to Text. Speech to Text støttes for øyeblikket kun med Kilo.",
   "settings.experimental.speechToTextModel.title": "Tale-til-tekst-modell",
   "settings.experimental.speechToTextModel.description": "Velg Kilo Gateway-transkripsjonsmodellen for taleinndata.",
   "settings.experimental.continueOnDeny.title": "Fortsett ved avvisning",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1222,7 +1222,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Aktiver taleinndata i prompt-felt ved å bruke din Kilo-konto gjennom Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Aktiver Kilo-leverandøren og logg inn for å bruke Speech to Text. Speech to Text støttes for øyeblikket kun med Kilo.",
+    "Aktiver og logg på Kilo-leverandøren for å bruke Speech to Text. Speech to Text støttes for øyeblikket bare med Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Tale-til-tekst-modell",
   "settings.experimental.speechToTextModel.description": "Velg Kilo Gateway-transkripsjonsmodellen for taleinndata.",
   "settings.experimental.continueOnDeny.title": "Fortsett ved avvisning",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1221,7 +1221,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Włącz wprowadzanie głosowe w polach promptów przy użyciu konta Kilo za pośrednictwem Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Włącz Kilo provider i zaloguj się, aby korzystać z wprowadzania głosowego w polach promptów.",
+    "Włącz dostawcę Kilo i zaloguj się, aby używać Speech to Text. Funkcja Speech to Text jest obecnie obsługiwana tylko przez Kilo.",
   "settings.experimental.speechToTextModel.title": "Model mowy na tekst",
   "settings.experimental.speechToTextModel.description":
     "Wybierz model transkrypcji Kilo Gateway dla wprowadzania głosowego.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1221,7 +1221,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Włącz wprowadzanie głosowe w polach promptów przy użyciu konta Kilo za pośrednictwem Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Włącz dostawcę Kilo i zaloguj się, aby używać Speech to Text. Funkcja Speech to Text jest obecnie obsługiwana tylko przez Kilo.",
+    "Włącz i zaloguj się do dostawcy Kilo, aby korzystać ze Speech to Text. Speech to Text jest obecnie obsługiwane tylko z Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Model mowy na tekst",
   "settings.experimental.speechToTextModel.description":
     "Wybierz model transkrypcji Kilo Gateway dla wprowadzania głosowego.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1259,7 +1259,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Включите голосовой ввод в полях запросов, используя вашу учетную запись Kilo через Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Включите Kilo provider и войдите в него, чтобы использовать голосовой ввод в полях запросов.",
+    "Включите провайдер Kilo и войдите в него, чтобы использовать Speech to Text. Сейчас Speech to Text поддерживается только в Kilo.",
   "settings.experimental.speechToTextModel.title": "Модель речи в текст",
   "settings.experimental.speechToTextModel.description":
     "Выберите модель транскрипции Kilo Gateway для голосового ввода.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1259,7 +1259,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Включите голосовой ввод в полях запросов, используя вашу учетную запись Kilo через Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Включите провайдер Kilo и войдите в него, чтобы использовать Speech to Text. Сейчас Speech to Text поддерживается только в Kilo.",
+    "Включите провайдер Kilo и выполните вход, чтобы использовать Speech to Text. В настоящее время Speech to Text поддерживается только с Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Модель речи в текст",
   "settings.experimental.speechToTextModel.description":
     "Выберите модель транскрипции Kilo Gateway для голосового ввода.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1242,7 +1242,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "เปิดใช้งานการป้อนข้อมูลด้วยเสียงในช่องพรอมต์โดยใช้บัญชี Kilo ของคุณผ่าน Kilo Gateway",
   "settings.experimental.speechToText.disabledDescription":
-    "เปิดใช้งานและลงชื่อเข้าใช้ผู้ให้บริการ Kilo เพื่อใช้ Speech to Text ขณะนี้ Speech to Text รองรับเฉพาะกับ Kilo เท่านั้น",
+    "เปิดใช้งานและลงชื่อเข้าใช้ผู้ให้บริการ Kilo เพื่อใช้ Speech to Text ปัจจุบัน Speech to Text รองรับเฉพาะกับ Kilo Gateway เท่านั้น",
   "settings.experimental.speechToTextModel.title": "โมเดลแปลงเสียงเป็นข้อความ",
   "settings.experimental.speechToTextModel.description":
     "เลือกโมเดลการถอดเสียง Kilo Gateway สำหรับการป้อนข้อมูลด้วยเสียง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1242,7 +1242,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "เปิดใช้งานการป้อนข้อมูลด้วยเสียงในช่องพรอมต์โดยใช้บัญชี Kilo ของคุณผ่าน Kilo Gateway",
   "settings.experimental.speechToText.disabledDescription":
-    "เปิดใช้งานและลงชื่อเข้าใช้ Kilo provider เพื่อใช้การป้อนข้อมูลด้วยเสียงในช่องพรอมต์",
+    "เปิดใช้งานและลงชื่อเข้าใช้ผู้ให้บริการ Kilo เพื่อใช้ Speech to Text ขณะนี้ Speech to Text รองรับเฉพาะกับ Kilo เท่านั้น",
   "settings.experimental.speechToTextModel.title": "โมเดลแปลงเสียงเป็นข้อความ",
   "settings.experimental.speechToTextModel.description":
     "เลือกโมเดลการถอดเสียง Kilo Gateway สำหรับการป้อนข้อมูลด้วยเสียง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1255,7 +1255,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway üzerinden Kilo hesabınızı kullanarak komut alanlarında sesli girişi etkinleştirin.",
   "settings.experimental.speechToText.disabledDescription":
-    "Komut alanlarında sesli girişi kullanmak için Kilo provider'ı etkinleştirin ve giriş yapın.",
+    "Speech to Text kullanmak için Kilo sağlayıcısını etkinleştirin ve giriş yapın. Speech to Text şu anda yalnızca Kilo ile desteklenmektedir.",
   "settings.experimental.speechToTextModel.title": "Sesten metne modeli",
   "settings.experimental.speechToTextModel.description": "Sesli giriş için Kilo Gateway transkripsiyon modelini seçin.",
   "settings.experimental.continueOnDeny.title": "Reddetme Durumunda Devam Et",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1255,7 +1255,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Kilo Gateway üzerinden Kilo hesabınızı kullanarak komut alanlarında sesli girişi etkinleştirin.",
   "settings.experimental.speechToText.disabledDescription":
-    "Speech to Text kullanmak için Kilo sağlayıcısını etkinleştirin ve giriş yapın. Speech to Text şu anda yalnızca Kilo ile desteklenmektedir.",
+    "Speech to Text kullanmak için Kilo sağlayıcısını etkinleştirin ve giriş yapın. Speech to Text şu anda yalnızca Kilo Gateway ile desteklenmektedir.",
   "settings.experimental.speechToTextModel.title": "Sesten metne modeli",
   "settings.experimental.speechToTextModel.description": "Sesli giriş için Kilo Gateway transkripsiyon modelini seçin.",
   "settings.experimental.continueOnDeny.title": "Reddetme Durumunda Devam Et",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1255,7 +1255,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Увімкніть голосове введення в полях запитів, використовуючи ваш обліковий запис Kilo через Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Увімкніть провайдер Kilo й увійдіть, щоб використовувати Speech to Text. Наразі Speech to Text підтримується лише в Kilo.",
+    "Увімкніть провайдер Kilo та виконайте вхід, щоб використовувати Speech to Text. Наразі Speech to Text підтримується лише з Kilo Gateway.",
   "settings.experimental.speechToTextModel.title": "Модель мовлення в текст",
   "settings.experimental.speechToTextModel.description":
     "Виберіть модель транскрипції Kilo Gateway для голосового введення.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1255,7 +1255,7 @@ export const dict = {
   "settings.experimental.speechToText.description":
     "Увімкніть голосове введення в полях запитів, використовуючи ваш обліковий запис Kilo через Kilo Gateway.",
   "settings.experimental.speechToText.disabledDescription":
-    "Увімкніть Kilo provider і увійдіть, щоб використовувати голосове введення в полях запитів.",
+    "Увімкніть провайдер Kilo й увійдіть, щоб використовувати Speech to Text. Наразі Speech to Text підтримується лише в Kilo.",
   "settings.experimental.speechToTextModel.title": "Модель мовлення в текст",
   "settings.experimental.speechToTextModel.description":
     "Виберіть модель транскрипції Kilo Gateway для голосового введення.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1222,7 +1222,8 @@ export const dict = {
   "settings.experimental.agentManagerTool.description": "允许智能体通过工具调用启动 Agent Manager 本地会话和工作树会话",
   "settings.experimental.speechToText.title": "语音转文本",
   "settings.experimental.speechToText.description": "通过 Kilo Gateway 使用您的 Kilo 帐户在提示词字段中启用语音输入。",
-  "settings.experimental.speechToText.disabledDescription": "启用并登录 Kilo provider 以在提示词字段中使用语音输入。",
+  "settings.experimental.speechToText.disabledDescription":
+    "启用并登录 Kilo 提供商以使用 Speech to Text。目前 Speech to Text 仅支持使用 Kilo。",
   "settings.experimental.speechToTextModel.title": "语音转文本模型",
   "settings.experimental.speechToTextModel.description": "选择用于语音输入的 Kilo Gateway 转录模型。",
   "settings.experimental.continueOnDeny.title": "拒绝后继续",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1223,7 +1223,7 @@ export const dict = {
   "settings.experimental.speechToText.title": "语音转文本",
   "settings.experimental.speechToText.description": "通过 Kilo Gateway 使用您的 Kilo 帐户在提示词字段中启用语音输入。",
   "settings.experimental.speechToText.disabledDescription":
-    "启用并登录 Kilo 提供商以使用 Speech to Text。目前 Speech to Text 仅支持使用 Kilo。",
+    "启用并登录 Kilo 提供商以使用 Speech to Text。Speech to Text 目前仅支持通过 Kilo Gateway 使用。",
   "settings.experimental.speechToTextModel.title": "语音转文本模型",
   "settings.experimental.speechToTextModel.description": "选择用于语音输入的 Kilo Gateway 转录模型。",
   "settings.experimental.continueOnDeny.title": "拒绝后继续",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1192,7 +1192,7 @@ export const dict = {
   "settings.experimental.speechToText.title": "語音轉文字",
   "settings.experimental.speechToText.description": "透過 Kilo Gateway 使用您的 Kilo 帳戶在提示詞欄位中啟用語音輸入。",
   "settings.experimental.speechToText.disabledDescription":
-    "啟用並登入 Kilo 提供者以使用 Speech to Text。目前 Speech to Text 僅支援使用 Kilo。",
+    "啟用並登入 Kilo 供應商以使用 Speech to Text。Speech to Text 目前僅支援透過 Kilo Gateway 使用。",
   "settings.experimental.speechToTextModel.title": "語音轉文字模型",
   "settings.experimental.speechToTextModel.description": "選擇用於語音輸入的 Kilo Gateway 轉錄模型。",
   "settings.experimental.continueOnDeny.title": "拒絕後繼續",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1191,7 +1191,8 @@ export const dict = {
     "允許 Agent 透過工具呼叫啟動 Agent Manager 本機工作階段和工作樹工作階段",
   "settings.experimental.speechToText.title": "語音轉文字",
   "settings.experimental.speechToText.description": "透過 Kilo Gateway 使用您的 Kilo 帳戶在提示詞欄位中啟用語音輸入。",
-  "settings.experimental.speechToText.disabledDescription": "啟用並登入 Kilo provider 以在提示詞欄位中使用語音輸入。",
+  "settings.experimental.speechToText.disabledDescription":
+    "啟用並登入 Kilo 提供者以使用 Speech to Text。目前 Speech to Text 僅支援使用 Kilo。",
   "settings.experimental.speechToTextModel.title": "語音轉文字模型",
   "settings.experimental.speechToTextModel.description": "選擇用於語音輸入的 Kilo Gateway 轉錄模型。",
   "settings.experimental.continueOnDeny.title": "拒絕後繼續",


### PR DESCRIPTION
Speech to Text can be disabled in Experimental settings without making clear that voice input depends on a signed-in Kilo account through Kilo Gateway, especially for users who already have another provider configured.

Show an actionable disabled-state tooltip explaining that the Kilo provider must be enabled and signed in because Speech to Text is currently supported only through Kilo Gateway.