### PR TITLE
Improve suggest bar responsiveness

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/mistral.md
+++ b/packages/kilo-docs/pages/ai-providers/mistral.md
@@ -76,7 +76,7 @@ Other Mistral models do not get automatic reasoning variants, even if they appea
 
 ## Using Codestral
 
-[Codestral](https://docs.mistral.ai/capabilities/code_generation/) is a model specifically designed for code generation and interaction.
+[Codestral](https://docs.mistral.ai/vibe/code/overview) is a model specifically designed for code generation and interaction.
 Only for Codestral you could use different endpoints (Default: codestral.mistral.ai).
 For the La Platforme API Key change the **Codestral Base Url** to: https://api.mistral.ai
 

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/suggest-bar-review-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/suggest-bar-review-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eee5f5d61cf2ac9ad0b987a8b220d76c503be0d11447766e6669da4684698c82
-size 6130
+oid sha256:bbdf3df267cb9c32febbaa486b7a63e8561e1d968bda24bb5278634307eac873
+size 5962

--- a/packages/kilo-vscode/webview-ui/src/styles/suggest-bar.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/suggest-bar.css
@@ -45,5 +45,17 @@
     align-items: center;
     gap: 6px;
     flex-shrink: 0;
+
+    [data-component="button"] {
+      min-width: 100px;
+      white-space: normal;
+    }
+  }
+}
+
+@media (max-width: 700px) {
+  [data-component="suggest-bar"] {
+    flex-direction: column;
+    align-items: stretch;
   }
 }


### PR DESCRIPTION

Fixes #10640 

## Context

Add min-width and text wrapping for action buttons and introduce a responsive layout that stacks the suggest bar vertically on narrow viewports.

## Screenshots / Video

| before | after |
|---|---|
| https://github.com/user-attachments/assets/915280a9-c7a6-408d-8608-563f0b92f833 | https://github.com/user-attachments/assets/8c181212-1893-48de-a254-3a26c97a5a2d |

