### PR TITLE
fix(cli): surface empty provider responses as retryable errors

### DIFF
--- a/.changeset/retry-empty-provider-responses.md
+++ b/.changeset/retry-empty-provider-responses.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Surface empty provider responses as retryable errors instead of ending active tasks without a summary.

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -25,6 +25,8 @@ export namespace KiloSessionProcessor {
     "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
   export const PROVIDER_FINISH_ERROR_MESSAGE =
     "The provider ended the response with an error before returning details. Start a new message to retry; Kilo will compact the oversized conversation first if needed."
+  export const EMPTY_PROVIDER_RESPONSE_MESSAGE =
+    "The provider ended the response without returning output. Start a new message to retry; Kilo will compact the oversized conversation first if needed."
 
   export function reviewTelemetry(command: string | undefined): ReviewTelemetry | undefined {
     if (!isReviewCommand(command)) return
@@ -209,15 +211,25 @@ export namespace KiloSessionProcessor {
     return OUTPUT_LENGTH_WARNING
   }
 
-  export function providerFinishError(msg: MessageV2.Assistant) {
-    if (msg.finish !== "error") return false
+  export function providerFinishError(
+    msg: MessageV2.Assistant,
+    step?: { reasoning: boolean; text: boolean; tool: boolean },
+  ) {
+    const empty =
+      msg.finish === "other" &&
+      msg.tokens.output === 0 &&
+      step &&
+      !step.reasoning &&
+      !step.text &&
+      !step.tool
+    if (msg.finish !== "error" && !empty) return false
     if (msg.error) return false
     const err = new MessageV2.APIError({
-      message: PROVIDER_FINISH_ERROR_MESSAGE,
+      message: empty ? EMPTY_PROVIDER_RESPONSE_MESSAGE : PROVIDER_FINISH_ERROR_MESSAGE,
       isRetryable: true,
     }).toObject()
     msg.error = err
-    log.warn("provider finish error", { messageID: msg.id })
+    log.warn(empty ? "empty provider response" : "provider finish error", { messageID: msg.id })
     return err
   }
 }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -602,7 +602,7 @@ export const layer: Layer.Layer<
                 ignored: true,
               })
             }
-            const providerError = KiloSessionProcessor.providerFinishError(ctx.assistantMessage)
+            const providerError = KiloSessionProcessor.providerFinishError(ctx.assistantMessage, ctx.step)
             if (providerError) {
               yield* bus.publish(Session.Event.Error, {
                 sessionID: ctx.assistantMessage.sessionID,

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -338,6 +338,154 @@ describe("session processor empty tool-calls", () => {
     ),
   )
 
+  it.effect("treats empty provider responses with other finish as retryable API errors", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "other",
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          const result = yield* handle.process(input)
+          expect(result).toBe("stop")
+          expect(handle.message.finish).toBe("other")
+          expect(handle.message.error?.name).toBe("APIError")
+          if (handle.message.error?.name !== "APIError") return
+          expect(handle.message.error.data.isRetryable).toBe(true)
+          expect(handle.message.error.data.message).toContain("without returning output")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.effect("preserves other finish when provider returns visible output", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "text-start", id: "text", providerMetadata: undefined } as LLM.Event,
+            { type: "text-delta", id: "text", text: "answer", providerMetadata: undefined } as LLM.Event,
+            { type: "text-end", id: "text", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "other",
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          const result = yield* handle.process(input)
+          expect(result).toBe("continue")
+          expect(handle.message.finish).toBe("other")
+          expect(handle.message.error).toBeUndefined()
+        }),
+      { git: true },
+    ),
+  )
+
   it.effect("adds generic warning when model stops after text length finish", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
Provider streams can close cleanly without emitting content or a recognized finish reason. The provider SDK represents that shape as `finish: other`, and the CLI previously accepted it as a completed turn. Active tasks could therefore stop abruptly without producing a final response or summary.

This change routes the exact empty `other` shape through the existing provider-finish recovery path:

- Surface a retryable API error when a step reports zero output tokens and emits no text, reasoning, or tool activity.
- Preserve provider-specific `other` completions when they contain visible output, even if usage metadata is missing.
- Keep the substantive behavior in Kilo-owned processor code with only a one-line extension to the shared processor hook.

The patch changeset records the user-visible recovery behavior for release notes.