### PR TITLE
fix(vscode): detect bundled FFmpeg Windows microphones

### DIFF
--- a/.changeset/windows-speech-devices.md
+++ b/.changeset/windows-speech-devices.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Detect Windows microphones for voice transcription when using the bundled FFmpeg helper.

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -313,7 +313,30 @@ async function listDshowAudioDevices(bin: string): Promise<string[]> {
 
 export function parseDshowAudioDevices(raw: string): string[] {
   const devices = new Set<string>()
-  for (const match of raw.matchAll(/"([^"]+)"\s+\(audio\)/g)) devices.add(match[1]!)
+  let audio = false
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (/DirectShow audio devices/i.test(line)) {
+      audio = true
+      continue
+    }
+    if (/DirectShow video devices/i.test(line)) {
+      audio = false
+      continue
+    }
+    if (/\]\s+Alternative name\s+"/i.test(line)) continue
+
+    const tagged = line.match(/"([^"]+)"\s+\(audio\)/i)
+    if (tagged) {
+      devices.add(tagged[1]!)
+      continue
+    }
+    if (!audio || /"\s+\(video\)/i.test(line)) continue
+
+    const match = line.match(/"([^"]+)"/)
+    if (match) devices.add(match[1]!)
+  }
+
   return [...devices]
 }
 

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -14,6 +14,36 @@ describe("parseDshowAudioDevices", () => {
     expect(parseDshowAudioDevices(raw)).toEqual(["Microphone Array (Realtek Audio)", "Webcam Microphone"])
   })
 
+  it("extracts audio devices from bundled Windows FFmpeg output", () => {
+    const raw = `
+[dshow @ 000001] DirectShow video devices (some may be both video and audio devices)
+[dshow @ 000001]  "Integrated Camera"
+[dshow @ 000001]     Alternative name "@devicepnp\\camera"
+[dshow @ 000001] DirectShow audio devices
+[dshow @ 000001]  "Microphone Array (LG MONITOR WEBCAM MIC)"
+[dshow @ 000001]     Alternative name "@devicecm\\wave_mic"
+[dshow @ 000001]  "Microphone (Voice Changer Virtual Audio Device (WDM))"
+[dshow @ 000001]     Alternative name "@devicecm\\wave_virtual"
+dummy: Immediate exit requested
+`
+
+    expect(parseDshowAudioDevices(raw)).toEqual([
+      "Microphone Array (LG MONITOR WEBCAM MIC)",
+      "Microphone (Voice Changer Virtual Audio Device (WDM))",
+    ])
+  })
+
+  it("keeps audio device names containing parser-label text", () => {
+    const raw = `
+[dshow @ 000001] DirectShow audio devices
+[dshow @ 000001]  "Alternative name Microphone"
+[dshow @ 000001]     Alternative name "@devicecm\\wave_mic"
+[dshow @ 000001]  "Microphone (Video)"
+`
+
+    expect(parseDshowAudioDevices(raw)).toEqual(["Alternative name Microphone", "Microphone (Video)"])
+  })
+
   it("deduplicates repeated dshow audio device names", () => {
     const raw = `"Microphone" (audio)\n"Microphone" (audio)`
 


### PR DESCRIPTION
The Windows speech input flow discovers microphone candidates from FFmpeg DirectShow output before any Gateway request. The bundled Windows FFmpeg helper emits microphone names beneath a `DirectShow audio devices` section without the `(audio)` suffix currently required by the parser, so working inputs are discarded and recording fails with `No Windows audio input devices found for speech input`.

Accept both DirectShow output formats: explicitly tagged audio entries and untagged primary device names within the audio section. Continue excluding FFmpeg alternative-name metadata, while matching that metadata narrowly enough that valid driver-provided microphone names containing parser-label text are not rejected. Include a patch changeset because this restores voice transcription for affected Windows extension users.

This supersedes #10550 and #10594 by addressing the same device-detection failure while preserving valid primary device display names those implementations can skip.