### PR TITLE
Docs: document webhook trigger overview

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -147,6 +147,12 @@ Triggers allow you to initiate cloud agent sessions automatically, either via HT
 Triggers are currently in beta and subject to change.
 {% /callout %}
 
+Webhook triggers and scheduled triggers use the same trigger concepts across Cloud
+Agent and KiloClaw, but target different agents. Use Cloud Agent triggers when an
+HTTP event or schedule should start a Cloud Agent session against a repository.
+Use KiloClaw triggers when the event should deliver a chat message to a KiloClaw
+instance.
+
 ### Accessing Triggers
 
 Triggers are accessible from the main sidebar under **Webhooks / Triggers** and link to [https://app.kilo.ai/cloud/triggers](https://app.kilo.ai/cloud/triggers) for personal accounts. Organization-level trigger configurations are available through your organization's sidebar.
@@ -185,6 +191,15 @@ Additional limits:
 - **In-flight cap**: at most **20 requests per trigger** can be in `captured` or `inprogress` at once (returns `429`)
 
 The trigger endpoint will return rate limit responses when the number of queued or processing requests exceeds system capacity.
+
+### Request History
+
+Open a trigger's request history to inspect recent invocations. History entries
+show the source (webhook or scheduled), status such as captured, in progress,
+success, or failed, request metadata, payload details when available, and links
+or sharing actions for the resulting session. Use this view to debug webhook
+payloads, scheduled runs, and organization handoff without changing the trigger
+configuration.
 
 ### Prompt Template Variables
 

--- a/packages/kilo-docs/pages/kiloclaw/triggers/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/index.md
@@ -9,6 +9,12 @@ Triggers let external events and schedules drive your KiloClaw agent automatical
 
 All triggers are managed from the **Settings** page in the KiloClaw section of the sidebar.
 
+Webhook triggers and scheduled triggers use the same trigger concepts across
+KiloClaw and Cloud Agent, but target different agents. Use KiloClaw triggers when
+an HTTP event or schedule should deliver a chat message to a KiloClaw instance.
+Use Cloud Agent triggers when the automation should start a Cloud Agent session
+against a repository.
+
 ## Trigger Types
 
 | Type | Description |
@@ -28,6 +34,14 @@ Each trigger type has its own set of template variables. See the [Webhooks](/doc
 {% callout type="warning" title="Triggers send prompts directly to your agent" %}
 When a trigger fires, the rendered message is sent directly to your KiloClaw agent as a prompt. If your instance is configured with a permission model that allows all actions, the agent will execute commands automatically without your explicit approval. This means triggers can cause your agent to take actions without you being aware. Review your instance's [permission settings](/docs/kiloclaw/control-ui/exec-approvals) and prompt templates carefully before enabling triggers.
 {% /callout %}
+
+## Request History
+
+Trigger activity appears in request history so you can inspect recent webhook and
+scheduled invocations. History entries show the source (webhook or scheduled),
+status such as captured, in progress, success, or failed, request metadata,
+payload details when available, and links or sharing actions for the resulting
+session.
 
 ## Related
 

--- a/packages/kilo-docs/pages/kiloclaw/triggers/scheduled.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/scheduled.md
@@ -7,6 +7,10 @@ description: "Run tasks on a schedule using cron expressions"
 
 Scheduled triggers let your KiloClaw agent run tasks automatically on a recurring schedule. Instead of waiting for an external event, a scheduled trigger fires at the times you define using cron expressions. When it fires, the prompt template is rendered and delivered as a chat message to your KiloClaw instance, just like a webhook.
 
+Scheduled triggers are one trigger mode shared by KiloClaw and Cloud Agent. In
+KiloClaw, the rendered prompt is delivered to the KiloClaw instance on this page;
+in Cloud Agent, the same trigger concept starts a Cloud Agent repository session.
+
 ## Setup
 
 1. Go to **Settings** under the KiloClaw section in the sidebar

--- a/packages/kilo-docs/pages/kiloclaw/triggers/webhooks.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/webhooks.md
@@ -7,6 +7,10 @@ description: "Trigger your KiloClaw agent from external events using webhooks"
 
 KiloClaw supports inbound webhooks so external events can trigger your agent automatically. Form submissions, alerts, calendar updates, ecommerce orders, IoT sensor data; anything that can send an HTTP request can kick off a conversation with your agent. When a webhook fires, the payload is rendered through a prompt template and delivered as a chat message to your KiloClaw instance. The agent processes and responds as if you typed it yourself.
 
+Webhook triggers are one trigger mode shared by KiloClaw and Cloud Agent. In
+KiloClaw, the rendered prompt is delivered to the KiloClaw instance on this page;
+in Cloud Agent, the same trigger concept starts a Cloud Agent repository session.
+
 ## Setup
 
 1. Go to **Settings** under the KiloClaw section in the sidebar


### PR DESCRIPTION
## Summary
This gives users a clearer overview of webhook triggers and how they relate to scheduled triggers and Cloud Agent usage.

- Adds overview-level webhook trigger guidance across the relevant public docs pages.
- Follows the existing trigger documentation organization.

## Tests
Not run; docs-only change.