### PR TITLE
fix(kilo-docs): use stable external links

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/openrouter.md
+++ b/packages/kilo-docs/pages/ai-providers/openrouter.md
@@ -70,7 +70,7 @@ Then set your default model:
 
 ## Supported Transforms
 
-OpenRouter provides an [optional "middle-out" message transform](https://openrouter.ai/docs/features/message-transforms) to help with prompts that exceed the maximum context size of a model.
+OpenRouter provides an [optional "middle-out" message transform](https://openrouter.ai/docs/guides/features/message-transforms) to help with prompts that exceed the maximum context size of a model.
 
 {% tabs %}
 {% tab label="VSCode & CLI" %}

--- a/packages/kilo-docs/pages/code-with-ai/platforms/mobile.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/mobile.md
@@ -8,7 +8,7 @@ description: "Using Kilo Code on iOS and Android"
 Use Kilo Code from your phone to keep coding sessions moving while you are away from your desk. The mobile app connects to Cloud Agents, KiloClaw, and remote sessions from your local CLI or editor extensions.
 
 {% callout type="info" title="Android app available now" %}
-Install Kilo Code for Android from [Google Play](https://kilocode.onelink.me/ZzZZ/r10ni4zy).
+Install Kilo Code for Android from [Google Play](https://play.google.com/store/apps/details?id=com.kilocode.kiloapp).
 {% /callout %}
 
 ## What you can do
@@ -39,7 +39,7 @@ The mobile app lets you:
 
 The Android app is available now on Google Play.
 
-[Install the Android app →](https://kilocode.onelink.me/ZzZZ/r10ni4zy)
+[Install the Android app →](https://play.google.com/store/apps/details?id=com.kilocode.kiloapp)
 
 ## iOS App
 

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -146,7 +146,7 @@
   <!-- packages/opencode/src/cli/cmd/tui/config/tui-migrate.ts -->
 - <https://opencode.ai/zen>
   <!-- packages/kilo-vscode/webview-ui/src/i18n/en.ts -->
-- <https://openrouter.ai/docs/use-cases/usage-accounting>
+- <https://openrouter.ai/docs/cookbook/administration/usage-accounting>
   <!-- packages/opencode/src/kilocode/session/index.ts -->
 - <https://opentelemetry.io/blog/2025/how-to-name-your-span-attributes/>
   <!-- packages/opencode/src/server/routes/instance/trace.ts -->

--- a/packages/opencode/src/kilocode/session/index.ts
+++ b/packages/opencode/src/kilocode/session/index.ts
@@ -169,7 +169,7 @@ export namespace KiloSession {
    * Returns `undefined` when no provider cost is available, so the caller
    * should fall back to the standard token-based calculation.
    *
-   * Reference: https://openrouter.ai/docs/use-cases/usage-accounting
+   * Reference: https://openrouter.ai/docs/cookbook/administration/usage-accounting
    */
   export function providerCost(input: {
     metadata?: ProviderMetadata


### PR DESCRIPTION
Documentation link checks intermittently fail because legacy OpenRouter routes and the AppsFlyer Android short link add redirect hops that can time out in CI.

Use canonical OpenRouter documentation URLs and link Android installs directly to Google Play. Regenerate the extracted source-link inventory so validation checks the canonical usage-accounting page as well.