### PR TITLE
Docs: update Kilo Pass links

### DIFF
--- a/packages/kilo-docs/pages/getting-started/adding-credits.md
+++ b/packages/kilo-docs/pages/getting-started/adding-credits.md
@@ -7,7 +7,7 @@ description: "How to add credits to your Kilo Code account"
 
 Once you've used any initial free Kilo Credits, you can easily add more:
 
-- Subscribe to the [Kilo Pass](https://kilo.ai/features/kilo-pass), the most cost effective way to add credits.
+- Subscribe to the [Kilo Pass](https://kilo.ai/pricing/kilo-pass), the most cost effective way to add credits.
 - Purchase additional credits as a one-time transaction.
 - Enable [automatic top-up](https://kilo.ai/features/auto-top-ups), which purchases additional credits when your balance runs low. Auto top-up is available for both individual and organization accounts.
 

--- a/packages/kilo-docs/pages/getting-started/setup-authentication.md
+++ b/packages/kilo-docs/pages/getting-started/setup-authentication.md
@@ -46,7 +46,7 @@ That's it! You're ready to [start your first task](/docs/getting-started/quickst
 {% /tabs %}
 
 {% callout type="tip" title="Add Credits" %}
-[Add credits to your account](https://app.kilo.ai/profile), or sign up for [Kilo Pass](https://kilo.ai/features/kilo-pass).
+[Add credits to your account](https://app.kilo.ai/profile), or sign up for [Kilo Pass](https://kilo.ai/pricing/kilo-pass).
 {% /callout %}
 
 ## Kilo Gateway API Key

--- a/packages/kilo-docs/pages/kiloclaw/end-to-end.md
+++ b/packages/kilo-docs/pages/kiloclaw/end-to-end.md
@@ -160,4 +160,4 @@ Or ask your Claw to build a custom skill from scratch — it has a built-in skil
 
 **Model picker:** Balanced is a good starting point. Frontier is more capable but significantly more expensive.
 
-You can also use your KiloPass credits — find this under **Profile** in the dashboard.
+You can also use your [Kilo Pass](https://kilo.ai/pricing/kilo-pass) credits — find this under **Profile** in the dashboard.


### PR DESCRIPTION
## Summary
This keeps billing and Kilo Pass references pointed at the current destination.

- Updates Kilo Pass links across getting-started and KiloClaw docs.
- Preserves the existing surrounding docs content and link style.

## Tests
Not run; docs-only change.