### PR TITLE
fix(cli): keep docs agents out of planning markdown

### DIFF
--- a/.changeset/quiet-docs-routing.md
+++ b/.changeset/quiet-docs-routing.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep documentation subagents focused on documentation changes instead of planning or specification Markdown.

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -19,6 +19,7 @@ Usage notes:
 4. The agent's outputs should generally be trusted
 5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
 6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
+7. Documentation-writing agents are for documentation changes only. Do not use them for plans, feature specifications, design proposals, or other planning Markdown files requested by the user.
 
 Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
 


### PR DESCRIPTION
Documentation subagents are meant for user-facing documentation changes, but broad agent descriptions can incorrectly route plans and feature specifications through them.

Keep planning Markdown in the normal agent workflow while preserving docs-agent delegation for actual documentation work.