### PR TITLE
test(vscode): enforce scoped webview accessibility coverage

### DIFF
--- a/.changeset/webview-accessibility-validation.md
+++ b/.changeset/webview-accessibility-validation.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support accessibility regression checks and assistive-technology testing for VS Code webviews.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -26,7 +26,7 @@ jobs:
               - "packages/kilo-vscode/.storybook/**"
               - "packages/kilo-vscode/tests/visual-regression*"
               - "packages/kilo-vscode/tests/permission-dock-dropdown*"
-              - "packages/kilo-vscode/tests/accessibility*"
+              - "packages/kilo-vscode/tests/accessibility*" # kilocode_change
               - "packages/kilo-docs/public/img/screenshot-tests/**"
               - ".github/workflows/visual-regression.yml"
       - name: Check if PR is from a fork
@@ -278,7 +278,7 @@ jobs:
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
 
-      - name: Generate baselines and enforce webview accessibility checks
+      - name: Generate baselines and enforce webview accessibility checks # kilocode_change
         run: bun run test:visual:update
         working-directory: packages/kilo-vscode
         env:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -26,6 +26,7 @@ jobs:
               - "packages/kilo-vscode/.storybook/**"
               - "packages/kilo-vscode/tests/visual-regression*"
               - "packages/kilo-vscode/tests/permission-dock-dropdown*"
+              - "packages/kilo-vscode/tests/accessibility*"
               - "packages/kilo-docs/public/img/screenshot-tests/**"
               - ".github/workflows/visual-regression.yml"
       - name: Check if PR is from a fork
@@ -277,7 +278,7 @@ jobs:
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
 
-      - name: Generate baselines for new/missing stories
+      - name: Generate baselines and enforce webview accessibility checks
         run: bun run test:visual:update
         working-directory: packages/kilo-vscode
         env:

--- a/bun.lock
+++ b/bun.lock
@@ -266,7 +266,9 @@
         "zod": "^3.24.2",
       },
       "devDependencies": {
+        "@axe-core/playwright": "4.11.3",
         "@playwright/test": "1.57.0",
+        "@storybook/addon-a11y": "10.2.10",
         "@storybook/addon-docs": "10.2.10",
         "@types/diff": "^6.0.0",
         "@types/mocha": "^10.0.10",
@@ -831,6 +833,8 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.18", "", { "dependencies": { "@smithy/types": "^4.14.1", "fast-xml-parser": "5.5.8", "tslib": "^2.6.2" } }, "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
 
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -4443,6 +4447,8 @@
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1032.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.1", "@aws-sdk/nested-clients": "^3.996.21", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA=="],
 
     "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
+
+    "@axe-core/playwright/axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
     "@azure/identity/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 

--- a/packages/kilo-vscode/.storybook/main.ts
+++ b/packages/kilo-vscode/.storybook/main.ts
@@ -5,7 +5,7 @@ import solidPlugin from "vite-plugin-solid"
 const config: StorybookConfig = {
   framework: "storybook-solidjs-vite",
   stories: ["../webview-ui/src/stories/**/*.stories.@(ts|tsx)"],
-  addons: ["@storybook/addon-docs"],
+  addons: ["@storybook/addon-docs", "@storybook/addon-a11y"],
   staticDirs: [{ from: "../assets/icons", to: "/icons" }],
   refs: {},
   viteFinal: async (config) => {

--- a/packages/kilo-vscode/.storybook/preview.tsx
+++ b/packages/kilo-vscode/.storybook/preview.tsx
@@ -82,6 +82,7 @@ const preview: Preview = {
     theme: "kilo-vscode",
     colorScheme: "dark",
     vscodeTheme: "dark-modern",
+    a11y: { manual: true },
   },
 }
 

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1015,6 +1015,7 @@
     "rebuild-sdk": "bun run --cwd ../sdk/js build",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build -o storybook-static",
+    "test:a11y": "playwright test tests/accessibility.spec.ts",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "snapshot:build": "bun script/dev-snapshot.ts build",
@@ -1022,7 +1023,9 @@
     "extension": "bun script/launch.ts"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
     "@playwright/test": "1.57.0",
+    "@storybook/addon-a11y": "10.2.10",
     "@storybook/addon-docs": "10.2.10",
     "@types/diff": "^6.0.0",
     "@types/mocha": "^10.0.10",

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -14,6 +14,7 @@
  *   --wait            Block until the VS Code window is closed
  *   --clean           Wipe the user-data and extensions dirs before launching
  *   --preserve-settings  Merge defaults into existing VS Code user settings
+ *   --accessible      Enable VS Code accessibility support for assistive-technology testing
  *
  * Environment:
  *   VSCODE_EXEC_PATH  Path to VS Code executable (same as --app-path)
@@ -86,6 +87,7 @@ const explicit = opts["app-path"] as string | undefined
 const blocking = opts["wait"] === true
 const clean = opts["clean"] === true
 const preserve = opts["preserve-settings"] === true
+const accessible = opts["accessible"] === true
 
 // ---------------------------------------------------------------------------
 // VS Code executable detection
@@ -251,11 +253,11 @@ async function installVsix(path: string, app: string) {
 // Settings for isolated instance
 // ---------------------------------------------------------------------------
 
-function settings(keep: boolean) {
+function settings(keep: boolean, enabled: boolean) {
   const dir = join(userDir, "User")
   const file = join(dir, "settings.json")
   const defaults = {
-    "editor.accessibilitySupport": "off",
+    "editor.accessibilitySupport": enabled ? "on" : "off",
     "extensions.autoCheckUpdates": false,
     "extensions.autoUpdate": false,
     "extensions.ignoreRecommendations": true,
@@ -270,6 +272,7 @@ function settings(keep: boolean) {
 
   mkdirSync(dir, { recursive: true })
   const cfg = keep && existsSync(file) ? { ...defaults, ...load(file) } : defaults
+  if (enabled) cfg["editor.accessibilitySupport"] = "on"
 
   writeFileSync(file, JSON.stringify(cfg, null, 2) + "\n")
 }
@@ -306,7 +309,7 @@ async function launch() {
 
   const app = detect()
 
-  settings(preserve)
+  settings(preserve, accessible)
 
   const args = [workspace, `--extensions-dir=${extDir}`, `--user-data-dir=${userDir}`, "--skip-release-notes"]
 
@@ -338,6 +341,7 @@ async function launch() {
   console.log(`[launch] Executable: ${app}`)
   console.log(`[launch] Workspace:  ${workspace}`)
   console.log(`[launch] State:      ${base}`)
+  console.log(`[launch] Accessibility support: ${accessible ? "on" : "off"}`)
 
   if (blocking) {
     const result = Bun.spawnSync([app, ...args], {

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -271,8 +271,10 @@ function settings(keep: boolean, enabled: boolean) {
   }
 
   mkdirSync(dir, { recursive: true })
-  const cfg = keep && existsSync(file) ? { ...defaults, ...load(file) } : defaults
-  if (enabled) cfg["editor.accessibilitySupport"] = "on"
+  const cfg =
+    keep && existsSync(file)
+      ? { ...defaults, ...load(file), ...(enabled ? { "editor.accessibilitySupport": "on" } : {}) }
+      : defaults
 
   writeFileSync(file, JSON.stringify(cfg, null, 2) + "\n")
 }

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -1,5 +1,5 @@
 import AxeBuilder from "@axe-core/playwright"
-import { expect, test, type Page } from "@playwright/test"
+import { expect, test, type Locator, type Page } from "@playwright/test"
 
 const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
 const RULES = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"]
@@ -33,6 +33,13 @@ async function scan(page: Page) {
   expect(result.violations, details).toEqual([])
 }
 
+async function reach(page: Page, target: Locator) {
+  for (let step = 0; step < 10; step++) {
+    await page.keyboard.press("Tab")
+    if (await target.evaluate((node) => node === document.activeElement)) return
+  }
+}
+
 test.describe("webview accessibility ratchet", () => {
   for (const story of STORIES) {
     test(`${story.name} passes automated WCAG checks`, async ({ page }) => {
@@ -45,7 +52,7 @@ test.describe("webview accessibility ratchet", () => {
     await open(page, "profile--not-logged-in")
 
     const login = page.getByRole("button", { name: "Login with Kilo Code" })
-    await page.keyboard.press("Tab")
+    await reach(page, login)
     await expect(login).toBeFocused()
 
     await login.evaluate((node) => {

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -1,0 +1,57 @@
+import AxeBuilder from "@axe-core/playwright"
+import { expect, test, type Page } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+const RULES = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22a", "wcag22aa"]
+
+// Explicitly ratchet in repaired/stable workflows rather than making existing
+// untriaged Storybook findings block unrelated webview changes.
+const STORIES = [
+  { id: "profile--not-logged-in", name: "Profile / not logged in" },
+  { id: "profile--logged-in-personal", name: "Profile / personal account" },
+  { id: "profile--logged-in", name: "Profile / organization account" },
+  { id: "settings--providers-configure", name: "Settings / providers empty state" },
+  { id: "marketplace--skills-tab-empty", name: "Marketplace / skills empty state" },
+  { id: "marketplace--agents-tab-empty", name: "Marketplace / agents empty state" },
+]
+
+function url(id: string) {
+  return `/iframe.html?id=${id}&viewMode=story&globals=${GLOBALS}`
+}
+
+async function open(page: Page, id: string) {
+  await page.goto(url(id), { waitUntil: "load" })
+  await page.waitForSelector("#storybook-root *", { state: "attached" })
+}
+
+async function scan(page: Page) {
+  const result = await new AxeBuilder({ page }).include("#storybook-root").withTags(RULES).analyze()
+  const details = result.violations
+    .map((item) => `${item.id}: ${item.help}\n${item.nodes.map((node) => `  ${node.target.join(" ")}`).join("\n")}`)
+    .join("\n")
+
+  expect(result.violations, details).toEqual([])
+}
+
+test.describe("webview accessibility ratchet", () => {
+  for (const story of STORIES) {
+    test(`${story.name} passes automated WCAG checks`, async ({ page }) => {
+      await open(page, story.id)
+      await scan(page)
+    })
+  }
+
+  test("Profile login exposes a keyboard-operable named control", async ({ page }) => {
+    await open(page, "profile--not-logged-in")
+
+    const login = page.getByRole("button", { name: "Login with Kilo Code" })
+    await page.keyboard.press("Tab")
+    await expect(login).toBeFocused()
+
+    await login.evaluate((node) => {
+      node.addEventListener("click", () => node.setAttribute("data-keyboard-activated", "true"), { once: true })
+    })
+    await page.keyboard.press("Enter")
+    await expect(login).toHaveAttribute("data-keyboard-activated", "true")
+  })
+})


### PR DESCRIPTION
VS Code webview workflows have screenshot coverage, but it cannot catch regressions in accessible names, semantic relationships, or keyboard operation. The isolated development launch path also forces accessibility support off, leaving accessibility repairs without a durable gate or practical assistive-technology validation path.

This change adds a scoped Playwright and axe accessibility ratchet for stable webview story states, with focused keyboard coverage and a Storybook inspection panel. The scope is intentionally incremental so existing accessibility backlog does not block unrelated work, while repaired workflows can be enrolled as they land. It also adds an accessible extension launch mode that enables assistive-technology validation without changing the default development behavior.

Closes #10673