### PR TITLE
fix(vscode): restore readable Pierre diff highlights

### DIFF
--- a/.changeset/readable-diff-highlights.md
+++ b/.changeset/readable-diff-highlights.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+---
+
+Restore readable diff add and remove highlights in VS Code across dark and light themes.

--- a/packages/kilo-ui/src/styles/vscode-bridge.css
+++ b/packages/kilo-ui/src/styles/vscode-bridge.css
@@ -283,45 +283,16 @@ html[data-theme="kilo-vscode"] {
   --diffs-light-bg: var(--background-stronger);
   --diffs-dark-bg: var(--background-stronger);
 
-  --diffs-bg-addition-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 82%,
-    var(--syntax-diff-add, #318430)
-  );
-  --diffs-bg-addition-number-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 72%,
-    var(--syntax-diff-add, #318430)
-  );
+  /* Pierre 1.1 mixes line and gutter tints from the diff color.
+     Only word emphasis uses a final background override. */
   --diffs-bg-addition-emphasis-override: color-mix(
     in lab,
-    var(--vscode-editor-background, #1e1e1e) 60%,
+    var(--background-stronger) 60%,
     var(--syntax-diff-add, #318430)
-  );
-  --diffs-bg-addition-hover-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 72%,
-    var(--syntax-diff-add, #318430)
-  );
-
-  --diffs-bg-deletion-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 82%,
-    var(--syntax-diff-delete, #da3319)
-  );
-  --diffs-bg-deletion-number-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 72%,
-    var(--syntax-diff-delete, #da3319)
   );
   --diffs-bg-deletion-emphasis-override: color-mix(
     in lab,
-    var(--vscode-editor-background, #1e1e1e) 60%,
-    var(--syntax-diff-delete, #da3319)
-  );
-  --diffs-bg-deletion-hover-override: color-mix(
-    in lab,
-    var(--vscode-editor-background, #1e1e1e) 72%,
+    var(--background-stronger) 60%,
     var(--syntax-diff-delete, #da3319)
   );
 


### PR DESCRIPTION
Pierre 1.1 changed how add and remove colors are composed in VS Code diffs, causing changed lines to blend into the surrounding editor background, especially in dark themes.

Restore readable, theme-aware highlights by leaving line tint computation to Pierre while retaining Kilo's VS Code background integration and word-level emphasis.

Before:

<img width="731" height="468" alt="image" src="https://github.com/user-attachments/assets/c7e38f4c-58cf-4dc3-b4a7-b1a9bf5ee262" />

After:

<img width="598" height="651" alt="image" src="https://github.com/user-attachments/assets/589ae664-151f-439d-9896-ca4c0107a567" />
