### PR TITLE
Docs: update KiloClaw public docs

### DIFF
--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/index.md
@@ -1,13 +1,21 @@
 ---
 title: "Chat Platforms"
-description: "Connect your KiloClaw agent to Telegram, Discord, and Slack"
+description: "Use Kilo Chat or connect your KiloClaw agent to Telegram, Discord, and Slack"
 ---
 
 # Chat Platforms
 
-KiloClaw supports connecting your AI agent to messaging platforms so it can receive instructions and send responses directly in your chat apps. You can configure channels from the **Settings** tab on your [KiloClaw dashboard](/docs/kiloclaw/dashboard#channels), or from the OpenClaw Control UI after accessing your instance.
+KiloClaw includes Kilo Chat as its first-party channel and also supports connecting your AI agent to messaging platforms so it can receive instructions and send responses directly in your chat apps. You can configure third-party channels from the **Settings** tab on your [KiloClaw dashboard](/docs/kiloclaw/dashboard#channels), or from the OpenClaw Control UI after accessing your instance.
 
-The general steps to connect any chat platform are:
+## Kilo Chat
+
+Kilo Chat is the zero-setup, first-party channel for KiloClaw. It is enabled by default, does not require a per-sandbox channel token, and is available from the Kilo web and mobile apps as well as supported Kilo Code editor and TUI surfaces.
+
+Use Kilo Chat when you want to talk to your Claw without configuring a separate bot or app in another messaging platform. For external team chat tools, use one of the third-party channels below.
+
+## Third-Party Platforms
+
+The general steps to connect a third-party chat platform are:
 
 1. Configure the channel token in Settings
 2. Redeploy the KiloClaw instance
@@ -16,6 +24,7 @@ The general steps to connect any chat platform are:
 
 ## Supported Platforms
 
+- [**Kilo Chat**](https://app.kilo.ai) — Use the built-in first-party channel with no token setup.
 - [**Telegram**](/docs/kiloclaw/chat-platforms/telegram) — Connect via a BotFather bot token.
 - [**Discord**](/docs/kiloclaw/chat-platforms/discord) — Connect via a Discord Developer Portal bot token.
 - [**Slack**](/docs/kiloclaw/chat-platforms/slack) — Connect via a Slack app manifest with app-level and bot tokens.

--- a/packages/kilo-docs/pages/kiloclaw/dashboard.md
+++ b/packages/kilo-docs/pages/kiloclaw/dashboard.md
@@ -9,6 +9,10 @@ This page covers everything you can do from the KiloClaw dashboard. For getting 
 
 {% image src="/docs/img/kiloclaw/dashboard.png" alt="Connect account screen" width="800" caption="The KiloClaw Dashboard" /%}
 
+## Personal and Organization Instances
+
+The dashboard controls are the same for personal and organization-scoped KiloClaw instances. Organization instances are selected from the organization context and are listed separately from your **Personal** instance. Availability depends on your organization membership and KiloClaw entitlement.
+
 ## Instance Status
 
 Your instance is always in one of these states as indicated by the status label at the top of your dashboard:
@@ -88,7 +92,7 @@ For access to the full catalog of 335+ models, use the `/model` and `/models` co
 
 ### Channels
 
-You can connect Telegram, Discord, and Slack by entering bot tokens in the Settings tab. See [Connecting Chat Platforms](/docs/kiloclaw/chat-platforms) for setup instructions.
+Kilo Chat is always available as KiloClaw's first-party channel and does not need a token. You can also connect Telegram, Discord, and Slack by entering bot tokens in the Settings tab. See [Connecting Chat Platforms](/docs/kiloclaw/chat-platforms) for setup instructions.
 
 {% callout type="info" %}
 After saving channel tokens, you need to **Redeploy** or **Restart OpenClaw** for the changes to take effect.
@@ -154,7 +158,7 @@ Do not use the **Update** feature in the OpenClaw Control UI to update KiloClaw.
 
 When your instance is running, the dashboard shows any pending pairing requests. These appear when:
 
-- Someone messages your bot on Telegram, Discord, or Slack for the first time
+- Someone messages your bot on a third-party chat channel for the first time
 - A new browser or device connects to the Control UI
 
 You need to **approve** each request before the user or device can interact with your agent. See [Pairing Requests](/docs/kiloclaw/chat-platforms#pairing-requests) for details.

--- a/packages/kilo-docs/pages/kiloclaw/end-to-end.md
+++ b/packages/kilo-docs/pages/kiloclaw/end-to-end.md
@@ -21,7 +21,7 @@ We recommend creating **separate accounts** for your KiloClaw rather than connec
 
 ### Chat platform options
 
-- **[Kilo Chat](https://app.kilo.ai)** — available in the web app and coming soon to iOS and Android; requires zero configuration
+- **[Kilo Chat](https://app.kilo.ai)** — available in the Kilo web and mobile apps, plus supported Kilo Code editor and TUI surfaces; requires zero configuration
 - **[Telegram](/docs/kiloclaw/chat-platforms/telegram)** — easy to set up, private by default
 - **[Discord](/docs/kiloclaw/chat-platforms/discord)** — moderate setup
 - **[Slack](/docs/kiloclaw/chat-platforms/slack)** — most involved setup
@@ -66,7 +66,7 @@ A Workspace-managed account benefits from your organization's admin policies, ma
 
 ## Set up a messaging platform
 
-Your Claw needs a way to communicate with you. **[Kilo Chat](https://app.kilo.ai)** requires no setup — just open the web app. For other platforms, follow the relevant guide:
+Your Claw needs a way to communicate with you. **[Kilo Chat](https://app.kilo.ai)** requires no setup — open the Kilo web or mobile app, or use a supported Kilo Code editor or TUI surface. For other platforms, follow the relevant guide:
 
 - [Telegram](/docs/kiloclaw/chat-platforms/telegram) — about 2 minutes
 - [Discord](/docs/kiloclaw/chat-platforms/discord) — about 10 minutes
@@ -160,4 +160,4 @@ Or ask your Claw to build a custom skill from scratch — it has a built-in skil
 
 **Model picker:** Balanced is a good starting point. Frontier is more capable but significantly more expensive.
 
-You can also use your KiloPass credits — find this under **Profile** in the dashboard.
+You can also use your [Kilo Pass](https://kilo.ai/pricing/kilo-pass) credits — find this under **Profile** in the dashboard.

--- a/packages/kilo-docs/pages/kiloclaw/overview.md
+++ b/packages/kilo-docs/pages/kiloclaw/overview.md
@@ -1,19 +1,20 @@
 ---
 title: "KiloClaw"
-description: "One-click deployment of your personal AI agent with OpenClaw"
+description: "One-click deployment of your Kilo-hosted AI agent with OpenClaw"
 ---
 
 # KiloClaw 🦀
 
-KiloClaw is Kilo's hosted [OpenClaw](https://openclaw.ai) service — a one-click deployment that gives you a personal AI agent without the complexity of self-hosting. OpenClaw is a 24/7, open source AI agent that connects to chat platforms like Telegram, Discord, and Slack so it can take real actions automatically, not just chat.
+KiloClaw is Kilo's hosted [OpenClaw](https://openclaw.ai) service — a one-click deployment that gives you a personal or organization-scoped AI agent without the complexity of self-hosting. OpenClaw is a 24/7, open source AI agent that connects to Kilo Chat and optional chat platforms like Telegram, Discord, and Slack so it can take real actions automatically, not just chat.
 
-KiloClaw is powered by KiloCode. The API key is platform-managed, so you never need to bring your own.
+KiloClaw is powered by Kilo Code. The API key is platform-managed, so you never need to bring your own.
 
 ## Why KiloClaw?
 
 - **No infrastructure setup** — Skip Docker, servers, and configuration files
 - **Instant provisioning** — Your agent is ready in seconds
-- **Powered by KiloCode** — API key is automatically generated and refreshed
+- **Kilo Chat included** — Use the first-party Kilo Chat channel without token setup
+- **Powered by Kilo Code** — API key is automatically generated and refreshed
 - **Uses existing credits** — Runs on your Kilo Gateway balance
 - **Multiple free models** — Choose from several models at no additional cost
 - **Web UI included** — Access your agent's web interface directly from the dashboard
@@ -23,9 +24,10 @@ KiloClaw is powered by KiloCode. The API key is platform-managed, so you never n
 - **Kilo account** — Sign up at [kilo.ai](https://kilo.ai) if you haven't already
 - **Model access** — KiloClaw uses **Kilo Gateway by default**, which provides access to **500+ AI models** through a single integration.
 
-You can also run KiloClaw using:
+Depending on your setup, you can also use:
 
 - **Your own provider API keys (BYOK)** such as Anthropic, OpenAI, Google, or other supported providers.
+- **Organization access** if your organization has KiloClaw enabled and you want the instance scoped to that organization.
 
 ## Creating an Instance
 
@@ -39,10 +41,18 @@ You can also run KiloClaw using:
 
 {% image src="/docs/img/kiloclaw/create-instance.png" alt="Create instance modal with model selection" width="600" caption="Model selection during instance creation" /%}
 
-5. Optionally configure chat channels (Telegram, Discord, Slack) — you can also do this later from [Settings](/docs/kiloclaw/dashboard#settings)
+5. Optionally configure third-party chat channels (Telegram, Discord, Slack) — Kilo Chat is already available, and you can add other channels later from [Settings](/docs/kiloclaw/dashboard#settings)
 6. Click **Create & Provision**
 
 Your instance will be provisioned in seconds. Each instance runs on a dedicated machine with 2 shared vCPUs, 3 GB RAM, and a 10 GB persistent SSD. Once created in a region, your instance always runs there.
+
+## Organization KiloClaw
+
+If your organization has KiloClaw enabled, you can use an organization-scoped instance for work that belongs to that organization. The core KiloClaw experience is the same as a personal instance, with these differences:
+
+- Organization instances are separated from your **Personal** instance in KiloClaw lists.
+- Provisioning depends on your organization membership and the organization's KiloClaw entitlement.
+- Instance ownership and routing are scoped to the organization, so use organization-approved accounts and credentials for connected services.
 
 ## Managing Your Instance
 
@@ -75,7 +85,7 @@ When you initialize a new channel for the first time, or a new device connects t
 
 ## Using your OpenClaw Agent
 
-OpenClaw lets you customize your own AI assistant that can actually take action — check your email, manage your calendar, control smart devices, browse the web, and message you on Telegram or Discord when something needs attention. It's like having a personal assistant that runs 24/7, with the skills and access you choose to give it.
+OpenClaw lets you customize your own AI assistant that can actually take action — check your email, manage your calendar, control smart devices, browse the web, and message you through Kilo Chat or connected third-party channels when something needs attention. It's like having a personal assistant that runs 24/7, with the skills and access you choose to give it.
 
 ### Browser Tool
 


### PR DESCRIPTION
## Summary
This refreshes the public KiloClaw docs so key overview, dashboard, chat platform, and end-to-end guidance stays accurate.

- Updates public KiloClaw content across the main user-facing pages.
- Keeps the edits within the existing KiloClaw docs structure.

## Tests
Not run; docs-only change.