### PR TITLE
feat(cli): guide Agent Manager recall usage

### DIFF
--- a/.changeset/recall-sibling-context.md
+++ b/.changeset/recall-sibling-context.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Guide Agent Manager orchestration to recall completed session context only when needed.

--- a/packages/opencode/src/kilocode/tool/agent-manager.txt
+++ b/packages/opencode/src/kilocode/tool/agent-manager.txt
@@ -10,4 +10,6 @@ Each task may provide a prompt, a short display name, and a branch name. Keep di
 
 By default, multiple tasks are started as independent Agent Manager sessions. Set `versions` to true only when all tasks are alternate versions of the same work that should be compared together. Versioned worktrees are grouped in Agent Manager and branch names may receive version suffixes.
 
+If available, use `kilo_local_recall` only if you need context from a completed Agent Manager session.
+
 Do not use this for ordinary subagent research. Use the `task` tool for internal subagents, and use this only when the user wants visible Agent Manager sessions in the extension.


### PR DESCRIPTION
Agent Manager orchestration may need context from other completed sessions, but cross-session recall should not be attempted without a concrete need or when the recall tool is unavailable.

This updates the `agent_manager` tool guidance to use `kilo_local_recall` only when it is available and completed Agent Manager session context is needed. Parallel work remains independent by default while deliberate completed-session handoffs stay possible.