### PR TITLE
ci(codeql): split Kotlin analysis into dedicated workflow

### DIFF
--- a/.github/workflows/codeql-kotlin.yml
+++ b/.github/workflows/codeql-kotlin.yml
@@ -1,0 +1,60 @@
+# kilocode_change - new file
+name: "CodeQL Kotlin"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "packages/kilo-jetbrains/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "packages/kilo-jetbrains/**"
+  schedule:
+    - cron: "29 10 * * 5"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build Java/Kotlin
+        shell: bash
+        run: ./gradlew typecheck --rerun-tasks --no-build-cache
+        working-directory: packages/kilo-jetbrains
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/codeql-kotlin.yml
+++ b/.github/workflows/codeql-kotlin.yml
@@ -6,10 +6,12 @@ on:
     branches: ["main"]
     paths:
       - "packages/kilo-jetbrains/**"
+      - ".github/workflows/codeql-kotlin.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "packages/kilo-jetbrains/**"
+      - ".github/workflows/codeql-kotlin.yml"
   schedule:
     - cron: "29 10 * * 5"
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,11 +14,11 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '29 10 * * 5'
+    - cron: "29 10 * * 5"
   workflow_dispatch:
 
 jobs:
@@ -45,12 +45,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: java-kotlin
-          build-mode: manual
-        - language: javascript-typescript
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -60,58 +58,24 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
-    - name: Setup Bun
-      if: matrix.language == 'java-kotlin'
-      uses: ./.github/actions/setup-bun
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-    - name: Setup Java
-      if: matrix.language == 'java-kotlin'
-      uses: actions/setup-java@v4
-      with:
-        distribution: temurin
-        java-version: "21"
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    - name: Setup Gradle
-      if: matrix.language == 'java-kotlin'
-      uses: gradle/actions/setup-gradle@v4
-      with:
-        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        config-file: ./.github/codeql/codeql-config.yml
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Build Java/Kotlin
-      if: matrix.language == 'java-kotlin'
-      shell: bash
-      run: ./gradlew typecheck
-      working-directory: packages/kilo-jetbrains
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/script/check-workflows.ts
+++ b/script/check-workflows.ts
@@ -36,6 +36,7 @@ const active = new Set([
   "check-org-member.yml",
   "close-issues.yml",
   "close-stale-prs.yml",
+  "codeql-kotlin.yml",
   "codeql.yml",
   "containers.yml",
   "docs-build.yml",


### PR DESCRIPTION

## Why

The Kotlin CodeQL scan was configured in manual mode, so it needed to observe an actual compilation to collect source data. When Gradle restored every compilation task from cache, the Kotlin compiler never ran and CodeQL failed because it could not find any Kotlin code to analyze.


## Implementation

Extract java-kotlin language analysis from the shared CodeQL Advanced workflow into a dedicated codeql-kotlin.yml workflow. This allows the Kotlin analysis (which requires Java, Gradle, and a manual build) to run independently with path filtering on packages/kilo-jetbrains, reducing unnecessary CI runs for unrelated changes.

- Add new codeql-kotlin.yml with path-scoped triggers
- Remove java-kotlin from the matrix in codeql.yml
- Simplify codeql.yml by removing conditional Java/Gradle setup steps
- Register codeql-kotlin.yml in check-workflows.ts active set

## Alternative

Alternative considered: use CodeQL `build-mode: none` so the scan does not depend on Gradle compilation or its cache. However, buildless analysis supports Java but not Kotlin, so it would effectively skip security analysis for most of the JetBrains plugin. Instead, this PR keeps manual Kotlin compilation and disables Gradle task caching during the scan.
