### PR TITLE
fix(vscode): detect Windows speech input devices

### DIFF
--- a/.changeset/bright-mics-tap.md
+++ b/.changeset/bright-mics-tap.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Windows speech input device detection when FFmpeg lists DirectShow microphones by section.

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -313,7 +313,29 @@ async function listDshowAudioDevices(bin: string): Promise<string[]> {
 
 export function parseDshowAudioDevices(raw: string): string[] {
   const devices = new Set<string>()
-  for (const match of raw.matchAll(/"([^"]+)"\s+\(audio\)/g)) devices.add(match[1]!)
+  const state = { audio: false }
+  const legacy = /"([^"]+)"\s+\(audio\)/
+  const quoted = /"([^"]+)"/
+  const section = (line: string) => /DirectShow audio devices/i.test(line)
+  const other = (line: string) => /DirectShow (video|external) devices/i.test(line)
+  const alt = (line: string) => /Alternative name/i.test(line)
+  for (const line of raw.split(/\r?\n/)) {
+    const match = legacy.exec(line)
+    if (match) devices.add(match[1]!)
+
+    if (section(line)) {
+      state.audio = true
+      continue
+    }
+    if (other(line)) {
+      if (!state.audio) continue
+      state.audio = false
+      break
+    }
+    if (!state.audio || alt(line)) continue
+    const found = quoted.exec(line)
+    if (found) devices.add(found[1]!)
+  }
   return [...devices]
 }
 

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -318,7 +318,7 @@ export function parseDshowAudioDevices(raw: string): string[] {
   const quoted = /"([^"]+)"/
   const section = (line: string) => /DirectShow audio devices/i.test(line)
   const other = (line: string) => /DirectShow (video|external) devices/i.test(line)
-  const alt = (line: string) => /Alternative name/i.test(line)
+  const alt = (line: string) => /\]\s+Alternative name\s+"/i.test(line)
   for (const line of raw.split(/\r?\n/)) {
     const match = legacy.exec(line)
     if (match) devices.add(match[1]!)

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -14,6 +14,24 @@ describe("parseDshowAudioDevices", () => {
     expect(parseDshowAudioDevices(raw)).toEqual(["Microphone Array (Realtek Audio)", "Webcam Microphone"])
   })
 
+  it("extracts section-listed Windows dshow audio device names", () => {
+    const raw = `
+[dshow @ 000001] DirectShow video devices (some may be both video and audio devices)
+[dshow @ 000001]  "OBS Virtual Camera"
+[dshow @ 000001]     Alternative name "@device_video"
+[dshow @ 000001] DirectShow audio devices
+[dshow @ 000001]  "Headset (2- Bose QuietComfort 35 Series II)"
+[dshow @ 000001]     Alternative name "@device_headset"
+[dshow @ 000001]  "Microphone (MSI Sound Tune)"
+[dshow @ 000001]     Alternative name "@device_microphone"
+`
+
+    expect(parseDshowAudioDevices(raw)).toEqual([
+      "Headset (2- Bose QuietComfort 35 Series II)",
+      "Microphone (MSI Sound Tune)",
+    ])
+  })
+
   it("deduplicates repeated dshow audio device names", () => {
     const raw = `"Microphone" (audio)\n"Microphone" (audio)`
 

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -24,11 +24,14 @@ describe("parseDshowAudioDevices", () => {
 [dshow @ 000001]     Alternative name "@device_headset"
 [dshow @ 000001]  "Microphone (MSI Sound Tune)"
 [dshow @ 000001]     Alternative name "@device_microphone"
+[dshow @ 000001]  "Alternative name Microphone"
+[dshow @ 000001]     Alternative name "@device_alternative"
 `
 
     expect(parseDshowAudioDevices(raw)).toEqual([
       "Headset (2- Bose QuietComfort 35 Series II)",
       "Microphone (MSI Sound Tune)",
+      "Alternative name Microphone",
     ])
   })
 


### PR DESCRIPTION
Fix Windows speech input device detection for FFmpeg DirectShow output.

On Windows, the bundled FFmpeg can list audio devices under a `DirectShow audio devices` section without appending `(audio)` to each device name. Kilo only parsed the `(audio)` form, so valid microphones were ignored and users saw “No Windows audio input devices found for speech input.”

This keeps the existing `(audio)` parsing and adds support for section-listed DirectShow audio devices while ignoring alternative device names.

Tested:
- `npx bun test ./tests/unit/speech-to-text-capture.test.ts`
- `npx bun run package` from `packages/kilo-vscode/`