### PR TITLE
fix: stop publishing without changelog updates

### DIFF
--- a/.changeset/italian-language-support.md
+++ b/.changeset/italian-language-support.md
@@ -1,5 +1,4 @@
 ---
-"@opencode-ai/app": patch
 "@opencode-ai/ui": patch
 "@kilocode/kilo-ui": patch
 "@kilocode/kilo-i18n": patch

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -21,10 +21,7 @@ console.log("=== publishing ===\n")
         .catch(() => ""),
     )
   }
-  const res = await $`bunx changeset version`.nothrow()
-  if (res.exitCode !== 0) {
-    console.warn("changeset version failed (exit " + res.exitCode + ")")
-  }
+  await $`bunx changeset version`
   // Changeset computes its own version from package.json, but we use
   // Script.version. Fix the heading in any changelog that was modified.
   for (const p of paths) {


### PR DESCRIPTION
## Summary
- Remove the stale `@opencode-ai/app` package entry that causes Changesets planning to fail after the desktop workspace removal.
- Let `bunx changeset version` fail the publish job instead of continuing with version bumps and stale changelogs.

## Context
Releases `v7.3.16` through `v7.3.18` continued publishing after changelog generation failed, leaving the CLI and VS Code changelogs pinned at `v7.3.15`. The historical changelog repair is intentionally handled separately so these already released changes are not presented as new in the next release.