### PR TITLE
Docs: add App Builder template guidance

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/app-builder.md
+++ b/packages/kilo-docs/pages/code-with-ai/app-builder.md
@@ -53,6 +53,14 @@ Before using App Builder:
 
 ---
 
+## Start From a Template
+
+When you do not want to begin from a blank prompt, choose one of the available templates in App Builder. Templates give you a starter project that you can customize through chat after it opens.
+
+Template options may change over time, so use the in-app gallery as the source of truth for the current list.
+
+---
+
 ## How App Builder Works
 
 - When you describe your application:


### PR DESCRIPTION
## Summary
This helps users understand how to start from App Builder templates instead of a blank slate.

- Adds high-level template guidance to the App Builder docs.
- Keeps the guidance aligned with the existing App Builder page flow.

## Tests
Not run; docs-only change.