### PR TITLE
fix(jetbrains): emit log warnings before updating state values

### DIFF
--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendAppService.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendAppService.kt
@@ -495,14 +495,14 @@ class KiloBackendAppService private constructor(
 
     private fun setAppReady(data: AppData) {
         warnings = data.warnings
-        _appState.value = KiloAppState.Ready(data)
         if (data.warnings.isNotEmpty()) warnAppWarnings(data.warnings)
+        _appState.value = KiloAppState.Ready(data)
     }
 
     private fun setAppError(message: String, errors: List<LoadError>) {
         val state = KiloAppState.Error(message, errors)
-        _appState.value = state
         warnAppError(state)
+        _appState.value = state
     }
 
     private fun warnAppError(state: KiloAppState.Error) {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspace.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspace.kt
@@ -291,8 +291,8 @@ class KiloBackendWorkspace(
     }
 
     private fun setWorkspaceError(message: String, errors: List<LoadError>) {
-        _state.value = KiloWorkspaceState.Error(message, errors)
         log.warn("Workspace error [$directory]: $message")
+        _state.value = KiloWorkspaceState.Error(message, errors)
     }
 
     private data class FetchResult<T>(val value: T?, val error: LoadError?) {


### PR DESCRIPTION
## Summary
- Emit terminal JetBrains backend warnings before publishing the corresponding ready/error state.
- Prevent tests and state consumers from observing completion before its diagnostic log has been written.

## Why
A JetBrains unit test failed intermittently because it observed `Error` and asserted the final warning log during the small window before that log was emitted.