### PR TITLE
docs: allow detailed PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Changeset descriptions appear directly in release notes and are read by end user
 
 ## Pull Requests
 
-PR descriptions should be 2-3 lines covering **what** changed and **why**. Focus on intent and context a reviewer can't get from the diff — skip file-by-file inventories, test result summaries, and anything obvious from the code itself.
+PR descriptions should explain **what** changed, **why** the change is needed, and the intent or constraints a reviewer cannot infer from the diff alone. Keep simple PRs brief, but give non-trivial changes enough context to stand on their own. Skip file-by-file inventories, test result summaries, and anything obvious from the code itself.
 
 ## GitHub Issues
 


### PR DESCRIPTION
The repository guidance limits PR descriptions to 2-3 lines, which makes it difficult for substantial changes to preserve motivation, constraints, and reviewer-relevant decisions in the PR itself.

This updates the guidance so simple PRs can remain brief while non-trivial changes include enough context to stand on their own. It retains the guardrails against file-by-file inventories, test-result summaries, and details already apparent from the diff, without imposing an artificial length limit.