### PR TITLE
fix(vscode): center session history delete button

### DIFF
--- a/.changeset/center-history-delete.md
+++ b/.changeset/center-history-delete.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Center local session history delete buttons within their rows.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/history-sessionlist/with-items-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/history-sessionlist/with-items-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65686e2d0978adcf09ae504d9414e2d81f304eb18ff2275be7a33a9c3579a5e5
-size 18209
+oid sha256:32fa296aeee4f45f1cefe49d8eaca08099a8b3b8c23d4e9cdec803ce7fd1f0a1
+size 18207

--- a/packages/kilo-vscode/webview-ui/src/styles/history.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/history.css
@@ -50,6 +50,8 @@ body.vscode-light
 }
 
 .session-list [data-slot="session-delete-button"] {
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
   margin-left: 4px;
   opacity: 0;


### PR DESCRIPTION
Local session history rows display the delete action slightly off-center because the icon wrapper follows inline baseline alignment, making the row affordance look visibly misaligned.

Render the delete action wrapper as an aligned inline flex container so the trash icon remains vertically centered in each history row while preserving the existing hover and delete interaction.

Before:
<img width="190" height="52" alt="image" src="https://github.com/user-attachments/assets/c9e2550c-fc70-4bf9-9e83-dab2cb545a2f" />
After:
<img width="167" height="66" alt="image" src="https://github.com/user-attachments/assets/653942e5-98c4-4fda-8fe0-bfaeb97f511b" />
