### PR TITLE
Remove wrappers for Provider service

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -111,6 +111,20 @@ export namespace KiloSessions {
     })
   }
 
+  async function model(providerID: ProviderID, modelID: ModelID) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return AppRuntime.runPromise(Provider.Service.use((svc) => svc.getModel(providerID, modelID)))
+  }
+
+  async function models(refs: Array<{ providerID: string; modelID: string }>) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return AppRuntime.runPromise(
+      Provider.Service.use((svc) =>
+        Effect.all(refs.map((ref) => svc.getModel(ProviderID.make(ref.providerID), ModelID.make(ref.modelID)))),
+      ),
+    )
+  }
+
   type Client = {
     url: string
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -233,11 +247,8 @@ export namespace KiloSessions {
           yield* watch(MessageV2.Event.Updated, async (evt) => {
             await ingest.sync(evt.properties.info.sessionID, [{ type: "message", data: evt.properties.info }])
             if (evt.properties.info.role !== "user") return
-            const model = await Provider.getModel(
-              evt.properties.info.model.providerID,
-              evt.properties.info.model.modelID,
-            )
-            await ingest.sync(evt.properties.info.sessionID, [{ type: "model", data: [model] }])
+            const mdl = await model(evt.properties.info.model.providerID, evt.properties.info.model.modelID)
+            await ingest.sync(evt.properties.info.sessionID, [{ type: "model", data: [mdl] }])
           })
           yield* watch(MessageV2.Event.PartUpdated, (evt) =>
             ingest.sync(evt.properties.part.sessionID, [{ type: "part", data: evt.properties.part }]),
@@ -628,11 +639,8 @@ export namespace KiloSessions {
     const diffs = await SessionSummary.diff({ sessionID: SessionID.make(sessionId) })
     const messages = await Array.fromAsync(MessageV2.stream(SessionID.make(sessionId)))
     messages.reverse()
-    const models = await Promise.all(
-      messages
-        .filter((m) => m.info.role === "user")
-        .map((m) => (m.info as SDK.UserMessage).model)
-        .map((m) => Provider.getModel(ProviderID.make(m.providerID), ModelID.make(m.modelID)).then((m) => m)),
+    const mdls = await models(
+      messages.filter((m) => m.info.role === "user").map((m) => (m.info as SDK.UserMessage).model),
     )
 
     await ingest.sync(sessionId, [
@@ -655,7 +663,7 @@ export namespace KiloSessions {
       },
       {
         type: "model",
-        data: models,
+        data: mdls,
       },
       {
         type: "session_status",

--- a/packages/opencode/src/kilocode/cli/cmd/roll-call.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/roll-call.ts
@@ -4,6 +4,7 @@ import { Provider } from "../../../provider/provider"
 import { ProviderTransform } from "../../../provider/transform"
 import { cmd } from "../../../cli/cmd/cmd"
 import { UI } from "../../../cli/ui"
+import { AppRuntime } from "../../../effect/app-runtime"
 import { generateText } from "ai"
 import { randomUUID } from "crypto"
 
@@ -125,8 +126,16 @@ interface Result {
   errorMessage: string | null
 }
 
+function list() {
+  return AppRuntime.runPromise(Provider.Service.use((svc) => svc.list()))
+}
+
+function lang(model: Provider.Model) {
+  return AppRuntime.runPromise(Provider.Service.use((svc) => svc.getLanguage(model)))
+}
+
 export async function handle(args: ArgumentsCamelCase) {
-  const list = args.list ?? Provider.list
+  const load = args.list ?? list
 
   if (args.parallel < 1) {
     UI.error("--parallel must be at least 1")
@@ -161,7 +170,7 @@ export async function handle(args: ArgumentsCamelCase) {
   await WithInstance.provide({
     directory: process.cwd(),
     async fn() {
-      const providers = await list()
+      const providers = await load()
       const regex = (() => {
         try {
           return new RegExp(args.filter, "i")
@@ -272,7 +281,7 @@ async function call(
   start: number,
 ): Promise<Omit<Result, "model">> {
   try {
-    const language = await Provider.getLanguage(model)
+    const language = await lang(model)
     const sessionID = randomUUID()
     const options = ProviderTransform.options({ model, sessionID })
     const providerOptions = ProviderTransform.providerOptions(model, options)
@@ -342,5 +351,5 @@ type ArgumentsCamelCase = {
   output: "table" | "json" | "md"
   verbose: boolean
   quiet: boolean
-  list?: typeof Provider.list
+  list?: typeof list
 }

--- a/packages/opencode/src/kilocode/commit-message/generate.ts
+++ b/packages/opencode/src/kilocode/commit-message/generate.ts
@@ -11,6 +11,16 @@ import { getGitContext } from "./git-context"
 const log = Log.create({ service: "commit-message" })
 
 export const CommitMessageRuntime = {
+  model() {
+    return AppRuntime.runPromise(
+      Provider.Service.use((svc) =>
+        Effect.gen(function* () {
+          const ref = yield* svc.defaultModel()
+          return (yield* svc.getSmallModel(ref.providerID)) ?? (yield* svc.getModel(ref.providerID, ref.modelID))
+        }),
+      ),
+    )
+  },
   generate(input: LLM.StreamInput, signal: AbortSignal) {
     // runPromise is needed until generateCommitMessage() uses Effect
     return AppRuntime.runPromise(
@@ -141,10 +151,7 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
     files: ctx.files.length,
   })
 
-  const defaultModel = await Provider.defaultModel()
-  const model =
-    (await Provider.getSmallModel(defaultModel.providerID)) ??
-    (await Provider.getModel(defaultModel.providerID, defaultModel.modelID))
+  const model = await CommitMessageRuntime.model()
 
   const agent: Agent.Info = {
     name: "commit-message",

--- a/packages/opencode/src/kilocode/enhance-prompt.ts
+++ b/packages/opencode/src/kilocode/enhance-prompt.ts
@@ -2,6 +2,8 @@ import { generateText } from "ai"
 import { mergeDeep } from "remeda"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
+import { AppRuntime } from "@/effect/app-runtime"
+import { Effect } from "effect"
 import * as Log from "@opencode-ai/core/util/log"
 
 const log = Log.create({ service: "enhance-prompt" })
@@ -28,19 +30,23 @@ export function clean(text: string) {
 export async function enhancePrompt(text: string): Promise<string> {
   log.info("enhancing", { length: text.length })
 
-  const defaultModel = await Provider.defaultModel()
-  const model =
-    (await Provider.getSmallModel(defaultModel.providerID)) ??
-    (await Provider.getModel(defaultModel.providerID, defaultModel.modelID))
-
-  const language = await Provider.getLanguage(model)
+  const resolved = await AppRuntime.runPromise(
+    Provider.Service.use((svc) =>
+      Effect.gen(function* () {
+        const ref = yield* svc.defaultModel()
+        const model = (yield* svc.getSmallModel(ref.providerID)) ?? (yield* svc.getModel(ref.providerID, ref.modelID))
+        const language = yield* svc.getLanguage(model)
+        return { model, language }
+      }),
+    ),
+  )
 
   const result = await generateText({
-    model: language,
-    temperature: model.capabilities.temperature ? 0.7 : undefined,
+    model: resolved.language,
+    temperature: resolved.model.capabilities.temperature ? 0.7 : undefined,
     providerOptions: ProviderTransform.providerOptions(
-      model,
-      mergeDeep(ProviderTransform.smallOptions(model), model.options),
+      resolved.model,
+      mergeDeep(ProviderTransform.smallOptions(resolved.model), resolved.model.options),
     ),
     maxRetries: 3,
     system: INSTRUCTION,

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -98,6 +98,7 @@ export namespace KiloTask {
     agent: Pick<Agent.Info, "model" | "variant">
     config: Pick<Config.Info, "subagent_model" | "subagent_variant">
     parent: Model
+    provider: Provider.Interface
   }) {
     const state = yield* saved(input.name)
     const cfg = parse(input.config.subagent_model)
@@ -116,10 +117,8 @@ export namespace KiloTask {
     for (const choice of choices) {
       if (!choice) continue
       if (choice.direct) return { model: choice.model, variant: choice.variant }
-      const full = yield* Effect.tryPromise(() =>
-        Provider.getModel(choice.model.providerID, choice.model.modelID),
-      ).pipe(
-        Effect.catch((err) =>
+      const full = yield* input.provider.getModel(choice.model.providerID, choice.model.modelID).pipe(
+        Effect.catchDefect((err) =>
           Effect.sync(() => {
             log.debug("skipping unavailable task subagent model", {
               providerID: choice.model.providerID,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -7,7 +7,6 @@ import * as Log from "@opencode-ai/core/util/log"
 import { Npm } from "@opencode-ai/core/npm"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { Plugin } from "../plugin"
-import { makeRuntime } from "@/effect/run-service" // kilocode_change
 import { type LanguageModelV3 } from "@ai-sdk/provider"
 import * as ModelsDev from "./models"
 import { Auth } from "../auth"
@@ -1808,17 +1807,6 @@ export function sort<T extends { id: string }>(models: T[]) {
     [(model) => model.id, "desc"],
   )
 }
-
-// kilocode_change start - legacy promise helpers for Kilo callsites
-const { runPromise: runProviderPromise } = makeRuntime(Service, defaultLayer)
-export const list = () => runProviderPromise((svc) => svc.list())
-export const getModel = (providerID: ProviderID, modelID: ModelID) =>
-  runProviderPromise((svc) => svc.getModel(providerID, modelID))
-export const getProvider = (providerID: ProviderID) => runProviderPromise((svc) => svc.getProvider(providerID))
-export const getLanguage = (model: Model) => runProviderPromise((svc) => svc.getLanguage(model))
-export const getSmallModel = (providerID: ProviderID) => runProviderPromise((svc) => svc.getSmallModel(providerID))
-export const defaultModel = () => runProviderPromise((svc) => svc.defaultModel())
-// kilocode_change end
 
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -6,6 +6,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
+import { Provider } from "@/provider/provider" // kilocode_change
 import { KiloTask } from "../kilocode/tool/task" // kilocode_change
 import { KiloCostPropagation } from "../kilocode/session/cost-propagation" // kilocode_change
 import { KiloSessionProcessor } from "../kilocode/session/processor" // kilocode_change
@@ -38,6 +39,7 @@ export const TaskTool = Tool.define(
     const agent = yield* Agent.Service
     const config = yield* Config.Service
     const sessions = yield* Session.Service
+    const provider = yield* Provider.Service // kilocode_change
 
     const run = Effect.fn("TaskTool.execute")(function* (
       params: Schema.Schema.Type<typeof Parameters>,
@@ -128,6 +130,7 @@ export const TaskTool = Tool.define(
           modelID: msg.info.modelID,
           providerID: msg.info.providerID,
         },
+        provider,
       })
       const model = selected.model
       const variant = selected.variant

--- a/packages/opencode/test/kilocode/commit-message/generate.test.ts
+++ b/packages/opencode/test/kilocode/commit-message/generate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, mock, beforeEach, spyOn } from "bun:test"
 import type { GitContext } from "@/kilocode/commit-message/types"
+import type { Provider } from "@/provider/provider"
 
 // Mock dependencies before importing the module under test.
 // IMPORTANT: Bun's mock.module() is process-wide and permanent. To avoid
@@ -7,7 +8,6 @@ import type { GitContext } from "@/kilocode/commit-message/types"
 // this test needs.
 
 const realLog = await import("@opencode-ai/core/util/log")
-const realProvider = await import("@/provider/provider")
 const realAgent = await import("@/agent/agent")
 const realGitContext = await import("@/kilocode/commit-message/git-context")
 
@@ -36,19 +36,6 @@ mock.module("@/kilocode/commit-message/git-context", () => ({
   },
 }))
 
-mock.module("@/provider/provider", () => ({
-  ...realProvider,
-  Provider: {
-    ...realProvider.Provider,
-    defaultModel: async () => ({ providerID: "test", modelID: "test-model" }),
-    getSmallModel: async () => ({
-      providerID: "test",
-      id: "test-small-model",
-    }),
-    getModel: async () => ({ providerID: "test", id: "test-model" }),
-  },
-}))
-
 mock.module("@/agent/agent", () => ({
   ...realAgent,
   Agent: {},
@@ -67,10 +54,14 @@ mock.module("@opencode-ai/core/util/log", () => ({
 import { CommitMessageRuntime, generateCommitMessage } from "../../../src/kilocode/commit-message/generate"
 
 const stream = spyOn(CommitMessageRuntime, "generate").mockImplementation(async () => mockStreamText)
+const model = spyOn(CommitMessageRuntime, "model").mockImplementation(
+  async () => ({ providerID: "test", id: "test-small-model" }) as Provider.Model,
+)
 
 describe("commit-message.generate", () => {
   beforeEach(() => {
     stream.mockImplementation(async () => mockStreamText)
+    model.mockImplementation(async () => ({ providerID: "test", id: "test-small-model" }) as Provider.Model)
     mockStreamText = "feat(src): add hello world logging"
     mockGitContext = { ...defaultGitContext }
     captured = { path: "" }

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Provider } from "../../src/provider/provider"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
@@ -26,6 +27,7 @@ const it = testEffect(
     CrossSpawnSpawner.defaultLayer,
     Session.defaultLayer,
     Truncate.defaultLayer,
+    Provider.defaultLayer,
     ToolRegistry.defaultLayer,
   ),
 )

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -12,6 +12,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Provider } from "../../src/provider/provider"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
@@ -94,6 +95,7 @@ const it = testEffect(
     CrossSpawnSpawner.defaultLayer,
     Session.defaultLayer,
     Truncate.defaultLayer,
+    Provider.defaultLayer,
     ToolRegistry.defaultLayer,
   ),
 )

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID, SessionID } from "../../src/session/schema" // kilocode_change - SessionID used by cost propagation tests
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Provider } from "../../src/provider/provider" // kilocode_change
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
@@ -30,6 +31,7 @@ const it = testEffect(
     CrossSpawnSpawner.defaultLayer,
     Session.defaultLayer,
     Truncate.defaultLayer,
+    Provider.defaultLayer, // kilocode_change
     ToolRegistry.defaultLayer,
   ),
 )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -5802,7 +5802,7 @@ export class Kilo extends HeyApiClient {
   /**
    * Next Edit completion
    *
-   * Proxy a Mercury-style Next Edit request. The user supplies the already-templated sentinel-tagged prompt in `content`; the gateway forwards to the upstream edit endpoint (currently Inception's /v1/edit/completions) and returns the unwrapped reply.
+   * Proxy a Mercury-style Next Edit request. The client supplies structured editor context; the gateway assembles the sentinel-tagged prompt and forwards to the upstream edit endpoint.
    */
   public edit<ThrowOnError extends boolean = false>(
     parameters?: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -8,18 +8,16 @@ export type Event =
   | EventServerConnected
   | EventGlobalDisposed
   | EventGlobalConfigUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow1
-  | EventTuiSessionSelect
-  | EventKilocodeAgentManagerStart
-  | EventIndexingStatus
   | EventServerInstanceDisposed
   | EventLspClientDiagnostics
   | EventLspUpdated
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow1
+  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventSessionNetworkAsked
@@ -48,6 +46,7 @@ export type Event =
   | EventSessionCompacted
   | EventCommandExecuted
   | EventProjectUpdated
+  | EventKilocodeAgentManagerStart
   | EventVcsBranchUpdated
   | EventKiloSessionsRemoteStatusChanged
   | EventWorkspaceReady
@@ -92,6 +91,7 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
+  | EventIndexingStatus
 
 export type OAuth = {
   type: "oauth"
@@ -117,71 +117,6 @@ export type WellKnownAuth = {
 }
 
 export type Auth = OAuth | ApiAuth | WellKnownAuth
-
-export type EventTuiPromptAppend = {
-  id: string
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  id: string
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  id: string
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  id: string
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
-}
-
-export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
-
-export type IndexingStatus = {
-  state: IndexingStatusState
-  message: string
-  processedFiles: number
-  totalFiles: number
-  percent: number
-}
 
 export type QuestionOption = {
   /**
@@ -243,6 +178,61 @@ export type QuestionReplied = {
 export type QuestionRejected = {
   sessionID: string
   requestID: string
+}
+
+export type EventTuiPromptAppend = {
+  id: string
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  id: string
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  id: string
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  id: string
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
 }
 
 export type SessionNetworkWait = {
@@ -867,6 +857,16 @@ export type Prompt = {
   agents?: Array<PromptAgentAttachment>
 }
 
+export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
+
+export type IndexingStatus = {
+  state: IndexingStatusState
+  message: string
+  processedFiles: number
+  totalFiles: number
+  percent: number
+}
+
 export type GlobalEvent = {
   directory: string
   project?: string
@@ -875,18 +875,16 @@ export type GlobalEvent = {
     | EventServerConnected
     | EventGlobalDisposed
     | EventGlobalConfigUpdated
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
-    | EventKilocodeAgentManagerStart
-    | EventIndexingStatus
     | EventServerInstanceDisposed
     | EventLspClientDiagnostics
     | EventLspUpdated
     | EventQuestionAsked
     | EventQuestionReplied
     | EventQuestionRejected
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventSessionNetworkAsked
@@ -915,6 +913,7 @@ export type GlobalEvent = {
     | EventSessionCompacted
     | EventCommandExecuted
     | EventProjectUpdated
+    | EventKilocodeAgentManagerStart
     | EventVcsBranchUpdated
     | EventKiloSessionsRemoteStatusChanged
     | EventWorkspaceReady
@@ -959,6 +958,7 @@ export type GlobalEvent = {
     | EventSessionNextCompactionStarted
     | EventSessionNextCompactionDelta
     | EventSessionNextCompactionEnded
+    | EventIndexingStatus
     | SyncEventMessageUpdated
     | SyncEventMessageRemoved
     | SyncEventMessagePartUpdated
@@ -2544,30 +2544,6 @@ export type EventGlobalConfigUpdated = {
   }
 }
 
-export type EventKilocodeAgentManagerStart = {
-  id: string
-  type: "kilocode.agent_manager.start"
-  properties: {
-    requestID: string
-    sessionID: string
-    mode: "worktree" | "local"
-    versions?: boolean
-    tasks: Array<{
-      prompt?: string
-      name?: string
-      branchName?: string
-    }>
-  }
-}
-
-export type EventIndexingStatus = {
-  id: string
-  type: "indexing.status"
-  properties: {
-    status: IndexingStatus
-  }
-}
-
 export type EventServerInstanceDisposed = {
   id: string
   type: "server.instance.disposed"
@@ -2867,6 +2843,22 @@ export type EventProjectUpdated = {
   id: string
   type: "project.updated"
   properties: Project
+}
+
+export type EventKilocodeAgentManagerStart = {
+  id: string
+  type: "kilocode.agent_manager.start"
+  properties: {
+    requestID: string
+    sessionID: string
+    mode: "worktree" | "local"
+    versions?: boolean
+    tasks: Array<{
+      prompt?: string
+      name?: string
+      branchName?: string
+    }>
+  }
 }
 
 export type EventVcsBranchUpdated = {
@@ -3392,6 +3384,14 @@ export type EventSessionNextCompactionEnded = {
     sessionID: string
     text: string
     include?: string
+  }
+}
+
+export type EventIndexingStatus = {
+  id: string
+  type: "indexing.status"
+  properties: {
+    status: IndexingStatus
   }
 }
 


### PR DESCRIPTION
Part of #10655

## Context

Remove legacy `Provider` promise wrappers and migrate Kilo callsites to use the Effect service through injected dependencies or `AppRuntime`.