### PR TITLE
docs: refresh README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <p align="center">
   <a href="https://kilo.ai">Website</a> ·
   <a href="https://kilo.ai/install">Install</a> ·
-  <a href="https://kilo.ai/install">IDE</a> ·
+  <a href="https://kilo.ai/landing/vs-code">IDE</a> ·
   <a href="https://kilo.ai/cli">CLI</a> ·
   <a href="https://kilo.ai/docs">Docs</a> ·
   <a href="https://kilo.ai/leaderboard">Models</a> ·

--- a/README.md
+++ b/README.md
@@ -7,10 +7,33 @@
 </p>
 
 <p align="center">
- <img width="250" alt="kilo-code-logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" />
+  <a href="https://kilo.ai"><img width="250" alt="kilo-code-logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
 </p>
 
-> Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.
+<p align="center">
+  <strong>Kilo is the all-in-one agentic engineering platform.</strong><br>
+  Build, ship, and iterate faster with the most popular open source coding agent.
+</p>
+
+<p align="center">
+  <img width="100%" alt="Kilo Code running inside VS Code" src="https://kilo.ai/_next/image?url=%2Fscreenshots%2Fvs-code%2Fvs-code-home-page-screenshot.png&w=3840&q=75">
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai">Website</a> ·
+  <a href="https://kilo.ai/install">Install</a> ·
+  <a href="https://kilo.ai/install">IDE</a> ·
+  <a href="https://kilo.ai/cli">CLI</a> ·
+  <a href="https://kilo.ai/docs">Docs</a> ·
+  <a href="https://kilo.ai/leaderboard">Models</a> ·
+  <a href="https://kilo.ai/gateway">Gateway</a> ·
+  <a href="https://kilo.ai/pricing">Pricing</a> ·
+  <a href="https://kilo.ai/pricing/kilo-pass">Kilo Pass</a>
+</p>
+
+<p align="center">
+  500+ models. One open source agent in <a href="https://kilo.ai/install">VS Code</a>, <a href="https://kilo.ai/features/jetbrains-native">JetBrains</a>, <a href="https://kilo.ai/cli">CLI</a>, <a href="https://kilo.ai/slack">Slack</a>, and <a href="https://kilo.ai/cloud">Cloud</a>.
+</p>
 
 - ✨ Generate code from natural language
 - ✅ Checks its own work

--- a/packages/kilo-vscode/README.md
+++ b/packages/kilo-vscode/README.md
@@ -6,22 +6,34 @@
   <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
 </p>
 
-# 🚀 Kilo
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="kilo-code-logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
 
-> Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.
+<p align="center">
+  <strong>Kilo is the all-in-one agentic engineering platform.</strong><br>
+  Build, ship, and iterate faster with the most popular open source coding agent.
+</p>
 
-- ✨ Generate code from natural language
-- ✅ Checks its own work
-- 🧪 Run terminal commands
-- 🌐 Automate the browser
-- ⚡ Inline autocomplete suggestions
-- 🤖 Latest AI models
-- 🎁 API keys optional
+<p align="center">
+  <img width="100%" alt="Kilo Code running inside VS Code" src="https://kilo.ai/_next/image?url=%2Fscreenshots%2Fvs-code%2Fvs-code-home-page-screenshot.png&w=3840&q=75">
+</p>
 
-## Quick Links
+<p align="center">
+  <a href="https://kilo.ai">Website</a> ·
+  <a href="https://kilo.ai/install">Install</a> ·
+  <a href="https://kilo.ai/landing/vs-code">IDE</a> ·
+  <a href="https://kilo.ai/cli">CLI</a> ·
+  <a href="https://kilo.ai/docs">Docs</a> ·
+  <a href="https://kilo.ai/leaderboard">Models</a> ·
+  <a href="https://kilo.ai/gateway">Gateway</a> ·
+  <a href="https://kilo.ai/pricing">Pricing</a> ·
+  <a href="https://kilo.ai/pricing/kilo-pass">Kilo Pass</a>
+</p>
 
-- [VS Code Marketplace](https://kilo.ai/vscode-marketplace?utm_source=Readme) (download)
-- [Official Kilo.ai Home page](https://kilo.ai) (learn more)
+<p align="center">
+  500+ models. One open source agent in <a href="https://kilo.ai/install">VS Code</a>, <a href="https://kilo.ai/features/jetbrains-native">JetBrains</a>, <a href="https://kilo.ai/cli">CLI</a>, <a href="https://kilo.ai/slack">Slack</a>, and <a href="https://kilo.ai/cloud">Cloud</a>.
+</p>
 
 > 🚀 **Coming from Roo Code?** Switch to Kilo and check out our [migration guide](https://kilo.ai/articles/roo-to-kilo-migration-guide)!
 


### PR DESCRIPTION
## Summary
- Refresh the README hero with a linked logo, centered positioning copy, screenshot, and navigation links.

<img width="1002" height="802" alt="image" src="https://github.com/user-attachments/assets/14698937-07cc-4180-9467-f61b55c2c52c" />