### PR TITLE
fix(ci): cap stalled unit jobs at 45 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           - name: windows
             host: blacksmith-4vcpu-windows-2025 # kilocode_change
     runs-on: ${{ matrix.settings.host }}
-    timeout-minutes: 45 # kilocode_change
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           - name: windows
             host: blacksmith-4vcpu-windows-2025 # kilocode_change
     runs-on: ${{ matrix.settings.host }}
+    timeout-minutes: 45 # kilocode_change
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           - name: windows
             host: blacksmith-4vcpu-windows-2025 # kilocode_change
     runs-on: ${{ matrix.settings.host }}
-    timeout-minutes: 45
+    timeout-minutes: 45 # kilocode_change
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
CLI unit subprocess leaks can leave the `unit` matrix job running until GitHub's default six-hour timeout, consuming runner capacity and blocking the required test check.

Cap the unit job at 45 minutes. Healthy runs finish well below that ceiling, while a leaked subprocess now fails within a bounded window instead of retaining a runner for hours.

This is intentionally a containment measure, not a test-runtime optimization. Follow-up work should harden process-tree cancellation in the CLI test runner and profile the Windows TUI plugin lifecycle slowdown.