### PR TITLE
refactor(cli): make notebook read routing explicit

### DIFF
--- a/packages/opencode/src/kilocode/tool/notebook.ts
+++ b/packages/opencode/src/kilocode/tool/notebook.ts
@@ -25,9 +25,11 @@ const render = (kind: "markdown" | "code", text: string) => {
   return `<${kind}_cell>\n${body}</${kind}_cell>`
 }
 
-export async function open(filepath: string): Promise<Readable | undefined> {
-  if (path.extname(filepath).toLowerCase() !== ".ipynb") return undefined
+export function isFile(filepath: string) {
+  return path.extname(filepath).toLowerCase() === ".ipynb"
+}
 
+export async function open(filepath: string): Promise<Readable> {
   const raw = (await Encoding.read(filepath)).text
   const data = parse(raw)
   if (!object(data) || !Array.isArray(data.cells)) return Readable.from([raw])

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -359,8 +359,7 @@ export const ReadTool = Tool.define(
 // routed through TextStream.withFallback so non-UTF-8 files are decoded via
 // iconv. The body otherwise matches upstream.
 export async function lines(filepath: string, opts: { limit: number; offset: number }) {
-  const extracted = await Notebook.open(filepath) // kilocode_change - extract readable notebook cells before paging
-  if (extracted) return readLines(extracted, opts) // kilocode_change
+  if (Notebook.isFile(filepath)) return readLines(await Notebook.open(filepath), opts) // kilocode_change - extract readable notebook cells before paging
   return TextStream.withFallback(filepath, (stream) => readLines(stream, opts))
 }
 


### PR DESCRIPTION
Follow-up to #10733. Notebook reads take a format-specific extraction path, but the shared read hook currently has to infer that choice from an optional extraction result.

Expose notebook file matching on the notebook domain and guard the extraction route explicitly in the read hook. This keeps notebook parsing and content rendering isolated in Kilo-owned code while making the shared control flow immediately readable. Runtime behavior is unchanged.