### PR TITLE
fix(jetbrains): ignore stale SSE callbacks after restart

### DIFF
--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendConnectionService.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendConnectionService.kt
@@ -233,12 +233,14 @@ class KiloConnectionService(
 
     private val listener = object : EventSourceListener() {
         override fun onOpen(src: EventSource, response: Response) {
+            if (source.get() !== src) return
             log.info("SSE: connected")
             setState(ConnectionState.Connected(port, password))
             lastEvent.set(System.currentTimeMillis())
         }
 
         override fun onEvent(src: EventSource, id: String?, type: String?, data: String) {
+            if (source.get() !== src) return
             lastEvent.set(System.currentTimeMillis())
             val kind = type ?: KiloCliDataParser.extractEventType(data)
             log.debug { "evt=$kind bytes=${data.length} hasId=${id != null} ${ChatLogSummary.body(data)}" }
@@ -246,11 +248,13 @@ class KiloConnectionService(
         }
 
         override fun onClosed(src: EventSource) {
+            if (source.get() !== src) return
             log.info("SSE: stream closed — scheduling reconnect")
             scheduleReconnect()
         }
 
         override fun onFailure(src: EventSource, t: Throwable?, response: Response?) {
+            if (source.get() !== src) return
             val detail = when {
                 t != null -> t.stackTraceToString()
                 response != null -> response.body?.string()


### PR DESCRIPTION
## Context

While upgrading a dependency the PR had a CI failure on jetbrains test which caused failures in other checks depending on it. After a retry the test passed proving it was a transient issue.

```
> Task :backend:test
Warning: [0.008s][warning][cds] Archived non-system classes are disabled because the java.system.class.loader property is specified (value = "com.intellij.util.lang.PathClassLoader"). To use archived non-system classes, this property must not be set

KiloConnectionServiceTest > restart tears down and reconnects() FAILED
    org.opentest4j.AssertionFailedError at KiloConnectionServiceTest.kt:170

387 tests completed, 1 failed

> Task :backend:test FAILED

gradle/actions: Writing build results to /home/runner/_work/_temp/.gradle-actions/build-results/__run-1780400539209.json
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':backend:test'.
> There were failing tests. See the report at: file:///home/runner/_work/kilocode/kilocode/packages/kilo-jetbrains/backend/build/reports/tests/test/index.html
``` 

## Implementation

The CI failure showed restart `tears down` and `reconnects()` reaching the reconnect path but ending in `ConnectionState.Error` immediately after waiting for `Connected`. That points to a race where callbacks from the canceled pre-restart SSE stream can still run and overwrite state for the new connection. This change ignores SSE callbacks unless they belong to the current active EventSource.

### Manual/local verification

- cd packages/kilo-jetbrains
- ./gradlew :backend:test --rerun-tasks