### PR TITLE
docs: remove good/bad code blocks from AGENTS.md style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,24 +164,7 @@ try {
 
 ### Prefer single word naming
 
-Try your best to find a single word name for your variables, functions, etc.
-Only use multiple words if you cannot.
-
-Good:
-
-```ts
-const foo = 1
-const bar = 2
-const baz = 3
-```
-
-Bad:
-
-```ts
-const fooBar = 1
-const barBaz = 2
-const bazFoo = 3
-```
+Default to a single-word name for variables, parameters, and helper functions. Reach for a multi-word name only when a single word would be genuinely ambiguous in context — not just because the longer name "reads nicer". The rule is about meaning, not character count: don't introduce camelCase compounds like `inputPID`, `existingClient`, `connectTimeout`, or `workerPath` when `pid`, `client`, `timeout`, or `path` is already clear from the surrounding code. See the "Naming Enforcement" section above for the preferred vocabulary.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,23 +85,7 @@ Turborepo + Bun workspaces. The packages you'll work with most:
 
 ### Avoid let statements
 
-We don't like `let` statements, especially combined with if/else statements.
-Prefer `const`.
-
-Good:
-
-```ts
-const foo = condition ? 1 : 2
-```
-
-Bad:
-
-```ts
-let foo
-
-if (condition) foo = 1
-else foo = 2
-```
+Prefer `const`. Replace `let` + if/else assignment with a ternary or an IIFE. Reassignment is the only legitimate reason to reach for `let`.
 
 ### Naming Enforcement (Read This)
 
@@ -116,25 +100,7 @@ THIS RULE IS MANDATORY FOR AGENT WRITTEN CODE.
 
 ### Avoid else statements
 
-Prefer early returns or using an `iife` to avoid else statements.
-
-Good:
-
-```ts
-function foo() {
-  if (condition) return 1
-  return 2
-}
-```
-
-Bad:
-
-```ts
-function foo() {
-  if (condition) return 1
-  else return 2
-}
-```
+Prefer early returns (or an IIFE) over `else`. After an `if` that returns/throws, the `else` is redundant.
 
 ### No empty catch blocks
 
@@ -142,25 +108,7 @@ Never leave a `catch` block empty. An empty `catch` silently swallows errors and
 
 1. Is the `try`/`catch` even needed? (prefer removing it)
 2. Should the error be handled explicitly? (recover, retry, rethrow)
-3. At minimum, log it so failures are visible
-
-Good:
-
-```ts
-try {
-  await save(data)
-} catch (err) {
-  log.error("save failed", { err })
-}
-```
-
-Bad:
-
-```ts
-try {
-  await save(data)
-} catch {}
-```
+3. At minimum, log it via `log.error("...", { err })` so failures are visible — never `catch {}` or `catch (e) {}` with no body.
 
 ### Prefer single word naming
 


### PR DESCRIPTION
The good/bad code blocks under the style guide rules added length without clarifying the rules. The naming examples in particular (foo/bar/baz vs fooBar/barBaz/bazFoo) trained the wrong intuition — that the rule is about character count rather than meaning.

Replaced four good/bad blocks with prose:

- **Prefer single word naming** — points at the existing "Naming Enforcement" section, which already lists realistic preferred names and anti-examples.
- **Avoid let statements** — one line: prefer ternary/IIFE; \`let\` is for reassignment.
- **Avoid else statements** — one line: early returns over \`else\`.
- **No empty catch blocks** — folded the example into the existing checklist.

Docs only, no behavior change. Net −73 / +4 lines.