### PR TITLE
ci: parallelize JetBrains checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,6 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
 
-      # kilocode_change start
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      # kilocode_change end
-
       - name: Configure git identity
         run: |
           git config --global user.email "kilo-maintainer[bot]@users.noreply.github.com"
@@ -81,15 +73,8 @@ jobs:
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-
             turbo-${{ runner.os }}-
 
-      # kilocode_change start
-      - name: Warm up Gradle wrapper
-        if: runner.os == 'Linux'
-        run: ./gradlew --version
-        working-directory: packages/kilo-jetbrains
-      # kilocode_change end
-
       - name: Run unit tests
-        run: bun turbo test:ci
+        run: bun turbo test:ci --filter='!@kilocode/kilo-jetbrains'
         env:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
@@ -113,14 +98,69 @@ jobs:
           retention-days: 7
           path: packages/*/.artifacts/unit/junit.xml
 
+  # kilocode_change start
+  jetbrains:
+    name: jetbrains
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run JetBrains unit tests
+        run: bun script/test-ci.ts
+        working-directory: packages/kilo-jetbrains
+
+      - name: Publish JetBrains unit reports
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: packages/kilo-jetbrains/.artifacts/unit/junit.xml
+          check_name: "unit results (jetbrains)"
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload JetBrains unit artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-jetbrains-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/kilo-jetbrains/.artifacts/unit/junit.xml
+  # kilocode_change end
+
   required:
     name: test (linux)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - unit
+      - jetbrains
     if: always()
     steps:
       - name: Verify upstream test jobs passed
         run: |
           echo "unit=${{ needs.unit.result }}"
+          echo "jetbrains=${{ needs.jetbrains.result }}"
           test "${{ needs.unit.result }}" = "success"
+          test "${{ needs.jetbrains.result }}" = "success"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  typecheck:
+  typecheck-js:
+    name: typecheck-js
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -18,12 +19,48 @@ jobs:
         uses: ./.github/actions/setup-bun
 
       # kilocode_change start
+      - name: Run TypeScript typecheck
+        run: bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'
+      # kilocode_change end
+
+  # kilocode_change start
+  typecheck-jetbrains:
+    name: typecheck-jetbrains
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "21"
-      # kilocode_change end
 
-      - name: Run typecheck
-        run: bun typecheck
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run JetBrains typecheck
+        run: ./gradlew typecheck
+        working-directory: packages/kilo-jetbrains
+
+  required:
+    name: typecheck
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - typecheck-js
+      - typecheck-jetbrains
+    if: always()
+    steps:
+      - name: Verify typecheck jobs passed
+        run: |
+          echo "typecheck-js=${{ needs.typecheck-js.result }}"
+          echo "typecheck-jetbrains=${{ needs.typecheck-jetbrains.result }}"
+          test "${{ needs.typecheck-js.result }}" = "success"
+          test "${{ needs.typecheck-jetbrains.result }}" = "success"
+  # kilocode_change end

--- a/packages/kilo-jetbrains/gradle.properties
+++ b/packages/kilo-jetbrains/gradle.properties
@@ -1,5 +1,6 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true
 org.gradle.caching=true
+org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 org.jetbrains.intellij.platform.useCacheRedirector=false

--- a/packages/kilo-jetbrains/gradle.properties
+++ b/packages/kilo-jetbrains/gradle.properties
@@ -1,6 +1,5 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m
 org.jetbrains.intellij.platform.useCacheRedirector=false

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -3,9 +3,11 @@
 /**
  * CI test runner for the JetBrains plugin.
  *
- * Runs ./gradlew test --continue --no-daemon so all modules run even when some fail,
+ * Runs ./gradlew test --continue --no-build-cache so all modules run even when some fail,
  * then collects per-module JUnit XML results into .artifacts/unit/junit.xml
  * so mikepenz/action-junit-report can find them at the standard path.
+ * The generated OpenAPI client can otherwise restore stale compile outputs
+ * when the spec changes without a clean build directory.
  *
  * Exits with Gradle's exit code on Linux/macOS so test failures fail the
  * repo-wide `bun turbo test:ci` run. On Windows, exits 0 regardless — IntelliJ
@@ -18,7 +20,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 
 
 const root = join(import.meta.dir, "..")
 const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew"
-const args = ["test", "--continue", "--no-daemon"]
+const args = ["test", "--continue", "--no-build-cache"]
 const cmd = process.platform === "win32" ? ["cmd.exe", "/c", gradlew, ...args] : [gradlew, ...args]
 const fallback = 45 * 60 * 1000
 const parsed = Number(process.env.KILO_JETBRAINS_TEST_TIMEOUT_MS ?? fallback)

--- a/turbo.json
+++ b/turbo.json
@@ -37,7 +37,6 @@
       "outputs": []
     },
     "@kilocode/kilo-jetbrains#test:ci": {
-      "dependsOn": ["@kilocode/kilo-jetbrains#typecheck"],
       "outputs": [".artifacts/unit/junit.xml"]
     },
     "@opencode-ai/ui#test": {


### PR DESCRIPTION
## Summary
- Split JetBrains typecheck and unit tests out of the monolithic Turbo CI jobs while preserving the required gate check names.
- Add Gradle setup for JetBrains CI and avoid stale generated OpenAPI build-cache outputs in the JetBrains test wrapper.
- Total net win across the compared required workflows: 1m 33s faster.

## CI Timing Impact

Compared against PR #9984 (`ci(jetbrains): include plugin build in typecheck`) using completed check durations from GitHub.

| Check / workflow | #9984 | This PR | Runtime change |
|---|---:|---:|---:|
| `test` workflow critical path | 17m 27s | 15m 42s | 1m 45s faster |
| `unit (linux)` | 12m 32s | 5m 00s | 7m 32s faster |
| `unit (windows)` | 16m 09s | 15m 15s | 54s faster |
| JetBrains unit tests | included in `unit (linux)` | 11m 32s (`jetbrains`) | split into parallel job |
| `typecheck` workflow critical path | 2m 59s | 3m 11s | 12s slower |
| JS typecheck | included in `typecheck` | 1m 16s (`typecheck-js`) | split into parallel job |
| JetBrains typecheck | included in `typecheck` | 2m 57s (`typecheck-jetbrains`) | split into parallel job |
| Required `test (linux)` gate | 4s | 8s | 4s slower |
| Required `typecheck` gate | 2m 59s monolithic | 4s aggregator | gate preserved |
| Total required workflow critical path | 20m 26s | 18m 53s | 1m 33s faster |

## JetBrains Build Cache

JetBrains unit tests run with `./gradlew test --continue --no-build-cache`. The generated OpenAPI Kotlin client is derived from the current CLI server spec during the Gradle build, and Gradle build-cache restores have previously reused stale generated compile outputs when that spec changed without a clean build directory. Disabling the build cache for this CI test wrapper keeps the test job correctness-first while still allowing dependency/cache setup from `gradle/actions/setup-gradle`; typecheck keeps its normal Gradle behavior.

## Validation
- bun run script/check-workflows.ts
- bun turbo typecheck --filter='!@kilocode/kilo-jetbrains' --dry=json
- bun turbo test:ci --filter='!@kilocode/kilo-jetbrains' --dry=json
- ./gradlew typecheck (packages/kilo-jetbrains)
- bun script/test-ci.ts (packages/kilo-jetbrains)
- pre-push hook: bun turbo typecheck
