### PR TITLE
feat: disclose free model data collection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -240,6 +240,7 @@
         "@kilocode/kilo-ui": "workspace:*",
         "@kilocode/sdk": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
+        "@pierre/diffs": "catalog:",
         "@thisbeyond/solid-dnd": "0.7.5",
         "@xterm/addon-clipboard": "0.2.0",
         "@xterm/addon-fit": "0.11.0",

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
@@ -109,10 +109,10 @@ class ModelPicker : PickerButton() {
         val item = selected ?: items.firstOrNull()
         val display = item?.display ?: ""
         text = "${ModelText.sanitize(display)} ▴"
-        icon = if (item?.free == true) AllIcons.General.Warning else null
+        icon = if (item?.let(ModelText::collectsData) == true) AllIcons.General.Warning else null
         horizontalTextPosition = SwingConstants.LEFT
         iconTextGap = JBUI.CurrentTheme.ActionsList.elementIconGap()
-        toolTipText = if (item?.free == true) ModelText.dataCollected() else KiloBundle.message("model.picker.tooltip")
+        toolTipText = if (item?.let(ModelText::collectsData) == true) ModelText.dataCollected() else KiloBundle.message("model.picker.tooltip")
         isEnabled = true
         cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
     }
@@ -417,6 +417,8 @@ internal object ModelText {
     fun dataCollected(): String = KiloBundle.message("model.picker.dataCollected")
 
     fun freeLabel(): String = KiloBundle.message("model.picker.free")
+
+    fun collectsData(item: ModelPicker.Item): Boolean = item.free && item.provider == "kilo"
 
     fun freeBg(): JBColor = JBColor.namedColor("Kilo.ModelPicker.freeBadgeBackground", JBColor(0x95D6AC, 0x7FCA99))
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
@@ -416,7 +416,7 @@ internal object ModelText {
 
     fun dataCollected(): String = KiloBundle.message("model.picker.dataCollected")
 
-    fun freeLabel(): String = dataCollected()
+    fun freeLabel(): String = KiloBundle.message("model.picker.free")
 
     fun freeBg(): JBColor = JBColor.namedColor("Kilo.ModelPicker.freeBadgeBackground", JBColor(0x95D6AC, 0x7FCA99))
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
@@ -3,6 +3,7 @@ package ai.kilocode.client.session.ui.model
 import ai.kilocode.client.plugin.KiloBundle
 import ai.kilocode.client.ui.PickerButton
 import ai.kilocode.rpc.dto.ModelSelectionDto
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.PopupShowOptions
@@ -34,6 +35,7 @@ import javax.swing.JScrollPane
 import javax.swing.KeyStroke
 import javax.swing.ListSelectionModel
 import javax.swing.ScrollPaneConstants
+import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import javax.swing.event.DocumentEvent
 
@@ -100,14 +102,17 @@ class ModelPicker : PickerButton() {
         if (items.isEmpty()) {
             isEnabled = false
             text = " "
+            icon = null
             cursor = Cursor.getDefaultCursor()
             return
         }
         val item = selected ?: items.firstOrNull()
         val display = item?.display ?: ""
-        val suffix = if (item?.free == true) " · ${ModelText.dataCollected()}" else ""
-        text = "${ModelText.sanitize(display)}$suffix ▴"
-        toolTipText = if (item?.free == true) ModelText.freeTip() else KiloBundle.message("model.picker.tooltip")
+        text = "${ModelText.sanitize(display)} ▴"
+        icon = if (item?.free == true) AllIcons.General.Warning else null
+        horizontalTextPosition = SwingConstants.LEFT
+        iconTextGap = JBUI.CurrentTheme.ActionsList.elementIconGap()
+        toolTipText = if (item?.free == true) ModelText.dataCollected() else KiloBundle.message("model.picker.tooltip")
         isEnabled = true
         cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
     }
@@ -411,9 +416,7 @@ internal object ModelText {
 
     fun dataCollected(): String = KiloBundle.message("model.picker.dataCollected")
 
-    fun freeLabel(): String = "${KiloBundle.message("model.picker.free")} - ${dataCollected()}"
-
-    fun freeTip(): String = KiloBundle.message("model.picker.freeData.tooltip")
+    fun freeLabel(): String = dataCollected()
 
     fun freeBg(): JBColor = JBColor.namedColor("Kilo.ModelPicker.freeBadgeBackground", JBColor(0x95D6AC, 0x7FCA99))
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
@@ -103,8 +103,11 @@ class ModelPicker : PickerButton() {
             cursor = Cursor.getDefaultCursor()
             return
         }
-        val display = selected?.display ?: items.firstOrNull()?.display ?: ""
-        text = "${ModelText.sanitize(display)} ▴"
+        val item = selected ?: items.firstOrNull()
+        val display = item?.display ?: ""
+        val suffix = if (item?.free == true) " · ${ModelText.dataCollected()}" else ""
+        text = "${ModelText.sanitize(display)}$suffix ▴"
+        toolTipText = if (item?.free == true) ModelText.freeTip() else KiloBundle.message("model.picker.tooltip")
         isEnabled = true
         cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
     }
@@ -405,6 +408,12 @@ internal object ModelText {
     fun small(item: ModelPicker.Item): Boolean = item.provider == "kilo" && item.id in small
 
     fun providerSort(id: String): Int = if (id == "kilo") 0 else 1
+
+    fun dataCollected(): String = KiloBundle.message("model.picker.dataCollected")
+
+    fun freeLabel(): String = "${KiloBundle.message("model.picker.free")} - ${dataCollected()}"
+
+    fun freeTip(): String = KiloBundle.message("model.picker.freeData.tooltip")
 
     fun freeBg(): JBColor = JBColor.namedColor("Kilo.ModelPicker.freeBadgeBackground", JBColor(0x95D6AC, 0x7FCA99))
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
@@ -69,10 +69,16 @@ internal class ModelPickerRenderer(
         ModelText.freeBg(),
         JBColor.namedColor("Kilo.ModelPicker.freeBadgeForeground", JBColor.WHITE),
     )
+    private val warn = JBLabel(AllIcons.General.Warning).apply {
+        toolTipText = ModelText.dataCollected()
+    }
     private val provider = JBLabel()
     private val head = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
         add(title)
         add(BadgeLabel(badge).apply {
+            border = JBUI.Borders.emptyLeft(JBUI.CurrentTheme.ActionsList.elementIconGap())
+        })
+        add(warn.apply {
             border = JBUI.Borders.emptyLeft(JBUI.CurrentTheme.ActionsList.elementIconGap())
         })
         add(provider)
@@ -91,7 +97,7 @@ internal class ModelPickerRenderer(
     init {
         isOpaque = true
         top.isOpaque = true
-        UiStyle.Components.transparent(row, check, title, head, provider, star)
+        UiStyle.Components.transparent(row, check, title, head, warn, provider, star)
         row.border = JBUI.Borders.empty(
             UiStyle.Gap.md(),
             UiStyle.Gap.lg(),
@@ -133,6 +139,7 @@ internal class ModelPickerRenderer(
         title.append(name.model, SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, fg))
 
         head.getComponent(1).isVisible = value.item.free
+        warn.isVisible = value.item.free
         provider.isVisible = value.favorite
         provider.text = value.item.providerName
         provider.foreground = weak
@@ -155,6 +162,10 @@ internal class ModelPickerRenderer(
     internal fun badgeVisible(): Boolean = head.getComponent(1).isVisible
 
     internal fun badgeText(): String = badge.text
+
+    internal fun warningVisible(): Boolean = warn.isVisible
+
+    internal fun warningTooltip(): String? = warn.toolTipText
 
     private class BadgeLabel(icon: Icon) : JBLabel(icon)
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
@@ -139,7 +139,7 @@ internal class ModelPickerRenderer(
         title.append(name.model, SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, fg))
 
         head.getComponent(1).isVisible = value.item.free
-        warn.isVisible = value.item.free
+        warn.isVisible = ModelText.collectsData(value.item)
         provider.isVisible = value.favorite
         provider.text = value.item.providerName
         provider.foreground = weak

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPickerRenderer.kt
@@ -1,6 +1,5 @@
 package ai.kilocode.client.session.ui.model
 
-import ai.kilocode.client.plugin.KiloBundle
 import ai.kilocode.client.session.ui.PickerRow
 import ai.kilocode.client.ui.FilledBadgeIcon
 import ai.kilocode.client.ui.UiStyle
@@ -66,7 +65,7 @@ internal class ModelPickerRenderer(
     }
     private val title = SimpleColoredComponent()
     private val badge = FilledBadgeIcon(
-        KiloBundle.message("model.picker.free"),
+        ModelText.freeLabel(),
         ModelText.freeBg(),
         JBColor.namedColor("Kilo.ModelPicker.freeBadgeForeground", JBColor.WHITE),
     )
@@ -154,6 +153,8 @@ internal class ModelPickerRenderer(
     internal fun starIcon(): Icon? = star.icon
 
     internal fun badgeVisible(): Boolean = head.getComponent(1).isVisible
+
+    internal fun badgeText(): String = badge.text
 
     private class BadgeLabel(icon: Icon) : JBLabel(icon)
 }

--- a/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
+++ b/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
@@ -140,6 +140,8 @@ model.picker.no.matches=No matching models
 model.picker.favorite.add=Add to favorites
 model.picker.favorite.remove=Remove from favorites
 model.picker.free=Free
+model.picker.dataCollected=Data collected
+model.picker.freeData.tooltip=Usage with free Kilo models is collected for model improvement.
 model.picker.reset=Reset model to default
 reasoning.picker.tooltip=Select reasoning effort
 

--- a/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
+++ b/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
@@ -141,7 +141,6 @@ model.picker.favorite.add=Add to favorites
 model.picker.favorite.remove=Remove from favorites
 model.picker.free=Free
 model.picker.dataCollected=Data collected
-model.picker.freeData.tooltip=Usage with free Kilo models is collected for model improvement.
 model.picker.reset=Reset model to default
 reasoning.picker.tooltip=Select reasoning effort
 

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -153,6 +153,14 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertEquals(listOf("low", "high"), item.variants)
     }
 
+    fun `test selected free model indicates data collection`() {
+        val picker = ModelPicker()
+
+        picker.setItems(listOf(item("auto", "Auto Free", "kilo", "Kilo", free = true)))
+
+        assertTrue(picker.text.contains("Data collected"))
+    }
+
     fun `test display parts split provider prefix`() {
         val parts = ModelText.parts(item("claude-opus", "Anthropic Claude Opus 4.7", "anthropic", "Anthropic"))
 
@@ -261,6 +269,7 @@ class ModelPickerTest : BasePlatformTestCase() {
         renderer.getListCellRendererComponent(list, row, 0, false, false)
 
         assertTrue(renderer.badgeVisible())
+        assertEquals("Free - Data collected", renderer.badgeText())
     }
 
     private fun item(

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -163,6 +163,15 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertEquals("Data collected", picker.toolTipText)
     }
 
+    fun `test selected non-kilo free model does not indicate data collection`() {
+        val picker = ModelPicker()
+
+        picker.setItems(listOf(item("free", "OpenRouter Free", "openrouter", "OpenRouter", free = true)))
+
+        assertNull(picker.icon)
+        assertEquals("Select model", picker.toolTipText)
+    }
+
     fun `test display parts split provider prefix`() {
         val parts = ModelText.parts(item("claude-opus", "Anthropic Claude Opus 4.7", "anthropic", "Anthropic"))
 
@@ -274,6 +283,19 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertEquals("Free", renderer.badgeText())
         assertTrue(renderer.warningVisible())
         assertEquals("Data collected", renderer.warningTooltip())
+    }
+
+    fun `test renderer hides data collection warning for non-kilo free model`() {
+        val row = ModelPickerRow(ModelPicker.Item("free", "Free", "openrouter", "OpenRouter", free = true), "OpenRouter", false)
+        val model = CollectionListModel(listOf(row))
+        val renderer = ModelPickerRenderer(model, { null }, { emptySet() })
+        val list = JBList(model)
+
+        renderer.getListCellRendererComponent(list, row, 0, false, false)
+
+        assertTrue(renderer.badgeVisible())
+        assertEquals("Free", renderer.badgeText())
+        assertFalse(renderer.warningVisible())
     }
 
     private fun item(

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -271,7 +271,9 @@ class ModelPickerTest : BasePlatformTestCase() {
         renderer.getListCellRendererComponent(list, row, 0, false, false)
 
         assertTrue(renderer.badgeVisible())
-        assertEquals("Data collected", renderer.badgeText())
+        assertEquals("Free", renderer.badgeText())
+        assertTrue(renderer.warningVisible())
+        assertEquals("Data collected", renderer.warningTooltip())
     }
 
     private fun item(

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -158,7 +158,9 @@ class ModelPickerTest : BasePlatformTestCase() {
 
         picker.setItems(listOf(item("auto", "Auto Free", "kilo", "Kilo", free = true)))
 
-        assertTrue(picker.text.contains("Data collected"))
+        assertFalse(picker.text.contains("Data collected"))
+        assertSame(AllIcons.General.Warning, picker.icon)
+        assertEquals("Data collected", picker.toolTipText)
     }
 
     fun `test display parts split provider prefix`() {
@@ -269,7 +271,7 @@ class ModelPickerTest : BasePlatformTestCase() {
         renderer.getListCellRendererComponent(list, row, 0, false, false)
 
         assertTrue(renderer.badgeVisible())
-        assertEquals("Free - Data collected", renderer.badgeText())
+        assertEquals("Data collected", renderer.badgeText())
     }
 
     private fun item(

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1061,6 +1061,7 @@
     "@kilocode/kilo-ui": "workspace:*",
     "@kilocode/sdk": "workspace:*",
     "@opencode-ai/ui": "workspace:*",
+    "@pierre/diffs": "catalog:",
     "@thisbeyond/solid-dnd": "0.7.5",
     "@xterm/addon-clipboard": "0.2.0",
     "@xterm/addon-fit": "0.11.0",

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -202,6 +202,15 @@ describe("Agent Manager Provider Messages", () => {
   })
 })
 
+describe("Agent Manager Model Picker", () => {
+  it("discloses data collection for free models in compare picker", () => {
+    const source = fs.readFileSync(path.join(ROOT, "webview-ui/agent-manager/MultiModelSelector.tsx"), "utf-8")
+
+    expect(source).toContain("model.tag.freeData.tooltip")
+    expect(source).toContain("model.isFree")
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Provider message routing — static-analysis regression tests
 //

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -206,7 +206,7 @@ describe("Agent Manager Model Picker", () => {
   it("discloses data collection for free models in compare picker", () => {
     const source = fs.readFileSync(path.join(ROOT, "webview-ui/agent-manager/MultiModelSelector.tsx"), "utf-8")
 
-    expect(source).toContain("model.tag.freeData.tooltip")
+    expect(source).toContain("model.tag.dataCollected")
     expect(source).toContain("model.isFree")
   })
 })

--- a/packages/kilo-vscode/tests/unit/model-preview-data-line.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-preview-data-line.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const root = path.resolve(import.meta.dir, "../..")
+const preview = fs.readFileSync(path.join(root, "webview-ui/src/components/shared/ModelPreview.tsx"), "utf8")
+const styles = fs.readFileSync(path.join(root, "webview-ui/src/styles/model-selector.css"), "utf8")
+
+describe("model preview data collection line", () => {
+  it("shows a visible data collection row above context details", () => {
+    const data = preview.indexOf('class="model-preview-data-line"')
+    const context = preview.indexOf("model.preview.label.context")
+
+    expect(data).toBeGreaterThanOrEqual(0)
+    expect(context).toBeGreaterThan(data)
+    expect(preview).toContain('Icon name="warning"')
+    expect(preview).toContain('language.t("model.tag.dataCollected")')
+    expect(styles).toContain(".model-preview-data-line")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/model-preview-data-line.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-preview-data-line.test.ts
@@ -14,6 +14,7 @@ describe("model preview data collection line", () => {
     expect(data).toBeGreaterThanOrEqual(0)
     expect(context).toBeGreaterThan(data)
     expect(preview).toContain('Icon name="warning"')
+    expect(preview).toContain("isDataCollectedModel(model())")
     expect(preview).toContain('language.t("model.tag.dataCollected")')
     expect(styles).toContain(".model-preview-data-line")
   })

--- a/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
@@ -7,6 +7,7 @@ import {
   KILO_GATEWAY_ID,
   PROVIDER_ORDER,
   freeDataLabel,
+  isDataCollectedModel,
 } from "../../webview-ui/src/components/shared/model-selector-utils"
 
 const labels = { select: "Select model", noProviders: "No providers", notSet: "Not set" }
@@ -98,6 +99,14 @@ describe("sanitizeName", () => {
 describe("freeDataLabel", () => {
   it("uses the data collection label without repeating free", () => {
     expect(freeDataLabel("Free", "Data collected")).toBe("Data collected")
+  })
+})
+
+describe("isDataCollectedModel", () => {
+  it("only marks free Kilo Gateway models as data collected", () => {
+    expect(isDataCollectedModel({ providerID: KILO_GATEWAY_ID, isFree: true })).toBe(true)
+    expect(isDataCollectedModel({ providerID: "openrouter", isFree: true })).toBe(false)
+    expect(isDataCollectedModel({ providerID: KILO_GATEWAY_ID, isFree: false })).toBe(false)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
@@ -6,6 +6,7 @@ import {
   sanitizeName,
   KILO_GATEWAY_ID,
   PROVIDER_ORDER,
+  freeDataLabel,
 } from "../../webview-ui/src/components/shared/model-selector-utils"
 
 const labels = { select: "Select model", noProviders: "No providers", notSet: "Not set" }
@@ -91,6 +92,12 @@ describe("sanitizeName", () => {
   it("handles extra whitespace around (free) suffix", () => {
     expect(sanitizeName("Llama 3 (free)  ")).toBe("Llama 3")
     expect(sanitizeName("Model  (free)  ")).toBe("Model")
+  })
+})
+
+describe("freeDataLabel", () => {
+  it("combines free and data collection labels", () => {
+    expect(freeDataLabel("Free", "Data collected")).toBe("Free - Data collected")
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
@@ -96,8 +96,8 @@ describe("sanitizeName", () => {
 })
 
 describe("freeDataLabel", () => {
-  it("combines free and data collection labels", () => {
-    expect(freeDataLabel("Free", "Data collected")).toBe("Free - Data collected")
+  it("uses the data collection label without repeating free", () => {
+    expect(freeDataLabel("Free", "Data collected")).toBe("Data collected")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
@@ -1,9 +1,10 @@
 import { type Component, createSignal, createMemo, For, Show, onMount } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useProvider } from "../src/context/provider"
 import type { EnrichedModel } from "../src/context/provider"
 import { useLanguage } from "../src/context/language"
-import { KILO_GATEWAY_ID, providerSortKey } from "../src/components/shared/model-selector-utils"
+import { KILO_GATEWAY_ID, freeDataLabel, providerSortKey } from "../src/components/shared/model-selector-utils"
 import {
   type ModelAllocations,
   MAX_MULTI_VERSIONS,
@@ -32,6 +33,8 @@ export const MultiModelSelector: Component<{
   const { t } = useLanguage()
   const [search, setSearch] = createSignal("")
   let searchRef: HTMLInputElement | undefined
+  const freeLabel = () => freeDataLabel(t("model.tag.free"), t("model.tag.dataCollected"))
+  const freeTip = () => t("model.tag.freeData.tooltip")
 
   const visibleModels = createMemo(() => {
     const c = connected()
@@ -107,6 +110,14 @@ export const MultiModelSelector: Component<{
                           }
                         />
                         <span class="am-mm-item-name">{model.name}</span>
+                        <Show when={model.isFree}>
+                          <Tooltip value={freeTip()} placement="top">
+                            <span class="am-mm-free-data" aria-label={freeTip()}>
+                              <Icon name="warning" size="small" />
+                              <span>{freeLabel()}</span>
+                            </span>
+                          </Tooltip>
+                        </Show>
                       </label>
                       <Show when={checked()}>
                         <select

--- a/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
@@ -4,7 +4,12 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useProvider } from "../src/context/provider"
 import type { EnrichedModel } from "../src/context/provider"
 import { useLanguage } from "../src/context/language"
-import { KILO_GATEWAY_ID, freeDataLabel, providerSortKey } from "../src/components/shared/model-selector-utils"
+import {
+  KILO_GATEWAY_ID,
+  freeDataLabel,
+  isDataCollectedModel,
+  providerSortKey,
+} from "../src/components/shared/model-selector-utils"
 import {
   type ModelAllocations,
   MAX_MULTI_VERSIONS,
@@ -113,11 +118,13 @@ export const MultiModelSelector: Component<{
                         <Show when={model.isFree}>
                           <span class="am-mm-free-data">
                             <span class="am-mm-free-badge">{freeLabel()}</span>
-                            <Tooltip value={dataLabel()} placement="top">
-                              <span class="am-mm-free-data-icon" aria-label={dataLabel()}>
-                                <Icon name="warning" size="small" />
-                              </span>
-                            </Tooltip>
+                            <Show when={isDataCollectedModel(model)}>
+                              <Tooltip value={dataLabel()} placement="top">
+                                <span class="am-mm-free-data-icon" aria-label={dataLabel()}>
+                                  <Icon name="warning" size="small" />
+                                </span>
+                              </Tooltip>
+                            </Show>
                           </span>
                         </Show>
                       </label>

--- a/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
@@ -1,6 +1,5 @@
 import { type Component, createSignal, createMemo, For, Show, onMount } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
-import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useProvider } from "../src/context/provider"
 import type { EnrichedModel } from "../src/context/provider"
 import { useLanguage } from "../src/context/language"
@@ -34,7 +33,6 @@ export const MultiModelSelector: Component<{
   const [search, setSearch] = createSignal("")
   let searchRef: HTMLInputElement | undefined
   const freeLabel = () => freeDataLabel(t("model.tag.free"), t("model.tag.dataCollected"))
-  const freeTip = () => t("model.tag.freeData.tooltip")
 
   const visibleModels = createMemo(() => {
     const c = connected()
@@ -111,12 +109,9 @@ export const MultiModelSelector: Component<{
                         />
                         <span class="am-mm-item-name">{model.name}</span>
                         <Show when={model.isFree}>
-                          <Tooltip value={freeTip()} placement="top">
-                            <span class="am-mm-free-data" aria-label={freeTip()}>
-                              <Icon name="warning" size="small" />
-                              <span>{freeLabel()}</span>
-                            </span>
-                          </Tooltip>
+                          <span class="am-mm-free-data">
+                            <span>{freeLabel()}</span>
+                          </span>
                         </Show>
                       </label>
                       <Show when={checked()}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/MultiModelSelector.tsx
@@ -1,5 +1,6 @@
 import { type Component, createSignal, createMemo, For, Show, onMount } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useProvider } from "../src/context/provider"
 import type { EnrichedModel } from "../src/context/provider"
 import { useLanguage } from "../src/context/language"
@@ -32,7 +33,8 @@ export const MultiModelSelector: Component<{
   const { t } = useLanguage()
   const [search, setSearch] = createSignal("")
   let searchRef: HTMLInputElement | undefined
-  const freeLabel = () => freeDataLabel(t("model.tag.free"), t("model.tag.dataCollected"))
+  const freeLabel = () => t("model.tag.free")
+  const dataLabel = () => freeDataLabel(t("model.tag.free"), t("model.tag.dataCollected"))
 
   const visibleModels = createMemo(() => {
     const c = connected()
@@ -110,7 +112,12 @@ export const MultiModelSelector: Component<{
                         <span class="am-mm-item-name">{model.name}</span>
                         <Show when={model.isFree}>
                           <span class="am-mm-free-data">
-                            <span>{freeLabel()}</span>
+                            <span class="am-mm-free-badge">{freeLabel()}</span>
+                            <Tooltip value={dataLabel()} placement="top">
+                              <span class="am-mm-free-data-icon" aria-label={dataLabel()}>
+                                <Icon name="warning" size="small" />
+                              </span>
+                            </Tooltip>
                           </span>
                         </Show>
                       </label>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2804,19 +2804,29 @@ body.am-wt-dragging-active * {
 .am-mm-free-data {
   display: inline-flex;
   align-items: center;
+  gap: 4px;
   flex-shrink: 0;
   max-width: 132px;
+  white-space: nowrap;
+}
+
+.am-mm-free-badge {
+  display: inline-flex;
+  align-items: center;
   padding: 1px 4px;
   border-radius: var(--radius-sm);
   color: #fff;
   background: var(--vscode-testing-iconPassed, #4caf50);
   font-size: var(--kilo-font-size-10);
-  white-space: nowrap;
-}
-
-.am-mm-free-data span {
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.am-mm-free-data-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
+  flex-shrink: 0;
 }
 
 .am-mm-count-select {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2801,6 +2801,25 @@ body.am-wt-dragging-active * {
   white-space: nowrap;
 }
 
+.am-mm-free-data {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  max-width: 132px;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  color: var(--vscode-inputValidation-warningForeground, var(--text-weaker));
+  background: var(--surface-inset-base);
+  font-size: var(--kilo-font-size-10);
+  white-space: nowrap;
+}
+
+.am-mm-free-data span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .am-mm-count-select {
   flex-shrink: 0;
   padding: 2px 4px;

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2804,13 +2804,12 @@ body.am-wt-dragging-active * {
 .am-mm-free-data {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
   flex-shrink: 0;
   max-width: 132px;
   padding: 1px 4px;
   border-radius: var(--radius-sm);
-  color: var(--vscode-inputValidation-warningForeground, var(--text-weaker));
-  background: var(--surface-inset-base);
+  color: #fff;
+  background: var(--vscode-testing-iconPassed, #4caf50);
   font-size: var(--kilo-font-size-10);
   white-space: nowrap;
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -46,7 +46,8 @@ export const ModelPreview: Component<Props> = (props) => {
             return fmtCachedPrice(cost()!) ?? language.t("model.preview.value.notSupported")
           }
           const avg = () => (cost() ? avgPrice(cost()!) : undefined)
-          const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
+          const freeLabel = () => language.t("model.tag.free")
+          const dataLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
           const ctx = () => model().limit?.context ?? model().contextLength
           const caps = () => model().capabilities
           const inputs = () => caps()?.input
@@ -90,7 +91,14 @@ export const ModelPreview: Component<Props> = (props) => {
                     </Show>
                   </div>
                   <Show when={model().isFree}>
-                    <span class="model-preview-badge model-preview-badge--free">{freeLabel()}</span>
+                    <span class="model-preview-free-data">
+                      <span class="model-preview-badge model-preview-badge--free">{freeLabel()}</span>
+                      <Tooltip value={dataLabel()} placement="top">
+                        <span class="model-preview-free-data-icon" aria-label={dataLabel()}>
+                          <Icon name="warning" size="small" />
+                        </span>
+                      </Tooltip>
+                    </span>
                   </Show>
                 </div>
                 <span class="model-preview-provider">{model().providerName}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -5,7 +5,7 @@ import { Markdown } from "@kilocode/kilo-ui/markdown"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../context/language"
-import { freeDataLabel, sanitizeName } from "./model-selector-utils"
+import { freeDataLabel, isDataCollectedModel, sanitizeName } from "./model-selector-utils"
 import { avgPrice, fmtCachedPrice, fmtPrice } from "./model-preview-utils"
 
 interface Props {
@@ -93,11 +93,13 @@ export const ModelPreview: Component<Props> = (props) => {
                   <Show when={model().isFree}>
                     <span class="model-preview-free-data">
                       <span class="model-preview-badge model-preview-badge--free">{freeLabel()}</span>
-                      <Tooltip value={dataLabel()} placement="top">
-                        <span class="model-preview-free-data-icon" aria-label={dataLabel()}>
-                          <Icon name="warning" size="small" />
-                        </span>
-                      </Tooltip>
+                      <Show when={isDataCollectedModel(model())}>
+                        <Tooltip value={dataLabel()} placement="top">
+                          <span class="model-preview-free-data-icon" aria-label={dataLabel()}>
+                            <Icon name="warning" size="small" />
+                          </span>
+                        </Tooltip>
+                      </Show>
                     </span>
                   </Show>
                 </div>
@@ -128,7 +130,7 @@ export const ModelPreview: Component<Props> = (props) => {
                   <span class="model-preview-value">{fmtPrice(avg()!)}</span>
                 </Show>
 
-                <Show when={model().isFree}>
+                <Show when={isDataCollectedModel(model())}>
                   <span class="model-preview-data-line" aria-label={dataLabel()}>
                     <Icon name="warning" size="small" />
                     <span>- {dataLabel()}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -128,6 +128,13 @@ export const ModelPreview: Component<Props> = (props) => {
                   <span class="model-preview-value">{fmtPrice(avg()!)}</span>
                 </Show>
 
+                <Show when={model().isFree}>
+                  <span class="model-preview-data-line" aria-label={dataLabel()}>
+                    <Icon name="warning" size="small" />
+                    <span>- {dataLabel()}</span>
+                  </span>
+                </Show>
+
                 {/* Context window */}
                 <Show when={ctx()}>
                   <span class="model-preview-label">{language.t("model.preview.label.context")}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -5,7 +5,7 @@ import { Markdown } from "@kilocode/kilo-ui/markdown"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../context/language"
-import { sanitizeName } from "./model-selector-utils"
+import { freeDataLabel, sanitizeName } from "./model-selector-utils"
 import { avgPrice, fmtCachedPrice, fmtPrice } from "./model-preview-utils"
 
 interface Props {
@@ -46,6 +46,8 @@ export const ModelPreview: Component<Props> = (props) => {
             return fmtCachedPrice(cost()!) ?? language.t("model.preview.value.notSupported")
           }
           const avg = () => (cost() ? avgPrice(cost()!) : undefined)
+          const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
+          const freeTip = () => language.t("model.tag.freeData.tooltip")
           const ctx = () => model().limit?.context ?? model().contextLength
           const caps = () => model().capabilities
           const inputs = () => caps()?.input
@@ -62,9 +64,11 @@ export const ModelPreview: Component<Props> = (props) => {
           return (
             <>
               <Show when={model().isFree}>
-                <span class="model-preview-badge model-preview-badge--free model-preview-badge--top-right">
-                  {language.t("model.tag.free")}
-                </span>
+                <Tooltip value={freeTip()} placement="top">
+                  <span class="model-preview-badge model-preview-badge--free model-preview-badge--top-right">
+                    {freeLabel()}
+                  </span>
+                </Tooltip>
               </Show>
               {/* Header — name + provider + star */}
               <div class="model-preview-header">

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -47,7 +47,6 @@ export const ModelPreview: Component<Props> = (props) => {
           }
           const avg = () => (cost() ? avgPrice(cost()!) : undefined)
           const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
-          const freeTip = () => language.t("model.tag.freeData.tooltip")
           const ctx = () => model().limit?.context ?? model().contextLength
           const caps = () => model().capabilities
           const inputs = () => caps()?.input
@@ -63,37 +62,35 @@ export const ModelPreview: Component<Props> = (props) => {
 
           return (
             <>
-              <Show when={model().isFree}>
-                <Tooltip value={freeTip()} placement="top">
-                  <span class="model-preview-badge model-preview-badge--free model-preview-badge--top-right">
-                    {freeLabel()}
-                  </span>
-                </Tooltip>
-              </Show>
               {/* Header — name + provider + star */}
               <div class="model-preview-header">
-                <div class="model-preview-name-row">
-                  <span class="model-preview-name">{sanitizeName(model().name)}</span>
-                  <Show when={session}>
-                    {(() => {
-                      const starred = () =>
-                        session!
-                          .favoriteModels()
-                          .some((f) => f.providerID === model().providerID && f.modelID === model().id)
-                      return (
-                        <button
-                          type="button"
-                          class={`model-selector-star model-selector-star--preview${starred() ? " model-selector-star--active" : ""}`}
-                          aria-label={
-                            starred() ? language.t("model.favorite.remove") : language.t("model.favorite.add")
-                          }
-                          aria-pressed={starred()}
-                          onClick={() => session!.toggleFavorite(model().providerID, model().id)}
-                        >
-                          <Icon name={starred() ? "star-filled" : "star"} size="small" />
-                        </button>
-                      )
-                    })()}
+                <div class="model-preview-title-row">
+                  <div class="model-preview-name-row">
+                    <span class="model-preview-name">{sanitizeName(model().name)}</span>
+                    <Show when={session}>
+                      {(() => {
+                        const starred = () =>
+                          session!
+                            .favoriteModels()
+                            .some((f) => f.providerID === model().providerID && f.modelID === model().id)
+                        return (
+                          <button
+                            type="button"
+                            class={`model-selector-star model-selector-star--preview${starred() ? " model-selector-star--active" : ""}`}
+                            aria-label={
+                              starred() ? language.t("model.favorite.remove") : language.t("model.favorite.add")
+                            }
+                            aria-pressed={starred()}
+                            onClick={() => session!.toggleFavorite(model().providerID, model().id)}
+                          >
+                            <Icon name={starred() ? "star-filled" : "star"} size="small" />
+                          </button>
+                        )
+                      })()}
+                    </Show>
+                  </div>
+                  <Show when={model().isFree}>
+                    <span class="model-preview-badge model-preview-badge--free">{freeLabel()}</span>
                   </Show>
                 </div>
                 <span class="model-preview-provider">{model().providerName}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -36,6 +36,7 @@ import {
   isSmall,
   providerSortKey,
   isFree,
+  isDataCollectedModel,
   freeDataLabel,
   buildTriggerLabel,
   sanitizeName,
@@ -587,6 +588,11 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const describedBy = () => (props.description ? descriptionID : undefined)
   const freeLabel = () => language.t("model.tag.free")
   const dataLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
+  const activeCollectsData = () => {
+    const model = activeModel()
+    if (!model) return false
+    return isDataCollectedModel(model)
+  }
 
   return (
     <>
@@ -627,7 +633,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
         trigger={
           <>
             <span class="model-selector-trigger-label">{triggerLabel()}</span>
-            <Show when={activeModel()?.isFree}>
+            <Show when={activeCollectsData()}>
               <Tooltip value={dataLabel()} placement="top">
                 <span class="model-selector-trigger-free-data" aria-label={dataLabel()}>
                   <Icon name="warning" size="small" />
@@ -827,11 +833,13 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                           <span class="model-selector-data-badge">
                                             <Tag data-variant="member">{freeLabel()}</Tag>
                                           </span>
-                                          <Tooltip value={dataLabel()} placement="top">
-                                            <span class="model-selector-free-data-icon" aria-label={dataLabel()}>
-                                              <Icon name="warning" size="small" />
-                                            </span>
-                                          </Tooltip>
+                                          <Show when={isDataCollectedModel(model)}>
+                                            <Tooltip value={dataLabel()} placement="top">
+                                              <span class="model-selector-free-data-icon" aria-label={dataLabel()}>
+                                                <Icon name="warning" size="small" />
+                                              </span>
+                                            </Tooltip>
+                                          </Show>
                                         </span>
                                       </Show>
                                       <Show when={showProvider()}>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -586,7 +586,6 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const searchLabel = () => `${controlLabel()}. ${language.t("dialog.model.search.placeholder")}`
   const describedBy = () => (props.description ? descriptionID : undefined)
   const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
-  const freeTip = () => language.t("model.tag.freeData.tooltip")
 
   return (
     <>
@@ -628,11 +627,9 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
           <>
             <span class="model-selector-trigger-label">{triggerLabel()}</span>
             <Show when={activeModel()?.isFree}>
-              <Tooltip value={freeTip()} placement="top">
-                <span class="model-selector-trigger-free-data" aria-label={freeTip()}>
-                  <Icon name="warning" size="small" />
-                </span>
-              </Tooltip>
+              <span class="model-selector-trigger-free-data model-selector-data-badge">
+                <Tag data-variant="member">{freeLabel()}</Tag>
+              </span>
             </Show>
             <svg class="model-selector-trigger-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 4l4 5H4l4-5z" />
@@ -823,11 +820,9 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                         })()}
                                       </span>
                                       <Show when={isFree(model)}>
-                                        <Tooltip value={freeTip()} placement="top">
-                                          <span class="model-selector-free-data">
-                                            <Tag data-variant="member">{freeLabel()}</Tag>
-                                          </span>
-                                        </Tooltip>
+                                        <span class="model-selector-free-data model-selector-data-badge">
+                                          <Tag data-variant="member">{freeLabel()}</Tag>
+                                        </span>
                                       </Show>
                                       <Show when={showProvider()}>
                                         <span class="model-selector-item-provider-tag">{model.providerName}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -36,6 +36,7 @@ import {
   isSmall,
   providerSortKey,
   isFree,
+  freeDataLabel,
   buildTriggerLabel,
   sanitizeName,
 } from "./model-selector-utils"
@@ -584,6 +585,8 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const controlLabel = () => `${label()}: ${triggerLabel()}`
   const searchLabel = () => `${controlLabel()}. ${language.t("dialog.model.search.placeholder")}`
   const describedBy = () => (props.description ? descriptionID : undefined)
+  const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
+  const freeTip = () => language.t("model.tag.freeData.tooltip")
 
   return (
     <>
@@ -624,6 +627,13 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
         trigger={
           <>
             <span class="model-selector-trigger-label">{triggerLabel()}</span>
+            <Show when={activeModel()?.isFree}>
+              <Tooltip value={freeTip()} placement="top">
+                <span class="model-selector-trigger-free-data" aria-label={freeTip()}>
+                  <Icon name="warning" size="small" />
+                </span>
+              </Tooltip>
+            </Show>
             <svg class="model-selector-trigger-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 4l4 5H4l4-5z" />
             </svg>
@@ -813,7 +823,11 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                         })()}
                                       </span>
                                       <Show when={isFree(model)}>
-                                        <Tag data-variant="member">{language.t("model.tag.free")}</Tag>
+                                        <Tooltip value={freeTip()} placement="top">
+                                          <span class="model-selector-free-data">
+                                            <Tag data-variant="member">{freeLabel()}</Tag>
+                                          </span>
+                                        </Tooltip>
                                       </Show>
                                       <Show when={showProvider()}>
                                         <span class="model-selector-item-provider-tag">{model.providerName}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -627,9 +627,11 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
           <>
             <span class="model-selector-trigger-label">{triggerLabel()}</span>
             <Show when={activeModel()?.isFree}>
-              <span class="model-selector-trigger-free-data model-selector-data-badge">
-                <Tag data-variant="member">{freeLabel()}</Tag>
-              </span>
+              <Tooltip value={freeLabel()} placement="top">
+                <span class="model-selector-trigger-free-data" aria-label={freeLabel()}>
+                  <Icon name="warning" size="small" />
+                </span>
+              </Tooltip>
             </Show>
             <svg class="model-selector-trigger-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 4l4 5H4l4-5z" />

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -585,7 +585,8 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const controlLabel = () => `${label()}: ${triggerLabel()}`
   const searchLabel = () => `${controlLabel()}. ${language.t("dialog.model.search.placeholder")}`
   const describedBy = () => (props.description ? descriptionID : undefined)
-  const freeLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
+  const freeLabel = () => language.t("model.tag.free")
+  const dataLabel = () => freeDataLabel(language.t("model.tag.free"), language.t("model.tag.dataCollected"))
 
   return (
     <>
@@ -627,8 +628,8 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
           <>
             <span class="model-selector-trigger-label">{triggerLabel()}</span>
             <Show when={activeModel()?.isFree}>
-              <Tooltip value={freeLabel()} placement="top">
-                <span class="model-selector-trigger-free-data" aria-label={freeLabel()}>
+              <Tooltip value={dataLabel()} placement="top">
+                <span class="model-selector-trigger-free-data" aria-label={dataLabel()}>
                   <Icon name="warning" size="small" />
                 </span>
               </Tooltip>
@@ -822,8 +823,15 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                         })()}
                                       </span>
                                       <Show when={isFree(model)}>
-                                        <span class="model-selector-free-data model-selector-data-badge">
-                                          <Tag data-variant="member">{freeLabel()}</Tag>
+                                        <span class="model-selector-free-data">
+                                          <span class="model-selector-data-badge">
+                                            <Tag data-variant="member">{freeLabel()}</Tag>
+                                          </span>
+                                          <Tooltip value={dataLabel()} placement="top">
+                                            <span class="model-selector-free-data-icon" aria-label={dataLabel()}>
+                                              <Icon name="warning" size="small" />
+                                            </span>
+                                          </Tooltip>
                                         </span>
                                       </Show>
                                       <Show when={showProvider()}>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
@@ -22,6 +22,10 @@ export function isFree(model: Pick<EnrichedModel, "isFree">): boolean {
   return model.isFree === true
 }
 
+export function freeDataLabel(free: string, data: string): string {
+  return `${free} - ${data}`
+}
+
 // Strips trailing "(free)" parenthesized suffix from model display names, e.g.
 // "Llama 3 (free)" → "Llama 3". A separate "Free" label/tag is rendered
 // elsewhere, so preserve bare trailing "Free" words (e.g. "Kilo Auto Free").

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
@@ -22,8 +22,8 @@ export function isFree(model: Pick<EnrichedModel, "isFree">): boolean {
   return model.isFree === true
 }
 
-export function freeDataLabel(free: string, data: string): string {
-  return `${free} - ${data}`
+export function freeDataLabel(_free: string, data: string): string {
+  return data
 }
 
 // Strips trailing "(free)" parenthesized suffix from model display names, e.g.

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
@@ -22,6 +22,10 @@ export function isFree(model: Pick<EnrichedModel, "isFree">): boolean {
   return model.isFree === true
 }
 
+export function isDataCollectedModel(model: Pick<EnrichedModel, "providerID" | "isFree">): boolean {
+  return model.isFree === true && model.providerID === KILO_GATEWAY_ID
+}
+
 export function freeDataLabel(_free: string, data: string): string {
   return data
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -174,6 +174,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "تم فصل {{provider}}",
   "provider.disconnect.toast.disconnected.description": "لم تعد نماذج {{provider}} متاحة.",
   "model.tag.free": "مجاني",
+  "model.tag.dataCollected": "يتم جمع البيانات",
+  "model.tag.freeData.tooltip": "يتم جمع استخدام نماذج Kilo المجانية لتحسين النماذج.",
   "model.tag.latest": "الأحدث",
   "model.group.recommended": "موصى به",
   "model.group.favorites": "المفضلة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -175,7 +175,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "لم تعد نماذج {{provider}} متاحة.",
   "model.tag.free": "مجاني",
   "model.tag.dataCollected": "يتم جمع البيانات",
-  "model.tag.freeData.tooltip": "يتم جمع استخدام نماذج Kilo المجانية لتحسين النماذج.",
   "model.tag.latest": "الأحدث",
   "model.group.recommended": "موصى به",
   "model.group.favorites": "المفضلة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} desconectado",
   "provider.disconnect.toast.disconnected.description": "Os modelos de {{provider}} não estão mais disponíveis.",
   "model.tag.free": "Grátis",
+  "model.tag.dataCollected": "Dados coletados",
+  "model.tag.freeData.tooltip": "O uso de modelos gratuitos do Kilo é coletado para melhorar os modelos.",
   "model.tag.latest": "Mais recente",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Os modelos de {{provider}} não estão mais disponíveis.",
   "model.tag.free": "Grátis",
   "model.tag.dataCollected": "Dados coletados",
-  "model.tag.freeData.tooltip": "O uso de modelos gratuitos do Kilo é coletado para melhorar os modelos.",
   "model.tag.latest": "Mais recente",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -177,7 +177,6 @@ export const dict = {
 
   "model.tag.free": "Besplatno",
   "model.tag.dataCollected": "Podaci se prikupljaju",
-  "model.tag.freeData.tooltip": "Korištenje besplatnih Kilo modela prikuplja se radi poboljšanja modela.",
   "model.tag.latest": "Najnovije",
   "model.group.recommended": "Preporučeno",
   "model.group.favorites": "Favoriti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -176,6 +176,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modeli više nisu dostupni.",
 
   "model.tag.free": "Besplatno",
+  "model.tag.dataCollected": "Podaci se prikupljaju",
+  "model.tag.freeData.tooltip": "Korištenje besplatnih Kilo modela prikuplja se radi poboljšanja modela.",
   "model.tag.latest": "Najnovije",
   "model.group.recommended": "Preporučeno",
   "model.group.favorites": "Favoriti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} frakoblet",
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke længere tilgængelige.",
   "model.tag.free": "Gratis",
+  "model.tag.dataCollected": "Data indsamles",
+  "model.tag.freeData.tooltip": "Brug af gratis Kilo-modeller indsamles for at forbedre modellerne.",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalet",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke længere tilgængelige.",
   "model.tag.free": "Gratis",
   "model.tag.dataCollected": "Data indsamles",
-  "model.tag.freeData.tooltip": "Brug af gratis Kilo-modeller indsamles for at forbedre modellerne.",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalet",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -180,7 +180,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Die {{provider}}-Modelle sind nicht mehr verfügbar.",
   "model.tag.free": "Kostenlos",
   "model.tag.dataCollected": "Daten erfasst",
-  "model.tag.freeData.tooltip": "Die Nutzung kostenloser Kilo-Modelle wird zur Modellverbesserung erfasst.",
   "model.tag.latest": "Neueste",
   "model.group.recommended": "Empfohlen",
   "model.group.favorites": "Favoriten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -179,6 +179,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} getrennt",
   "provider.disconnect.toast.disconnected.description": "Die {{provider}}-Modelle sind nicht mehr verfügbar.",
   "model.tag.free": "Kostenlos",
+  "model.tag.dataCollected": "Daten erfasst",
+  "model.tag.freeData.tooltip": "Die Nutzung kostenloser Kilo-Modelle wird zur Modellverbesserung erfasst.",
   "model.tag.latest": "Neueste",
   "model.group.recommended": "Empfohlen",
   "model.group.favorites": "Favoriten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -177,7 +177,6 @@ export const dict = {
 
   "model.tag.free": "Free",
   "model.tag.dataCollected": "Data collected",
-  "model.tag.freeData.tooltip": "Usage with free Kilo models is collected for model improvement.",
   "model.tag.latest": "Latest",
   "model.group.recommended": "Recommended",
   "model.group.favorites": "Favorites",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -176,6 +176,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} models are no longer available.",
 
   "model.tag.free": "Free",
+  "model.tag.dataCollected": "Data collected",
+  "model.tag.freeData.tooltip": "Usage with free Kilo models is collected for model improvement.",
   "model.tag.latest": "Latest",
   "model.group.recommended": "Recommended",
   "model.group.favorites": "Favorites",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -177,7 +177,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Los modelos de {{provider}} ya no están disponibles.",
   "model.tag.free": "Gratis",
   "model.tag.dataCollected": "Datos recopilados",
-  "model.tag.freeData.tooltip": "El uso de modelos gratuitos de Kilo se recopila para mejorar los modelos.",
   "model.tag.latest": "Último",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -176,6 +176,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} desconectado",
   "provider.disconnect.toast.disconnected.description": "Los modelos de {{provider}} ya no están disponibles.",
   "model.tag.free": "Gratis",
+  "model.tag.dataCollected": "Datos recopilados",
+  "model.tag.freeData.tooltip": "El uso de modelos gratuitos de Kilo se recopila para mejorar los modelos.",
   "model.tag.latest": "Último",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -178,7 +178,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Les modèles {{provider}} ne sont plus disponibles.",
   "model.tag.free": "Gratuit",
   "model.tag.dataCollected": "Données collectées",
-  "model.tag.freeData.tooltip": "L'utilisation des modèles Kilo gratuits est collectée pour améliorer les modèles.",
   "model.tag.latest": "Dernier",
   "model.group.recommended": "Recommandé",
   "model.group.favorites": "Favoris",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -177,6 +177,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} déconnecté",
   "provider.disconnect.toast.disconnected.description": "Les modèles {{provider}} ne sont plus disponibles.",
   "model.tag.free": "Gratuit",
+  "model.tag.dataCollected": "Données collectées",
+  "model.tag.freeData.tooltip": "L'utilisation des modèles Kilo gratuits est collectée pour améliorer les modèles.",
   "model.tag.latest": "Dernier",
   "model.group.recommended": "Recommandé",
   "model.group.favorites": "Favoris",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -152,7 +152,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "I modelli {{provider}} non sono più disponibili.",
   "model.tag.free": "Gratis",
   "model.tag.dataCollected": "Dati raccolti",
-  "model.tag.freeData.tooltip": "L'uso dei modelli Kilo gratuiti viene raccolto per migliorare i modelli.",
   "model.tag.latest": "Più recente",
   "model.group.recommended": "Consigliati",
   "model.group.favorites": "Preferiti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -151,6 +151,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} disconnesso",
   "provider.disconnect.toast.disconnected.description": "I modelli {{provider}} non sono più disponibili.",
   "model.tag.free": "Gratis",
+  "model.tag.dataCollected": "Dati raccolti",
+  "model.tag.freeData.tooltip": "L'uso dei modelli Kilo gratuiti viene raccolto per migliorare i modelli.",
   "model.tag.latest": "Più recente",
   "model.group.recommended": "Consigliati",
   "model.group.favorites": "Preferiti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -174,6 +174,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}}が切断されました",
   "provider.disconnect.toast.disconnected.description": "{{provider}}のモデルは利用できなくなりました。",
   "model.tag.free": "無料",
+  "model.tag.dataCollected": "データ収集あり",
+  "model.tag.freeData.tooltip": "無料のKiloモデルの使用状況は、モデル改善のために収集されます。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推奨",
   "model.group.favorites": "お気に入り",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -175,7 +175,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}}のモデルは利用できなくなりました。",
   "model.tag.free": "無料",
   "model.tag.dataCollected": "データ収集あり",
-  "model.tag.freeData.tooltip": "無料のKiloモデルの使用状況は、モデル改善のために収集されます。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推奨",
   "model.group.favorites": "お気に入り",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -178,6 +178,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 연결 해제됨",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 모델을 더 이상 사용할 수 없습니다.",
   "model.tag.free": "무료",
+  "model.tag.dataCollected": "데이터 수집됨",
+  "model.tag.freeData.tooltip": "무료 Kilo 모델 사용 내용은 모델 개선을 위해 수집됩니다.",
   "model.tag.latest": "최신",
   "model.group.recommended": "추천",
   "model.group.favorites": "즐겨찾기",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -179,7 +179,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} 모델을 더 이상 사용할 수 없습니다.",
   "model.tag.free": "무료",
   "model.tag.dataCollected": "데이터 수집됨",
-  "model.tag.freeData.tooltip": "무료 Kilo 모델 사용 내용은 모델 개선을 위해 수집됩니다.",
   "model.tag.latest": "최신",
   "model.group.recommended": "추천",
   "model.group.favorites": "즐겨찾기",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -176,6 +176,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modellen zijn niet langer beschikbaar.",
 
   "model.tag.free": "Gratis",
+  "model.tag.dataCollected": "Gegevens verzameld",
+  "model.tag.freeData.tooltip": "Gebruik van gratis Kilo-modellen wordt verzameld voor modelverbetering.",
   "model.tag.latest": "Nieuwste",
   "model.group.recommended": "Aanbevolen",
   "model.group.favorites": "Favorieten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -177,7 +177,6 @@ export const dict = {
 
   "model.tag.free": "Gratis",
   "model.tag.dataCollected": "Gegevens verzameld",
-  "model.tag.freeData.tooltip": "Gebruik van gratis Kilo-modellen wordt verzameld voor modelverbetering.",
   "model.tag.latest": "Nieuwste",
   "model.group.recommended": "Aanbevolen",
   "model.group.favorites": "Favorieten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -179,7 +179,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke lenger tilgjengelige.",
   "model.tag.free": "Gratis",
   "model.tag.dataCollected": "Data samles inn",
-  "model.tag.freeData.tooltip": "Bruk av gratis Kilo-modeller samles inn for å forbedre modellene.",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalt",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -178,6 +178,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} frakoblet",
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke lenger tilgjengelige.",
   "model.tag.free": "Gratis",
+  "model.tag.dataCollected": "Data samles inn",
+  "model.tag.freeData.tooltip": "Bruk av gratis Kilo-modeller samles inn for å forbedre modellene.",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalt",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Modele {{provider}} nie są już dostępne.",
   "model.tag.free": "Darmowy",
   "model.tag.dataCollected": "Dane zbierane",
-  "model.tag.freeData.tooltip": "Użycie bezpłatnych modeli Kilo jest zbierane w celu ulepszania modeli.",
   "model.tag.latest": "Najnowszy",
   "model.group.recommended": "Zalecane",
   "model.group.favorites": "Ulubione",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "Rozłączono {{provider}}",
   "provider.disconnect.toast.disconnected.description": "Modele {{provider}} nie są już dostępne.",
   "model.tag.free": "Darmowy",
+  "model.tag.dataCollected": "Dane zbierane",
+  "model.tag.freeData.tooltip": "Użycie bezpłatnych modeli Kilo jest zbierane w celu ulepszania modeli.",
   "model.tag.latest": "Najnowszy",
   "model.group.recommended": "Zalecane",
   "model.group.favorites": "Ulubione",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} отключён",
   "provider.disconnect.toast.disconnected.description": "Модели {{provider}} больше недоступны.",
   "model.tag.free": "Бесплатно",
+  "model.tag.dataCollected": "Данные собираются",
+  "model.tag.freeData.tooltip": "Использование бесплатных моделей Kilo собирается для улучшения моделей.",
   "model.tag.latest": "Последняя",
   "model.group.recommended": "Рекомендуемые",
   "model.group.favorites": "Избранное",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Модели {{provider}} больше недоступны.",
   "model.tag.free": "Бесплатно",
   "model.tag.dataCollected": "Данные собираются",
-  "model.tag.freeData.tooltip": "Использование бесплатных моделей Kilo собирается для улучшения моделей.",
   "model.tag.latest": "Последняя",
   "model.group.recommended": "Рекомендуемые",
   "model.group.favorites": "Избранное",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "โมเดล {{provider}} ไม่พร้อมใช้งานอีกต่อไป",
 
   "model.tag.free": "ฟรี",
+  "model.tag.dataCollected": "มีการเก็บข้อมูล",
+  "model.tag.freeData.tooltip": "การใช้งานโมเดล Kilo ฟรีจะถูกเก็บรวบรวมเพื่อปรับปรุงโมเดล",
   "model.tag.latest": "ล่าสุด",
   "model.group.recommended": "แนะนำ",
   "model.group.favorites": "รายการโปรด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -176,7 +176,6 @@ export const dict = {
 
   "model.tag.free": "ฟรี",
   "model.tag.dataCollected": "มีการเก็บข้อมูล",
-  "model.tag.freeData.tooltip": "การใช้งานโมเดล Kilo ฟรีจะถูกเก็บรวบรวมเพื่อปรับปรุงโมเดล",
   "model.tag.latest": "ล่าสุด",
   "model.group.recommended": "แนะนำ",
   "model.group.favorites": "รายการโปรด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -176,7 +176,6 @@ export const dict = {
 
   "model.tag.free": "Ücretsiz",
   "model.tag.dataCollected": "Veri toplanır",
-  "model.tag.freeData.tooltip": "Ücretsiz Kilo modellerinin kullanımı model iyileştirmesi için toplanır.",
   "model.tag.latest": "En yeni",
   "model.group.recommended": "Önerilen",
   "model.group.favorites": "Favoriler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modelleri artık kullanılabilir değil.",
 
   "model.tag.free": "Ücretsiz",
+  "model.tag.dataCollected": "Veri toplanır",
+  "model.tag.freeData.tooltip": "Ücretsiz Kilo modellerinin kullanımı model iyileştirmesi için toplanır.",
   "model.tag.latest": "En yeni",
   "model.group.recommended": "Önerilen",
   "model.group.favorites": "Favoriler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -177,7 +177,6 @@ export const dict = {
 
   "model.tag.free": "Безкоштовно",
   "model.tag.dataCollected": "Дані збираються",
-  "model.tag.freeData.tooltip": "Використання безкоштовних моделей Kilo збирається для покращення моделей.",
   "model.tag.latest": "Остання",
   "model.group.recommended": "Рекомендовані",
   "model.group.favorites": "Обране",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -176,6 +176,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Моделі {{provider}} більше недоступні.",
 
   "model.tag.free": "Безкоштовно",
+  "model.tag.dataCollected": "Дані збираються",
+  "model.tag.freeData.tooltip": "Використання безкоштовних моделей Kilo збирається для покращення моделей.",
   "model.tag.latest": "Остання",
   "model.group.recommended": "Рекомендовані",
   "model.group.favorites": "Обране",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免费",
   "model.tag.dataCollected": "已收集数据",
-  "model.tag.freeData.tooltip": "使用免费的 Kilo 模型时，使用情况会被收集用于模型改进。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推荐",
   "model.group.favorites": "收藏夹",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 已断开连接",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免费",
+  "model.tag.dataCollected": "已收集数据",
+  "model.tag.freeData.tooltip": "使用免费的 Kilo 模型时，使用情况会被收集用于模型改进。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推荐",
   "model.group.favorites": "收藏夹",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -176,7 +176,6 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免費",
   "model.tag.dataCollected": "已收集資料",
-  "model.tag.freeData.tooltip": "使用免費 Kilo 模型時，使用情況會被收集用於模型改進。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推薦",
   "model.group.favorites": "我的最愛",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -175,6 +175,8 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 已中斷連線",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免費",
+  "model.tag.dataCollected": "已收集資料",
+  "model.tag.freeData.tooltip": "使用免費 Kilo 模型時，使用情況會被收集用於模型改進。",
   "model.tag.latest": "最新",
   "model.group.recommended": "推薦",
   "model.group.favorites": "我的最愛",

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -407,6 +407,7 @@
 .model-selector-trigger-free-data {
   display: inline-flex;
   align-items: center;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
   flex-shrink: 0;
 }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -142,6 +142,15 @@
   font-variant-numeric: tabular-nums;
 }
 
+.model-preview-data-line {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--kilo-font-size-11);
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
+}
+
 /* Capability badge row */
 .model-preview-caps {
   display: flex;

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -158,7 +158,6 @@
 .model-preview-badge--free {
   background: var(--vscode-testing-iconPassed, #4caf50);
   color: #fff;
-  text-transform: uppercase;
 }
 
 .model-preview-badge--top-right {
@@ -388,10 +387,21 @@
   flex-shrink: 0;
   background: var(--vscode-testing-iconPassed, #4caf50) !important;
   color: #fff !important;
-  text-transform: uppercase;
   font-size: var(--kilo-font-size-10) !important;
   padding: 1px 3px !important;
   opacity: 0.8;
+}
+
+.model-selector-free-data {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.model-selector-trigger-free-data {
+  display: inline-flex;
+  align-items: center;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
+  flex-shrink: 0;
 }
 
 .model-selector-item-provider-tag {

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -173,6 +173,21 @@
   white-space: nowrap;
 }
 
+.model-preview-free-data {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.model-preview-free-data-icon,
+.model-selector-free-data-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
+  flex-shrink: 0;
+}
+
 .model-selector-preview--visible {
   /* height is set inline via previewHeight signal */
   border-top-width: 0;
@@ -399,16 +414,18 @@
   opacity: 0.8;
 }
 
-.model-selector-free-data {
-  display: inline-flex;
-  min-width: 0;
-}
-
 .model-selector-trigger-free-data {
   display: inline-flex;
   align-items: center;
   color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
   flex-shrink: 0;
+}
+
+.model-selector-free-data {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
 }
 
 .model-selector-item-provider-tag {

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -62,10 +62,18 @@
   gap: 2px;
 }
 
+.model-preview-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .model-preview-name-row {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .model-preview-name {
@@ -73,6 +81,9 @@
   font-weight: 600;
   color: var(--vscode-editor-foreground);
   line-height: 1.3;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .model-preview-provider {
@@ -158,12 +169,8 @@
 .model-preview-badge--free {
   background: var(--vscode-testing-iconPassed, #4caf50);
   color: #fff;
-}
-
-.model-preview-badge--top-right {
-  position: absolute;
-  top: 12px;
-  right: 14px;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .model-selector-preview--visible {
@@ -383,7 +390,7 @@
   text-overflow: ellipsis;
 }
 
-.model-selector-item [data-component="tag"] {
+.model-selector-data-badge [data-component="tag"] {
   flex-shrink: 0;
   background: var(--vscode-testing-iconPassed, #4caf50) !important;
   color: #fff !important;
@@ -400,7 +407,6 @@
 .model-selector-trigger-free-data {
   display: inline-flex;
   align-items: center;
-  color: var(--vscode-inputValidation-warningForeground, var(--vscode-descriptionForeground));
   flex-shrink: 0;
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -12,6 +12,7 @@ import type { Model } from "@kilocode/sdk/v2" // kilocode_change
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { ModelInfoPanel } from "@/kilocode/components/model-info-panel" // kilocode_change
+import { FreeModelDisclosure } from "@/kilocode/components/free-model-disclosure" // kilocode_change
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
@@ -63,6 +64,12 @@ export function DialogModel(props: { providerID?: string }) {
     if (!next) return
     setPreview(next)
   })
+
+  const footer = (providerID: string, model: Model) => {
+    if (model.isFree) return FreeModelDisclosure.label
+    if (model.cost?.input === 0 && providerID === "opencode") return "Free"
+    return undefined
+  }
   // kilocode_change end
 
   const options = createMemo(() => {
@@ -86,7 +93,7 @@ export function DialogModel(props: { providerID?: string }) {
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: footer(provider.id, model),
             onSelect: () => {
               onSelect(provider.id, model.id)
             },
@@ -129,7 +136,7 @@ export function DialogModel(props: { providerID?: string }) {
               : undefined,
             // kilocode_change end
             disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: footer(provider.id, info),
             onSelect() {
               onSelect(provider.id, model)
             },
@@ -149,7 +156,7 @@ export function DialogModel(props: { providerID?: string }) {
             // kilocode_change start - Sort within Recommended / Kilo Gateway
             (x) => (x.value.providerID === "kilo" ? (kiloRank().get(x.value.modelID) ?? Infinity) : 0),
             // kilocode_change end
-            (x) => x.footer !== "Free",
+            (x) => x.footer === undefined,
             (x) => x.title,
           ),
         ),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -93,7 +93,7 @@ export function DialogModel(props: { providerID?: string }) {
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: footer(provider.id, model),
+            footer: footer(provider.id, model), // kilocode_change
             onSelect: () => {
               onSelect(provider.id, model.id)
             },
@@ -136,7 +136,7 @@ export function DialogModel(props: { providerID?: string }) {
               : undefined,
             // kilocode_change end
             disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: footer(provider.id, info),
+            footer: footer(provider.id, info), // kilocode_change
             onSelect() {
               onSelect(provider.id, model)
             },
@@ -156,7 +156,9 @@ export function DialogModel(props: { providerID?: string }) {
             // kilocode_change start - Sort within Recommended / Kilo Gateway
             (x) => (x.value.providerID === "kilo" ? (kiloRank().get(x.value.modelID) ?? Infinity) : 0),
             // kilocode_change end
+            // kilocode_change start - free model footers include Kilo disclosure labels
             (x) => x.footer === undefined,
+            // kilocode_change end
             (x) => x.title,
           ),
         ),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -66,7 +66,7 @@ export function DialogModel(props: { providerID?: string }) {
   })
 
   const footer = (providerID: string, model: Model) => {
-    if (model.isFree) return FreeModelDisclosure.label
+    if (providerID === "kilo" && FreeModelDisclosure.collectsData(model)) return FreeModelDisclosure.label
     if (model.cost?.input === 0 && providerID === "opencode") return "Free"
     return undefined
   }

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,3 +1,4 @@
 export const FreeModelDisclosure = {
   label: "Data collected",
+  panel: "Free - data collected",
 } as const

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,4 +1,3 @@
 export const FreeModelDisclosure = {
   label: "Data collected",
-  description: "Data collected",
 } as const

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,0 +1,4 @@
+export const FreeModelDisclosure = {
+  label: "Free - data collected",
+  description: "Usage data is collected for model improvement.",
+} as const

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,4 +1,4 @@
 export const FreeModelDisclosure = {
-  label: "Free - data collected",
+  label: "Data collected",
   description: "Usage data is collected for model improvement.",
 } as const

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,4 +1,4 @@
 export const FreeModelDisclosure = {
   label: "Data collected",
-  description: "Usage data is collected for model improvement.",
+  description: "Data collected",
 } as const

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,4 +1,7 @@
 export const FreeModelDisclosure = {
   label: "Data collected",
   panel: "Free - data collected",
+  collectsData(model: { isFree?: boolean; api?: { npm?: string } }): boolean {
+    return model.isFree === true && model.api?.npm === "@kilocode/kilo-gateway"
+  },
 } as const

--- a/packages/opencode/src/kilocode/components/model-info-panel.tsx
+++ b/packages/opencode/src/kilocode/components/model-info-panel.tsx
@@ -69,7 +69,7 @@ export function ModelInfoPanel(props: Props) {
         </box>
         <Show when={m().isFree}>
           <box>
-            <text fg={theme.text}>{FreeModelDisclosure.label}</text>
+            <text fg={theme.text}>{FreeModelDisclosure.panel}</text>
           </box>
         </Show>
         <Show when={m().family}>

--- a/packages/opencode/src/kilocode/components/model-info-panel.tsx
+++ b/packages/opencode/src/kilocode/components/model-info-panel.tsx
@@ -67,7 +67,7 @@ export function ModelInfoPanel(props: Props) {
           </text>
           <text fg={theme.textMuted}>{props.provider ?? m().providerID ?? ""}</text>
         </box>
-        <Show when={m().isFree}>
+        <Show when={FreeModelDisclosure.collectsData(m())}>
           <box>
             <text fg={theme.text}>{FreeModelDisclosure.panel}</text>
           </box>

--- a/packages/opencode/src/kilocode/components/model-info-panel.tsx
+++ b/packages/opencode/src/kilocode/components/model-info-panel.tsx
@@ -68,11 +68,8 @@ export function ModelInfoPanel(props: Props) {
           <text fg={theme.textMuted}>{props.provider ?? m().providerID ?? ""}</text>
         </box>
         <Show when={m().isFree}>
-          <box flexDirection="column">
+          <box>
             <text fg={theme.text}>{FreeModelDisclosure.label}</text>
-            <text fg={theme.textMuted} width={23}>
-              {FreeModelDisclosure.description}
-            </text>
           </box>
         </Show>
         <Show when={m().family}>

--- a/packages/opencode/src/kilocode/components/model-info-panel.tsx
+++ b/packages/opencode/src/kilocode/components/model-info-panel.tsx
@@ -3,6 +3,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { createMemo, Show } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import type { Model } from "@kilocode/sdk/v2"
+import { FreeModelDisclosure } from "./free-model-disclosure"
 import { avgPrice, fmtCachedPrice, fmtContext, fmtDate, fmtPrice } from "./model-info-panel-utils"
 
 interface Props {
@@ -67,8 +68,11 @@ export function ModelInfoPanel(props: Props) {
           <text fg={theme.textMuted}>{props.provider ?? m().providerID ?? ""}</text>
         </box>
         <Show when={m().isFree}>
-          <box>
-            <text fg={theme.text}>Free</text>
+          <box flexDirection="column">
+            <text fg={theme.text}>{FreeModelDisclosure.label}</text>
+            <text fg={theme.textMuted} width={23}>
+              {FreeModelDisclosure.description}
+            </text>
           </box>
         </Show>
         <Show when={m().family}>

--- a/packages/opencode/test/kilocode/free-model-disclosure.test.ts
+++ b/packages/opencode/test/kilocode/free-model-disclosure.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { FreeModelDisclosure } from "../../src/kilocode/components/free-model-disclosure"
+
+describe("FreeModelDisclosure", () => {
+  test("only Kilo Gateway free models collect data", () => {
+    expect(
+      FreeModelDisclosure.collectsData({
+        isFree: true,
+        api: { npm: "@kilocode/kilo-gateway" },
+      }),
+    ).toBe(true)
+    expect(
+      FreeModelDisclosure.collectsData({
+        isFree: true,
+        api: { npm: "@openrouter/ai-sdk-provider" },
+      }),
+    ).toBe(false)
+    expect(
+      FreeModelDisclosure.collectsData({
+        isFree: false,
+        api: { npm: "@kilocode/kilo-gateway" },
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -8,16 +8,18 @@ export type Event =
   | EventServerConnected
   | EventGlobalDisposed
   | EventGlobalConfigUpdated
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow1
+  | EventTuiSessionSelect
+  | EventKilocodeAgentManagerStart
+  | EventIndexingStatus
   | EventServerInstanceDisposed
   | EventLspClientDiagnostics
   | EventLspUpdated
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow1
-  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventSessionNetworkAsked
@@ -46,7 +48,6 @@ export type Event =
   | EventSessionCompacted
   | EventCommandExecuted
   | EventProjectUpdated
-  | EventKilocodeAgentManagerStart
   | EventVcsBranchUpdated
   | EventKiloSessionsRemoteStatusChanged
   | EventWorkspaceReady
@@ -91,7 +92,6 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
-  | EventIndexingStatus
 
 export type OAuth = {
   type: "oauth"
@@ -117,6 +117,71 @@ export type WellKnownAuth = {
 }
 
 export type Auth = OAuth | ApiAuth | WellKnownAuth
+
+export type EventTuiPromptAppend = {
+  id: string
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  id: string
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  id: string
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  id: string
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+}
+
+export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
+
+export type IndexingStatus = {
+  state: IndexingStatusState
+  message: string
+  processedFiles: number
+  totalFiles: number
+  percent: number
+}
 
 export type QuestionOption = {
   /**
@@ -178,61 +243,6 @@ export type QuestionReplied = {
 export type QuestionRejected = {
   sessionID: string
   requestID: string
-}
-
-export type EventTuiPromptAppend = {
-  id: string
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  id: string
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  id: string
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  id: string
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
 }
 
 export type SessionNetworkWait = {
@@ -857,16 +867,6 @@ export type Prompt = {
   agents?: Array<PromptAgentAttachment>
 }
 
-export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
-
-export type IndexingStatus = {
-  state: IndexingStatusState
-  message: string
-  processedFiles: number
-  totalFiles: number
-  percent: number
-}
-
 export type GlobalEvent = {
   directory: string
   project?: string
@@ -875,16 +875,18 @@ export type GlobalEvent = {
     | EventServerConnected
     | EventGlobalDisposed
     | EventGlobalConfigUpdated
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
+    | EventKilocodeAgentManagerStart
+    | EventIndexingStatus
     | EventServerInstanceDisposed
     | EventLspClientDiagnostics
     | EventLspUpdated
     | EventQuestionAsked
     | EventQuestionReplied
     | EventQuestionRejected
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventSessionNetworkAsked
@@ -913,7 +915,6 @@ export type GlobalEvent = {
     | EventSessionCompacted
     | EventCommandExecuted
     | EventProjectUpdated
-    | EventKilocodeAgentManagerStart
     | EventVcsBranchUpdated
     | EventKiloSessionsRemoteStatusChanged
     | EventWorkspaceReady
@@ -958,7 +959,6 @@ export type GlobalEvent = {
     | EventSessionNextCompactionStarted
     | EventSessionNextCompactionDelta
     | EventSessionNextCompactionEnded
-    | EventIndexingStatus
     | SyncEventMessageUpdated
     | SyncEventMessageRemoved
     | SyncEventMessagePartUpdated
@@ -1180,6 +1180,8 @@ export type ProviderConfig = {
       name?: string
       family?: string
       prompt?: "codex" | "gemini" | "beast" | "anthropic" | "trinity" | "anthropic_without_todo" | "ling" | "gpt55"
+      isFree?: boolean
+      ai_sdk_provider?: "alibaba" | "anthropic" | "openai" | "openai-compatible" | "openrouter"
       release_date?: string
       attachment?: boolean
       reasoning?: boolean
@@ -2543,6 +2545,30 @@ export type EventGlobalConfigUpdated = {
   }
 }
 
+export type EventKilocodeAgentManagerStart = {
+  id: string
+  type: "kilocode.agent_manager.start"
+  properties: {
+    requestID: string
+    sessionID: string
+    mode: "worktree" | "local"
+    versions?: boolean
+    tasks: Array<{
+      prompt?: string
+      name?: string
+      branchName?: string
+    }>
+  }
+}
+
+export type EventIndexingStatus = {
+  id: string
+  type: "indexing.status"
+  properties: {
+    status: IndexingStatus
+  }
+}
+
 export type EventServerInstanceDisposed = {
   id: string
   type: "server.instance.disposed"
@@ -2842,22 +2868,6 @@ export type EventProjectUpdated = {
   id: string
   type: "project.updated"
   properties: Project
-}
-
-export type EventKilocodeAgentManagerStart = {
-  id: string
-  type: "kilocode.agent_manager.start"
-  properties: {
-    requestID: string
-    sessionID: string
-    mode: "worktree" | "local"
-    versions?: boolean
-    tasks: Array<{
-      prompt?: string
-      name?: string
-      branchName?: string
-    }>
-  }
 }
 
 export type EventVcsBranchUpdated = {
@@ -3383,14 +3393,6 @@ export type EventSessionNextCompactionEnded = {
     sessionID: string
     text: string
     include?: string
-  }
-}
-
-export type EventIndexingStatus = {
-  id: string
-  type: "indexing.status"
-  properties: {
-    status: IndexingStatus
   }
 }
 


### PR DESCRIPTION
Adds free-model data-collection indicators across the CLI, VS Code extension, Agent Manager, and JetBrains (JB not tested locally) model pickers.

<img width="1002" height="280" alt="image" src="https://github.com/user-attachments/assets/efdf7f7d-c5e8-423c-991d-561bd95db57e" />
(on mouseover)
<img width="211" height="68" alt="image" src="https://github.com/user-attachments/assets/dd0e4279-8b55-4662-94be-8c3c0c39fc72" />
<img width="464" height="183" alt="image" src="https://github.com/user-attachments/assets/33d1ed16-d1cb-4c0b-86aa-b93642a901ce" />
<img width="449" height="235" alt="image" src="https://github.com/user-attachments/assets/4ede8a83-6929-43f4-8eb7-f0382438076c" />


