### PR TITLE
fix: constrain Kilo indexing embedding models

### DIFF
--- a/.changeset/kilo-embedding-model-presets.md
+++ b/.changeset/kilo-embedding-model-presets.md
@@ -1,0 +1,8 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+"@kilocode/kilo-indexing": patch
+"@kilocode/sdk": patch
+---
+
+Use supported hosted model presets for Kilo indexing and clear obsolete model and dimension overrides.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/indexing-kilo-catalog-loading-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/indexing-kilo-catalog-loading-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d70e12fc78142601de74977fea330a91f3662851cc8f56023a6ec819724dbb8
+size 48958

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/indexing-kilo-model-preset-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/indexing-kilo-model-preset-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7ad739b2099b5b35abf3989bca8e8f63c2926906decfddf7530d6b97fb0e6b1
+size 50711

--- a/packages/kilo-indexing/src/config.ts
+++ b/packages/kilo-indexing/src/config.ts
@@ -21,11 +21,12 @@ export const IndexingConfig = z
   .object({
     enabled: z.boolean().optional().describe("Enable codebase indexing"),
     provider: z.enum(providers).optional().describe("Embedding provider to use for codebase indexing"),
-    model: z.string().optional().describe("Embedding model ID (uses provider default if omitted)"),
+    model: z.string().nullable().optional().describe("Embedding model ID (uses provider default if omitted)"),
     dimension: z
       .number()
       .int()
       .positive()
+      .nullable()
       .optional()
       .describe("Override embedding vector dimension (auto-detected from model if omitted)"),
     vectorStore: z.enum(stores).optional().describe("Vector store backend (default: qdrant)"),
@@ -140,10 +141,10 @@ export const IndexingSchema = Schema.Struct({
   provider: Schema.optional(Provider).annotate({
     description: "Embedding provider to use for codebase indexing",
   }),
-  model: Schema.optional(Schema.String).annotate({
+  model: Schema.optional(Schema.NullOr(Schema.String)).annotate({
     description: "Embedding model ID (uses provider default if omitted)",
   }),
-  dimension: Schema.optional(PositiveInt).annotate({
+  dimension: Schema.optional(Schema.NullOr(PositiveInt)).annotate({
     description: "Override embedding vector dimension (auto-detected from model if omitted)",
   }),
   vectorStore: Schema.optional(Store).annotate({ description: "Vector store backend (default: qdrant)" }),
@@ -237,8 +238,8 @@ export function toIndexingConfigInput(cfg: IndexingConfig | undefined): Indexing
     enabled: cfg?.enabled ?? false,
     embedderProvider: provider,
     vectorStoreProvider: cfg?.vectorStore,
-    modelId: cfg?.model,
-    modelDimension: cfg?.dimension,
+    modelId: cfg?.model ?? undefined,
+    modelDimension: cfg?.dimension ?? undefined,
     lancedbVectorStoreDirectory: cfg?.lancedb?.directory,
     qdrantUrl: cfg?.qdrant?.url,
     qdrantApiKey: cfg?.qdrant?.apiKey,

--- a/packages/kilo-vscode/tests/indexing-provider-blur-race.spec.ts
+++ b/packages/kilo-vscode/tests/indexing-provider-blur-race.spec.ts
@@ -10,15 +10,19 @@ if (IS_DARWIN) {
 
 const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
 const STORY_ID = "settings--indexing-provider-blur-race"
+const KILO_STORY_ID = "settings--indexing-kilo-model-preset"
+const KILO_LOADING_STORY_ID = "settings--indexing-kilo-catalog-loading"
 
 type Saved = {
   provider?: string
+  model?: string | null
+  dimension?: number | null
   openai?: { apiKey?: string }
   gemini?: { apiKey?: string }
 }
 
-function storyUrl() {
-  return `/iframe.html?id=${STORY_ID}&viewMode=story&globals=${GLOBALS}`
+function storyUrl(id = STORY_ID) {
+  return `/iframe.html?id=${id}&viewMode=story&globals=${GLOBALS}`
 }
 
 async function disableAnimations(page: Page) {
@@ -32,6 +36,10 @@ async function disableAnimations(page: Page) {
       }
     `,
   })
+}
+
+function field(page: Page, title: string) {
+  return page.locator('[data-slot="settings-row"]', { hasText: title }).locator("input")
 }
 
 test("provider switch writes to selected provider bucket", async ({ page }) => {
@@ -58,6 +66,55 @@ test("provider switch writes to selected provider bucket", async ({ page }) => {
   const cfg = JSON.parse(text) as Saved
 
   expect(cfg.provider).toBe("gemini")
+  expect(cfg.model).toBeNull()
+  expect(cfg.dimension).toBeNull()
   expect(cfg.openai?.apiKey ?? "").toBe("")
   expect(cfg.gemini?.apiKey ?? "").toBe("")
+
+  const model = field(page, "Embedding model").first()
+  await expect(model).toHaveValue("")
+  await expect(model).toHaveAttribute("placeholder", "Enter model ID")
+})
+
+test("Kilo exposes only supported embedding model presets", async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 720 })
+  await page.goto(storyUrl(KILO_STORY_ID), { waitUntil: "load" })
+  await disableAnimations(page)
+  await page.waitForSelector("#storybook-root *", { state: "attached" })
+
+  await expect(page.getByText("Kilo model preset", { exact: true })).toBeVisible()
+  await expect(page.getByText("Embedding model", { exact: true })).toHaveCount(0)
+  await expect(page.getByText("Vector dimension", { exact: true })).toBeVisible()
+
+  const preset = page.locator('[data-component="select"] [data-slot="select-select-trigger"]').nth(1)
+  await expect(preset).toContainText("Provider Model")
+
+  const dimension = field(page, "Vector dimension").first()
+  await expect(dimension).toHaveValue("")
+
+  await preset.click()
+  await page.locator('[data-slot="select-select-item-label"]', { hasText: "Provider Compact" }).click()
+  await expect(preset).toContainText("Provider Compact")
+})
+
+test("enabling Kilo before its catalog loads does not store an empty model", async ({ page }) => {
+  const saved = page.getByTestId("indexing-kilo-loading-save")
+  const cfg = async () => JSON.parse(((await saved.textContent()) ?? "{}").trim()) as Saved
+  const verify = async () => {
+    await expect.poll(async () => (await cfg()).provider).toBe("kilo")
+    expect((await cfg()).model).toBeNull()
+    expect((await cfg()).dimension).toBeNull()
+  }
+
+  await page.setViewportSize({ width: 420, height: 720 })
+  await page.goto(storyUrl(KILO_LOADING_STORY_ID), { waitUntil: "load" })
+  await disableAnimations(page)
+  await page.waitForSelector("#storybook-root *", { state: "attached" })
+  await page.locator('[data-component="switch"] [data-slot="switch-control"]').nth(1).click()
+  await verify()
+
+  await page.goto(storyUrl(KILO_LOADING_STORY_ID), { waitUntil: "load" })
+  await page.waitForSelector("#storybook-root *", { state: "attached" })
+  await page.locator('[data-component="switch"] [data-slot="switch-control"]').first().click()
+  await verify()
 })

--- a/packages/kilo-vscode/webview-ui/src/components/settings/IndexingTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/IndexingTab.tsx
@@ -1,10 +1,6 @@
 import { Component, For, Show, createMemo, createSignal } from "solid-js"
 import { Card } from "@kilocode/kilo-ui/card"
-import {
-  formatKiloEmbeddingModelLabel,
-  getKiloEmbeddingModel,
-  normalizeKiloEmbeddingModelId,
-} from "@kilocode/kilo-indexing/embedding-models"
+import { formatKiloEmbeddingModelLabel, getKiloEmbeddingModel } from "@kilocode/kilo-indexing/embedding-models"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Switch } from "@kilocode/kilo-ui/switch"
 import { TextField } from "@kilocode/kilo-ui/text-field"
@@ -96,16 +92,20 @@ const IndexingTab: Component = () => {
   }
 
   const vectorStore = () => cfg().vectorStore ?? "qdrant"
-  const kiloDefault = () => embeds.catalog().defaultModel
+  const kiloDefault = () =>
+    getKiloEmbeddingModel(embeds.catalog().defaultModel, embeds.catalog())?.id ?? embeds.catalog().defaultModel
   const kiloModels = createMemo(() =>
     embeds.catalog().models.map((model) => ({
       value: model.id,
       label: formatKiloEmbeddingModelLabel(model),
     })),
   )
-  const knownKiloModel = (model: string | undefined) => getKiloEmbeddingModel(model, embeds.catalog())?.id
+  const knownKiloModel = (model: string | null | undefined) =>
+    getKiloEmbeddingModel(model ?? undefined, embeds.catalog())?.id
+  const kiloValue = () => knownKiloModel(cfg().model) ?? kiloDefault()
   const kiloAvailable = () => !!server.profileData() || provider.authStates()[KILO_PROVIDER_ID] !== undefined
   const selectedProvider = () => cfg().provider ?? (kiloAvailable() ? "kilo" : undefined)
+  const staleKiloModel = () => selectedProvider() === "kilo" && !!cfg().model && !knownKiloModel(cfg().model)
   const providers = createMemo(() =>
     allProviders.filter((item) => item.value !== "kilo" || kiloAvailable() || selectedProvider() === "kilo"),
   )
@@ -113,15 +113,15 @@ const IndexingTab: Component = () => {
 
   const saveProvider = (next: ProviderId | undefined) => {
     if (next === "kilo") {
-      const model = knownKiloModel(cfg().model) ?? (kiloDefault() || undefined)
+      const model = knownKiloModel(cfg().model) ?? (kiloDefault() || null)
       updateIndexing({
         provider: next,
         model,
-        dimension: undefined,
+        dimension: null,
       })
       return
     }
-    updateIndexing({ provider: next, model: undefined, dimension: undefined })
+    updateIndexing({ provider: next, model: null, dimension: null })
   }
 
   const saveEnabled = (enabled: boolean) => {
@@ -129,7 +129,8 @@ const IndexingTab: Component = () => {
       updateIndexing({
         enabled,
         provider: "kilo",
-        model: knownKiloModel(cfg().model) ?? kiloDefault(),
+        model: knownKiloModel(cfg().model) ?? (kiloDefault() || null),
+        dimension: null,
       })
       return
     }
@@ -142,7 +143,8 @@ const IndexingTab: Component = () => {
         indexing: {
           enabled,
           provider: "kilo",
-          model: knownKiloModel(cfg().model) ?? kiloDefault(),
+          model: knownKiloModel(cfg().model) ?? (kiloDefault() || null),
+          dimension: null,
         },
       })
       return
@@ -151,15 +153,9 @@ const IndexingTab: Component = () => {
   }
 
   const saveModel = (value: string) => {
+    if (selectedProvider() === "kilo") return
     const trimmed = value.trim()
-    if (!trimmed) {
-      updateIndexing({ model: undefined })
-      return
-    }
-    updateIndexing({
-      model:
-        selectedProvider() === "kilo" ? (normalizeKiloEmbeddingModelId(trimmed, embeds.catalog()) ?? trimmed) : trimmed,
-    })
+    updateIndexing({ model: trimmed || null })
   }
 
   const providerValue = (group: string, key: string) => {
@@ -189,13 +185,13 @@ const IndexingTab: Component = () => {
   }
 
   const saveNumber = (
-    key: keyof IndexingConfig,
+    key: TuningKey | "dimension",
     value: string,
     options?: { integer?: boolean; min?: number; max?: number },
   ) => {
     const trimmed = value.trim()
     if (!trimmed) {
-      updateIndexing({ [key]: undefined })
+      updateIndexing({ [key]: key === "dimension" ? null : undefined })
       return
     }
 
@@ -272,35 +268,37 @@ const IndexingTab: Component = () => {
             >
               <Select
                 options={kiloModels()}
-                current={kiloModels().find((item) => item.value === knownKiloModel(cfg().model))}
+                current={kiloModels().find((item) => item.value === kiloValue())}
                 value={(item) => item.value}
                 label={(item) => item.label}
-                onSelect={(item) => updateIndexing({ model: item?.value ?? kiloDefault(), dimension: undefined })}
+                onSelect={(item) => updateIndexing({ model: item?.value ?? kiloDefault(), dimension: null })}
                 variant="secondary"
                 size="small"
                 triggerVariant="settings"
-                placeholder="Custom model"
+                placeholder="Select a model"
               />
             </SettingsRow>
           </Show>
         </Show>
-        <SettingsRow
-          title={language.t("settings.indexing.model.title")}
-          description={language.t("settings.indexing.model.description")}
-        >
-          <TextField
-            value={cfg().model ?? ""}
-            placeholder={selectedProvider() === "kilo" ? kiloDefault() || "provider/model" : "text-embedding-3-small"}
-            onChange={saveModel}
-          />
-        </SettingsRow>
+        <Show when={selectedProvider() !== "kilo"}>
+          <SettingsRow
+            title={language.t("settings.indexing.model.title")}
+            description={language.t("settings.indexing.model.description")}
+          >
+            <TextField value={cfg().model ?? ""} placeholder="Enter model ID" onChange={saveModel} />
+          </SettingsRow>
+        </Show>
         <SettingsRow
           title={language.t("settings.indexing.dimension.title")}
           description={language.t("settings.indexing.dimension.description")}
           last={!selectedProvider() || (fields().length === 0 && !(selectedProvider() === "kilo" && !kiloAvailable()))}
         >
           <TextField
-            value={cfg().dimension === undefined ? "" : String(cfg().dimension)}
+            value={
+              staleKiloModel() || cfg().dimension === undefined || cfg().dimension === null
+                ? ""
+                : String(cfg().dimension)
+            }
             placeholder={language.t("settings.indexing.dimension.placeholder")}
             onChange={(value) => saveNumber("dimension", value, { integer: true, min: 1 })}
           />

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -43,6 +43,7 @@ import type {
   Config,
   KilocodeNotification,
   PermissionRequest,
+  ProviderAuthState,
   QuestionRequest,
   SuggestionRequest,
 } from "../types/messages"
@@ -89,7 +90,7 @@ const MOCK_PROVIDERS = {
 const MOCK_MODELS = flattenModels(MOCK_PROVIDERS as any)
 
 /** A synchronous mock ProviderContext — provides models without waiting for a postMessage round-trip. */
-const MockProviderProvider: ParentComponent = (props) => {
+const MockProviderProvider: ParentComponent<{ kiloAuth?: boolean }> = (props) => {
   const value = {
     providers: () => MOCK_PROVIDERS as any,
     connected: () => ["kilo"],
@@ -98,7 +99,7 @@ const MockProviderProvider: ParentComponent = (props) => {
     models: () => MOCK_MODELS,
     findModel: (sel: any) => _findModel(MOCK_MODELS, sel),
     authMethods: () => ({}),
-    authStates: () => ({}),
+    authStates: () => (props.kiloAuth ? { kilo: "oauth" } : {}) as Record<string, ProviderAuthState>,
     isModelValid: () => true,
   }
   return <ProviderContext.Provider value={value}>{props.children}</ProviderContext.Provider>
@@ -271,6 +272,7 @@ interface StoryProvidersProps {
   /** When provided, injects a mock ConfigContext with this config instead of the real ConfigProvider. */
   config?: Config
   onConfigChange?: (config: Config) => void
+  kiloAuth?: boolean
   /** When true, renders children without the default 12px padding wrapper */
   noPadding?: boolean
 }
@@ -346,7 +348,7 @@ export const StoryProviders: ParentComponent<StoryProvidersProps> = (props) => {
         <FeedbackProvider>
           <ConfigWrapper config={props.config} onConfigChange={props.onConfigChange}>
             <DisplayProvider>
-              <MockProviderProvider>
+              <MockProviderProvider kiloAuth={props.kiloAuth}>
                 <DialogProvider>
                   <LanguageContext.Provider
                     value={{

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -7,6 +7,7 @@ import { onMount, createSignal } from "solid-js"
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
 import { StoryProviders, mockSessionValue } from "./StoryProviders"
 import { SessionContext } from "../context/session"
+import { KiloEmbeddingModelsContext } from "../context/kilo-embedding-models"
 import Settings from "../components/settings/Settings"
 import ProvidersTab from "../components/settings/ProvidersTab"
 import ModelsTab from "../components/settings/ModelsTab"
@@ -412,6 +413,8 @@ export const IndexingProviderBlurRace: Story = {
       },
       indexing: {
         provider: "openai",
+        model: "text-embedding-3-large",
+        dimension: 3072,
         openai: { apiKey: "" },
         gemini: { apiKey: "" },
       },
@@ -427,6 +430,66 @@ export const IndexingProviderBlurRace: Story = {
           </div>
         </StoryProviders>
         <pre data-testid="indexing-provider-save">{JSON.stringify(saved(), null, 2)}</pre>
+      </>
+    )
+  },
+}
+
+export const IndexingKiloModelPreset: Story = {
+  name: "IndexingTab - Kilo stale custom model fallback",
+  render: () => {
+    const cfg: Config = {
+      experimental: {
+        semantic_indexing: true,
+      },
+      indexing: {
+        provider: "kilo",
+        model: "custom/model",
+        dimension: 2048,
+      },
+    }
+    const catalog = {
+      defaultModel: "provider/model",
+      models: [
+        { id: "provider/model", name: "Provider Model", dimension: 1024, scoreThreshold: 0.4 },
+        { id: "provider/compact", name: "Provider Compact", dimension: 512, scoreThreshold: 0.35 },
+      ],
+      aliases: {},
+    }
+    return (
+      <StoryProviders config={cfg}>
+        <KiloEmbeddingModelsContext.Provider value={{ catalog: () => catalog }}>
+          <div style={{ "max-height": "700px", overflow: "auto" }}>
+            <IndexingTab />
+          </div>
+        </KiloEmbeddingModelsContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+export const IndexingKiloCatalogLoading: Story = {
+  name: "IndexingTab - Kilo catalog loading",
+  render: () => {
+    const [saved, setSaved] = createSignal<Record<string, unknown>>({})
+    const cfg: Config = {
+      experimental: {
+        semantic_indexing: true,
+      },
+      indexing: {},
+    }
+    return (
+      <>
+        <StoryProviders
+          config={cfg}
+          kiloAuth
+          onConfigChange={(next: Config) => setSaved((next.indexing ?? {}) as Record<string, unknown>)}
+        >
+          <div style={{ "max-height": "700px", overflow: "auto" }}>
+            <IndexingTab />
+          </div>
+        </StoryProviders>
+        <pre data-testid="indexing-kilo-loading-save">{JSON.stringify(saved(), null, 2)}</pre>
       </>
     )
   },

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -67,8 +67,8 @@ export type IndexingProvider =
 export interface IndexingConfig {
   enabled?: boolean
   provider?: IndexingProvider
-  model?: string
-  dimension?: number
+  model?: string | null
+  dimension?: number | null
   vectorStore?: "lancedb" | "qdrant"
   kilo?: { apiKey?: string; baseUrl?: string; organizationId?: string }
   openai?: { apiKey?: string }

--- a/packages/opencode/src/kilocode/components/dialog-indexing.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-indexing.tsx
@@ -9,10 +9,11 @@
 import { useDialog } from "@tui/ui/dialog"
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
 import { DialogPrompt } from "@tui/ui/dialog-prompt"
-import { getKiloEmbeddingModel, normalizeKiloEmbeddingModelId } from "@kilocode/kilo-indexing/embedding-models"
+import { formatKiloEmbeddingModelLabel } from "@kilocode/kilo-indexing/embedding-models"
+import { fetchKiloEmbeddingModelCatalog } from "@kilocode/kilo-gateway"
 import { useSync } from "@tui/context/sync"
 import { useToast } from "@tui/ui/toast"
-import { createResource } from "solid-js"
+import { createResource, Show } from "solid-js"
 import { reconcile } from "solid-js/store"
 import type { IndexingConfig, Config } from "@kilocode/sdk/v2"
 import { hasKiloIndexingAuth, resolveKiloIndexingAuth, shouldDefaultIndexingToKilo } from "../indexing-auth"
@@ -22,10 +23,6 @@ type UseSDK = any
 type SDK = any
 
 type EmbeddingProvider = NonNullable<IndexingConfig["provider"]>
-
-function kiloModel(model: string | undefined): string | undefined {
-  return getKiloEmbeddingModel(model)?.id
-}
 
 const PROVIDER_LABELS: Record<EmbeddingProvider, string> = {
   kilo: "Kilo",
@@ -93,7 +90,7 @@ function defaultIndexing(sync: ReturnType<typeof useSync>, global?: IndexingConf
   const provider = sync.data.provider_next.all.find((item) => item.id === "kilo")
   const auth = resolveKiloIndexingAuth({ config: sync.data.config, provider })
   if (!shouldDefaultIndexingToKilo({ ...global, ...indexing }, auth)) return indexing
-  return { ...indexing, provider: "kilo", model: kiloModel(indexing.model) }
+  return { ...indexing, provider: "kilo", model: null, dimension: null }
 }
 
 async function saveIndexing(
@@ -204,20 +201,12 @@ function ProviderSelect(props: SubDialogProps) {
       onSelect={async (option) => {
         const provider = option.value
         const current = getIndexing(sync)
-        const updated: IndexingConfig =
-          provider === "kilo"
-            ? {
-                ...current,
-                provider,
-                model: kiloModel(current.model),
-                dimension: undefined,
-              }
-            : {
-                ...current,
-                provider,
-                model: undefined,
-                dimension: undefined,
-              }
+        const updated: IndexingConfig = {
+          ...current,
+          provider,
+          model: null,
+          dimension: null,
+        }
         const saved = await saveIndexing(sdk, sync, updated, toast)
         if (!saved) {
           dialog.clear()
@@ -226,6 +215,59 @@ function ProviderSelect(props: SubDialogProps) {
         showProviderSettings(dialog, sync, sdk, toast, provider, props.useSDK)
       }}
     />
+  )
+}
+
+function KiloModelSelect(props: SubDialogProps) {
+  const dialog = useDialog()
+  const sync = useSync()
+  const sdk = props.useSDK()
+  const toast = useToast()
+  const indexing = defaultIndexing(sync)
+  const provider = sync.data.provider_next.all.find((item) => item.id === "kilo")
+  const auth = resolveKiloIndexingAuth({ config: sync.data.config, provider })
+  const [catalog] = createResource(() => fetchKiloEmbeddingModelCatalog({ baseURL: auth.baseUrl, token: auth.apiKey }))
+  const options = () =>
+    (catalog()?.models ?? []).map((model) => ({
+      value: model.id,
+      title: formatKiloEmbeddingModelLabel(model),
+    }))
+  const current = () => {
+    const cfg = catalog()
+    if (!cfg) return undefined
+    const fallback = cfg.aliases[cfg.defaultModel] ?? cfg.defaultModel
+    const id = indexing.model ? (cfg.aliases[indexing.model] ?? indexing.model) : fallback
+    if (cfg.models.some((model) => model.id === id)) return id
+    return fallback
+  }
+
+  return (
+    <Show
+      when={!catalog.loading && options().length > 0}
+      fallback={
+        <DialogSelect
+          title="Kilo Embedding Model"
+          options={[
+            {
+              value: "",
+              title: catalog.loading ? "Loading supported models..." : "No supported models available",
+              disabled: true,
+            },
+          ]}
+          renderFilter={false}
+        />
+      }
+    >
+      <DialogSelect
+        title="Kilo Embedding Model"
+        options={options()}
+        current={current()}
+        onSelect={async (option) => {
+          await saveIndexing(sdk, sync, { ...getIndexing(sync), model: option.value, dimension: null }, toast)
+          dialog.replace(() => <DialogIndexing useSDK={props.useSDK} />)
+        }}
+      />
+    </Show>
   )
 }
 
@@ -466,9 +508,9 @@ export function DialogIndexing(props: DialogIndexingProps) {
     },
     {
       value: "model",
-      title: "Embedding Model",
+      title: indexing.provider === "kilo" ? "Kilo Model Preset" : "Embedding Model",
       category: "Embedding",
-      description: indexing.model ?? "default",
+      description: indexing.provider === "kilo" ? "hosted presets only" : (indexing.model ?? "default"),
     },
     {
       value: "dimension",
@@ -543,21 +585,17 @@ export function DialogIndexing(props: DialogIndexingProps) {
             }
             break
           case "model": {
+            if (indexing.provider === "kilo") {
+              dialog.replace(() => <KiloModelSelect useSDK={props.useSDK} />)
+              break
+            }
             const result = await DialogPrompt.show(dialog, "Embedding Model", {
               value: indexing.model ?? "",
-              placeholder: indexing.provider === "kilo" ? "provider/model" : "e.g. text-embedding-3-small",
+              placeholder: "Enter model ID",
             })
             if (result !== null) {
               const trimmed = result.trim()
-              const updated = {
-                ...getIndexing(sync),
-                model: trimmed
-                  ? indexing.provider === "kilo"
-                    ? (normalizeKiloEmbeddingModelId(trimmed) ?? trimmed)
-                    : trimmed
-                  : undefined,
-              }
-              await saveIndexing(sdk, sync, updated, toast)
+              await saveIndexing(sdk, sync, { ...getIndexing(sync), model: trimmed || null }, toast)
             }
             dialog.replace(() => <DialogIndexing useSDK={props.useSDK} />)
             break
@@ -578,7 +616,7 @@ export function DialogIndexing(props: DialogIndexingProps) {
                   break
                 }
               }
-              const updated = { ...getIndexing(sync), dimension: dim }
+              const updated = { ...getIndexing(sync), dimension: dim ?? null }
               await saveIndexing(sdk, sync, updated, toast)
             }
             dialog.replace(() => <DialogIndexing useSDK={props.useSDK} />)

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -84,17 +84,31 @@ function enrichKilo(input: ReturnType<typeof toIndexingConfigInput>, auth: KiloI
 
 async function model(input: ReturnType<typeof toIndexingConfigInput>, auth: KiloIndexingAuth) {
   if (input.embedderProvider !== "kilo") return input
-  if (input.modelId && input.modelDimension) return input
 
   const catalog = await fetchKiloEmbeddingModelCatalog({ baseURL: auth.baseUrl, token: auth.apiKey })
   const id = input.modelId ? (catalog.aliases[input.modelId] ?? input.modelId) : catalog.defaultModel
-  const found = catalog.models.find((item) => item.id === id)
-  if (!found) return { ...input, modelId: id || input.modelId }
+  const chosen = catalog.models.find((item) => item.id === id)
+  const fallback = catalog.aliases[catalog.defaultModel] ?? catalog.defaultModel
+  const found = chosen ?? catalog.models.find((item) => item.id === fallback)
+
+  if (!found) {
+    if (input.modelId || input.modelDimension) {
+      log.warn("ignoring unsupported Kilo embedding model configuration", { model: input.modelId })
+    }
+    return { ...input, modelId: undefined, modelDimension: undefined }
+  }
+
+  if (input.modelId && !chosen) {
+    log.warn("using default Kilo embedding model instead of unsupported configuration", {
+      model: input.modelId,
+      fallback: found.id,
+    })
+  }
 
   return {
     ...input,
     modelId: found.id,
-    modelDimension: input.modelDimension ?? found.dimension,
+    modelDimension: chosen ? (input.modelDimension ?? found.dimension) : found.dimension,
     searchMinScore: input.searchMinScore ?? found.scoreThreshold,
   }
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -290,6 +290,11 @@ function applyLegacySchemaOverrides(spec: OpenApiSpec) {
   const model = schemas.ProviderConfig?.properties?.models?.additionalProperties
   const variants = typeof model === "object" ? model.properties?.variants?.additionalProperties : undefined
   if (variants && typeof variants === "object") variants.additionalProperties = {}
+  // kilocode_change start - preserve model reset sentinels in indexing config patches
+  const indexing = schemas.IndexingConfig?.properties
+  if (indexing?.model) indexing.model = nullable(indexing.model)
+  if (indexing?.dimension) indexing.dimension = nullable(indexing.dimension)
+  // kilocode_change end
   const syncInfo = schemas.SyncEventSessionUpdated?.properties?.data?.properties?.info
   if (syncInfo?.properties) makePropertiesNullable(syncInfo.properties)
 }

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -14,6 +14,7 @@ import { Config } from "../../../src/config/config"
 import { ConfigMarkdown } from "../../../src/config/markdown"
 import { Env } from "../../../src/env"
 import { KiloIndexing } from "../../../src/kilocode/indexing"
+import { KilocodeConfig } from "../../../src/kilocode/config/config"
 import { WithInstance } from "../../../src/project/with-instance"
 import { Filesystem } from "../../../src/util/filesystem"
 import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
@@ -167,5 +168,24 @@ describe("kilocode indexing config", () => {
   test("global indexing enabled applies when project indexing is disabled", async () => {
     const input = KiloIndexing.input({ enabled: false }, { enabled: true })
     expect(input.enabled).toBe(true)
+  })
+
+  test("accepts delete sentinels for indexing model overrides", () => {
+    const patch = Config.Info.zod.parse({ indexing: { model: null, dimension: null } })
+    const merged = KilocodeConfig.mergeConfig(
+      {
+        indexing: {
+          provider: "openai",
+          model: "text-embedding-3-large",
+          dimension: 3072,
+        },
+      },
+      patch,
+    )
+    const input = KiloIndexing.input(patch.indexing)
+
+    expect(merged.indexing).toEqual({ provider: "openai" })
+    expect(input.modelId).toBeUndefined()
+    expect(input.modelDimension).toBeUndefined()
   })
 })

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -64,6 +64,19 @@ const implicitOpenAi: Partial<Config.Info> = {
     },
   },
 }
+const staleKilo: Partial<Config.Info> = {
+  plugin: ["@kilocode/kilo-indexing"],
+  experimental: {
+    semantic_indexing: true,
+  },
+  indexing: {
+    enabled: true,
+    provider: "kilo",
+    model: "custom/model",
+    dimension: 2048,
+    vectorStore: "qdrant",
+  },
+}
 const configDir = process.env["KILO_CONFIG_DIR"]
 const disabled = process.env["KILO_DISABLE_CODEBASE_INDEXING"]
 const error = new Error("test indexing initialization failed")
@@ -314,6 +327,125 @@ describe("indexing startup degradation", () => {
       else process.env.KILO_API_KEY = key
       if (org === undefined) delete process.env.KILO_ORG_ID
       else process.env.KILO_ORG_ID = org
+      init.mockRestore()
+    }
+  })
+
+  test("falls back from unsupported stored Kilo models to the hosted default", async () => {
+    global.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            defaultModel: "mistralai/mistral-embed-2312",
+            models: [
+              { id: "mistralai/mistral-embed-2312", name: "Mistral Embed 2312", dimension: 1024, scoreThreshold: 0.35 },
+            ],
+            aliases: {},
+          }),
+        ),
+      )) as unknown as typeof global.fetch
+    const init = spyOn(CodeIndexManager.prototype, "initialize").mockResolvedValue({ requiresRestart: false })
+    const key = process.env.KILO_API_KEY
+
+    await using tmp = await tmpdir({ git: true, config: staleKilo })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    process.env.KILO_API_KEY = "kilo-token"
+
+    try {
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await called(init)
+          expect(init.mock.calls[0]?.[0]).toMatchObject({
+            embedderProvider: "kilo",
+            modelId: "mistralai/mistral-embed-2312",
+            modelDimension: 1024,
+            searchMinScore: 0.35,
+          })
+        },
+      })
+    } finally {
+      if (key === undefined) delete process.env.KILO_API_KEY
+      else process.env.KILO_API_KEY = key
+      init.mockRestore()
+    }
+  })
+
+  test("keeps configured dimensions for supported Kilo models", async () => {
+    global.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            defaultModel: "mistralai/mistral-embed-2312",
+            models: [
+              { id: "mistralai/mistral-embed-2312", name: "Mistral Embed 2312", dimension: 1024, scoreThreshold: 0.35 },
+              {
+                id: "openai/text-embedding-3-small",
+                name: "OpenAI Text Embedding 3 Small",
+                dimension: 1536,
+                scoreThreshold: 0.4,
+              },
+            ],
+            aliases: {},
+          }),
+        ),
+      )) as unknown as typeof global.fetch
+    const init = spyOn(CodeIndexManager.prototype, "initialize").mockResolvedValue({ requiresRestart: false })
+    const key = process.env.KILO_API_KEY
+    const config: Partial<Config.Info> = {
+      ...staleKilo,
+      indexing: {
+        ...staleKilo.indexing,
+        model: "openai/text-embedding-3-small",
+        dimension: 256,
+      },
+    }
+
+    await using tmp = await tmpdir({ git: true, config })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    process.env.KILO_API_KEY = "kilo-token"
+
+    try {
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await called(init)
+          expect(init.mock.calls[0]?.[0]).toMatchObject({
+            embedderProvider: "kilo",
+            modelId: "openai/text-embedding-3-small",
+            modelDimension: 256,
+          })
+        },
+      })
+    } finally {
+      if (key === undefined) delete process.env.KILO_API_KEY
+      else process.env.KILO_API_KEY = key
+      init.mockRestore()
+    }
+  })
+
+  test("does not execute stored Kilo models when the hosted catalog is unavailable", async () => {
+    global.fetch = (() => Promise.resolve(new Response(undefined, { status: 500 }))) as unknown as typeof global.fetch
+    const init = spyOn(CodeIndexManager.prototype, "initialize").mockResolvedValue({ requiresRestart: false })
+    const key = process.env.KILO_API_KEY
+
+    await using tmp = await tmpdir({ git: true, config: staleKilo })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    process.env.KILO_API_KEY = "kilo-token"
+
+    try {
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await called(init)
+          expect(init.mock.calls[0]?.[0]).toMatchObject({ embedderProvider: "kilo" })
+          expect(init.mock.calls[0]?.[0].modelId).toBeUndefined()
+          expect(init.mock.calls[0]?.[0].modelDimension).toBeUndefined()
+        },
+      })
+    } finally {
+      if (key === undefined) delete process.env.KILO_API_KEY
+      else process.env.KILO_API_KEY = key
       init.mockRestore()
     }
   })

--- a/packages/opencode/test/kilocode/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-bridge.test.ts
@@ -36,6 +36,10 @@ function sortSchema(input: unknown): unknown {
   )
 }
 
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return !!input && typeof input === "object" && !Array.isArray(input)
+}
+
 type Operation = {
   responses?: unknown
 }
@@ -53,6 +57,14 @@ function providerSchema(input: unknown) {
   const provider = props.provider
   if (!provider || typeof provider !== "object" || !("additionalProperties" in provider)) return undefined
   return provider.additionalProperties
+}
+
+function indexingNullableFields(input: unknown) {
+  if (!isRecord(input) || !isRecord(input.components) || !isRecord(input.components.schemas)) return []
+  const indexing = input.components.schemas.IndexingConfig
+  if (!isRecord(indexing) || !isRecord(indexing.properties)) return []
+  const properties = indexing.properties
+  return ["model", "dimension"].filter((key) => JSON.stringify(properties[key]).includes('"null"'))
 }
 
 function responseSchema(input: {
@@ -136,6 +148,14 @@ describe("Kilo HttpApi bridge", () => {
     const effect = effectOpenApi()
 
     expect(stableSchema(providerSchema(effect))).toBe(stableSchema(providerSchema(hono)))
+  })
+
+  test("keeps nullable indexing model reset sentinels in both APIs", async () => {
+    const hono = await Server.openapiHono()
+    const effect = effectOpenApi()
+
+    expect(indexingNullableFields(effect)).toEqual(["model", "dimension"])
+    expect(indexingNullableFields(hono)).toEqual(["model", "dimension"])
   })
 
   test("matches Kilo FIM SSE response schema", async () => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1023,8 +1023,8 @@ export type IndexingConfig = {
     | "bedrock"
     | "openrouter"
     | "voyage"
-  model?: string
-  dimension?: number
+  model?: string | null
+  dimension?: number | null
   vectorStore?: "lancedb" | "qdrant"
   kilo?: {
     apiKey?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15663,11 +15663,25 @@
             ]
           },
           "model": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "dimension": {
-            "type": "integer",
-            "exclusiveMinimum": 0
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "vectorStore": {
             "type": "string",


### PR DESCRIPTION
Semantic indexing through Kilo is a managed path: Kilo defines the supported hosted embedding models and their compatible defaults. Exposing a free-text Kilo model override was redundant and could leave stale or unsupported model IDs configured.

This restricts Kilo indexing to hosted presets in VS Code and the CLI, and validates stored Kilo model IDs before runtime use. Custom model strings remain available for local and external providers through the normal custom-model input.

Provider or hosted-preset changes persistently reset obsolete model and dimension overrides, so an old Kilo model or incompatible vector dimension is not silently carried into the next selection.

<img width="991" height="146" alt="image" src="https://github.com/user-attachments/assets/fd793741-fbe1-421e-b8ce-8559321d4541" />
<img width="982" height="149" alt="image" src="https://github.com/user-attachments/assets/8d5ab042-1180-44c5-9631-57f7f7f304f0" />