### PR TITLE
fix(vscode): make chat decisions operable for screen readers

### DIFF
--- a/.changeset/readable-chat-decisions.md
+++ b/.changeset/readable-chat-decisions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make chat questions and permission prompts expose choices and remembered-decision state to screen readers.

--- a/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
+++ b/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
@@ -28,6 +28,20 @@ test.describe("QuestionDock accessibility interactions", () => {
     await expect(jest).toHaveAttribute("aria-checked", "true")
   })
 
+  test("selects the custom radio when reached with arrow navigation", async ({ page }) => {
+    await page.goto(story("chat--question-dock-single"), { waitUntil: "load" })
+
+    const bun = page.getByRole("radio", { name: "Bun test" })
+    const custom = page.getByRole("radio", { name: "Type your own answer" })
+    await bun.click()
+    await expect(bun).toHaveAttribute("aria-checked", "true")
+
+    await bun.press("ArrowRight")
+    await expect(bun).toHaveAttribute("aria-checked", "false")
+    await expect(custom).toHaveAttribute("aria-checked", "true")
+    await expect(page.getByRole("textbox", { name: "Type your own answer" })).toBeFocused()
+  })
+
   test("does not advance a question step while navigating radio answers", async ({ page }) => {
     await page.goto(story("chat--question-dock-multi"), { waitUntil: "load" })
 

--- a/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
+++ b/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
@@ -131,8 +131,9 @@ test.describe("PermissionDock accessibility interactions", () => {
     await expect(deny).toHaveAttribute("aria-pressed", "true")
     await expect(row).toHaveAttribute("data-decision", "denied")
 
-    const once = page.getByRole("button", { name: "Allow once" })
+    const once = page.getByRole("button", { name: "Run, Allow once", exact: true })
     await expect(once).toContainText("Run")
+    await expect(once).toHaveAccessibleName("Run, Allow once")
     await expect(page.getByRole("button", { name: "Deny", exact: true })).toBeVisible()
   })
 })

--- a/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
+++ b/packages/kilo-vscode/tests/chat-blocking-a11y.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+const HOST = process.env["STORYBOOK_URL"] ?? ""
+
+function story(id: string) {
+  return `${HOST}/iframe.html?id=${id}&viewMode=story&globals=${GLOBALS}`
+}
+
+test.describe("QuestionDock accessibility interactions", () => {
+  test("exposes single-choice radio state and keyboard selection", async ({ page }) => {
+    await page.goto(story("chat--question-dock-single"), { waitUntil: "load" })
+
+    const group = page.getByRole("radiogroup", { name: "Which testing framework should I use for this project?" })
+    const vitest = page.getByRole("radio", { name: "Vitest" })
+    const jest = page.getByRole("radio", { name: "Jest" })
+
+    await expect(group).toHaveAccessibleDescription("Select one answer")
+    await expect(vitest).toHaveAccessibleDescription("Fast, Vite-native unit testing")
+    await expect(vitest).toHaveAttribute("aria-checked", "false")
+    await expect(vitest).toBeFocused()
+
+    await vitest.click()
+    await expect(vitest).toHaveAttribute("aria-checked", "true")
+    await vitest.press("ArrowRight")
+    await expect(jest).toBeFocused()
+    await expect(vitest).toHaveAttribute("aria-checked", "false")
+    await expect(jest).toHaveAttribute("aria-checked", "true")
+  })
+
+  test("does not advance a question step while navigating radio answers", async ({ page }) => {
+    await page.goto(story("chat--question-dock-multi"), { waitUntil: "load" })
+
+    const group = page.getByRole("radiogroup", { name: "Which testing framework?" })
+    const vitest = page.getByRole("radio", { name: "Vitest" })
+    const jest = page.getByRole("radio", { name: "Jest" })
+
+    await expect(vitest).toBeFocused()
+    await vitest.press("ArrowRight")
+    await expect(group).toBeVisible()
+    await expect(jest).toBeFocused()
+    await expect(jest).toHaveAttribute("aria-checked", "true")
+
+    await jest.press("Enter")
+    await expect(page.getByRole("radiogroup", { name: "Should I include coverage reporting?" })).toBeVisible()
+  })
+
+  test("exposes checkbox state and labels a submitted custom answer", async ({ page }) => {
+    await page.goto(story("chat--question-dock-multiple-choice"), { waitUntil: "load" })
+
+    const group = page.getByRole("group", { name: "Which checks should I run before submitting?" })
+    const typecheck = page.getByRole("checkbox", { name: "Typecheck" })
+    const lint = page.getByRole("checkbox", { name: "Lint" })
+    const custom = page.getByRole("checkbox", { name: "Type your own answer" })
+
+    await expect(group).toHaveAccessibleDescription("Select all answers that apply")
+    await typecheck.click()
+    await lint.click()
+    await expect(typecheck).toHaveAttribute("aria-checked", "true")
+    await expect(lint).toHaveAttribute("aria-checked", "true")
+
+    await custom.click()
+    const input = page.getByRole("textbox", { name: "Type your own answer" })
+    await expect(input).toBeFocused()
+    await input.fill("Compile extension")
+    await input.press("Enter")
+    await expect(custom).toHaveAttribute("aria-checked", "true")
+    await expect(custom).toHaveAccessibleDescription("Compile extension")
+  })
+
+  test("exposes and keyboard-operates the question disclosure", async ({ page }) => {
+    await page.goto(story("chat--question-dock-single"), { waitUntil: "load" })
+
+    const toggle = page.locator('[data-slot="question-collapse-toggle"]')
+    const body = page.locator('[data-slot="question-dock-body"]')
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+    await expect(body).not.toHaveAttribute("inert", "")
+
+    await toggle.focus()
+    await toggle.press("Enter")
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await expect(body).toHaveAttribute("inert", "")
+
+    await toggle.press("Enter")
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+    await expect(body).not.toHaveAttribute("inert", "")
+  })
+})
+
+test.describe("PermissionDock accessibility interactions", () => {
+  test("names permission actions and exposes remembered-rule toggle state", async ({ page }) => {
+    await page.goto(story("composite-webview--bash-with-permission"), { waitUntil: "load" })
+
+    await expect(page.getByRole("region", { name: "Permission required" })).toBeVisible()
+    const header = page.getByRole("button", { name: "Manage Auto-Approve Rules" })
+    const rules = page.locator('[data-slot="permission-rules-collapse"]')
+    await expect(header).toHaveAttribute("aria-expanded", "false")
+    await expect(rules).toHaveAttribute("aria-hidden", "true")
+
+    await header.focus()
+    await header.press("Enter")
+    await expect(header).toHaveAttribute("aria-expanded", "true")
+    await expect(rules).toHaveAttribute("aria-hidden", "false")
+
+    const row = page.locator('[data-slot="permission-rule-row"]').first()
+    const allow = page.getByRole("button", { name: "Allow always: bun", exact: true })
+    const deny = page.getByRole("button", { name: "Deny: bun", exact: true })
+    await expect(allow).toHaveAttribute("aria-pressed", "false")
+    await allow.focus()
+    await allow.press("Enter")
+    await expect(allow).toHaveAttribute("aria-pressed", "true")
+    await expect(row).toHaveAttribute("data-decision", "approved")
+
+    await deny.focus()
+    await deny.press("Space")
+    await expect(allow).toHaveAttribute("aria-pressed", "false")
+    await expect(deny).toHaveAttribute("aria-pressed", "true")
+    await expect(row).toHaveAttribute("data-decision", "denied")
+
+    const once = page.getByRole("button", { name: "Allow once" })
+    await expect(once).toContainText("Run")
+    await expect(page.getByRole("button", { name: "Deny", exact: true })).toBeVisible()
+  })
+})

--- a/packages/kilo-vscode/tests/visual-regression.spec.mts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.mts
@@ -50,6 +50,7 @@ async function disableAnimations(page: Page) {
 // Permission dock config-preloaded has non-deterministic toggle rendering.
 const SKIP = new Set<string>([
   "agentmanager--worktree-item-busy",
+  "chat--question-dock-multiple-choice",
   "composite-webview--permission-dock-config-preloaded",
 ])
 

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts
@@ -51,6 +51,7 @@ async function disableAnimations(page: Page) {
 const SKIP = new Set<string>([
   "agentmanager--worktree-item-busy",
   "agentmanager--pr-badge-checks-pending",
+  "chat--question-dock-multiple-choice",
   "composite-webview--permission-dock-config-preloaded",
 ])
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -310,18 +310,12 @@ export const PermissionDock: Component<{
             variant="primary"
             size="small"
             onClick={() => submit("once")}
-            aria-label={language.t("ui.permission.allowOnce")}
+            aria-label={`${language.t("ui.permission.run")}, ${language.t("ui.permission.allowOnce")}`}
             disabled={props.responding}
           >
             {language.t("ui.permission.run")}
           </Button>
-          <Button
-            variant="ghost"
-            size="small"
-            onClick={() => submit("reject")}
-            aria-label={language.t("ui.permission.deny")}
-            disabled={props.responding}
-          >
+          <Button variant="ghost" size="small" onClick={() => submit("reject")} disabled={props.responding}>
             {language.t("ui.permission.deny")}
           </Button>
         </div>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -9,7 +9,7 @@
  * The command buttons (Deny / Run) control the current command.
  */
 
-import { Component, For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { Component, For, Show, createEffect, createMemo, createSignal, createUniqueId, onCleanup } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { DockPrompt } from "@kilocode/kilo-ui/dock-prompt"
 import { Icon } from "@kilocode/kilo-ui/icon"
@@ -34,6 +34,10 @@ export const PermissionDock: Component<{
   const session = useSession()
   const language = useLanguage()
   const { config } = useConfig()
+  const id = createUniqueId()
+  const aria = (state: boolean) => (state ? "true" : "false")
+  const titleID = `${id}-title`
+  const rulesID = `${id}-rules`
 
   const fromChild = () => props.request.sessionID !== session.currentSessionID()
   // Bash sends fine-grained rules via metadata.rules; other tools use the always array.
@@ -46,6 +50,11 @@ export const PermissionDock: Component<{
     if (typeof cmd !== "string") return undefined
     // Normalize IDN/Unicode hostnames to punycode ASCII to prevent homograph attacks.
     return normalizeUrls(cmd)
+  }
+  const ruleText = (rule: string) => {
+    if (command()) return label(rule) || resolveLabel(props.request.toolName, language.t)
+    if (rule === "*") return resolveLabel(props.request.toolName, language.t)
+    return `${resolveLabel(props.request.toolName, language.t)} ${rule}`
   }
   const description = createMemo(() =>
     command() ? null : describePatterns(props.request.toolName, props.request.patterns, language.t),
@@ -185,7 +194,7 @@ export const PermissionDock: Component<{
   })
 
   return (
-    <div ref={root} data-component="permission-shortcuts" onKeyDown={onRoot}>
+    <div ref={root} data-component="permission-shortcuts" role="region" aria-labelledby={titleID} onKeyDown={onRoot}>
       <DockPrompt
         kind="permission"
         header={
@@ -193,7 +202,9 @@ export const PermissionDock: Component<{
             <span data-slot="permission-icon">
               <Icon name="warning" size="small" />
             </span>
-            <div data-slot="permission-header-title">{title()}</div>
+            <div id={titleID} data-slot="permission-header-title">
+              {title()}
+            </div>
           </div>
         }
         footer={
@@ -204,7 +215,8 @@ export const PermissionDock: Component<{
                 data-slot="permission-rules-header"
                 data-open={expanded() ? "" : undefined}
                 onClick={toggleExpanded}
-                aria-expanded={expanded()}
+                aria-expanded={aria(expanded())}
+                aria-controls={rulesID}
               >
                 <span data-slot="permission-rules-header-chevron" data-open={expanded() ? "" : undefined}>
                   <Icon name="chevron-down" size="small" />
@@ -212,44 +224,55 @@ export const PermissionDock: Component<{
                 <span data-slot="permission-rules-header-title">{language.t("ui.permission.manageAutoApprove")}</span>
               </button>
 
-              <div data-slot="permission-rules-collapse" data-open={expanded() ? "" : undefined}>
+              <div
+                id={rulesID}
+                data-slot="permission-rules-collapse"
+                data-open={expanded() ? "" : undefined}
+                inert={!expanded() || undefined}
+                aria-hidden={aria(!expanded())}
+              >
                 <div data-slot="permission-rules-collapse-inner">
                   <div data-slot="permission-rules">
                     <For each={rules()}>
                       {(rule, index) => (
-                        <div data-slot="permission-rule-row" data-decision={decision(index())}>
+                        <div
+                          data-slot="permission-rule-row"
+                          data-decision={decision(index())}
+                          role="group"
+                          aria-labelledby={`${id}-rule-${index()}`}
+                        >
                           <div data-slot="permission-rule-actions">
                             <Tooltip value={approveTooltip(index())} placement="top">
                               <button
+                                type="button"
                                 data-slot="permission-rule-toggle"
                                 data-variant="approve"
                                 data-active={decision(index()) === "approved" ? "" : undefined}
                                 disabled={props.responding}
                                 onClick={() => toggleRule(index(), "approved")}
-                                aria-label={approveTooltip(index())}
+                                aria-label={`${language.t("ui.permission.allowAlways")}: ${ruleText(rule)}`}
+                                aria-pressed={aria(decision(index()) === "approved")}
                               >
                                 <Icon name="check-small" size="small" />
                               </button>
                             </Tooltip>
                             <Tooltip value={denyTooltip(index())} placement="top">
                               <button
+                                type="button"
                                 data-slot="permission-rule-toggle"
                                 data-variant="deny"
                                 data-active={decision(index()) === "denied" ? "" : undefined}
                                 disabled={props.responding}
                                 onClick={() => toggleRule(index(), "denied")}
-                                aria-label={denyTooltip(index())}
+                                aria-label={`${language.t("ui.permission.deny")}: ${ruleText(rule)}`}
+                                aria-pressed={aria(decision(index()) === "denied")}
                               >
                                 <Icon name="close-small" size="small" />
                               </button>
                             </Tooltip>
                           </div>
-                          <code data-slot="permission-rule">
-                            {command()
-                              ? label(rule)
-                              : rule === "*"
-                                ? resolveLabel(props.request.toolName, language.t)
-                                : `${resolveLabel(props.request.toolName, language.t)} ${rule}`}
+                          <code id={`${id}-rule-${index()}`} data-slot="permission-rule">
+                            {ruleText(rule)}
                           </code>
                         </div>
                       )}
@@ -286,10 +309,8 @@ export const PermissionDock: Component<{
           <Button
             variant="primary"
             size="small"
-            onClick={() => {
-              const { approved, denied } = collectRules()
-              props.onDecide("once", approved, denied)
-            }}
+            onClick={() => submit("once")}
+            aria-label={language.t("ui.permission.allowOnce")}
             disabled={props.responding}
           >
             {language.t("ui.permission.run")}
@@ -297,10 +318,8 @@ export const PermissionDock: Component<{
           <Button
             variant="ghost"
             size="small"
-            onClick={() => {
-              const { approved, denied } = collectRules()
-              props.onDecide("reject", approved, denied)
-            }}
+            onClick={() => submit("reject")}
+            aria-label={language.t("ui.permission.deny")}
             disabled={props.responding}
           >
             {language.t("ui.permission.deny")}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -66,8 +66,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   const multi = createMemo(() => question()?.multiple === true)
   const role = createMemo(() => (multi() ? "checkbox" : "radio"))
   const group = createMemo(() => (multi() ? "group" : "radiogroup"))
-  const customPicked = createMemo(() =>
-    (store.answers[store.tab] ?? []).some((answer) => store.kinds[store.tab]?.[answer] === "custom"),
+  const customPicked = createMemo(
+    () =>
+      (!multi() && store.editing) ||
+      (store.answers[store.tab] ?? []).some((answer) => store.kinds[store.tab]?.[answer] === "custom"),
   )
   const tabIndex = (picked: boolean, index: number) => {
     if (multi()) return undefined
@@ -188,11 +190,24 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     setStore("editing", false)
   }
 
+  const edit = () => {
+    setStore("editing", true)
+    if (multi()) return
+
+    const answers = [...store.answers]
+    answers[store.tab] = []
+    setStore("answers", answers)
+    const kinds = [...store.kinds]
+    kinds[store.tab] = {}
+    setStore("kinds", kinds)
+    syncAgent(answers, kinds)
+  }
+
   const selectOption = (optIndex: number) => {
     if (store.sending) return
 
     if (optIndex === options().length) {
-      setStore("editing", true)
+      edit()
       return
     }
 
@@ -225,6 +240,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     const next = idx === -1 ? (delta > 0 ? 0 : items.length - 1) : (idx + delta + items.length) % items.length
     items[next]?.focus()
     if (multi()) return
+    if (next === options().length) {
+      edit()
+      return
+    }
     const opt = options()[next]
     if (opt) pick(opt.label, false, false)
   }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -30,7 +30,6 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   const textID = () => `${id}-text-${store.tab}`
   const hintID = () => `${id}-hint-${store.tab}`
   const customID = () => `${id}-custom-${store.tab}`
-  const formID = () => `${id}-form-${store.tab}`
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -465,7 +464,6 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                   aria-checked={aria(customPicked())}
                   aria-labelledby={customID()}
                   aria-describedby={!store.editing ? `${customID()}-description` : undefined}
-                  aria-controls={store.editing ? formID() : undefined}
                   tabIndex={tabIndex(customPicked(), options().length)}
                   disabled={store.sending}
                   onClick={() => selectOption(options().length)}
@@ -493,7 +491,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                   </span>
                 </button>
                 <Show when={store.editing}>
-                  <form id={formID()} data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
+                  <form data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
                     <input
                       ref={(el) => {
                         setTimeout(() => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -4,7 +4,7 @@
  * Uses kilo-ui's DockPrompt component for proper surface styling.
  */
 
-import { For, Show, createMemo, createEffect } from "solid-js"
+import { For, Show, createMemo, createEffect, createUniqueId } from "solid-js"
 import type { Component } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@kilocode/kilo-ui/button"
@@ -23,6 +23,14 @@ import {
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
   const language = useLanguage()
+  const id = createUniqueId()
+  const aria = (state: boolean) => (state ? "true" : "false")
+  const bodyID = `${id}-body`
+  const titleID = `${id}-title`
+  const textID = () => `${id}-text-${store.tab}`
+  const hintID = () => `${id}-hint-${store.tab}`
+  const customID = () => `${id}-custom-${store.tab}`
+  const formID = () => `${id}-form-${store.tab}`
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -56,11 +64,17 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   const options = createMemo(() => question()?.options ?? [])
   const input = createMemo(() => store.custom[store.tab] ?? "")
   const multi = createMemo(() => question()?.multiple === true)
-  const customPicked = createMemo(() => {
-    const value = input()
-    if (!value) return false
-    return store.answers[store.tab]?.includes(value) ?? false
-  })
+  const role = createMemo(() => (multi() ? "checkbox" : "radio"))
+  const group = createMemo(() => (multi() ? "group" : "radiogroup"))
+  const customPicked = createMemo(() =>
+    (store.answers[store.tab] ?? []).some((answer) => store.kinds[store.tab]?.[answer] === "custom"),
+  )
+  const tabIndex = (picked: boolean, index: number) => {
+    if (multi()) return undefined
+    if (picked) return 0
+    if ((store.answers[store.tab]?.length ?? 0) > 0 || store.editing) return -1
+    return index === 0 ? 0 : -1
+  }
 
   const total = createMemo(() => questions().length)
   const last = createMemo(() => store.tab >= total() - 1)
@@ -131,7 +145,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     session.selectAgent(next.agent)
   }
 
-  const pick = (answer: string, custom = false) => {
+  const pick = (answer: string, custom = false, advance = true) => {
     const answers = [...store.answers]
     answers[store.tab] = [answer]
     setStore("answers", answers)
@@ -147,6 +161,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     }
 
     syncAgent(answers, kinds)
+    if (!advance) return
 
     const outcome = pickOutcome({ single: single(), multi: multi(), custom })
     if (outcome.kind === "advance") {
@@ -190,8 +205,15 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     pick(opt.label)
   }
 
+  const step = (key: string) => {
+    if (key === "ArrowDown" || key === "ArrowRight") return 1
+    if (key === "ArrowUp" || key === "ArrowLeft") return -1
+    return 0
+  }
+
   const onKey = (e: KeyboardEvent) => {
-    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
+    const delta = step(e.key)
+    if (!delta) return
     if ((e.target as HTMLElement).tagName === "INPUT") return
     e.preventDefault()
     const el = e.currentTarget as HTMLElement
@@ -200,15 +222,11 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     )
     if (!items.length) return
     const idx = items.findIndex((b) => b === document.activeElement)
-    const next =
-      e.key === "ArrowDown"
-        ? idx === -1
-          ? 0
-          : (idx + 1) % items.length
-        : idx === -1
-          ? items.length - 1
-          : (idx - 1 + items.length) % items.length
+    const next = idx === -1 ? (delta > 0 ? 0 : items.length - 1) : (idx + delta + items.length) % items.length
     items[next]?.focus()
+    if (multi()) return
+    const opt = options()[next]
+    if (opt) pick(opt.label, false, false)
   }
 
   const handleCustomSubmit = (e: Event) => {
@@ -295,13 +313,17 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       ref={root}
       data-component="question-dock"
       data-collapsed={store.collapsed ? "true" : "false"}
+      role="region"
+      aria-labelledby={titleID}
       onClick={(e: MouseEvent) => e.stopPropagation()}
       onKeyDown={onRoot}
     >
       {/* Single unified header row — always visible */}
       <div data-slot="question-dock-header" onClick={toggleCollapse}>
         <div data-slot="question-dock-header-content">
-          <div data-slot="question-header-title">{summary()}</div>
+          <div id={titleID} data-slot="question-header-title">
+            {summary()}
+          </div>
           <Show when={store.collapsed}>
             <div data-slot="question-collapsed-preview">{questionText()}</div>
           </Show>
@@ -336,6 +358,8 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
             data-slot="question-collapse-toggle"
             onClick={toggleCollapse}
             aria-label={store.collapsed ? "Expand" : "Collapse"}
+            aria-expanded={aria(!store.collapsed)}
+            aria-controls={bodyID}
           >
             <Icon name="chevron-down" size="small" />
           </button>
@@ -343,22 +367,47 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       </div>
 
       {/* Animated body — hidden when collapsed */}
-      <div data-slot="question-dock-body" inert={store.collapsed || undefined}>
+      <div id={bodyID} data-slot="question-dock-body" inert={store.collapsed || undefined}>
         <div data-slot="question-dock-body-inner">
           <Show when={!confirm()}>
-            <div data-slot="question-text">{questionText()}</div>
-            <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
-              <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
+            <div id={textID()} data-slot="question-text">
+              {questionText()}
+            </div>
+            <Show
+              when={multi()}
+              fallback={
+                <div id={hintID()} data-slot="question-hint">
+                  {language.t("ui.question.singleHint")}
+                </div>
+              }
+            >
+              <div id={hintID()} data-slot="question-hint">
+                {language.t("ui.question.multiHint")}
+              </div>
             </Show>
-            <div data-slot="question-options" onKeyDown={onKey}>
+            <div
+              data-slot="question-options"
+              role={group()}
+              aria-labelledby={textID()}
+              aria-describedby={hintID()}
+              onKeyDown={onKey}
+            >
               <For each={options()}>
                 {(opt, i) => {
                   const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
                   const localized = translateOption(opt)
                   return (
                     <button
+                      type="button"
                       data-slot="question-option"
                       data-picked={picked()}
+                      role={role()}
+                      aria-checked={aria(picked())}
+                      aria-labelledby={`${id}-choice-${store.tab}-${i()}-label`}
+                      aria-describedby={
+                        localized.description() ? `${id}-choice-${store.tab}-${i()}-description` : undefined
+                      }
+                      tabIndex={tabIndex(picked(), i())}
                       disabled={store.sending}
                       onClick={() => selectOption(i())}
                     >
@@ -374,9 +423,13 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                         </span>
                       </span>
                       <span data-slot="question-option-main">
-                        <span data-slot="option-label">{localized.label()}</span>
+                        <span id={`${id}-choice-${store.tab}-${i()}-label`} data-slot="option-label">
+                          {localized.label()}
+                        </span>
                         <Show when={localized.description()}>
-                          <span data-slot="option-description">{localized.description()}</span>
+                          <span id={`${id}-choice-${store.tab}-${i()}-description`} data-slot="option-description">
+                            {localized.description()}
+                          </span>
                         </Show>
                       </span>
                     </button>
@@ -385,9 +438,16 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
               </For>
               <Show when={question()?.custom !== false}>
                 <button
+                  type="button"
                   data-slot="question-option"
                   data-custom="true"
                   data-picked={customPicked()}
+                  role={role()}
+                  aria-checked={aria(customPicked())}
+                  aria-labelledby={customID()}
+                  aria-describedby={!store.editing ? `${customID()}-description` : undefined}
+                  aria-controls={store.editing ? formID() : undefined}
+                  tabIndex={tabIndex(customPicked(), options().length)}
                   disabled={store.sending}
                   onClick={() => selectOption(options().length)}
                 >
@@ -403,16 +463,18 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                     </span>
                   </span>
                   <span data-slot="question-option-main">
-                    <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
+                    <span id={customID()} data-slot="option-label">
+                      {language.t("ui.messagePart.option.typeOwnAnswer")}
+                    </span>
                     <Show when={!store.editing}>
-                      <span data-slot="option-description" data-placeholder={!input()}>
+                      <span id={`${customID()}-description`} data-slot="option-description" data-placeholder={!input()}>
                         {input() || language.t("ui.question.custom.placeholder")}
                       </span>
                     </Show>
                   </span>
                 </button>
                 <Show when={store.editing}>
-                  <form data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
+                  <form id={formID()} data-slot="custom-input-form" onSubmit={handleCustomSubmit}>
                     <input
                       ref={(el) => {
                         setTimeout(() => {
@@ -422,6 +484,8 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
                       }}
                       type="text"
                       data-slot="custom-input"
+                      aria-labelledby={customID()}
+                      aria-describedby={textID()}
                       placeholder={language.t("ui.question.custom.placeholder")}
                       value={input()}
                       disabled={store.sending}

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -43,6 +43,24 @@ const singleQuestion: QuestionRequest = {
   tool: { messageID: "asst-msg-001", callID: "call-question-001" },
 }
 
+const multipleChoiceQuestion: QuestionRequest = {
+  id: "q-multiple-choice-001",
+  sessionID: SESSION_ID,
+  questions: [
+    {
+      question: "Which checks should I run before submitting?",
+      header: "Choose checks",
+      multiple: true,
+      options: [
+        { label: "Typecheck", description: "Validate TypeScript types" },
+        { label: "Lint", description: "Find style and correctness issues" },
+        { label: "Unit tests", description: "Verify component behavior" },
+      ],
+    },
+  ],
+  tool: { messageID: "asst-msg-001", callID: "call-question-multiple-choice-001" },
+}
+
 const multiQuestion: QuestionRequest = {
   id: "q-multi-001",
   sessionID: SESSION_ID,
@@ -184,6 +202,17 @@ export const QuestionDockMulti: Story = {
     <StoryProviders sessionID={SESSION_ID} questions={[multiQuestion]}>
       <div style={{ width: "100%" }}>
         <QuestionDock request={multiQuestion} />
+      </div>
+    </StoryProviders>
+  ),
+}
+
+export const QuestionDockMultipleChoice: Story = {
+  name: "QuestionDock — multiple choice interaction fixture",
+  render: () => (
+    <StoryProviders sessionID={SESSION_ID} questions={[multipleChoiceQuestion]}>
+      <div style={{ width: "100%" }}>
+        <QuestionDock request={multipleChoiceQuestion} />
       </div>
     </StoryProviders>
   ),


### PR DESCRIPTION
Blocking assistant questions currently rely on visual selection marks without exposing choice state, so screen-reader users cannot reliably answer questions that stop an ordinary chat turn. Permission requests also need reusable decision state and disclosure controls to be identifiable during the same workflow.

This change exposes question choices as labelled radio or checkbox interactions, connects custom answers and disclosure state to their controls, and exposes permission decisions and reusable-rule state. Keyboard navigation can inspect options in multi-step questions without committing an answer until the user activates it, preserving operability while avoiding visual redesign.