### PR TITLE
refactor(cli): remove legacy Vcs facade

### DIFF
--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -354,7 +354,7 @@ export namespace KiloSessions {
       const getSessions = async () => {
         const [gitUrl, gitBranch] = await Promise.all([
           getGitUrl().catch(() => undefined),
-          Vcs.branch().catch(() => undefined),
+          branch().catch(() => undefined),
         ])
         const { AppRuntime } = await import("@/effect/app-runtime")
         const statusMap = await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.list()))
@@ -723,11 +723,16 @@ export namespace KiloSessions {
     })
   }
 
+  async function branch() {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return AppRuntime.runPromise(Vcs.Service.use((svc) => svc.branch()))
+  }
+
   async function meta(sessionId?: string) {
     const override = sessionId ? KiloSession.resolvePlatform(sessionId) : undefined
     const platform = override || process.env["KILO_PLATFORM"] || "cli"
     const orgId = await getOrgId()
-    const gitBranch = await Vcs.branch().catch(() => undefined)
+    const gitBranch = await branch().catch(() => undefined)
     const gitUrl = await getGitUrl().catch(() => undefined)
 
     return {

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -7,7 +7,6 @@ import { FileWatcher } from "@/file/watcher"
 import { Git } from "@/git"
 import * as Log from "@opencode-ai/core/util/log"
 import { zod, zodObject } from "@/util/effect-zod"
-import { makeRuntime } from "@/effect/run-service" // kilocode_change
 import { NonNegativeInt, withStatics } from "@/util/schema"
 
 const log = Log.create({ service: "vcs" })
@@ -407,11 +406,5 @@ export const layer: Layer.Layer<Service, never, Git.Service | Bus.Service> = Lay
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Git.defaultLayer), Layer.provide(Bus.layer))
-
-// kilocode_change start - legacy promise helpers for Kilo callsites
-const { runPromise } = makeRuntime(Service, defaultLayer)
-export const branch = () => runPromise((svc) => svc.branch())
-export const defaultBranch = () => runPromise((svc) => svc.defaultBranch())
-// kilocode_change end
 
 export * as Vcs from "./vcs"

--- a/script/check-opencode-promise-facades.ts
+++ b/script/check-opencode-promise-facades.ts
@@ -20,7 +20,6 @@ const allow: Record<string, string> = {
   "cli/cmd/tui/config/tui.ts": "separately tracked TUI config facade",
   "installation/index.ts": "existing installation facade outside #10655",
   "permission/index.ts": "transitional facade removed by #10620",
-  "project/vcs.ts": "transitional facade removed by #10620",
   "provider/provider.ts": "transitional facade tracked by #10655",
   "question/index.ts": "transitional facade deferred for upstream reconciliation in #10655",
   "session/compaction.ts": "existing compaction facade outside #10655",


### PR DESCRIPTION
Upstream no longer exposes a Promise-backed Vcs facade, but Kilo still restored one solely for branch metadata reads in Kilo Sessions. Keeping that runtime-backed adapter broadens the shared fork diff and allows new callers to depend on migration-only behavior.

This removes the Vcs Promise boundary and resolves branch metadata through `Vcs.Service` at the existing Kilo-owned `AppRuntime` boundary. Branch metadata remains best-effort: non-git repositories and lookup failures omit branch information instead of interrupting session metadata or remote heartbeat flows.

Closes #10712
Part of #10655