### PR TITLE
chore: backfill changelogs for v7.3.16 through v7.3.18

### DIFF
--- a/.changeset/agent-manager-snapshot-wait.md
+++ b/.changeset/agent-manager-snapshot-wait.md
@@ -1,6 +1,0 @@
----
-"@kilocode/cli": patch
-"kilo-code": patch
----
-
-Keep Agent Manager turns running while slow snapshot baselines initialize instead of stopping for an interactive question.

--- a/.changeset/bright-mics-tap.md
+++ b/.changeset/bright-mics-tap.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Fix Windows speech input device detection when FFmpeg lists DirectShow microphones by section.

--- a/.changeset/clear-history-navigation.md
+++ b/.changeset/clear-history-navigation.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Correct screen reader and keyboard operation for session history rows and Local or Cloud history navigation.

--- a/.changeset/clear-model-navigation.md
+++ b/.changeset/clear-model-navigation.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Make model selection in chat and settings operable with screen readers by announcing searchable options, keyboard navigation, selected values, and model-setting purpose.

--- a/.changeset/fix-cli-share-links.md
+++ b/.changeset/fix-cli-share-links.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Use Kilo session share links when sharing conversations from the CLI.

--- a/.changeset/fix-lancedb-metadata-type-coercion.md
+++ b/.changeset/fix-lancedb-metadata-type-coercion.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Fix LanceDB metadata corruption that caused a full re-index on every VS Code restart

--- a/.changeset/forked-session-context.md
+++ b/.changeset/forked-session-context.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Preserve prior context in forked sessions while recognizing the selected direction and current worktree context.

--- a/.changeset/gateway-byok-footer-link.md
+++ b/.changeset/gateway-byok-footer-link.md
@@ -1,5 +1,0 @@
----
-"kilo-code": minor
----
-
-Link to Kilo Gateway BYOK usage information from provider API key connection dialogs.

--- a/.changeset/italian-language-support.md
+++ b/.changeset/italian-language-support.md
@@ -1,7 +1,0 @@
----
-"@opencode-ai/ui": patch
-"@kilocode/kilo-ui": patch
-"@kilocode/kilo-i18n": patch
----
-
-Support Italian as a display language.

--- a/.changeset/jetbrains-smooth-scroll-button.md
+++ b/.changeset/jetbrains-smooth-scroll-button.md
@@ -1,5 +1,0 @@
----
-"@kilocode/kilo-jetbrains": patch
----
-
-Smooth the JetBrains session scroll button edges while preserving theme-aware SVG colors.

--- a/.changeset/jetbrains-static-svg-icons.md
+++ b/.changeset/jetbrains-static-svg-icons.md
@@ -1,5 +1,0 @@
----
-"@kilocode/kilo-jetbrains": patch
----
-
-Use static light and dark SVG icon assets in the JetBrains plugin instead of runtime SVG recoloring.

--- a/.changeset/read-docx-text.md
+++ b/.changeset/read-docx-text.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Support reading text from DOCX files through the read tool.

--- a/.changeset/read-notebook-cells.md
+++ b/.changeset/read-notebook-cells.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Read Jupyter notebooks as ordered markdown and code cell content instead of raw notebook payloads.

--- a/.changeset/read-xlsx-spreadsheets.md
+++ b/.changeset/read-xlsx-spreadsheets.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Support reading XLSX spreadsheets as labelled tabular text

--- a/.changeset/recall-sibling-context.md
+++ b/.changeset/recall-sibling-context.md
@@ -1,5 +1,0 @@
----
-"@kilocode/cli": patch
----
-
-Guide Agent Manager orchestration to recall completed session context only when needed.

--- a/.changeset/smooth-diff-worker-highlight.md
+++ b/.changeset/smooth-diff-worker-highlight.md
@@ -1,6 +1,0 @@
----
-"kilo-code": patch
-"@kilocode/kilo-ui": patch
----
-
-Reduce lag and gray placeholders in the diff and Changes views by enabling worker-backed highlighting and rendering patch-backed review hunks without rebuilding full source files.

--- a/.changeset/visible-semantic-indexing.md
+++ b/.changeset/visible-semantic-indexing.md
@@ -1,6 +1,0 @@
----
-"@kilocode/cli": patch
-"kilo-code": patch
----
-
-Access semantic indexing without an experimental feature toggle while keeping indexing disabled until enabled globally or for a project.

--- a/.changeset/vscode-italian-language.md
+++ b/.changeset/vscode-italian-language.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Support Italian as a display language in the VS Code extension.

--- a/.changeset/webview-accessibility-validation.md
+++ b/.changeset/webview-accessibility-validation.md
@@ -1,5 +1,0 @@
----
-"kilo-code": patch
----
-
-Support accessibility regression checks and assistive-technology testing for VS Code webviews.

--- a/packages/kilo-vscode/CHANGELOG.md
+++ b/packages/kilo-vscode/CHANGELOG.md
@@ -1,5 +1,47 @@
 # kilo-code
 
+## 7.3.18
+
+### Patch Changes
+
+- [#10594](https://github.com/Kilo-Org/kilocode/pull/10594) [`56d2ac4`](https://github.com/Kilo-Org/kilocode/commit/56d2ac40da6710adfe3de94f6b09bd53d9bb6db9) Thanks [@Ipsumlorem](https://github.com/Ipsumlorem)! - Fix Windows speech input device detection when FFmpeg lists DirectShow microphones by section.
+
+- [#10730](https://github.com/Kilo-Org/kilocode/pull/10730) [`51ce1b8`](https://github.com/Kilo-Org/kilocode/commit/51ce1b82b3374a9d573e3fe5ecbe19f4a22db9a4) - Reduce lag and gray placeholders in the diff and Changes views by enabling worker-backed highlighting and rendering patch-backed review hunks without rebuilding full source files.
+
+- Updated dependencies [[`51ce1b8`](https://github.com/Kilo-Org/kilocode/commit/51ce1b82b3374a9d573e3fe5ecbe19f4a22db9a4)]:
+  - @kilocode/kilo-ui@7.3.18
+
+## 7.3.17
+
+### Minor Changes
+
+- [#10674](https://github.com/Kilo-Org/kilocode/pull/10674) [`41729dc`](https://github.com/Kilo-Org/kilocode/commit/41729dcb596dfa37c32bac1b9e9143197e862252) - Link to Kilo Gateway BYOK usage information from provider API key connection dialogs.
+
+### Patch Changes
+
+- [#10721](https://github.com/Kilo-Org/kilocode/pull/10721) [`2efa216`](https://github.com/Kilo-Org/kilocode/commit/2efa216ee5bfffa6e01f51ae5add7c5b9034833c) - Keep Agent Manager turns running while slow snapshot baselines initialize instead of stopping for an interactive question.
+
+- [#10686](https://github.com/Kilo-Org/kilocode/pull/10686) [`d3c5f28`](https://github.com/Kilo-Org/kilocode/commit/d3c5f2886f07dbcd7669ee691a6a2a0b72a6f6e1) - Correct screen reader and keyboard operation for session history rows and Local or Cloud history navigation.
+
+- [#10688](https://github.com/Kilo-Org/kilocode/pull/10688) [`38fcaa6`](https://github.com/Kilo-Org/kilocode/commit/38fcaa65e7320e3befa73066ee1a890057d7173b) - Make model selection in chat and settings operable with screen readers by announcing searchable options, keyboard navigation, selected values, and model-setting purpose.
+
+- [#10609](https://github.com/Kilo-Org/kilocode/pull/10609) [`4e6f366`](https://github.com/Kilo-Org/kilocode/commit/4e6f366a75c71b6c5a2e3499e116b61c21355fbe) - Preserve prior context in forked sessions while recognizing the selected direction and current worktree context.
+
+- [#10668](https://github.com/Kilo-Org/kilocode/pull/10668) [`ef2390d`](https://github.com/Kilo-Org/kilocode/commit/ef2390d7a4ffafc379d1e15db94d3a2cd6dcce9b) - Access semantic indexing without an experimental feature toggle while keeping indexing disabled until enabled globally or for a project.
+
+- [#10680](https://github.com/Kilo-Org/kilocode/pull/10680) [`63f39f6`](https://github.com/Kilo-Org/kilocode/commit/63f39f6ae49dd7f9d5a8115f3907d53a3b92a4dd) - Support accessibility regression checks and assistive-technology testing for VS Code webviews.
+
+## 7.3.16
+
+### Patch Changes
+
+- [#9796](https://github.com/Kilo-Org/kilocode/pull/9796) [`663fbdb`](https://github.com/Kilo-Org/kilocode/commit/663fbdb58547ac5b946ba4610918239b8a7e336f) Thanks [@ale-saglia](https://github.com/ale-saglia)! - Support Italian as a display language in the VS Code extension.
+
+- Updated dependencies [[`663fbdb`](https://github.com/Kilo-Org/kilocode/commit/663fbdb58547ac5b946ba4610918239b8a7e336f)]:
+  - @opencode-ai/ui@7.3.16
+  - @kilocode/kilo-ui@7.3.16
+  - @kilocode/kilo-i18n@7.3.16
+
 ## 7.3.15
 
 ### Patch Changes

--- a/packages/opencode/CHANGELOG.md
+++ b/packages/opencode/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @kilocode/cli
 
+## 7.3.18
+
+### Patch Changes
+
+- [#10736](https://github.com/Kilo-Org/kilocode/pull/10736) [`57bc6ee`](https://github.com/Kilo-Org/kilocode/commit/57bc6eea583e22e4c3b8b00ad1c64fed62dc85e8) - Use Kilo session share links when sharing conversations from the CLI.
+
+- [#10737](https://github.com/Kilo-Org/kilocode/pull/10737) [`f574294`](https://github.com/Kilo-Org/kilocode/commit/f5742940ccd06bafd2708e32af30023eef241241) - Support reading text from DOCX files through the read tool.
+
+- [#10740](https://github.com/Kilo-Org/kilocode/pull/10740) [`2081af2`](https://github.com/Kilo-Org/kilocode/commit/2081af2b3344890481cb4bd44260e60a8cccba80) - Support reading XLSX spreadsheets as labelled tabular text
+
+## 7.3.17
+
+### Patch Changes
+
+- [#10721](https://github.com/Kilo-Org/kilocode/pull/10721) [`2efa216`](https://github.com/Kilo-Org/kilocode/commit/2efa216ee5bfffa6e01f51ae5add7c5b9034833c) - Keep Agent Manager turns running while slow snapshot baselines initialize instead of stopping for an interactive question.
+
+- [#10703](https://github.com/Kilo-Org/kilocode/pull/10703) [`eeff6d9`](https://github.com/Kilo-Org/kilocode/commit/eeff6d9df8d378c561c4ca212d650be1dfbd912a) Thanks [@barzhomi](https://github.com/barzhomi)! - Fix LanceDB metadata corruption that caused a full re-index on every VS Code restart
+
+- [#10733](https://github.com/Kilo-Org/kilocode/pull/10733) [`4967c22`](https://github.com/Kilo-Org/kilocode/commit/4967c228611f58bb84c0b762eee88d306ab1b624) - Read Jupyter notebooks as ordered markdown and code cell content instead of raw notebook payloads.
+
+- [#10669](https://github.com/Kilo-Org/kilocode/pull/10669) [`0107a01`](https://github.com/Kilo-Org/kilocode/commit/0107a0163cf73004ee13b0ae5fd46811a273d80a) - Guide Agent Manager orchestration to recall completed session context only when needed.
+
+- [#10668](https://github.com/Kilo-Org/kilocode/pull/10668) [`ef2390d`](https://github.com/Kilo-Org/kilocode/commit/ef2390d7a4ffafc379d1e15db94d3a2cd6dcce9b) - Access semantic indexing without an experimental feature toggle while keeping indexing disabled until enabled globally or for a project.
+
+## 7.3.16
+
 ## 7.3.15
 
 ## 7.3.14


### PR DESCRIPTION
## Summary
- Restore the generated CLI and VS Code changelog entries for already published releases `v7.3.16`, `v7.3.17`, and `v7.3.18`, preserving the original Changesets PR/commit attribution.
- Consume the nineteen pending changesets whose changes were included in those releases, so the next release does not present them as newly delivered work.
- Leave the JetBrains changelog untouched because it is maintained through its dedicated reviewed release workflow rather than the CLI/VS Code changelog stream.

## Context
This PR is intentionally stacked on #10749, which fixes the invalid package reference and makes future Changesets generation fail closed. Once #10749 merges, retarget this PR to `main` before merging it. Stacking avoids an artificial modify/delete conflict over the consumed Italian language changeset.