### PR TITLE
Remove provider/provider.ts from promise facade allowlist

### DIFF
--- a/script/check-opencode-promise-facades.ts
+++ b/script/check-opencode-promise-facades.ts
@@ -21,7 +21,6 @@ const allow: Record<string, string> = {
   "installation/index.ts": "existing installation facade outside #10655",
   "permission/index.ts": "transitional facade removed by #10620",
   "project/vcs.ts": "transitional facade removed by #10620",
-  "provider/provider.ts": "transitional facade tracked by #10655",
   "question/index.ts": "transitional facade deferred for upstream reconciliation in #10655",
   "session/compaction.ts": "existing compaction facade outside #10655",
   "session/prompt.ts": "transitional facade tracked by #10655",


### PR DESCRIPTION
Fixes #10714 

Small followup from https://github.com/Kilo-Org/kilocode/pull/10658

Removed from the list that checks files that still have Promise wrappers around Effect logic