### PR TITLE
fix: correct architect use of plan exit to save the plan file correctly

### DIFF
--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -16,6 +16,7 @@ import { Permission } from "@/permission"
 import { environmentDetails, type EditorContext } from "@/kilocode/editor-context"
 import { Identifier } from "@/id/id"
 import { Filesystem } from "@/util/filesystem"
+import { InstanceState } from "@/effect/instance-state"
 import PROMPT_PLAN from "@/session/prompt/plan.txt"
 import CODE_SWITCH from "@/session/prompt/code-switch.txt"
 
@@ -48,7 +49,8 @@ export namespace KiloSessionPrompt {
     abort: AbortSignal
   }): Promise<"continue" | "break"> {
     if (!shouldAskPlanFollowup({ messages: input.messages, abort: input.abort })) return "break"
-    const action = await PlanFollowup.ask({
+    const ask = InstanceState.bind(PlanFollowup.ask)
+    const action = await ask({
       sessionID: input.sessionID,
       messages: input.messages,
       abort: input.abort,
@@ -227,23 +229,29 @@ export namespace KiloSessionPrompt {
    * Ensures the plan file directory exists and tells the agent where to write.
    */
   export async function insertPlanReminders(input: {
-    agent: { name: string }
+    agent: { name: string; options?: Record<string, unknown> }
     session: Session.Info
     userMessage: MessageV2.WithParts
   }) {
-    if (input.agent.name !== "plan") return
-    const plan = Session.plan(input.session, Instance.current)
+    if (input.agent.name !== "plan" && input.agent.options?.id !== "architect") return
+    // keep bind(): inside Effect.promise the project context is lost, so Instance.current throws without it
+    const plan = InstanceState.bind(() => Session.plan(input.session, Instance.current))()
     const exists = await Filesystem.exists(plan)
     if (!exists) await ensurePlanDir(path.dirname(plan))
     const info = exists
       ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.`
       : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`
+    const planFile = `## Plan File\n${info}\nThis is the ONLY file you are allowed to write to or edit.`
+    const text =
+      input.agent.name === "plan"
+        ? `${PROMPT_PLAN}\n\n${planFile}`
+        : `<system-reminder>\n${planFile} Before writing this file or calling plan_exit, ask the user to choose exactly one of: "Finalize and save the plan" or "Continue refining". If the user chooses to finalize, write the complete plan to this exact file, then call plan_exit with no arguments.\n</system-reminder>`
     input.userMessage.parts.push({
       id: PartID.ascending(),
       messageID: input.userMessage.info.id,
       sessionID: input.userMessage.info.sessionID,
       type: "text",
-      text: PROMPT_PLAN + `\n\n## Plan File\n${info}\nThis is the ONLY file you are allowed to write to or edit.`,
+      text,
       synthetic: true,
     })
   }

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -241,11 +241,15 @@ export namespace KiloSessionPrompt {
     const info = exists
       ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.`
       : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`
-    const planFile = `## Plan File\n${info}\nThis is the ONLY file you are allowed to write to or edit.`
+    const limit =
+      input.agent.name === "plan"
+        ? "This is the ONLY file you are allowed to write to or edit."
+        : "Use this as the main plan file to write or edit. Do not write or edit other files unless the user explicitly asks and your permissions allow it."
+    const planFile = `## Plan File\n${info}\n${limit}`
     const text =
       input.agent.name === "plan"
         ? `${PROMPT_PLAN}\n\n${planFile}`
-        : `<system-reminder>\n${planFile} Before writing this file or calling plan_exit, ask the user to choose exactly one of: "Finalize and save the plan" or "Continue refining". If the user chooses to finalize, write the complete plan to this exact file, then call plan_exit with no arguments.\n</system-reminder>`
+        : `<system-reminder>\n${planFile} Before writing this file or calling plan_exit, ask the user to choose exactly one of: "Finalize and save the plan" or "Continue refining". If the user chooses to finalize, write the main plan to this exact file, then call plan_exit with no arguments. If the user explicitly asks for additional plan files and your permissions allow it, you may create them and reference them from the main plan.\n</system-reminder>`
     input.userMessage.parts.push({
       id: PartID.ascending(),
       messageID: input.userMessage.info.id,


### PR DESCRIPTION
## Issue

N/A

## Context

Fix CLI plan follow-up after plan_exit for Architect/plan-style flows. The plan file was saved successfully, but the CLI could stop without showing the “Ready to implement?” prompt when the follow-up needed to read the saved plan file.

## Implementation

Bind the Kilo-owned plan follow-up entrypoint before running the async follow-up flow. This preserves the active instance context across the Effect.promise boundary, so PlanFollowup.ask can still resolve the saved plan path when it falls back to reading the plan file from disk.
Kept the fix in Kilo-owned code instead of changing shared opencode logic.

## Screenshots / Video

<img width="1535" height="1058" alt="Screenshot 2026-06-01 at 21 32 50" src="https://github.com/user-attachments/assets/071977e7-59ac-4b3a-bfc4-88c01ce1745e" />

<img width="1201" height="862" alt="Screenshot 2026-06-01 at 21 34 19" src="https://github.com/user-attachments/assets/cca90b68-8345-4e9b-949b-d75b15786cce" />


## How to Test 

### Reviewer test steps

- Tested different scenarios on the architect agent to build a plan and continue implementation on a new session
- Tested CLI and Extension
