### PR TITLE
fix: restore Harbor dataset filtering in smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,7 +125,7 @@ jobs:
           ./scripts/run_eval.sh \
             -m kilo/anthropic/claude-sonnet-4.6 \
             -d terminal-bench-sample \
-            -t "log-summary-date-ranges" \
+            --include-task-name "log-summary-date-ranges" \
             --job-name smoke-test-log-summary \
             --timeout-multiplier 2
 


### PR DESCRIPTION
## Summary
- Restore dataset filtering in the pre-publish smoke workflow after the Harbor 0.6.6 bump made `-t` select standalone `org/name` tasks.
- Use `--include-task-name` so `terminal-bench-sample` continues to run only `log-summary-date-ranges`, fixing the failure in https://github.com/Kilo-Org/kilocode/actions/runs/26576431276/job/78298257960.