### PR TITLE
docs(kilo-docs): document JetBrains v7 EAP install

### DIFF
--- a/packages/kilo-docs/markdoc/partials/install-jetbrains.md
+++ b/packages/kilo-docs/markdoc/partials/install-jetbrains.md
@@ -28,6 +28,31 @@ Before installing the Kilo Code plugin, ensure you have:
 4. Search for "Kilo Code"
 5. Click **Install** and restart your IDE
 
+### Try the v7 EAP plugin
+
+The v7 EAP plugin is available for users who want to try the newest JetBrains experience before it reaches the default Marketplace channel. It uses a JetBrains-native UI and is designed to work well with JetBrains remote development.
+
+{% callout type="info" %}
+EAP builds may update more frequently than the default Marketplace release. Share feedback in the JetBrains channel on the [Kilo Discord](https://kilo.ai/discord).
+{% /callout %}
+
+To install the EAP build and receive updates:
+
+1. Open IntelliJ IDEA or another JetBrains IDE
+2. Go to **Settings/Preferences → Plugins**
+3. Click the gear icon and choose **Manage Plugin Repositories**
+4. Add this repository URL:
+
+```text
+https://plugins.jetbrains.com/plugins/list?channel=eap&pluginId=28350
+```
+
+5. Return to the **Marketplace** tab
+6. Search for **Kilo Code**
+7. Click **Install** or **Update** and restart your IDE if prompted
+
+After the custom repository is added, JetBrains will offer EAP updates through the normal plugin update flow.
+
 ### Supported IDEs
 
 - IntelliJ IDEA

--- a/packages/kilo-docs/markdoc/partials/install-jetbrains.md
+++ b/packages/kilo-docs/markdoc/partials/install-jetbrains.md
@@ -28,7 +28,7 @@ Before installing the Kilo Code plugin, ensure you have:
 4. Search for "Kilo Code"
 5. Click **Install** and restart your IDE
 
-### Try the v7 EAP plugin
+### Try the v7 Early Access Program plugin
 
 The v7 EAP plugin is available for users who want to try the newest JetBrains experience before it reaches the default Marketplace channel. It uses a JetBrains-native UI and is designed to work well with JetBrains remote development.
 


### PR DESCRIPTION
## Issue

No linked issue; docs-only update requested directly.

## Context

Document how JetBrains users can try the v7 EAP plugin before it reaches the default Marketplace channel. The new copy highlights the JetBrains-native UI, remote development support, custom EAP plugin repository, update behavior, and Discord feedback path.

## Implementation

Updated the shared JetBrains install partial so both the dedicated JetBrains page and the general installation page show the same EAP instructions.

## Screenshots / Video

N/A — docs copy only.

## How to Test

### Manual/local verification

- Agent ran `bun run script/extract-source-links.ts`; no source link diff remained.
- Agent ran `bun run build` from `packages/kilo-docs`; build passed.
- Push hook ran `bun turbo typecheck`; typecheck passed.

### Reviewer test steps

1. Open `/docs/code-with-ai/platforms/jetbrains` or `/docs/getting-started/installing`.
2. Confirm the JetBrains install section includes the v7 EAP instructions.
3. Confirm the custom plugin repository URL is `https://plugins.jetbrains.com/plugins/list?channel=eap&pluginId=28350`.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Kilo team.