### PR TITLE
docs: clarify per-directory AGENTS.md loading behavior

### DIFF
--- a/packages/kilo-docs/pages/customize/agents-md.md
+++ b/packages/kilo-docs/pages/customize/agents-md.md
@@ -57,21 +57,25 @@ my-project/
 The filename must be uppercase (`AGENTS.md`), not lowercase (`agents.md`). This ensures consistency across different operating systems and tools.
 {% /callout %}
 
-### Subdirectory AGENTS.md Files
+### Per-Directory AGENTS.md Files
 
-You can also place AGENTS.md files in subdirectories to provide context-specific instructions:
+You can place AGENTS.md files in subdirectories to provide context-specific instructions when the agent accesses files in those locations:
 
 ```
 my-project/
 ├── AGENTS.md                    # Root-level instructions
 ├── src/
 │   └── backend/
-│       └── AGENTS.md            # Backend-specific instructions
+│       └── AGENTS.md            # Backend-specific instructions (loaded when reading backend files)
 └── docs/
-    └── AGENTS.md                # Documentation-specific instructions
+    └── AGENTS.md                # Documentation-specific instructions (loaded when reading docs files)
 ```
 
-When working in a subdirectory, Kilo Code will load both the root AGENTS.md and any subdirectory AGENTS.md files, with subdirectory files taking precedence for conflicting instructions.
+{% callout type="info" %}
+Per-directory AGENTS.md files are **dynamically loaded** when the agent reads files in that directory - they are not pre-loaded at session start. When the agent reads a file in `src/backend/`, the corresponding `AGENTS.md` is discovered and its contents are injected into the conversation as `<system-reminder>` tags.
+
+This is useful for providing context-specific guidance for different parts of a monorepo or project.
+{% /callout %}
 
 ## File Protection
 

--- a/packages/kilo-docs/pages/customize/custom-instructions.md
+++ b/packages/kilo-docs/pages/customize/custom-instructions.md
@@ -50,7 +50,7 @@ Project-level instructions are loaded before global instructions and apply to ev
 
 You can place `AGENTS.md` files in any subdirectory of your project. These are loaded dynamically — when the agent's Read tool accesses a file in that directory, the corresponding `AGENTS.md` is discovered and its contents are injected into the conversation as `<system-reminder>` tags.
 
-This is useful for providing context-specific guidance for different parts of a monorepo or project.
+This is useful for providing context-specific guidance for different parts of a monorepo or project. The subdirectory file does not need to duplicate root-level instructions; it supplements them for tasks within that directory.
 
 ## Additional Instruction Sources
 
@@ -127,7 +127,7 @@ Project-level instructions are loaded before global instructions and apply to ev
 
 You can place `AGENTS.md` files in any subdirectory of your project. These are loaded dynamically — when the agent's Read tool accesses a file in that directory, the corresponding `AGENTS.md` is discovered and its contents are injected into the conversation as `<system-reminder>` tags.
 
-This is useful for providing context-specific guidance for different parts of a monorepo or project.
+This is useful for providing context-specific guidance for different parts of a monorepo or project. The subdirectory file does not need to duplicate root-level instructions; it supplements them for tasks within that directory.
 
 ## Additional Instruction Sources
 


### PR DESCRIPTION
## Issue

Closes #10705

## Context

The per-directory AGENTS.md loading behavior was misdocumented. The previous docs stated that subdirectory files take "precedence" over root files, implying static loading with conflict resolution. In reality, these files are loaded dynamically during file access - when the agent reads a file in a subdirectory, it discovers and loads the corresponding AGENTS.md, injecting it as `<system-reminder>` context. This dynamic behavior is more powerful for monorepos but was confusing to users expecting static precedence.

## Implementation

Updated the documentation to accurately reflect the dynamic loading mechanism. The changes clarify that:
- Per-directory AGENTS.md files are NOT pre-loaded at session start
- They are discovered and injected during file access operations
- The `_resolve()` method in `src/session/instruction.ts` walks upward from the file being read and attaches nearby instruction files as system reminders
- This provides context-sensitive guidance without requiring manual file loading

The docs now correctly explain when and how subdirectory AGENTS.md files become available to the agent, helping users understand they should place instructions in subdirectories relevant to the code those instructions govern.

## Screenshots / Video

### Before

<img width="866" height="356" alt="image" src="https://github.com/user-attachments/assets/1166b189-5314-4af4-8b70-b6c6a41ad4f5" />

<img width="868" height="180" alt="image" src="https://github.com/user-attachments/assets/d8c1758d-cf6c-45ee-a69b-91cfd72b52ea" />

### After

<img width="866" height="555" alt="agents-md-per-directory-instructions" src="https://github.com/user-attachments/assets/2efb3a0d-6d69-4f2f-b1a8-c1d81a4af7cb" />

<img width="857" height="195" alt="custom-instructions-per-directory-instructions" src="https://github.com/user-attachments/assets/1dec18d1-0681-4b11-bf34-3d2f610bb3fb" />

## How to Test

### Manual/local verification

I opened the docs pages and verified they are correct.

### Reviewer test steps

1. Run `bun run dev` in `packages/kilo-docs`
2. Navigate to /docs/customize/agents-md and /docs/customize/custom-instructions
3. Verify changes

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18