### PR TITLE
Docs: add DoltHub coverage

### DIFF
--- a/packages/kilo-docs/pages/automate/integrations.md
+++ b/packages/kilo-docs/pages/automate/integrations.md
@@ -5,7 +5,7 @@ description: "Overview of Kilo Code integrations"
 
 # Kilo Code Integrations
 
-Kilo Integrations lets you connect your GitHub or GitLab account (soon Bitbucket) to enable advanced features inside Kilo Code. Once connected, Kilo can access your repositories securely, enabling features like **Code Reviews**, **Cloud Agents**, and **Kilo Deploy**.
+Kilo Integrations lets you connect GitHub or GitLab for repository workflows and DoltHub for Dolt-versioned data. Once connected, Kilo can access authorized resources securely, enabling features like **Code Reviews**, **Cloud Agents**, **Kilo Deploy**, and data workflows through **Kilo Connect**.
 
 ## Supported Platforms
 
@@ -13,12 +13,14 @@ Kilo Integrations lets you connect your GitHub or GitLab account (soon Bitbucket
 |---|---|---|
 | GitHub | GitHub App | [GitHub Setup](#connecting-github) |
 | GitLab | OAuth or PAT | [GitLab Setup](#connecting-gitlab) |
+| DoltHub | OAuth | [DoltHub Setup](#connecting-dolthub) |
 
 ## What You Can Do With Integrations
 
-- **Connect GitHub or GitLab to Kilo Code** in a few clicks
+- **Connect GitHub, GitLab, or DoltHub to Kilo Code** in a few clicks
 - **Enable advanced features** like Cloud Agents, Code Reviews, and Kilo Deploy
-- **Authorize repository access** so Kilo can analyze and work with your code
+- **Authorize GitHub or GitLab repository access** so Kilo can analyze and work with your code
+- **Query Dolt-versioned data** from your workspace through Kilo Connect
 
 ## Prerequisites
 
@@ -27,6 +29,7 @@ Before connecting:
 - You must have a **GitHub** or **GitLab** account.
 - For GitHub: You need permission to install GitHub Apps for the repositories you want Kilo to access.
 - For GitLab: You need **Maintainer** role (or higher) on the projects you want to connect.
+- For DoltHub: You need a DoltHub account to authorize the OAuth connection.
 - (Optional) If you're connecting an organization, you must be an admin or have app installation permissions.
 
 ---
@@ -109,9 +112,24 @@ For self-hosted GitLab instances using OAuth, you need to register an OAuth appl
 
 ---
 
+## Connecting DoltHub
+
+DoltHub is available through [Kilo Connect](/docs/code-with-ai/platforms/kilo-connect) for teams that work with Dolt-versioned data.
+
+1. Go to the **Integrations** page:
+   - **Personal**: [app.kilo.ai/integrations/dolthub](https://app.kilo.ai/integrations/dolthub)
+   - **Organization**: Your organization → Integrations → DoltHub
+2. Click **Connect DoltHub**.
+3. Authorize the connection with DoltHub.
+4. Return to Kilo and confirm DoltHub shows a **Connected** status.
+
+To remove the connection, click **Disconnect** from the DoltHub integration page.
+
+---
+
 ## What Happens After Connecting
 
-Once your Git provider is connected, the following features are enabled in Kilo:
+Once your integrations are connected, the following features are enabled in Kilo:
 
 ### Cloud Agents
 
@@ -130,6 +148,11 @@ Once your Git provider is connected, the following features are enabled in Kilo:
 - Deploy Next.js 14 & 15 apps directly from Kilo
 - Trigger rebuilds automatically on push
 - Manage deployment logs and history
+
+### DoltHub data access
+
+- Query Dolt-versioned databases from your workspace
+- Use DoltHub alongside GitHub or GitLab when a workflow also needs repository access
 
 ### Upcoming:
 
@@ -156,6 +179,13 @@ From the **Integrations** page:
 - Your tokens are cleared, but webhook configuration is preserved so reconnecting restores your setup
 
 > Disconnecting from Kilo does not revoke OAuth tokens on GitLab's side. You can manually revoke them from **GitLab → User Settings → Applications → Authorized Applications**.
+
+### DoltHub
+
+From the **Integrations** page, open DoltHub to:
+
+- View the connected status
+- Disconnect DoltHub from Kilo
 
 ---
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/kilo-connect.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/kilo-connect.md
@@ -1,21 +1,22 @@
 ---
 title: "Kilo Connect"
-description: "Use Kilo Code directly from Slack, GitHub, and Linear"
+description: "Use Kilo Code from Slack, GitHub, and Linear, and connect DoltHub data"
 ---
 
 # Kilo Connect
 
-**Kilo Connect** brings Kilo Code into the tools your team already uses. Instead of switching to a separate interface, you can trigger implementations, ask questions, and get pull requests opened directly from your chat, issue tracker, or code review workflow.
+**Kilo Connect** brings Kilo Code into the tools your team already uses. Instead of switching to a separate interface, you can trigger implementations, ask questions, and get pull requests opened from your chat, issue tracker, or code review workflow. You can also connect DoltHub as a data source for Dolt-versioned data.
 
 ---
 
 ## Supported Integrations
 
-| Integration | Trigger | What It Can Do |
+| Integration | Entry Point | What It Can Do |
 |---|---|---|
 | [Slack](/docs/code-with-ai/platforms/slack) | `@Kilo` in any channel or DM | Ask questions, implement fixes, debug issues |
 | [GitHub](/docs/code-with-ai/platforms/github) | `@kilocode-bot` on issues and PRs | Fix issues, review code, cross-repo changes |
 | [Linear](/docs/code-with-ai/platforms/linear) | `@kilo` on any issue | Implement fixes, investigate bugs, cross-repo changes |
+| DoltHub | [Connect DoltHub](https://app.kilo.ai/integrations/dolthub) from Integrations | Query Dolt-versioned data from your workspace |
 
 ---
 
@@ -24,5 +25,5 @@ description: "Use Kilo Code directly from Slack, GitHub, and Linear"
 All integrations are configured from the **Integrations** tab at [app.kilo.ai](https://app.kilo.ai). Each integration requires:
 
 - A Kilo Code account with available credits
-- A connected Git provider (GitHub or GitLab) so Kilo can access your repositories
 - The specific integration installed and authorized for your workspace
+- A connected Git provider (GitHub or GitLab) for repository workflows such as Cloud Agents, Code Reviews, and Kilo Deploy


### PR DESCRIPTION
## Summary
This fills the public docs gap for DoltHub integration coverage.

- Adds DoltHub to the relevant integration and Kilo Connect docs.
- Follows the existing integration documentation patterns.

## Tests
Not run; docs-only change.