### PR TITLE
fix(vscode): sort permission exceptions

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
@@ -48,6 +48,7 @@ export function permissionExceptions(
   return Object.entries(rule)
     .filter(([key, action]) => key !== "*" && action !== null)
     .map(([pattern, action]) => ({ pattern, action: action as PermissionLevel }))
+    .sort((a, b) => a.pattern.localeCompare(b.pattern))
 }
 
 export function setGroupedPatch(ids: string[], level: PermissionLevel): PermissionPatch {


### PR DESCRIPTION
## Context

Auto-Approve permission exception lists can become hard to scan when users add many command patterns. This makes it difficult to locate a specific permission, especially in the Bash commands exceptions list.

## Implementation

Sort permission exceptions by their pattern before rendering them. This keeps Bash command exceptions such as `git status` before `npm install`, and applies the same predictable ordering to the other granular permission exception lists.

## Screenshots / Video

Before

<img width="905" height="963" alt="before-sorting" src="https://github.com/user-attachments/assets/b1d581bf-5629-4585-b61b-1391291a14af" />

After


https://github.com/user-attachments/assets/92a0a7cf-7eb4-4a6e-bae0-2d8b986885c6




## How to Test

### Manual/local verification

- Agent executed `bun run typecheck` from `packages/kilo-vscode/` successfully.
- Push hook executed `bun turbo typecheck` successfully.

### Reviewer test steps

1. Open Kilo Settings.
2. Navigate to Auto-Approve.
3. Add multiple Bash command exceptions, for example `npm install` and `git status`.
4. Confirm the Exceptions list is ordered alphabetically by command pattern.

