### PR TITLE
fix(vscode): keep tool handoffs out of virtual history

### DIFF
--- a/.changeset/stable-tool-scroll.md
+++ b/.changeset/stable-tool-scroll.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep chat auto-scroll stable while edit, write, and patch tools hand off between assistant steps.

--- a/packages/kilo-vscode/tests/unit/session-queue.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-queue.test.ts
@@ -34,6 +34,19 @@ const layout = (messages: Message[], status: SessionStatusInfo, boundary?: strin
   )
 }
 
+const expectLayout = (
+  messages: Message[],
+  status: SessionStatusInfo,
+  expected: { virtual: string[]; direct: string[]; queued: string[] },
+) => {
+  const result = layout(messages, status)
+  expect({
+    virtual: result.virtual.map((turn) => turn.user.id),
+    direct: result.direct.map((turn) => turn.user.id),
+    queued: result.queued.map((turn) => turn.user.id),
+  }).toEqual(expected)
+}
+
 describe("queuedUserMessageIDs", () => {
   it("keeps follow-ups queued before the first assistant exists", () => {
     const messages = [user("message_1"), user("message_2")]
@@ -107,6 +120,58 @@ describe("partitionTurns", () => {
     expect(result.virtual).toEqual([])
     expect(result.direct.map((turn) => turn.user.id)).toEqual(["message_1"])
     expect(result.queued).toEqual([])
+  })
+
+  it("keeps completed resumable assistants direct while the session is active", () => {
+    const messages = (finish: string) => [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish, time: { created: 1, completed: 2 } }),
+      user("message_3"),
+    ]
+    const expected = { virtual: [], direct: ["message_1"], queued: ["message_3"] }
+
+    expectLayout(messages("tool-calls"), { type: "busy" }, expected)
+    expectLayout(messages("unknown"), { type: "busy" }, expected)
+    expectLayout(messages("tool-calls"), { type: "retry", attempt: 1, message: "retrying", next: 2 }, expected)
+    expectLayout(messages("tool-calls"), { type: "offline", message: "offline" }, expected)
+  })
+
+  it("does not retain a completed tool-call assistant with an error", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", {
+        finish: "tool-calls",
+        time: { created: 1, completed: 2 },
+        error: { name: "MessageAbortedError" },
+      }),
+      user("message_3"),
+    ]
+
+    expectLayout(messages, { type: "busy" }, { virtual: ["message_1"], direct: ["message_3"], queued: [] })
+  })
+
+  it("does not revive a completed tool-call step behind an errored assistant", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish: "tool-calls", time: { created: 1, completed: 2 } }),
+      assistant("message_3", "message_1", { error: { name: "MessageAbortedError" } }),
+      user("message_4"),
+    ]
+
+    expectLayout(messages, { type: "busy" }, { virtual: ["message_1"], direct: ["message_4"], queued: [] })
+  })
+
+  it("does not revive completed resumable steps behind a terminal assistant", () => {
+    const messages = (finish: string) => [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish, time: { created: 1, completed: 2 } }),
+      assistant("message_3", "message_1", { finish: "stop", time: { created: 3, completed: 4 } }),
+      user("message_4"),
+    ]
+    const expected = { virtual: ["message_1"], direct: ["message_4"], queued: [] }
+
+    expectLayout(messages("tool-calls"), { type: "busy" }, expected)
+    expectLayout(messages("unknown"), { type: "busy" }, expected)
   })
 
   it("keeps an active partial turn direct when later loaded prompts are queued", () => {
@@ -370,6 +435,15 @@ describe("activeUserMessageID", () => {
     ]
 
     expect(activeUserMessageID(messages, { type: "busy" })).toBe("message_1")
+  })
+
+  it("ignores completed tool-call assistants after the session becomes idle", () => {
+    const messages = [
+      user("message_1"),
+      assistant("message_2", "message_1", { finish: "tool-calls", time: { created: 1, completed: 2 } }),
+    ]
+
+    expect(activeUserMessageID(messages, { type: "idle" })).toBeUndefined()
   })
 
   it("keeps unknown assistants active until cleanup finishes", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-queue.ts
@@ -106,13 +106,17 @@ export function stableMessageTurns(next: MessageTurn[], prev: MessageTurn[] = []
   })
 }
 
-function active(messages: Message[]) {
+function active(messages: Message[], status: SessionStatusInfo) {
+  let latest = true
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i]
     if (!msg || msg.role !== "assistant") continue
-    if (typeof msg.time?.completed === "number") continue
+    const resumable = msg.finish === "tool-calls" || msg.finish === "unknown"
+    const running = latest && status.type !== "idle" && resumable
+    latest = false
+    if (typeof msg.time?.completed === "number" && !running) continue
     if (msg.error) continue
-    if (msg.finish && !["tool-calls", "unknown"].includes(msg.finish)) continue
+    if (msg.finish && !resumable) continue
     if (!msg.parentID) break
     const parent = messages.find((item) => item.id === msg.parentID)
     if (!parent) return msg.parentID
@@ -146,7 +150,7 @@ function pending(messages: Message[]) {
 // Find the user message whose turn the server is actively processing.
 // Any user message after this one is "queued" (waiting for its turn).
 export function activeUserMessageID(messages: Message[], status: SessionStatusInfo) {
-  const id = active(messages)
+  const id = active(messages, status)
   if (id) return id
   if (status.type === "idle") return undefined
   return pending(messages)
@@ -155,7 +159,7 @@ export function activeUserMessageID(messages: Message[], status: SessionStatusIn
 export function queuedUserMessageIDs(messages: Message[], status: SessionStatusInfo) {
   if (status.type === "idle") return []
   const users = messages.filter((msg) => msg.role === "user")
-  const running = active(messages)
+  const running = active(messages, status)
   if (running) {
     const idx = users.findIndex((msg) => msg.id === running)
     if (idx < 0) return users.map((msg) => msg.id)


### PR DESCRIPTION
## Issue

Part of #10741

## Context

Edit, write, and patch tool handoffs could briefly move the active turn into virtualized history and disrupt scrolling.

## Implementation

Keep the latest resumable assistant step directly rendered while the session remains active, including retry and offline states. Do not revive stale terminal or errored steps.

## Screenshots / Video

Before


https://github.com/user-attachments/assets/04c6185e-19a7-4ba2-8d76-60975d428c41



After


https://github.com/user-attachments/assets/4383f348-2293-46ad-bb14-6479fd09db51



## How to Test

### Manual/local verification

- Run `bun test ./tests/unit/session-queue.test.ts` from `packages/kilo-vscode/`.
- Manual testing as shown in the video

