### PR TITLE
docs(design): add shared design source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".kilo/design"]
 	path = .kilo/design
-	url = git@github.com:Kilo-Org/kilo-design.git
+	url = https://github.com/Kilo-Org/kilo-design.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".kilo/design"]
+	path = .kilo/design
+	url = git@github.com:Kilo-Org/kilo-design.git

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,17 @@
+# Kilo Editor Design
+
+Canonical design source is vendored into this repo as a Git submodule:
+
+```txt
+.kilo/design
+```
+
+Read in order:
+
+1. `.kilo/design/DESIGN.md`
+2. `.kilo/design/products/editor.md`
+3. `.kilo/design/tokens.json`
+
+Do not add independent design rules in this repo. Promote design changes back to `kilo-design`, then update product implementation here.
+
+Update the `.kilo/design` submodule pointer when canonical design guidance changes.


### PR DESCRIPTION
## Summary
- Adds the canonical `kilo-design` repo as a `.kilo/design` submodule.
- Adds a root `DESIGN.md` entrypoint that points to the shared editor overlay and tokens.

## Verification
- Reviewed the root `DESIGN.md` entrypoint paths against the `.kilo/design` submodule layout.
- Confirmed the submodule is pinned to the initial shared design source commit.

## Visual Changes
N/A

## Reviewer Notes
The submodule points at `Kilo-Org/kilo-design` commit `acdcc60`. Fresh clones should initialize submodules with `git submodule update --init --recursive`.