### PR TITLE
docs(jetbrains): link v7 early access guide

### DIFF
--- a/packages/kilo-docs/markdoc/partials/install-jetbrains.md
+++ b/packages/kilo-docs/markdoc/partials/install-jetbrains.md
@@ -28,7 +28,7 @@ Before installing the Kilo Code plugin, ensure you have:
 4. Search for "Kilo Code"
 5. Click **Install** and restart your IDE
 
-<a id="v7-early-access"></a>
+<a id="jetbrains-early-access"></a>
 
 ### Try the v7 Early Access Program plugin
 

--- a/packages/kilo-docs/markdoc/partials/install-jetbrains.md
+++ b/packages/kilo-docs/markdoc/partials/install-jetbrains.md
@@ -28,6 +28,8 @@ Before installing the Kilo Code plugin, ensure you have:
 4. Search for "Kilo Code"
 5. Click **Install** and restart your IDE
 
+<a id="v7-early-access"></a>
+
 ### Try the v7 Early Access Program plugin
 
 The v7 EAP plugin is available for users who want to try the newest JetBrains experience before it reaches the default Marketplace channel. It uses a JetBrains-native UI and is designed to work well with JetBrains remote development.

--- a/packages/kilo-jetbrains/README.md
+++ b/packages/kilo-jetbrains/README.md
@@ -2,7 +2,7 @@
 
 AI coding agent plugin for JetBrains IDEs.
 
-To try the v7 Early Access Program plugin, follow the [JetBrains EAP installation guide](https://kilo.ai/docs/code-with-ai/platforms/jetbrains#v7-early-access).
+To try the v7 Early Access Program plugin, follow the [JetBrains EAP installation guide](https://kilo.ai/docs/code-with-ai/platforms/jetbrains#jetbrains-early-access).
 
 ---
 

--- a/packages/kilo-jetbrains/README.md
+++ b/packages/kilo-jetbrains/README.md
@@ -2,6 +2,8 @@
 
 AI coding agent plugin for JetBrains IDEs.
 
+To try the v7 Early Access Program plugin, follow the [JetBrains EAP installation guide](https://kilo.ai/docs/code-with-ai/platforms/jetbrains#v7-early-access).
+
 ---
 
 ## Set up your environment


### PR DESCRIPTION
## Summary
- Add a stable anchor for the JetBrains v7 Early Access Program instructions.
- Link the JetBrains package README to the public docs guide for trying v7 early access.