### PR TITLE
refactor(cli): remove SessionSummary promise facade

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -634,7 +634,10 @@ export namespace KiloSessions {
     log.info("full sync", { sessionId })
 
     const session = await Session.get(SessionID.make(sessionId))
-    const diffs = await SessionSummary.diff({ sessionID: SessionID.make(sessionId) })
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    const diffs = await AppRuntime.runPromise(
+      SessionSummary.Service.use((svc) => svc.diff({ sessionID: SessionID.make(sessionId) })),
+    )
     const messages = await Array.fromAsync(MessageV2.stream(SessionID.make(sessionId)))
     messages.reverse()
     const models = await Promise.all(

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -7,7 +7,6 @@ import { withStatics } from "@/util/schema"
 import * as Session from "./session"
 import { MessageV2 } from "./message-v2"
 import { SessionID, MessageID } from "./schema"
-import { makeRuntime } from "@/effect/run-service" // kilocode_change
 
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
@@ -170,10 +169,5 @@ export const DiffInput = Schema.Struct({
   messageID: Schema.optional(MessageID),
 }).pipe(withStatics((s) => ({ zod: zod(s) })))
 export type DiffInput = Schema.Schema.Type<typeof DiffInput>
-
-// kilocode_change start - legacy promise helpers for Kilo callsites
-const { runPromise } = makeRuntime(Service, defaultLayer)
-export const diff = (input: { sessionID: SessionID; messageID?: MessageID }) => runPromise((svc) => svc.diff(input))
-// kilocode_change end
 
 export * as SessionSummary from "./summary"

--- a/script/check-opencode-promise-facades.ts
+++ b/script/check-opencode-promise-facades.ts
@@ -27,7 +27,6 @@ const allow: Record<string, string> = {
   "session/compaction.ts": "existing compaction facade outside #10655",
   "session/prompt.ts": "transitional facade tracked by #10655",
   "session/session.ts": "transitional facade tracked by #10655",
-  "session/summary.ts": "transitional facade removed by #10620",
   "sync/index.ts": "sync event runtime boundary",
   "tool/registry.ts": "transitional facade removed by #10620",
 }


### PR DESCRIPTION
SessionSummary still exposes a runtime-backed Promise wrapper solely for Kilo session full sync, keeping a shared upstream Effect module divergent after its callers can use the composed application runtime directly.

Route the full-sync diff read through `SessionSummary.Service` at the existing Kilo-owned `AppRuntime` boundary, then remove the obsolete shared-module facade and its ratchet exception. This leaves diff payload and error behavior intact while preventing the bridge from being reintroduced.

Closes #10677
Part of #10655