### PR TITLE
feat: remove semantic indexing experimental gate

### DIFF
--- a/.changeset/visible-semantic-indexing.md
+++ b/.changeset/visible-semantic-indexing.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Access semantic indexing without an experimental feature toggle while keeping indexing disabled until enabled globally or for a project.

--- a/packages/kilo-docs/pages/customize/context/codebase-indexing.md
+++ b/packages/kilo-docs/pages/customize/context/codebase-indexing.md
@@ -7,8 +7,8 @@ description: "Index your codebase for improved AI understanding"
 
 Codebase Indexing enables semantic code search across your entire project using AI embeddings. Instead of searching for exact text matches, it understands the _meaning_ of your queries, helping Kilo Code find relevant code even when you don't know specific function names or file locations.
 
-{% callout type="warning" title="Experimental" %}
-Codebase Indexing is currently **experimental** in the CLI and the new VS Code extension. You must explicitly opt in before the feature becomes available — see the **Setup** section below. Behavior, configuration, and defaults may change in future releases.
+{% callout type="info" title="Opt-in indexing" %}
+Codebase Indexing is disabled by default. It starts only after you enable indexing globally or for an individual project. Configuring an embedding provider without enabling one of those toggles does not start indexing.
 {% /callout %}
 
 ## What It Does
@@ -34,28 +34,10 @@ This enables natural language queries like "user authentication logic" or "datab
 {% tabs %}
 {% tab label="VSCode" %}
 
-### 1. Enable the experimental flag
-
-Codebase Indexing is gated behind an experimental flag. Until the flag is on, the Indexing UI is hidden and `semantic_search` is unavailable.
-
-1. Open Kilo Code **Settings** → **Experimental**.
-2. Toggle **Semantic Indexing** on.
-3. The **Indexing** tab will appear in Settings and the indexing status indicator will appear at the bottom of the prompt input panel.
-
-Alternatively, set `experimental.semantic_indexing` to `true` in your `kilo.jsonc`:
-
-```json
-{
-  "experimental": {
-    "semantic_indexing": true
-  }
-}
-```
-
-### 2. Configure indexing
+### Configure indexing
 
 1. Open Kilo Code **Settings** → **Indexing**, or click the indexing indicator at the bottom of the prompt input panel.
-2. Toggle **Enable Indexing** on.
+2. Turn on **Global Enable** to index every workspace, or turn on **Enable for This Project** to index only the current workspace. Both toggles are off until explicitly enabled.
 3. Pick an **Embedding Provider** and fill in its required fields.
 4. Pick a **Vector Store** (`Qdrant` or `LanceDB`) and configure it.
 5. Optionally adjust **Tuning Parameters** (search score, batch size, retries, max results).
@@ -106,23 +88,9 @@ The prompt input panel shows a compact indexing status indicator that reflects t
 {% /tab %}
 {% tab label="CLI" %}
 
-### 1. Enable the experimental flag
+### Configure indexing
 
-Codebase Indexing is gated behind an experimental flag. Until the flag is on, the `/indexing` command is hidden and `semantic_search` is unavailable.
-
-Set the flag in your `kilo.jsonc`:
-
-```json
-{
-  "experimental": {
-    "semantic_indexing": true
-  }
-}
-```
-
-Restart the CLI for the change to take effect. The `/indexing` command (and aliases `/index`, `/embedding`) will appear in the command palette once the flag is active.
-
-### 2. Configure indexing
+The `/indexing` command (and aliases `/index`, `/embedding`) is available when the indexing plugin is installed. Indexing remains disabled until it is enabled globally or for the current project.
 
 Open a Kilo TUI session and run:
 
@@ -198,7 +166,7 @@ When indexing is enabled, the CLI shows an indexing status badge at the bottom o
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}
 
-The legacy extension does not require an experimental flag.
+The legacy extension uses its own Codebase Indexing settings panel.
 
 ### Open Codebase Indexing Settings
 

--- a/packages/kilo-vscode/src/features.ts
+++ b/packages/kilo-vscode/src/features.ts
@@ -4,7 +4,6 @@ type PluginSpec = string | [string, Record<string, unknown>]
 
 type ConfigLike = {
   plugin?: readonly PluginSpec[] | null
-  experimental?: { semantic_indexing?: boolean } | null
 }
 
 export type Features = {
@@ -13,6 +12,6 @@ export type Features = {
 
 export function configFeatures(config?: ConfigLike | null): Features {
   return {
-    indexing: hasIndexingPlugin(config?.plugin ?? []) && config?.experimental?.semantic_indexing === true,
+    indexing: hasIndexingPlugin(config?.plugin ?? []),
   }
 }

--- a/packages/kilo-vscode/tests/unit/indexing-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/indexing-utils.test.ts
@@ -85,37 +85,19 @@ describe("indexing SSE mapping", () => {
 })
 
 describe("indexing feature detection", () => {
-  it("requires experimental.semantic_indexing when indexing plugin is present", () => {
-    expect(configFeatures({ plugin: ["kilo-indexing"] }).indexing).toBe(false)
-    expect(configFeatures({ plugin: ["kilo-indexing"], experimental: {} }).indexing).toBe(false)
-    expect(configFeatures({ plugin: ["kilo-indexing"], experimental: { semantic_indexing: false } }).indexing).toBe(
-      false,
-    )
+  it("enables indexing settings when the indexing plugin is present", () => {
+    expect(configFeatures({ plugin: ["kilo-indexing"] }).indexing).toBe(true)
   })
 
-  it("detects supported indexing plugin specifiers when experimental.semantic_indexing is true", () => {
-    expect(configFeatures({ plugin: ["kilo-indexing"], experimental: { semantic_indexing: true } }).indexing).toBe(true)
-    expect(
-      configFeatures({ plugin: ["kilo-indexing@1.2.3"], experimental: { semantic_indexing: true } }).indexing,
-    ).toBe(true)
-    expect(
-      configFeatures({ plugin: ["@kilocode/kilo-indexing"], experimental: { semantic_indexing: true } }).indexing,
-    ).toBe(true)
-    expect(
-      configFeatures({ plugin: ["@kilocode/kilo-indexing@1.2.3"], experimental: { semantic_indexing: true } }).indexing,
-    ).toBe(true)
-    expect(
-      configFeatures({
-        plugin: ["file:///tmp/.opencode/plugin/kilo-indexing.js"],
-        experimental: { semantic_indexing: true },
-      }).indexing,
-    ).toBe(true)
-    expect(
-      configFeatures({
-        plugin: ["file:///tmp/node_modules/@kilocode/kilo-indexing/index.js"],
-        experimental: { semantic_indexing: true },
-      }).indexing,
-    ).toBe(true)
+  it("detects supported indexing plugin specifiers", () => {
+    expect(configFeatures({ plugin: ["kilo-indexing"] }).indexing).toBe(true)
+    expect(configFeatures({ plugin: ["kilo-indexing@1.2.3"] }).indexing).toBe(true)
+    expect(configFeatures({ plugin: ["@kilocode/kilo-indexing"] }).indexing).toBe(true)
+    expect(configFeatures({ plugin: ["@kilocode/kilo-indexing@1.2.3"] }).indexing).toBe(true)
+    expect(configFeatures({ plugin: ["file:///tmp/.opencode/plugin/kilo-indexing.js"] }).indexing).toBe(true)
+    expect(configFeatures({ plugin: ["file:///tmp/node_modules/@kilocode/kilo-indexing/index.js"] }).indexing).toBe(
+      true,
+    )
   })
 
   it("ignores unrelated plugin lists", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -165,19 +165,6 @@ const ExperimentalTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
-          title={language.t("settings.experimental.semanticIndexing.title")}
-          description={language.t("settings.experimental.semanticIndexing.description")}
-        >
-          <Switch
-            checked={experimental().semantic_indexing ?? false}
-            onChange={(checked) => updateExperimental("semantic_indexing", checked)}
-            hideLabel
-          >
-            {language.t("settings.experimental.semanticIndexing.title")}
-          </Switch>
-        </SettingsRow>
-
-        <SettingsRow
           title={language.t("settings.experimental.codebaseSearch.title")}
           description={language.t("settings.experimental.codebaseSearch.description")}
         >

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1233,9 +1233,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "عدم تلخيص المحتوى الملصق الكبير",
   "settings.experimental.batch.title": "أداة دفعية",
   "settings.experimental.batch.description": "تمكين المعالجة الدفعية لاستدعاءات الأدوات",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "بحث في قاعدة الكود",
   "settings.experimental.codebaseSearch.description": "تمكين البحث بالذكاء الاصطناعي باللغة الطبيعية عبر قاعدة الكود",
   "settings.experimental.speechToText.title": "تحويل الصوت إلى نص",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1261,9 +1261,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Não resumir conteúdo colado grande",
   "settings.experimental.batch.title": "Ferramenta em lote",
   "settings.experimental.batch.description": "Ativar processamento em lote de chamadas de ferramentas",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Pesquisa de código",
   "settings.experimental.codebaseSearch.description":
     "Ativar pesquisa por linguagem natural com IA em toda a base de código",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1262,9 +1262,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Ne sažimaj veliki zalijepljeni sadržaj",
   "settings.experimental.batch.title": "Batch alat",
   "settings.experimental.batch.description": "Omogući batch obradu poziva alata",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Pretraga koda",
   "settings.experimental.codebaseSearch.description": "Omogući AI pretragu prirodnim jezikom kroz bazu koda",
   "settings.experimental.speechToText.title": "Govor u tekst",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1255,9 +1255,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Resumér ikke stort indsat indhold",
   "settings.experimental.batch.title": "Batchværktøj",
   "settings.experimental.batch.description": "Aktiver batchbehandling af flere værktøjskald",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Kodesøgning",
   "settings.experimental.codebaseSearch.description": "Aktiver AI-drevet naturlig sprogsøgning på tværs af kodebasen",
   "settings.experimental.speechToText.title": "Tale til tekst",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1276,9 +1276,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Große eingefügte Inhalte nicht zusammenfassen",
   "settings.experimental.batch.title": "Batch-Werkzeug",
   "settings.experimental.batch.description": "Bündelung mehrerer Werkzeugaufrufe aktivieren",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Codebase-Suche",
   "settings.experimental.codebaseSearch.description":
     "KI-gestützte Suche in natürlicher Sprache über die gesamte Codebasis aktivieren",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1242,9 +1242,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Don't summarize large pasted content",
   "settings.experimental.batch.title": "Batch Tool",
   "settings.experimental.batch.description": "Enable batching of multiple tool calls",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Codebase Search",
   "settings.experimental.codebaseSearch.description": "Enable AI-powered natural language search across your codebase",
   "settings.experimental.speechToText.title": "Speech to Text",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1268,9 +1268,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "No resumir contenido pegado grande",
   "settings.experimental.batch.title": "Herramienta por lotes",
   "settings.experimental.batch.description": "Habilitar procesamiento por lotes de llamadas a herramientas",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Búsqueda de código",
   "settings.experimental.codebaseSearch.description":
     "Habilitar búsqueda por lenguaje natural con IA en toda la base de código",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1280,9 +1280,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Ne pas résumer le contenu collé volumineux",
   "settings.experimental.batch.title": "Outil par lot",
   "settings.experimental.batch.description": "Activer le traitement par lot d'appels d'outils",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Recherche de code",
   "settings.experimental.codebaseSearch.description":
     "Activer la recherche en langage naturel par IA dans toute la base de code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1250,9 +1250,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "大量のペーストコンテンツを要約しない",
   "settings.experimental.batch.title": "バッチツール",
   "settings.experimental.batch.description": "複数のツール呼び出しのバッチ処理を有効にする",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "コードベース検索",
   "settings.experimental.codebaseSearch.description": "コードベース全体でAIによる自然言語検索を有効にする",
   "settings.experimental.speechToText.title": "音声認識",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1244,9 +1244,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "대량 붙여넣기 콘텐츠를 요약하지 않음",
   "settings.experimental.batch.title": "배치 도구",
   "settings.experimental.batch.description": "여러 도구 호출의 배치 처리 활성화",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "코드베이스 검색",
   "settings.experimental.codebaseSearch.description": "코드베이스 전체에서 AI 기반 자연어 검색 활성화",
   "settings.experimental.speechToText.title": "음성 텍스트 변환",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1257,9 +1257,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Vat grote geplakte inhoud niet samen",
   "settings.experimental.batch.title": "Batch Tool",
   "settings.experimental.batch.description": "Schakel batching van meerdere tool calls in",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Codebase Zoeken",
   "settings.experimental.codebaseSearch.description":
     "Schakel AI-aangedreven zoeken in natuurlijke taal door je codebase in",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1221,9 +1221,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Ikke oppsummer stort limt innhold",
   "settings.experimental.batch.title": "Batchverktøy",
   "settings.experimental.batch.description": "Aktiver batchbehandling av verktøykall",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Kodesøk",
   "settings.experimental.codebaseSearch.description": "Aktiver AI-drevet naturlig språksøk på tvers av kodebasen",
   "settings.experimental.speechToText.title": "Tale til tekst",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1220,9 +1220,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Nie podsumowuj dużego wklejonego tekstu",
   "settings.experimental.batch.title": "Narzędzie wsadowe",
   "settings.experimental.batch.description": "Włącz przetwarzanie wsadowe wywołań narzędzi",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Wyszukiwanie kodu",
   "settings.experimental.codebaseSearch.description": "Włącz wyszukiwanie w języku naturalnym z AI w całej bazie kodu",
   "settings.experimental.speechToText.title": "Mowa na tekst",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1258,9 +1258,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Не суммировать большой вставленный контент",
   "settings.experimental.batch.title": "Пакетный инструмент",
   "settings.experimental.batch.description": "Включить пакетную обработку вызовов инструментов",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Поиск по коду",
   "settings.experimental.codebaseSearch.description": "Включить поиск на естественном языке с ИИ по всей кодовой базе",
   "settings.experimental.speechToText.title": "Речь в текст",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1241,9 +1241,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "ไม่สรุปเนื้อหาที่วางขนาดใหญ่",
   "settings.experimental.batch.title": "เครื่องมือแบทช์",
   "settings.experimental.batch.description": "เปิดใช้งานการประมวลผลแบทช์ของการเรียกเครื่องมือ",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "ค้นหาโค้ดเบส",
   "settings.experimental.codebaseSearch.description": "เปิดใช้งานการค้นหาด้วยภาษาธรรมชาติโดย AI ทั่วทั้งโค้ดเบส",
   "settings.experimental.speechToText.title": "แปลงเสียงเป็นข้อความ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1250,9 +1250,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Büyük yapıştırılan içeriği özetleme",
   "settings.experimental.batch.title": "Toplu Araç",
   "settings.experimental.batch.description": "Birden fazla araç çağrısının toplu işlenmesini etkinleştir",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Kod Tabanı Araması",
   "settings.experimental.codebaseSearch.description":
     "Kod tabanınız genelinde yapay zeka destekli doğal dil aramasını etkinleştir",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1250,9 +1250,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "Підсумовувати великий вставлений вміст",
   "settings.experimental.batch.title": "Пакетний інструмент",
   "settings.experimental.batch.description": "Увімкнути пакетну обробку кількох викликів інструментів",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "Пошук по кодовій базі",
   "settings.experimental.codebaseSearch.description":
     "Увімкнути пошук природною мовою на основі ШІ по всій кодовій базі",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1223,9 +1223,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "不对大量粘贴内容进行摘要",
   "settings.experimental.batch.title": "批量工具",
   "settings.experimental.batch.description": "启用多个工具调用的批处理",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "代码库搜索",
   "settings.experimental.codebaseSearch.description": "启用 AI 驱动的自然语言代码库搜索",
   "settings.experimental.speechToText.title": "语音转文本",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1191,9 +1191,6 @@ export const dict = {
   "settings.experimental.pasteSummary.description": "不對大量貼上內容進行摘要",
   "settings.experimental.batch.title": "批次工具",
   "settings.experimental.batch.description": "啟用多個工具呼叫的批次處理",
-  "settings.experimental.semanticIndexing.title": "Semantic Indexing",
-  "settings.experimental.semanticIndexing.description":
-    "Enable semantic codebase indexing and the semantic_search tool. Requires indexing configuration.",
   "settings.experimental.codebaseSearch.title": "程式碼庫搜尋",
   "settings.experimental.codebaseSearch.description": "啟用 AI 驅動的自然語言程式碼庫搜尋",
   "settings.experimental.speechToText.title": "語音轉文字",

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -292,7 +292,7 @@ const ConfigWrapper: ParentComponent<{ config?: Config; onConfigChange?: (config
       }
 
       return {
-        indexing: hasIndexingPlugin(config.plugin ?? []) && config.experimental?.semantic_indexing === true,
+        indexing: hasIndexingPlugin(config.plugin ?? []),
       }
     })
 

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -408,9 +408,6 @@ export const IndexingProviderBlurRace: Story = {
   render: () => {
     const [saved, setSaved] = createSignal<Record<string, unknown>>({})
     const cfg: Config = {
-      experimental: {
-        semantic_indexing: true,
-      },
       indexing: {
         provider: "openai",
         model: "text-embedding-3-large",
@@ -439,9 +436,6 @@ export const IndexingKiloModelPreset: Story = {
   name: "IndexingTab - Kilo stale custom model fallback",
   render: () => {
     const cfg: Config = {
-      experimental: {
-        semantic_indexing: true,
-      },
       indexing: {
         provider: "kilo",
         model: "custom/model",
@@ -473,9 +467,6 @@ export const IndexingKiloCatalogLoading: Story = {
   render: () => {
     const [saved, setSaved] = createSignal<Record<string, unknown>>({})
     const cfg: Config = {
-      experimental: {
-        semantic_indexing: true,
-      },
       indexing: {},
     }
     return (

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -40,7 +40,6 @@ export interface WatcherConfig {
 export interface ExperimentalConfig {
   disable_paste_summary?: boolean
   batch_tool?: boolean
-  semantic_indexing?: boolean
   codebase_search?: boolean
   speech_to_text_model?: string
   primary_tools?: string[]

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -74,7 +74,7 @@ function mergeConfigConcatArrays(target: Info, source: Info): Info {
 
 function normalizeLoadedConfig(data: unknown, source: string) {
   if (!isRecord(data)) return data
-  const copy = { ...data }
+  const copy = KilocodeConfig.retireIndexingFlag({ ...data }, source) // kilocode_change
   const hadLegacy = "theme" in copy || "keybinds" in copy || "tui" in copy
   if (!hadLegacy) return copy
   delete copy.theme
@@ -350,9 +350,6 @@ export const Info = Schema.Struct({
       batch_tool: Schema.optional(Schema.Boolean).annotate({ description: "Enable the batch tool" }),
       codebase_search: Schema.optional(Schema.Boolean).annotate({ description: "Enable AI-powered codebase search" }), // kilocode_change
       // kilocode_change start
-      semantic_indexing: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable semantic codebase indexing and the semantic_search tool",
-      }),
       speech_to_text_model: Schema.optional(Schema.String).annotate({
         description: "Speech-to-text transcription model ID to use for voice input",
       }),

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -115,6 +115,14 @@ export namespace KilocodeConfig {
     return stripGlobalIndexing(info)
   }
 
+  export function retireIndexingFlag(info: Record<string, unknown>, source: string) {
+    if (!isRecord(info.experimental) || !("semantic_indexing" in info.experimental)) return info
+    const experimental = { ...info.experimental }
+    delete experimental.semantic_indexing
+    log.warn("ignored retired experimental.semantic_indexing config; use indexing.enabled instead", { path: source })
+    return { ...info, experimental }
+  }
+
   function stripGlobalIndexing(info: Config.Info): Config.Info {
     // Indexing provider/storage settings can be global, but enablement is exposed separately from project enablement.
     if (info.indexing?.enabled === undefined) return info

--- a/packages/opencode/src/kilocode/indexing-feature.ts
+++ b/packages/opencode/src/kilocode/indexing-feature.ts
@@ -9,7 +9,6 @@ type PluginSpec = string | [string, Record<string, unknown>]
 
 type ConfigLike = {
   plugin?: readonly PluginSpec[] | null
-  experimental?: { semantic_indexing?: boolean } | null
 }
 
 type Req = {
@@ -21,7 +20,7 @@ type LogLike = {
 }
 
 export function indexingEnabled(config?: ConfigLike | null): boolean {
-  return hasIndexingPlugin(config?.plugin ?? []) && config?.experimental?.semantic_indexing === true
+  return hasIndexingPlugin(config?.plugin ?? [])
 }
 
 export function resolveIndexingPlugin(req: Req, log?: LogLike): string {

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -242,15 +242,6 @@ export namespace KiloIndexing {
       return track(hit, await inert(() => missing()))
     }
 
-    if (cfg.experimental?.semantic_indexing !== true) {
-      return track(
-        hit,
-        await inert(() =>
-          disabledIndexingStatus("Semantic indexing is disabled. Enable it in the Experimental settings."),
-        ),
-      )
-    }
-
     if (isWorktreePath(dir)) {
       return track(hit, await inert(() => worktreeDisabled()))
     }

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -54,9 +54,6 @@ async function writeConfig(dir: string, config: object, name = "kilo.json") {
 
 const cfg: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     provider: "ollama",
     vectorStore: "qdrant",
@@ -93,6 +90,22 @@ describe("markdown substitutions", () => {
 })
 
 describe("kilocode indexing config", () => {
+  test("ignores retired semantic indexing flags in existing configs", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await writeConfig(tmp.path, {
+      experimental: { semantic_indexing: true, batch_tool: true },
+    })
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.experimental?.batch_tool).toBe(true)
+        expect(config.experimental).not.toHaveProperty("semantic_indexing")
+      },
+    })
+  })
+
   test("keeps global indexing enabled in global config", async () => {
     await using globalTmp = await tmpdir()
     await using tmp = await tmpdir()

--- a/packages/opencode/test/kilocode/indexing-feature.test.ts
+++ b/packages/opencode/test/kilocode/indexing-feature.test.ts
@@ -9,12 +9,8 @@ import {
 describe("indexing plugin helpers", () => {
   test("detects plugin-enabled configs", () => {
     expect(indexingEnabled({ plugin: ["global-plugin"] })).toBe(false)
-    expect(indexingEnabled({ plugin: [INDEXING_PLUGIN] })).toBe(false)
-    expect(indexingEnabled({ plugin: [INDEXING_PLUGIN], experimental: { semantic_indexing: false } })).toBe(false)
-    expect(indexingEnabled({ plugin: [INDEXING_PLUGIN], experimental: { semantic_indexing: true } })).toBe(true)
-    expect(
-      indexingEnabled({ plugin: ["@kilocode/kilo-indexing@1.0.0"], experimental: { semantic_indexing: true } }),
-    ).toBe(true)
+    expect(indexingEnabled({ plugin: [INDEXING_PLUGIN] })).toBe(true)
+    expect(indexingEnabled({ plugin: ["@kilocode/kilo-indexing@1.0.0"] })).toBe(true)
   })
 
   test("adds indexing plugin when present but missing from config", () => {

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -292,7 +292,7 @@ describe("indexing startup degradation", () => {
     await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
-        const status = await KiloIndexing.current()
+        const status = await wait(() => KiloIndexing.current(), "Disabled")
 
         expect(status).toMatchObject({
           state: "Disabled",

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -16,9 +16,6 @@ const fetch = global.fetch
 
 const cfg: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: true,
     provider: "ollama",
@@ -29,13 +26,9 @@ const cfg: Partial<Config.Info> = {
   },
 }
 
-const off: Partial<Config.Info> = {
+const unset: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: false,
-  },
   indexing: {
-    enabled: true,
     provider: "ollama",
     vectorStore: "qdrant",
     ollama: {
@@ -45,9 +38,6 @@ const off: Partial<Config.Info> = {
 }
 const inactive: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: false,
     provider: "ollama",
@@ -56,9 +46,6 @@ const inactive: Partial<Config.Info> = {
 }
 const kilo: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: true,
     vectorStore: "qdrant",
@@ -66,9 +53,6 @@ const kilo: Partial<Config.Info> = {
 }
 const implicitOpenAi: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: true,
     vectorStore: "qdrant",
@@ -79,9 +63,6 @@ const implicitOpenAi: Partial<Config.Info> = {
 }
 const staleKilo: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: true,
     provider: "kilo",
@@ -303,8 +284,8 @@ describe("indexing startup degradation", () => {
     }
   })
 
-  test("stays disabled when semantic indexing flag is off", async () => {
-    await using tmp = await tmpdir({ git: true, config: off })
+  test("stays disabled when indexing enablement is unset", async () => {
+    await using tmp = await tmpdir({ git: true, config: unset })
     process.env["KILO_CONFIG_DIR"] = tmp.path
     const init = spyOn(CodeIndexManager.prototype, "initialize")
 
@@ -315,11 +296,11 @@ describe("indexing startup degradation", () => {
 
         expect(status).toMatchObject({
           state: "Disabled",
-          message: "Semantic indexing is disabled. Enable it in the Experimental settings.",
+          message: "Indexing disabled.",
         })
         expect(await KiloIndexing.available()).toBe(false)
         expect(KiloIndexing.ready()).toBe(false)
-        expect(await KiloIndexing.search("flag off")).toEqual([])
+        expect(await KiloIndexing.search("disabled")).toEqual([])
         expect(init).not.toHaveBeenCalled()
       },
     })

--- a/packages/opencode/test/kilocode/indexing-worktree.test.ts
+++ b/packages/opencode/test/kilocode/indexing-worktree.test.ts
@@ -7,9 +7,6 @@ import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 
 const cfg: Partial<Config.Info> = {
   plugin: ["@kilocode/kilo-indexing"],
-  experimental: {
-    semantic_indexing: true,
-  },
   indexing: {
     enabled: true,
     provider: "ollama",

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1427,7 +1427,6 @@ export type Config = {
     disable_paste_summary?: boolean
     batch_tool?: boolean
     codebase_search?: boolean
-    semantic_indexing?: boolean
     speech_to_text_model?: string
     openTelemetry?: boolean
     primary_tools?: Array<string>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16786,9 +16786,6 @@
               "codebase_search": {
                 "type": "boolean"
               },
-              "semantic_indexing": {
-                "type": "boolean"
-              },
               "speech_to_text_model": {
                 "type": "string"
               },


### PR DESCRIPTION
Semantic indexing is hidden behind `experimental.semantic_indexing` even though indexing already has explicit global and project opt-in controls. This adds a redundant configuration step and prevents users from accessing indexing settings until a separate flag is enabled.

Expose semantic indexing settings and CLI controls whenever the indexing plugin is available, and retire the experimental configuration key. Indexing still remains disabled until it is explicitly enabled globally or for a project, and existing configurations containing the retired flag continue to load without changing indexing enablement. `semantic_search` remains gated by an enabled and initialized index.