### PR TITLE
feat(vscode): enable voice input for signed-in Kilo users

### DIFF
--- a/.changeset/bright-voices-appear.md
+++ b/.changeset/bright-voices-appear.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show voice transcription automatically when you are signed in with the Kilo provider.

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,7 +34,7 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Bun dependencies
-      uses: actions/cache@v5 # kilocode_change
+      uses: actions/cache@v4
       with:
         path: ${{ steps.cache.outputs.dir }}
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,7 +34,7 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Cache Bun dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5 # kilocode_change
       with:
         path: ${{ steps.cache.outputs.dir }}
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}

--- a/packages/kilo-docs/pages/code-with-ai/features/speech-to-text.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/speech-to-text.md
@@ -5,11 +5,7 @@ description: Dictate prompts through your signed-in Kilo account.
 
 # Voice Transcription
 
-{% callout type="warning" title="Experimental feature" %}
-Speech to Text is experimental. Expect issues and changes as it matures.
-{% /callout %}
-
-Use voice input in prompt fields instead of typing. Transcription uses your Kilo account through Kilo Gateway.
+Use voice input in prompt fields instead of typing. When the Kilo provider is enabled and you are signed in, the microphone appears automatically and transcription uses your account through Kilo Gateway.
 
 ---
 
@@ -43,29 +39,15 @@ Enable and sign in to the Kilo provider to use voice input in prompt fields. Req
 
 ---
 
-## Enable input
+## Choose a model
 
-Voice input is experimental and must be enabled:
-
-1. Open Kilo Code settings
-2. Open **Experimental** settings
-3. Enable the **Speech to Text** experiment
-
-Kilo stores this toggle in your global Kilo CLI config (`~/.config/kilo/kilo.jsonc`), not VS Code user settings:
-
-```json
-{
-  "experimental": {
-    "speech_to_text": true
-  }
-}
-```
+You can optionally choose a transcription model in **Settings** > **Experimental** > **Speech to Text Model**. Kilo stores this choice as `experimental.speech_to_text_model` in your global Kilo CLI config (`~/.config/kilo/kilo.jsonc`).
 
 ---
 
 ## Record prompts
 
-Once enabled, a microphone button appears in prompt fields:
+When you are signed in to the enabled Kilo provider, a microphone button appears in prompt fields:
 
 1. Click the microphone button to start recording
 2. Speak your message clearly
@@ -87,13 +69,12 @@ The feature includes real-time audio level visualization and voice activity dete
 
 **Microphone button not appearing:**
 
-- Ensure the Speech to Text experiment is enabled
-- Verify FFmpeg is installed and in your PATH
 - Enable and sign in to the Kilo provider
 
 **Transcription errors:**
 
 - Confirm the Kilo provider remains enabled and signed in
+- Verify FFmpeg is installed and in your PATH
 - Check your internet connection
 - Try speaking more clearly or adjusting your microphone settings
 
@@ -101,7 +82,7 @@ The feature includes real-time audio level visualization and voice activity dete
 
 ## Know limits
 
-Speech to Text is experimental and may have limitations:
+Voice transcription has these requirements:
 
 - Requires an active internet connection
 - Requires Kilo Gateway access through your Kilo account

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -193,22 +193,22 @@ Use this option only if you are certain you want to remove all Kilo Code data or
 
 The new extension exposes experimental features via the **Experimental** tab in Settings (click the gear icon {% codicon name="gear" /%} → Experimental).
 
-Available experimental toggles include:
+Available experimental settings include:
 
-- **Share mode** — `manual`, `auto`, or `disabled` session sharing
-- **LSP integration** — expose language server diagnostics to the agent
-- **Paste summary** — summarize large clipboard pastes before including them
-- **Speech to Text**: enable voice transcription in chat
-- **Batch tool** — allow the agent to batch multiple tool calls in one step
+- **Share mode** - `manual`, `auto`, or `disabled` session sharing
+- **LSP integration** - expose language server diagnostics to the agent
+- **Paste summary** - summarize large clipboard pastes before including them
+- **Speech to Text Model** - optionally select the transcription model
+- **Batch tool** - allow the agent to batch multiple tool calls in one step
 - **Agent Manager Tool** - allow agents to start Agent Manager local and worktree sessions from chat
-- **OpenTelemetry** — enable Kilo telemetry and optional OTLP export when configured
+- **OpenTelemetry** - enable Kilo telemetry and optional OTLP export when configured
 
-Speech to Text is enabled from this Experimental tab. Kilo stores that toggle in your global Kilo CLI config (`~/.config/kilo/kilo.jsonc`), not VS Code user settings:
+Voice input appears automatically when the Kilo provider is enabled and you are signed in. Choosing **Speech to Text Model** stores `experimental.speech_to_text_model` in your global Kilo CLI config (`~/.config/kilo/kilo.jsonc`):
 
 ```json
 {
   "experimental": {
-    "speech_to_text": true
+    "speech_to_text_model": "openai/gpt-4o-mini-transcribe"
   }
 }
 ```

--- a/packages/kilo-vscode/tests/unit/config-scope.test.ts
+++ b/packages/kilo-vscode/tests/unit/config-scope.test.ts
@@ -33,17 +33,15 @@ describe("splitConfigByScope", () => {
     expect(split.project).toEqual({})
   })
 
-  it("writes speech-to-text experimental settings to global config", () => {
+  it("writes the speech-to-text model setting to global config", () => {
     const split = splitConfigByScope({
       experimental: {
-        speech_to_text: true,
         speech_to_text_model: "openai/gpt-4o-mini-transcribe",
       },
     })
 
     expect(split.global).toEqual({
       experimental: {
-        speech_to_text: true,
         speech_to_text_model: "openai/gpt-4o-mini-transcribe",
       },
     })

--- a/packages/kilo-vscode/tests/unit/speech-to-text-availability.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-availability.test.ts
@@ -5,17 +5,18 @@ import {
 } from "../../webview-ui/src/components/speech-to-text/availability"
 import { DEFAULT_SPEECH_TO_TEXT_MODEL } from "../../src/speech-to-text/models"
 
-describe("speech-to-text config availability", () => {
+describe("speech-to-text availability", () => {
   const providers = ["kilo"]
   const profile = {}
 
-  it("enables speech input from resolved config when Kilo access exists", () => {
-    expect(canUseSpeechToText({ experimental: { speech_to_text: true } }, providers, profile)).toBe(true)
+  it("shows speech input by default when Kilo access exists", () => {
+    expect(canUseSpeechToText({}, providers, profile)).toBe(true)
   })
 
-  it("hides speech input when the config flag is false or unset", () => {
-    expect(canUseSpeechToText({ experimental: { speech_to_text: false } }, providers, profile)).toBe(false)
-    expect(canUseSpeechToText({}, providers, profile)).toBe(false)
+  it("hides speech input without a signed-in, enabled Kilo provider", () => {
+    expect(canUseSpeechToText({}, [], profile)).toBe(false)
+    expect(canUseSpeechToText({}, providers, null)).toBe(false)
+    expect(canUseSpeechToText({ disabled_providers: ["kilo"] }, providers, profile)).toBe(false)
   })
 
   it("normalizes configured and unknown transcription models", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -204,10 +204,10 @@ const ExperimentalTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
-          title={language.t("settings.experimental.speechToText.title")}
+          title={language.t("settings.experimental.speechToTextModel.title")}
           description={
             kiloReady()
-              ? language.t("settings.experimental.speechToText.description")
+              ? language.t("settings.experimental.speechToTextModel.description")
               : language.t("settings.experimental.speechToText.disabledDescription")
           }
         >
@@ -216,35 +216,21 @@ const ExperimentalTab: Component = () => {
             placement="top"
             inactive={kiloReady()}
           >
-            <Switch
-              checked={experimental().speech_to_text ?? false}
-              onChange={(checked) => updateExperimental("speech_to_text", checked)}
+            <Select
+              options={SPEECH_TO_TEXT_MODEL_OPTIONS}
+              current={SPEECH_TO_TEXT_MODEL_OPTIONS.find((item) => item.value === speechModel())}
+              value={(item) => item.value}
+              label={(item) => `${item.label} (${item.provider})`}
+              onSelect={(item) =>
+                updateExperimental("speech_to_text_model", item?.value ?? DEFAULT_SPEECH_TO_TEXT_MODEL.id)
+              }
+              variant="secondary"
+              size="small"
+              triggerVariant="settings"
               disabled={!kiloReady()}
-              hideLabel
-            >
-              {language.t("settings.experimental.speechToText.title")}
-            </Switch>
+              placeholder={DEFAULT_SPEECH_TO_TEXT_MODEL.label}
+            />
           </Tooltip>
-        </SettingsRow>
-
-        <SettingsRow
-          title={language.t("settings.experimental.speechToTextModel.title")}
-          description={language.t("settings.experimental.speechToTextModel.description")}
-        >
-          <Select
-            options={SPEECH_TO_TEXT_MODEL_OPTIONS}
-            current={SPEECH_TO_TEXT_MODEL_OPTIONS.find((item) => item.value === speechModel())}
-            value={(item) => item.value}
-            label={(item) => `${item.label} (${item.provider})`}
-            onSelect={(item) =>
-              updateExperimental("speech_to_text_model", item?.value ?? DEFAULT_SPEECH_TO_TEXT_MODEL.id)
-            }
-            variant="secondary"
-            size="small"
-            triggerVariant="settings"
-            disabled={!kiloReady()}
-            placeholder={DEFAULT_SPEECH_TO_TEXT_MODEL.label}
-          />
         </SettingsRow>
 
         <SettingsRow

--- a/packages/kilo-vscode/webview-ui/src/components/speech-to-text/availability.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/speech-to-text/availability.ts
@@ -4,7 +4,6 @@ import { getSpeechToTextModel } from "../../../../src/speech-to-text/models"
 type Cfg = {
   disabled_providers?: string[]
   experimental?: {
-    speech_to_text?: boolean
     speech_to_text_model?: string
   }
 }
@@ -14,7 +13,7 @@ export function hasSpeechToTextAccess(cfg: Cfg, providers: readonly string[], pr
 }
 
 export function canUseSpeechToText(cfg: Cfg, providers: readonly string[], profile: unknown | null): boolean {
-  return cfg.experimental?.speech_to_text === true && hasSpeechToTextAccess(cfg, providers, profile)
+  return hasSpeechToTextAccess(cfg, providers, profile)
 }
 
 export function selectedSpeechToTextModel(cfg: Cfg): string {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -282,7 +282,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "زر «حسّن الموجه» يطوّر موجهك بإضافة سياق أو توضيح أو إعادة صياغة. جرّب اكتب موجه هنا ثم اضغط الزر مرة ثانية وشوف النتيجة.",
 
-  "speechToText.tooltip.start": "بدء الإدخال الصوتي",
+  "speechToText.tooltip.start": "بدء الإدخال الصوتي باستخدام Kilo Gateway",
   "speechToText.tooltip.stop": "إيقاف التقاط الصوت",
   "speechToText.tooltip.transcribing": "جاري تحويل الصوت إلى نص... انقر للإلغاء.",
   "speechToText.tooltip.error": "فشل الإدخال الصوتي. انقر للمسح.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -286,7 +286,7 @@ export const dict = {
     "O botão 'Aprimorar prompt' ajuda a melhorar seu pedido fornecendo contexto adicional, esclarecimentos ou reformulações. Tente digitar um pedido aqui e clique no botão novamente para ver como funciona.",
   "prompt.action.indexing": "Configurações de indexação",
 
-  "speechToText.tooltip.start": "Iniciar entrada de voz",
+  "speechToText.tooltip.start": "Iniciar entrada de voz com o Kilo Gateway",
   "speechToText.tooltip.stop": "Parar captura",
   "speechToText.tooltip.transcribing": "Transcrevendo... Clique para cancelar.",
   "speechToText.tooltip.error": "Falha na entrada de voz. Clique para limpar.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -286,7 +286,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Dugme 'Poboljšaj prompt' pomaže poboljšati vaš zahtjev pružajući dodatni kontekst, pojašnjenje ili preformulaciju. Pokušajte upisati zahtjev ovdje i ponovo kliknite na dugme da vidite kako funkcioniše.",
 
-  "speechToText.tooltip.start": "Započni glasovni unos",
+  "speechToText.tooltip.start": "Započni glasovni unos sa Kilo Gateway",
   "speechToText.tooltip.stop": "Zaustavi hvatanje zvuka",
   "speechToText.tooltip.transcribing": "Prepisivanje... Kliknite da otkažete.",
   "speechToText.tooltip.error": "Glasovni unos nije uspio. Kliknite da očistite.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -285,7 +285,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Knappen 'Forbedr prompt' hjælper med at forbedre din forespørgsel ved at give ekstra kontekst, præcisering eller omformulering. Prøv at skrive en forespørgsel her og klik på knappen igen for at se hvordan det virker.",
 
-  "speechToText.tooltip.start": "Start stemmeinput",
+  "speechToText.tooltip.start": "Start stemmeinput med Kilo Gateway",
   "speechToText.tooltip.stop": "Stop lydoptagelse",
   "speechToText.tooltip.transcribing": "Transskriberer... Klik for at annullere.",
   "speechToText.tooltip.error": "Stemmeinput mislykkedes. Klik for at rydde.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -289,7 +289,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Die Schaltfläche 'Prompt verbessern' hilft, deine Anfrage durch zusätzlichen Kontext, Klarstellungen oder Umformulierungen zu verbessern. Versuche, hier eine Anfrage einzugeben und klicke erneut auf die Schaltfläche, um zu sehen, wie es funktioniert.",
 
-  "speechToText.tooltip.start": "Spracheingabe starten",
+  "speechToText.tooltip.start": "Spracheingabe mit Kilo Gateway starten",
   "speechToText.tooltip.stop": "Audioerfassung beenden",
   "speechToText.tooltip.transcribing": "Transkribieren... Zum Abbrechen klicken.",
   "speechToText.tooltip.error": "Spracheingabe fehlgeschlagen. Zum Löschen klicken.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -284,7 +284,7 @@ export const dict = {
   "prompt.action.resetModel": "Reset model to default",
   "prompt.action.enhanceDescription":
     "The 'Enhance Prompt' button helps improve your prompt by providing additional context, clarification, or rephrasing. Try typing a prompt in here and clicking the button again to see how it works.",
-  "speechToText.tooltip.start": "Start voice input",
+  "speechToText.tooltip.start": "Start voice input with Kilo Gateway",
   "speechToText.tooltip.stop": "Stop capturing",
   "speechToText.tooltip.transcribing": "Transcribing... Click to cancel.",
   "speechToText.tooltip.error": "Speech input failed. Click to clear.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -287,7 +287,7 @@ export const dict = {
     "El botón 'Mejorar el mensaje' ayuda a mejorar tu petición proporcionando contexto adicional, aclaraciones o reformulaciones. Intenta escribir una petición aquí y haz clic en el botón nuevamente para ver cómo funciona.",
   "prompt.action.indexing": "Configuración de indexación",
 
-  "speechToText.tooltip.start": "Iniciar entrada de voz",
+  "speechToText.tooltip.start": "Iniciar entrada de voz con Kilo Gateway",
   "speechToText.tooltip.stop": "Detener captura",
   "speechToText.tooltip.transcribing": "Transcribiendo... Haz clic para cancelar.",
   "speechToText.tooltip.error": "Falló la entrada de voz. Haz clic para borrar.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -288,7 +288,7 @@ export const dict = {
     "Le bouton 'Améliorer la requête' aide à améliorer votre demande en fournissant un contexte supplémentaire, des clarifications ou des reformulations. Essayez de taper une demande ici et cliquez à nouveau sur le bouton pour voir comment cela fonctionne.",
   "prompt.action.indexing": "Paramètres d'indexation",
 
-  "speechToText.tooltip.start": "Démarrer la saisie vocale",
+  "speechToText.tooltip.start": "Démarrer la saisie vocale avec Kilo Gateway",
   "speechToText.tooltip.stop": "Arrêter la capture audio",
   "speechToText.tooltip.transcribing": "Transcription en cours... Cliquez pour annuler.",
   "speechToText.tooltip.error": "La saisie vocale a échoué. Cliquez pour effacer.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -283,7 +283,7 @@ export const dict = {
     "「プロンプトを強化」ボタンは、追加コンテキスト、説明、または言い換えを提供することで、リクエストを改善します。ここにリクエストを入力し、ボタンを再度クリックして動作を確認してください。",
   "prompt.action.indexing": "インデックス設定",
 
-  "speechToText.tooltip.start": "音声入力を開始",
+  "speechToText.tooltip.start": "Kilo Gatewayで音声入力を開始",
   "speechToText.tooltip.stop": "音声キャプチャを停止",
   "speechToText.tooltip.transcribing": "文字起こし中... クリックしてキャンセル。",
   "speechToText.tooltip.error": "音声入力に失敗しました。クリックしてクリア。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -285,7 +285,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "'프롬프트 향상' 버튼은 추가 컨텍스트, 명확화 또는 재구성을 제공하여 요청을 개선합니다. 여기에 요청을 입력한 다음 버튼을 다시 클릭하여 작동 방식을 확인해보세요.",
 
-  "speechToText.tooltip.start": "음성 입력 시작",
+  "speechToText.tooltip.start": "Kilo Gateway로 음성 입력 시작",
   "speechToText.tooltip.stop": "음성 캡처 중지",
   "speechToText.tooltip.transcribing": "변환 중... 취소하려면 클릭하세요.",
   "speechToText.tooltip.error": "음성 입력에 실패했습니다. 지우려면 클릭하세요.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -287,7 +287,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "De knop 'Prompt verbeteren' helpt je prompt te verbeteren door extra context, verduidelijking of herformulering te bieden. Typ hier een prompt en klik nogmaals op de knop om te zien hoe het werkt.",
 
-  "speechToText.tooltip.start": "Spraakinvoer starten",
+  "speechToText.tooltip.start": "Spraakinvoer starten met Kilo Gateway",
   "speechToText.tooltip.stop": "Audio vastleggen stoppen",
   "speechToText.tooltip.transcribing": "Transcriberen... Klik om te annuleren.",
   "speechToText.tooltip.error": "Spraakinvoer mislukt. Klik om te wissen.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -289,7 +289,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Knappen 'Forbedre prompt' hjelper med å forbedre forespørselen din ved å gi ekstra kontekst, avklaring eller omformulering. Prøv å skrive en forespørsel her og klikk på knappen igjen for å se hvordan det fungerer.",
 
-  "speechToText.tooltip.start": "Start taleinndata",
+  "speechToText.tooltip.start": "Start taleinndata med Kilo Gateway",
   "speechToText.tooltip.stop": "Stopp lydfangst",
   "speechToText.tooltip.transcribing": "Transkriberer... Klikk for å avbryte.",
   "speechToText.tooltip.error": "Taleinndata mislyktes. Klikk for å tømme.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -286,7 +286,7 @@ export const dict = {
     "Przycisk 'Ulepsz podpowiedź' pomaga ulepszyć Twoją prośbę, dostarczając dodatkowy kontekst, wyjaśnienia lub przeformułowania. Spróbuj wpisać prośbę tutaj i kliknij przycisk ponownie, aby zobaczyć, jak to działa.",
   "prompt.action.indexing": "Ustawienia indeksowania",
 
-  "speechToText.tooltip.start": "Rozpocznij wprowadzanie głosowe",
+  "speechToText.tooltip.start": "Rozpocznij wprowadzanie głosowe z Kilo Gateway",
   "speechToText.tooltip.stop": "Zatrzymaj przechwytywanie dźwięku",
   "speechToText.tooltip.transcribing": "Transkrybowanie... Kliknij, aby anulować.",
   "speechToText.tooltip.error": "Wprowadzanie głosowe nie powiodło się. Kliknij, aby wyczyścić.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -284,7 +284,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Кнопка 'Улучшить запрос' помогает сделать ваш запрос лучше, предоставляя дополнительный контекст, уточнения или переформулировку. Попробуйте ввести запрос и снова нажать кнопку, чтобы увидеть, как это работает.",
 
-  "speechToText.tooltip.start": "Начать голосовой ввод",
+  "speechToText.tooltip.start": "Начать голосовой ввод с Kilo Gateway",
   "speechToText.tooltip.stop": "Остановить захват звука",
   "speechToText.tooltip.transcribing": "Распознавание... Нажмите для отмены.",
   "speechToText.tooltip.error": "Ошибка голосового ввода. Нажмите, чтобы очистить.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -284,7 +284,7 @@ export const dict = {
     "ปุ่ม 'ปรับปรุงพรอมต์' ช่วยปรับปรุงพรอมต์ของคุณโดยให้บริบทเพิ่มเติม ชี้แจง หรือเขียนใหม่ ลองพิมพ์พรอมต์ที่นี่และคลิกปุ่มอีกครั้งเพื่อดูว่ามันทำงานอย่างไร",
   "prompt.action.indexing": "การตั้งค่าการสร้างดัชนี",
 
-  "speechToText.tooltip.start": "เริ่มการป้อนข้อมูลด้วยเสียง",
+  "speechToText.tooltip.start": "เริ่มการป้อนข้อมูลด้วยเสียงด้วย Kilo Gateway",
   "speechToText.tooltip.stop": "หยุดจับเสียง",
   "speechToText.tooltip.transcribing": "กำลังถอดเสียง... คลิกเพื่อยกเลิก",
   "speechToText.tooltip.error": "การป้อนข้อมูลด้วยเสียงล้มเหลว คลิกเพื่อล้าง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -284,7 +284,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "'Komutu Geliştir' düğmesi, ek bağlam, açıklama veya yeniden ifadelendirme sağlayarak komutunuzu iyileştirmeye yardımcı olur. Buraya bir komut yazıp düğmeye tekrar tıklayarak nasıl çalıştığını görebilirsiniz.",
 
-  "speechToText.tooltip.start": "Sesli girişi başlat",
+  "speechToText.tooltip.start": "Kilo Gateway ile sesli girişi başlatın",
   "speechToText.tooltip.stop": "Ses yakalamayı durdur",
   "speechToText.tooltip.transcribing": "Metne dönüştürülüyor... İptal etmek için tıklayın.",
   "speechToText.tooltip.error": "Sesli giriş başarısız oldu. Temizlemek için tıklayın.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -286,7 +286,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "Кнопка 'Покращити запит' допомагає вдосконалити ваш запит, надаючи додатковий контекст, уточнення або перефразування. Введіть запит тут і натисніть кнопку ще раз, щоб побачити, як це працює.",
 
-  "speechToText.tooltip.start": "Почати голосове введення",
+  "speechToText.tooltip.start": "Почати голосове введення з Kilo Gateway",
   "speechToText.tooltip.stop": "Зупинити захоплення звуку",
   "speechToText.tooltip.transcribing": "Транскрибування... Натисніть, щоб скасувати.",
   "speechToText.tooltip.error": "Помилка голосового введення. Натисніть, щоб очистити.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -283,7 +283,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "'增强提示'按钮通过提供额外上下文、澄清或重新表述来帮助改进您的请求。尝试在此处输入请求，然后再次点击按钮查看其工作原理。",
 
-  "speechToText.tooltip.start": "开始语音输入",
+  "speechToText.tooltip.start": "使用 Kilo Gateway 开始语音输入",
   "speechToText.tooltip.stop": "停止捕获音频",
   "speechToText.tooltip.transcribing": "正在转录... 点击取消。",
   "speechToText.tooltip.error": "语音输入失败。点击清除。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -282,7 +282,7 @@ export const dict = {
   "prompt.action.enhanceDescription":
     "「強化提示詞」按鈕可透過提供額外內容、說明或改寫來協助改善提示詞。試著在這裡輸入提示詞，再點選一次按鈕以了解其運作方式。",
 
-  "speechToText.tooltip.start": "開始語音輸入",
+  "speechToText.tooltip.start": "使用 Kilo Gateway 開始語音輸入",
   "speechToText.tooltip.stop": "停止擷取音訊",
   "speechToText.tooltip.transcribing": "正在轉錄... 點擊取消。",
   "speechToText.tooltip.error": "語音輸入失敗。點擊清除。",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -43,7 +43,6 @@ export interface ExperimentalConfig {
   semantic_indexing?: boolean
   codebase_search?: boolean
   agent_manager_tool?: boolean
-  speech_to_text?: boolean
   speech_to_text_model?: string
   primary_tools?: string[]
   continue_loop_on_deny?: boolean

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -357,9 +357,6 @@ export const Info = Schema.Struct({
       agent_manager_tool: Schema.optional(Schema.Boolean).annotate({
         description: "Enable the VS Code Agent Manager orchestration tool",
       }),
-      speech_to_text: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable speech-to-text voice input in Kilo clients",
-      }),
       speech_to_text_model: Schema.optional(Schema.String).annotate({
         description: "Speech-to-text transcription model ID to use for voice input",
       }),

--- a/packages/opencode/test/kilocode/config/speech-to-text-config.test.ts
+++ b/packages/opencode/test/kilocode/config/speech-to-text-config.test.ts
@@ -1,26 +1,19 @@
 import { describe, expect, test } from "bun:test"
 import { Config } from "../../../src/config/config"
 
-describe("Config.Info experimental speech-to-text", () => {
-  test("parses speech-to-text enablement and model", () => {
+describe("Config.Info experimental speech-to-text model", () => {
+  test("parses the selected speech-to-text model", () => {
     const parsed = Config.Info.zod.parse({
       experimental: {
-        speech_to_text: true,
         speech_to_text_model: "openai/gpt-4o-mini-transcribe",
       },
     })
 
-    expect(parsed.experimental?.speech_to_text).toBe(true)
     expect(parsed.experimental?.speech_to_text_model).toBe("openai/gpt-4o-mini-transcribe")
   })
 
-  test("preserves explicit disabled speech-to-text", () => {
-    const parsed = Config.Info.zod.parse({ experimental: { speech_to_text: false } })
-    expect(parsed.experimental?.speech_to_text).toBe(false)
-  })
-
   test("keeps existing experimental defaults", () => {
-    const parsed = Config.Info.zod.parse({ experimental: { speech_to_text: true } })
+    const parsed = Config.Info.zod.parse({ experimental: { speech_to_text_model: "google/chirp-3" } })
     expect(parsed.experimental?.openTelemetry).toBe(true)
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1429,7 +1429,6 @@ export type Config = {
     codebase_search?: boolean
     semantic_indexing?: boolean
     agent_manager_tool?: boolean
-    speech_to_text?: boolean
     speech_to_text_model?: string
     openTelemetry?: boolean
     primary_tools?: Array<string>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16771,9 +16771,6 @@
               "agent_manager_tool": {
                 "type": "boolean"
               },
-              "speech_to_text": {
-                "type": "boolean"
-              },
               "speech_to_text_model": {
                 "type": "string"
               },


### PR DESCRIPTION
Show voice transcription automatically when the enabled Kilo provider is signed in, removing the extra experimental opt-in that hid an available input path.

Keep Kilo Gateway explicit in the microphone affordance and retain transcription model selection as an optional advanced setting.

<img width="307" height="113" alt="image" src="https://github.com/user-attachments/assets/c7c7b700-4850-4be7-9054-f1af5cc967ff" />
