### PR TITLE
fix(cli): avoid indexing plugin blocking startup

### DIFF
--- a/.changeset/quiet-indexing-startup.md
+++ b/.changeset/quiet-indexing-startup.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep the extension usable on fresh startup when semantic indexing is enabled globally.

--- a/packages/opencode/src/kilocode/config/default-plugins.ts
+++ b/packages/opencode/src/kilocode/config/default-plugins.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "module"
 import type { ConfigPlugin } from "@/config/plugin"
+import { isIndexingPlugin } from "@kilocode/kilo-indexing/detect"
 import { ensureIndexingPlugin, resolveIndexingPlugin } from "@/kilocode/indexing-feature"
 
 type Log = {
@@ -13,17 +14,10 @@ export namespace KilocodeDefaultPlugins {
     cfg: T,
     opts: { disabled: boolean; log?: Log },
   ): T {
-    const before = cfg.plugin ?? []
     const plugin = opts.disabled ? undefined : resolveIndexingPlugin(req, opts.log)
-    const after = ensureIndexingPlugin(before, plugin)
-    if (after.length > before.length) {
-      const added = after[after.length - 1]
-      cfg.plugin_origins = [
-        ...(cfg.plugin_origins ?? []),
-        { spec: added, source: "builtin", scope: "global" as ConfigPlugin.Scope },
-      ]
-    }
-    cfg.plugin = after
+    cfg.plugin = ensureIndexingPlugin(cfg.plugin ?? [], plugin)
+    // Built-in indexing is not loaded through external plugins and must not wait for their setup.
+    cfg.plugin_origins = cfg.plugin_origins?.filter((item) => !isIndexingPlugin(item.spec))
     return cfg
   }
 }

--- a/packages/opencode/test/kilocode/config/indexing-default-plugin.test.ts
+++ b/packages/opencode/test/kilocode/config/indexing-default-plugin.test.ts
@@ -6,6 +6,9 @@ import { hasIndexingPlugin } from "@kilocode/kilo-indexing/detect"
 import { Account } from "../../../src/account/account"
 import { Auth } from "../../../src/auth"
 import { Config } from "../../../src/config/config"
+import type { ConfigPlugin } from "../../../src/config/plugin"
+import { KilocodeDefaultPlugins } from "../../../src/kilocode/config/default-plugins"
+import { INDEXING_PLUGIN } from "../../../src/kilocode/indexing-feature"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { Env } from "../../../src/env"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -48,6 +51,28 @@ describe("kilocode default indexing plugin", () => {
   afterEach(async () => {
     await clear()
     await disposeAllInstances()
+  })
+
+  test("injects indexing without registering an external plugin origin", () => {
+    const config: { plugin?: ConfigPlugin.Spec[]; plugin_origins?: ConfigPlugin.Origin[] } = {}
+
+    KilocodeDefaultPlugins.apply(config, { disabled: false })
+
+    expect(hasIndexingPlugin(config.plugin ?? [])).toBe(true)
+    expect(config.plugin_origins).toBeUndefined()
+  })
+
+  test("removes a persisted indexing marker from external plugin origins", () => {
+    const external: ConfigPlugin.Origin = { spec: "global-plugin", source: "global", scope: "global" }
+    const config = {
+      plugin: [INDEXING_PLUGIN, external.spec],
+      plugin_origins: [{ spec: INDEXING_PLUGIN, source: "global", scope: "global" as const }, external],
+    }
+
+    KilocodeDefaultPlugins.apply(config, { disabled: true })
+
+    expect(config.plugin).toEqual([INDEXING_PLUGIN, external.spec])
+    expect(config.plugin_origins).toEqual([external])
   })
 
   test("does not hard-enable indexing plugin when default plugins are disabled", async () => {


### PR DESCRIPTION
When semantic indexing is available globally, the built-in indexing marker is recorded as an external plugin origin. On fresh extension startup this can make workspace initialization wait for external plugin dependency preparation before the detached indexing worker can begin, leaving the sidebar waiting for initial backend data.

This keeps semantic indexing advertised in configuration for capability detection and worker startup, but excludes indexing markers from external plugin origins, including markers persisted by older configurations. Real external plugins continue to use dependency preparation, while built-in semantic indexing no longer holds workspace startup open.