### PR TITLE
fix(indexing): project indexing setting should override global setting

### DIFF
--- a/.changeset/clear-comics-end.md
+++ b/.changeset/clear-comics-end.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix project indexing setting to override global setting

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -188,7 +188,7 @@ export namespace KiloIndexing {
   export function input(config?: IndexingConfig, global?: IndexingConfig) {
     return toIndexingConfigInput({
       ...config,
-      enabled: config?.enabled === true || global?.enabled === true,
+      enabled: config?.enabled ?? global?.enabled ?? false,
     })
   }
 

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -180,9 +180,9 @@ describe("kilocode indexing config", () => {
     }
   })
 
-  test("global indexing enabled applies when project indexing is disabled", async () => {
+  test("project indexing disabled overrides global indexing enabled", async () => {
     const input = KiloIndexing.input({ enabled: false }, { enabled: true })
-    expect(input.enabled).toBe(true)
+    expect(input.enabled).toBe(false)
   })
 
   test("accepts delete sentinels for indexing model overrides", () => {


### PR DESCRIPTION
## Issue

Fixes #10807

## Context

Global indexing config was overriding project level config, but this was incorrect. This fixes it so project indexing config properly takes precedence.

## Screenshots

N/A

## How to Test

### Manual/local verification

- Have indexing enabled globally
- Disable indexing for a specific project
- Verify that indexing does not enable for that project

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord
