### PR TITLE
fix(indexing): prevent LanceDB metadata type coercion causing full re-index on restart

### DIFF
--- a/.changeset/fix-lancedb-metadata-type-coercion.md
+++ b/.changeset/fix-lancedb-metadata-type-coercion.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix LanceDB metadata corruption that caused a full re-index on every VS Code restart

--- a/packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts
+++ b/packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts
@@ -136,7 +136,7 @@ export class LanceDBVectorStore implements IVectorStore {
     return [
       {
         key: KEY.size,
-        value: this.vectorSize,
+        value: String(this.vectorSize),
       },
       {
         key: KEY.provider,
@@ -148,11 +148,11 @@ export class LanceDBVectorStore implements IVectorStore {
       },
       {
         key: KEY.dimension,
-        value: this.profile.dimension,
+        value: String(this.profile.dimension),
       },
       {
         key: KEY.complete,
-        value: false,
+        value: "false",
       },
     ]
   }
@@ -572,7 +572,7 @@ export class LanceDBVectorStore implements IVectorStore {
       }
       const metadataTable = await db.openTable(this.metadataTableName)
       const metadataResults = await metadataTable.query().where(`key = '${KEY.complete}'`).toArray()
-      const indexed = metadataResults.length > 0 ? metadataResults[0].value : false
+      const indexed = metadataResults.length > 0 ? String(metadataResults[0].value) === "true" : false
       log.info("LanceDB indexing metadata evaluated", {
         workspacePath: this.workspacePath,
         pointCount,
@@ -590,14 +590,16 @@ export class LanceDBVectorStore implements IVectorStore {
       throw new Error(`Invalid metadata key: ${key}`)
     }
     await metadataTable.delete(`key = '${key}'`)
-    await metadataTable.add([{ key, value }])
+    // All values must be strings to prevent LanceDB from inferring the value column
+    // type as number from the first row, which corrupts subsequent string/boolean values.
+    await metadataTable.add([{ key, value: String(value) }])
   }
 
   private async _persistEmbeddingProfile(metadataTable: Table): Promise<void> {
     await this._upsertMetadata(metadataTable, KEY.provider, this.profile.provider)
     await this._upsertMetadata(metadataTable, KEY.model, this.profile.modelId)
-    await this._upsertMetadata(metadataTable, KEY.dimension, this.profile.dimension)
-    await this._upsertMetadata(metadataTable, KEY.size, this.vectorSize)
+    await this._upsertMetadata(metadataTable, KEY.dimension, String(this.profile.dimension))
+    await this._upsertMetadata(metadataTable, KEY.size, String(this.vectorSize))
   }
 
   /**
@@ -609,7 +611,7 @@ export class LanceDBVectorStore implements IVectorStore {
       const db = await this.getDb()
       const metadataTable = await db.openTable(this.metadataTableName)
       await this._persistEmbeddingProfile(metadataTable)
-      await this._upsertMetadata(metadataTable, KEY.complete, true)
+      await this._upsertMetadata(metadataTable, KEY.complete, "true")
       log.info("Marked indexing as complete")
     } catch (error) {
       log.error("Failed to mark indexing as complete", { error })
@@ -626,7 +628,7 @@ export class LanceDBVectorStore implements IVectorStore {
       const db = await this.getDb()
       const metadataTable = await db.openTable(this.metadataTableName)
       await this._persistEmbeddingProfile(metadataTable)
-      await this._upsertMetadata(metadataTable, KEY.complete, false)
+      await this._upsertMetadata(metadataTable, KEY.complete, "false")
       log.info("Marked indexing as incomplete (in progress)")
     } catch (error) {
       log.error("Failed to mark indexing as incomplete", { error })

--- a/packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts
+++ b/packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts
@@ -598,8 +598,8 @@ export class LanceDBVectorStore implements IVectorStore {
   private async _persistEmbeddingProfile(metadataTable: Table): Promise<void> {
     await this._upsertMetadata(metadataTable, KEY.provider, this.profile.provider)
     await this._upsertMetadata(metadataTable, KEY.model, this.profile.modelId)
-    await this._upsertMetadata(metadataTable, KEY.dimension, String(this.profile.dimension))
-    await this._upsertMetadata(metadataTable, KEY.size, String(this.vectorSize))
+    await this._upsertMetadata(metadataTable, KEY.dimension, this.profile.dimension)
+    await this._upsertMetadata(metadataTable, KEY.size, this.vectorSize)
   }
 
   /**


### PR DESCRIPTION
# Fix: LanceDB metadata table type corruption causes full re-index on every restart

## Summary

Fix a bug where the LanceDB metadata table's `value` column was inferred as `number` by LanceDB because the first row contained a numeric value (`vector_size: 1024`). All subsequent string values (`embedding_provider`, `embedding_model_id`) and boolean values (`indexing_complete`) were silently coerced to `NaN`/`0`/`1`, corrupting the stored metadata.

On every VS Code restart, `_getStoredEmbeddingProfile()` received `NaN` for the provider/model fields, failed the `typeof !== "string"` check, returned `undefined`, which set `needsRecreation = true` — causing the entire LanceDB database to be dropped and recreated, the file-hash cache to be cleared, and a full re-index to start from scratch.

## Root Cause

In `packages/kilo-indexing/src/indexing/vector-store/lancedb-vector-store.ts`:

```typescript
// BEFORE: mixed types cause LanceDB to infer value column as number
_createMetadataData() {
  return [
    { key: "vector_size",         value: 1024 },              // number — column type set here
    { key: "embedding_provider",  value: "ollama" },           // string → coerced to NaN
    { key: "embedding_model_id",  value: "qwen3-embed:0.6b" }, // string → coerced to NaN
    { key: "embedding_dimension", value: 1024 },                // number → OK
    { key: "indexing_complete",   value: false },               // boolean → coerced to 0/1
  ]
}
```

LanceDB infers the `value` column type from the first row's value (`1024` = number). All subsequent rows with different types are silently coerced, losing their values.

**Actual metadata stored on disk (confirmed via LanceDB query):**
```
embedding_provider  = NaN     ← should be "ollama"
embedding_model_id  = NaN     ← should be "qwen3-embedding:0.6b"
indexing_complete   = 1       ← should be true/false
```

## Fix

All metadata values are now explicitly converted to strings before being passed to LanceDB, ensuring a consistent `string` column type:

- `_createMetadataData()` — wrap numeric/boolean values with `String()`
- `_upsertMetadata()` — convert `value` to `String(value)` before storing
- `markIndexingComplete()` — store `"true"` instead of `true`
- `markIndexingIncomplete()` — store `"false"` instead of `false`
- `hasIndexedData()` — compare with `"true"` string instead of truthy check

The same issue was present in `_persistEmbeddingProfile()` which calls `_upsertMetadata()` with raw numeric values — now also uses `String()`.

## Verification

Tested end-to-end with the CLI binary on a small project:

| Run | Message | Files | Mode |
|---|---|---|---|
| First (fresh DB) | `"Starting workspace scan..."` | 7/7 | Full scan |
| Second (restart) | `"Checking for new or modified files..."` | 0/0 | **Incremental** |

Metadata after fix (all strings):
```
embedding_provider  = "ollama"                    ✓
embedding_model_id  = "qwen3-embedding:0.6b"      ✓
embedding_dimension = "1024"                      ✓
vector_size         = "1024"                      ✓
indexing_complete   = "true"                      ✓
```

File-hash cache persists across restarts (1123 bytes, not cleared).

## Backward Compatibility

Existing databases with corrupted metadata (NaN values) will be auto-repaired on the first restart after this fix: the corrupted profile check triggers a one-time table recreation, which writes correct string values. Subsequent restarts use the persistent database normally.