### PR TITLE
fix: prioritize Kilo environment auth overrides

### DIFF
--- a/.changeset/sync-api-key-sessions.md
+++ b/.changeset/sync-api-key-sessions.md
@@ -1,5 +1,7 @@
 ---
 "@kilocode/cli": patch
+"@kilocode/kilo-gateway": patch
+"@kilocode/kilo-telemetry": patch
 ---
 
-Sync CLI sessions to Kilo session history when authenticated with `KILO_API_KEY`, and make it override other options when present.
+Make `KILO_API_KEY` consistently override stored Kilo credentials and configured provider tokens across CLI modes, including inference, indexing, server-backed clients, and session synchronization.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -567,9 +567,13 @@ Anyone with access to your Kilo account can send messages to your computer when 
 
 The CLI supports overriding config values with environment variables. The supported environment variables are:
 
-- `KILO_PROVIDER`: Override the active provider ID
-- For `kilocode` provider: `KILOCODE_<FIELD_NAME>` (e.g., `KILOCODE_MODEL` → `kilocodeModel`)
-- For other providers: `KILO_<FIELD_NAME>` (e.g., `KILO_API_KEY` → `apiKey`)
+- `KILO_PROVIDER`: Override the active provider ID.
+- For the `kilocode` provider: `KILOCODE_<FIELD_NAME>` (for example, `KILOCODE_MODEL` → `kilocodeModel`).
+- For other providers: `KILO_<FIELD_NAME>` (for example, `KILO_API_KEY` → `apiKey`).
+
+`KILO_API_KEY` is the highest-priority Kilo Gateway credential. When it is set to a non-empty value, it overrides credentials saved by `kilo auth login` and tokens configured under `provider.kilo.options`. The override applies consistently to the TUI, `kilo run`, `kilo serve`, VS Code clients connected to that server, model discovery, indexing, session synchronization, sharing, and remote mode.
+
+`KILO_ORG_ID` is the corresponding highest-priority organization override. Account-management actions such as changing the saved `/teams` selection still require an interactive OAuth login.
 
 ## Using the CLI in an Organization
 

--- a/packages/kilo-gateway/src/api/profile.ts
+++ b/packages/kilo-gateway/src/api/profile.ts
@@ -1,6 +1,7 @@
 import { select } from "@clack/prompts"
 import type { KilocodeProfile, Organization, KilocodeBalance } from "../types.js"
 import { KILO_API_BASE, DEFAULT_MODEL, DEFAULT_FREE_MODEL } from "./constants.js"
+import { getApiKey, getKiloOrganizationId } from "../auth/token.js"
 
 /**
  * Fetch user profile from Kilo API
@@ -77,34 +78,36 @@ export const getKiloBalance = fetchBalance
 
 /**
  * Fetch default model for a given organization context
- * When token is provided, returns the authenticated user's default model
- * When no token is provided, returns the default free model for anonymous usage
+ * When a token or KILO_API_KEY override is provided, returns the authenticated user's default model.
+ * When no credential is available, returns the default free model for anonymous usage.
  */
 export async function fetchDefaultModel(token?: string, organizationId?: string): Promise<string> {
-  const path = organizationId ? `/api/organizations/${organizationId}/defaults` : `/api/defaults`
+  const key = getApiKey({ kilocodeToken: token })
+  const org = getKiloOrganizationId({ kilocodeOrganizationId: organizationId })
+  const path = org ? `/api/organizations/${org}/defaults` : `/api/defaults`
   const url = `${KILO_API_BASE}${path}`
 
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     }
-    if (token) {
-      headers.Authorization = `Bearer ${token}`
+    if (key) {
+      headers.Authorization = `Bearer ${key}`
     }
 
     const response = await fetch(url, { headers })
 
     if (!response.ok) {
-      return token ? DEFAULT_MODEL : DEFAULT_FREE_MODEL
+      return key ? DEFAULT_MODEL : DEFAULT_FREE_MODEL
     }
 
     const data = (await response.json()) as { defaultModel?: string; defaultFreeModel?: string }
-    if (token) {
+    if (key) {
       return data.defaultModel || DEFAULT_MODEL
     }
     return data.defaultFreeModel || DEFAULT_FREE_MODEL
   } catch {
-    return token ? DEFAULT_MODEL : DEFAULT_FREE_MODEL
+    return key ? DEFAULT_MODEL : DEFAULT_FREE_MODEL
   }
 }
 

--- a/packages/kilo-gateway/src/auth/token.ts
+++ b/packages/kilo-gateway/src/auth/token.ts
@@ -26,9 +26,42 @@ export function isValidKilocodeToken(token: string): boolean {
   return token.length > 10
 }
 
+type KiloEnv = {
+  KILO_API_KEY?: string
+  KILO_ORG_ID?: string
+}
+
+function text(value: string | undefined) {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+function runtime(env?: KiloEnv): KiloEnv {
+  if (env) return env
+  if (typeof process === "undefined") return {}
+  return {
+    KILO_API_KEY: process.env.KILO_API_KEY,
+    KILO_ORG_ID: process.env.KILO_ORG_ID,
+  }
+}
+
+export function getEnvApiKey(env?: KiloEnv) {
+  return text(runtime(env).KILO_API_KEY)
+}
+
+export function getEnvOrganizationId(env?: KiloEnv) {
+  return text(runtime(env).KILO_ORG_ID)
+}
+
 /**
- * Get API key from options or environment
+ * Get the Kilo API key, preferring the explicit environment override.
  */
-export function getApiKey(options: { kilocodeToken?: string; apiKey?: string }): string | undefined {
-  return options.kilocodeToken ?? options.apiKey
+export function getApiKey(options: { kilocodeToken?: string; apiKey?: string; env?: KiloEnv } = {}): string | undefined {
+  return getEnvApiKey(options.env) ?? text(options.kilocodeToken) ?? text(options.apiKey)
+}
+
+export function getKiloOrganizationId(
+  options: { kilocodeOrganizationId?: string; env?: KiloEnv } = {},
+): string | undefined {
+  return getEnvOrganizationId(options.env) ?? text(options.kilocodeOrganizationId)
 }

--- a/packages/kilo-gateway/src/index.ts
+++ b/packages/kilo-gateway/src/index.ts
@@ -16,7 +16,14 @@ export { buildKiloHeaders, getEditorNameHeader, getFeatureHeader, getDefaultHead
 // ============================================================================
 export { authenticateWithDeviceAuth } from "./auth/device-auth.js"
 export { authenticateWithDeviceAuthTUI } from "./auth/device-auth-tui.js"
-export { getKiloUrlFromToken, isValidKilocodeToken, getApiKey } from "./auth/token.js"
+export {
+  getKiloUrlFromToken,
+  isValidKilocodeToken,
+  getApiKey,
+  getEnvApiKey,
+  getEnvOrganizationId,
+  getKiloOrganizationId,
+} from "./auth/token.js"
 export { poll, formatTimeRemaining } from "./auth/polling.js"
 export { migrateLegacyKiloAuth, LEGACY_CONFIG_PATH } from "./auth/legacy-migration.js"
 

--- a/packages/kilo-gateway/src/provider-debug.ts
+++ b/packages/kilo-gateway/src/provider-debug.ts
@@ -1,9 +1,9 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import type { Provider as SDK } from "ai"
 import type { KiloProviderOptions } from "./types.js"
-import { getApiKey } from "./auth/token.js"
+import { getApiKey, getEnvApiKey, getEnvOrganizationId, getKiloOrganizationId } from "./auth/token.js"
 import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
-import { ANONYMOUS_API_KEY } from "./api/constants.js"
+import { ANONYMOUS_API_KEY, HEADER_ORGANIZATIONID } from "./api/constants.js"
 import { resolveKiloOpenRouterBaseUrl } from "./api/url.js"
 import { buildRequestHeaders } from "./provider.js"
 
@@ -17,20 +17,23 @@ export function createKiloDebug(options: KiloProviderOptions = {}): SDK {
   // Get API key from options or environment
   const apiKey = getApiKey(options)
   console.log("🔑 [KILO DEBUG] API Key extracted:")
-  console.log("  - Source:", options.kilocodeToken ? "kilocodeToken" : options.apiKey ? "apiKey" : "none")
+  console.log("  - Source:", getEnvApiKey() ? "KILO_API_KEY" : options.kilocodeToken ? "kilocodeToken" : options.apiKey ? "apiKey" : "none")
   console.log("  - Value:", apiKey ? `${apiKey.substring(0, 8)}...${apiKey.substring(apiKey.length - 8)}` : "MISSING!")
 
   const openRouterUrl = resolveKiloOpenRouterBaseUrl({ baseURL: options.baseURL, token: apiKey })
   console.log("🔗 [KILO DEBUG] OpenRouter URL:", openRouterUrl)
 
   // Merge custom headers with defaults
+  const organizationId = getKiloOrganizationId(options)
+  const override = getEnvOrganizationId()
   const customHeaders = {
     ...getDefaultHeaders(),
     ...buildKiloHeaders(undefined, {
-      kilocodeOrganizationId: options.kilocodeOrganizationId,
+      kilocodeOrganizationId: organizationId,
       kilocodeTesterWarningsDisabledUntil: undefined,
     }),
     ...options.headers,
+    ...(override ? { [HEADER_ORGANIZATIONID]: override } : {}),
   }
   console.log("📝 [KILO DEBUG] Custom headers:", JSON.stringify(customHeaders, null, 2))
 
@@ -42,6 +45,8 @@ export function createKiloDebug(options: KiloProviderOptions = {}): SDK {
     console.log("  - Method:", init?.method || "GET")
 
     const headers = buildRequestHeaders(customHeaders, init?.headers)
+
+    if (override) headers.set(HEADER_ORGANIZATIONID, override)
 
     // Add authorization if API key exists
     if (apiKey) {

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -4,9 +4,9 @@ import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import type { KiloProvider, KiloProviderOptions } from "./types.js"
-import { getApiKey } from "./auth/token.js"
+import { getApiKey, getEnvOrganizationId, getKiloOrganizationId } from "./auth/token.js"
 import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
-import { ANONYMOUS_API_KEY } from "./api/constants.js"
+import { ANONYMOUS_API_KEY, HEADER_ORGANIZATIONID } from "./api/constants.js"
 import { resolveKiloOpenRouterBaseUrl } from "./api/url.js"
 import { sanitizeResponsesBody } from "./responses.js"
 
@@ -41,13 +41,16 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const openRouterUrl = resolveKiloOpenRouterBaseUrl({ baseURL: options.baseURL, token: apiKey })
 
   // Merge custom headers with defaults
+  const organizationId = getKiloOrganizationId(options)
+  const override = getEnvOrganizationId()
   const customHeaders = {
     ...getDefaultHeaders(),
     ...buildKiloHeaders(undefined, {
-      kilocodeOrganizationId: options.kilocodeOrganizationId,
+      kilocodeOrganizationId: organizationId,
       kilocodeTesterWarningsDisabledUntil: undefined,
     }),
     ...options.headers,
+    ...(override ? { [HEADER_ORGANIZATIONID]: override } : {}),
   }
 
   // Create custom fetch wrapper to add dynamic headers
@@ -55,6 +58,8 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const wrappedFetch = async (input: string | URL | Request, init?: RequestInit) => {
     const headers = buildRequestHeaders(customHeaders, init?.headers)
     const body = sanitizeResponsesBody(input, init?.body)
+
+    if (override) headers.set(HEADER_ORGANIZATIONID, override)
 
     // Add authorization if API key exists
     if (apiKey) {

--- a/packages/kilo-gateway/src/server/edit.ts
+++ b/packages/kilo-gateway/src/server/edit.ts
@@ -3,7 +3,7 @@ import { DIRECT_EDIT_ENV, extractFencedBody, resolveEditTarget, type EditTarget,
 import { buildMercuryEditPrompt, type MercuryEditContext } from "../edit-prompt.js"
 import type { DirectAutocompleteProviderID } from "../autocomplete.js"
 import { buildKiloHeaders } from "../headers.js"
-import type { AuthStore } from "./handlers.js"
+import { getOrganizationId, getToken, type AuthStore } from "./handlers.js"
 
 type Auth = Pick<AuthStore, "get">
 
@@ -18,11 +18,9 @@ async function getProviderKey(Auth: Auth, provider: DirectAutocompleteProviderID
 
 async function getProxyAuth(Auth: Auth) {
   const auth = await Auth.get("kilo")
-  const token = auth?.type === "api" ? auth.key : auth?.type === "oauth" ? auth.access : undefined
   return {
-    auth,
-    token,
-    organizationId: auth?.type === "oauth" ? auth.accountId : undefined,
+    token: getToken(auth),
+    organizationId: getOrganizationId(auth),
   }
 }
 
@@ -38,10 +36,6 @@ export function createEditHandler(Auth: Auth) {
     const proxy = target.provider === "kilo" ? await getProxyAuth(Auth) : undefined
     const token =
       target.provider === "kilo" ? proxy?.token : await getProviderKey(Auth, target.provider as DirectAutocompleteProviderID)
-
-    if (target.provider === "kilo" && !proxy?.auth) {
-      return c.json({ error: "Not authenticated with Kilo Gateway" }, 401 as any)
-    }
 
     if (!token) {
       return c.json({ error: `Missing ${target.provider} provider API key` }, 401 as any)

--- a/packages/kilo-gateway/src/server/fim.ts
+++ b/packages/kilo-gateway/src/server/fim.ts
@@ -2,7 +2,7 @@ import { HEADER_FEATURE } from "../api/constants.js"
 import type { DirectAutocompleteProviderID } from "../autocomplete.js"
 import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget, type FimTarget } from "../fim.js"
 import { buildKiloHeaders } from "../headers.js"
-import type { AuthStore } from "./handlers.js"
+import { getOrganizationId, getToken, type AuthStore } from "./handlers.js"
 
 type Auth = Pick<AuthStore, "get">
 
@@ -10,11 +10,9 @@ const FIM_TIMEOUT_MS = 30_000
 
 async function getProxyAuth(Auth: Auth) {
   const auth = await Auth.get("kilo")
-  const token = auth?.type === "api" ? auth.key : auth?.type === "oauth" ? auth.access : undefined
   return {
-    auth,
-    token,
-    organizationId: auth?.type === "oauth" ? auth.accountId : undefined,
+    token: getToken(auth),
+    organizationId: getOrganizationId(auth),
   }
 }
 
@@ -72,10 +70,6 @@ export function createFimHandler(Auth: Auth) {
     const fimTemperature = temperature ?? 0.2
     const proxy = target.provider === "kilo" ? await getProxyAuth(Auth) : undefined
     const token = target.provider === "kilo" ? proxy?.token : await getProviderKey(Auth, target.provider)
-
-    if (target.provider === "kilo" && !proxy?.auth) {
-      return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
-    }
 
     if (target.provider === "kilo" && !token) {
       return c.json({ error: "No valid token found" }, 401)

--- a/packages/kilo-gateway/src/server/handlers.ts
+++ b/packages/kilo-gateway/src/server/handlers.ts
@@ -4,6 +4,7 @@ import { clearModesCache } from "../api/modes.js"
 import { HEADER_ORGANIZATIONID, KILO_API_BASE, KILO_CHAT_URL, KILO_EVENT_SERVICE_URL } from "../api/constants.js"
 import type { KilocodeBalance, KilocodeProfile } from "../types.js"
 import { buildKiloHeaders } from "../headers.js"
+import { getApiKey, getEnvApiKey, getKiloOrganizationId } from "../auth/token.js"
 
 export type KiloAuth =
   | { type: "api"; key: string }
@@ -52,25 +53,22 @@ export class GatewayError extends Error {
 }
 
 export function getToken(auth: KiloAuth | undefined) {
-  if (auth?.type === "api") return auth.key
-  if (auth?.type === "oauth") return auth.access
-  return undefined
+  const token =
+    auth?.type === "api" ? auth.key : auth?.type === "oauth" ? auth.access : auth?.type === "wellknown" ? auth.token : undefined
+  return getApiKey({ kilocodeToken: token })
 }
 
 export function getOrganizationId(auth: KiloAuth | undefined) {
-  if (auth?.type === "oauth") return auth.accountId
-  return undefined
+  return getKiloOrganizationId({ kilocodeOrganizationId: auth?.type === "oauth" ? auth.accountId : undefined })
 }
 
 export async function getProfile(auth: AuthStore): Promise<KiloProfileResult> {
   const info = await auth.get("kilo")
-  if (!info || info.type !== "oauth") throw new UnauthorizedError("Not authenticated with Kilo Gateway")
+  const token = getToken(info)
+  if (!token) throw new UnauthorizedError("Not authenticated with Kilo Gateway")
 
-  const currentOrgId = info.accountId ?? null
-  const [profile, balance] = await Promise.all([
-    fetchProfile(info.access),
-    fetchBalance(info.access, currentOrgId ?? undefined),
-  ])
+  const currentOrgId = getOrganizationId(info) ?? null
+  const [profile, balance] = await Promise.all([fetchProfile(token), fetchBalance(token, currentOrgId ?? undefined)])
   return { profile, balance, currentOrgId }
 }
 
@@ -125,7 +123,7 @@ export async function getClawChatCredentials(auth: AuthStore): Promise<ClawChatC
   const token = getToken(info)
   if (!token) throw new UnauthorizedError("No valid token found")
 
-  const expires = info?.type === "oauth" ? info.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
+  const expires = !getEnvApiKey() && info?.type === "oauth" ? info.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
   return {
     token,
     expiresAt: new Date(expires).toISOString(),

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -20,7 +20,9 @@ import {
   getClawStatus,
   getCloudSessions,
   getNotifications,
+  getOrganizationId,
   getProfile,
+  getToken,
   setOrganization,
 } from "./handlers.js"
 
@@ -152,11 +154,9 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
 
   const getProxyAuth = async () => {
     const auth = await Auth.get("kilo")
-    const token = auth?.type === "api" ? auth.key : auth?.type === "oauth" ? auth.access : undefined
     return {
-      auth,
-      token,
-      organizationId: auth?.type === "oauth" ? auth.accountId : undefined,
+      token: getToken(auth),
+      organizationId: getOrganizationId(auth),
     }
   }
 
@@ -282,20 +282,11 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
       }),
       async (c: any) => {
         const auth = await Auth.get("kilo")
+        const token = getToken(auth)
+        if (!token) return c.json({ modes: [] })
 
-        if (!auth || auth.type !== "oauth") {
-          return c.json({ modes: [] })
-        }
-
-        const token = auth.access
-        if (!token) {
-          return c.json({ modes: [] })
-        }
-
-        const orgId = auth.accountId
-        if (!orgId) {
-          return c.json({ modes: [] })
-        }
+        const orgId = getOrganizationId(auth)
+        if (!orgId) return c.json({ modes: [] })
 
         try {
           const modes = await fetchOrganizationModes(token, orgId)
@@ -407,8 +398,6 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
       ),
       async (c: any) => {
         const proxy = await getProxyAuth()
-        if (!proxy.auth) return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
-
         if (!proxy.token) return c.json({ error: "No valid token found" }, 401)
 
         const body = c.req.valid("json")
@@ -479,8 +468,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
       async (c: any) => {
         try {
           const auth = await Auth.get("kilo")
-          if (!auth) return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
-          const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
+          const token = getToken(auth)
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
           const { id } = c.req.valid("param")
@@ -522,8 +510,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           const { sessionId } = c.req.valid("json")
 
           const auth = await Auth.get("kilo")
-          if (!auth) return c.json({ error: "Not authenticated with Kilo" }, 401)
-          const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
+          const token = getToken(auth)
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
           const fetched = await fetchCloudSessionForImport(token, sessionId)
@@ -694,9 +681,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
       async (c: any) => {
         try {
           const auth = await Auth.get("kilo")
-          if (!auth) return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
-
-          const token = auth.type === "api" ? auth.key : auth.type === "oauth" ? auth.access : undefined
+          const token = getToken(auth)
           if (!token) return c.json({ error: "No valid token found" }, 401)
 
           return c.json(await getCloudSessions(token, c.req.valid("query")))

--- a/packages/kilo-gateway/test/provider.test.ts
+++ b/packages/kilo-gateway/test/provider.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import { getApiKey, getKiloOrganizationId } from "../src/auth/token"
 import { buildRequestHeaders } from "../src/provider"
+import { getOrganizationId, getToken, setOrganization, UnauthorizedError } from "../src/server/handlers"
+
+const key = process.env.KILO_API_KEY
+const org = process.env.KILO_ORG_ID
+
+afterEach(() => {
+  if (key === undefined) delete process.env.KILO_API_KEY
+  else process.env.KILO_API_KEY = key
+  if (org === undefined) delete process.env.KILO_ORG_ID
+  else process.env.KILO_ORG_ID = org
+})
 
 describe("Kilo provider request headers", () => {
   test("request headers override provider defaults", () => {
@@ -19,5 +31,56 @@ describe("Kilo provider request headers", () => {
     expect(headers.get("x-kilocode-feature")).toBe("agent-manager")
     expect(headers.get("x-default-only")).toBe("kept")
     expect(headers.get("x-request-only")).toBe("kept-too")
+  })
+})
+
+describe("Kilo provider environment overrides", () => {
+  test("prefers KILO_API_KEY over stored and configured tokens", () => {
+    expect(
+      getApiKey({
+        env: { KILO_API_KEY: " env-token " },
+        kilocodeToken: "stored-token",
+        apiKey: "config-token",
+      }),
+    ).toBe("env-token")
+  })
+
+  test("ignores an empty KILO_API_KEY override", () => {
+    expect(getApiKey({ env: { KILO_API_KEY: " " }, kilocodeToken: "stored-token" })).toBe("stored-token")
+  })
+
+  test("prefers KILO_ORG_ID over the stored organization", () => {
+    expect(
+      getKiloOrganizationId({ env: { KILO_ORG_ID: " org-env " }, kilocodeOrganizationId: "org-stored" }),
+    ).toBe("org-env")
+  })
+})
+
+describe("Kilo server environment overrides", () => {
+  test("prefers environment overrides over stored auth", () => {
+    process.env.KILO_API_KEY = " env-token "
+    process.env.KILO_ORG_ID = " org-env "
+
+    expect(getToken({ type: "api", key: "stored-token" })).toBe("env-token")
+    expect(getOrganizationId({ type: "oauth", access: "stored-token", refresh: "refresh", expires: 1, accountId: "org-stored" })).toBe(
+      "org-env",
+    )
+  })
+
+  test("keeps saved organization mutation OAuth-only", async () => {
+    process.env.KILO_API_KEY = "env-token"
+    await expect(
+      setOrganization(
+        {
+          auth: {
+            get: async () => undefined,
+            set: async () => undefined,
+          },
+          clear: () => undefined,
+          dispose: async () => undefined,
+        },
+        "org-env",
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedError)
   })
 })

--- a/packages/kilo-telemetry/src/identity.ts
+++ b/packages/kilo-telemetry/src/identity.ts
@@ -1,5 +1,5 @@
 import * as path from "path"
-import { fetchProfile } from "@kilocode/kilo-gateway"
+import { fetchProfile, getApiKey, getKiloOrganizationId } from "@kilocode/kilo-gateway"
 
 export namespace Identity {
   let machineId: string | null = null
@@ -52,14 +52,15 @@ export namespace Identity {
   }
 
   export async function updateFromKiloAuth(token: string | null, accountId?: string): Promise<void> {
-    organizationId = accountId || null
+    const key = getApiKey({ kilocodeToken: token ?? undefined })
+    organizationId = getKiloOrganizationId({ kilocodeOrganizationId: accountId }) ?? null
 
-    if (!token) {
+    if (!key) {
       userId = null
       return
     }
 
-    const profile = await fetchProfile(token).catch(() => null)
+    const profile = await fetchProfile(key).catch(() => null)
     userId = profile?.email || null
   }
 

--- a/packages/kilo-telemetry/src/telemetry.ts
+++ b/packages/kilo-telemetry/src/telemetry.ts
@@ -102,10 +102,11 @@ export namespace Telemetry {
     await Identity.updateFromKiloAuth(token, accountId)
 
     const email = Identity.getUserId()
+    const org = Identity.getOrganizationId()
     if (email && previousId && email !== previousId) {
       // Identify the user with their email and properties
       Client.identify(email, {
-        ...(accountId && { kilocodeOrganizationId: accountId }),
+        ...(org && { kilocodeOrganizationId: org }),
         appName: props.appName,
         appVersion: props.appVersion,
         platform: props.platform,

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -552,6 +552,8 @@ export const layer = Layer.effect(
 
       const env = {
         KILO_AUTH_CONTENT: JSON.stringify(yield* auth.all()),
+        KILO_API_KEY: process.env.KILO_API_KEY, // kilocode_change
+        KILO_ORG_ID: process.env.KILO_ORG_ID, // kilocode_change
         KILO_WORKSPACE_ID: config.id,
         KILO_EXPERIMENTAL_WORKSPACES: "true",
         OTEL_EXPORTER_OTLP_HEADERS: process.env.OTEL_EXPORTER_OTLP_HEADERS,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -162,11 +162,9 @@ let cli = yargs(args) // kilocode_change
     )
 
     const kiloAuth = await AppRuntime.runPromise(Auth.Service.use((svc) => svc.get("kilo")))
-    if (kiloAuth) {
-      const token = kiloAuth.type === "oauth" ? kiloAuth.access : kiloAuth.key
-      const accountId = kiloAuth.type === "oauth" ? kiloAuth.accountId : undefined
-      await Telemetry.updateIdentity(token, accountId)
-    }
+    const token = kiloAuth?.type === "oauth" ? kiloAuth.access : kiloAuth?.type === "api" ? kiloAuth.key : null
+    const accountId = kiloAuth?.type === "oauth" ? kiloAuth.accountId : undefined
+    await Telemetry.updateIdentity(token, accountId)
 
     Telemetry.trackCliStart()
     // kilocode_change end

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -16,7 +16,7 @@ import { clearInFlightCache, withInFlightCache } from "@/kilo-sessions/inflight-
 import type * as SDK from "@kilocode/sdk/v2"
 import z from "zod"
 import { Context, Effect, Layer, Schema, Stream } from "effect"
-import { KILO_API_BASE } from "@kilocode/kilo-gateway"
+import { getApiKey, getKiloOrganizationId, KILO_API_BASE } from "@kilocode/kilo-gateway"
 import { Config } from "@/config/config"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -103,13 +103,13 @@ export namespace KiloSessions {
 
   async function kilocodeToken() {
     return withInFlightCache(tokenKey, ttlMs, async () => {
+      const key = getApiKey()
+      if (key) return key
+
       const auth = await runtime.runPromise((svc) => svc.get("kilo"))
       if (auth?.type === "api" && auth.key.length > 0) return auth.key
       if (auth?.type === "oauth" && auth.access.length > 0) return auth.access
       if (auth?.type === "wellknown" && auth.token.length > 0) return auth.token
-
-      const key = process.env["KILO_API_KEY"]?.trim()
-      if (key) return key
       return undefined
     })
   }
@@ -767,8 +767,8 @@ export namespace KiloSessions {
   }
 
   async function getOrgId(): Promise<Uuid | undefined> {
-    const env = process.env["KILO_ORG_ID"]
-    if (isUuid(env)) return env
+    const env = getKiloOrganizationId()
+    if (env) return isUuid(env) ? env : undefined
 
     return withInFlightCache(orgKey, ttlMs, async () => {
       const auth = await runtime.runPromise((svc) => svc.get("kilo"))

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -15,7 +15,7 @@ import { ConfigError } from "../../config/error"
 import type { Config } from "../../config/config"
 import type { ConfigAgent } from "../../config/agent"
 import { ModesMigrator } from "../modes-migrator"
-import { fetchOrganizationModes } from "@kilocode/kilo-gateway"
+import { fetchOrganizationModes, getApiKey, getKiloOrganizationId } from "@kilocode/kilo-gateway"
 import { RulesMigrator } from "../rules-migrator"
 import { WorkflowsMigrator } from "../workflows-migrator"
 import { McpMigrator } from "../mcp-migrator"
@@ -304,8 +304,10 @@ export namespace KilocodeConfig {
     const warnings: Config.Warning[] = []
     try {
       const kilo = auth["kilo"]
-      if (kilo?.type === "oauth" && kilo.access && kilo.accountId) {
-        const modes = await fetchOrganizationModes(kilo.access, kilo.accountId)
+      const token = getApiKey({ kilocodeToken: kilo?.type === "oauth" ? kilo.access : undefined })
+      const org = getKiloOrganizationId({ kilocodeOrganizationId: kilo?.type === "oauth" ? kilo.accountId : undefined })
+      if (token && org) {
+        const modes = await fetchOrganizationModes(token, org)
         if (modes.length > 0) {
           const agents = ModesMigrator.convertOrganizationModes(modes)
           log.debug("loaded organization custom modes", {

--- a/packages/opencode/src/kilocode/indexing-auth.ts
+++ b/packages/opencode/src/kilocode/indexing-auth.ts
@@ -1,4 +1,5 @@
 import type { IndexingConfig } from "@kilocode/kilo-indexing/config"
+import { getApiKey, getKiloOrganizationId } from "@kilocode/kilo-gateway"
 
 type Auth = unknown
 
@@ -78,23 +79,27 @@ export function resolveKiloIndexingAuth(input: {
   const providerOptions = record(provider.options)
   const providerConfig = record(options.options)
   const kilo = record(record(config.indexing).kilo)
-  const env = input.env ?? process.env
+  const env = input.env ?? { KILO_API_KEY: process.env.KILO_API_KEY, KILO_ORG_ID: process.env.KILO_ORG_ID }
 
   return {
-    apiKey:
-      text(kilo.apiKey) ??
-      text(providerConfig.apiKey) ??
-      token(input.auth) ??
-      text(provider.key) ??
-      text(providerOptions.kilocodeToken) ??
-      text(env.KILO_API_KEY),
+    apiKey: getApiKey({
+      env,
+      kilocodeToken:
+        text(kilo.apiKey) ??
+        text(providerConfig.apiKey) ??
+        token(input.auth) ??
+        text(provider.key) ??
+        text(providerOptions.kilocodeToken),
+    }),
     baseUrl: text(kilo.baseUrl) ?? text(providerConfig.baseURL) ?? text(providerConfig.baseUrl),
-    organizationId:
-      text(kilo.organizationId) ??
-      text(providerConfig.kilocodeOrganizationId) ??
-      org(input.auth) ??
-      text(providerOptions.kilocodeOrganizationId) ??
-      text(env.KILO_ORG_ID),
+    organizationId: getKiloOrganizationId({
+      env,
+      kilocodeOrganizationId:
+        text(kilo.organizationId) ??
+        text(providerConfig.kilocodeOrganizationId) ??
+        org(input.auth) ??
+        text(providerOptions.kilocodeOrganizationId),
+    }),
   }
 }
 

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -73,9 +73,9 @@ function enrichKilo(input: ReturnType<typeof toIndexingConfigInput>, auth: KiloI
 
   return {
     ...input,
-    kiloApiKey: input.kiloApiKey ?? auth.apiKey,
+    kiloApiKey: auth.apiKey ?? input.kiloApiKey,
     kiloBaseUrl: input.kiloBaseUrl ?? auth.baseUrl,
-    kiloOrganizationId: input.kiloOrganizationId ?? auth.organizationId,
+    kiloOrganizationId: auth.organizationId ?? input.kiloOrganizationId,
   }
 }
 

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -3,6 +3,7 @@ import {
   fetchCloudSession,
   fetchCloudSessionForImport,
   getCloudSessions,
+  getEnvApiKey,
   getOrganizationId,
   getToken,
   importSessionToDb,
@@ -50,11 +51,12 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const profile = Effect.fn("KiloGatewayHttpApi.profile")(function* () {
       const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
-      if (!info || info.type !== "oauth") return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const token = getToken(info)
+      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
-      const currentOrgId = info.accountId ?? null
+      const currentOrgId = getOrganizationId(info) ?? null
       const [profile, balance] = yield* Effect.tryPromise({
-        try: () => Promise.all([fetchProfile(info.access), fetchBalance(info.access, currentOrgId ?? undefined)]),
+        try: () => Promise.all([fetchProfile(token), fetchBalance(token, currentOrgId ?? undefined)]),
         catch: () => new HttpApiError.BadRequest({}),
       })
       return { profile, balance, currentOrgId }
@@ -63,7 +65,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     const proxyAuth = Effect.fn("KiloGatewayHttpApi.proxyAuth")(function* () {
       const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
       return {
-        auth: info,
         token: getToken(info),
         organizationId: getOrganizationId(info),
       }
@@ -71,10 +72,11 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const modes = Effect.fn("KiloGatewayHttpApi.modes")(function* () {
       const info = yield* auth.get("kilo").pipe(Effect.catch(() => Effect.succeed(undefined)))
-      if (!info || info.type !== "oauth" || !info.access || !info.accountId) return { modes: [] }
+      const token = getToken(info)
+      const org = getOrganizationId(info)
+      if (!token || !org) return { modes: [] }
 
-      const org = info.accountId
-      return yield* Effect.promise(() => fetchOrganizationModes(info.access, org)).pipe(
+      return yield* Effect.promise(() => fetchOrganizationModes(token, org)).pipe(
         Effect.map((modes) => ({ modes })),
         Effect.catch(() => Effect.succeed({ modes: [] })),
       )
@@ -90,7 +92,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
         return DIRECT_FIM_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
       })
 
-      if (target.provider === "kilo" && !info?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -158,10 +159,12 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const edit = Effect.fn("KiloGatewayHttpApi.edit")(function* (ctx: { payload: typeof EditBody.Type }) {
       const target = resolveEditTarget(ctx.payload.provider, ctx.payload.model)
-      if (target.provider !== "inception") {
+      if (target.provider === "kilo" && !target.url) {
         return yield* Effect.fail(new HttpApiError.BadRequest({}))
       }
+      const info = target.provider === "kilo" ? yield* proxyAuth() : undefined
       const token = yield* Effect.gen(function* () {
+        if (target.provider === "kilo") return info?.token
         const item = yield* auth.get(target.provider).pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
         if (item?.type === "api") return item.key
         return DIRECT_EDIT_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
@@ -193,6 +196,10 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
+            ...(target.provider === "kilo"
+              ? buildKiloHeaders(undefined, { kilocodeOrganizationId: info?.organizationId })
+              : {}),
+            ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
           },
           signal,
           body: JSON.stringify({
@@ -236,7 +243,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       payload: typeof AudioTranscriptionsBody.Type
     }) {
       const info = yield* proxyAuth()
-      if (!info.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!info.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -325,7 +331,7 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       const token = getToken(info)
       if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
-      const expires = info?.type === "oauth" ? info.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
+      const expires = !getEnvApiKey() && info?.type === "oauth" ? info.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
       return {
         token,
         expiresAt: new Date(expires).toISOString(),

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -1,5 +1,5 @@
 // kilocode_change - new file
-import { fetchKiloModels, type KiloModelsResult } from "@kilocode/kilo-gateway"
+import { fetchKiloModels, getApiKey, getKiloOrganizationId, type KiloModelsResult } from "@kilocode/kilo-gateway"
 import { Context, Duration, Effect, Layer, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Config } from "../config/config"
@@ -129,8 +129,10 @@ export const layer: Layer.Layer<
           if (info.accountId) options.kilocodeOrganizationId = info.accountId
         }
 
-        if (process.env.KILO_API_KEY) options.kilocodeToken = process.env.KILO_API_KEY
-        if (process.env.KILO_ORG_ID) options.kilocodeOrganizationId = process.env.KILO_ORG_ID
+        options.kilocodeToken = getApiKey({ kilocodeToken: options.kilocodeToken })
+        options.kilocodeOrganizationId = getKiloOrganizationId({
+          kilocodeOrganizationId: options.kilocodeOrganizationId,
+        })
         log.debug("auth options resolved", {
           providerID,
           hasToken: !!options.kilocodeToken,
@@ -173,7 +175,13 @@ export const layer: Layer.Layer<
           }),
         ),
       )
-      return yield* fetchModels(providerID, { ...resolved, ...options })
+      const merged = { ...resolved, ...options }
+      if (providerID !== "kilo") return yield* fetchModels(providerID, merged)
+      return yield* fetchModels(providerID, {
+        ...merged,
+        kilocodeToken: getApiKey({ kilocodeToken: merged.kilocodeToken, apiKey: merged.apiKey }),
+        kilocodeOrganizationId: getKiloOrganizationId({ kilocodeOrganizationId: merged.kilocodeOrganizationId }),
+      })
     })
 
     const key = (providerID: string, options?: Options) => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -12,7 +12,7 @@ import { withTransientReadRetry } from "@/util/effect-http-client"
 import { Config } from "../config/config"
 import { ModelCache } from "./model-cache"
 import { Auth } from "../auth"
-import { AI_SDK_PROVIDERS, KILO_OPENROUTER_BASE, PROMPTS } from "@kilocode/kilo-gateway"
+import { AI_SDK_PROVIDERS, getKiloOrganizationId, KILO_OPENROUTER_BASE, PROMPTS } from "@kilocode/kilo-gateway"
 // kilocode_change end
 
 // kilocode_change start
@@ -20,7 +20,7 @@ const normalizeKiloBaseURL = (baseURL: string | undefined, org: string | undefin
   if (!baseURL) return undefined
   const trimmed = baseURL.replace(/\/+$/, "")
   if (org) {
-    if (trimmed.includes("/api/organizations/")) return trimmed
+    if (trimmed.includes("/api/organizations/")) return trimmed.replace(/\/api\/organizations\/[^/]+/, `/api/organizations/${org}`)
     if (trimmed.endsWith("/api")) return `${trimmed}/organizations/${org}`
     return `${trimmed}/api/organizations/${org}`
   }
@@ -212,7 +212,9 @@ export const layer: Layer.Layer<Service, never, Requirements> = Layer.effect(
       if (kiloAllowed) {
         const opts = config.provider?.kilo?.options
         const info = yield* auth.get("kilo").pipe(Effect.catch(() => Effect.succeed(undefined)))
-        const org = opts?.kilocodeOrganizationId ?? (info?.type === "oauth" ? info.accountId : undefined)
+        const org = getKiloOrganizationId({
+          kilocodeOrganizationId: opts?.kilocodeOrganizationId ?? (info?.type === "oauth" ? info.accountId : undefined),
+        })
         const base = normalizeKiloBaseURL(opts?.baseURL, org)
         const fetch = {
           ...(base ? { baseURL: base } : {}),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -5,6 +5,11 @@ import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { markInstanceForDisposal } from "../lifecycle"
+// kilocode_change start
+import { fetchDefaultModel } from "@kilocode/kilo-gateway"
+import { Auth } from "@/auth"
+import { ModelID, ProviderID } from "@/provider/schema"
+// kilocode_change end
 
 export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (handlers) =>
   Effect.gen(function* () {
@@ -29,9 +34,24 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
 
     const providers = Effect.fn("ConfigHttpApi.providers")(function* () {
       const providers = yield* providerSvc.list()
+      const defaults = Provider.defaultModelIDs(providers)
+
+      // kilocode_change start - Keep Kilo API default-model lookup aligned with the legacy Hono route.
+      if (providers[ProviderID.kilo]) {
+        const auth = yield* Auth.Service
+        const kiloAuth = yield* auth.get("kilo").pipe(Effect.orDie)
+        const token = kiloAuth?.type === "oauth" ? kiloAuth.access : kiloAuth?.key
+        const organizationId = kiloAuth?.type === "oauth" ? kiloAuth.accountId : undefined
+        const kiloApiDefault = yield* Effect.promise(() => fetchDefaultModel(token, organizationId))
+        if (kiloApiDefault && providers[ProviderID.kilo]?.models[kiloApiDefault]) {
+          defaults[ProviderID.kilo] = ModelID.make(kiloApiDefault)
+        }
+      }
+      // kilocode_change end
+
       return {
         providers: Object.values(providers),
-        default: Provider.defaultModelIDs(providers),
+        default: defaults, // kilocode_change
       }
     })
 

--- a/packages/opencode/test/control-plane/workspace.test.ts
+++ b/packages/opencode/test/control-plane/workspace.test.ts
@@ -48,6 +48,8 @@ const it = testEffect(testServerLayer)
 const originalWorkspacesFlag = Flag.KILO_EXPERIMENTAL_WORKSPACES
 const originalEnv = {
   KILO_AUTH_CONTENT: process.env.KILO_AUTH_CONTENT,
+  KILO_API_KEY: process.env.KILO_API_KEY, // kilocode_change
+  KILO_ORG_ID: process.env.KILO_ORG_ID, // kilocode_change
   OTEL_EXPORTER_OTLP_HEADERS: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   OTEL_RESOURCE_ATTRIBUTES: process.env.OTEL_RESOURCE_ATTRIBUTES,
@@ -407,6 +409,8 @@ describe("workspace-old CRUD", () => {
   test("create configures, persists, creates, starts local sync, and passes environment", async () => {
     await withInstance(async (dir) => {
       process.env.KILO_AUTH_CONTENT = JSON.stringify({ test: { type: "api", key: "secret" } })
+      process.env.KILO_API_KEY = "env-token" // kilocode_change
+      process.env.KILO_ORG_ID = "env-org" // kilocode_change
       process.env.OTEL_EXPORTER_OTLP_HEADERS = "authorization=otel"
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://otel.test"
       process.env.OTEL_RESOURCE_ATTRIBUTES = "service.name=opencode-test"
@@ -459,6 +463,8 @@ describe("workspace-old CRUD", () => {
       expect(JSON.parse(recorded.calls.create[0].env.KILO_AUTH_CONTENT ?? "{}")).toEqual({
         test: { type: "api", key: "secret" },
       })
+      expect(recorded.calls.create[0].env.KILO_API_KEY).toBe("env-token") // kilocode_change
+      expect(recorded.calls.create[0].env.KILO_ORG_ID).toBe("env-org") // kilocode_change
       expect(recorded.calls.create[0].env.KILO_WORKSPACE_ID).toBe(workspaceID)
       expect(recorded.calls.create[0].env.KILO_EXPERIMENTAL_WORKSPACES).toBe("true")
       expect(recorded.calls.create[0].env.OTEL_EXPORTER_OTLP_HEADERS).toBe("authorization=otel")

--- a/packages/opencode/test/kilocode/indexing-auth.test.ts
+++ b/packages/opencode/test/kilocode/indexing-auth.test.ts
@@ -34,6 +34,26 @@ describe("Kilo indexing auth resolution", () => {
     })
   })
 
+  test("prefers environment overrides over every other Kilo auth source", () => {
+    const auth = resolveKiloIndexingAuth({
+      config: {
+        indexing: { kilo: { apiKey: "idx-token", organizationId: "org_idx" } },
+        provider: { kilo: { options: { apiKey: "cfg-token", kilocodeOrganizationId: "org_cfg" } } },
+      },
+      provider: { key: "provider-key", options: { kilocodeToken: "provider-token", kilocodeOrganizationId: "org_provider" } },
+      auth: { type: "oauth", access: "oauth-token", accountId: "org_oauth" },
+      env: { KILO_API_KEY: " env-token ", KILO_ORG_ID: " org_env " },
+    })
+
+    expect(auth).toEqual({ apiKey: "env-token", organizationId: "org_env" })
+  })
+
+  test("ignores empty environment overrides", () => {
+    expect(resolveKiloIndexingAuth({ config: { indexing: { kilo: { apiKey: "idx-token" } } }, env: { KILO_API_KEY: " " } }).apiKey).toBe(
+      "idx-token",
+    )
+  })
+
   test("defaults to Kilo only when no provider or other embedder config is present", () => {
     const auth = { apiKey: "kilo-token" }
 

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -350,7 +350,13 @@ describe("indexing startup degradation", () => {
     const key = process.env.KILO_API_KEY
     const org = process.env.KILO_ORG_ID
 
-    await using tmp = await tmpdir({ git: true, config: kilo })
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        ...kilo,
+        indexing: { ...kilo.indexing, kilo: { apiKey: "config-token", organizationId: "org_config" } },
+      },
+    })
     process.env["KILO_CONFIG_DIR"] = tmp.path
     process.env.KILO_API_KEY = "kilo-token"
     process.env.KILO_ORG_ID = "org_123"

--- a/packages/opencode/test/kilocode/kilo-sessions.test.ts
+++ b/packages/opencode/test/kilocode/kilo-sessions.test.ts
@@ -90,7 +90,7 @@ it.instance("bootstraps session ingest from KILO_API_KEY without stored auth", (
   )
 })
 
-it.instance("prefers stored auth over KILO_API_KEY for session ingest", () => {
+it.instance("prefers KILO_API_KEY over stored auth for session ingest", () => {
   const original = process.env.KILO_API_KEY
   const calls: string[] = []
   const fetch: typeof globalThis.fetch = Object.assign(
@@ -117,7 +117,7 @@ it.instance("prefers stored auth over KILO_API_KEY for session ingest", () => {
     const auth = yield* Auth.Service
     yield* auth.set("kilo", { type: "api", key: "stored-token" })
     yield* Effect.promise(() => KiloSessions.bootstrap("session-auth"))
-    expect(calls).toEqual(["Bearer stored-token", "Bearer stored-token"])
+    expect(calls).toEqual(["Bearer env-token", "Bearer env-token"])
   }).pipe(
     Effect.ensuring(
       Effect.gen(function* () {

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -81,6 +81,40 @@ it.live("model fetch without OAuth accountId does not set kilocodeOrganizationId
   }),
 )
 
+it.live("environment overrides win over caller and stored model fetch options", () => {
+  const key = process.env.KILO_API_KEY
+  const org = process.env.KILO_ORG_ID
+  process.env.KILO_API_KEY = " env-token "
+  process.env.KILO_ORG_ID = " org-env "
+
+  return Effect.gen(function* () {
+    const captured = yield* Ref.make<Options | undefined>(undefined)
+    const info = new Auth.Oauth({
+      type: "oauth",
+      access: "oauth-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 3600000,
+      accountId: "org-oauth",
+    })
+    yield* ModelCache.Service.use((cache) =>
+      cache.fetch("kilo", { kilocodeToken: "caller-token", kilocodeOrganizationId: "org-caller" }),
+    ).pipe(Effect.provide(layer(info, captured)))
+    expect(yield* Ref.get(captured)).toMatchObject({
+      kilocodeToken: "env-token",
+      kilocodeOrganizationId: "org-env",
+    })
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        if (key === undefined) delete process.env.KILO_API_KEY
+        else process.env.KILO_API_KEY = key
+        if (org === undefined) delete process.env.KILO_ORG_ID
+        else process.env.KILO_ORG_ID = org
+      }),
+    ),
+  )
+})
+
 it.live("ModelCache.clear removes cached entry so next fetch hits the network", () =>
   Effect.gen(function* () {
     const captured = yield* Ref.make<Options | undefined>(undefined)


### PR DESCRIPTION
## Summary
- Treat non-empty `KILO_API_KEY` and `KILO_ORG_ID` values as explicit runtime overrides for Kilo authentication and organization routing.
- Apply the same precedence across inference, model discovery, indexing, session sync, server-backed clients, telemetry identity, and workspace child processes while keeping the Hono and Effect HTTP paths aligned.
- Document the override contract and keep persisted organization selection intentionally OAuth-only.

## Stack
- Stacked on #10751 so the original session-ingest fix remains focused and this broader consistency change can be reviewed separately.