### PR TITLE
fix(cli): handle string-form permission in migrateBashPermission

### DIFF
--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -356,10 +356,16 @@ export namespace KilocodeConfig {
       .catch(() => "{}")
 
     if (target.endsWith(".jsonc")) {
-      const edits = modify(text, ["permission", "bash"], "allow", {
-        formattingOptions: { insertSpaces: true, tabSize: 2 },
-      })
-      await Bun.write(target, applyEdits(text, edits))
+      const data = parseJsonc(text) ?? {}
+      if (typeof data.permission === "string") {
+        const merged = { ...data, permission: { "*": data.permission, bash: "allow" } }
+        await Bun.write(target, JSON.stringify(merged, null, 2))
+      } else {
+        const edits = modify(text, ["permission", "bash"], "allow", {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+        })
+        await Bun.write(target, applyEdits(text, edits))
+      }
       log.info("migrated bash permission to allow for existing user", { path: target })
       return
     }


### PR DESCRIPTION
## Issue

Fixes #10595

## Context

`migrateBashPermission()` crashes when the user's `.jsonc` config uses string shorthand (`"permission": "allow"`) instead of the object form. The function calls `jsonc-parser`'s `modify()` directly to set `permission.bash`, which fails when `permission` is a scalar node:

```
Error: Can not add index to parent of type string
    at setProperty (jsonc-parser/lib/esm/impl/edit.js:147:19)
    at migrateBashPermission (src/config/config.ts:1374:21)
```

The codebase has `patchJsonc()` in `packages/opencode/src/config/config.ts` that handles scalar promotion, but it's not exported. This fix inlines the same detection logic in `migrateBashPermission`.

## Implementation

When `permission` is a string in a `.jsonc` file, promote it to `{ "*": originalValue, "bash": "allow" }` before writing — matching `patchJsonc`'s existing behavior for permission keys. This preserves the user's original wildcard default.

**Before:**
```typescript
if (target.endsWith(".jsonc")) {
  const edits = modify(text, ["permission", "bash"], "allow", {
    formattingOptions: { insertSpaces: true, tabSize: 2 },
  })
  await Bun.write(target, applyEdits(text, edits))
  ...
}
```

**After:**
```typescript
if (target.endsWith(".jsonc")) {
  const data = parseJsonc(text) ?? {}
  if (typeof data.permission === "string") {
    const merged = { ...data, permission: { "*": data.permission, bash: "allow" } }
    await Bun.write(target, JSON.stringify(merged, null, 2))
  } else {
    const edits = modify(text, ["permission", "bash"], "allow", {
      formattingOptions: { insertSpaces: true, tabSize: 2 },
    })
    await Bun.write(target, applyEdits(text, edits))
  }
  ...
}
```

No new imports needed — `parseJsonc` is already imported.

## How to Test

### Manual/local verification
1. Create `~/.config/kilo/opencode.jsonc` with `"permission": "allow"` (string form)
2. Run `kilo` — should start without crashing
3. Verify config now contains `"permission": { "*": "allow", "bash": "allow" }`
4. Repeat with `"permission": { "existing": "ask" }` — should add `bash: "allow"` without touching `existing`
5. Repeat with no config — new user path, should not crash
6. Repeat with `.json` (not `.jsonc`) — should use the existing `JSON.stringify` path unchanged

### Reviewer test steps
- Confirm `parseJsonc` is already imported — no new imports
- Confirm scalar promotion preserves wildcard default via `"*": scalarValue`, matching `patchJsonc` behavior
- Confirm `.json` path is untouched

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] Screenshots/video — N/A (CLI, no visual changes)
- [x] Changeset considered — bugfix only
- [x] Personally reviewed diff