### PR TITLE
fix(cli): reduce read context overhead from line prefixes

### DIFF
--- a/.changeset/trim-read-prefixes.md
+++ b/.changeset/trim-read-prefixes.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reduce context consumed by file reads by returning source text without repeated line-number prefixes.

--- a/packages/opencode/src/session/prompt/ling.txt
+++ b/packages/opencode/src/session/prompt/ling.txt
@@ -106,15 +106,7 @@ CORRECT — description is always required:
 </example>
 
 - CRITICAL: The edit tool parameter names are EXACTLY `oldString` and `newString` — never use abbreviations like `oldStr`, `newStr`, `old_string`, or `new_string`. Using the wrong key causes immediate schema validation failure with "received undefined".
-- CRITICAL: When using the edit tool, `oldString` MUST contain only actual file content — NEVER include line number prefixes from Read tool output. The Read tool prefixes each line with `N: ` for display only; strip these before constructing `oldString`.
-
-<example tool="edit">
-WRONG — oldString contains line number prefixes (will fail to match):
-{"oldString": "1: <!doctype html>\n2: <html lang=\"en\">\n3:   <head>"}
-
-CORRECT — oldString contains only the actual file content:
-{"oldString": "<!doctype html>\n<html lang=\"en\">\n  <head>"}
-</example>
+- CRITICAL: When using the edit tool, `oldString` MUST contain only exact file content from Read output, including its original indentation.
 
 # Code References
 When referencing code, use the pattern `file_path:line_number`.

--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -2,7 +2,7 @@ Performs exact string replacements in files.
 
 Usage:
 - You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
-- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: line number + colon + space (e.g., `1: `). Everything after that space is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
+- When editing text from Read tool output, preserve the exact indentation (tabs/spaces) from the file content in `oldString` and `newString`.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
 - The edit will FAIL if `oldString` is not found in the file with an error "oldString not found in content".

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -314,7 +314,7 @@ export const ReadTool = Tool.define(
       }
 
       let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
-      output += file.raw.map((line, i) => `${i + file.offset}: ${line}`).join("\n")
+      output += file.raw.join("\n") // kilocode_change - omit repeated line prefixes from model context
 
       const last = file.offset + file.raw.length - 1
       const next = last + 1

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -7,7 +7,7 @@ Usage:
 - To read later sections, call this tool again with a larger offset.
 - Use the grep tool to find specific content in large files or files with long lines.
 - If you are unsure of the correct file path, use the glob tool to look up filenames by glob pattern.
-- Contents are returned with each line prefixed by its line number as `<line>: <content>`. For example, if a file has contents "foo\n", you will receive "1: foo\n". For directories, entries are returned one per line (without line numbers) with a trailing `/` for subdirectories.
+- File contents are returned as source text. For directories, entries are returned one per line with a trailing `/` for subdirectories.
 - Any line longer than 2000 characters is truncated.
 - Call this tool in parallel when you know there are multiple files you want to read.
 - Avoid tiny repeated slices (30 line chunks). If you need more context, read a larger window.

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -306,14 +306,13 @@ describe("tool.read truncation", () => {
       yield* put(path.join(dir, "offset.txt"), lines)
 
       const result = yield* exec(dir, { filePath: path.join(dir, "offset.txt"), offset: 10, limit: 5 })
-      expect(result.output).toContain("10: line10")
-      expect(result.output).toContain("14: line14")
-      expect(result.output).not.toContain("9: line10")
-      expect(result.output).not.toContain("15: line15")
+      expect(result.output).not.toContain("10: line10") // kilocode_change - read content is unnumbered
+      expect(result.output).not.toContain("14: line14") // kilocode_change - read content is unnumbered
       expect(result.output).toContain("line10")
       expect(result.output).toContain("line14")
       expect(result.output).not.toContain("line0")
       expect(result.output).not.toContain("line15")
+      expect(result.output).toContain("Showing lines 10-14 of 20") // kilocode_change - preserve bounded-read range
     }),
   )
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -306,8 +306,10 @@ describe("tool.read truncation", () => {
       yield* put(path.join(dir, "offset.txt"), lines)
 
       const result = yield* exec(dir, { filePath: path.join(dir, "offset.txt"), offset: 10, limit: 5 })
-      expect(result.output).not.toContain("10: line10") // kilocode_change - read content is unnumbered
-      expect(result.output).not.toContain("14: line14") // kilocode_change - read content is unnumbered
+      // kilocode_change start
+      expect(result.output).not.toContain("10: line10")
+      expect(result.output).not.toContain("14: line14")
+      // kilocode_change end
       expect(result.output).toContain("line10")
       expect(result.output).toContain("line14")
       expect(result.output).not.toContain("line0")


### PR DESCRIPTION
## Why this change

Ordinary text reads currently add a line-number prefix to every returned source line, even though Kilo edits match source text or patch context rather than displayed line positions. This adds repeated context overhead on a high-frequency tool path without providing input required by the editing tools.

Current model-visible output:

```text
<path>/repo/src/a.ts</path>
<type>file</type>
<content>
41: const a = 1
42: export { a }

(End of file - total 42 lines)
</content>
```

This PR returns the ordinary source text instead:

```text
<path>/repo/src/a.ts</path>
<type>file</type>
<content>
const a = 1
export { a }

(End of file - total 42 lines)
</content>
```

Partial reads still report their original line range in the continuation notice, so bounded navigation remains available without repeating positional prefixes on every content line.

## Measured motivation

This change is based on an aggregate internal measurement of completed Kilo `read` tool outputs, not only on an implementation hypothesis. We measured the model-visible text attributable to the repeated line-number prefixes and found that they account for about 10% of stored `read` output payload in the analyzed sample.

That percentage describes removable context text, not exact billed tokens or cost. Tool outputs can be retained, cached, or replayed in later model steps, so paired before/after session accounting is still needed to quantify the billing impact. Absolute usage, token, and cost figures are intentionally not included here.

## Why line prefixes are removable

- Kilo `edit` uses exact or flexible textual `oldString` replacement; displayed line-number prefixes are not consumed by the tool.
- Kilo `apply_patch` locates contextual source chunks rather than applying changes at displayed line positions.
- Removing prefixes makes read text directly reusable for exact-text edits and reduces model-visible output growth after raw source lines have already been budgeted.
- The tradeoff is less immediate line-by-line citation from a single read. Range notices and line-located search results remain available, and citation usability can be evaluated after rollout.

## Preserved behavior

This PR intentionally changes only the repeated line prefixes for ordinary text file contents.

| Behavior | Decision |
|---|---|
| `<path>`, `<type>`, and `<content>` envelope | Preserved |
| Partial-read range and end-of-file notices | Preserved |
| Nested `<system-reminder>` delivery for scoped instructions | Preserved |
| Directory and binary/image handling | Preserved |
| Read/edit prompting | Updated to match raw source-text output |

## Upstream origin and intent

The numbered format is inherited upstream behavior, originally chosen for navigation clarity rather than edit correctness.

| Upstream history | Relevance to this PR |
|---|---|
| [Initial traceable numbered view commit](https://github.com/anomalyco/opencode/commit/2437ce3f8b79a7f9d987862b633f3340bfa2c1c4) | Described displaying file contents with line numbers for easy reference; GitHub does not associate this commit with a PR. |
| [PR #10678](https://github.com/anomalyco/opencode/pull/10678) | Added dynamic nested `AGENTS.md` resolution as an agent explores directories. That separate correctness behavior is retained here. |
| [PR #13090](https://github.com/anomalyco/opencode/pull/13090) | Added the structured `<path>`, `<type>`, and `<content>` read output and adjusted editing guidance. The structural envelope is retained here. |
| [PR #13198](https://github.com/anomalyco/opencode/pull/13198) | Made read offsets 1-based to align with displayed line numbers. This PR keeps range accounting and notices 1-based. |
| [PR #21070](https://github.com/anomalyco/opencode/pull/21070) | Added newline separation after `<content>` to make the structured result unambiguous. That clarity behavior is retained here. |

## Comparable harness behavior

Other agent harnesses show that text editing and scoped navigation do not require mandatory prefixes on every source line.

| Harness | Relevant behavior |
|---|---|
| [pi v0.75.5](https://github.com/earendil-works/pi/tree/v0.75.5/packages/coding-agent/src/core/tools) | Returns ordinary read content as source text and edits by textual replacement. |
| [Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/41c9260cae32badf4905029f2af1ddb0a9afce3f/packages/core/src/tools/read-file.ts) | Supports ranged reads without prefixing every returned source line; its replacement tool consumes source text, and its read path also supports just-in-time scoped context. |
| [Codex CLI](https://github.com/openai/codex/blob/bc005029bdd88749f71be5fc9134b6a5b2aea941/codex-rs/core/src/tools/spec_plan.rs) | Its core editing flow is contextual `apply_patch`, without relying on a mandatory dedicated numbered file-read output. |
| [Claude Code v2.1.86](https://github.com/anthropics/claude-code/releases/tag/v2.1.86) | Retains numbered reads, but specifically reduced their token usage through compact numbering and unchanged-read deduplication. |

## Follow-up measurement

The intended outcome is lower read-related prompt context without a meaningful regression in editing or navigation. Evaluation should compare model-visible read output, prompt-side usage, edit retries, and file-location reporting quality before making a quantitative savings claim about billed usage or cost.