### PR TITLE
refactor(cli): remove Storage promise facade

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -493,7 +493,7 @@ export namespace KiloSessions {
 
     const result = (await response.json()) as { id: string; ingestPath: string }
 
-    await Storage.write(["session_share", sessionId], result)
+    await save(sessionId, result)
 
     log.info("session bootstrap completed", { sessionId })
 
@@ -537,7 +537,7 @@ export namespace KiloSessions {
 
     const url = `https://app.kilo.ai/s/${result.public_id}`
 
-    await Storage.write(["session_share", sessionId], {
+    await save(sessionId, {
       ...current,
       url,
     })
@@ -578,15 +578,23 @@ export namespace KiloSessions {
     }
     delete next.url
 
-    await Storage.write(["session_share", sessionId], next)
+    await save(sessionId, next)
   }
 
-  function get(sessionId: string) {
-    return Storage.read<{
-      id: string
-      url?: string
-      ingestPath: string
-    }>(["session_share", sessionId])
+  type Share = {
+    id: string
+    url?: string
+    ingestPath: string
+  }
+
+  async function save(sessionId: string, share: Share) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return AppRuntime.runPromise(Storage.Service.use((svc) => svc.write(["session_share", sessionId], share)))
+  }
+
+  async function get(sessionId: string) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return AppRuntime.runPromise(Storage.Service.use((svc) => svc.read<Share>(["session_share", sessionId])))
   }
 
   export async function remove(sessionId: string) {
@@ -618,7 +626,8 @@ export namespace KiloSessions {
       return
     }
 
-    await Storage.remove(["session_share", sessionId])
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    await AppRuntime.runPromise(Storage.Service.use((svc) => svc.remove(["session_share", sessionId])))
   }
 
   async function fullSync(sessionId: string) {

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -7,7 +7,6 @@ import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Effect, Exit, Layer, Option, RcMap, Schema, Context, TxReentrantLock } from "effect"
 import { NonNegativeInt } from "@/util/schema"
 import { Git } from "@/git"
-import { makeRuntime } from "@/effect/run-service" // kilocode_change
 
 const log = Log.create({ service: "storage" })
 
@@ -331,14 +330,5 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer), Layer.provide(Git.defaultLayer))
-
-// kilocode_change start - legacy promise helpers for Kilo callsites
-const { runPromise } = makeRuntime(Service, defaultLayer)
-export const read = <T>(key: string[]) => runPromise((svc) => svc.read<T>(key))
-export const write = <T>(key: string[], content: T) => runPromise((svc) => svc.write<T>(key, content))
-export const remove = (key: string[]) => runPromise((svc) => svc.remove(key))
-export const list = (prefix: string[]) => runPromise((svc) => svc.list(prefix))
-export const update = <T>(key: string[], fn: (draft: T) => void) => runPromise((svc) => svc.update<T>(key, fn))
-// kilocode_change end
 
 export * as Storage from "./storage"

--- a/script/check-opencode-promise-facades.ts
+++ b/script/check-opencode-promise-facades.ts
@@ -29,7 +29,6 @@ const allow: Record<string, string> = {
   "session/session.ts": "transitional facade tracked by #10655",
   "session/summary.ts": "transitional facade removed by #10620",
   "snapshot/index.ts": "transitional facade tracked by #10660",
-  "storage/storage.ts": "transitional facade tracked by #10659",
   "sync/index.ts": "sync event runtime boundary",
   "tool/registry.ts": "transitional facade removed by #10620",
 }


### PR DESCRIPTION
Storage had regained a Kilo-only runtime-backed Promise facade after upstream removed it, solely to support session-sharing persistence. This leaves shared Storage source divergent and conflicts with the Promise-facade ratchet introduced in #10662.

Move session-share persistence to `Storage.Service` through `AppRuntime` at the Kilo-owned boundary, then remove the shared Storage facade and its ratchet exception. Storage keys, persisted share payloads, and existing synchronization and error behavior remain unchanged.

This is a focused subtask of #10655. It overlaps open #10620 in `packages/opencode/src/kilo-sessions/kilo-sessions.ts`; whichever lands second must reconcile both service-boundary migrations, and #10620's added session metadata test must stop calling the removed Storage facade.

Fixes #10659