### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/minimax.md
+++ b/packages/kilo-docs/pages/ai-providers/minimax.md
@@ -6,7 +6,7 @@ sidebar_label: MiniMax
 
 # Using MiniMax With Kilo Code
 
-MiniMax is a global AI foundation model company focused on fast, cost-efficient multimodal models with strong coding, tool-use, and agentic capabilities. Their flagship MiniMax M2.1 model delivers high-speed inference, long-context reasoning, and advanced development workflow support.
+MiniMax is a global AI foundation model company focused on fast, cost-efficient multimodal models with strong coding, tool-use, and agentic capabilities. Their flagship MiniMax-M3 model delivers peak performance with multimodal image input, a 524,288-token context window, enhanced reasoning and coding capabilities, high-speed inference, and advanced development workflow support.
 
 **Website:** [https://www.minimax.io/](https://www.minimax.io/)
 
@@ -61,15 +61,32 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "minimax/MiniMax-M1",
+  "model": "minimax/MiniMax-M3",
 }
 ```
 
 {% /tab %}
 {% /tabs %}
 
+## Available Models
+
+| Model | Description | Context Window |
+|-------|------------|---------------|
+| **MiniMax-M3** | Latest flagship model with multimodal image input, enhanced reasoning and coding. | 524,288 tokens |
+| **MiniMax-M2.7** | M2.7 with strong reasoning and coding. | 204,800 tokens |
+| **MiniMax-M2.7-highspeed** | High-speed version of M2.7 for low-latency scenarios. | 204,800 tokens |
+
+## Pricing
+
+| Model | Input | Output | Prompt Caching Read | Prompt Caching Write |
+|-------|-------|--------|---------------------|----------------------|
+| MiniMax-M3 | $0.60 / M tokens | $2.40 / M tokens | $0.12 / M tokens | $0.375 / M tokens |
+| MiniMax-M2.7 | $0.30 / M tokens | $1.20 / M tokens | $0.06 / M tokens | $0.375 / M tokens |
+| MiniMax-M2.7-highspeed | $0.60 / M tokens | $2.40 / M tokens | $0.06 / M tokens | $0.375 / M tokens |
+
 ## Tips and Notes
 
-- **Performance:** MiniMax M2.1 emphasizes fast inference, strong coding ability, and exceptional tool-calling performance.
-- **Context Window:** MiniMax models support ultra-long context windows suitable for large codebases and agent workflows.
-- **Pricing:** Pricing varies by model, with input costs ranging from $0.20 to $0.30 per million tokens and output costs from $1.10 to $2.20 per million tokens. Refer to the MiniMax documentation for the most current pricing information.
+- **Performance:** MiniMax-M3 is the latest flagship model with multimodal image input and enhanced reasoning and coding capabilities.
+- **Context Window:** MiniMax-M3 supports a 524,288-token context window; M2.7 models support 204,800 tokens. All suitable for large codebases and complex agent workflows.
+- **Speed:** Use `MiniMax-M2.7-highspeed` for faster inference while maintaining the same level of performance.
+- **API Documentation:** See the [MiniMax API Reference](https://platform.minimax.io/docs/api-reference/text-anthropic-api) for detailed API documentation.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -490,6 +490,7 @@ export function temperature(model: Provider.Model) {
   if (id.includes("glm-4.6")) return 1.0
   if (id.includes("glm-4.7")) return 1.0
   if (id.includes("minimax-m2")) return 1.0
+  if (id.includes("minimax-m3")) return 1.0
   if (id.includes("kimi-k2")) {
     // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
     if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
@@ -504,7 +505,7 @@ export function temperature(model: Provider.Model) {
 export function topP(model: Provider.Model) {
   const id = model.id.toLowerCase()
   if (id.includes("qwen")) return 1
-  if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
+  if (["minimax-m2", "minimax-m3", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
     return 0.95
   }
   if (isLing(model.api.id)) return 0.95 // kilocode_change
@@ -516,6 +517,9 @@ export function topK(model: Provider.Model) {
   if (id.includes("minimax-m2")) {
     if (["m2.", "m25", "m21"].some((s) => id.includes(s))) return 40
     return 20
+  }
+  if (id.includes("minimax-m3")) {
+    return 40
   }
   if (id.includes("gemini")) return 64
   if (isLing(model.api.id)) return 20 // kilocode_change

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2343,12 +2343,12 @@ describe("ProviderTransform.variants", () => {
 
   test("minimax returns empty object", () => {
     const model = createMockModel({
-      id: "minimax/minimax-model",
+      id: "minimax/MiniMax-M3",
       providerID: "minimax",
       api: {
-        id: "minimax-model",
-        url: "https://api.minimax.com",
-        npm: "@ai-sdk/openai-compatible",
+        id: "MiniMax-M3",
+        url: "https://api.minimax.io/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
       },
     })
     const result = ProviderTransform.variants(model)
@@ -4052,6 +4052,135 @@ describe("ProviderTransform.options - OpenAI Responses API params guard", () => 
       })
       expect(result.reasoningEffort).toBe("medium")
     }
+  })
+})
+
+describe("ProviderTransform.temperature - MiniMax models", () => {
+  const createMinimaxModel = (modelId: string): any => ({
+    id: modelId,
+    providerID: "minimax",
+    api: {
+      id: modelId,
+      url: "https://api.minimax.io/anthropic/v1",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: modelId,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.6, output: 2.4, cache: { read: 0.12, write: 0.375 } },
+    limit: { context: 524288, output: 131072 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-06-01",
+  })
+
+  test("MiniMax-M3 returns temperature 1.0", () => {
+    const model = createMinimaxModel("MiniMax-M3")
+    expect(ProviderTransform.temperature(model)).toBe(1.0)
+  })
+
+  test("MiniMax-M2.7 returns temperature 1.0", () => {
+    const model = createMinimaxModel("MiniMax-M2.7")
+    expect(ProviderTransform.temperature(model)).toBe(1.0)
+  })
+
+  test("MiniMax-M2.7-highspeed returns temperature 1.0", () => {
+    const model = createMinimaxModel("MiniMax-M2.7-highspeed")
+    expect(ProviderTransform.temperature(model)).toBe(1.0)
+  })
+})
+
+describe("ProviderTransform.topP - MiniMax models", () => {
+  const createMinimaxModel = (modelId: string): any => ({
+    id: modelId,
+    providerID: "minimax",
+    api: {
+      id: modelId,
+      url: "https://api.minimax.io/anthropic/v1",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: modelId,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.6, output: 2.4, cache: { read: 0.12, write: 0.375 } },
+    limit: { context: 524288, output: 131072 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-06-01",
+  })
+
+  test("MiniMax-M3 returns topP 0.95", () => {
+    const model = createMinimaxModel("MiniMax-M3")
+    expect(ProviderTransform.topP(model)).toBe(0.95)
+  })
+
+  test("MiniMax-M2.7 returns topP 0.95", () => {
+    const model = createMinimaxModel("MiniMax-M2.7")
+    expect(ProviderTransform.topP(model)).toBe(0.95)
+  })
+
+  test("MiniMax-M2.7-highspeed returns topP 0.95", () => {
+    const model = createMinimaxModel("MiniMax-M2.7-highspeed")
+    expect(ProviderTransform.topP(model)).toBe(0.95)
+  })
+})
+
+describe("ProviderTransform.topK - MiniMax models", () => {
+  const createMinimaxModel = (modelId: string): any => ({
+    id: modelId,
+    providerID: "minimax",
+    api: {
+      id: modelId,
+      url: "https://api.minimax.io/anthropic/v1",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: modelId,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.6, output: 2.4, cache: { read: 0.12, write: 0.375 } },
+    limit: { context: 524288, output: 131072 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-06-01",
+  })
+
+  test("MiniMax-M3 returns topK 40", () => {
+    const model = createMinimaxModel("MiniMax-M3")
+    expect(ProviderTransform.topK(model)).toBe(40)
+  })
+
+  test("MiniMax-M2.7 returns topK 40", () => {
+    const model = createMinimaxModel("MiniMax-M2.7")
+    expect(ProviderTransform.topK(model)).toBe(40)
+  })
+
+  test("MiniMax-M2.7-highspeed returns topK 40", () => {
+    const model = createMinimaxModel("MiniMax-M2.7-highspeed")
+    expect(ProviderTransform.topK(model)).toBe(40)
   })
 })
 // kilocode_change end


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to use MiniMax-M3 as the default model. M3 introduces a 512K context window (524,288 tokens), 128K max output, image input, and improved reasoning and coding capabilities.

## Changes

- **`packages/opencode/src/provider/transform.ts`** — Add MiniMax-M3 handling for `temperature` (1.0), `topP` (0.95), and `topK` (40), aligning M3 with the existing M2-family defaults.
- **`packages/opencode/test/provider/transform.test.ts`** — Add unit tests for temperature/topP/topK across `MiniMax-M3`, `MiniMax-M2.7`, and `MiniMax-M2.7-highspeed`; update the existing variants test to use a realistic MiniMax model id.
- **`packages/kilo-docs/pages/ai-providers/minimax.md`** — Update docs to use M3 as the recommended default; add an Available Models table and a Pricing table; rewrite the Tips and Notes section to reflect current model lineup.

## Why

MiniMax-M3 is the latest MiniMax flagship model with a 512K context window, image input support, and improved reasoning and coding capabilities. The kilocode `transform.ts` already special-cases M2-family parameters; this PR extends that special-casing to M3 so the same defaults are applied. M3 itself is already published in [models.dev](https://models.dev/api.json) for the `minimax` provider, so once this is merged the snapshot regeneration will surface M3 in the model list automatically.

Older models (M2.5/M2.1/M2/M1) are unchanged — they remain in models.dev and continue to work via the existing `minimax-m2` substring rule.

## Testing

- `bun test test/provider/transform.test.ts` — 252 pass, 0 fail (includes the new M3/M2.7 transform tests).