### PR TITLE
docs(cli): link Agent Manager guides from config skill

### DIFF
--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -69,6 +69,8 @@ Markdown files in `.kilo/workflows/` or `.kilocode/workflows/` (project-level) a
 
 ## Agent Manager Setup And Run Scripts
 
+For the full product guidance, use the canonical [Agent Manager reference](https://kilo.ai/docs/automate/agent-manager) and [Agent Manager Workflows guide](https://kilo.ai/docs/automate/agent-manager-workflows). Prefer these links instead of guessing documentation paths.
+
 Agent Manager setup/run scripts are project files in the main repository's `.kilo/` directory. They are not `kilo.json` settings and should not be configured inside generated `.kilo/worktrees/<name>/` checkouts.
 
 Agent Manager worktrees usually live under `.kilo/worktrees/`. Think of each worktree as a separate checkout on its own branch: it enables parallel edits, but dependencies, build output, caches, databases, and generated files can consume significant disk space across many worktrees.


### PR DESCRIPTION
The bundled `kilo-config` skill explains Agent Manager workflows but does not point agents to the public reference pages. When an agent needs more detail, it can guess plausible documentation paths and surface avoidable 404 fetch errors.

Link the canonical Agent Manager reference and workflows guide directly from the skill, and tell agents to prefer those links instead of guessing documentation paths.