### PR TITLE
fix(cli): reduce grep context amplification

### DIFF
--- a/.changeset/tidy-grep-output.md
+++ b/.changeset/tidy-grep-output.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reduce oversized grep context output by limiting long match lines and truncating large result sets.

--- a/packages/opencode/src/kilocode/tool/grep.ts
+++ b/packages/opencode/src/kilocode/tool/grep.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect"
+import * as Truncate from "@/tool/truncate"
+
+export namespace GrepBudget {
+  export const MAX_LINE_LENGTH = 500
+  export const DESCRIPTION = `- Matching source lines are previewed to ${MAX_LINE_LENGTH} characters; use Read at the reported file and line for full content.`
+
+  export function notice(saved: boolean) {
+    const prefix = `Some match lines truncated to ${MAX_LINE_LENGTH} chars.`
+    const detail = saved ? " Saved grep output also contains shortened previews." : ""
+    return `[${prefix}${detail} Use Read on the original file at the reported line to see full content.]`
+  }
+
+  export function line(text: string) {
+    if (text.length <= MAX_LINE_LENGTH) return { text, truncated: false } as const
+    return { text: `${text.slice(0, MAX_LINE_LENGTH)}... [truncated]`, truncated: true } as const
+  }
+
+  export const make = Effect.gen(function* () {
+    const truncate = yield* Truncate.Service
+    const max = Math.min((yield* truncate.limits()).maxBytes, Truncate.MAX_BYTES)
+    return Effect.fn("GrepBudget.output")(function* (text: string) {
+      return yield* truncate.output(text, { maxBytes: max })
+    })
+  })
+}

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -7,8 +7,7 @@ import { Ripgrep } from "../file/ripgrep"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import DESCRIPTION from "./grep.txt"
 import * as Tool from "./tool"
-
-const MAX_LINE_LENGTH = 2000
+import { GrepBudget } from "@/kilocode/tool/grep" // kilocode_change
 
 export const Parameters = Schema.Struct({
   pattern: Schema.String.annotate({ description: "The regex pattern to search for in file contents" }),
@@ -25,15 +24,16 @@ export const GrepTool = Tool.define(
   Effect.gen(function* () {
     const fs = yield* AppFileSystem.Service
     const rg = yield* Ripgrep.Service
+    const budget = yield* GrepBudget.make // kilocode_change
 
     return {
-      description: DESCRIPTION,
+      description: `${DESCRIPTION}\n${GrepBudget.DESCRIPTION}`, // kilocode_change
       parameters: Parameters,
       execute: (params: { pattern: string; path?: string; include?: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const empty = {
             title: params.pattern,
-            metadata: { matches: 0, truncated: false },
+            metadata: { matches: 0, truncated: false, linesTruncated: false, outputPath: undefined as string | undefined }, // kilocode_change
             output: "No files found",
           }
           if (!params.pattern) {
@@ -114,15 +114,18 @@ export const GrepTool = Tool.define(
           const output = [`Found ${total} matches${truncated ? ` (showing first ${limit})` : ""}`]
 
           let current = ""
+          let linesTruncated = false // kilocode_change
           for (const match of final) {
             if (current !== match.path) {
               if (current !== "") output.push("")
               current = match.path
               output.push(`${match.path}:`)
             }
-            const text =
-              match.text.length > MAX_LINE_LENGTH ? match.text.substring(0, MAX_LINE_LENGTH) + "..." : match.text
-            output.push(`  Line ${match.line}: ${text}`)
+            // kilocode_change start
+            const text = GrepBudget.line(match.text)
+            linesTruncated = linesTruncated || text.truncated
+            output.push(`  Line ${match.line}: ${text.text}`)
+            // kilocode_change end
           }
 
           if (truncated) {
@@ -137,13 +140,16 @@ export const GrepTool = Tool.define(
             output.push("(Some paths were inaccessible and skipped)")
           }
 
+          const capped = yield* budget(output.join("\n")) // kilocode_change
           return {
             title: params.pattern,
             metadata: {
               matches: total,
-              truncated,
+              truncated: truncated || capped.truncated, // kilocode_change
+              linesTruncated, // kilocode_change
+              ...(capped.truncated && { outputPath: capped.outputPath }), // kilocode_change
             },
-            output: output.join("\n"),
+            output: linesTruncated ? `${capped.content}\n\n${GrepBudget.notice(capped.truncated)}` : capped.content, // kilocode_change
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/test/kilocode/grep-budget.test.ts
+++ b/packages/opencode/test/kilocode/grep-budget.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { GrepTool } from "@/tool/grep"
+import { Truncate } from "@/tool/truncate"
+import { Agent } from "@/agent/agent"
+import { Ripgrep } from "@/file/ripgrep"
+import { MessageID, SessionID } from "@/session/schema"
+import { TestInstance } from "../fixture/fixture"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    AppFileSystem.defaultLayer,
+    Ripgrep.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+  ),
+)
+
+const raised = testEffect(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    AppFileSystem.defaultLayer,
+    Ripgrep.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+    TestConfig.layer({ get: () => Effect.succeed({ tool_output: { max_bytes: 100 * 1024 } }) }),
+  ),
+)
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("kilocode grep budget", () => {
+  it.instance("limits each matching line to 500 characters", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const text = `needle${"x".repeat(600)}`
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "long.txt"), text))
+      const grep = yield* (yield* GrepTool).init()
+      const result = yield* grep.execute({ pattern: "needle", path: test.directory }, ctx)
+
+      expect(grep.description).toContain("previewed to 500 characters")
+      expect(result.metadata.linesTruncated).toBe(true)
+      expect(result.output).toContain(`Line 1: ${text.slice(0, 500)}... [truncated]`)
+      expect(result.output).toContain("Use Read on the original file at the reported line to see full content")
+      expect(result.output).not.toContain(text.slice(0, 501))
+    }),
+  )
+
+  raised.instance("truncates a 100-match preview at the grep cap even when configured higher", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const content = Array.from(
+        { length: 100 },
+        (_, i) => `needle${String(i).padStart(3, "0")}${"x".repeat(700)}`,
+      ).join("\n")
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "large.txt"), content))
+      const grep = yield* (yield* GrepTool).init()
+      const result = yield* grep.execute({ pattern: "needle", path: test.directory }, ctx)
+
+      expect(result.metadata.matches).toBe(100)
+      expect(result.metadata.truncated).toBe(true)
+      expect(result.metadata.linesTruncated).toBe(true)
+      expect(result.output).toContain("The tool call succeeded but the output was truncated")
+      expect(result.output).toContain("Saved grep output also contains shortened previews")
+      expect(result.output).toContain("Use Read on the original file at the reported line to see full content")
+      const file = result.metadata.outputPath
+      if (!file) throw new Error("expected saved full output")
+      const saved = yield* Effect.promise(() => Bun.file(file).text())
+      expect(Buffer.byteLength(saved, "utf-8")).toBeGreaterThan(50 * 1024)
+      expect(Buffer.byteLength(result.output, "utf-8")).toBeLessThan(Buffer.byteLength(saved, "utf-8"))
+      expect(saved).toContain("Line 100:")
+    }),
+  )
+})


### PR DESCRIPTION
## Problem

`grep` is a high-volume model-facing context ingress path. Upstream OpenCode limits breadth to 100 matches and clips single lines at 2,000 characters, but its grep result bypasses the generic output truncation path because it already supplies truncation metadata. Broad matches over minified, generated, snapshot, or serialized content can therefore carry disproportionate text into later model requests.

## Implementation

This change moves the Kilo-specific policy into `src/kilocode/tool/grep.ts` and keeps only a narrowly annotated hook in shared OpenCode code. `grep` now:

- previews an individual matching source line at 500 characters, using an explicit `... [truncated]` marker;
- tells the model to use `Read` on the original file at the reported line when a preview is shortened;
- applies a final model-visible grep preview ceiling no greater than 50 KiB, even when generic tool-output configuration is higher;
- uses the existing saved-output path for aggregate truncation and makes clear that a saved grep preview still contains any shortened line previews; and
- records line truncation in metadata and discloses the preview contract in the tool description.

## Prior Art And Design Research

| Harness | Verified search-output behavior | Relevance to this change |
|---|---|---|
| pi `v0.75.5` | Its optional dedicated `grep` defaults to 100 matches, truncates matching/context lines to 500 characters, applies a final 50 KiB cap, and emits `Use read tool to see full lines` guidance. The cap was introduced for tool-result truncation in `earendil-works/pi#134`; a maintainer specifically described it as handling minified files. | This change adopts pi's bounded-preview and explicit recovery contract, not only its numeric limit. |
| Upstream OpenCode `dev` | Its dedicated `grep` returns at most 100 matches and clips lines at 2,000 characters, but currently bypasses the shared final output budget. | This is the inherited amplification path being narrowed. |
| Gemini CLI current | Its grep-style tools default to 100 matches and clip rendered lines at 2,000 characters; they expose additional narrowing controls and may add context for low-match searches. | Demonstrates a less aggressive line-preview tradeoff and the value of explicit narrowing/recovery controls. |
| Codex CLI current | It directs the model to invoke `rg` through shell/exec rather than exposing an equivalent grep formatter; search output is controlled by generic command-output budgets, commonly around 10K bytes or tokens depending on model/policy. | Confirms that bounded search context is common, but is not a direct line-cap precedent. |

Pi reference: https://github.com/earendil-works/pi/issues/134 and https://github.com/earendil-works/pi/commit/b813a8b92bf9b906608b9644490c9fec424f8476

## Relative Historical Impact Assessment

A counterfactual pass over locally stored completed Kilo tool-result payloads from the prior-month analysis window was used to estimate model-visible payload reduction. This analysis reports percentages only, not session volumes or spend.

| Observation | Relative result |
|---|---:|
| Share of completed tool-output payload contributed by `grep` | 15.0% |
| Share contributed jointly by `read`, `bash`, and `grep` | 85.6% |
| Grep calls with at least one line that would receive the 500-character preview | 3.79% |
| Grep payload reduction from the line-preview rule alone, including its recovery notice | approximately 4.30% |
| Grep payload reduction from a final 50 KiB cap alone | approximately 2.26% |
| Combined grep payload reduction with both rules applied in order | approximately 4.34% |
| Combined reduction as a share of all completed tool-output payload | approximately 0.65% |

The line-preview rule accounts for most of the observed historical reduction; final-cap cases are rarer and primarily provide protection against future pathological broad searches. Since `grep` is the third-largest stored tool-output contributor in the measured workload, this is a meaningful narrow improvement, but not expected to eliminate overall tool-context growth by itself. `read` and `bash` remain larger optimization targets.

These percentages measure stored/model-visible payload characters under a counterfactual formatter. They are directional context-ingress estimates, not exact billed-token or monetary savings: tool output may be replayed over subsequent turns, served through prompt caching, pruned, compacted, or repriced by different models/providers. The expected product outcome is lower avoidable grep context amplification, with billed savings to be measured after rollout using request-level token and cache accounting.

## Quality Tradeoffs

The 500-character rule deliberately treats `grep` as a locator for unusually long lines, rather than as a full-content retrieval tool. This is most relevant for minified code, large JSON/JSONL values, generated schemas, snapshots, embedded markup, and serialized fixtures. In those cases, characters beyond the preview may contain needed evidence.

To avoid silently degrading answer quality, this change preserves paths and line numbers, visibly marks shortened match text, and directs the model to `Read` the original source file for authoritative full content. Aggregate saved-output artifacts preserve content removed by the final preview ceiling, but cannot restore characters already omitted by per-line previewing; the notice states that constraint explicitly.

The existing 100-match limit is unchanged. This PR bounds line width and final rendered payload while preserving the existing refinement workflow for broad result sets.