### PR TITLE
docs(kilo-docs): document inline session renaming

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -136,6 +136,12 @@ Imported work stays associated with its branch or worktree and can be continued 
 - Use session history to reopen local sessions or preview cloud sessions
 - Continue a cloud session locally from Agent Manager using the same extension sign-in and provider settings
 
+### Renaming Worktrees
+
+Double-click a worktree name to edit its label inline. You can also right-click the worktree and choose **Rename**. Press `Enter` or click outside the field to save, or press `Escape` to cancel.
+
+Renaming a worktree changes only the label shown in Agent Manager. It does not rename the underlying git branch.
+
 ## Starting Sessions From Chat
 
 Kilo can start Agent Manager sessions from chat with the `agent_manager` tool. It is available by default only in the VS Code extension because Agent Manager is an extension feature.
@@ -168,7 +174,7 @@ Sections let you group worktrees into collapsible, color-coded folders in the si
 
 Multi-version worktrees (created via Multi-Version Mode) are moved together — assigning one version to a section moves all versions in the group.
 
-### Renaming
+### Renaming Sections
 
 Right-click the section header and select **Rename Section**. An inline text field appears — type the new name and press `Enter` to confirm or `Escape` to cancel.
 

--- a/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
@@ -82,6 +82,12 @@ Run `/export` in chat, or open a local session's **History** context menu and ch
 
 Kilo builds the export from the complete local session history, not only the messages currently loaded in the chat view.
 
+**Renaming sessions:**
+
+Double-click the current session title at the top of the chat to edit it inline. Press `Enter` or click outside the field to save, or press `Escape` to cancel.
+
+You can also rename local sessions from **History** using the edit button or the session's context menu.
+
 {% /tab %}
 {% tab label="CLI" %}
 


### PR DESCRIPTION
Inline session renaming is now available in both the sidebar chat and Agent Manager, but the existing docs did not explain how to discover or use the gesture. This left the new controls easy to miss, especially because the interaction is primarily a double-click rather than a dedicated button.

Document the sidebar title workflow and the Agent Manager worktree label workflow, including how to save or cancel inline edits. Clarify that worktree renaming only changes the Agent Manager label and does not rename the underlying git branch, and distinguish section renaming from worktree renaming in the Agent Manager reference.