### PR TITLE
docs(kilo-docs): improve tabbed install docs

### DIFF
--- a/packages/kilo-docs/components/TableOfContents.tsx
+++ b/packages/kilo-docs/components/TableOfContents.tsx
@@ -3,17 +3,18 @@ import Link from "next/link"
 
 const TAB_SYNC_EVENT = "kilo-tab-select"
 
+function slugify(label: string) {
+  return label
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+}
+
 export function TableOfContents({ toc }) {
   const [tab, setTab] = useState("")
   const [activeHash, setActiveHash] = useState("")
   const items = toc.filter((item) => {
     if (!item.id || (item.level !== 2 && item.level !== 3)) return false
-    if (
-      tab === "jetbrains" &&
-      ["manual-installations", "open-vsx-registry", "via-vsix", "troubleshooting"].includes(item.id)
-    ) {
-      return false
-    }
 
     return !item.tab || item.tab.slug === tab
   })
@@ -28,9 +29,8 @@ export function TableOfContents({ toc }) {
 
     const sync = (e: Event) => {
       const label = (e as CustomEvent<string>).detail
-      const item = toc.find((entry) => entry.tab?.label === label)
       setActiveHash(window.location.hash)
-      setTab(item?.tab?.slug ?? "")
+      setTab(slugify(label))
     }
 
     update()

--- a/packages/kilo-docs/components/TableOfContents.tsx
+++ b/packages/kilo-docs/components/TableOfContents.tsx
@@ -1,16 +1,46 @@
 import React, { useState, useEffect } from "react"
 import Link from "next/link"
 
+const TAB_SYNC_EVENT = "kilo-tab-select"
+
 export function TableOfContents({ toc }) {
-  const items = toc.filter((item) => item.id && (item.level === 2 || item.level === 3))
+  const [tab, setTab] = useState("")
   const [activeHash, setActiveHash] = useState("")
+  const items = toc.filter((item) => {
+    if (!item.id || (item.level !== 2 && item.level !== 3)) return false
+    if (
+      tab === "jetbrains" &&
+      ["manual-installations", "open-vsx-registry", "via-vsix", "troubleshooting"].includes(item.id)
+    ) {
+      return false
+    }
+
+    return !item.tab || item.tab.slug === tab
+  })
 
   useEffect(() => {
-    const updateHash = () => setActiveHash(window.location.hash)
-    updateHash()
-    window.addEventListener("hashchange", updateHash)
-    return () => window.removeEventListener("hashchange", updateHash)
-  }, [])
+    const update = () => {
+      const hash = window.location.hash.slice(1)
+      const item = toc.find((entry) => entry.id === hash && entry.tab)
+      setActiveHash(window.location.hash)
+      setTab(item?.tab?.slug ?? (toc.some((entry) => entry.tab?.slug === hash) ? hash : ""))
+    }
+
+    const sync = (e: Event) => {
+      const label = (e as CustomEvent<string>).detail
+      const item = toc.find((entry) => entry.tab?.label === label)
+      setActiveHash(window.location.hash)
+      setTab(item?.tab?.slug ?? "")
+    }
+
+    update()
+    window.addEventListener("hashchange", update)
+    window.addEventListener(TAB_SYNC_EVENT, sync)
+    return () => {
+      window.removeEventListener("hashchange", update)
+      window.removeEventListener(TAB_SYNC_EVENT, sync)
+    }
+  }, [toc])
 
   if (items.length <= 1) {
     return null
@@ -22,14 +52,27 @@ export function TableOfContents({ toc }) {
         {items.map((item) => {
           const href = `#${item.id}`
           const active = activeHash === href
+          const select = (e: React.MouseEvent<HTMLAnchorElement>) => {
+            if (!item.tab) return
+
+            e.preventDefault()
+            window.dispatchEvent(new CustomEvent(TAB_SYNC_EVENT, { detail: item.tab.label }))
+            setActiveHash(href)
+            setTab(item.tab.slug)
+            history.pushState(null, "", href)
+            requestAnimationFrame(() => document.getElementById(item.id)?.scrollIntoView())
+          }
+
           return (
             <li
-              key={item.title}
+              key={`${item.tab?.slug ?? "page"}-${item.id}`}
               className={[active ? "active" : undefined, item.level === 3 ? "padded" : undefined]
                 .filter(Boolean)
                 .join(" ")}
             >
-              <Link href={href}>{item.title}</Link>
+              <Link href={href} onClick={select}>
+                {item.title}
+              </Link>
             </li>
           )
         })}

--- a/packages/kilo-docs/components/Tabs.tsx
+++ b/packages/kilo-docs/components/Tabs.tsx
@@ -18,6 +18,17 @@ function slugify(label: string) {
     .replace(/[^a-z0-9-]/g, "")
 }
 
+function contains(node: ReactNode, hash: string): boolean {
+  return Children.toArray(node).some((child) => {
+    if (!isValidElement(child)) return false
+
+    const props = child.props as { children?: ReactNode; id?: string }
+    if (props.id === hash) return true
+
+    return contains(props.children, hash)
+  })
+}
+
 export function Tab({ children }: TabProps) {
   return <>{children}</>
 }
@@ -32,7 +43,10 @@ export function Tabs({ children }: TabsProps) {
     const hash = window.location.hash.slice(1)
     if (!hash) return 0
     const found = tabs.findIndex((tab) => slugify(tab.props.label) === hash)
-    return found >= 0 ? found : 0
+    if (found >= 0) return found
+
+    const child = tabs.findIndex((tab) => contains(tab.props.children, hash))
+    return child >= 0 ? child : 0
   }
 
   const [activeIndex, setActiveIndex] = useState(0)
@@ -54,6 +68,13 @@ export function Tabs({ children }: TabsProps) {
       window.removeEventListener(TAB_SYNC_EVENT, onSync)
     }
   }, [])
+
+  useEffect(() => {
+    const hash = window.location.hash.slice(1)
+    if (!hash) return
+
+    requestAnimationFrame(() => document.getElementById(hash)?.scrollIntoView())
+  }, [activeIndex])
 
   const selectTab = (index: number) => {
     setActiveIndex(index)

--- a/packages/kilo-docs/components/Tabs.tsx
+++ b/packages/kilo-docs/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Children, isValidElement, ReactNode, ReactElement } from "react"
+import React, { useState, useEffect, useRef, Children, isValidElement, ReactNode, ReactElement } from "react"
 
 const TAB_SYNC_EVENT = "kilo-tab-select"
 
@@ -50,15 +50,24 @@ export function Tabs({ children }: TabsProps) {
   }
 
   const [activeIndex, setActiveIndex] = useState(0)
+  const scroll = useRef(false)
 
   useEffect(() => {
-    setActiveIndex(indexFromHash())
-    const onHashChange = () => setActiveIndex(indexFromHash())
+    const activate = () => {
+      const hash = window.location.hash.slice(1)
+      const index = indexFromHash()
+      scroll.current = Boolean(hash && contains(tabs[index]?.props.children, hash))
+      setActiveIndex(index)
+    }
+
+    activate()
+    const onHashChange = activate
     window.addEventListener("hashchange", onHashChange)
 
     const onSync = (e: Event) => {
       const label = (e as CustomEvent<string>).detail
       const found = tabs.findIndex((tab) => tab.props.label === label)
+      scroll.current = false
       if (found >= 0) setActiveIndex(found)
     }
     window.addEventListener(TAB_SYNC_EVENT, onSync)
@@ -71,8 +80,9 @@ export function Tabs({ children }: TabsProps) {
 
   useEffect(() => {
     const hash = window.location.hash.slice(1)
-    if (!hash) return
+    if (!hash || !scroll.current) return
 
+    scroll.current = false
     requestAnimationFrame(() => document.getElementById(hash)?.scrollIntoView())
   }, [activeIndex])
 

--- a/packages/kilo-docs/markdoc/partials/install-jetbrains.md
+++ b/packages/kilo-docs/markdoc/partials/install-jetbrains.md
@@ -11,7 +11,10 @@ Before installing the Kilo Code plugin, ensure you have:
 
 2. **Node.js:**
    - Download LTS version from [https://nodejs.org/](https://nodejs.org/)
-   - Required for the extension's backend services
+
+{% callout type="tip" %}
+Try the [v7 Early Access Program plugin](#jetbrains-early-access) for a JetBrains-native experience that does not require Node.js or manual API key configuration.
+{% /callout %}
 
 ### Install directly
 
@@ -28,14 +31,12 @@ Before installing the Kilo Code plugin, ensure you have:
 4. Search for "Kilo Code"
 5. Click **Install** and restart your IDE
 
-<a id="jetbrains-early-access"></a>
-
-### Try the v7 Early Access Program plugin
+### Try the v7 Early Access Program plugin {% #jetbrains-early-access %}
 
 The v7 EAP plugin is available for users who want to try the newest JetBrains experience before it reaches the default Marketplace channel. It uses a JetBrains-native UI and is designed to work well with JetBrains remote development.
 
 {% callout type="info" %}
-EAP builds may update more frequently than the default Marketplace release. Share feedback in the JetBrains channel on the [Kilo Discord](https://kilo.ai/discord).
+The v7 EAP plugin supports JetBrains IDEs with 261+ builds. EAP builds may update more frequently than the default Marketplace release. Share feedback in the JetBrains channel on the [Kilo Discord](https://kilo.ai/discord).
 {% /callout %}
 
 To install the EAP build and receive updates:

--- a/packages/kilo-docs/pages/_app.tsx
+++ b/packages/kilo-docs/pages/_app.tsx
@@ -28,27 +28,42 @@ import type { MarkdocNextJsPageProps } from "@markdoc/next.js"
 const TITLE = "Kilo Code Documentation"
 const DESCRIPTION = "Build, ship, and iterate faster with the most popular open source coding agent."
 
-function collectHeadings(node, sections = []) {
+function slugify(label) {
+  return label
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+}
+
+function collectHeadings(node, sections = [], tab = undefined) {
   if (node) {
-    // Skip headings inside tabs - they're not always visible
     if (node.name === "Tabs") {
+      for (const child of node.children || []) {
+        const label = child.attributes?.label
+        collectHeadings(
+          child,
+          sections,
+          typeof label === "string" ? { label, slug: slugify(label) } : undefined,
+        )
+      }
       return sections
     }
 
     if (node.name === "Heading") {
-      const title = node.children[0]
+      const title = typeof node.children[0] === "string" ? node.children[0].trim() : node.children[0]
 
       if (typeof title === "string") {
         sections.push({
           ...node.attributes,
           title,
+          tab,
         })
       }
     }
 
     if (node.children) {
       for (const child of node.children) {
-        collectHeadings(child, sections)
+        collectHeadings(child, sections, tab)
       }
     }
   }

--- a/packages/kilo-docs/pages/getting-started/installing.md
+++ b/packages/kilo-docs/pages/getting-started/installing.md
@@ -25,49 +25,6 @@ The current Kilo Code extension is built on the [Kilo CLI](https://github.com/Ki
 The "pre-release" label is a VS Code Marketplace distribution channel — the extension is stable and recommended for all users.
 {% /callout %}
 
-{% /tab %}
-{% tab label="CLI" %}
-
-## Command Line Interface
-
-{% partial file="install-cli.md" /%}
-
-{% /tab %}
-{% tab label="VS Code (Legacy)" %}
-
-## VS Code Legacy Extension
-
-The legacy extension is the previous version of Kilo Code for VS Code. It is still available but is no longer actively developed. We recommend installing the current extension (see the **VS Code** tab).
-
-To install or switch back to the legacy version:
-
-1. Open VS Code
-2. Go to Extensions (`Ctrl+Shift+X` / `Cmd+Shift+X`)
-3. Search for "Kilo Code"
-4. Click the dropdown arrow next to **Install** and select **Switch to Release Version**
-
-{% /tab %}
-{% tab label="JetBrains" %}
-
-## JetBrains IDEs
-
-{% partial file="install-jetbrains.md" /%}
-
-{% /tab %}
-{% tab label="Slack" %}
-
-## Slack Integration
-
-{% partial file="install-slack.md" /%}
-
-{% /tab %}
-{% tab label="Other IDEs" %}
-
-{% partial file="install-other-ides.md" /%}
-
-{% /tab %}
-{% /tabs %}
-
 ## Manual Installations
 
 ### Open VSX Registry
@@ -135,6 +92,49 @@ If you plan to remain on that version for a while, you may also want to temporar
   2. Under **System variables**, select **Path** → **Edit** → **New**
   3. Add: `C:\Windows\System32\WindowsPowerShell\v1.0\`
   4. Click **OK** and restart VS Code
+
+{% /tab %}
+{% tab label="CLI" %}
+
+## Command Line Interface
+
+{% partial file="install-cli.md" /%}
+
+{% /tab %}
+{% tab label="VS Code (Legacy)" %}
+
+## VS Code Legacy Extension
+
+The legacy extension is the previous version of Kilo Code for VS Code. It is still available but is no longer actively developed. We recommend installing the current extension (see the **VS Code** tab).
+
+To install or switch back to the legacy version:
+
+1. Open VS Code
+2. Go to Extensions (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+3. Search for "Kilo Code"
+4. Click the dropdown arrow next to **Install** and select **Switch to Release Version**
+
+{% /tab %}
+{% tab label="JetBrains" %}
+
+## JetBrains IDEs
+
+{% partial file="install-jetbrains.md" /%}
+
+{% /tab %}
+{% tab label="Slack" %}
+
+## Slack Integration
+
+{% partial file="install-slack.md" /%}
+
+{% /tab %}
+{% tab label="Other IDEs" %}
+
+{% partial file="install-other-ides.md" /%}
+
+{% /tab %}
+{% /tabs %}
 
 ## Next Steps
 


### PR DESCRIPTION
## Issue

No linked issue; follow-up to local review of the JetBrains installation docs.

## Context

The installation page mixes several platform-specific install paths inside tabs. The JetBrains tab needed a working deep link for the v7 Early Access Program section, clearer v7 prerequisite guidance, and a right-side table of contents that reflects the active tab instead of showing unrelated platform sections.

## Implementation

- Make the docs table of contents tab-aware so it shows headings for the active tab and can link to headings inside tab content.
- Activate the relevant tab when opening a hash URL that targets a heading inside that tab, including `#jetbrains-early-access`.
- Replace the broken raw JetBrains EAP anchor HTML with a proper Markdoc heading anchor.
- Move VS Code-specific manual installation and troubleshooting content into the VS Code tab so it no longer appears in the JetBrains flow.
- Update the JetBrains prerequisite copy with a tip linking to the v7 EAP plugin, noting it is JetBrains-native and does not require Node.js or manual API key configuration.
- Document that the v7 EAP plugin supports JetBrains IDEs with 261+ builds.

## Screenshots / Video

N/A. The docs UI behavior was verified locally with the dev server and through production docs build validation.

## How to Test

### Manual/local verification

- Agent ran `bun run build` from `packages/kilo-docs` successfully.
- Agent ran the local docs dev server on port `3002` and verified the target page was available for local review.
- User reviewed the local docs page and requested follow-up TOC/content adjustments, which were applied.
- Push hook/root `bun turbo typecheck` passed after the follow-up review commit.

### Reviewer test steps

1. Run `bun dev` from `packages/kilo-docs`.
2. Open `/docs/getting-started/installing#jetbrains-early-access`.
3. Confirm the JetBrains tab activates and scrolls to the v7 EAP section.
4. Confirm the right TOC shows JetBrains headings and does not include VS Code manual install or troubleshooting sections.
5. Confirm the VS Code tab still contains manual installation and troubleshooting content.
6. Confirm the JetBrains prerequisites include the v7 EAP tip and the EAP section mentions 261+ build support.

### Blocked checks and substitute verification

- No blocked checks.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

PR created by Kilo Code on behalf of the requester.