### PR TITLE
refactor(vscode): extract marketplace handling from KiloProvider

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -47,12 +47,7 @@ import { GitOps } from "./agent-manager/GitOps"
 import { GitStatsPoller, type LocalStats } from "./agent-manager/GitStatsPoller"
 import { diffSummary as localDiffSummary } from "./agent-manager/local-diff"
 import { getWorkspaceRoot } from "./review-utils"
-import {
-  MarketplaceService,
-  type MarketplaceItem,
-  type AgentMarketplaceItem,
-  type RemoveResult,
-} from "./services/marketplace"
+import { MarketplaceHandler, type MarketplaceContext } from "./kilo-provider/handlers/marketplace"
 import type { RemoteStatusService } from "./services/RemoteStatusService"
 import { resolveProjectDirectory } from "./project-directory"
 import { getBusySessionCount, seedSessionStatuses } from "./session-status"
@@ -239,7 +234,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private ignoreController: FileIgnoreController | null = null
   private ignoreControllerDir: string | null = null
-  private marketplace: MarketplaceService | null = null
+  private readonly marketplace = new MarketplaceHandler(() => this.marketplaceCtx)
   private chatAutocomplete: ChatTextAreaAutocomplete | null = null
   private projectDirectory: string | null | undefined
   private slimEditMetadata = true
@@ -833,15 +828,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           this.fetchAndSendCommands().catch((e) => console.error("[Kilo New] fetchAndSendCommands failed:", e))
           break
         case "removeSkill":
-          this.removeSkillViaCli(message.location).catch((e: unknown) =>
-            console.error("[Kilo New] removeSkill failed:", e),
-          )
+          this.marketplace
+            .removeSkill(message.location)
+            .catch((e: unknown) => console.error("[Kilo New] removeSkill failed:", e))
           break
         case "removeAgent":
-          this.handleRemoveAgent(message.name).catch((e) => console.error("[Kilo New] handleRemoveAgent failed:", e))
+          this.marketplace
+            .removeAgent(message.name)
+            .catch((e) => console.error("[Kilo New] handleRemoveAgent failed:", e))
           break
         case "removeMcp":
-          this.handleRemoveMcp(message.name).catch((e) => console.error("[Kilo New] handleRemoveMcp failed:", e))
+          this.marketplace.removeMcp(message.name).catch((e) => console.error("[Kilo New] handleRemoveMcp failed:", e))
           break
         case "requestMcpStatus":
           this.fetchAndSendMcpStatus().catch((e) => console.error("[Kilo New] fetchAndSendMcpStatus failed:", e))
@@ -1101,7 +1098,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         }
         case "fetchMarketplaceData": {
-          await this.handleFetchMarketplaceData()
+          await this.marketplace.fetchData()
           break
         }
         case "filterMarketplaceItems": {
@@ -1109,33 +1106,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         }
         case "installMarketplaceItem": {
-          const workspace = this.getProjectDirectory(this.currentSession?.id)
-          const scope = message.mpInstallOptions?.target ?? "project"
-          const result = await this.getMarketplace().install(message.mpItem, message.mpInstallOptions, workspace)
-          if (result.success) {
-            await this.invalidateAfterMarketplaceChange(scope)
-          }
-          this.postMessage({
-            type: "marketplaceInstallResult",
-            success: result.success,
-            slug: result.slug,
-            error: result.error,
-          })
+          await this.marketplace.install(message.mpItem, message.mpInstallOptions)
           break
         }
         case "removeInstalledMarketplaceItem": {
-          const scope = message.mpInstallOptions?.target ?? "project"
-          const result = await this.removeMarketplaceItem(message.mpItem, scope)
-          this.postMessage({
-            type: "marketplaceRemoveResult",
-            success: result.success,
-            slug: result.slug,
-            error: result.error,
-          })
+          await this.marketplace.remove(message.mpItem, message.mpInstallOptions?.target ?? "project")
           break
         }
         case "dismissAgentMigrationBanner": {
-          await this.extensionContext?.globalState.update("kilo.agentMigrationBannerDismissed", true)
+          await this.marketplace.dismissBanner()
           break
         }
       }
@@ -1149,15 +1128,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       diff: this.diffVirtualProvider,
       storage: this.extensionContext?.globalStorageUri,
     })
-  }
-
-  private async handleFetchMarketplaceData(): Promise<void> {
-    const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const mp = this.getMarketplace()
-    const skills = await this.fetchCliSkills()
-    const data = await mp.fetchData(workspace, skills)
-    const dismissed = this.extensionContext?.globalState.get<boolean>("kilo.agentMigrationBannerDismissed") ?? false
-    this.postMessage({ type: "marketplaceData", ...data, showAgentMigrationBanner: !dismissed })
   }
 
   /**
@@ -1909,132 +1879,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  private async fetchCliSkills(): Promise<Array<{ name: string; location: string }> | undefined> {
-    if (!this.client) return undefined
-    try {
-      const dir = this.getWorkspaceDirectory()
-      const { data } = await retry(() => this.client!.app.skills({ directory: dir }, { throwOnError: true }))
-      return data
-    } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to fetch CLI skills for marketplace:", error)
-      return undefined
-    }
-  }
-
-  /**
-   * Remove a skill via the CLI backend (deletes from disk + clears cache), then refresh.
-   * Returns true on success, false on failure.
-   * On failure, re-fetches skills so the webview reverts to the authoritative state.
-   */
-  private async removeSkillViaCli(location: string): Promise<boolean> {
-    if (!this.client) return false
-    try {
-      const dir = this.getWorkspaceDirectory()
-      const result = await this.client.kilocode.removeSkill({ location, directory: dir })
-      if (result.error) {
-        console.error("[Kilo New] removeSkill returned error:", result.error)
-        this.cachedSkillsMessage = null
-        this.clearCommandsCache()
-        await Promise.all([this.fetchAndSendSkills(), this.fetchAndSendCommands()])
-        return false
-      }
-    } catch (error) {
-      console.error("[Kilo New] Failed to remove skill:", error)
-      this.cachedSkillsMessage = null
-      this.cachedCommandsMessage = null
-      await Promise.all([this.fetchAndSendSkills(), this.fetchAndSendCommands()])
-      return false
-    }
-    this.cachedSkillsMessage = null
-    this.cachedCommandsMessage = null
-    await Promise.all([this.fetchAndSendSkills(), this.fetchAndSendCommands()])
-    return true
-  }
-
-  /** Remove an agent via CLI, falling back to kilo.json removal. */
-  private async handleRemoveAgent(name: string): Promise<void> {
-    if (!this.client) return
-    try {
-      const result = await this.client.kilocode.removeAgent({ name, directory: this.getWorkspaceDirectory() })
-      if (!result.error) {
-        this.cachedAgentsMessage = null
-        await this.fetchAndSendAgents()
-        return
-      }
-    } catch {
-      // fall through to kilo.json removal
-    }
-    const stub: AgentMarketplaceItem = {
-      id: name,
-      type: "agent",
-      name,
-      description: "",
-      content: { mode: "primary", description: "", prompt: "" },
-    }
-    if (!(await this.removeMarketplaceItemFromAllScopes(stub))) {
-      console.error("[Kilo New] KiloProvider: Failed to remove agent:", name)
-    }
-  }
-
-  private async handleRemoveMcp(name: string): Promise<void> {
-    // Remove from legacy files first so that the subsequent invalidation
-    // causes the CLI to re-read config without the legacy entry.
-    await this.removeLegacyMcp(name)
-
-    const stub = { id: name, type: "mcp" as const, name, description: "", url: "", content: "" }
-    const removed = await this.removeMarketplaceItemFromAllScopes(stub)
-    if (!removed) {
-      console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name)
-    }
-  }
-
-  /**
-   * Remove an MCP server from legacy config files (.kilo/mcp.json, .kilocode/mcp.json,
-   * and the VS Code global storage mcp_settings.json). These files are read by the
-   * CLI-side McpMigrator and merged into config at the lowest precedence level.
-   * Returns true if the entry was found and removed from at least one file.
-   */
-  private async removeLegacyMcp(name: string): Promise<boolean> {
-    const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const files: vscode.Uri[] = []
-
-    // Project-level legacy files
-    if (workspace) {
-      files.push(vscode.Uri.file(path.join(workspace, ".kilo", "mcp.json")))
-      files.push(vscode.Uri.file(path.join(workspace, ".kilocode", "mcp.json")))
-    }
-
-    // Global legacy file (VS Code extension global storage)
-    const storage = this.extensionContext?.globalStorageUri
-    if (storage) {
-      files.push(vscode.Uri.joinPath(storage, "settings", "mcp_settings.json"))
-    }
-
-    let removed = false
-    for (const uri of files) {
-      const bytes = await vscode.workspace.fs.readFile(uri).then(
-        (b) => b,
-        () => null,
-      )
-      if (!bytes) continue
-
-      try {
-        const parsed = JSON.parse(Buffer.from(bytes).toString("utf8")) as Record<string, unknown>
-        const servers = parsed.mcpServers as Record<string, unknown> | undefined
-        if (!servers?.[name]) continue
-
-        delete servers[name]
-        const content = Buffer.from(JSON.stringify(parsed, null, 2), "utf8")
-        await vscode.workspace.fs.writeFile(uri, content)
-        removed = true
-      } catch (err) {
-        console.warn("[Kilo New] KiloProvider: Failed to remove legacy MCP from", uri.fsPath, err)
-      }
-    }
-
-    return removed
-  }
-
   private async fetchAndSendMcpStatus(): Promise<void> {
     if (!this.client) {
       if (this.cachedMcpStatusMessage) {
@@ -2054,75 +1898,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch MCP status:", error)
     }
-  }
-
-  /**
-   * Remove a marketplace item from a single scope and invalidate CLI caches.
-   */
-  private async removeMarketplaceItem(item: MarketplaceItem, scope: "project" | "global"): Promise<RemoveResult> {
-    const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const result = await this.getMarketplace().remove(item, scope, workspace)
-    if (result.success) {
-      await this.invalidateAfterMarketplaceChange(scope)
-    }
-    return result
-  }
-
-  /**
-   * Remove a marketplace item from both project and global scopes.
-   * mp.remove returns success even when the entry doesn't exist (no-op),
-   * so we must attempt both scopes to cover dual-scope installations.
-   * Returns true if at least one scope removal succeeded.
-   */
-  private async removeMarketplaceItemFromAllScopes(item: MarketplaceItem): Promise<boolean> {
-    const workspace = this.getProjectDirectory(this.currentSession?.id)
-    const mp = this.getMarketplace()
-    const project = await mp.remove(item, "project", workspace)
-    const global = await mp.remove(item, "global", workspace)
-
-    if (project.success || global.success) {
-      const scope = global.success ? "global" : "project"
-      await this.invalidateAfterMarketplaceChange(scope)
-      return true
-    }
-    return false
-  }
-
-  /**
-   * Invalidate CLI caches and refresh the webview after a marketplace install/remove.
-   *
-   * For global scope: uses global.config.update with the freshly-written config file
-   * contents rather than global.dispose. This goes through Config.updateGlobal() which
-   * calls Config.global.reset() to invalidate the lazy-cached global config, ensuring
-   * the newly installed/removed MCP entry is visible on the next config.get call.
-   * (global.dispose alone is not sufficient on older CLI versions that lack the
-   * Config.global.reset() call in the dispose handler.)
-   *
-   * For project scope: instance.dispose is sufficient because the per-instance
-   * Config.state is cleared and re-reads all files (including global) on next access.
-   */
-  private async invalidateAfterMarketplaceChange(scope: "project" | "global"): Promise<void> {
-    if (!this.client) return
-    if (scope === "global") {
-      // Use global.config.update with an empty config to trigger Config.updateGlobal()
-      // which calls Config.global.reset(). This invalidates the lazy-cached global
-      // config in the CLI process so it re-reads kilo.json from disk.
-      // An empty object merge is a no-op for the file content but resets the cache.
-      // (global.dispose alone is insufficient on older CLI versions that lack
-      // the Config.global.reset() call in the dispose handler.)
-      await this.client.global.config.update({ config: {} }).catch((e: unknown) => {
-        console.warn("[Kilo New] global.config.update after marketplace change failed:", e)
-      })
-    }
-    // Always dispose the per-project instance so it rebuilds state from
-    // the (possibly updated) global + project config on the next request.
-    const dir = this.getWorkspaceDirectory()
-    await this.client.instance.dispose({ directory: dir }).catch((e: unknown) => {
-      console.warn("[Kilo New] instance.dispose() after marketplace change failed:", e)
-    })
-    this.cachedAgentsMessage = null
-    this.cachedConfigMessage = null
-    await Promise.all([this.fetchAndSendAgents(), this.fetchAndSendConfig()])
   }
 
   /**
@@ -3426,10 +3201,32 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   // legacy-migration end ---------------------------------------------------------
 
-  private getMarketplace(): MarketplaceService {
-    if (this.marketplace) return this.marketplace
-    this.marketplace = new MarketplaceService()
-    return this.marketplace
+  private get marketplaceCtx(): MarketplaceContext {
+    return {
+      client: this.client,
+      state: this.extensionContext?.globalState,
+      storage: this.extensionContext?.globalStorageUri,
+      postMessage: (msg) => this.postMessage(msg),
+      getWorkspaceDirectory: () => this.getWorkspaceDirectory(),
+      getProjectDirectory: () => this.getProjectDirectory(this.currentSession?.id),
+      clearAgentsCache: () => {
+        this.cachedAgentsMessage = null
+      },
+      clearSkillsCache: () => {
+        this.cachedSkillsMessage = null
+      },
+      clearCommandsCache: () => this.clearCommandsCache(),
+      clearCommandsMessageCache: () => {
+        this.cachedCommandsMessage = null
+      },
+      clearConfigCache: () => {
+        this.cachedConfigMessage = null
+      },
+      fetchAndSendAgents: () => this.fetchAndSendAgents(),
+      fetchAndSendSkills: () => this.fetchAndSendSkills(),
+      fetchAndSendCommands: () => this.fetchAndSendCommands(),
+      fetchAndSendConfig: () => this.fetchAndSendConfig(),
+    }
   }
 
   // ── Worktree stats polling (sidebar diff badge) ──────────────────
@@ -3497,6 +3294,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.sessionStatusMap.clear()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
-    ;(this.marketplace?.dispose(), disposeGitChangesTarget())
+    ;(this.marketplace.dispose(), disposeGitChangesTarget())
   }
 }

--- a/packages/kilo-vscode/src/kilo-provider/handlers/legacy-mcp.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/legacy-mcp.ts
@@ -1,0 +1,46 @@
+import * as path from "path"
+import * as vscode from "vscode"
+
+interface LegacyMcpOptions {
+  name: string
+  workspace?: string
+  storage?: vscode.Uri
+}
+
+/** Remove an MCP server from legacy files read by the CLI-side migrator. */
+export async function removeLegacyMcp(opts: LegacyMcpOptions): Promise<boolean> {
+  const files: vscode.Uri[] = []
+
+  if (opts.workspace) {
+    files.push(vscode.Uri.file(path.join(opts.workspace, ".kilo", "mcp.json")))
+    files.push(vscode.Uri.file(path.join(opts.workspace, ".kilocode", "mcp.json")))
+  }
+
+  if (opts.storage) {
+    files.push(vscode.Uri.joinPath(opts.storage, "settings", "mcp_settings.json"))
+  }
+
+  let removed = false
+  for (const uri of files) {
+    const bytes = await vscode.workspace.fs.readFile(uri).then(
+      (data) => data,
+      () => null,
+    )
+    if (!bytes) continue
+
+    try {
+      const parsed = JSON.parse(Buffer.from(bytes).toString("utf8")) as Record<string, unknown>
+      const servers = parsed.mcpServers as Record<string, unknown> | undefined
+      if (!servers?.[opts.name]) continue
+
+      delete servers[opts.name]
+      const content = Buffer.from(JSON.stringify(parsed, null, 2), "utf8")
+      await vscode.workspace.fs.writeFile(uri, content)
+      removed = true
+    } catch (err) {
+      console.warn("[Kilo New] KiloProvider: Failed to remove legacy MCP from", uri.fsPath, err)
+    }
+  }
+
+  return removed
+}

--- a/packages/kilo-vscode/src/kilo-provider/handlers/marketplace.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/marketplace.ts
@@ -26,7 +26,9 @@ export interface MarketplaceContext {
   getProjectDirectory(): string | undefined
   clearAgentsCache(): void
   clearSkillsCache(): void
+  /** Clear the webview message and module-level command caches after an API error. */
   clearCommandsCache(): void
+  /** Clear only the webview message cache after a thrown error or successful removal. */
   clearCommandsMessageCache(): void
   clearConfigCache(): void
   fetchAndSendAgents(): Promise<void>
@@ -49,12 +51,13 @@ export class MarketplaceHandler {
   }
 
   async install(item: MarketplaceItem, options: InstallMarketplaceItemOptions): Promise<void> {
+    const ctx = this.ctx()
     const scope = options?.target ?? "project"
-    const result = await this.getService().install(item, options, this.ctx().getProjectDirectory())
+    const result = await this.getService().install(item, options, ctx.getProjectDirectory())
     if (result.success) {
       await this.invalidate(scope)
     }
-    this.ctx().postMessage({
+    ctx.postMessage({
       type: "marketplaceInstallResult",
       success: result.success,
       slug: result.slug,

--- a/packages/kilo-vscode/src/kilo-provider/handlers/marketplace.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/marketplace.ts
@@ -1,0 +1,203 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import type * as vscode from "vscode"
+import { retry } from "../../services/cli-backend/retry"
+import {
+  MarketplaceService,
+  type AgentMarketplaceItem,
+  type InstallMarketplaceItemOptions,
+  type MarketplaceItem,
+  type RemoveResult,
+} from "../../services/marketplace"
+import { removeLegacyMcp } from "./legacy-mcp"
+
+type Scope = "project" | "global"
+
+interface MarketplaceState {
+  get<T>(key: string): T | undefined
+  update(key: string, value: unknown): PromiseLike<void>
+}
+
+export interface MarketplaceContext {
+  readonly client: KiloClient | null
+  readonly state: MarketplaceState | undefined
+  readonly storage: vscode.Uri | undefined
+  postMessage(msg: unknown): void
+  getWorkspaceDirectory(): string
+  getProjectDirectory(): string | undefined
+  clearAgentsCache(): void
+  clearSkillsCache(): void
+  clearCommandsCache(): void
+  clearCommandsMessageCache(): void
+  clearConfigCache(): void
+  fetchAndSendAgents(): Promise<void>
+  fetchAndSendSkills(): Promise<void>
+  fetchAndSendCommands(): Promise<void>
+  fetchAndSendConfig(): Promise<void>
+}
+
+export class MarketplaceHandler {
+  private service: MarketplaceService | null = null
+
+  constructor(private readonly ctx: () => MarketplaceContext) {}
+
+  async fetchData(): Promise<void> {
+    const ctx = this.ctx()
+    const skills = await this.fetchCliSkills(ctx)
+    const data = await this.getService().fetchData(ctx.getProjectDirectory(), skills)
+    const dismissed = ctx.state?.get<boolean>("kilo.agentMigrationBannerDismissed") ?? false
+    ctx.postMessage({ type: "marketplaceData", ...data, showAgentMigrationBanner: !dismissed })
+  }
+
+  async install(item: MarketplaceItem, options: InstallMarketplaceItemOptions): Promise<void> {
+    const scope = options?.target ?? "project"
+    const result = await this.getService().install(item, options, this.ctx().getProjectDirectory())
+    if (result.success) {
+      await this.invalidate(scope)
+    }
+    this.ctx().postMessage({
+      type: "marketplaceInstallResult",
+      success: result.success,
+      slug: result.slug,
+      error: result.error,
+    })
+  }
+
+  async remove(item: MarketplaceItem, scope: Scope): Promise<void> {
+    const result = await this.removeItem(item, scope)
+    this.ctx().postMessage({
+      type: "marketplaceRemoveResult",
+      success: result.success,
+      slug: result.slug,
+      error: result.error,
+    })
+  }
+
+  async dismissBanner(): Promise<void> {
+    await this.ctx().state?.update("kilo.agentMigrationBannerDismissed", true)
+  }
+
+  /** Remove a skill via the CLI backend, then refresh authoritative skill and command data. */
+  async removeSkill(location: string): Promise<boolean> {
+    const ctx = this.ctx()
+    if (!ctx.client) return false
+    try {
+      const result = await ctx.client.kilocode.removeSkill({ location, directory: ctx.getWorkspaceDirectory() })
+      if (result.error) {
+        console.error("[Kilo New] removeSkill returned error:", result.error)
+        ctx.clearSkillsCache()
+        ctx.clearCommandsCache()
+        await Promise.all([ctx.fetchAndSendSkills(), ctx.fetchAndSendCommands()])
+        return false
+      }
+    } catch (err) {
+      console.error("[Kilo New] Failed to remove skill:", err)
+      ctx.clearSkillsCache()
+      ctx.clearCommandsMessageCache()
+      await Promise.all([ctx.fetchAndSendSkills(), ctx.fetchAndSendCommands()])
+      return false
+    }
+    ctx.clearSkillsCache()
+    ctx.clearCommandsMessageCache()
+    await Promise.all([ctx.fetchAndSendSkills(), ctx.fetchAndSendCommands()])
+    return true
+  }
+
+  /** Remove an agent via CLI, falling back to kilo.json removal. */
+  async removeAgent(name: string): Promise<void> {
+    const ctx = this.ctx()
+    if (!ctx.client) return
+    try {
+      const result = await ctx.client.kilocode.removeAgent({ name, directory: ctx.getWorkspaceDirectory() })
+      if (!result.error) {
+        ctx.clearAgentsCache()
+        await ctx.fetchAndSendAgents()
+        return
+      }
+    } catch (err) {
+      console.warn("[Kilo New] removeAgent via CLI failed, falling back to marketplace removal:", err)
+    }
+    const stub: AgentMarketplaceItem = {
+      id: name,
+      type: "agent",
+      name,
+      description: "",
+      content: { mode: "primary", description: "", prompt: "" },
+    }
+    if (!(await this.removeAll(stub))) {
+      console.error("[Kilo New] KiloProvider: Failed to remove agent:", name)
+    }
+  }
+
+  async removeMcp(name: string): Promise<void> {
+    const ctx = this.ctx()
+    await removeLegacyMcp({ name, workspace: ctx.getProjectDirectory(), storage: ctx.storage })
+
+    const stub = { id: name, type: "mcp" as const, name, description: "", url: "", content: "" }
+    if (!(await this.removeAll(stub))) {
+      console.error("[Kilo New] KiloProvider: Failed to remove MCP server:", name)
+    }
+  }
+
+  dispose(): void {
+    this.service?.dispose()
+  }
+
+  private getService(): MarketplaceService {
+    if (this.service) return this.service
+    this.service = new MarketplaceService()
+    return this.service
+  }
+
+  private async fetchCliSkills(
+    ctx: MarketplaceContext,
+  ): Promise<Array<{ name: string; location: string }> | undefined> {
+    if (!ctx.client) return undefined
+    try {
+      const { data } = await retry(() =>
+        ctx.client!.app.skills({ directory: ctx.getWorkspaceDirectory() }, { throwOnError: true }),
+      )
+      return data
+    } catch (err) {
+      console.error("[Kilo New] KiloProvider: Failed to fetch CLI skills for marketplace:", err)
+      return undefined
+    }
+  }
+
+  private async removeItem(item: MarketplaceItem, scope: Scope): Promise<RemoveResult> {
+    const result = await this.getService().remove(item, scope, this.ctx().getProjectDirectory())
+    if (result.success) {
+      await this.invalidate(scope)
+    }
+    return result
+  }
+
+  /** Remove from both scopes because service removal is idempotent and an item may exist in both. */
+  private async removeAll(item: MarketplaceItem): Promise<boolean> {
+    const ctx = this.ctx()
+    const workspace = ctx.getProjectDirectory()
+    const service = this.getService()
+    const project = await service.remove(item, "project", workspace)
+    const global = await service.remove(item, "global", workspace)
+
+    if (!(project.success || global.success)) return false
+    await this.invalidate(global.success ? "global" : "project")
+    return true
+  }
+
+  /** Reset CLI config caches before refreshing dependent webview data. */
+  private async invalidate(scope: Scope): Promise<void> {
+    const ctx = this.ctx()
+    if (!ctx.client) return
+    if (scope === "global") {
+      await ctx.client.global.config.update({ config: {} }).catch((err: unknown) => {
+        console.warn("[Kilo New] global.config.update after marketplace change failed:", err)
+      })
+    }
+    await ctx.client.instance.dispose({ directory: ctx.getWorkspaceDirectory() }).catch((err: unknown) => {
+      console.warn("[Kilo New] instance.dispose() after marketplace change failed:", err)
+    })
+    ctx.clearAgentsCache()
+    ctx.clearConfigCache()
+    await Promise.all([ctx.fetchAndSendAgents(), ctx.fetchAndSendConfig()])
+  }
+}


### PR DESCRIPTION

Part of #8666

## Context

Extract marketplace-specific responsibilities from `KiloProvider` so the provider remains focused on webview routing and dependency adaptation. This is one step in the broader `KiloProvider` decomposition tracked by #8666.

## Implementation

Move marketplace fetching, lazy service ownership, installation and removal flows, banner dismissal, cache invalidation, and refresh orchestration behind a narrow handler context. Keep legacy MCP compatibility-file cleanup separate because it depends on VS Code filesystem APIs. Preserve project/global scope resolution, service disposal, webview message payloads, and the existing refresh ordering after marketplace changes.

### Testing

Checked basic CRUD on MarketPlace Agent Modes, MCPs, Skills


