### PR TITLE
fix(vscode): improve history context menu sizing

### DIFF
--- a/.changeset/history-context-menu-size.md
+++ b/.changeset/history-context-menu-size.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve the size and readability of the local History session context menu.

--- a/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/SessionList.tsx
@@ -115,7 +115,7 @@ const SessionList: Component<SessionListProps> = (props) => {
           {node}
         </ContextMenu.Trigger>
         <ContextMenu.Portal>
-          <ContextMenu.Content>
+          <ContextMenu.Content class="session-list-menu">
             <ContextMenu.Item onSelect={() => startRename(item)}>
               <ContextMenu.ItemLabel>{language.t("common.rename")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>

--- a/packages/kilo-vscode/webview-ui/src/styles/history.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/history.css
@@ -63,16 +63,14 @@ body.vscode-light
 
 .session-list-menu {
   min-width: 180px;
-  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent) !important;
-  box-shadow: var(--shadow-md) !important;
+  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent);
+  box-shadow: var(--shadow-md);
 
   [data-slot="context-menu-item"] {
     padding: 6px 10px;
-    font-size: var(--font-size-small);
     line-height: var(--line-height-large);
     transition: none;
 
-    &:hover,
     &[data-highlighted] {
       background: var(--surface-raised-base-hover);
     }

--- a/packages/kilo-vscode/webview-ui/src/styles/history.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/history.css
@@ -61,6 +61,28 @@ body.vscode-light
   opacity: 1;
 }
 
+.session-list-menu {
+  min-width: 180px;
+  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent) !important;
+  box-shadow: var(--shadow-md) !important;
+
+  [data-slot="context-menu-item"] {
+    padding: 6px 10px;
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+    transition: none;
+
+    &:hover,
+    &[data-highlighted] {
+      background: var(--surface-raised-base-hover);
+    }
+  }
+
+  [data-slot="context-menu-separator"] {
+    margin: 4px 0;
+  }
+}
+
 /* History View (unified Local + Cloud tabs) */
 .history-view {
   display: flex;


### PR DESCRIPTION
The local History actions menu is currently too compressed to comfortably scan and select its actions. Its rename, export, and delete entries inherit a compact menu treatment that makes this frequently used sidebar menu feel cramped and visually broken.

This gives only the local History session menu a readable minimum width, normal item spacing, and consistent hover and separator treatment. The adjustment is intentionally scoped to menu presentation and does not change session rename behavior or broaden the styling of unrelated context menus.

Before:
<img width="429" height="165" alt="image" src="https://github.com/user-attachments/assets/52f2d714-5260-4b55-876f-1ba7101f7448" />
After:
<img width="257" height="158" alt="image" src="https://github.com/user-attachments/assets/f581cbea-366f-4f1d-b408-a9a50fdb7ccd" />
