### PR TITLE
docs: add details about contributor ownership and mass creation of PRs/Issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -67,6 +67,7 @@ Docs-only, config-only, and similar changes still need concrete evidence. For ex
 - [ ] Tests/verification described
 - [ ] Screenshots/video included for visual changes, or marked N/A
 - [ ] Changeset considered for user-facing changes
+- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
 
 ## Get in Touch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,28 @@ Contributor guidance exists to protect maintainer review time and keep reviews f
 - **UI Changes:** Include screenshots or videos (before/after).
 - **Logic Changes:** Explain how you verified it works.
 
+### Contribution Ownership and AI Assistance
+
+AI and coding agents are allowed, but contributors own the work they submit. Before requesting review, make sure you personally understand the change, have tested it appropriately, can explain the diff, and understand how it interacts with the affected packages and the rest of the repo.
+
+If you use an agent, start it from the repo root so the root `AGENTS.md` is available. When your change touches a package with its own guidance, read and follow that package's `AGENTS.md` or contributor docs too.
+
+Maintainers may close PRs that appear to be submitted without credible contributor ownership or understanding, including AI-assisted work that the contributor cannot explain or has not meaningfully reviewed.
+
+### Tracker Use and Automation
+
+Do not submit batches of agent-generated, untested, or weakly reviewed PRs.
+
+Please keep concurrent PRs focused and limited. As a rule, open no more than three PRs at a time, especially if you are a new contributor. Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
+
+For issues, do not mass-create tickets through automation or agents. Search existing issues first, open issues only when you have enough context for someone to act, and prioritize the most important reports instead of filing every possible finding. Maintainers may close duplicate, low-signal, automated, or weakly reviewed issues without action.
+
+Repeated disregard of this contribution guide, or high-volume automated or agent-generated tracker spam across issues or PRs, may result in maintainers blocking the responsible account.
+
+### Bug Bounties
+
+Kilo has bug bounties. To be eligible, make sure your GitHub account is connected in your Kilo account.
+
 ### Testing Evidence
 
 Every PR marked ready for review must include testing evidence. A bare `Not tested` or `N/A` answer is not sufficient.
@@ -285,6 +307,7 @@ Maintainers may close or decline review of PRs presented as review-ready at thei
 - Linked issue context
 - A clear what/why explanation
 - Credible testing evidence
+- Credible contributor ownership of AI-assisted work
 - Relevant UI proof for visual UI changes
 
 When a PR is close to this bar, addresses important work, or would benefit from further shaping, maintainers may ask for specific fixes instead of closing or declining review. Contributors may reopen or resubmit once the PR meets the documented bar.
@@ -303,6 +326,8 @@ Use conventional commit style PR titles such as:
 ## Issue and PR Lifecycle
 
 To keep our backlog manageable, we automatically close inactive issues and PRs after a period of inactivity. This isn't a judgment on quality — older items tend to lose context over time and we'd rather start fresh if they're still relevant. Feel free to reopen or create a new issue/PR if you're still working on something!
+
+Maintainers may also close issues or PRs that disregard the contribution guide, bypass required context, or lack credible contributor ownership of AI-assisted work.
 
 ## Style Preferences
 

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -53,6 +53,14 @@ While not strictly necessary for running the extension, these extensions are rec
 
 The full list of recommended extensions is in `.vscode/extensions.json`
 
+### Using AI and Coding Agents
+
+AI and coding agents are allowed in this repo. If you use one, start it from the repository root so the root `AGENTS.md` is available, then check package-specific guidance when your change touches a package with its own `AGENTS.md` or contributor docs.
+
+You remain responsible for the submitted work. Before opening a PR, personally review the diff, test the change, make sure you can explain it, and understand how it interacts with the affected package and the rest of the repo. Do not use agents to submit batches of agent-generated, untested, or weakly reviewed PRs. Keep concurrent PRs limited, generally no more than three at a time, and prioritize high-impact issues first. Do not use automation or agents to mass-create issues without human review and prioritization.
+
+Kilo has bug bounties. To be eligible, make sure your GitHub account is connected in your Kilo account.
+
 ### Project Structure
 
 The project is organized into several key packages:

--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -52,6 +52,14 @@ git checkout -b docs/your-change-description
 - Include appropriate tests for new features
 - Update documentation for any user-facing changes
 
+### Contribution Ownership and AI Assistance
+
+AI and coding agents are welcome in Kilo contributions. Contributors still own the work they submit: you must personally understand the change, test it appropriately, be able to explain the diff, and understand how it interacts with the affected package and the rest of the repo.
+
+When using an agent, start it from the repository root so the root `AGENTS.md` is available. If you work in a package with its own guidance, check and follow the package-specific `AGENTS.md` or contributor docs too.
+
+Maintainers may close PRs that appear to be submitted without credible contributor ownership or understanding, including AI-assisted work that has not been meaningfully reviewed by the contributor.
+
 ### Commit Guidelines
 
 - Write clear, concise commit messages
@@ -131,12 +139,27 @@ Follow the issue-first policy by linking the relevant issue when you open a PR. 
    - Manual/local verification performed
    - Any command blocker plus substitute verification
    - Screenshots or video for visual UI changes, showing the relevant before/after or resulting state
+   - Confirmation that you personally reviewed the diff and can explain the changes, including any AI-assisted work
 
 Keep the description focused on context reviewers cannot infer from the diff. Skip file-by-file summaries, placeholders, and other filler.
 
-Maintainers may close or decline review of PRs presented as review-ready at their discretion when they lack linked issue context, a clear what/why explanation, credible testing evidence, or relevant UI proof for visual UI changes.
+Maintainers may close or decline review of PRs presented as review-ready at their discretion when they lack linked issue context, a clear what/why explanation, credible testing evidence, credible contributor ownership of AI-assisted work, or relevant UI proof for visual UI changes.
 
 When a PR is close to this bar, addresses important work, or would benefit from further shaping, maintainers may ask for specific fixes instead of closing or declining review. Contributors may reopen or resubmit once the PR meets the documented bar.
+
+## Tracker Use and Automation
+
+Please keep the issue and PR trackers useful for maintainers and contributors. Do not submit batches of agent-generated, untested, or weakly reviewed PRs.
+
+Keep concurrent PRs focused and limited. As a rule, open no more than three PRs at a time, especially if you are a new contributor. Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
+
+For issues, do not mass-create tickets through automation or agents. Search existing issues first, open issues only when you have enough context for someone to act, and prioritize the most important reports instead of filing every possible finding. Maintainers may close duplicate, low-signal, automated, or weakly reviewed issues without action.
+
+Maintainers may close issues or PRs that disregard the contribution guide, bypass required context, or lack credible contributor ownership of AI-assisted work. Repeated disregard of this contribution guide, or high-volume automated or agent-generated tracker spam across issues or PRs, may result in maintainers blocking the responsible account.
+
+## Bug Bounties
+
+Kilo has bug bounties. To be eligible, make sure your GitHub account is connected in your Kilo account.
 
 ## Contributing to the Kilo Marketplace
 


### PR DESCRIPTION
## Context

Adding details about contribution ownership of AI assisted work and details about mass creation of PRs

## Implementation

- Added clause in checklist to as a reminder to review the code
- Added details that contributors should review their code
- Added details that contributors should not create several PRs or Issues at once
- Add details about minimum requirement for Bug Bounty
