### PR TITLE
fix(cli): handle string permission migration

### DIFF
--- a/.changeset/fix-string-permission-migration.md
+++ b/.changeset/fix-string-permission-migration.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Handle string-form permission values when migrating bash permissions.

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { pathToFileURL } from "url"
 import { existsSync } from "fs"
 import { Effect, Schema } from "effect"
-import { applyEdits, findNodeAtLocation, modify, parse as parseJsonc, parseTree } from "jsonc-parser"
+import { applyEdits, modify, parse as parseJsonc } from "jsonc-parser"
 import { mergeDeep } from "remeda"
 import * as Log from "@opencode-ai/core/util/log"
 import { Global } from "@opencode-ai/core/global"
@@ -353,7 +353,7 @@ export namespace KilocodeConfig {
         .catch(() => "")
       const data = parseJsonc(text) ?? {}
       configs.push({ file, data })
-      if (isRecord(data.permission) && data.permission.bash) return
+      if (typeof data.permission === "string" || (isRecord(data.permission) && data.permission.bash)) return
     }
 
     // A schema-only file is generated for editor completion. It does not mean
@@ -373,24 +373,16 @@ export namespace KilocodeConfig {
       .catch(() => "{}")
 
     if (target.endsWith(".jsonc")) {
-      const tree = parseTree(text)
-      const permission = tree && findNodeAtLocation(tree, ["permission"])
-      const edits = modify(
-        text,
-        permission && permission.type !== "object" ? ["permission"] : ["permission", "bash"],
-        permission && permission.type !== "object" ? { "*": permission.value, bash: "allow" } : "allow",
-        {
-          formattingOptions: { insertSpaces: true, tabSize: 2 },
-        },
-      )
+      const edits = modify(text, ["permission", "bash"], "allow", {
+        formattingOptions: { insertSpaces: true, tabSize: 2 },
+      })
       await Bun.write(target, applyEdits(text, edits))
       log.info("migrated bash permission to allow for existing user", { path: target })
       return
     }
 
     const data = parseJsonc(text) ?? {}
-    const permission = isRecord(data.permission) ? data.permission : { "*": data.permission }
-    const merged = { ...data, permission: { ...permission, bash: "allow" } }
+    const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
     await Bun.write(target, JSON.stringify(merged, null, 2))
     log.info("migrated bash permission to allow for existing user", { path: target })
   }

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -2,7 +2,7 @@ import path from "path"
 import { pathToFileURL } from "url"
 import { existsSync } from "fs"
 import { Effect, Schema } from "effect"
-import { applyEdits, modify, parse as parseJsonc } from "jsonc-parser"
+import { applyEdits, findNodeAtLocation, modify, parse as parseJsonc, parseTree } from "jsonc-parser"
 import { mergeDeep } from "remeda"
 import * as Log from "@opencode-ai/core/util/log"
 import { Global } from "@opencode-ai/core/global"
@@ -373,16 +373,24 @@ export namespace KilocodeConfig {
       .catch(() => "{}")
 
     if (target.endsWith(".jsonc")) {
-      const edits = modify(text, ["permission", "bash"], "allow", {
-        formattingOptions: { insertSpaces: true, tabSize: 2 },
-      })
+      const tree = parseTree(text)
+      const permission = tree && findNodeAtLocation(tree, ["permission"])
+      const edits = modify(
+        text,
+        permission && permission.type !== "object" ? ["permission"] : ["permission", "bash"],
+        permission && permission.type !== "object" ? { "*": permission.value, bash: "allow" } : "allow",
+        {
+          formattingOptions: { insertSpaces: true, tabSize: 2 },
+        },
+      )
       await Bun.write(target, applyEdits(text, edits))
       log.info("migrated bash permission to allow for existing user", { path: target })
       return
     }
 
     const data = parseJsonc(text) ?? {}
-    const merged = { ...data, permission: { ...data.permission, bash: "allow" } }
+    const permission = isRecord(data.permission) ? data.permission : { "*": data.permission }
+    const merged = { ...data, permission: { ...permission, bash: "allow" } }
     await Bun.write(target, JSON.stringify(merged, null, 2))
     log.info("migrated bash permission to allow for existing user", { path: target })
   }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -4,7 +4,6 @@ import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Config } from "@/config/config"
 import { ConfigManaged } from "@/config/managed"
 import { ConfigParse } from "../../src/config/parse"
-import { KilocodeConfig } from "../../src/kilocode/config/config"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 import { InstanceRef } from "../../src/effect/instance-ref"
@@ -366,101 +365,6 @@ test("updates global config and omits empty shell key in jsonc", async () => {
     expect(writtenConfig).not.toContain('"shell"')
     expect(parsed.shell).toBeUndefined()
     expect(parsed.model).toBe("test/model")
-  } finally {
-    ;(Global.Path as { config: string }).config = prev
-    await clear(true)
-  }
-})
-
-test("migrates string-form global permission in jsonc without throwing", async () => {
-  await using globalTmp = await tmpdir({
-    init: async (dir) => {
-      await Filesystem.write(
-        path.join(dir, "kilo.jsonc"),
-        `{
-  "$schema": "https://app.kilo.ai/config.json",
-  "permission": "allow"
-}`,
-      )
-    },
-  })
-
-  const prev = Global.Path.config
-  ;(Global.Path as { config: string }).config = globalTmp.path
-  await clear(true)
-
-  try {
-    await KilocodeConfig.migrateBashPermission()
-
-    const file = path.join(globalTmp.path, "kilo.jsonc")
-    const writtenConfig = await Filesystem.readText(file)
-    const parsed = ConfigParse.schema(Config.Info.zod, ConfigParse.jsonc(writtenConfig, file), file)
-    expect(parsed.permission?.["*"]).toBe("allow")
-    expect(parsed.permission?.bash).toBe("allow")
-  } finally {
-    ;(Global.Path as { config: string }).config = prev
-    await clear(true)
-  }
-})
-
-test("migrates string-form global permission in json without throwing", async () => {
-  await using globalTmp = await tmpdir({
-    init: async (dir) => {
-      await Filesystem.write(
-        path.join(dir, "kilo.json"),
-        JSON.stringify({
-          $schema: "https://app.kilo.ai/config.json",
-          permission: "allow",
-        }),
-      )
-    },
-  })
-
-  const prev = Global.Path.config
-  ;(Global.Path as { config: string }).config = globalTmp.path
-  await clear(true)
-
-  try {
-    await KilocodeConfig.migrateBashPermission()
-
-    const writtenConfig = await Filesystem.readJson<Config.Info>(path.join(globalTmp.path, "kilo.json"))
-    expect(writtenConfig.permission).toEqual({
-      "*": "allow",
-      bash: "allow",
-    })
-  } finally {
-    ;(Global.Path as { config: string }).config = prev
-    await clear(true)
-  }
-})
-
-test("migrates object-form global permission in jsonc", async () => {
-  await using globalTmp = await tmpdir({
-    init: async (dir) => {
-      await Filesystem.write(
-        path.join(dir, "kilo.jsonc"),
-        `{
-  "$schema": "https://app.kilo.ai/config.json",
-  "permission": {
-    "read": "allow"
-  }
-}`,
-      )
-    },
-  })
-
-  const prev = Global.Path.config
-  ;(Global.Path as { config: string }).config = globalTmp.path
-  await clear(true)
-
-  try {
-    await KilocodeConfig.migrateBashPermission()
-
-    const file = path.join(globalTmp.path, "kilo.jsonc")
-    const writtenConfig = await Filesystem.readText(file)
-    const parsed = ConfigParse.schema(Config.Info.zod, ConfigParse.jsonc(writtenConfig, file), file)
-    expect(parsed.permission?.read).toBe("allow")
-    expect(parsed.permission?.bash).toBe("allow")
   } finally {
     ;(Global.Path as { config: string }).config = prev
     await clear(true)

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -403,6 +403,37 @@ test("migrates string-form global permission in jsonc without throwing", async (
   }
 })
 
+test("migrates string-form global permission in json without throwing", async () => {
+  await using globalTmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "kilo.json"),
+        JSON.stringify({
+          $schema: "https://app.kilo.ai/config.json",
+          permission: "allow",
+        }),
+      )
+    },
+  })
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear(true)
+
+  try {
+    await KilocodeConfig.migrateBashPermission()
+
+    const writtenConfig = await Filesystem.readJson<Config.Info>(path.join(globalTmp.path, "kilo.json"))
+    expect(writtenConfig.permission).toEqual({
+      "*": "allow",
+      bash: "allow",
+    })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear(true)
+  }
+})
+
 test("migrates object-form global permission in jsonc", async () => {
   await using globalTmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -4,6 +4,7 @@ import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { Config } from "@/config/config"
 import { ConfigManaged } from "@/config/managed"
 import { ConfigParse } from "../../src/config/parse"
+import { KilocodeConfig } from "../../src/kilocode/config/config"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 import { InstanceRef } from "../../src/effect/instance-ref"
@@ -365,6 +366,70 @@ test("updates global config and omits empty shell key in jsonc", async () => {
     expect(writtenConfig).not.toContain('"shell"')
     expect(parsed.shell).toBeUndefined()
     expect(parsed.model).toBe("test/model")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear(true)
+  }
+})
+
+test("migrates string-form global permission in jsonc without throwing", async () => {
+  await using globalTmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "kilo.jsonc"),
+        `{
+  "$schema": "https://app.kilo.ai/config.json",
+  "permission": "allow"
+}`,
+      )
+    },
+  })
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear(true)
+
+  try {
+    await KilocodeConfig.migrateBashPermission()
+
+    const file = path.join(globalTmp.path, "kilo.jsonc")
+    const writtenConfig = await Filesystem.readText(file)
+    const parsed = ConfigParse.schema(Config.Info.zod, ConfigParse.jsonc(writtenConfig, file), file)
+    expect(parsed.permission?.["*"]).toBe("allow")
+    expect(parsed.permission?.bash).toBe("allow")
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear(true)
+  }
+})
+
+test("migrates object-form global permission in jsonc", async () => {
+  await using globalTmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "kilo.jsonc"),
+        `{
+  "$schema": "https://app.kilo.ai/config.json",
+  "permission": {
+    "read": "allow"
+  }
+}`,
+      )
+    },
+  })
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear(true)
+
+  try {
+    await KilocodeConfig.migrateBashPermission()
+
+    const file = path.join(globalTmp.path, "kilo.jsonc")
+    const writtenConfig = await Filesystem.readText(file)
+    const parsed = ConfigParse.schema(Config.Info.zod, ConfigParse.jsonc(writtenConfig, file), file)
+    expect(parsed.permission?.read).toBe("allow")
+    expect(parsed.permission?.bash).toBe("allow")
   } finally {
     ;(Global.Path as { config: string }).config = prev
     await clear(true)

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { afterEach, describe, expect, test } from "bun:test"
 import { Effect, Layer, Option, Schema } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
@@ -12,6 +11,7 @@ import { Account } from "../../../src/account/account"
 import { Auth } from "../../../src/auth"
 import { Config } from "../../../src/config/config"
 import { ConfigMarkdown } from "../../../src/config/markdown"
+import { ConfigParse } from "../../../src/config/parse"
 import { Env } from "../../../src/env"
 import { KiloIndexing } from "../../../src/kilocode/indexing"
 import { KilocodeConfig } from "../../../src/kilocode/config/config"
@@ -397,6 +397,109 @@ describe("agent config", () => {
       expect(written).not.toContain('"model"')
       expect(written).not.toContain('"variant"')
       expect(written).toContain('"description": "Keep me"')
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+})
+
+describe("bash permission migration", () => {
+  test("migrates string-form global permission in jsonc without throwing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "kilo.jsonc"),
+          `{
+  "$schema": "https://app.kilo.ai/config.json",
+  "permission": "allow"
+}`,
+        )
+      },
+    })
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = tmp.path
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await KilocodeConfig.migrateBashPermission()
+
+      const file = path.join(tmp.path, "kilo.jsonc")
+      const text = await Filesystem.readText(file)
+      const parsed = ConfigParse.schema(Config.Info, ConfigParse.jsonc(text, file), file)
+      expect(parsed.permission?.["*"]).toBe("allow")
+      expect(parsed.permission?.bash).toBe("allow")
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+
+  test("migrates string-form global permission in json without throwing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "kilo.json"),
+          JSON.stringify({
+            $schema: "https://app.kilo.ai/config.json",
+            permission: "allow",
+          }),
+        )
+      },
+    })
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = tmp.path
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await KilocodeConfig.migrateBashPermission()
+
+      const parsed = await Filesystem.readJson<Config.Info>(path.join(tmp.path, "kilo.json"))
+      expect(parsed.permission).toEqual({
+        "*": "allow",
+        bash: "allow",
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+
+  test("migrates object-form global permission in jsonc", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "kilo.jsonc"),
+          `{
+  "$schema": "https://app.kilo.ai/config.json",
+  "permission": {
+    "read": "allow"
+  }
+}`,
+        )
+      },
+    })
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = tmp.path
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await KilocodeConfig.migrateBashPermission()
+
+      const file = path.join(tmp.path, "kilo.jsonc")
+      const text = await Filesystem.readText(file)
+      const parsed = ConfigParse.schema(Config.Info, ConfigParse.jsonc(text, file), file)
+      expect(parsed.permission?.read).toBe("allow")
+      expect(parsed.permission?.bash).toBe("allow")
     } finally {
       ;(Global.Path as { config: string }).config = prev
       await clear()

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -406,71 +406,71 @@ describe("agent config", () => {
 })
 
 describe("bash permission migration", () => {
-  test("migrates string-form global permission in jsonc without throwing", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Filesystem.write(
-          path.join(dir, "kilo.jsonc"),
-          `{
+  for (const action of ["allow", "ask", "deny"] as const) {
+    test(`preserves string-form ${action} permission in jsonc`, async () => {
+      const input = `{
   "$schema": "https://app.kilo.ai/config.json",
-  "permission": "allow"
-}`,
-        )
-      },
-    })
-
-    const prev = Global.Path.config
-    ;(Global.Path as { config: string }).config = tmp.path
-    await clear()
-    await disposeAllInstances()
-
-    try {
-      await KilocodeConfig.migrateBashPermission()
-
-      const file = path.join(tmp.path, "kilo.jsonc")
-      const text = await Filesystem.readText(file)
-      const parsed = ConfigParse.schema(Config.Info, ConfigParse.jsonc(text, file), file)
-      expect(parsed.permission?.["*"]).toBe("allow")
-      expect(parsed.permission?.bash).toBe("allow")
-    } finally {
-      ;(Global.Path as { config: string }).config = prev
-      await clear()
-      await disposeAllInstances()
-    }
-  })
-
-  test("migrates string-form global permission in json without throwing", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Filesystem.write(
-          path.join(dir, "kilo.json"),
-          JSON.stringify({
-            $schema: "https://app.kilo.ai/config.json",
-            permission: "allow",
-          }),
-        )
-      },
-    })
-
-    const prev = Global.Path.config
-    ;(Global.Path as { config: string }).config = tmp.path
-    await clear()
-    await disposeAllInstances()
-
-    try {
-      await KilocodeConfig.migrateBashPermission()
-
-      const parsed = await Filesystem.readJson<Config.Info>(path.join(tmp.path, "kilo.json"))
-      expect(parsed.permission).toEqual({
-        "*": "allow",
-        bash: "allow",
+  "permission": "${action}"
+}`
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Filesystem.write(path.join(dir, "kilo.jsonc"), input)
+        },
       })
-    } finally {
-      ;(Global.Path as { config: string }).config = prev
+
+      const prev = Global.Path.config
+      ;(Global.Path as { config: string }).config = tmp.path
       await clear()
       await disposeAllInstances()
-    }
-  })
+
+      try {
+        await KilocodeConfig.migrateBashPermission()
+
+        const file = path.join(tmp.path, "kilo.jsonc")
+        const text = await Filesystem.readText(file)
+        const parsed = ConfigParse.schema(Config.Info, ConfigParse.jsonc(text, file), file)
+        expect(text).toBe(input)
+        expect(parsed.permission?.["*"]).toBe(action)
+        expect(parsed.permission?.bash).toBeUndefined()
+      } finally {
+        ;(Global.Path as { config: string }).config = prev
+        await clear()
+        await disposeAllInstances()
+      }
+    })
+
+    test(`preserves string-form ${action} permission in json`, async () => {
+      const input = JSON.stringify({
+        $schema: "https://app.kilo.ai/config.json",
+        permission: action,
+      })
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Filesystem.write(path.join(dir, "kilo.json"), input)
+        },
+      })
+
+      const prev = Global.Path.config
+      ;(Global.Path as { config: string }).config = tmp.path
+      await clear()
+      await disposeAllInstances()
+
+      try {
+        await KilocodeConfig.migrateBashPermission()
+
+        const file = path.join(tmp.path, "kilo.json")
+        const text = await Filesystem.readText(file)
+        const parsed = ConfigParse.schema(Config.Info, ConfigParse.jsonc(text, file), file)
+        expect(text).toBe(input)
+        expect(parsed.permission?.["*"]).toBe(action)
+        expect(parsed.permission?.bash).toBeUndefined()
+      } finally {
+        ;(Global.Path as { config: string }).config = prev
+        await clear()
+        await disposeAllInstances()
+      }
+    })
+  }
 
   test("migrates object-form global permission in jsonc", async () => {
     await using tmp = await tmpdir({


### PR DESCRIPTION
## Summary
Fixes #10595.

Handle string-form `permission` values when migrating bash permissions from JSONC config files.

## Changes
- avoid writing nested `permission.bash` directly into a scalar JSONC permission node
- promote string-form permission values safely during migration
- add regression coverage for string-form and object-form permission migration

## Testing
- `bun test test/config/config.test.ts -t "migrates string-form global permission in jsonc without throwing"`
- `bun test test/config/config.test.ts -t "migrates object-form global permission in jsonc"`
- `bun test test/config/config.test.ts`
- `bun run typecheck`
- `git diff --check`