### PR TITLE
fix(jetbrains): reduce flaky CI builds

### DIFF
--- a/packages/kilo-jetbrains/build.gradle.kts
+++ b/packages/kilo-jetbrains/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.InstrumentCodeTask
 import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware.SplitModeTarget
 import java.time.LocalDate
@@ -170,6 +171,10 @@ intellijPlatform {
 }
 
 tasks {
+    withType<InstrumentCodeTask> {
+        enabled = false
+    }
+
     runIdeBackend {
         splitModeServerPort.set(splitPort)
         dependsOn(":backend:prepareLocalCli")

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -3,7 +3,7 @@
 /**
  * CI test runner for the JetBrains plugin.
  *
- * Runs ./gradlew test --continue --no-build-cache so all modules run even when some fail,
+ * Runs ./gradlew clean test --continue --no-build-cache so all modules run even when some fail,
  * then collects per-module JUnit XML results into .artifacts/unit/junit.xml
  * so mikepenz/action-junit-report can find them at the standard path.
  * The generated OpenAPI client can otherwise restore stale compile outputs
@@ -20,7 +20,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 
 
 const root = join(import.meta.dir, "..")
 const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew"
-const args = ["test", "--continue", "--no-build-cache"]
+const args = ["clean", "test", "--continue", "--no-build-cache"]
 const cmd = process.platform === "win32" ? ["cmd.exe", "/c", gradlew, ...args] : [gradlew, ...args]
 const fallback = 45 * 60 * 1000
 const parsed = Number(process.env.KILO_JETBRAINS_TEST_TIMEOUT_MS ?? fallback)

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -3,7 +3,7 @@
 /**
  * CI test runner for the JetBrains plugin.
  *
- * Runs ./gradlew clean test --continue --no-build-cache so all modules run even when some fail,
+ * Runs ./gradlew clean test --continue --no-build-cache --stacktrace so all modules run even when some fail,
  * then collects per-module JUnit XML results into .artifacts/unit/junit.xml
  * so mikepenz/action-junit-report can find them at the standard path.
  * The generated OpenAPI client can otherwise restore stale compile outputs
@@ -20,7 +20,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 
 
 const root = join(import.meta.dir, "..")
 const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew"
-const args = ["clean", "test", "--continue", "--no-build-cache"]
+const args = ["clean", "test", "--continue", "--no-build-cache", "--stacktrace"]
 const cmd = process.platform === "win32" ? ["cmd.exe", "/c", gradlew, ...args] : [gradlew, ...args]
 const fallback = 45 * 60 * 1000
 const parsed = Number(process.env.KILO_JETBRAINS_TEST_TIMEOUT_MS ?? fallback)


### PR DESCRIPTION
## Summary
- Disable root-level JetBrains instrumentation tasks, which can make CI builds flaky for the split plugin.
- Run the JetBrains CI test script from a clean Gradle state so stale generated outputs do not mask failures.

## Verification
- `./gradlew typecheck` from `packages/kilo-jetbrains/`