### PR TITLE
fix(vscode): preserve primary sidebar on restore

### DIFF
--- a/.changeset/friendly-sidebar-restore.md
+++ b/.changeset/friendly-sidebar-restore.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent Kilo Code from closing VS Code's primary sidebar during startup restore.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -476,7 +476,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private setSidebarVisible(visible: boolean): void {
     this.setStreamVisibility(visible)
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)
-    this.opts.onSidebarVisibilityChange?.(visible)
   }
 
   /** Resolve a WebviewPanel for displaying Kilo in an editor tab. */

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -28,7 +28,6 @@ let shuttingDown = false
 const RESTORE_KEY = "kilo.workbench.restore"
 
 type RestoreState = {
-  sidebar?: boolean
   agentManager?: boolean
 }
 
@@ -49,10 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
   // Create shared connection service (one server for all webviews)
   const connectionService = new KiloConnectionService(context)
   let restore = context.workspaceState.get<RestoreState>(RESTORE_KEY) ?? {}
-  const closeSidebar = restore.sidebar === false
   const remember = (patch: RestoreState) => {
     const next = { ...restore, ...patch }
-    if (shuttingDown && patch.sidebar === false) next.sidebar = restore.sidebar
     if (shuttingDown && patch.agentManager === false) next.agentManager = restore.agentManager
     restore = next
     void context.workspaceState.update(RESTORE_KEY, restore)
@@ -123,9 +120,7 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   // Create the provider with shared service
-  const provider = new KiloProvider(context.extensionUri, connectionService, context, {
-    onSidebarVisibilityChange: (visible) => remember({ sidebar: visible }),
-  })
+  const provider = new KiloProvider(context.extensionUri, connectionService, context)
   provider.setRemoteService(remoteService)
 
   // Register the webview view provider for the sidebar.
@@ -135,7 +130,6 @@ export function activate(context: vscode.ExtensionContext) {
       webviewOptions: { retainContextWhenHidden: true },
     }),
   )
-  if (closeSidebar) void vscode.commands.executeCommand("workbench.action.closeSidebar")
 
   // Ensure Agent Manager navigation keybindings work when a VS Code terminal has focus.
   // The terminal intercepts all keystrokes unless the command is listed in

--- a/packages/kilo-vscode/src/kilo-provider/options.ts
+++ b/packages/kilo-vscode/src/kilo-provider/options.ts
@@ -4,6 +4,5 @@ export type KiloProviderOptions = {
   snapshotInitialization?: "wait"
   slimEditMetadata?: boolean
   tabTitle?: (title: string) => void
-  onSidebarVisibilityChange?: (visible: boolean) => void
   worktreeDirectories?: () => string[]
 }

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -117,6 +117,10 @@ describe("Extension — package.json command sync", () => {
 describe("Extension — KiloProvider handler wiring", () => {
   const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
 
+  it("does not close the global primary sidebar during Kilo restore", () => {
+    expect(ext).not.toContain("workbench.action.closeSidebar")
+  })
+
   /**
    * Every `new KiloProvider(` in extension.ts must be followed (before the
    * next `new KiloProvider(`) by a `setContinueInWorktreeHandler` call.


### PR DESCRIPTION
## What
Prevent Kilo Code startup restore from closing VS Code's global primary sidebar.

## Why
The restore logic was recording Kilo sidebar visibility, then calling workbench.action.closeSidebar when that state was false. That command hides the entire VS Code primary sidebar, including Explorer, Source Control, and other views.

## Testing
- bun test tests/unit/extension-arch.test.ts
- bun run typecheck
- bun run lint
- bun run check-kilocode-change

Closes #10561