### PR TITLE
fix(vscode): declare Pierre worker dependency for builds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,7 @@
         "@kilocode/kilo-ui": "workspace:*",
         "@kilocode/sdk": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
+        "@pierre/diffs": "catalog:",
         "@thisbeyond/solid-dnd": "0.7.5",
         "@xterm/addon-clipboard": "0.2.0",
         "@xterm/addon-fit": "0.11.0",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1061,6 +1061,7 @@
     "@kilocode/kilo-ui": "workspace:*",
     "@kilocode/sdk": "workspace:*",
     "@opencode-ai/ui": "workspace:*",
+    "@pierre/diffs": "catalog:",
     "@thisbeyond/solid-dnd": "0.7.5",
     "@xterm/addon-clipboard": "0.2.0",
     "@xterm/addon-fit": "0.11.0",


### PR DESCRIPTION
## What changed

Declare `@pierre/diffs` directly in `packages/kilo-vscode` and update its Bun lockfile importer entry.

## Why

PR #10730 added extension-owned direct consumers of Pierre's worker APIs: `packages/kilo-vscode/esbuild.js` now resolves `@pierre/diffs/worker/worker.js` for the bundled Shiki worker asset, and `packages/kilo-vscode/webview-ui/pierre-worker.ts` imports `@pierre/diffs/worker`. It did not add `@pierre/diffs` to the extension package dependencies.

Under Bun's isolated workspace installs, the extension cannot depend on `@pierre/diffs` being present only through sibling UI packages. A clean extension build therefore fails in the production esbuild path with:

```
Could not resolve "@pierre/diffs/worker/worker.js"
```

Declaring the dependency at the package that directly consumes it preserves the worker implementation and avoids relying on accidental hoisting or cross-workspace dependency visibility.

## Release and CI context

The `v7.3.18` pre-release workflow began before #10730 merged: its `build-vscode` job checked out `7bbac24c696403e658c78e7dfb494b0a5c9c5944`, and the published VSIX artifacts do not contain the `dist/shiki-worker.js` asset introduced by that PR. This is therefore a correction for current `main` before an affected VSIX ships, rather than a shipped behavior change requiring release notes.

The regression passed PR checks because the VS Code checks exercise unit tests, linting, filtered typechecking, Knip, and Storybook visual builds, but do not execute the production extension `node esbuild.js --production` bundle path that creates the synthetic worker entry. This PR applies the minimal dependency ownership fix; adding production bundle coverage to PR CI should be handled as follow-up prevention work.