### PR TITLE
fix(jetbrains): show history runtime summaries

### DIFF
--- a/.changeset/kind-lagoon-history.md
+++ b/.changeset/kind-lagoon-history.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Show JetBrains history badges and session costs from backend session summaries without retaining hidden chat UIs.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
@@ -179,7 +179,7 @@ Options:
       --format                        format: default (formatted) or json (raw JSON events)  [string] [choices: "default", "json"] [default: "default"]
   -f, --file                          file(s) to attach to message  [array]
       --title                         title for the session (uses truncated prompt if no value provided)  [string]
-      --attach                        attach to a running opencode server (e.g., http://localhost:4096)  [string]
+      --attach                        attach to a running kilo server (e.g., http://localhost:4096)  [string]
   -p, --password                      basic auth password (defaults to KILO_SERVER_PASSWORD)  [string]
   -u, --username                      basic auth username (defaults to KILO_SERVER_USERNAME or 'kilo')  [string]
       --dir                           directory to run in, path on remote server if attaching  [string]

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/turn-outcome-failed-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/turn-outcome-failed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6d0ccfb86ad9a6eaab64e1afe455a96cd4c1443f12fbd47698a4730724712b6
-size 931
+oid sha256:5b8208c98b0ab3551094af455bf2c7a947c2973f0adb6fe6fa99f16da970454a
+size 1184

--- a/packages/kilo-gateway/src/edit-prompt.ts
+++ b/packages/kilo-gateway/src/edit-prompt.ts
@@ -49,7 +49,12 @@ function insertCursorToken(lines: string[], cursorLine: number, cursorCharacter:
 export function recentlyViewedSnippetsBlock(snippets: MercuryRecentSnippet[]): string {
   const inner = snippets
     .map((s) =>
-      [RECENTLY_VIEWED_SNIPPET_OPEN, `code_snippet_file_path: ${s.filepath}`, s.content, RECENTLY_VIEWED_SNIPPET_CLOSE].join("\n"),
+      [
+        RECENTLY_VIEWED_SNIPPET_OPEN,
+        `code_snippet_file_path: ${s.filepath}`,
+        s.content,
+        RECENTLY_VIEWED_SNIPPET_CLOSE,
+      ].join("\n"),
     )
     .join("\n")
   return [RECENTLY_VIEWED_SNIPPETS_OPEN, inner, RECENTLY_VIEWED_SNIPPETS_CLOSE].join("\n")
@@ -74,7 +79,12 @@ export function currentFileContentBlock(
     CODE_TO_EDIT_CLOSE,
     ...withCursor.slice(end + 1),
   ]
-  return [CURRENT_FILE_CONTENT_OPEN, `current_file_path: ${currentFilePath}`, instrumented.join("\n"), CURRENT_FILE_CONTENT_CLOSE].join("\n")
+  return [
+    CURRENT_FILE_CONTENT_OPEN,
+    `current_file_path: ${currentFilePath}`,
+    instrumented.join("\n"),
+    CURRENT_FILE_CONTENT_CLOSE,
+  ].join("\n")
 }
 
 export function editDiffHistoryBlock(diffs: string[]): string {

--- a/packages/kilo-gateway/src/server/edit.ts
+++ b/packages/kilo-gateway/src/server/edit.ts
@@ -1,5 +1,11 @@
 import { HEADER_FEATURE } from "../api/constants.js"
-import { DIRECT_EDIT_ENV, extractFencedBody, resolveEditTarget, type EditTarget, type EditUpstreamResponse } from "../edit.js"
+import {
+  DIRECT_EDIT_ENV,
+  extractFencedBody,
+  resolveEditTarget,
+  type EditTarget,
+  type EditUpstreamResponse,
+} from "../edit.js"
 import { buildMercuryEditPrompt, type MercuryEditContext } from "../edit-prompt.js"
 import type { DirectAutocompleteProviderID } from "../autocomplete.js"
 import { buildKiloHeaders } from "../headers.js"
@@ -37,7 +43,9 @@ export function createEditHandler(Auth: Auth) {
 
     const proxy = target.provider === "kilo" ? await getProxyAuth(Auth) : undefined
     const token =
-      target.provider === "kilo" ? proxy?.token : await getProviderKey(Auth, target.provider as DirectAutocompleteProviderID)
+      target.provider === "kilo"
+        ? proxy?.token
+        : await getProviderKey(Auth, target.provider as DirectAutocompleteProviderID)
 
     if (target.provider === "kilo" && !proxy?.auth) {
       return c.json({ error: "Not authenticated with Kilo Gateway" }, 401 as any)

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendSessionManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendSessionManager.kt
@@ -6,9 +6,12 @@ import ai.kilocode.log.KiloLog
 import ai.kilocode.jetbrains.api.client.DefaultApi
 import ai.kilocode.jetbrains.api.model.GlobalSession
 import ai.kilocode.jetbrains.api.model.SessionStatus
+import ai.kilocode.rpc.dto.ChatEventDto
 import ai.kilocode.rpc.dto.CloudSessionListDto
+import ai.kilocode.rpc.dto.SessionActivityDto
 import ai.kilocode.rpc.dto.SessionDto
 import ai.kilocode.rpc.dto.SessionListDto
+import ai.kilocode.rpc.dto.SessionRuntimeDto
 import ai.kilocode.rpc.dto.SessionStatusDto
 import ai.kilocode.rpc.dto.SessionSummaryDto
 import ai.kilocode.rpc.dto.SessionTimeDto
@@ -52,6 +55,11 @@ class KiloBackendSessionManager(
     private val _statuses = MutableStateFlow<Map<String, SessionStatusDto>>(emptyMap())
     val statuses: StateFlow<Map<String, SessionStatusDto>> = _statuses.asStateFlow()
 
+    private val _runtime = MutableStateFlow(SessionRuntimeDto())
+    val runtime: StateFlow<SessionRuntimeDto> = _runtime.asStateFlow()
+
+    private val costs = ConcurrentHashMap<String, ConcurrentHashMap<String, Double>>()
+
     private var client: DefaultApi? = null
     private var http: OkHttpClient? = null
     private var base: String? = null
@@ -64,11 +72,13 @@ class KiloBackendSessionManager(
         if (watcher?.isActive == true) return
         watcher = cs.launch {
             events.collect { event ->
-                if (event.type == "session.status") {
+                when (event.type) {
+                    "session.status" -> {
                     val pair = KiloCliDataParser.parseSessionStatus(event.data)
                     if (pair != null) {
                         val prev = _statuses.value[pair.first]
-                        _statuses.update { it + pair }
+                        mergeRuntime(statuses = mapOf(pair))
+                        syncActivity(pair.first)
                         val total = _statuses.value.size
                         log.debug { "${ChatLogSummary.sid(pair.first)} evt=session.status ${ChatLogSummary.status(pair.second)}" }
                         if (pair.second.type != "busy") {
@@ -78,6 +88,9 @@ class KiloBackendSessionManager(
                             )
                         }
                     }
+                }
+                    "permission.asked", "permission.replied", "question.asked", "question.replied", "question.rejected",
+                    "message.updated", "session.error", "session.turn.open" -> updateRuntime(event)
                 }
             }
         }
@@ -91,6 +104,8 @@ class KiloBackendSessionManager(
         http = null
         base = null
         _statuses.value = emptyMap()
+        _runtime.value = SessionRuntimeDto()
+        costs.clear()
         log.info("Session manager stopped")
     }
 
@@ -100,27 +115,11 @@ class KiloBackendSessionManager(
     // ------ session CRUD ------
 
     fun list(dir: String): SessionListDto {
-        seed(dir)
-        val raw = requireClient().sessionList(directory = dir, roots = JsonPrimitive(true))
-        val mapped = raw.map(::dto)
-        val ids = mapped.map { it.id }.toSet()
-        val relevant = _statuses.value.filterKeys { it in ids }
-        return SessionListDto(mapped, relevant)
+        return overview(dir, limit = null, worktrees = false)
     }
 
     fun recent(dir: String, limit: Int): SessionListDto {
-        seed(dir)
-        val raw = requireClient().experimentalSessionList(
-            directory = dir,
-            worktrees = true,
-            roots = JsonPrimitive(true),
-            limit = limit.toDouble(),
-            archived = JsonPrimitive(false),
-        )
-        val mapped = raw.map(::dto)
-        val ids = mapped.map { it.id }.toSet()
-        val relevant = _statuses.value.filterKeys { it in ids }
-        return SessionListDto(mapped, relevant)
+        return overview(dir, limit = limit, worktrees = true)
     }
 
     /**
@@ -244,12 +243,112 @@ class KiloBackendSessionManager(
         try {
             val raw = requireClient().sessionStatus(directory = dir)
             val mapped = raw.mapValues { (_, v) -> statusDto(v) }
-            _statuses.update { it + mapped }
+            mergeRuntime(statuses = mapped)
             val meta = if (log.isDebugEnabled) ChatLogSummary.dir(dir) else "kind=status"
             log.info("kind=status $meta seeded=${mapped.size}")
         } catch (e: Exception) {
             log.warn("kind=status dir=${ChatLogSummary.dir(dir)} seed=true failed message=${e.message}", e)
         }
+    }
+
+    private fun overview(dir: String, limit: Int?, worktrees: Boolean): SessionListDto {
+        val h = http ?: throw IllegalStateException("Session manager not started")
+        val url = base ?: throw IllegalStateException("Session manager not started")
+        val builder = "$url/kilocode/session/overview".toHttpUrl().newBuilder()
+            .addQueryParameter("directory", dir)
+            .addQueryParameter("roots", "true")
+            .addQueryParameter("worktrees", worktrees.toString())
+            .addQueryParameter("archived", "false")
+        if (limit != null) builder.addQueryParameter("limit", limit.toString())
+        val request = Request.Builder().url(builder.build()).get().build()
+        h.newCall(request).execute().use { response ->
+            val raw = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                log.warn("Session overview failed: HTTP ${response.code}, body=$raw")
+                throw RuntimeException("Session overview failed: HTTP ${response.code} — $raw")
+            }
+            val parsed = KiloCliDataParser.parseSessionOverview(raw)
+            val ids = parsed.sessions.map { it.id }.toSet()
+            val result = parsed.copy(
+                statuses = parsed.statuses.filterKeys { it in ids },
+                activities = parsed.activities.filterKeys { it in ids },
+                costs = parsed.costs.filterKeys { it in ids },
+            )
+            mergeRuntime(parsed.statuses, parsed.activities, parsed.costs)
+            return result
+        }
+    }
+
+    private fun updateRuntime(event: SseEvent) {
+        val parsed = KiloCliDataParser.parseChatEvent(event.type, event.data) ?: return
+        when (parsed) {
+            is ChatEventDto.PermissionAsked -> mergeRuntime(activities = mapOf(parsed.sessionID to SessionActivityDto("permission", parsed.request.id)))
+            is ChatEventDto.PermissionReplied -> clearActivity(parsed.sessionID, parsed.requestID)
+            is ChatEventDto.QuestionAsked -> {
+                val kind = if (parsed.request.questions.any { it.questionKey == "plan.followup.question" || it.headerKey == "plan.followup.header" }) "plan" else "question"
+                mergeRuntime(activities = mapOf(parsed.sessionID to SessionActivityDto(kind, parsed.request.id)))
+            }
+            is ChatEventDto.QuestionReplied -> clearActivity(parsed.sessionID, parsed.requestID)
+            is ChatEventDto.QuestionRejected -> clearActivity(parsed.sessionID, parsed.requestID)
+            is ChatEventDto.MessageUpdated -> {
+                val cost = parsed.info.cost
+                if (parsed.info.role == "assistant" && cost != null) updateCost(parsed.info.sessionID, parsed.info.id, cost)
+                clearLogin(parsed.info.sessionID)
+            }
+            is ChatEventDto.Error -> parsed.sessionID?.let { mergeRuntime(activities = mapOf(it to SessionActivityDto("login_required", message = parsed.error?.message))) }
+            is ChatEventDto.TurnOpen -> clearLogin(parsed.sessionID)
+            else -> Unit
+        }
+    }
+
+    private fun mergeRuntime(
+        statuses: Map<String, SessionStatusDto> = emptyMap(),
+        activities: Map<String, SessionActivityDto> = emptyMap(),
+        costs: Map<String, Double> = emptyMap(),
+    ) {
+        _runtime.update {
+            SessionRuntimeDto(
+                statuses = it.statuses + statuses,
+                activities = it.activities + activities,
+                costs = it.costs + costs,
+            )
+        }
+        _statuses.value = _runtime.value.statuses
+    }
+
+    private fun clearActivity(id: String, request: String) {
+        _runtime.update {
+            val activity = it.activities[id]
+            if (activity?.requestID != request) return@update it
+            it.copy(activities = it.activities - id)
+        }
+        syncActivity(id)
+    }
+
+    private fun syncActivity(id: String) {
+        val status = _runtime.value.statuses[id]
+        val current = _runtime.value.activities[id]
+        if (status?.type == "busy" && current == null) {
+            mergeRuntime(activities = mapOf(id to SessionActivityDto("running")))
+            return
+        }
+        if (status?.type != "busy" && current?.kind == "running") {
+            _runtime.update { it.copy(activities = it.activities - id) }
+        }
+    }
+
+    private fun clearLogin(id: String) {
+        _runtime.update {
+            if (it.activities[id]?.kind != "login_required") return@update it
+            it.copy(activities = it.activities - id)
+        }
+    }
+
+    private fun updateCost(id: String, msg: String, cost: Double) {
+        val session = costs.getOrPut(id) { ConcurrentHashMap() }
+        val prev = session.put(msg, cost)
+        val next = if (prev == null) (_runtime.value.costs[id] ?: 0.0) + cost else (_runtime.value.costs[id] ?: 0.0) - prev + cost
+        mergeRuntime(costs = mapOf(id to next))
     }
 
     // ------ worktree directory management ------

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
@@ -28,7 +28,9 @@ import ai.kilocode.rpc.dto.QuestionOptionDto
 import ai.kilocode.rpc.dto.QuestionReplyDto
 import ai.kilocode.rpc.dto.QuestionRequestDto
 import ai.kilocode.rpc.dto.SessionDto
+import ai.kilocode.rpc.dto.SessionActivityDto
 import ai.kilocode.rpc.dto.SessionStatusDto
+import ai.kilocode.rpc.dto.SessionListDto
 import ai.kilocode.rpc.dto.SessionSummaryDto
 import ai.kilocode.rpc.dto.SessionTimeDto
 import ai.kilocode.rpc.dto.TodoDto
@@ -255,6 +257,33 @@ object KiloCliDataParser {
     fun parseSession(raw: String): SessionDto {
         val obj = json.parseToJsonElement(raw).jsonObject
         return parseSessionObject(obj)
+    }
+
+    fun parseSessionOverview(raw: String): SessionListDto {
+        val obj = tryParseObject(raw) ?: return SessionListDto(emptyList(), emptyMap())
+        val costs = obj["costs"]?.jsonObject?.mapValues { (_, value) -> value.jsonPrimitive.doubleOrNull ?: 0.0 }.orEmpty()
+        val sessions = obj["sessions"]?.jsonArray?.mapNotNull { elem ->
+            runCatching {
+                val session = parseSessionObject(elem.jsonObject)
+                session.copy(cost = costs[session.id])
+            }.getOrNull()
+        }.orEmpty()
+        val statuses = obj["statuses"]?.jsonObject?.mapValues { (_, value) -> parseStatus(value.jsonObject) }.orEmpty()
+        val activities = obj["activities"]?.jsonObject?.mapNotNull { (id, value) ->
+            val activity = value.jsonObject
+            val kind = activity.str("kind") ?: return@mapNotNull null
+            id to SessionActivityDto(
+                kind = kind,
+                requestID = activity.str("requestID"),
+                message = activity.str("message"),
+            )
+        }?.toMap().orEmpty()
+        return SessionListDto(
+            sessions = sessions,
+            statuses = statuses,
+            activities = activities,
+            costs = costs,
+        )
     }
 
     /**
@@ -712,6 +741,7 @@ object KiloCliDataParser {
                     files = it.long("files")?.safeInt() ?: 0,
                 )
             },
+            cost = obj.num("cost"),
         )
     }
 

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloSessionRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloSessionRpcApiImpl.kt
@@ -21,6 +21,7 @@ import ai.kilocode.rpc.dto.QuestionReplyDto
 import ai.kilocode.rpc.dto.QuestionRequestDto
 import ai.kilocode.rpc.dto.SessionDto
 import ai.kilocode.rpc.dto.SessionListDto
+import ai.kilocode.rpc.dto.SessionRuntimeDto
 import ai.kilocode.rpc.dto.SessionStatusDto
 import com.intellij.openapi.components.service
 import ai.kilocode.log.KiloLog
@@ -91,6 +92,9 @@ class KiloSessionRpcApiImpl : KiloSessionRpcApi {
 
     override suspend fun statuses(): Flow<Map<String, SessionStatusDto>> =
         sessions.statuses
+
+    override suspend fun runtime(): Flow<SessionRuntimeDto> =
+        sessions.runtime
 
     override suspend fun setDirectory(id: String, directory: String) =
         sessions.setDirectory(id, directory)

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/app/KiloBackendSessionManagerTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/app/KiloBackendSessionManagerTest.kt
@@ -124,7 +124,7 @@ class KiloBackendSessionManagerTest {
     }
 
     @Test
-    fun `recent returns global sessions from experimental endpoint`() = runBlocking {
+    fun `recent returns global sessions from overview endpoint`() = runBlocking {
         mock.recentSessions = """[
             {"id":"ses_1","slug":"s1","projectID":"prj","directory":"/repo","title":"Session 1","version":"1","time":{"created":1000,"updated":5000},"project":{"id":"prj","worktree":"/repo","name":"Repo"},"summary":{"additions":10,"deletions":2,"files":3}},
             {"id":"ses_2","slug":"s2","projectID":"prj","directory":"/repo-wt","title":"Session 2","version":"1","time":{"created":2000,"updated":4000},"project":{"id":"prj","worktree":"/repo","name":"Repo"},"parentID":"ses_parent"}
@@ -149,12 +149,12 @@ class KiloBackendSessionManagerTest {
 
         app.sessions.recent("/repo path", 5)
 
-        val path = mock.lastExperimentalSessionPath ?: error("missing experimental session request")
-        assertTrue(path.startsWith("/experimental/session?"))
+        val path = mock.lastSessionOverviewPath ?: error("missing overview session request")
+        assertTrue(path.startsWith("/kilocode/session/overview?"))
         assertTrue(URLDecoder.decode(path, "UTF-8").contains("directory=/repo path"), path)
         assertTrue(path.contains("worktrees=true"), path)
         assertTrue(path.contains("roots=true"), path)
-        assertTrue(path.contains("limit=5.0"), path)
+        assertTrue(path.contains("limit=5"), path)
         assertTrue(path.contains("archived=false"), path)
     }
 

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
@@ -65,6 +65,7 @@ class MockCliServer : AutoCloseable {
     @Volatile var recentSessions = "[]"
     @Volatile var sessionCreate = """{"id":"ses_test","slug":"test","projectID":"prj_test","directory":"/test","title":"New Session","version":"1.0.0","time":{"created":1000,"updated":1000}}"""
     @Volatile var sessionStatuses = "{}"
+    @Volatile var sessionOverview: String? = null
     @Volatile var summarizeResponse = "true"
     @Volatile var sessionsStatus = 200
     @Volatile var recentSessionsStatus = 200
@@ -104,6 +105,7 @@ class MockCliServer : AutoCloseable {
     fun requestCount(path: String): Int = counts[path]?.get() ?: 0
 
     @Volatile var lastExperimentalSessionPath: String? = null
+    @Volatile var lastSessionOverviewPath: String? = null
 
     /** Reset all request counters. */
     fun resetCounts() { counts.clear() }
@@ -265,6 +267,10 @@ class MockCliServer : AutoCloseable {
                     lastExperimentalSessionPath = path
                     respond(output, recentSessionsStatus, recentSessions)
                 }
+                bare == "/kilocode/session/overview" -> {
+                    lastSessionOverviewPath = path
+                    respond(output, sessionsStatus, overview(path))
+                }
                 bare == "/kilo/cloud-sessions" -> {
                     lastCloudSessionsPath = path
                     respond(output, cloudSessionsStatus, cloudSessions)
@@ -317,6 +323,13 @@ class MockCliServer : AutoCloseable {
         writer.write("\r\n")
         writer.write(body)
         writer.flush()
+    }
+
+    private fun overview(path: String): String {
+        val custom = sessionOverview
+        if (custom != null) return custom
+        val list = if (path.contains("worktrees=true")) recentSessions else sessions
+        return """{"sessions":$list,"statuses":$sessionStatuses,"activities":{},"costs":{}}"""
     }
 
     private fun handleSse(writer: BufferedWriter) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloSessionService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloSessionService.kt
@@ -18,6 +18,7 @@ import ai.kilocode.rpc.dto.QuestionReplyDto
 import ai.kilocode.rpc.dto.QuestionRequestDto
 import ai.kilocode.rpc.dto.SessionDto
 import ai.kilocode.rpc.dto.SessionListDto
+import ai.kilocode.rpc.dto.SessionRuntimeDto
 import ai.kilocode.rpc.dto.SessionStatusDto
 import com.intellij.openapi.components.Service
 import ai.kilocode.log.KiloLog
@@ -56,6 +57,9 @@ class KiloSessionService internal constructor(
     private val _sessions = MutableStateFlow<List<SessionDto>>(emptyList())
     val sessions: StateFlow<List<SessionDto>> = _sessions.asStateFlow()
 
+    val runtime: StateFlow<SessionRuntimeDto> =
+        stream { runtime() }.stateIn(cs, SharingStarted.Eagerly, SessionRuntimeDto())
+
     /** Live session status map from SSE events. */
     val statuses: StateFlow<Map<String, SessionStatusDto>> =
         stream { statuses() }.stateIn(cs, SharingStarted.Eagerly, emptyMap())
@@ -86,10 +90,25 @@ class KiloSessionService internal constructor(
         }
     }
 
-    internal fun activity(): Map<String, SessionActivityKind> =
-        statuses.value
+    internal fun activity(): Map<String, SessionActivityKind> {
+        val mapped = runtime.value.activities.mapNotNull { (id, value) ->
+            val kind = when (value.kind) {
+                "running" -> SessionActivityKind.RUNNING
+                "login_required" -> SessionActivityKind.LOGIN_REQUIRED
+                "permission" -> SessionActivityKind.PERMISSION
+                "plan" -> SessionActivityKind.PLAN
+                "question" -> SessionActivityKind.QUESTION
+                else -> null
+            } ?: return@mapNotNull null
+            id to kind
+        }.toMap()
+        val busy = statuses.value
             .filterValues { it.type == "busy" }
             .mapValues { SessionActivityKind.RUNNING }
+        return busy + mapped
+    }
+
+    internal fun costs(): Map<String, Double> = runtime.value.costs
 
     suspend fun list(dir: String): SessionListDto {
         val result = call { list(dir) }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionManager.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionManager.kt
@@ -18,6 +18,8 @@ interface SessionManager {
 
     fun titles(): Map<String, String> = emptyMap()
 
+    fun costs(): Map<String, Double> = emptyMap()
+
     fun activityChanged() {}
 
     fun openSession(session: SessionDto) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionSidePanelManager.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionSidePanelManager.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.cancel
 import java.awt.BorderLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.Timer
 
 class SessionSidePanelManager(
     private val project: Project,
@@ -42,6 +43,7 @@ class SessionSidePanelManager(
     private var current: SessionUi? = null
     private var latest: SessionUi? = null
     private var panel: JComponent? = null
+    private val cleanup = Timer(60_000) { cleanupInactive() }.apply { start() }
 
     val defaultFocusedComponent: JComponent? get() = current?.defaultFocusedComponent ?: (panel as? HistoryPanel)?.defaultFocusedComponent
 
@@ -66,15 +68,10 @@ class SessionSidePanelManager(
     }
 
     @RequiresEdt
-    override fun activity(): Map<String, SessionActivityKind> {
-        val base = status()
-        val live = all.mapNotNull { ui ->
-            val id = ui.id ?: return@mapNotNull null
-            val kind = ui.activityKind() ?: return@mapNotNull null
-            id to kind
-        }.toMap()
-        return base + live
-    }
+    override fun activity(): Map<String, SessionActivityKind> = status()
+
+    @RequiresEdt
+    override fun costs(): Map<String, Double> = project.service<KiloSessionService>().costs()
 
     @RequiresEdt
     override fun titles(): Map<String, String> = all.mapNotNull { ui ->
@@ -202,14 +199,25 @@ class SessionSidePanelManager(
         Disposer.dispose(ui)
     }
 
-    private fun disposeInactiveUi() = Registry.`is`("kilo.session.inactive.dispose", false)
+    private fun cleanupInactive() {
+        all.toList().forEach { ui ->
+            if (ui === current) return@forEach
+            if (ui.cacheKey == null) return@forEach
+            if (!ui.canDisposeInactive()) return@forEach
+            disposeUi(ui)
+        }
+    }
+
+    private fun disposeInactiveUi() = Registry.`is`("kilo.session.inactive.dispose", true)
 
     override fun dispose() {
+        cleanup.stop()
         val items = all.toList()
         opened.clear()
         all.clear()
         current = null
         latest = null
+        panel = null
         component.removeAll()
         items.forEach { Disposer.dispose(it) }
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryActivitySnapshot.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryActivitySnapshot.kt
@@ -5,9 +5,10 @@ import ai.kilocode.client.session.SessionActivityKind
 internal data class HistoryActivitySnapshot(
     val activity: Map<String, SessionActivityKind> = emptyMap(),
     val titles: Map<String, String> = emptyMap(),
+    val costs: Map<String, Double> = emptyMap(),
 ) {
     fun changed(next: HistoryActivitySnapshot): Set<String> =
-        (activity.keys + next.activity.keys + titles.keys + next.titles.keys).filterTo(mutableSetOf()) {
-            activity[it] != next.activity[it] || titles[it] != next.titles[it]
+        (activity.keys + next.activity.keys + titles.keys + next.titles.keys + costs.keys + next.costs.keys).filterTo(mutableSetOf()) {
+            activity[it] != next.activity[it] || titles[it] != next.titles[it] || costs[it] != next.costs[it]
         }
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryController.kt
@@ -62,6 +62,8 @@ class HistoryController(
 
     internal fun activity() = sessions.activity()
 
+    internal fun costs() = sessions.costs()
+
     fun reloadLocal() {
         edt { local.start() }
         cs.launch {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryListRenderer.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryListRenderer.kt
@@ -2,6 +2,7 @@ package ai.kilocode.client.session.history
 
 import ai.kilocode.client.session.ui.PickerRow
 import ai.kilocode.client.session.SessionActivityKind
+import ai.kilocode.client.session.ui.header.money
 import ai.kilocode.client.ui.FilledBadgeIcon
 import ai.kilocode.client.ui.UiStyle
 import com.intellij.icons.AllIcons
@@ -30,6 +31,7 @@ internal open class HistoryRenderer<T : HistoryItem>(
     private val deletable: Boolean,
     private val activity: () -> Map<String, SessionActivityKind>,
     private val titles: () -> Map<String, String> = { emptyMap() },
+    private val costs: () -> Map<String, Double> = { emptyMap() },
 ) : JPanel(BorderLayout()), ListCellRenderer<T> {
     companion object {
         private val icon: Icon = AllIcons.Actions.GC
@@ -62,6 +64,9 @@ internal open class HistoryRenderer<T : HistoryItem>(
     }
     private val title = SimpleColoredComponent()
     private val badge = BadgeLabel()
+    private val cost = JBLabel().apply {
+        border = JBUI.Borders.emptyRight(UiStyle.Gap.sm())
+    }
     private val time = JBLabel()
     private val del = JBLabel().apply {
         horizontalAlignment = SwingConstants.CENTER
@@ -74,7 +79,11 @@ internal open class HistoryRenderer<T : HistoryItem>(
     }
     private val main = JPanel(BorderLayout()).apply {
         add(head, BorderLayout.CENTER)
-        add(time, BorderLayout.EAST)
+        add(JPanel(FlowLayout(FlowLayout.RIGHT, 0, 0)).apply {
+            add(cost)
+            add(time)
+            UiStyle.Components.transparent(this, cost)
+        }, BorderLayout.EAST)
     }
     private val row = JPanel(BorderLayout()).apply {
         add(main, BorderLayout.CENTER)
@@ -87,7 +96,7 @@ internal open class HistoryRenderer<T : HistoryItem>(
         isOpaque = true
         top.isOpaque = true
         row.border = JBUI.Borders.empty(UiStyle.Gap.lg(), UiStyle.Gap.lg(), UiStyle.Gap.lg(), UiStyle.Gap.lg())
-        UiStyle.Components.transparent(row, main, head, title, badge, time, del)
+        UiStyle.Components.transparent(row, main, head, title, badge, cost, time, del)
         wrap.setContent(row)
         add(top, BorderLayout.NORTH)
         add(wrap, BorderLayout.CENTER)
@@ -119,6 +128,10 @@ internal open class HistoryRenderer<T : HistoryItem>(
         )
         time.text = value?.let(HistoryTime::relative).orEmpty()
         time.foreground = weak
+        val amount = value?.let { costs()[it.id] ?: (it as? LocalHistoryItem)?.session?.cost }
+        cost.text = money(amount).orEmpty()
+        cost.foreground = weak
+        cost.isVisible = cost.text.isNotEmpty()
         badge.setKind(value?.id?.let(activity()::get))
         if (deletable) del.icon = if (selected) icon else empty
 
@@ -131,6 +144,8 @@ internal open class HistoryRenderer<T : HistoryItem>(
     internal fun badgeText() = badge.kind?.label()
 
     internal fun titleText() = text
+
+    internal fun costText() = cost.text
 
     private class BadgeLabel : JBLabel() {
         var kind: SessionActivityKind? = null
@@ -153,7 +168,8 @@ internal class LocalHistoryRenderer(
     model: HistoryModel<LocalHistoryItem>,
     activity: () -> Map<String, SessionActivityKind> = { emptyMap() },
     titles: () -> Map<String, String> = { emptyMap() },
-) : HistoryRenderer<LocalHistoryItem>(model, deletable = true, activity, titles)
+    costs: () -> Map<String, Double> = { emptyMap() },
+) : HistoryRenderer<LocalHistoryItem>(model, deletable = true, activity, titles, costs)
 
 internal class CloudHistoryRenderer(
     model: HistoryModel<CloudHistoryItem>,

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryPanel.kt
@@ -222,7 +222,7 @@ class HistoryPanel(
     private fun localList() = JBList(controller.local).apply {
         selectionMode = ListSelectionModel.MULTIPLE_INTERVAL_SELECTION
         isFocusable = true
-        cellRenderer = LocalHistoryRenderer(controller.local, { snapshot.activity }, { snapshot.titles })
+        cellRenderer = LocalHistoryRenderer(controller.local, { snapshot.activity }, { snapshot.titles }, { snapshot.costs })
         cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
         emptyText.text = KiloBundle.message("history.empty")
         addMouseListener(object : MouseAdapter() {
@@ -296,6 +296,7 @@ class HistoryPanel(
         val next = HistoryActivitySnapshot(
             activity = manager?.activity() ?: controller.activity(),
             titles = manager?.titles().orEmpty(),
+            costs = manager?.costs() ?: controller.costs(),
         )
         val changed = snapshot.changed(next)
         snapshot = next

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeSessionRpcApi.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeSessionRpcApi.kt
@@ -15,6 +15,7 @@ import ai.kilocode.rpc.dto.QuestionReplyDto
 import ai.kilocode.rpc.dto.QuestionRequestDto
 import ai.kilocode.rpc.dto.SessionDto
 import ai.kilocode.rpc.dto.SessionListDto
+import ai.kilocode.rpc.dto.SessionRuntimeDto
 import ai.kilocode.rpc.dto.SessionStatusDto
 import ai.kilocode.rpc.dto.SessionTimeDto
 import kotlinx.coroutines.CompletableDeferred
@@ -65,6 +66,9 @@ class FakeSessionRpcApi : KiloSessionRpcApi {
 
     /** Push status updates here. */
     val statuses = MutableStateFlow<Map<String, SessionStatusDto>>(emptyMap())
+
+    /** Push runtime updates here. */
+    val runtime = MutableStateFlow(SessionRuntimeDto())
 
     /** Pending permissions returned by [pendingPermissions]. */
     val pendingPermissionList = mutableListOf<PermissionRequestDto>()
@@ -162,6 +166,11 @@ class FakeSessionRpcApi : KiloSessionRpcApi {
     override suspend fun statuses(): Flow<Map<String, SessionStatusDto>> {
         assertNotEdt("statuses")
         return statuses
+    }
+
+    override suspend fun runtime(): Flow<SessionRuntimeDto> {
+        assertNotEdt("runtime")
+        return runtime
     }
 
     override suspend fun setDirectory(id: String, directory: String) {

--- a/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/KiloSessionRpcApi.kt
+++ b/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/KiloSessionRpcApi.kt
@@ -13,6 +13,7 @@ import ai.kilocode.rpc.dto.QuestionReplyDto
 import ai.kilocode.rpc.dto.QuestionRequestDto
 import ai.kilocode.rpc.dto.SessionDto
 import ai.kilocode.rpc.dto.SessionListDto
+import ai.kilocode.rpc.dto.SessionRuntimeDto
 import ai.kilocode.rpc.dto.SessionStatusDto
 import com.intellij.platform.rpc.RemoteApiProviderService
 import fleet.rpc.RemoteApi
@@ -62,6 +63,9 @@ interface KiloSessionRpcApi : RemoteApi<Unit> {
 
     /** Observe live session status changes. */
     suspend fun statuses(): Flow<Map<String, SessionStatusDto>>
+
+    /** Observe live session runtime metadata. */
+    suspend fun runtime(): Flow<SessionRuntimeDto>
 
     /** Register a worktree directory override for a session. */
     suspend fun setDirectory(id: String, directory: String)

--- a/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/dto/SessionDto.kt
+++ b/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/dto/SessionDto.kt
@@ -12,6 +12,7 @@ data class SessionDto(
     val version: String,
     val time: SessionTimeDto,
     val summary: SessionSummaryDto? = null,
+    val cost: Double? = null,
 )
 
 @Serializable
@@ -38,7 +39,23 @@ data class SessionStatusDto(
 )
 
 @Serializable
+data class SessionActivityDto(
+    val kind: String,
+    val requestID: String? = null,
+    val message: String? = null,
+)
+
+@Serializable
+data class SessionRuntimeDto(
+    val statuses: Map<String, SessionStatusDto> = emptyMap(),
+    val activities: Map<String, SessionActivityDto> = emptyMap(),
+    val costs: Map<String, Double> = emptyMap(),
+)
+
+@Serializable
 data class SessionListDto(
     val sessions: List<SessionDto>,
     val statuses: Map<String, SessionStatusDto>,
+    val activities: Map<String, SessionActivityDto> = emptyMap(),
+    val costs: Map<String, Double> = emptyMap(),
 )

--- a/packages/kilo-ui/src/components/error-details.tsx
+++ b/packages/kilo-ui/src/components/error-details.tsx
@@ -11,7 +11,9 @@ export function ErrorDetails(props: ErrorDetailsProps) {
 
   return (
     <div class="error-details">
-      <pre class="error-detail-pre" data-scrollable>{raw()}</pre>
+      <pre class="error-detail-pre" data-scrollable>
+        {raw()}
+      </pre>
     </div>
   )
 }

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1377,12 +1377,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     <Show when={throttledText() && showSyntheticPart()}>
       <div data-component="text-part">
         <div data-slot="text-part-body">
-          <Markdown
-            text={throttledText()}
-            cacheKey={part().id}
-            streaming={streaming()}
-            onClick={handleMarkdownClick}
-          />
+          <Markdown text={throttledText()} cacheKey={part().id} streaming={streaming()} onClick={handleMarkdownClick} />
         </div>
         <Show when={showCopy()}>
           <div data-slot="assistant-copy-wrapper">

--- a/packages/kilo-ui/src/styles/vscode-bridge.css
+++ b/packages/kilo-ui/src/styles/vscode-bridge.css
@@ -192,9 +192,18 @@ html[data-theme="kilo-vscode"] {
   --border-warning-base: var(--vscode-charts-yellow);
   --border-warning-hover: var(--vscode-charts-yellow);
   --border-warning-selected: var(--vscode-charts-yellow);
-  --border-critical-base: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground, var(--vscode-charts-red)));
-  --border-critical-hover: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground, var(--vscode-charts-red)));
-  --border-critical-selected: var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground, var(--vscode-charts-red)));
+  --border-critical-base: var(
+    --vscode-inputValidation-errorBorder,
+    var(--vscode-errorForeground, var(--vscode-charts-red))
+  );
+  --border-critical-hover: var(
+    --vscode-inputValidation-errorBorder,
+    var(--vscode-errorForeground, var(--vscode-charts-red))
+  );
+  --border-critical-selected: var(
+    --vscode-inputValidation-errorBorder,
+    var(--vscode-errorForeground, var(--vscode-charts-red))
+  );
   --border-info-base: var(--vscode-charts-blue);
   --border-info-hover: var(--vscode-charts-blue);
   --border-info-selected: var(--vscode-charts-blue);

--- a/packages/opencode/src/config/mcp.ts
+++ b/packages/opencode/src/config/mcp.ts
@@ -2,7 +2,8 @@ import { Schema, SchemaGetter } from "effect" // kilocode_change
 import { zod } from "@/util/effect-zod"
 import { PositiveInt, withStatics } from "@/util/schema"
 
-const LocalCanonical = Schema.Struct({ // kilocode_change
+const LocalCanonical = Schema.Struct({
+  // kilocode_change
   type: Schema.Literal("local").annotate({ description: "Type of MCP server connection" }),
   command: Schema.mutable(Schema.Array(Schema.String)).annotate({
     description: "Command and arguments to run the MCP server",

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-process-list.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-process-list.tsx
@@ -146,7 +146,8 @@ export function DialogProcessList() {
     const busy = actions.busy()
     return list().map((item) => {
       const note = mode() === "all" ? session(sync, item.sessionID) : undefined
-      const footer = busy?.id === item.id ? `${busy.kind === "stop" ? "stopping" : "restarting"}...` : item.pid?.toString()
+      const footer =
+        busy?.id === item.id ? `${busy.kind === "stop" ? "stopping" : "restarting"}...` : item.pid?.toString()
       const title = `${note ? `(${note}) ` : ""}${label(item)} - ${item.command}`
 
       return {
@@ -286,9 +287,7 @@ function DialogProcessDetail(props: { id: string; back: () => void }) {
               <Show when={proc().exitCode !== undefined}>
                 <text fg={theme.textMuted}>Exit: {proc().exitCode}</text>
               </Show>
-              <Show when={proc().signal}>
-                {(signal) => <text fg={theme.textMuted}>Signal: {signal()}</text>}
-              </Show>
+              <Show when={proc().signal}>{(signal) => <text fg={theme.textMuted}>Signal: {signal()}</text>}</Show>
               <text fg={theme.textMuted}>Started: {Locale.datetime(proc().time.started)}</text>
               <text fg={theme.textMuted}>Updated: {Locale.datetime(proc().time.updated)}</text>
               <Show when={proc().time.ended}>

--- a/packages/opencode/src/kilocode/plugins/sidebar-background-processes.tsx
+++ b/packages/opencode/src/kilocode/plugins/sidebar-background-processes.tsx
@@ -44,9 +44,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
                   <span style={{ fg: tone(item, props.api) }}>●</span> {short(label(item))}
                 </text>
                 <text fg={theme().textMuted}>{short(item.command)}</text>
-                <Show when={item.pid}>
-                  {(pid) => <text fg={theme().textMuted}>PID: {pid()}</text>}
-                </Show>
+                <Show when={item.pid}>{(pid) => <text fg={theme().textMuted}>PID: {pid()}</text>}</Show>
                 <Show when={item.ports.length > 0}>
                   <text fg={theme().textMuted}>PORTS: {item.ports.join(", ")}</text>
                 </Show>

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -1,11 +1,31 @@
-import { Schema } from "effect"
+import { Schema, SchemaGetter } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { SessionOverview } from "@/kilocode/session/overview"
 import { Authorization } from "@/server/routes/instance/httpapi/middleware/authorization"
 import { InstanceContextMiddleware } from "@/server/routes/instance/httpapi/middleware/instance-context"
 import { WorkspaceRoutingMiddleware } from "@/server/routes/instance/httpapi/middleware/workspace-routing"
 import { described } from "@/server/routes/instance/httpapi/groups/metadata"
 
 const root = "/kilocode"
+
+const QueryBoolean = Schema.Literals(["true", "false"]).pipe(
+  Schema.decodeTo(Schema.Boolean, {
+    decode: SchemaGetter.transform((value) => value === "true"),
+    encode: SchemaGetter.transform((value) => (value ? "true" : "false")),
+  }),
+)
+
+export const SessionOverviewQuery = Schema.Struct({
+  directory: Schema.optional(Schema.String),
+  projectID: Schema.optional(Schema.String),
+  worktrees: Schema.optional(QueryBoolean),
+  roots: Schema.optional(QueryBoolean),
+  start: Schema.optional(Schema.NumberFromString),
+  cursor: Schema.optional(Schema.NumberFromString),
+  search: Schema.optional(Schema.String),
+  limit: Schema.optional(Schema.NumberFromString),
+  archived: Schema.optional(QueryBoolean),
+})
 
 export const RemoveSkillPayload = Schema.Struct({
   location: Schema.String,
@@ -16,6 +36,7 @@ export const RemoveAgentPayload = Schema.Struct({
 })
 
 export const KilocodePaths = {
+  sessionOverview: `${root}/session/overview`,
   heapSnapshot: `${root}/heap/snapshot`,
   removeSkill: `${root}/skill/remove`,
   removeAgent: `${root}/agent/remove`,
@@ -25,6 +46,17 @@ export const KilocodeApi = HttpApi.make("kilocode")
   .add(
     HttpApiGroup.make("kilocode")
       .add(
+        HttpApiEndpoint.get("sessionOverview", KilocodePaths.sessionOverview, {
+          query: SessionOverviewQuery,
+          success: described(SessionOverview.Response, "Session overview"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.session.overview",
+            summary: "Get session overview",
+            description: "Get sessions, runtime statuses, activities, and costs in one lightweight response.",
+          }),
+        ),
         HttpApiEndpoint.post("heapSnapshot", KilocodePaths.heapSnapshot, {
           success: described(Schema.String, "Heap snapshot file path"),
           error: HttpApiError.BadRequest,

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -215,10 +215,13 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
         )
       }
 
-      const json = yield* Effect.promise(() => response.json() as Promise<{
-        choices?: Array<{ message?: { content?: string } }>
-        usage?: { prompt_tokens?: number; completion_tokens?: number }
-      }>)
+      const json = yield* Effect.promise(
+        () =>
+          response.json() as Promise<{
+            choices?: Array<{ message?: { content?: string } }>
+            usage?: { prompt_tokens?: number; completion_tokens?: number }
+          }>,
+      )
       const raw = json.choices?.[0]?.message?.content ?? ""
       const body = extractFencedBody(raw)
       return {

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -3,14 +3,21 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as KiloAgent from "@/kilocode/agent"
 import { EffectBridge } from "@/effect/bridge"
 import { HeapSnapshot } from "@/kilocode/cli/heap-snapshot"
+import { SessionOverview } from "@/kilocode/session/overview"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Skill } from "@/skill"
-import { RemoveAgentPayload, RemoveSkillPayload } from "../groups/kilocode"
+import { RemoveAgentPayload, RemoveSkillPayload, SessionOverviewQuery } from "../groups/kilocode"
 
 export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode", (handlers) =>
   Effect.gen(function* () {
     const heapSnapshot = Effect.fn("KilocodeHttpApi.heapSnapshot")(function* () {
       return yield* Effect.sync(() => HeapSnapshot.write())
+    })
+
+    const sessionOverview = Effect.fn("KilocodeHttpApi.sessionOverview")(function* (ctx: {
+      query: typeof SessionOverviewQuery.Type
+    }) {
+      return yield* SessionOverview.build(ctx.query)
     })
 
     const removeSkill = Effect.fn("KilocodeHttpApi.removeSkill")(function* (ctx: {
@@ -28,6 +35,7 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
     })
 
     return handlers
+      .handle("sessionOverview", sessionOverview)
       .handle("heapSnapshot", heapSnapshot)
       .handle("removeSkill", removeSkill)
       .handle("removeAgent", removeAgent)

--- a/packages/opencode/src/kilocode/server/httpapi/instance.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/instance.ts
@@ -33,6 +33,7 @@ export function register(app: Hono, handler: Handler, context: Context.Context<u
   app.get(SuggestionPaths.list, (c) => handler(c.req.raw, context))
   app.post(SuggestionPaths.accept, (c) => handler(c.req.raw, context))
   app.post(SuggestionPaths.dismiss, (c) => handler(c.req.raw, context))
+  app.get(KilocodePaths.sessionOverview, (c) => handler(c.req.raw, context))
   app.post(KilocodePaths.heapSnapshot, (c) => handler(c.req.raw, context))
   app.post(KilocodePaths.removeSkill, (c) => handler(c.req.raw, context))
   app.post(KilocodePaths.removeAgent, (c) => handler(c.req.raw, context))

--- a/packages/opencode/src/kilocode/session/overview.ts
+++ b/packages/opencode/src/kilocode/session/overview.ts
@@ -1,0 +1,145 @@
+// kilocode_change - new file
+import { Effect, Schema } from "effect"
+import { inArray } from "@/storage/db"
+import { Database } from "@/storage/db"
+import { KiloSession } from "@/kilocode/session"
+import { MessageTable } from "@/session/session.sql"
+import { Permission } from "@/permission"
+import { Question } from "@/question"
+import { Session } from "@/session/session"
+import { SessionStatus } from "@/session/status"
+import { SessionID } from "@/session/schema"
+
+export namespace SessionOverview {
+  type ActivityKind = "running" | "login_required" | "permission" | "plan" | "question"
+
+  export const Activity = Schema.Struct({
+    kind: Schema.Literals(["running", "login_required", "permission", "plan", "question"]),
+    requestID: Schema.optional(Schema.String),
+    message: Schema.optional(Schema.String),
+  }).annotate({ identifier: "SessionActivity" })
+  export type Activity = Schema.Schema.Type<typeof Activity>
+
+  export const Query = Schema.Struct({
+    directory: Schema.optional(Schema.String),
+    projectID: Schema.optional(Schema.String),
+    worktrees: Schema.optional(Schema.Boolean),
+    roots: Schema.optional(Schema.Boolean),
+    start: Schema.optional(Schema.Number),
+    cursor: Schema.optional(Schema.Number),
+    search: Schema.optional(Schema.String),
+    limit: Schema.optional(Schema.Number),
+    archived: Schema.optional(Schema.Boolean),
+  })
+  export type Query = Schema.Schema.Type<typeof Query>
+
+  export const Response = Schema.Struct({
+    sessions: Schema.Array(Schema.Union([Session.Info, Session.GlobalInfo])),
+    statuses: Schema.Record(Schema.String, SessionStatus.Info),
+    activities: Schema.Record(Schema.String, Activity),
+    costs: Schema.Record(Schema.String, Schema.Number),
+  }).annotate({ identifier: "SessionOverview" })
+  export type Response = Schema.Schema.Type<typeof Response>
+
+  const rank: Record<ActivityKind, number> = {
+    permission: 5,
+    plan: 4,
+    question: 3,
+    login_required: 2,
+    running: 1,
+  }
+
+  function set(map: Map<string, Activity>, id: string, activity: Activity) {
+    const prev = map.get(id)
+    if (prev && rank[prev.kind] >= rank[activity.kind]) return
+    map.set(id, activity)
+  }
+
+  function plan(req: Question.Request) {
+    return req.questions.some(
+      (item) => item.questionKey === "plan.followup.question" || item.headerKey === "plan.followup.header",
+    )
+  }
+
+  function costs(ids: string[]) {
+    if (ids.length === 0) return {}
+    const rows = Database.use((db) =>
+      db
+        .select({ sessionID: MessageTable.session_id, data: MessageTable.data })
+        .from(MessageTable)
+        .where(
+          inArray(
+            MessageTable.session_id,
+            ids.map((id) => SessionID.make(id)),
+          ),
+        )
+        .all(),
+    )
+    const result: Record<string, number> = {}
+    for (const row of rows) {
+      if (row.data.role !== "assistant") continue
+      const cost = "cost" in row.data && typeof row.data.cost === "number" ? row.data.cost : undefined
+      if (cost === undefined || !Number.isFinite(cost)) continue
+      result[row.sessionID] = (result[row.sessionID] ?? 0) + cost
+    }
+    return result
+  }
+
+  export function build(input: Query) {
+    return Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const statuses = yield* SessionStatus.Service
+      const permissions = yield* Permission.Service
+      const questions = yield* Question.Service
+
+      const items = input.worktrees
+        ? yield* Effect.sync(() =>
+            Array.from(
+              KiloSession.listGlobal<Session.GlobalInfo>({
+                fromRow: Session.fromRow,
+                projectID: input.projectID,
+                directory: input.directory,
+                roots: input.roots,
+                start: input.start,
+                cursor: input.cursor,
+                search: input.search,
+                limit: input.limit,
+                archived: input.archived,
+              }),
+            ),
+          )
+        : yield* sessions.list({
+            directory: input.directory,
+            roots: input.roots,
+            start: input.start,
+            search: input.search,
+            limit: input.limit,
+          })
+
+      const ids = new Set<string>(items.map((item) => item.id))
+      const status = Object.fromEntries(
+        [...(yield* statuses.list())].filter(([id, value]) => ids.has(id) || value.type === "busy"),
+      )
+      const activity = new Map<string, Activity>()
+
+      for (const [id, value] of Object.entries(status)) {
+        if (value.type === "busy") set(activity, id, { kind: "running" })
+      }
+      for (const req of yield* permissions.list()) {
+        const id = KiloSession.resolveRoot(req.sessionID)
+        if (ids.has(id)) set(activity, id, { kind: "permission", requestID: String(req.id) })
+      }
+      for (const req of yield* questions.list()) {
+        const id = KiloSession.resolveRoot(req.sessionID)
+        if (ids.has(id)) set(activity, id, { kind: plan(req) ? "plan" : "question", requestID: String(req.id) })
+      }
+
+      return {
+        sessions: items,
+        statuses: status,
+        activities: Object.fromEntries(activity),
+        costs: costs(items.map((item) => item.id)),
+      }
+    })
+  }
+}

--- a/packages/opencode/src/plugin/xai.ts
+++ b/packages/opencode/src/plugin/xai.ts
@@ -119,7 +119,10 @@ function authHeaders() {
 // to make trust decisions, so unsigned decode is safe. Returns false for
 // opaque tokens (no JWT shape), which conservatively skips the proactive
 // refresh and lets the 401-on-call path drive the refresh instead.
-export function accessTokenIsExpiring(token: string | undefined, skewMs: number = ACCESS_TOKEN_REFRESH_SKEW_MS): boolean {
+export function accessTokenIsExpiring(
+  token: string | undefined,
+  skewMs: number = ACCESS_TOKEN_REFRESH_SKEW_MS,
+): boolean {
   if (!token || typeof token !== "string") return false
   const parts = token.split(".")
   if (parts.length < 2) return false

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -196,7 +196,9 @@ export const GlobalRoutes = lazy(() =>
         if (result.changed) {
           // kilocode_change start
           await AppRuntime.runPromise(
-            disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true }).pipe(Effect.catchCause(() => Effect.void)),
+            disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true }).pipe(
+              Effect.catchCause(() => Effect.void),
+            ),
           )
           // kilocode_change end
         }

--- a/packages/opencode/src/server/routes/instance/kilocode.ts
+++ b/packages/opencode/src/server/routes/instance/kilocode.ts
@@ -10,10 +10,78 @@ import { lazy } from "@/util/lazy"
 import { errors } from "../../error"
 import { SessionImportRoutes } from "@/kilocode/session-import/routes"
 import { HeapSnapshot } from "@/kilocode/cli/heap-snapshot"
+import { SessionOverview } from "@/kilocode/session/overview"
+import { jsonRequest } from "./trace"
+
+const QueryBoolean = z.union([
+  z.preprocess((value) => (value === "true" ? true : value === "false" ? false : value), z.boolean()),
+  z.enum(["true", "false"]),
+])
+
+function queryBoolean(value: z.infer<typeof QueryBoolean> | undefined) {
+  if (value === undefined) return
+  return value === true || value === "true"
+}
 
 export const KilocodeRoutes = lazy(() =>
   new Hono()
     .route("/session-import", SessionImportRoutes())
+    .get(
+      "/session/overview",
+      describeRoute({
+        summary: "Get session overview",
+        description: "Get sessions, runtime statuses, activities, and costs in one lightweight response.",
+        operationId: "kilocode.session.overview",
+        responses: {
+          200: {
+            description: "Session overview",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    sessions: z.array(z.unknown()),
+                    statuses: z.record(z.string(), z.unknown()),
+                    activities: z.record(z.string(), z.unknown()),
+                    costs: z.record(z.string(), z.number()),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          directory: z.string().optional(),
+          projectID: z.string().optional(),
+          worktrees: QueryBoolean.optional(),
+          roots: QueryBoolean.optional(),
+          start: z.coerce.number().optional(),
+          cursor: z.coerce.number().optional(),
+          search: z.string().optional(),
+          limit: z.coerce.number().optional(),
+          archived: QueryBoolean.optional(),
+        }),
+      ),
+      async (c) => {
+        const query = c.req.valid("query")
+        return jsonRequest("KilocodeRoutes.sessionOverview", c, function* () {
+          return yield* SessionOverview.build({
+            directory: query.directory,
+            projectID: query.projectID,
+            worktrees: queryBoolean(query.worktrees),
+            roots: queryBoolean(query.roots),
+            start: query.start,
+            cursor: query.cursor,
+            search: query.search,
+            limit: query.limit,
+            archived: queryBoolean(query.archived),
+          })
+        })
+      },
+    )
     .post(
       "/heap/snapshot",
       describeRoute({

--- a/packages/opencode/test/acp/agent-interface.test.ts
+++ b/packages/opencode/test/acp/agent-interface.test.ts
@@ -25,7 +25,8 @@ describe("acp.agent interface compliance", () => {
   type ACPRuntimeMethod = ACPAgentMethods | "resumeSession" | "closeSession" // kilocode_change
 
   // Methods that the SDK's router explicitly checks for at runtime
-  const sdkCheckedMethods: ACPRuntimeMethod[] = [ // kilocode_change
+  const sdkCheckedMethods: ACPRuntimeMethod[] = [
+    // kilocode_change
     // Required
     "initialize",
     "newSession",

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -664,7 +664,8 @@ describe("workspace-old CRUD", () => {
     })
   })
 
-  winSkip("sessionWarp applies source workspace patch to local target workspace", async () => { // kilocode_change
+  winSkip("sessionWarp applies source workspace patch to local target workspace", async () => {
+    // kilocode_change
     await withInstance(async (dir) => {
       const previousType = unique("warp-patch-prev-local")
       const targetType = unique("warp-patch-target-local")

--- a/packages/opencode/test/kilocode/local-review-command.test.ts
+++ b/packages/opencode/test/kilocode/local-review-command.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { localReviewCommand, localReviewUncommittedCommand, parseReviewCommand } from "../../src/kilocode/review/command"
+import {
+  localReviewCommand,
+  localReviewUncommittedCommand,
+  parseReviewCommand,
+} from "../../src/kilocode/review/command"
 
 describe("review command parsing", () => {
   test("parses review slash commands", () => {

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -161,7 +161,9 @@ describe("plan_exit detection", () => {
           ],
         })
 
-        expect(SessionPrompt.shouldAskPlanFollowup({ messages: seeded.messages, abort: AbortSignal.any([]) })).toBe(true)
+        expect(SessionPrompt.shouldAskPlanFollowup({ messages: seeded.messages, abort: AbortSignal.any([]) })).toBe(
+          true,
+        )
 
         const pending = PlanFollowup.ask({
           sessionID: seeded.sessionID,
@@ -179,7 +181,9 @@ describe("plan_exit detection", () => {
           PlanFollowup.ANSWER_NEW_SESSION,
           PlanFollowup.ANSWER_CONTINUE,
         ])
-        expect(question.questions[0].options.find((item) => item.label === PlanFollowup.ANSWER_CONTINUE)?.mode).toBe("code")
+        expect(question.questions[0].options.find((item) => item.label === PlanFollowup.ANSWER_CONTINUE)?.mode).toBe(
+          "code",
+        )
         await Question.reject(question.id)
         await expect(pending).resolves.toBe("break")
       } finally {

--- a/packages/opencode/test/kilocode/server/httpapi-bridge.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-bridge.test.ts
@@ -122,6 +122,7 @@ describe("Kilo HttpApi bridge", () => {
       "POST /kilocode/heap/snapshot",
       "POST /kilocode/skill/remove",
       "POST /kilocode/agent/remove",
+      "GET /kilocode/session/overview",
       "POST /kilocode/session-import/project",
       "POST /kilocode/session-import/session",
       "POST /kilocode/session-import/message",

--- a/packages/opencode/test/plugin/xai.test.ts
+++ b/packages/opencode/test/plugin/xai.test.ts
@@ -1,6 +1,13 @@
 // kilocode_change - new file
 import { describe, expect, test } from "bun:test"
-import { accessTokenIsExpiring, buildAuthorizeUrl, escapeHtml, pollDeviceCodeToken, requestDeviceCode, XaiAuthPlugin } from "../../src/plugin/xai"
+import {
+  accessTokenIsExpiring,
+  buildAuthorizeUrl,
+  escapeHtml,
+  pollDeviceCodeToken,
+  requestDeviceCode,
+  XaiAuthPlugin,
+} from "../../src/plugin/xai"
 import { OAUTH_DUMMY_KEY } from "../../src/auth"
 
 function makeJwt(payload: object): string {
@@ -114,7 +121,9 @@ describe("plugin.xai", () => {
     test("returns no options unless stored auth is OAuth and exposes methods in order", async () => {
       const hooks = await XaiAuthPlugin({} as any)
       expect(await hooks.auth!.loader!(async () => ({ type: "api", key: "sk-test" }), {} as any)).toEqual({})
-      expect(await hooks.auth!.loader!(async () => ({ type: "wellknown", key: "k", token: "t" }) as any, {} as any)).toEqual({})
+      expect(
+        await hooks.auth!.loader!(async () => ({ type: "wellknown", key: "k", token: "t" }) as any, {} as any),
+      ).toEqual({})
       expect(hooks.auth!.methods.map((m) => [m.type, m.label])).toEqual([
         ["oauth", "xAI Grok OAuth (SuperGrok Subscription)"],
         ["oauth", "xAI Grok OAuth (Headless / Remote / VPS)"],
@@ -153,12 +162,17 @@ describe("plugin.xai", () => {
         captured.push(request.headers)
         return new Response("{}", { status: 200 })
       })
-      const opts = await (await XaiAuthPlugin(input)).auth!.loader!(
+      const opts = await (
+        await XaiAuthPlugin(input)
+      ).auth!.loader!(
         async () => ({ type: "oauth", access: "tok", refresh: "rt", expires: Date.now() + 3600_000 }),
         {} as any,
       )
 
-      const objHeaders: Record<string, string> = { Authorization: `Bearer ${OAUTH_DUMMY_KEY}`, "x-trace": "plain-object" }
+      const objHeaders: Record<string, string> = {
+        Authorization: `Bearer ${OAUTH_DUMMY_KEY}`,
+        "x-trace": "plain-object",
+      }
       await opts.fetch!(new URL("/chat/completions", server.url), { headers: objHeaders })
       expect(objHeaders).toEqual({ Authorization: `Bearer ${OAUTH_DUMMY_KEY}`, "x-trace": "plain-object" })
 
@@ -171,7 +185,11 @@ describe("plugin.xai", () => {
       await opts.fetch!(new URL("/chat/completions", server.url), { headers: headersInstance })
       expect(headersInstance.get("x-trace")).toBe("headers-instance")
 
-      expect(captured.map((headers) => headers.get("x-trace"))).toEqual(["plain-object", "tuple-array", "headers-instance"])
+      expect(captured.map((headers) => headers.get("x-trace"))).toEqual([
+        "plain-object",
+        "tuple-array",
+        "headers-instance",
+      ])
       for (const headers of captured) {
         expect(headers.get("authorization")).toBe("Bearer tok")
         expect(headers.get("user-agent")).toMatch(/^kilocode\//)
@@ -185,14 +203,20 @@ describe("plugin.xai", () => {
         captured.push(request.headers)
         return new Response("{}", { status: 200 })
       })
-      const opts = await (await XaiAuthPlugin(input)).auth!.loader!(
+      const opts = await (
+        await XaiAuthPlugin(input)
+      ).auth!.loader!(
         async () => ({ type: "oauth", access: "tok", refresh: "rt", expires: Date.now() + 3600_000 }),
         {} as any,
       )
 
       await opts.fetch!(
         new Request(new URL("/chat/completions", server.url), {
-          headers: { Authorization: `Bearer ${OAUTH_DUMMY_KEY}`, "content-type": "application/json", "x-trace": "request" },
+          headers: {
+            Authorization: `Bearer ${OAUTH_DUMMY_KEY}`,
+            "content-type": "application/json",
+            "x-trace": "request",
+          },
         }),
         { headers: { "x-trace": "init", "x-extra": "yes" } },
       )
@@ -211,7 +235,9 @@ describe("plugin.xai", () => {
         return new Response("{}", { status: 200 })
       })
       let firstCall = true
-      const opts = await (await XaiAuthPlugin(input)).auth!.loader!(async () => {
+      const opts = await (
+        await XaiAuthPlugin(input)
+      ).auth!.loader!(async () => {
         if (firstCall) {
           firstCall = false
           return { type: "oauth", access: "tok", refresh: "rt", expires: Date.now() + 3600_000 }
@@ -240,10 +266,9 @@ describe("plugin.xai", () => {
         apiRequests.push(request.headers)
         return new Response("{}", { status: 200 })
       })
-      const opts = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
-        async () => ({ type: "oauth" as const, access: "old", refresh: "rt-old", expires: 0 }),
-        {} as any,
-      )
+      const opts = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(async () => ({ type: "oauth" as const, access: "old", refresh: "rt-old", expires: 0 }), {} as any)
 
       await Promise.all([
         opts.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
@@ -251,7 +276,10 @@ describe("plugin.xai", () => {
       ])
 
       expect(tokenRequests).toBe(1)
-      expect(apiRequests.map((headers) => headers.get("authorization"))).toEqual(["Bearer new-access", "Bearer new-access"])
+      expect(apiRequests.map((headers) => headers.get("authorization"))).toEqual([
+        "Bearer new-access",
+        "Bearer new-access",
+      ])
       expect(setCalls).toHaveLength(1)
       expect((setCalls[0].body as any).refresh).toBe("rt-new")
     })
@@ -265,14 +293,24 @@ describe("plugin.xai", () => {
           const refreshToken = new URLSearchParams(await request.text()).get("refresh_token")!
           tokenRequests.push(refreshToken)
           await new Promise((resolve) => setTimeout(resolve, 20))
-          return Response.json({ access_token: `access-${refreshToken}`, refresh_token: `next-${refreshToken}`, expires_in: 3600 })
+          return Response.json({
+            access_token: `access-${refreshToken}`,
+            refresh_token: `next-${refreshToken}`,
+            expires_in: 3600,
+          })
         }
         apiRequests.push(request.headers.get("authorization")!)
         return new Response("{}", { status: 200 })
       })
       const hooks = await XaiAuthPlugin(input, serverOptions(server))
-      const first = await hooks.auth!.loader!(async () => ({ type: "oauth", access: "old-a", refresh: "rt-a", expires: 0 }), {} as any)
-      const second = await hooks.auth!.loader!(async () => ({ type: "oauth", access: "old-b", refresh: "rt-b", expires: 0 }), {} as any)
+      const first = await hooks.auth!.loader!(
+        async () => ({ type: "oauth", access: "old-a", refresh: "rt-a", expires: 0 }),
+        {} as any,
+      )
+      const second = await hooks.auth!.loader!(
+        async () => ({ type: "oauth", access: "old-b", refresh: "rt-b", expires: 0 }),
+        {} as any,
+      )
 
       await Promise.all([
         first.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
@@ -290,17 +328,22 @@ describe("plugin.xai", () => {
         if (url.pathname === "/oauth2/token") {
           tokenRequests++
           if (tokenRequests === 2) return new Response("temporarily unavailable", { status: 503 })
-          return Response.json({ access_token: `new-${tokenRequests}`, refresh_token: `rt-${tokenRequests}`, expires_in: 3600 })
+          return Response.json({
+            access_token: `new-${tokenRequests}`,
+            refresh_token: `rt-${tokenRequests}`,
+            expires_in: 3600,
+          })
         }
         return new Response("{}", { status: 200 })
       })
-      const opts = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
-        async () => ({ type: "oauth", access: "old", refresh: "rt-old", expires: 0 }),
-        {} as any,
-      )
+      const opts = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(async () => ({ type: "oauth", access: "old", refresh: "rt-old", expires: 0 }), {} as any)
 
       await opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })
-      await expect(opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })).rejects.toThrow(/xAI token refresh failed \(503\)/)
+      await expect(opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })).rejects.toThrow(
+        /xAI token refresh failed \(503\)/,
+      )
       await opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })
       expect(tokenRequests).toBe(3)
     })
@@ -313,10 +356,9 @@ describe("plugin.xai", () => {
         captured.push(request.headers)
         return new Response("{}", { status: 200 })
       })
-      const opts = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
-        async () => ({ type: "oauth", access: "old", refresh: "rt-old", expires: 0 }),
-        {} as any,
-      )
+      const opts = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(async () => ({ type: "oauth", access: "old", refresh: "rt-old", expires: 0 }), {} as any)
 
       const resp = await opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })
       expect(resp.status).toBe(200)
@@ -334,7 +376,9 @@ describe("plugin.xai", () => {
         }
         return new Response("{}", { status: 200 })
       })
-      const fresh = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
+      const fresh = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(
         async () => ({
           type: "oauth",
           access: makeJwt({ exp: Math.floor(Date.now() / 1000) + 24 * 3600 }),
@@ -346,7 +390,9 @@ describe("plugin.xai", () => {
       await fresh.fetch!(new URL("/chat/completions", server.url), { headers: {} })
       expect(tokenRequests).toBe(0)
 
-      const jwtExpiring = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
+      const jwtExpiring = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(
         async () => ({
           type: "oauth",
           access: makeJwt({ exp: Math.floor((Date.now() + 30_000) / 1000) }),
@@ -355,10 +401,9 @@ describe("plugin.xai", () => {
         }),
         {} as any,
       )
-      const missingExpires = await (await XaiAuthPlugin(input, serverOptions(server))).auth!.loader!(
-        async () => ({ type: "oauth", access: "opaque-token", refresh: "rt", expires: 0 }),
-        {} as any,
-      )
+      const missingExpires = await (
+        await XaiAuthPlugin(input, serverOptions(server))
+      ).auth!.loader!(async () => ({ type: "oauth", access: "opaque-token", refresh: "rt", expires: 0 }), {} as any)
       await jwtExpiring.fetch!(new URL("/chat/completions", server.url), { headers: {} })
       await missingExpires.fetch!(new URL("/chat/completions", server.url), { headers: {} })
       expect(tokenRequests).toBe(2)
@@ -367,10 +412,9 @@ describe("plugin.xai", () => {
 
     test("network failure during refresh surfaces the underlying fetch error", async () => {
       const { input } = makeInput()
-      const opts = await (await XaiAuthPlugin(input, { tokenUrl: "http://127.0.0.1:9/oauth2/token" })).auth!.loader!(
-        async () => ({ type: "oauth", access: "old", refresh: "rt", expires: 0 }),
-        {} as any,
-      )
+      const opts = await (
+        await XaiAuthPlugin(input, { tokenUrl: "http://127.0.0.1:9/oauth2/token" })
+      ).auth!.loader!(async () => ({ type: "oauth", access: "old", refresh: "rt", expires: 0 }), {} as any)
 
       await expect(opts.fetch!("https://api.x.ai/v1/chat/completions", { headers: {} })).rejects.toThrow()
     })
@@ -395,7 +439,10 @@ describe("plugin.xai", () => {
         return new Response("unexpected request", { status: 500 })
       })
       const hooks = await XaiAuthPlugin({} as any, serverOptions(server))
-      const headless = hooks.auth!.methods.find((m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)")!
+      const headless = hooks.auth!.methods.find(
+        (m): m is Extract<typeof m, { type: "oauth" }> =>
+          m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)",
+      )!
       const result = await headless.authorize!()
 
       expect(result.method).toBe("auto")
@@ -408,12 +455,17 @@ describe("plugin.xai", () => {
     test("authorize falls back to verification_uri when verification_uri_complete is absent", async () => {
       using server = makeServer((_, url) => {
         if (url.pathname === "/oauth2/device/code") {
-          return Response.json({ device_code: "DEVICE-2", user_code: "WXYZ-9876", verification_uri: "https://x.ai/device" })
+          return Response.json({
+            device_code: "DEVICE-2",
+            user_code: "WXYZ-9876",
+            verification_uri: "https://x.ai/device",
+          })
         }
         return new Response("unexpected request", { status: 500 })
       })
       const headless = (await XaiAuthPlugin({} as any, serverOptions(server))).auth!.methods.find(
-        (m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)",
+        (m): m is Extract<typeof m, { type: "oauth" }> =>
+          m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)",
       )!
       expect((await headless.authorize!()).url).toBe("https://x.ai/device")
     })
@@ -437,8 +489,12 @@ describe("plugin.xai", () => {
       expect(parsed.get("scope")).toContain("offline_access")
       expect(parsed.get("scope")).toContain("grok-cli:access")
       expect(parsed.get("scope")).toContain("api:access")
-      await expect(requestDeviceCode({ deviceAuthorizationUrl: new URL("/error", server.url).toString() })).rejects.toThrow(/429.*rate limited/)
-      await expect(requestDeviceCode({ deviceAuthorizationUrl: new URL("/missing", server.url).toString() })).rejects.toThrow(/missing device_code/)
+      await expect(
+        requestDeviceCode({ deviceAuthorizationUrl: new URL("/error", server.url).toString() }),
+      ).rejects.toThrow(/429.*rate limited/)
+      await expect(
+        requestDeviceCode({ deviceAuthorizationUrl: new URL("/missing", server.url).toString() }),
+      ).rejects.toThrow(/missing device_code/)
     })
 
     test("pollDeviceCodeToken resolves on success and posts the device-code grant", async () => {
@@ -488,7 +544,13 @@ describe("plugin.xai", () => {
         using server = makeServer(() => Response.json(body, { status: 500 }))
         await expect(
           pollDeviceCodeToken(
-            { device_code: "DC", user_code: "UC", verification_uri: "https://x.ai/device", interval: 1, expires_in: 600 },
+            {
+              device_code: "DC",
+              user_code: "UC",
+              verification_uri: "https://x.ai/device",
+              interval: 1,
+              expires_in: 600,
+            },
             { sleep: async () => {}, tokenUrl: new URL("/oauth2/token", server.url).toString() },
           ),
         ).rejects.toThrow(error)
@@ -499,7 +561,11 @@ describe("plugin.xai", () => {
       await expect(
         pollDeviceCodeToken(
           { device_code: "DC", user_code: "UC", verification_uri: "https://x.ai/device", interval: 1, expires_in: 1 },
-          { sleep: async () => {}, now: () => 1_000_000 + tick++ * 600, tokenUrl: new URL("/oauth2/token", pending.url).toString() },
+          {
+            sleep: async () => {},
+            now: () => 1_000_000 + tick++ * 600,
+            tokenUrl: new URL("/oauth2/token", pending.url).toString(),
+          },
         ),
       ).rejects.toThrow(/timed out/)
     })
@@ -515,7 +581,13 @@ describe("plugin.xai", () => {
         })
         const sleeps: number[] = []
         await pollDeviceCodeToken(
-          { device_code: "DC", user_code: "UC", verification_uri: "https://x.ai/device", interval: bad as number, expires_in: 600 },
+          {
+            device_code: "DC",
+            user_code: "UC",
+            verification_uri: "https://x.ai/device",
+            interval: bad as number,
+            expires_in: 600,
+          },
           { sleep: async (ms) => void sleeps.push(ms), tokenUrl: new URL("/oauth2/token", server.url).toString() },
         )
         expect(sleeps[0]).toBe(8_000)
@@ -526,7 +598,13 @@ describe("plugin.xai", () => {
         expect(
           (
             await pollDeviceCodeToken(
-              { device_code: "DC", user_code: "UC", verification_uri: "https://x.ai/device", interval: 1, expires_in: bad as number },
+              {
+                device_code: "DC",
+                user_code: "UC",
+                verification_uri: "https://x.ai/device",
+                interval: 1,
+                expires_in: bad as number,
+              },
               { sleep: async () => {}, tokenUrl: new URL("/oauth2/token", server.url).toString() },
             )
           ).access_token,
@@ -537,14 +615,21 @@ describe("plugin.xai", () => {
     test("device-code authorize callback returns failed when polling errors", async () => {
       using server = makeServer((_, url) => {
         if (url.pathname === "/oauth2/device/code") {
-          return Response.json({ device_code: "DC", user_code: "UC", verification_uri: "https://x.ai/device", interval: 0, expires_in: 600 })
+          return Response.json({
+            device_code: "DC",
+            user_code: "UC",
+            verification_uri: "https://x.ai/device",
+            interval: 0,
+            expires_in: 600,
+          })
         }
         return Response.json({ error: "access_denied" }, { status: 400 })
       })
       const headless = (await XaiAuthPlugin({} as any, serverOptions(server))).auth!.methods.find(
-        (m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)",
+        (m): m is Extract<typeof m, { type: "oauth" }> =>
+          m.type === "oauth" && m.label === "xAI Grok OAuth (Headless / Remote / VPS)",
       )!
-      expect(await (await headless.authorize!() as any).callback()).toEqual({ type: "failed" })
+      expect(await ((await headless.authorize!()) as any).callback()).toEqual({ type: "failed" })
     })
   })
 })

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -107,7 +107,8 @@ afterEach(async () => {
   await resetDatabase()
 })
 
-describeProvider("provider HttpApi", () => { // kilocode_change
+describeProvider("provider HttpApi", () => {
+  // kilocode_change
   it.live(
     "matches legacy OAuth authorize response shapes",
     withProviderProject((dir) =>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -97,6 +97,8 @@ import type {
   KilocodeSessionImportProjectResponses,
   KilocodeSessionImportSessionErrors,
   KilocodeSessionImportSessionResponses,
+  KilocodeSessionOverviewErrors,
+  KilocodeSessionOverviewResponses,
   KiloEditErrors,
   KiloEditResponses,
   KiloFimErrors,
@@ -5946,6 +5948,58 @@ export class Kilo extends HeyApiClient {
   }
 }
 
+export class Session5 extends HeyApiClient {
+  /**
+   * Get session overview
+   *
+   * Get sessions, runtime statuses, activities, and costs in one lightweight response.
+   */
+  public overview<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      projectID?: string
+      worktrees?: "true" | "false"
+      roots?: boolean | "true" | "false"
+      start?: number
+      cursor?: number
+      search?: string
+      limit?: number
+      archived?: boolean | "true" | "false"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "projectID" },
+            { in: "query", key: "worktrees" },
+            { in: "query", key: "roots" },
+            { in: "query", key: "start" },
+            { in: "query", key: "cursor" },
+            { in: "query", key: "search" },
+            { in: "query", key: "limit" },
+            { in: "query", key: "archived" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      KilocodeSessionOverviewResponses,
+      KilocodeSessionOverviewErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/session/overview",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Heap extends HeyApiClient {
   /**
    * Write heap snapshot
@@ -6443,6 +6497,11 @@ export class Kilocode extends HeyApiClient {
         },
       },
     )
+  }
+
+  private _session?: Session5
+  get session(): Session5 {
+    return (this._session ??= new Session5({ client: this.client }))
   }
 
   private _heap?: Heap

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1992,6 +1992,25 @@ export type EffectHttpApiErrorServiceUnavailable = {
   _tag: "ServiceUnavailable"
 }
 
+export type SessionActivity = {
+  kind: "running" | "login_required" | "permission" | "plan" | "question"
+  requestID?: string
+  message?: string
+}
+
+export type SessionOverview = {
+  sessions: Array<Session | GlobalSession>
+  statuses: {
+    [key: string]: SessionStatus
+  }
+  activities: {
+    [key: string]: SessionActivity
+  }
+  costs: {
+    [key: string]: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  }
+}
+
 export type KilocodeSessionImportResult = {
   ok: boolean
   id: string
@@ -8147,6 +8166,42 @@ export type KiloCloudSessionImportResponses = {
 }
 
 export type KiloCloudSessionImportResponse = KiloCloudSessionImportResponses[keyof KiloCloudSessionImportResponses]
+
+export type KilocodeSessionOverviewData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+    projectID?: string
+    worktrees?: "true" | "false"
+    roots?: boolean | "true" | "false"
+    start?: number
+    cursor?: number
+    search?: string
+    limit?: number
+    archived?: boolean | "true" | "false"
+  }
+  url: "/kilocode/session/overview"
+}
+
+export type KilocodeSessionOverviewErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeSessionOverviewError = KilocodeSessionOverviewErrors[keyof KilocodeSessionOverviewErrors]
+
+export type KilocodeSessionOverviewResponses = {
+  /**
+   * Session overview
+   */
+  200: SessionOverview
+}
+
+export type KilocodeSessionOverviewResponse = KilocodeSessionOverviewResponses[keyof KilocodeSessionOverviewResponses]
 
 export type KilocodeHeapSnapshotData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10145,6 +10145,151 @@
         ]
       }
     },
+    "/kilo/edit": {
+      "post": {
+        "tags": ["kilo"],
+        "operationId": "kilo.edit",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Next Edit completion",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "type": "string"
+                    },
+                    "usage": {
+                      "type": "object",
+                      "properties": {
+                        "prompt_tokens": {
+                          "type": "number"
+                        },
+                        "completion_tokens": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["content"],
+                  "additionalProperties": false,
+                  "description": "Next Edit completion"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Proxy a Mercury-style Next Edit request. The client supplies structured editor context; the gateway assembles the sentinel-tagged prompt and forwards to the upstream edit endpoint.",
+        "summary": "Next Edit completion",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "maxTokens": {
+                    "type": "number"
+                  },
+                  "currentFilePath": {
+                    "type": "string"
+                  },
+                  "currentFileContent": {
+                    "type": "string"
+                  },
+                  "cursorLine": {
+                    "type": "number"
+                  },
+                  "cursorCharacter": {
+                    "type": "number"
+                  },
+                  "editableRegionStartLine": {
+                    "type": "number"
+                  },
+                  "editableRegionEndLine": {
+                    "type": "number"
+                  },
+                  "recentlyViewedSnippets": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "filepath": {
+                          "type": "string"
+                        },
+                        "content": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["filepath", "content"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "editDiffHistory": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "currentFilePath",
+                  "currentFileContent",
+                  "cursorLine",
+                  "cursorCharacter",
+                  "editableRegionStartLine",
+                  "editableRegionEndLine",
+                  "recentlyViewedSnippets",
+                  "editDiffHistory"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilo.edit({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/kilo/audio/transcriptions": {
       "post": {
         "tags": ["kilo"],
@@ -10952,6 +11097,141 @@
           {
             "lang": "js",
             "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilo.cloud.session.import({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/session/overview": {
+      "get": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.session.overview",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectID",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "worktrees",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            "required": false
+          },
+          {
+            "name": "roots",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                }
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            },
+            "required": false
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            },
+            "required": false
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "number"
+            },
+            "required": false
+          },
+          {
+            "name": "archived",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                }
+              ]
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session overview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionOverview"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get sessions, runtime statuses, activities, and costs in one lightweight response.",
+        "summary": "Get session overview",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.session.overview({\n  ...\n})"
           }
         ]
       }
@@ -18473,6 +18753,81 @@
           }
         },
         "required": ["_tag"],
+        "additionalProperties": false
+      },
+      "SessionActivity": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["running", "login_required", "permission", "plan", "question"]
+          },
+          "requestID": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["kind"],
+        "additionalProperties": false
+      },
+      "SessionOverview": {
+        "type": "object",
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/Session"
+                },
+                {
+                  "$ref": "#/components/schemas/GlobalSession"
+                }
+              ]
+            }
+          },
+          "statuses": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SessionStatus"
+            }
+          },
+          "activities": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/SessionActivity"
+            }
+          },
+          "costs": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "enum": ["NaN"]
+                },
+                {
+                  "type": "string",
+                  "enum": ["Infinity"]
+                },
+                {
+                  "type": "string",
+                  "enum": ["-Infinity"]
+                },
+                {
+                  "type": "string",
+                  "enum": ["Infinity", "-Infinity", "NaN"]
+                }
+              ]
+            }
+          }
+        },
+        "required": ["sessions", "statuses", "activities", "costs"],
         "additionalProperties": false
       },
       "KilocodeSessionImportResult": {


### PR DESCRIPTION
## Issue

No linked issue. Implements the requested JetBrains history/session runtime summary behavior from the local implementation plan.

## Context

JetBrains local history and recent sessions needed to show active badges and aggregate cost without keeping hidden `SessionUi` instances alive. The previous flow also loaded history with separate status and session requests.

## Implementation

Added a Kilo-owned `/kilocode/session/overview` endpoint that returns sessions, runtime statuses, activity summaries, and session costs in one response. JetBrains now consumes that overview for local history and recents, maintains backend runtime state from overview/SSE events, exposes it through RPC, and uses cached frontend state to repaint history badges and costs.

This also makes inactive `SessionUi` disposal default-on and adds a 60s cleanup pass for retained idle UIs. The PR includes SDK/OpenAPI regeneration and a patch changeset for the JetBrains-facing behavior.

## Screenshots / Video

N/A. Behavior is history metadata/badge/cost plumbing, not a new visual layout.

## How to Test

### Manual/local verification

- Agent: `./script/generate.ts`
- Agent: `bun run typecheck` from `packages/opencode/`
- Agent: `bun test ./test/kilocode/server/httpapi-bridge.test.ts` from `packages/opencode/`
- Agent: `./gradlew typecheck` from `packages/kilo-jetbrains/`
- Agent: `./gradlew :backend:test --tests ai.kilocode.backend.app.KiloBackendSessionManagerTest` from `packages/kilo-jetbrains/`
- Agent: `./gradlew :backend:test --tests ai.kilocode.backend.cli.KiloCliDataParserTest` from `packages/kilo-jetbrains/`
- Agent: `./gradlew :frontend:test --tests ai.kilocode.client.session.history.HistoryActivitySnapshotTest` from `packages/kilo-jetbrains/`
- Agent: `bun run script/check-opencode-annotations.ts` from repo root
- Agent/pre-push hook: `bun turbo typecheck`

### Reviewer test steps

1. Open the JetBrains plugin local history with sessions that have active permissions/questions/running turns.
2. Confirm history rows show badges without reopening/retaining hidden chat UIs.
3. Confirm local history rows show session costs after assistant messages with costs exist.
4. Switch between sessions/history and confirm idle hidden UIs are disposable while history metadata remains visible.

### Blocked checks and substitute verification

- No blocked checks.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Kilo agent-generated PR.