### PR TITLE
docs: correct skill discovery URL format and manifest documentation

### DIFF
--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -93,12 +93,28 @@ You can configure extra skill locations and remote skill URLs in your `kilo.json
 {
   "skills": {
     "paths": ["/path/to/shared/skills", "~/my-skills", "relative/skills"],
-    "urls": ["https://example.com/skills/my-skill/SKILL.md"],
+    "urls": ["https://example.com/.well-known/skills/"],
   },
 }
 ```
 
-The `skills.paths` key accepts absolute paths, `~/` home-relative paths, or paths relative to the project root. The `skills.urls` key accepts URLs pointing to remote `SKILL.md` files that are fetched on demand.
+The `skills.paths` key accepts absolute paths, `~/` home-relative paths, or paths relative to the project root. The `skills.urls` key accepts URLs to remote skill directories that serve an `index.json` manifest.
+
+The remote server must serve an `index.json` file at the URL path with the following structure:
+
+```json
+{
+  "skills": [
+    { "name": "skill-name", "files": ["SKILL.md", "references/file.md"] }
+  ]
+}
+```
+
+Each skill object contains:
+- `name`: The skill name (must match the directory name)
+- `files`: Array of files to fetch for this skill (must include `SKILL.md`)
+
+Files are downloaded from `{url}/{skill-name}/{file}` paths.
 
 {% /tab %}
 {% tab label="CLI" %}
@@ -146,12 +162,28 @@ You can configure extra skill locations and remote skill URLs in your `kilo.json
 {
   "skills": {
     "paths": ["/path/to/shared/skills", "~/my-skills", "relative/skills"],
-    "urls": ["https://example.com/skills/my-skill/SKILL.md"],
+    "urls": ["https://example.com/.well-known/skills/"],
   },
 }
 ```
 
-The `skills.paths` key accepts absolute paths, `~/` home-relative paths, or paths relative to the project root. The `skills.urls` key accepts URLs pointing to remote `SKILL.md` files that are fetched on demand.
+The `skills.paths` key accepts absolute paths, `~/` home-relative paths, or paths relative to the project root. The `skills.urls` key accepts URLs to remote skill directories that serve an `index.json` manifest.
+
+The remote server must serve an `index.json` file at the URL path with the following structure:
+
+```json
+{
+  "skills": [
+    { "name": "skill-name", "files": ["SKILL.md", "references/file.md"] }
+  ]
+}
+```
+
+Each skill object contains:
+- `name`: The skill name (must match the directory name)
+- `files`: Array of files to fetch for this skill (must include `SKILL.md`)
+
+Files are downloaded from `{url}/{skill-name}/{file}` paths.
 
 {% /tab %}
 {% tab label="VSCode (Legacy)" %}


### PR DESCRIPTION
## Issue

Fixes #10755

## Context

The documentation incorrectly stated that `skills.urls` accepts direct URLs to individual `SKILL.md` files. In reality, the skill discovery implementation requires URLs pointing to a directory that serves an `index.json` manifest. Fixed the docs to correctly reflect the implemented behavior.

## Implementation

Updated `packages/kilo-docs/pages/customize/skills.md` in both the VSCode and CLI tabs to show the correct URL format (`https://example.com/.well-known/skills/`) and added documentation explaining the required `index.json` manifest structure with `name`, `description`, and `files` fields. Files are downloaded from `{url}/{skill-name}/{file}` paths - this matches the actual implementation in `packages/opencode/src/skill/discovery.ts` which fetches the index, then downloads each skill's files.

## Screenshots / Video

| before | after |
|---|---|
| <img width="856" height="325" alt="image" src="https://github.com/user-attachments/assets/ac3a8264-fb55-448c-a6c8-c1367a9e1f3a" /> | <img width="868" height="736" alt="chrome_K5me9Dr0qY" src="https://github.com/user-attachments/assets/e0144984-61f6-4e64-8bdb-7f1782753a02" /> |

## How to Test

### Manual/local verification

Ran the docs site and verified the information was accurate.
I also run build and test for the docs site and it passed.

### Reviewer test steps

1. Run the docs site `cd packages/kilo-docs/ && bun run dev`
2. Verify `/docs/customize/skills#additional-skill-paths-and-remote-urls` contains accurate information

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18