### PR TITLE
fix(cli): fall back to compatible logo in SSH TUI sessions

### DIFF
--- a/.changeset/ssh-logo-fallback.md
+++ b/.changeset/ssh-logo-fallback.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use the compatible TUI logo in SSH sessions.

--- a/packages/opencode/src/kilocode/cli/logo.ts
+++ b/packages/opencode/src/kilocode/cli/logo.ts
@@ -47,10 +47,18 @@ function windows(env: NodeJS.ProcessEnv) {
   return false
 }
 
+function remote(env: NodeJS.ProcessEnv) {
+  if (env.SSH_TTY) return true
+  if (env.SSH_CLIENT) return true
+  if (env.SSH_CONNECTION) return true
+  return false
+}
+
 export function supports(env = process.env, platform = process.platform) {
   const override = flag(env.KILO_UNICODE_LOGO)
   if (override !== undefined) return override
   if (env.TERM === "dumb") return false
+  if (remote(env)) return false
   // Old Windows Console Host cannot render the sextant glyphs used by the modern logo.
   if (platform === "win32") return windows(env)
   if (env.ConEmuPID) return false

--- a/packages/opencode/test/kilocode/logo.test.ts
+++ b/packages/opencode/test/kilocode/logo.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { plain, session, supports, tui } from "../../src/kilocode/cli/logo"
 
 describe("kilocode logo", () => {
-  test("allows remote terminals", () => {
-    expect(supports({ SSH_TTY: "/dev/pts/0" }, "linux")).toBe(true)
-    expect(supports({ SSH_CLIENT: "127.0.0.1 12345 22" }, "linux")).toBe(true)
-    expect(supports({ SSH_CONNECTION: "127.0.0.1 12345 127.0.0.1 22" }, "linux")).toBe(true)
+  test("falls back for remote terminals", () => {
+    expect(supports({ SSH_TTY: "/dev/pts/0" }, "linux")).toBe(false)
+    expect(supports({ SSH_CLIENT: "127.0.0.1 12345 22" }, "linux")).toBe(false)
+    expect(supports({ SSH_CONNECTION: "127.0.0.1 12345 127.0.0.1 22" }, "linux")).toBe(false)
+    expect(tui({ SSH_TTY: "/dev/pts/0" }, "linux").join("\n")).not.toContain("🬺🬏")
   })
 
   test("falls back on old Windows terminals", () => {


### PR DESCRIPTION
## Summary
- fall back to the compatible TUI logo whenever Kilo detects an SSH session
- keep `KILO_UNICODE_LOGO=1` as the explicit opt-in for the modern sextant logo
- align runtime logo detection with the installer fallback behavior

Fixes #10598

## Tests
- `npx -y bun@1.3.13 test test/kilocode/logo.test.ts`
- `npx -y bun@1.3.13 run typecheck` from `packages/opencode`
- `npx -y bun@1.3.13 run lint`
- `npx -y bun@1.3.13 run script/check-opencode-annotations.ts`