### PR TITLE
fix(cli): preserve context for queued plan prompts

### DIFF
--- a/.changeset/quiet-dancers-breathe.md
+++ b/.changeset/quiet-dancers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix queued plan prompts stalling in VS Code after a completed turn.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1443,11 +1443,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         yield* Effect.promise(() => Suggestion.dismissAll(input.sessionID))
         yield* question.dismissAll(input.sessionID)
         if (input.noReply === true) return message
+        // Queue tails and runner fibers can resume outside the HTTP request's
+        // ambient instance context; bridge both Effect refs and legacy ALS.
+        const bridge = yield* runner()
         return yield* KiloSessionPromptQueue.enqueue(
           input.sessionID,
           message.info.id,
-          loop({ sessionID: input.sessionID, snapshotInitialization: input.snapshotInitialization }), // kilocode_change
-          lastAssistant(input.sessionID),
+          bridge.run(loop({ sessionID: input.sessionID, snapshotInitialization: input.snapshotInitialization })), // kilocode_change
+          bridge.run(lastAssistant(input.sessionID)),
         )
         // kilocode_change end
       },

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -2,9 +2,12 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Bus } from "../../src/bus"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { InstanceRef } from "../../src/effect/instance-ref"
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
 import { Suggestion } from "../../src/kilocode/suggestion"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { InstanceStore } from "../../src/project/instance-store"
 import { WithInstance } from "../../src/project/with-instance"
 import { Session } from "../../src/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -509,6 +512,77 @@ describe("session prompt queue", () => {
             expect(JSON.stringify(tail?.content)).toContain("second prompt")
           }),
       })
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  test("bridges legacy instance context for prompts after a completed turn", async () => {
+    const calls: number[] = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+
+        calls.push(Date.now())
+        const text = calls.length === 1 ? "first reply" : "second reply"
+        return new Response(reply({ text }), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: { apiKey: "test-key", baseURL: `${server.url.origin}/v1` },
+                },
+              },
+              agent: { plan: { model: "alibaba/qwen-plus" } },
+            }),
+          )
+        },
+      })
+
+      const ctx = await AppRuntime.runPromise(InstanceStore.Service.use((store) => store.load({ directory: tmp.path })))
+      const session = await AppRuntime.runPromise(
+        Session.Service.use((svc) => svc.create({ title: "Sequential prompt context regression" })).pipe(
+          Effect.provideService(InstanceRef, ctx),
+        ),
+      )
+
+      const first = await AppRuntime.runPromise(
+        SessionPrompt.Service.use((prompt) =>
+          prompt.prompt({
+            sessionID: session.id,
+            agent: "plan",
+            parts: [{ type: "text", text: "first prompt" }],
+          }),
+        ).pipe(Effect.provideService(InstanceRef, ctx)),
+      )
+      const second = await AppRuntime.runPromise(
+        SessionPrompt.Service.use((prompt) =>
+          prompt.prompt({
+            sessionID: session.id,
+            agent: "plan",
+            parts: [{ type: "text", text: "second prompt" }],
+          }),
+        ).pipe(Effect.provideService(InstanceRef, ctx)),
+      )
+
+      expect(calls).toHaveLength(2)
+      expect(hasText(first, "first reply")).toBe(true)
+      expect(hasText(second, "second reply")).toBe(true)
     } finally {
       server.stop(true)
     }


### PR DESCRIPTION
## Issue

No linked issue. Exception: diagnosed from a live stuck session where queued Plan prompts were persisted but immediately failed with `No context found for instance`.

## Context

Queued follow-up prompts in the VS Code backend could resume outside the request's legacy instance context after a completed turn. This made Plan-agent follow-ups appear accepted by the UI while the agent immediately returned to idle without producing an assistant response.

## Implementation

The queued prompt work now runs through `EffectBridge`, preserving both Effect refs and the legacy AsyncLocalStorage context used by Kilo-specific Plan prompt code. A regression test covers two sequential Plan prompts under the effect HTTP API-style context where only `InstanceRef` is initially provided.

## Screenshots / Video

N/A, no visual changes.

| before | after |
|---|---|
| N/A | N/A |

## How to Test

### Manual/local verification

- Agent ran `bun test ./test/kilocode/session-prompt-queue.test.ts` from `packages/opencode/`.
- Agent ran `bun run typecheck` from `packages/opencode/`.
- Agent ran `bun run script/check-opencode-annotations.ts` from the repo root.
- Agent ran `bun turbo typecheck` from the repo root via the pre-push hook.

### Reviewer test steps

1. Start the VS Code backend from this branch.
2. Open a session using the Plan agent.
3. Send a prompt and wait for the assistant to finish.
4. Send a follow-up prompt in the same session.
5. Confirm the follow-up produces an assistant response and the backend log does not show `No context found for instance`.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A.