### PR TITLE
fix(cli): restore Kilo Gateway next edit proxying

### DIFF
--- a/.changeset/restore-mercury-next-edit.md
+++ b/.changeset/restore-mercury-next-edit.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore Kilo Gateway-backed Mercury Next Edit completions.

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -158,14 +158,17 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const edit = Effect.fn("KiloGatewayHttpApi.edit")(function* (ctx: { payload: typeof EditBody.Type }) {
       const target = resolveEditTarget(ctx.payload.provider, ctx.payload.model)
-      if (target.provider !== "inception") {
+      if (target.provider === "kilo" && !target.url) {
         return yield* Effect.fail(new HttpApiError.BadRequest({}))
       }
+      const proxy = target.provider === "kilo" ? yield* proxyAuth() : undefined
       const token = yield* Effect.gen(function* () {
+        if (target.provider === "kilo") return proxy?.token
         const item = yield* auth.get(target.provider).pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
         if (item?.type === "api") return item.key
         return DIRECT_EDIT_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
       })
+      if (target.provider === "kilo" && !proxy?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -188,27 +191,44 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       })
 
       const response = yield* Effect.promise(async () => {
-        return fetch(target.url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          signal,
-          body: JSON.stringify({
-            model: target.model,
-            max_tokens: ctx.payload.maxTokens ?? 512,
-            // Mercury rejects role:"system" on this endpoint — must be a single user message.
-            messages: [{ role: "user", content }],
-          }),
-        })
+        try {
+          return await fetch(target.url, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+              ...(target.provider === "kilo"
+                ? buildKiloHeaders(undefined, { kilocodeOrganizationId: proxy?.organizationId })
+                : {}),
+              ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
+            },
+            signal,
+            body: JSON.stringify({
+              model: target.model,
+              max_tokens: ctx.payload.maxTokens ?? 512,
+              // Mercury rejects role:"system" on this endpoint — must be a single user message.
+              messages: [{ role: "user", content }],
+            }),
+          })
+        } catch (err) {
+          if (err instanceof DOMException && err.name === "TimeoutError")
+            return Response.json({ error: "Edit request timed out" }, { status: 504 })
+          if (signal.aborted) return Response.json({ error: "Edit request canceled" }, { status: 499 })
+          throw err
+        }
       })
 
       if (!response.ok) {
         // Pass the upstream status through (mirrors the FIM handler) so the
         // client can distinguish auth/credit/rate-limit/server failures
         // instead of collapsing everything to 400.
-        const text = yield* Effect.promise(() => response.text())
+        const text = yield* Effect.promise(async () => {
+          try {
+            return await response.text()
+          } catch {
+            return "<unreadable>"
+          }
+        })
         return HttpServerResponse.jsonUnsafe(
           { error: `Edit request failed: ${response.status} ${text}` },
           { status: response.status },

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -141,7 +141,7 @@ export const kiloScenarios: Scenario[] = [
   http.protected
     .post("/kilo/edit", "kilo.edit")
     .at((ctx) => ({ path: "/kilo/edit", headers: ctx.headers(), body: edit }))
-    .status(400),
+    .status(401),
   http.protected
     .post("/kilo/audio/transcriptions", "kilo.audio.transcriptions")
     .at((ctx) => ({

--- a/packages/opencode/test/kilocode/server/httpapi-kilo-edit.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-kilo-edit.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { ConfigProvider, Layer } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { HEADER_FEATURE, HEADER_ORGANIZATIONID } from "@kilocode/kilo-gateway"
+import * as Log from "@opencode-ai/core/util/log"
+import { KiloGatewayPaths } from "../../../src/kilocode/server/httpapi/groups/kilo-gateway"
+import { ExperimentalHttpApiServer } from "../../../src/server/routes/instance/httpapi/server"
+import { resetDatabase } from "../../fixture/db"
+import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
+
+void Log.init({ print: false })
+
+const env = {
+  KILO_AUTH_CONTENT: process.env.KILO_AUTH_CONTENT,
+  INCEPTION_API_KEY: process.env.INCEPTION_API_KEY,
+}
+
+const edit = {
+  provider: "kilo",
+  model: "inception/mercury-next-edit",
+  currentFilePath: "src/index.ts",
+  currentFileContent: "export const value = 1\n",
+  cursorLine: 0,
+  cursorCharacter: 0,
+  editableRegionStartLine: 0,
+  editableRegionEndLine: 0,
+  recentlyViewedSnippets: [],
+  editDiffHistory: [],
+}
+
+function app() {
+  const handler = HttpRouter.toWebHandler(
+    ExperimentalHttpApiServer.routes.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({})))),
+    { disableLogger: true },
+  ).handler
+
+  return {
+    request(input: string | URL | Request, init?: RequestInit) {
+      return handler(
+        input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init),
+        ExperimentalHttpApiServer.context,
+      )
+    },
+  }
+}
+
+async function send(body: Record<string, unknown> = edit, signal?: AbortSignal) {
+  await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+  return app().request(KiloGatewayPaths.edit, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-kilo-directory": tmp.path },
+    body: JSON.stringify(body),
+    signal,
+  })
+}
+
+function stub(run: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  const fetch: typeof globalThis.fetch = Object.assign(run, { preconnect: globalThis.fetch.preconnect })
+  return spyOn(globalThis, "fetch").mockImplementation(fetch)
+}
+
+function url(input: RequestInfo | URL) {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+function completion(input: RequestInfo | URL) {
+  return url(input).endsWith("/edit/completions")
+}
+
+function authenticate() {
+  process.env.KILO_AUTH_CONTENT = JSON.stringify({
+    kilo: {
+      type: "oauth",
+      refresh: "refresh-token",
+      access: "gateway-token",
+      expires: Date.now() + 60_000,
+      accountId: "org-1",
+    },
+  })
+}
+
+function restore() {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}
+
+afterEach(async () => {
+  restore()
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+describe("HttpApi Kilo next edit", () => {
+  test("requires Kilo Gateway authentication for the Kilo-backed model", async () => {
+    process.env.KILO_AUTH_CONTENT = "{}"
+    expect((await send()).status).toBe(401)
+  })
+
+  test("rejects non-edit placeholder targets", async () => {
+    process.env.KILO_AUTH_CONTENT = "{}"
+    expect((await send({ ...edit, model: "mistralai/codestral-2508" })).status).toBe(400)
+  })
+
+  test("proxies Kilo-backed edits with gateway auth and autocomplete headers", async () => {
+    authenticate()
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = []
+    const mock = stub(async (input, init) => {
+      if (!completion(input)) return Response.json([])
+      calls.push({ input, init })
+      return Response.json({
+        choices: [{ message: { content: "```typescript\nexport const value = 2\n```" } }],
+        usage: { prompt_tokens: 12, completion_tokens: 6 },
+      })
+    })
+
+    try {
+      const response = await send()
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        content: "export const value = 2",
+        usage: { prompt_tokens: 12, completion_tokens: 6 },
+      })
+      expect(calls).toHaveLength(1)
+      const call = calls[0]
+      if (!call) throw new Error("missing edit request")
+      expect(url(call.input)).toEndWith("/api/edit/completions")
+      const headers = new Headers(call.init?.headers)
+      expect(headers.get("authorization")).toBe("Bearer gateway-token")
+      expect(headers.get(HEADER_ORGANIZATIONID)).toBe("org-1")
+      expect(headers.get(HEADER_FEATURE)).toBe("autocomplete")
+      if (typeof call.init?.body !== "string") throw new Error("missing edit request body")
+      const body: unknown = JSON.parse(call.init.body)
+      expect(body).toMatchObject({ model: "inception/mercury-edit-2", messages: [{ role: "user" }] })
+    } finally {
+      mock.mockRestore()
+    }
+  })
+
+  test("preserves direct Inception BYOK edits", async () => {
+    process.env.KILO_AUTH_CONTENT = "{}"
+    process.env.INCEPTION_API_KEY = "inception-token"
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = []
+    const mock = stub(async (input, init) => {
+      if (!completion(input)) return Response.json([])
+      calls.push({ input, init })
+      return Response.json({ choices: [{ message: { content: "```\nconst value = 2\n```" } }] })
+    })
+
+    try {
+      const response = await send({ ...edit, provider: "inception", model: "mercury-next-edit" })
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ content: "const value = 2", usage: null })
+      const call = calls[0]
+      if (!call) throw new Error("missing edit request")
+      expect(url(call.input)).toBe("https://api.inceptionlabs.ai/v1/edit/completions")
+      const headers = new Headers(call.init?.headers)
+      expect(headers.get("authorization")).toBe("Bearer inception-token")
+      expect(headers.get(HEADER_ORGANIZATIONID)).toBeNull()
+      expect(headers.get(HEADER_FEATURE)).toBeNull()
+    } finally {
+      mock.mockRestore()
+    }
+  })
+
+  test("passes upstream statuses through when the error body is unreadable", async () => {
+    authenticate()
+    const mock = stub(async (input) => {
+      if (!completion(input)) return Response.json([])
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(new Error("broken upstream body"))
+          },
+        }),
+        { status: 502 },
+      )
+    })
+
+    try {
+      const response = await send()
+      expect(response.status).toBe(502)
+      expect(await response.json()).toEqual({ error: "Edit request failed: 502 <unreadable>" })
+    } finally {
+      mock.mockRestore()
+    }
+  })
+
+  test("maps upstream timeouts to 504", async () => {
+    authenticate()
+    const mock = stub(async (input) => {
+      if (!completion(input)) return Response.json([])
+      throw new DOMException("timed out", "TimeoutError")
+    })
+
+    try {
+      expect((await send()).status).toBe(504)
+    } finally {
+      mock.mockRestore()
+    }
+  })
+
+  test("maps request cancellation to 499", async () => {
+    authenticate()
+    const controller = new AbortController()
+    const mock = stub(async (input) => {
+      if (!completion(input)) return Response.json([])
+      controller.abort()
+      throw new DOMException("canceled", "AbortError")
+    })
+
+    try {
+      expect((await send(edit, controller.signal)).status).toBe(499)
+    } finally {
+      mock.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
The Effect HttpApi migration made `POST /kilo/edit` reject the Kilo Gateway-backed Mercury Next Edit target before authentication or forwarding. This left direct Inception BYOK available, but broke the normal Kilo-hosted Next Edit path selected by authenticated users.

Restore the Kilo proxy branch in the active Effect handler while keeping direct Inception BYOK and the non-edit placeholder guard intact. Kilo-backed requests now authenticate through the gateway token, forward organization metadata and `x-kilocode-feature: autocomplete`, preserve upstream status codes, safely handle unreadable error bodies, and map timeout or cancellation failures to the established `504` and `499` statuses.

The HttpApi exerciser now treats an unauthenticated Kilo-backed edit request as `401` rather than locking in the regressed `400` response.

Closes #10858