### PR TITLE
fix(vscode): defer collapsed historical tool details

### DIFF
--- a/.changeset/vscode-lazy-historical-tool-details.md
+++ b/.changeset/vscode-lazy-historical-tool-details.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Speed up Agent Manager switching for edit-heavy sessions by rendering collapsed historical tool details only when expanded.
+Speed up Agent Manager switching for long sessions by lazily mounting collapsed historical tool details and sharing timeline hover infrastructure across activity bars.

--- a/.changeset/vscode-lazy-historical-tool-details.md
+++ b/.changeset/vscode-lazy-historical-tool-details.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Speed up Agent Manager switching for edit-heavy sessions by rendering collapsed historical tool details only when expanded.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2293,6 +2293,7 @@ ToolRegistry.register({
           {...props}
           icon="code-lines"
           defer
+          hasDetails
           trigger={
             <div data-component="edit-trigger">
               <div data-slot="message-part-title-area">
@@ -2407,6 +2408,7 @@ ToolRegistry.register({
           {...props}
           icon="code-lines"
           defer
+          hasDetails
           trigger={
             <div data-component="write-trigger">
               <div data-slot="message-part-title-area">
@@ -2539,6 +2541,7 @@ ToolRegistry.register({
           {...props}
           icon="code-lines"
           defer
+          hasDetails
           trigger={
             <div data-component={single() ? "edit-trigger" : "write-trigger"}>
               <div data-slot="message-part-title-area">

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2189,6 +2189,11 @@ ToolRegistry.register({
     const subtitle = () => props.input.description ?? props.metadata.description
     const key = () => toolOpenKey(props)
     const [open, setOpen] = createSignal(readToolOpen(key(), props.defaultOpen ?? true) ?? true)
+    const [mounted, setMounted] = createSignal(open())
+
+    createEffect(() => {
+      if (open() || pending()) setMounted(true)
+    })
 
     // also apply processCarriageReturns for Windows CLI tools
     const cmd = createMemo(() => {
@@ -2208,6 +2213,7 @@ ToolRegistry.register({
         {...props}
         icon="console"
         animated
+        hasDetails
         defaultOpen={props.defaultOpen ?? true}
         onOpenChange={setOpen}
         allowPendingToggle
@@ -2222,7 +2228,9 @@ ToolRegistry.register({
           </div>
         }
       >
-        <BashHighlightedOutput cmd={cmd()} output={out()} outputPath={props.metadata.outputPath} active={open()} />
+        <Show when={mounted()}>
+          <BashHighlightedOutput cmd={cmd()} output={out()} outputPath={props.metadata.outputPath} active={open()} />
+        </Show>
       </BasicTool>
     )
   },

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -301,4 +301,13 @@ describe("Collapsed deferred tool details contract (source)", () => {
       expect(block).toContain("hasDetails")
     }
   })
+
+  it("lazy-mounts completed bash output and retains it after first expansion", () => {
+    const block =
+      message.match(/ToolRegistry\.register\(\{\s*name:\s*"bash"[\s\S]*?(?=ToolRegistry\.register\(|$)/)?.[0] ?? ""
+    expect(block).toContain("const [mounted, setMounted] = createSignal(open())")
+    expect(block).toMatch(/if \(open\(\) \|\| pending\(\)\) setMounted\(true\)/)
+    expect(block).toContain("hasDetails")
+    expect(block).toMatch(/<Show when=\{mounted\(\)\}>[\s\S]*?<BashHighlightedOutput/)
+  })
 })

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -19,6 +19,7 @@ import path from "node:path"
 
 const MONOREPO_ROOT = path.resolve(import.meta.dir, "../../../..")
 const KILO_UI_DIR = path.join(MONOREPO_ROOT, "packages/kilo-ui")
+const BASIC_TOOL_FILE = path.join(MONOREPO_ROOT, "packages/ui/src/components/basic-tool.tsx")
 const DATA_CONTEXT_FILE = path.join(MONOREPO_ROOT, "packages/ui/src/context/data.tsx")
 const MESSAGE_PART_FILE = path.join(MONOREPO_ROOT, "packages/ui/src/components/message-part.tsx")
 const KILO_MESSAGE_PART_FILE = path.join(MONOREPO_ROOT, "packages/kilo-ui/src/components/message-part.tsx")
@@ -277,5 +278,27 @@ describe("BasicTool export contract (runtime)", () => {
       process.exit(0)
     `)
     expect(result.ok, `BasicTool export check failed: ${result.output}`).toBe(true)
+  })
+})
+
+describe("Collapsed deferred tool details contract (source)", () => {
+  const basic = fs.readFileSync(BASIC_TOOL_FILE, "utf-8")
+  const message = fs.readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")
+
+  it("uses an explicit details hint before touching deferred children", () => {
+    expect(basic).toContain("hasDetails?: boolean")
+    expect(basic).toContain("props.hasDetails ?? !!props.children")
+    expect(basic).toMatch(/<Show when=\{!props\.defer \|\| ready\(\)\}>\{props\.children\}<\/Show>/)
+  })
+
+  it("opts edit-family transcript cards into collapsed lazy details", () => {
+    for (const name of ["edit", "write", "apply_patch"]) {
+      const block =
+        message.match(
+          new RegExp(`ToolRegistry\\.register\\(\\{\\s*name:\\s*"${name}"[\\s\\S]*?(?=ToolRegistry\\.register\\(|$)`),
+        )?.[0] ?? ""
+      expect(block).toContain("defer")
+      expect(block).toContain("hasDetails")
+    }
   })
 })

--- a/packages/kilo-vscode/tests/unit/task-timeline-tooltip.test.ts
+++ b/packages/kilo-vscode/tests/unit/task-timeline-tooltip.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+/**
+ * Regression guard for timeline tooltip mount cost.
+ *
+ * A long session can render hundreds of timeline bars. Wrapping every bar in
+ * the shared Tooltip component creates a Kobalte tooltip instance and
+ * MutationObserver per bar during session activation. The timeline keeps all
+ * bars but delegates hover handling to one portal tooltip instead.
+ */
+describe("TaskTimeline delegated tooltip contract", () => {
+  const path = join(__dirname, "..", "..", "webview-ui", "src", "components", "chat", "TaskTimeline.tsx")
+  const src = readFileSync(path, "utf8")
+
+  it("does not mount one shared Tooltip component per timeline bar", () => {
+    expect(src).not.toMatch(/@kilocode\/kilo-ui\/tooltip/)
+    expect(src).not.toMatch(/<Tooltip\b/)
+  })
+
+  it("keeps bar labels and renders one delegated portal tooltip", () => {
+    expect(src).toMatch(/data-tip=\{bar\(\)\.tip\}/)
+    expect(src).toMatch(/role="img"/)
+    expect(src).toMatch(/aria-label=\{bar\(\)\.tip\}/)
+    expect(src).toMatch(/if \(!bar \|\| !ref\?\.contains\(bar\)\) return hideTip\(\)/)
+    expect(src).toMatch(/<Portal>/)
+    expect(src).toMatch(/class="task-timeline-tooltip"/)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -12,8 +12,8 @@
  * updates bindings in place (unlike React). Even 1000+ bars are fine.
  */
 
-import { Component, Index, createMemo, createEffect, on, onCleanup } from "solid-js"
-import { Tooltip } from "@kilocode/kilo-ui/tooltip"
+import { Component, Index, Show, createMemo, createEffect, createSignal, on, onCleanup } from "solid-js"
+import { Portal } from "solid-js/web"
 import { useSession } from "../../context/session"
 import { color, label } from "../../utils/timeline/colors"
 import { sizes, MAX_HEIGHT } from "../../utils/timeline/sizes"
@@ -56,6 +56,8 @@ export const TaskTimeline: Component = () => {
   let dragging = false
   let startX = 0
   let startScroll = 0
+  let tipBar: HTMLElement | undefined
+  const [tip, setTip] = createSignal<{ text: string; x: number; y: number }>()
 
   const messages = () => session.visibleMessages()
   const allParts = () => {
@@ -85,8 +87,31 @@ export const TaskTimeline: Component = () => {
     ),
   )
 
+  const hideTip = () => {
+    tipBar = undefined
+    setTip(undefined)
+  }
+
+  createEffect(on(bars, hideTip, { defer: true }))
+
+  const showTip = (e: PointerEvent) => {
+    if (dragging || !(e.target instanceof Element)) return
+    const bar = e.target.closest<HTMLElement>(".task-timeline-bar")
+    if (!bar || !ref?.contains(bar)) return hideTip()
+    if (bar === tipBar) return
+    const rect = bar.getBoundingClientRect()
+    tipBar = bar
+    const margin = Math.min(160, window.innerWidth / 2)
+    setTip({
+      text: bar.dataset.tip ?? "",
+      x: Math.max(margin, Math.min(window.innerWidth - margin, rect.left + rect.width / 2)),
+      y: rect.top,
+    })
+  }
+
   // ── Drag scroll ──────────────────────────────────────────────────
   const onPointerDown = (e: PointerEvent) => {
+    hideTip()
     if (!ref) return
     dragging = true
     startX = e.clientX
@@ -97,7 +122,7 @@ export const TaskTimeline: Component = () => {
   }
 
   const onPointerMove = (e: PointerEvent) => {
-    if (!dragging || !ref) return
+    if (!dragging || !ref) return showTip(e)
     ref.scrollLeft = startScroll - (e.clientX - startX)
   }
 
@@ -111,6 +136,7 @@ export const TaskTimeline: Component = () => {
 
   // ── Wheel → horizontal scroll ────────────────────────────────────
   const onWheel = (e: WheelEvent) => {
+    hideTip()
     if (!ref) return
     e.preventDefault()
     ref.scrollLeft += e.deltaY || e.deltaX
@@ -124,23 +150,27 @@ export const TaskTimeline: Component = () => {
   })
 
   return (
-    <div class="task-timeline-outer">
-      <div
-        ref={ref}
-        class="task-timeline"
-        style={{ height: `${MAX_HEIGHT}px` }}
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-      >
-        <Index each={bars()}>
-          {(bar) => {
-            const active = () => busy() && bar().idx === bars().length - 1
-            return (
-              <Tooltip value={bar().tip} placement="top">
+    <>
+      <div class="task-timeline-outer">
+        <div
+          ref={ref}
+          class="task-timeline"
+          style={{ height: `${MAX_HEIGHT}px` }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onPointerLeave={hideTip}
+        >
+          <Index each={bars()}>
+            {(bar) => {
+              const active = () => busy() && bar().idx === bars().length - 1
+              return (
                 <div
                   class="task-timeline-bar"
+                  data-tip={bar().tip}
+                  role="img"
+                  aria-label={bar().tip}
                   style={{
                     width: `${bar().width}px`,
                     height: `${MAX_HEIGHT}px`,
@@ -157,11 +187,25 @@ export const TaskTimeline: Component = () => {
                     }}
                   />
                 </div>
-              </Tooltip>
-            )
-          }}
-        </Index>
+              )
+            }}
+          </Index>
+        </div>
       </div>
-    </div>
+      <Show when={tip()}>
+        {(current) => (
+          <Portal>
+            <div
+              data-component="tooltip"
+              class="task-timeline-tooltip"
+              role="tooltip"
+              style={{ left: `${current().x}px`, top: `${current().y}px` }}
+            >
+              {current().text}
+            </div>
+          </Portal>
+        )}
+      </Show>
+    </>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -169,6 +169,7 @@
   max-width: min(320px, calc(100vw - 16px));
   transform: translate(-50%, calc(-100% - 4px));
   white-space: normal;
+  pointer-events: none;
 }
 
 @keyframes timeline-fade-in {

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -164,6 +164,13 @@
   animation: timeline-pulse 2s ease-in-out infinite 0.5s;
 }
 
+.task-timeline-tooltip {
+  position: fixed;
+  max-width: min(320px, calc(100vw - 16px));
+  transform: translate(-50%, calc(-100% - 4px));
+  white-space: normal;
+}
+
 @keyframes timeline-fade-in {
   from {
     opacity: 0;

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -31,6 +31,7 @@ export interface BasicToolProps {
   defaultOpen?: boolean
   forceOpen?: boolean
   defer?: boolean
+  hasDetails?: boolean // kilocode_change
   locked?: boolean
   animated?: boolean
   allowPendingToggle?: boolean // kilocode_change
@@ -51,6 +52,7 @@ export function BasicTool(props: BasicToolProps) {
   const open = () => state.open
   const ready = () => state.ready
   const pending = () => props.status === "pending" || props.status === "running"
+  const hasDetails = () => props.hasDetails ?? !!props.children // kilocode_change
 
   let frame: number | undefined
 
@@ -199,7 +201,7 @@ export function BasicTool(props: BasicToolProps) {
         </div>
       </div>
       {/* kilocode_change start */}
-      <Show when={props.children && !props.hideDetails && !props.locked && (!pending() || props.allowPendingToggle)}>
+      <Show when={hasDetails() && !props.hideDetails && !props.locked && (!pending() || props.allowPendingToggle)}>
         <Collapsible.Arrow />
       </Show>
       {/* kilocode_change end */}
@@ -243,11 +245,13 @@ export function BasicTool(props: BasicToolProps) {
           {props.children}
         </div>
       </Show>
-      <Show when={!props.animated && props.children && !props.hideDetails}>
+      {/* kilocode_change start */}
+      <Show when={!props.animated && hasDetails() && !props.hideDetails}>
         <Collapsible.Content>
           <Show when={!props.defer || ready()}>{props.children}</Show>
         </Collapsible.Content>
       </Show>
+      {/* kilocode_change end */}
     </Collapsible>
   )
 }


### PR DESCRIPTION
VsCode/AM session switching becomes noticeably slower after a session accumulates many edit, write, or apply-patch tool calls. Even when those historical cards are collapsed, checking whether they have details can instantiate their inline diff children before the deferred content gate removes them. Edit-heavy transcripts therefore perform unnecessary diff rendering and syntax-highlighting work while becoming active.

Add an explicit details hint to the shared tool card primitive and opt the edit-family cards into it. Collapsed historical cards now render their headers and expansion affordances without touching inline diff children. Expanding a card still mounts its deferred details on demand, while tools that do not opt into the hint preserve their existing behavior.

The behavior was profiled in a prepared Agent Manager fixture with a session containing 49 historical edit cards. The review panel remained closed so the measurement isolates chat transcript activation rather than the standalone review surface. Profiles were captured from the Agent Manager webview renderer while switching from a lighter session into the edit-heavy session.

| Scenario | Before | After | Improvement |
|---|---:|---:|---:|
| Cold activation, longest blocking task | 619 ms | 172 ms | 72% lower |
| Cold activation, transient DOM nodes created | 48,524 | 7,769 | 84% lower |
| Cold activation, script duration | 1,619 ms | 304 ms | 81% lower |
| Repeated warm activation, longest blocking task | 399-440 ms | 159 ms | 60-64% lower |
| Repeated warm activation, transient DOM nodes created | 21,063 | 5,384 | 74% lower |
| Repeated warm activation, script duration | 1,052 ms | 106 ms | 90% lower |

Before this change, collapsed-session switches spent time in inline diff and syntax-highlighting paths such as `findNextMatchSync`, `applyHunksToDOM`, and `getOrCreateFileContainer`. Those collapsed-diff hotspots disappear after the change. The optimized transcript still renders all 49 historical edit headers immediately, but mounts zero inline edit bodies until a card is explicitly expanded.

Add a contract check for the lazy-details hook and the edit-family registrations, plus a patch changeset for the Agent Manager switching improvement.