### PR TITLE
refactor(vscode): extract editor actions from KiloProvider

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1,7 +1,5 @@
 import * as path from "path"
 import * as vscode from "vscode"
-import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "./image-preview"
-import { isAbsolutePath } from "./path-utils"
 import type {
   KiloClient,
   Session,
@@ -17,6 +15,7 @@ import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreCo
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
 import { buildWebviewHtml, getWebviewFontSize } from "./utils"
 import { saveImage } from "./kilo-provider/save-image"
+import { handleEditorAction } from "./kilo-provider/editor-actions"
 import { exportTranscript } from "./kilo-provider/export-transcript"
 import {
   TelemetryProxy,
@@ -778,9 +777,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "refreshProfile":
           await handleRefreshProfile(this.authCtx)
           break
-        case "openExternal":
-          this.openExternal(message.url)
-          break
         case "openSettingsPanel":
           vscode.commands.executeCommand("kilo-code.new.settingsButtonClicked", message.tab)
           break
@@ -792,9 +788,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "openMarketplacePanel":
           vscode.commands.executeCommand("kilo-code.new.marketplaceButtonClicked", this.projectDirectory)
-          break
-        case "openDiffVirtual":
-          this.openDiffVirtual(message.diff, message.initialDiffStyle)
           break
         case "forkSession":
           handleForkSession(this.forkCtx, message.sessionId, message.messageId).catch((e) =>
@@ -809,9 +802,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "openSubAgentViewer":
           vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
-          break
-        case "previewImage":
-          this.handlePreviewImage(message.dataUrl, message.filename)
           break
         case "saveImage":
           return saveImage(this.getWorkspaceDirectory(this.currentSession?.id), message)
@@ -1153,16 +1143,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webviewMessageDisposable = watchFontSizeConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
   }
 
-  private openExternal(url: unknown): void {
-    if (typeof url !== "string") return
-    void vscode.env.openExternal(vscode.Uri.parse(url))
-  }
-
-  private openDiffVirtual(diff: unknown, initialDiffStyle?: unknown): void {
-    if (!this.diffVirtualProvider || !diff) return
-    const d = diff as import("./DiffVirtualProvider").DiffVirtualFile
-    d.initialDiffStyle = initialDiffStyle === "split" ? "split" : "unified"
-    this.diffVirtualProvider.open(d)
+  private handleEditorOpenMessage(message: Parameters<typeof handleEditorAction>[0]): boolean {
+    return handleEditorAction(message, {
+      dir: () => this.getWorkspaceDirectory(this.currentSession?.id),
+      diff: this.diffVirtualProvider,
+      storage: this.extensionContext?.globalStorageUri,
+    })
   }
 
   private async handleFetchMarketplaceData(): Promise<void> {
@@ -2938,106 +2924,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to refresh providers after org switch:", error)
     }
-  }
-
-  private handlePreviewImage(dataUrl: string, filename: string): void {
-    const dir = this.extensionContext?.globalStorageUri
-    if (!dir) return
-
-    const img = parseImage(dataUrl, filename)
-    if (!img) return
-
-    const root = vscode.Uri.joinPath(dir, getPreviewDir())
-    const uri = vscode.Uri.joinPath(dir, buildPreviewPath(img.name, Date.now()))
-    const clean = () =>
-      vscode.workspace.fs.readDirectory(root).then(
-        (items) => {
-          const stale = trimEntries(items.map(([name]) => ({ path: name })))
-          return Promise.all(
-            stale.map((name) =>
-              Promise.resolve(vscode.workspace.fs.delete(vscode.Uri.joinPath(root, name), { recursive: true })).then(
-                undefined,
-                (err: unknown) => {
-                  console.warn("[Kilo New] KiloProvider: Failed to delete stale preview:", err)
-                },
-              ),
-            ),
-          )
-        },
-        () => [],
-      )
-    const open = () =>
-      vscode.commands
-        .executeCommand(...getPreviewCommand(uri))
-        .then(undefined, () => vscode.commands.executeCommand("vscode.open", uri))
-
-    void vscode.workspace.fs
-      .createDirectory(root)
-      .then(() => vscode.workspace.fs.writeFile(uri, img.data))
-      .then(() => clean())
-      .then(open, (err) => console.error("[Kilo New] KiloProvider: Failed to preview image:", err))
-  }
-
-  private handleEditorOpenMessage(message: {
-    type?: string
-    filePath?: string
-    line?: number
-    column?: number
-    content?: string
-    language?: string
-  }): boolean {
-    if (message.type === "openFile") {
-      if (message.filePath) this.handleOpenFile(message.filePath, message.line, message.column)
-      return true
-    }
-    if (message.type === "openContent") {
-      if (message.content) this.handleOpenContent(message.content, message.language)
-      return true
-    }
-    return false
-  }
-
-  /**
-   * Handle openContent request - open arbitrary text in an untitled VS Code editor tab.
-   */
-  private handleOpenContent(content: string, language?: string): void {
-    vscode.workspace.openTextDocument({ content, language: language || "log" }).then(
-      (doc) => vscode.window.showTextDocument(doc, { preview: true }),
-      (err) => console.error("[Kilo New] KiloProvider: Failed to open content:", err),
-    )
-  }
-
-  /**
-   * Handle openFile request from the webview — open a file in the VS Code editor.
-   * Resolves relative paths against the current session's directory (which may be
-   * a worktree path registered via setSessionDirectory), falling back to workspace root.
-   * Absolute paths (Unix `/…` or Windows `C:\…`) are used as-is.
-   */
-  private handleOpenFile(filePath: string, line?: number, column?: number): void {
-    const uri = isAbsolutePath(filePath)
-      ? vscode.Uri.file(filePath)
-      : vscode.Uri.joinPath(vscode.Uri.file(this.getWorkspaceDirectory(this.currentSession?.id)), filePath)
-    vscode.workspace.fs.stat(uri).then(
-      (stat) => {
-        if (stat.type & vscode.FileType.Directory) {
-          vscode.commands.executeCommand("revealInExplorer", uri)
-          return
-        }
-        vscode.workspace.openTextDocument(uri).then(
-          (doc) => {
-            const options: vscode.TextDocumentShowOptions = { preview: true }
-            if (line !== undefined && line > 0) {
-              const col = column !== undefined && column > 0 ? column - 1 : 0
-              const pos = new vscode.Position(line - 1, col)
-              options.selection = new vscode.Range(pos, pos)
-            }
-            vscode.window.showTextDocument(doc, options)
-          },
-          (err) => console.error("[Kilo New] KiloProvider: Failed to open file:", uri.fsPath, err),
-        )
-      },
-      (err) => console.error("[Kilo New] KiloProvider: Path does not exist:", uri.fsPath, err),
-    )
   }
 
   /**

--- a/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
+++ b/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "../image-preview"
 import { isAbsolutePath } from "../path-utils"
-import type { DiffVirtualProvider } from "../DiffVirtualProvider"
+import type { DiffVirtualFile, DiffVirtualProvider } from "../DiffVirtualProvider"
 
 type EditorOpenMessage = {
   type?: string
@@ -19,7 +19,7 @@ function openExternal(url: unknown): void {
 
 function openDiffVirtual(provider: DiffVirtualProvider | undefined, diff: unknown, initialDiffStyle?: unknown): void {
   if (!provider || !diff) return
-  const file = diff as import("../DiffVirtualProvider").DiffVirtualFile
+  const file = diff as DiffVirtualFile
   file.initialDiffStyle = initialDiffStyle === "split" ? "split" : "unified"
   provider.open(file)
 }

--- a/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
+++ b/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
@@ -1,0 +1,131 @@
+import * as vscode from "vscode"
+import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "../image-preview"
+import { isAbsolutePath } from "../path-utils"
+import type { DiffVirtualProvider } from "../DiffVirtualProvider"
+
+type EditorOpenMessage = {
+  type?: string
+  filePath?: string
+  line?: number
+  column?: number
+  content?: string
+  language?: string
+}
+
+function openExternal(url: unknown): void {
+  if (typeof url !== "string") return
+  void vscode.env.openExternal(vscode.Uri.parse(url))
+}
+
+function openDiffVirtual(provider: DiffVirtualProvider | undefined, diff: unknown, initialDiffStyle?: unknown): void {
+  if (!provider || !diff) return
+  const file = diff as import("../DiffVirtualProvider").DiffVirtualFile
+  file.initialDiffStyle = initialDiffStyle === "split" ? "split" : "unified"
+  provider.open(file)
+}
+
+function previewImage(dir: vscode.Uri | undefined, dataUrl: string, filename: string): void {
+  if (!dir) return
+
+  const img = parseImage(dataUrl, filename)
+  if (!img) return
+
+  const root = vscode.Uri.joinPath(dir, getPreviewDir())
+  const uri = vscode.Uri.joinPath(dir, buildPreviewPath(img.name, Date.now()))
+  const clean = () =>
+    vscode.workspace.fs.readDirectory(root).then(
+      (items) => {
+        const stale = trimEntries(items.map(([name]) => ({ path: name })))
+        return Promise.all(
+          stale.map((name) =>
+            Promise.resolve(vscode.workspace.fs.delete(vscode.Uri.joinPath(root, name), { recursive: true })).then(
+              undefined,
+              (err: unknown) => {
+                console.warn("[Kilo New] KiloProvider: Failed to delete stale preview:", err)
+              },
+            ),
+          ),
+        )
+      },
+      () => [],
+    )
+  const open = () =>
+    vscode.commands
+      .executeCommand(...getPreviewCommand(uri))
+      .then(undefined, () => vscode.commands.executeCommand("vscode.open", uri))
+
+  void vscode.workspace.fs
+    .createDirectory(root)
+    .then(() => vscode.workspace.fs.writeFile(uri, img.data))
+    .then(() => clean())
+    .then(open, (err) => console.error("[Kilo New] KiloProvider: Failed to preview image:", err))
+}
+
+export function handleEditorAction(
+  message: EditorOpenMessage & {
+    url?: unknown
+    diff?: unknown
+    initialDiffStyle?: unknown
+    dataUrl?: string
+    filename?: string
+  },
+  opts: {
+    dir: () => string
+    diff?: DiffVirtualProvider
+    storage?: vscode.Uri
+  },
+): boolean {
+  if (message.type === "openFile") {
+    if (message.filePath) openFile(opts.dir(), message.filePath, message.line, message.column)
+    return true
+  }
+  if (message.type === "openContent") {
+    if (message.content) openContent(message.content, message.language)
+    return true
+  }
+  if (message.type === "openExternal") {
+    openExternal(message.url)
+    return true
+  }
+  if (message.type === "openDiffVirtual") {
+    openDiffVirtual(opts.diff, message.diff, message.initialDiffStyle)
+    return true
+  }
+  if (message.type === "previewImage") {
+    if (message.dataUrl && message.filename) previewImage(opts.storage, message.dataUrl, message.filename)
+    return true
+  }
+  return false
+}
+
+function openContent(content: string, language?: string): void {
+  vscode.workspace.openTextDocument({ content, language: language || "log" }).then(
+    (doc) => vscode.window.showTextDocument(doc, { preview: true }),
+    (err) => console.error("[Kilo New] KiloProvider: Failed to open content:", err),
+  )
+}
+
+function openFile(dir: string, filePath: string, line?: number, column?: number): void {
+  const uri = isAbsolutePath(filePath) ? vscode.Uri.file(filePath) : vscode.Uri.joinPath(vscode.Uri.file(dir), filePath)
+  vscode.workspace.fs.stat(uri).then(
+    (stat) => {
+      if (stat.type & vscode.FileType.Directory) {
+        vscode.commands.executeCommand("revealInExplorer", uri)
+        return
+      }
+      vscode.workspace.openTextDocument(uri).then(
+        (doc) => {
+          const options: vscode.TextDocumentShowOptions = { preview: true }
+          if (line !== undefined && line > 0) {
+            const col = column !== undefined && column > 0 ? column - 1 : 0
+            const pos = new vscode.Position(line - 1, col)
+            options.selection = new vscode.Range(pos, pos)
+          }
+          vscode.window.showTextDocument(doc, options)
+        },
+        (err) => console.error("[Kilo New] KiloProvider: Failed to open file:", uri.fsPath, err),
+      )
+    },
+    (err) => console.error("[Kilo New] KiloProvider: Path does not exist:", uri.fsPath, err),
+  )
+}


### PR DESCRIPTION
## Issue

Part of #8666

## Context

`KiloProvider` is too large and handles several unrelated jobs. This PR starts splitting it into smaller files.

## Implementation

Move editor actions into `kilo-provider/editor-actions.ts`. This includes opening files, text content, external links, image previews, and virtual diffs. `KiloProvider` now delegates those messages to the smaller module.

## Screenshots / Video

N/A - no visual changes.

## How to Test

### Manual/local verification

- Agent executed `bun run test`, `bun run typecheck`, `bun run lint`, and `bun run knip` from `packages/kilo-vscode/` successfully.
- Push hook executed `bun turbo typecheck` successfully.
- Manually verified that the affected editor actions still work.

### Reviewer test steps

1. Open a file from chat and confirm VS Code opens it.
2. Open an external link, image preview, and virtual diff from chat and confirm each action still works.

