### PR TITLE
Review OpenCode v1.14.46 merge

### DIFF
--- a/BROKEN_PIPELINE_CHAINS.md
+++ b/BROKEN_PIPELINE_CHAINS.md
@@ -1,0 +1,127 @@
+# Broken Pipeline Chains Review
+
+Reviewed PR: `https://github.com/Kilo-Org/kilocode/pull/10822`
+
+Reviewed snapshot: `94fc42255c35827b197d97368d75d079242e9f4d`
+
+Reviewed PR base snapshot: `2f7f23deac683078a350014ec8a1a946aae46ce4`
+
+Pristine upstream target reference: `/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/merge/.worktrees/opencode-merge/opencode`
+
+## Scope And Methodology
+
+- Reviewed the 181-path PR diff and the 9 changed paths selected by `git diff --name-only -Gkilocode_change`.
+- Traced changed Kilo compatibility behavior from introduction through runtime propagation, OpenAPI generation, generated SDK call shape, and known consumers. This was intentionally chain-oriented rather than an exhaustive file checklist.
+- Compared the merged `packages/opencode/src/server/routes/instance/httpapi/public.ts` against pristine upstream to isolate the HttpApi query-contract architectural change: upstream removed global OpenAPI injection of `directory` and `workspace` and now requires every `WorkspaceRoutingMiddleware` endpoint to declare matching runtime query fields.
+- Audited all Kilo-owned HttpApi groups that apply `WorkspaceRoutingMiddleware`, including unchanged adjacent groups that became dependent on the new upstream contract.
+- Inspected focused regression tests and ran read-only guards where dependencies were available. No code, Git index, refs, or existing reports were mutated.
+
+## Findings
+
+### 1. High: 18 Kilo-only HttpApi endpoints lost workspace-routing query contracts
+
+The merge changes the contract for workspace routing. `packages/opencode/src/server/routes/instance/httpapi/public.ts:119` no longer injects `directory` and `workspace` into every instance route after OpenAPI generation. Instead, `packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts:17` defines `WorkspaceRoutingQueryFields`, with the explicit requirement that endpoint query schemas spread those fields because Effect middleware cannot declare query params.
+
+Many Kilo-owned groups were ported correctly, including background processes, indexing, Kilo gateway, remote control, session import, suggestions, and the Kilo-specific session viewed endpoint. The following endpoints still apply `WorkspaceRoutingMiddleware` but do not declare the routing fields in their endpoint query schema:
+
+| Product behavior | Endpoints | Suspect link |
+|---|---|---|
+| Agent builder | `POST /agent-builder/preview`, `PUT /agent-builder/:id` | `packages/opencode/src/kilocode/server/httpapi/groups/agent-builder.ts:46`, `packages/opencode/src/kilocode/server/httpapi/groups/agent-builder.ts:58` omit `WorkspaceRoutingQuery`. Generated SDK types expose `query?: never` at `packages/sdk/js/src/v2/gen/types.gen.ts:7656` and `packages/sdk/js/src/v2/gen/types.gen.ts:7701`. |
+| Commit message generation | `POST /commit-message` | `packages/opencode/src/kilocode/server/httpapi/groups/commit-message.ts:28` omits `WorkspaceRoutingQuery`. Generated SDK type exposes `query?: never` at `packages/sdk/js/src/v2/gen/types.gen.ts:7900`. |
+| Prompt enhancement | `POST /enhance-prompt` | `packages/opencode/src/kilocode/server/httpapi/groups/enhance-prompt.ts:22` omits `WorkspaceRoutingQuery`. Generated SDK type exposes `query?: never` at `packages/sdk/js/src/v2/gen/types.gen.ts:8172`. |
+| Network wait recovery | `GET /network`, `POST /network/:requestID/reply`, `POST /network/:requestID/reject` | `packages/opencode/src/kilocode/server/httpapi/groups/network.ts:22`, `packages/opencode/src/kilocode/server/httpapi/groups/network.ts:31`, and `packages/opencode/src/kilocode/server/httpapi/groups/network.ts:42` omit `WorkspaceRoutingQuery`. Generated SDK types expose `query?: never` at `packages/sdk/js/src/v2/gen/types.gen.ts:8809`, `packages/sdk/js/src/v2/gen/types.gen.ts:8827`, and `packages/sdk/js/src/v2/gen/types.gen.ts:8858`. |
+| Telemetry proxy | `POST /telemetry/capture`, `POST /telemetry/setEnabled` | `packages/opencode/src/kilocode/server/httpapi/groups/telemetry.ts:30` and `packages/opencode/src/kilocode/server/httpapi/groups/telemetry.ts:41` omit `WorkspaceRoutingQuery`. Generated SDK types expose `query?: never` at `packages/sdk/js/src/v2/gen/types.gen.ts:9357` and `packages/sdk/js/src/v2/gen/types.gen.ts:9384`. |
+| Kilo Console config | `GET /config/sources`, `GET /config/effective`, `PUT /config/rules`, `GET /config/model-state`, `PATCH /config/model-state`, `GET /tui/config`, `GET /tui/keybinds` | These endpoints in `packages/opencode/src/kilocode/server/httpapi/groups/config-console.ts` omit `WorkspaceRoutingQuery`; generated SDK types expose `query?: never`, for example `packages/sdk/js/src/v2/gen/types.gen.ts:7972`, `packages/sdk/js/src/v2/gen/types.gen.ts:8041`, and `packages/sdk/js/src/v2/gen/types.gen.ts:8078`. |
+| Kilo Console config with custom query schemas | `GET /config/rules`, `PATCH /tui/config` | `ConfigRulesQuery` and `TuiConfigQuery` omit `WorkspaceRoutingQueryFields` at `packages/opencode/src/kilocode/server/httpapi/groups/config-console.ts:56` and `packages/opencode/src/kilocode/server/httpapi/groups/config-console.ts:98`. Generated SDK query types retain only `scope`, not `directory` or `workspace`, at `packages/sdk/js/src/v2/gen/types.gen.ts:8004` and `packages/sdk/js/src/v2/gen/types.gen.ts:8124`. |
+
+Broken chain:
+
+1. Clients identify a directory/workspace using explicit query params or client-scoped headers.
+2. `WorkspaceRoutingMiddleware` consumes those values in `packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts:152` and `packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts:165`.
+3. Under the new Effect HttpApi contract, the endpoint query schema must accept the URL params before middleware can consume them.
+4. The listed Kilo endpoints omit that schema link. Explicit `?directory=...` or `?workspace=...` requests are rejected as unknown query fields, and generated SDK senders cannot express the params because they now expose `query?: never` or scope-only query types. Header-only direct requests still work, which lets existing exerciser coverage miss the break.
+
+Impact is not theoretical:
+
+- Kilo Console creates a directory-scoped SDK client at `packages/kilo-console/src/client.ts:150` and then calls affected methods such as `sdk.config.modelState()` and `sdk.tui.config.get()` at `packages/kilo-console/src/client.ts:368` and `packages/kilo-console/src/client.ts:371`. The SDK's v2 rewrite intentionally moves directory headers into URL query params only for `GET` and `HEAD` at `packages/sdk/js/src/v2/client.ts:17`. Those affected GET requests therefore carry `directory` and can receive 400 schema rejections.
+- The TUI hot-reload path calls affected `sdk.client.tui.config.get()` at `packages/opencode/src/kilocode/cli/cmd/tui/context/tui-config-hot-reload.ts:33`. Local TUI use may default to the correct directory, but attached or directory-scoped clients require human verification.
+- VS Code explicitly calls `client.network.list({ directory: dir })` and `net.reject({ requestID, directory: dir })` while draining waits at `packages/kilo-vscode/src/services/cli-backend/connection-service.ts:48` and `packages/kilo-vscode/src/services/cli-backend/connection-service.ts:52`. The regenerated SDK says these params are invalid and its runtime methods discard them, because `Network.list()` accepts `Options<never>` and `Network.reject()` maps only `requestID` at `packages/sdk/js/src/v2/gen/sdk.gen.ts:6957` and `packages/sdk/js/src/v2/gen/sdk.gen.ts:6988`. The local type assertion hides the sender/receiver mismatch rather than fixing it.
+
+The current exerciser does not detect this break: its Kilo scenarios use `x-kilo-directory` headers, for example `packages/opencode/test/server/httpapi-exercise/runner.ts:122`, while the missing link concerns URL query acceptance and generated SDK query shape. `packages/opencode/test/server/httpapi-query-schema-drift.test.ts:40` checks selected upstream routes only, and `packages/opencode/test/kilocode/server/httpapi-public.test.ts:54` checks only already-ported Kilo route families.
+
+### 2. Medium, human verification required: task deny-rule inheritance is bypassed when resuming an existing child session
+
+The merge adds `deriveSubagentSessionPermission()` in `packages/opencode/src/agent/subagent-permissions.ts:17` and uses it when creating a new task child in `packages/opencode/src/tool/task.ts:86`. This correctly propagates parent-agent denies such as plan-mode edit restrictions into a newly-created child session.
+
+However, `task_id` resume chooses the existing session before the create branch:
+
+- Existing task child lookup: `packages/opencode/src/tool/task.ts:74`
+- Existing-or-create decision: `packages/opencode/src/tool/task.ts:86`
+- New deny derivation only inside `sessions.create(...)`: `packages/opencode/src/tool/task.ts:92`
+
+Broken or suspect chain:
+
+1. A parent agent's deny rules are introduced on the agent definition.
+2. `deriveSubagentSessionPermission()` copies them into a newly-created child session.
+3. A resumed child skips `sessions.create(...)`, so the deny copy is not recomputed or persisted.
+4. A child created before the fix, or under a less restrictive parent and later resumed from plan mode, can retain permissive session rules.
+
+The new regression file `packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts` tests the pure helper for new derivations, but does not exercise the resumed `task_id` path. Existing resume coverage at `packages/opencode/test/tool/task.test.ts:207` confirms reuse without asserting refreshed permissions. Human verification should decide whether resumed task sessions must merge current parent-agent denies before prompting, or whether reuse across parent contexts is intentionally trusted.
+
+## Notable Non-Findings
+
+### Routed HttpApi flows that remain linked
+
+- The newly-required routing query fields are present on core instance groups and on the changed Kilo groups for background processes, indexing status, Kilo gateway, `/kilocode/*`, remote control, session import, and suggestions. `packages/opencode/test/kilocode/server/httpapi-public.test.ts:54` specifically checks background-process routing metadata, and `packages/opencode/test/kilocode/server/httpapi-public.test.ts:73` checks selected Kilo Console routes.
+- Kilo cloud-session pagination remains linked end-to-end: runtime accepts string `limit` in `packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts:353`, handler conversion applies `Number(...)` in `packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts:347`, the Kilo OpenAPI override publishes numeric caller shape in `packages/opencode/src/server/routes/instance/httpapi/public.ts:65`, and generated SDK exposes `limit?: number` in `packages/sdk/js/src/v2/gen/types.gen.ts:8588`.
+- Kilo path-parameter compatibility overrides remain present for `bgp*` background process IDs and `que*` network request IDs in `packages/opencode/src/server/routes/instance/httpapi/public.ts:523` and `packages/opencode/src/server/routes/instance/httpapi/public.ts:527`.
+
+### Provider metadata and status
+
+- Catalog status remains intentionally narrower (`alpha`, `beta`, `deprecated`) while normalized provider/config status also accepts `active` in `packages/opencode/src/provider/model-status.ts:3` and `packages/opencode/src/provider/model-status.ts:6`.
+- Status propagation is intact from models.dev/config inputs through normalized provider models (`packages/opencode/src/provider/provider.ts:1039`, `packages/opencode/src/provider/provider.ts:1246`) and into v2 model output (`packages/opencode/src/v2/model.ts:118`). Generated SDK exposes `active` at `packages/sdk/js/src/v2/gen/types.gen.ts:1530`.
+
+### Session diff optional-path compatibility
+
+- Storage and API schemas accept legacy missing `file` and `patch` values in `packages/opencode/src/snapshot/index.ts:26`. `SessionSummary.diff()` guards both optional values in `packages/opencode/src/session/summary.ts:137` and `packages/opencode/src/session/summary.ts:141`.
+- Share and ingest transport boundaries filter legacy summary rows without file names before satisfying SDK `Session` transport contracts in `packages/opencode/src/share/share-next.ts:92` and `packages/opencode/src/kilo-sessions/kilo-sessions.ts:133`.
+- CLI export redaction preserves counts while conditionally redacting optional file and patch data in `packages/opencode/src/cli/cmd/export.ts:26`.
+- Shared UI review and turn consumers reject rows lacking file paths before rendering in `packages/ui/src/components/session-review.tsx:73` and `packages/ui/src/components/session-turn.tsx:95`. Kilo UI normalizes missing names to an empty string in `packages/kilo-ui/src/components/session-diff.ts:56`; VS Code diff sources do the same in `packages/kilo-vscode/src/diff/sources/session.ts:71` and `packages/kilo-vscode/src/diff/sources/worktree.ts:148`.
+- VS Code turn summary de-duplication groups all missing-file rows under `""` at `packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx:86`. This is lossy but compatible with rows that cannot identify a file; no broken sender/receiver link was found.
+
+### ACP tool attachment replay
+
+- Completed tool attachments are persisted on `MessageV2.ToolStateCompleted` at `packages/opencode/src/session/message-v2.ts:312`, included in generated SDK types at `packages/sdk/js/src/v2/gen/types.gen.ts:664`, converted into ACP image content blocks by `completedToolContent()` at `packages/opencode/src/acp/agent.ts:1604`, and preserved in ACP raw output by `completedToolRawOutput()` at `packages/opencode/src/acp/agent.ts:1639`.
+- Both live completion and session replay call the same helpers at `packages/opencode/src/acp/agent.ts:352` and `packages/opencode/src/acp/agent.ts:838`. Focused tests cover both paths in `packages/opencode/test/acp/event-subscription.test.ts`.
+
+### TUI bootstrap aggregation and undefined messages
+
+- Blocking bootstrap calls are labeled, awaited with `Promise.allSettled`, and converted into one aggregate error at `packages/opencode/src/cli/cmd/tui/context/sync.tsx:592` and `packages/opencode/src/cli/cmd/tui/context/sync.tsx:602`. The Kilo global-config bootstrap call remains included at `packages/opencode/src/cli/cmd/tui/context/sync.tsx:597`.
+- Session sync now treats an errored messages response as an empty list at `packages/opencode/src/cli/cmd/tui/context/sync.tsx:807`, preserving the Kilo `strip(message.info)` projection.
+
+### SDK thrown-error interception
+
+- Both legacy and v2 SDK factories install the same interceptor in `packages/sdk/js/src/client.ts:64` and `packages/sdk/js/src/v2/client.ts:97`.
+- The generated clients pass `(error, response, request, opts)` to interceptors before the `throwOnError` branch at `packages/sdk/js/src/gen/client/client.gen.ts:163` and `packages/sdk/js/src/v2/gen/client/client.gen.ts:214`. `wrapClientError()` preserves result-tuple consumers and wraps only `throwOnError` callers at `packages/sdk/js/src/error-interceptor.ts:13`.
+
+### Config reset sentinels, events, and selected sender/receiver pairs
+
+- Indexing reset sentinels survive the OpenAPI optional-null cleanup: source config permits nullable `model` and `dimension` in `packages/kilo-indexing/src/config.ts:24`, the Kilo OpenAPI override re-adds nullability in `packages/opencode/src/server/routes/instance/httpapi/public.ts:278`, and generated SDK exposes both nullable values in `packages/sdk/js/src/v2/gen/types.gen.ts:1055`.
+- Kilo session ingest still subscribes to created/updated/message/part/diff/turn events and transports compatible sessions at `packages/opencode/src/kilo-sessions/kilo-sessions.ts:253`. No missing sender/receiver link was found in the event-only diffs, which are import moves into `@opencode-ai/core`.
+- MCP Docker `--rm` injection remains intact while the merge adds tolerant output-schema fallback in `packages/opencode/src/mcp/index.ts:155`; this is additive and does not remove the Windows process shim at `packages/opencode/src/mcp/index.ts:1`.
+
+## Command Outputs
+
+- `git diff --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d | wc -l` -> `181`
+- `git diff --name-only -Gkilocode_change 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d | wc -l` -> `9`
+- Custom read-only routed-endpoint audit -> `confirmed suspect routed Kilo endpoints: 18`, listed in Finding 1.
+- `git diff --check 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d` -> no output.
+- `bun run script/check-kilo-generated-artifacts.ts` -> `check-kilo-generated-artifacts: ok`
+- `bun run script/check-opencode-promise-facades.ts` -> `8 classified runtime site(s), 104 classified test reference(s), no runtime drift found.`
+- `bun run script/check-opencode-annotations.ts` -> `Skipping shared upstream annotation check — upstream merge detected.`
+
+## Limitations
+
+- Focused Bun regressions could not execute in this read-only review checkout because workspace dependencies are absent. The attempted command failed with unresolved packages such as `effect` and `@opencode-ai/core/util/log`. No `bun install` was run because it would mutate the review checkout and violate the review rules.
+- The audit establishes the missing query-schema and generated-SDK links statically. A human should verify affected Kilo Console, VS Code network-drain, attached TUI hot-reload, telemetry, agent-builder, commit-message, and enhance-prompt flows after the routing schemas are ported.
+- Existing untracked reports (`INFRASTRUCTURE_CHANGE.md`, `KILOCODE_CHANGE_MARKERS.md`, `OPENCODE_MENTIONS.md`, `TESTS.md`, and `UNNECESSARY_MARKERS.md`) were left untouched.

--- a/INFRASTRUCTURE_CHANGE.md
+++ b/INFRASTRUCTURE_CHANGE.md
@@ -1,0 +1,156 @@
+# Infrastructure Change Review
+
+## Scope and methodology
+
+Reviewed PR [#10822](https://github.com/Kilo-Org/kilocode/pull/10822) at snapshot `94fc42255c35827b197d97368d75d079242e9f4d` against PR base snapshot `2f7f23deac683078a350014ec8a1a946aae46ce4`. I inspected the changed-file inventory and focused diffs for GitHub Actions, CI configuration, release/deploy scripts, Docker/build infrastructure, package manager and workspace metadata, repository automation, issue templates, changelog automation, database migration infrastructure, and generated SDK/OpenAPI artifacts. I also compared relevant changes with the pristine upstream `v1.14.46` target at `d802b0a277f4e7f113b5efd8d5446fc1db22f4a4` in the read-only upstream reference checkout.
+
+The reviewed PR changes 181 files overall. This report intentionally lists only infrastructure-relevant findings and notable non-findings, not an exhaustive per-file checklist.
+
+## Findings requiring human confirmation
+
+### 1. Workspace package metadata normalization was retained for Kilo-only packages
+
+Files:
+
+- `packages/kilo-console/package.json`
+- `packages/kilo-web-ui/package.json`
+
+Both Kilo-only package manifests gain an explicit empty `"peerDependencies": {}` object. These edits do not appear in the pristine upstream target because those packages are not present upstream. The changes are likely harmless workspace normalization from merge/package processing, but they are not required by the reviewed upstream release and should be confirmed as intentional before merge.
+
+### 2. Root TUI fixture/config drops an explicit empty keybind map
+
+File:
+
+- `.opencode/tui.json`
+
+The checked-in config changes from:
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "keybinds": {}
+}
+```
+
+to:
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json"
+}
+```
+
+This matches the pristine upstream target. It is not CI or deploy infrastructure, but it is repository-level configuration and may affect local/manual TUI defaults or fixtures. Confirm that removing the explicit empty keybind object is desired in Kilo.
+
+### 3. Existing workspace database migration is changed in place
+
+Files:
+
+- `packages/opencode/migration/20260507164347_add_workspace_time/migration.sql`
+- `packages/opencode/test/storage/workspace-time-migration.test.ts`
+- `packages/opencode/src/storage/storage.ts`
+
+The migration changes from `ALTER TABLE workspace ADD time_used integer NOT NULL;` to `ALTER TABLE workspace ADD time_used integer NOT NULL DEFAULT 0;`, with a new regression test covering migration of an existing workspace row. This matches pristine upstream `v1.14.46` and is an intentional upstream fix, but it changes persisted database migration behavior and should receive explicit human confirmation because existing installations depend on migration correctness.
+
+### 4. SDK/OpenAPI generated artifacts changed substantially and should be regeneration-verified
+
+Generated or schema-derived files:
+
+- `packages/sdk/openapi.json`
+- `packages/sdk/js/src/gen/types.gen.ts`
+- `packages/sdk/js/src/v2/gen/sdk.gen.ts`
+- `packages/sdk/js/src/v2/gen/types.gen.ts`
+
+Related hand-written SDK client files:
+
+- `packages/sdk/js/src/client.ts`
+- `packages/sdk/js/src/v2/client.ts`
+- `packages/sdk/js/src/error-interceptor.ts`
+
+The SDK artifact diff is substantial: 7 changed files, 1,383 insertions, and 1,838 deletions. Endpoint/schema work in `packages/opencode/src/server/routes/instance/httpapi/**` explains generated OpenAPI and SDK churn. The new shared `wrapClientError` interceptor is hand-written, not generated, and is wired into both client versions.
+
+This appears to be an intentional upstream generated-SDK update plus Kilo compatibility adjustments, not infrastructure drift. Human verification should still confirm that `./script/generate.ts` reproduces the checked-in SDK/OpenAPI outputs in the resolved Kilo tree and that no expected generated SDK surfaces were omitted.
+
+### 5. Development type dependency was added to the CLI package and lockfile
+
+Files:
+
+- `packages/opencode/package.json`
+- `bun.lock`
+
+`@types/node: "catalog:"` is added to `packages/opencode` development dependencies and reflected by one lockfile line. This does not appear in the pristine upstream `packages/opencode/package.json` diff from upstream `v1.14.42` to `v1.14.46`; it is likely a Kilo merge/typecheck compatibility adjustment. Confirm that this local dependency addition is intentional.
+
+### 6. Schema utilities moved into the core package without package metadata changes
+
+Files:
+
+- `packages/opencode/src/util/effect-zod.ts` -> `packages/core/src/effect-zod.ts`
+- `packages/opencode/src/util/schema.ts` -> `packages/core/src/schema.ts`
+
+Git detects both moves as 100% renames. This is source architecture rather than build infrastructure, but it changes workspace package ownership and module boundaries. The Kilo `packages/core/package.json` remains unchanged and already exports `./*` from `./src/*.ts`, so no export-map update is required. Confirm that the move is intentional and that package-level typecheck/build coverage exercises the new ownership boundary.
+
+## Intentional dependency and generated-SDK updates
+
+- `.opencode-version` advances from `v1.14.42` to `v1.14.46`, which is the expected upstream merge bookkeeping update.
+- `bun.lock` changes only by adding the CLI package's `@types/node` development dependency. No broad lockfile resolution churn is present.
+- `packages/sdk/openapi.json` and the three generated SDK files listed above are expected generated artifacts for the HTTP API schema changes. They should be accepted after deterministic regeneration succeeds.
+- `packages/sdk/js/src/error-interceptor.ts`, `packages/sdk/js/src/client.ts`, and `packages/sdk/js/src/v2/client.ts` are related SDK runtime changes, but they are hand-written and should be reviewed separately from generated output.
+
+## Notable non-findings
+
+- No GitHub Actions workflow files changed in the reviewed PR.
+- No `.github/actions/**`, issue template, pull request template, CodeQL, or repository automation files changed.
+- No `script/**` release, deploy, changelog, SDK generation, upstream merge, or CI guard scripts changed.
+- No Docker, container, Nix, Husky, root workspace manifest, Turbo, Bun config, TypeScript root config, or changeset files changed.
+- No SDK build scripts, SDK package metadata, SDK TypeScript config, or generated-client implementation files under `packages/sdk/js/src/gen/client/**` changed.
+- The pristine upstream checkout contains many Kilo-incompatible infrastructure differences when directly compared with the Kilo PR base, including workflow additions/removals and script removals. Those upstream-only repository-layout differences were not imported into the reviewed PR, which is the desired result for preserving Kilo infrastructure.
+
+## Commands and relevant outputs
+
+```text
+$ git diff --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- .github .changeset script Dockerfile docker-compose.yml package.json turbo.json bunfig.toml tsconfig.json packages/core/package.json packages/sdk/js/package.json packages/sdk/js/script packages/sdk/js/tsconfig.json
+(no output)
+```
+
+```text
+$ git diff --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- .opencode-version .opencode/tui.json bun.lock packages/opencode/package.json packages/kilo-console/package.json packages/kilo-web-ui/package.json packages/sdk packages/opencode/migration packages/core
+M  .opencode-version
+M  .opencode/tui.json
+M  bun.lock
+A  packages/core/src/effect-zod.ts
+M  packages/core/src/flag/flag.ts
+A  packages/core/src/schema.ts
+M  packages/kilo-console/package.json
+M  packages/kilo-web-ui/package.json
+M  packages/opencode/migration/20260507164347_add_workspace_time/migration.sql
+M  packages/opencode/package.json
+M  packages/sdk/js/src/client.ts
+A  packages/sdk/js/src/error-interceptor.ts
+M  packages/sdk/js/src/gen/types.gen.ts
+M  packages/sdk/js/src/v2/client.ts
+M  packages/sdk/js/src/v2/gen/sdk.gen.ts
+M  packages/sdk/js/src/v2/gen/types.gen.ts
+M  packages/sdk/openapi.json
+```
+
+```text
+$ git diff --stat 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- packages/sdk
+7 files changed, 1383 insertions(+), 1838 deletions(-)
+```
+
+```text
+$ git diff --find-renames --summary 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- packages/opencode/src/util/effect-zod.ts packages/opencode/src/util/schema.ts packages/core/src/effect-zod.ts packages/core/src/schema.ts
+rename packages/{opencode/src/util => core/src}/effect-zod.ts (100%)
+rename packages/{opencode/src/util => core/src}/schema.ts (100%)
+```
+
+```text
+$ git rev-parse HEAD  # pristine upstream target reference
+d802b0a277f4e7f113b5efd8d5446fc1db22f4a4
+```
+
+## Limitations
+
+- This was a static, read-only review. I did not run SDK generation, dependency installation, builds, tests, CI guards, or migrations against a live user database.
+- Aside from writing this required report file, I did not edit code or configuration, stage, commit, push, merge, rebase, stash, or otherwise mutate Git state.
+- The report classifies likely generated output from paths and diffs. Deterministic reproduction still requires running the repository generation command in the writable resolver checkout.

--- a/KILOCODE_CHANGE_MARKERS.md
+++ b/KILOCODE_CHANGE_MARKERS.md
@@ -1,0 +1,68 @@
+# `kilocode_change` Marker Review
+
+## Scope and methodology
+
+Reviewed PR [#10822](https://github.com/Kilo-Org/kilocode/pull/10822) at snapshot `94fc42255c35827b197d97368d75d079242e9f4d` against PR base snapshot `2f7f23deac683078a350014ec8a1a946aae46ce4`, with pristine upstream target `d802b0a277f4e7f113b5efd8d5446fc1db22f4a4` (`v1.14.46`) as a read-only reference.
+
+- Checked the complete `git diff --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4...HEAD` result: **181 changed files**.
+- Reviewed every changed file for marker-bearing base content and PR-side marker state. Compared the Kilo base and reviewed snapshot marker inventories, then inspected all marker-text diffs with surrounding code.
+- Compared pristine upstream where provenance mattered, especially for shared `packages/opencode/` files whose Kilo-specific behavior was retained or adapted during the merge.
+- Result: **no accidental `kilocode_change` marker loss found**.
+
+## Findings
+
+### Marker removals that make sense
+
+- `packages/opencode/src/cli/cmd/tui/context/sync.tsx:300` removes a redundant inner `// kilocode_change start` / `// kilocode_change end` pair around the `suggestion.accepted`, `suggestion.dismissed`, and `suggestion.shown` cases. The cases and `handleSuggestionEvent(...)` call remain intact. They are still inside the broader Kilo-only network/suggestion block opened at `packages/opencode/src/cli/cmd/tui/context/sync.tsx:283` and closed at `packages/opencode/src/cli/cmd/tui/context/sync.tsx:339`, so annotation coverage is preserved while nested markers are simplified.
+- `packages/opencode/src/cli/cmd/tui/context/sync.tsx:597` moves the existing inline marker from `globalConfigPromise` in the old `Promise[]` array to the equivalent labeled entry `{ name: "global.config", promise: globalConfigPromise }`. The Kilo-only global config bootstrap request remains present and annotated after the upstream bootstrap failure aggregation refactor.
+- `packages/opencode/src/cli/cmd/tui/context/sync.tsx:809` moves the existing inline marker from the removed `messages.data!.map(...)` assignment to `infos.push(strip(message.info))` inside the replacement loop. The Kilo-specific `strip(...)` behavior remains present while adopting the upstream guard for undefined message responses.
+- `packages/opencode/test/cli/cmd/tui/sync.test.tsx` moves the shared sync test fixture into the new `packages/opencode/test/cli/cmd/tui/sync-fixture.tsx`. The removed markers for `ToastProvider`, `/global/config`, and the JSX wrapper reappear on the extracted fixture. The new fixture also annotates Kilo-only `/network` and `/background-process` routes. This is a coherent fixture extraction, not marker loss.
+- `packages/opencode/src/mcp/index.ts:49` changes the marker comment punctuation from a Unicode long dash to an ASCII hyphen around the existing Docker `--rm` injection. The marker block and `ensureDockerRm(...)` behavior are unchanged.
+
+### Notable non-findings
+
+- `packages/opencode/src/cli/cmd/export.ts:27` adds a correctly delimited marker block around the Kilo compatibility type that retains summary `additions` and `deletions` while accepting upstream optional `file` and `patch` values.
+- `packages/opencode/src/share/share-next.ts:90` adds a correctly delimited marker block for the Kilo share transport compatibility filter used when stored legacy summary diffs omit `file` details.
+- `packages/opencode/src/server/routes/instance/httpapi/public.ts:64` adds an inline marker for the Kilo cloud sessions `limit` query override. Existing Kilo OpenAPI markers remain present, including cloud cursor handling, Kilo server docs metadata, indexing nullability overrides, background-process IDs, and network request IDs.
+- `packages/sdk/js/src/error-interceptor.ts:41` adds an inline marker for the Kilo-branded empty-body fallback (`kilo server ...`). The file is new SDK code and the Kilo-only branding difference is explicitly marked.
+- No changed file was deleted. Rename handling reports the two schema utility moves at 100% similarity, and neither move loses markers.
+
+## Human verification items
+
+- None required for marker preservation. The only removed marker pair is the redundant nested pair in `packages/opencode/src/cli/cmd/tui/context/sync.tsx`, and the surrounding broader Kilo block clearly remains.
+
+## Command outputs
+
+```text
+$ git rev-parse HEAD
+94fc42255c35827b197d97368d75d079242e9f4d
+
+$ git rev-parse 2f7f23deac683078a350014ec8a1a946aae46ce4
+2f7f23deac683078a350014ec8a1a946aae46ce4
+
+$ git -C <pristine-upstream> rev-parse HEAD
+d802b0a277f4e7f113b5efd8d5446fc1db22f4a4
+
+$ git -C <pristine-upstream> describe --always --tags HEAD
+v1.14.46
+
+$ git diff --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4...HEAD | wc -l
+181
+
+$ git diff --shortstat 2f7f23deac683078a350014ec8a1a946aae46ce4...HEAD
+181 files changed, 5028 insertions(+), 2498 deletions(-)
+
+$ git diff --name-status -Gkilocode_change 2f7f23deac683078a350014ec8a1a946aae46ce4...HEAD | wc -l
+9
+
+$ bun run script/check-opencode-annotations.ts
+Skipping shared upstream annotation check — upstream merge detected.
+
+$ git diff --check 2f7f23deac683078a350014ec8a1a946aae46ce4...HEAD
+(no output)
+```
+
+## Limitations
+
+- `bun run script/check-opencode-annotations.ts` intentionally skips shared upstream annotation validation when an upstream merge is detected, so this report relies on manual file-by-file diff review, marker inventory comparison, targeted marker-text diffs, and pristine-upstream comparison rather than the guard script.
+- This report reviews marker preservation and marker placement changes only. It does not claim broader semantic correctness of the upstream merge or generated artifacts.

--- a/OPENCODE_MENTIONS.md
+++ b/OPENCODE_MENTIONS.md
@@ -1,0 +1,63 @@
+# OpenCode Mention Review: PR #10822
+
+## Scope and methodology
+
+Reviewed PR [#10822](https://github.com/Kilo-Org/kilocode/pull/10822) at snapshot `94fc42255c35827b197d97368d75d079242e9f4d` against PR base snapshot `2f7f23deac683078a350014ec8a1a946aae46ce4`. The review covered the 181 added, modified, and renamed files in the snapshot diff, with focused searches across added lines and the checked-out snapshot for `OpenCode`, `opencode`, OpenCode-hosted URLs, and upstream web properties. The pristine upstream target checkout at `/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/merge/.worktrees/opencode-merge/opencode` was searched to confirm the origin of the newly merged built-in skill.
+
+The review prioritized user-facing surfaces: CLI and TUI strings, docs and help-like content, config guidance, package metadata, server/OpenAPI descriptions, generated SDK descriptions, URLs, and error text. Existing mentions outside the PR diff were used only as context and are not reported as newly introduced findings.
+
+## Findings
+
+### Likely branding leak: upstream `customize-opencode` built-in skill was merged without Kilo adaptation
+
+The PR adds an upstream built-in skill that is surfaced to the model on unstable channels and can directly guide edits to a user's configuration. This is user-impacting even though the text is consumed by the agent rather than rendered as ordinary UI. The skill consistently teaches OpenCode branding, config filenames, directories, and schema URLs instead of Kilo's preferred configuration surface.
+
+Registration and trigger description:
+
+- `packages/opencode/src/skill/index.ts:39` registers the skill as `"customize-opencode"`.
+- `packages/opencode/src/skill/index.ts:41` says: `"Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. ..."`
+- `packages/core/src/flag/flag.ts:58` through `packages/core/src/flag/flag.ts:60` make the skill default-on for `dev`, `beta`, and `local`, while stable channels remain opt-in via `KILO_EXPERIMENTAL_CUSTOMIZE_SKILL`.
+
+Representative skill-body leaks:
+
+- `packages/opencode/src/skill/prompt/customize-opencode.md:7`: `# Customizing opencode`
+- `packages/opencode/src/skill/prompt/customize-opencode.md:11`: `` `https://opencode.ai/config.json` (the JSON Schema) and validate against it. ``
+- `packages/opencode/src/skill/prompt/customize-opencode.md:13`: ``Every `opencode.json` should declare `"$schema": "https://opencode.ai/config.json"` ``
+- `packages/opencode/src/skill/prompt/customize-opencode.md:20`: project config is documented as ``./opencode.json`, `./opencode.jsonc`, or `.opencode/opencode.json` ``.
+- `packages/opencode/src/skill/prompt/customize-opencode.md:21`: global config is documented as ``~/.config/opencode/opencode.json` ``.
+- `packages/opencode/src/skill/prompt/customize-opencode.md:22` through `packages/opencode/src/skill/prompt/customize-opencode.md:25`: agent and skill locations are documented only under `.opencode/` and `~/.config/opencode/`.
+- `packages/opencode/src/skill/prompt/customize-opencode.md:335`: the `KILO_CONFIG_CONTENT` escape hatch still embeds ``"$schema":"https://opencode.ai/config.json"``.
+- `packages/opencode/src/skill/prompt/customize-opencode.md:346`: instructs the model to fetch `https://opencode.ai/config.json` when uncertain.
+
+Why this appears wrong for Kilo: existing Kilo-specific guidance establishes `kilo.json` / `kilo.jsonc`, `.kilo/`, `~/.config/kilo/`, and `https://app.kilo.ai/config.json` as the preferred modern surface while retaining OpenCode paths only for compatibility. Examples include `packages/opencode/src/kilocode/system-prompt.ts:18`, `packages/opencode/src/kilocode/skills/kilo-config.md:3`, `packages/opencode/src/kilocode/skills/kilo-config.md:226`, and `packages/kilo-docs/pages/contributing/architecture/config-schema.md:8`. The new upstream skill can therefore steer agents toward legacy OpenCode locations and bypass Kilo's schema overlay.
+
+Human verification requested: decide whether Kilo should drop this upstream skill, adapt it into a Kilo-branded skill, or delegate entirely to the existing Kilo-owned `kilo-config` built-in skill. If retained for compatibility, the prompt should clearly mark OpenCode names and URLs as legacy fallback paths rather than the preferred configuration.
+
+## Intentional compatibility references
+
+- `.opencode/tui.json:2` contains `"$schema": "https://opencode.ai/tui.json"`. This line is present before and after the PR; the PR only removes an empty `"keybinds": {}` block. It is not a newly introduced OpenCode URL, but it remains an OpenCode-hosted schema reference worth retaining only if Kilo intentionally has no branded TUI schema endpoint.
+- The many added `@opencode-ai/core/...` imports are internal package namespace references caused by moving schema utilities into `packages/core/`. They are not user-facing branding leaks.
+- The added references in `packages/opencode/specs/effect/migration.md`, `packages/opencode/specs/effect/schema.md`, `packages/opencode/specs/openapi-translation-cleanup.md`, and `packages/opencode/specs/v2/tui-command-shim.md` describe internal package paths and implementation work. They are developer-facing upstream provenance, not end-user product copy.
+- The new tests at `packages/opencode/test/server/httpapi-provider.test.ts:266` and `packages/opencode/test/server/httpapi-provider.test.ts:306` use `https://opencode.ai/config.json` in fixtures. They exercise compatibility behavior and do not surface text to users.
+
+## Notable non-findings
+
+- No new display-cased `OpenCode` product strings were added in changed UI or CLI runtime content. The only added match in the changed UI/CLI subtree is the internal import `@opencode-ai/core/schema` in `packages/opencode/src/cli/cmd/tui/event.ts:3`.
+- No new OpenCode branding or OpenCode-hosted URLs were added to generated artifacts in `packages/sdk/openapi.json`, `packages/sdk/js/src/gen/types.gen.ts`, `packages/sdk/js/src/v2/gen/types.gen.ts`, or `packages/sdk/js/src/v2/gen/sdk.gen.ts`.
+- Existing generated SDK comments at `packages/sdk/js/src/gen/types.gen.ts:1212` and `packages/sdk/js/src/gen/types.gen.ts:1269` still link to `https://opencode.ai/docs/commands` and `https://opencode.ai/docs/agent`, but those lines are unchanged from the PR base snapshot and were not introduced by this merge.
+- Changed package metadata in `packages/opencode/package.json`, `packages/kilo-console/package.json`, `packages/kilo-web-ui/package.json`, and `bun.lock` adds dependency metadata only; no new user-visible OpenCode name or URL was introduced there.
+- The Kilo OpenAPI generation path still applies explicit branding rewrites in `packages/opencode/src/cli/cmd/generate.ts:40` through `packages/opencode/src/cli/cmd/generate.ts:44`, including `OpenCode` to `Kilo` and `https://opencode.ai/` to `https://kilo.ai/`. The changed generated outputs contain no newly added OpenCode residue.
+
+## Command outputs
+
+- `git rev-parse HEAD` in the review checkout returned `94fc42255c35827b197d97368d75d079242e9f4d`.
+- `git diff --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4..94fc42255c35827b197d97368d75d079242e9f4d` reported 181 changed paths.
+- Searching added lines for OpenCode web links found the unchanged `.opencode/tui.json:2` schema URL in a rewritten line, five `https://opencode.ai/config.json` references in the new skill prompt, and two test-fixture schema URLs.
+- Searching generated artifact additions for `opencode`, `OpenCode`, `opencode.ai`, `anomalyco`, and `sst.dev` returned no matches.
+- Searching the pristine upstream target confirmed that `packages/opencode/src/skill/index.ts`, `packages/opencode/src/skill/prompt/customize-opencode.md`, and the associated preload note originated upstream.
+
+## Limitations
+
+- This was a static diff and content-search review. No CLI, TUI, extension, or agent session was launched.
+- Existing OpenCode mentions outside the PR diff were not exhaustively audited. Some pre-existing user-facing references remain in the repository and may merit a separate branding audit.
+- The new built-in skill is default-on only for unstable channels unless explicitly enabled, so its exact production exposure depends on release channel and environment overrides.

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,59 @@
+# Kilo-Specific Test Coverage Review
+
+## Scope and methodology
+
+Reviewed PR [#10822](https://github.com/Kilo-Org/kilocode/pull/10822), snapshot `94fc42255c35827b197d97368d75d079242e9f4d`, against base snapshot `2f7f23deac683078a350014ec8a1a946aae46ce4`. Used read-only Git diffs to inspect deleted paths, changed test and fixture paths, removed assertions, `kilocode_change` movements, paths containing `kilo` or `kilocode`, and nearby replacement tests. Also inspected the pristine upstream target checkout at `/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/merge/.worktrees/opencode-merge/opencode` (`d802b0a277f4e7f113b5efd8d5446fc1db22f4a4`) as a reference.
+
+The focused test-path diff reports 27 changed test or fixture paths: 10 added, 17 modified, and 0 deleted. The entire PR reports 0 deleted paths. The Kilo-owned CLI test subtree `packages/opencode/test/kilocode` contains 193 files at both reviewed snapshots.
+
+## Findings
+
+### Human verification required: structured sync validation-error coverage is disabled
+
+- `packages/opencode/test/server/httpapi-sync.test.ts` changes `test("returns structured validation errors", ...)` to `test.todo("returns structured validation errors", ...)`.
+- This weakens active coverage: the test body still asserts HTTP `400`, JSON `content-type`, `body.success === false`, and an array in `body.error` or `body.errors`, but Bun no longer executes those assertions.
+- `packages/opencode/test/server/sdk-error-shape.test.ts` adds related SDK behavior coverage for a `400` response with an empty body. It verifies that the SDK throws a real `Error` with a non-empty message and `cause.status === 400`. This is not a replacement for the disabled server-side structured JSON validation-error contract.
+- The existing `validates seq values` test in `packages/opencode/test/server/httpapi-sync.test.ts` still verifies that invalid history and replay sequence values return HTTP `400`, but it does not verify the structured response body.
+- Human decision is required: either restore active structured-error coverage if that contract remains intentional, or confirm that the new Effect HTTP API behavior intentionally returns an empty validation-error body and remove or rewrite the obsolete `test.todo` with an explicit replacement contract.
+
+## Notable non-findings
+
+- No test files, fixture files, or other paths are deleted by the reviewed PR. No Kilo-owned test file disappears from `packages/opencode/test/kilocode`.
+- `packages/opencode/test/cli/cmd/tui/sync.test.tsx` removes a large inline test harness, including `kilocode_change` wrappers around `ToastProvider` and the `/global/config` fixture response, but this is coverage migration rather than loss. The harness moves to `packages/opencode/test/cli/cmd/tui/sync-fixture.tsx`, preserving those Kilo additions and adding `/network` and `/background-process` fixture responses. `packages/opencode/test/cli/cmd/tui/sync-undefined-messages.test.tsx` then reuses the fixture for a new failed-message-load regression case.
+- `packages/opencode/test/kilocode/background-process-tool.test.ts` only updates the `toJsonSchema` import after the utility moves to `@opencode-ai/core/effect-zod`; no assertion is removed.
+- `packages/opencode/test/kilocode/server/httpapi-public.test.ts` keeps its existing Kilo branding, agent-builder slug, and nullable organization-reset assertions. It adds explicit Kilo route coverage for `directory` and `workspace` query parameters on background-process and Kilo Console routes.
+- `packages/kilo-ui/src/components/session-diff.test.ts` keeps all existing assertions and adds legacy-snapshot coverage for missing file paths. `packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/SessionModelSerializationTest.kt` updates numeric expectations from integers to doubles without reducing the asserted fields.
+- `packages/opencode/test/server/httpapi-sdk.test.ts` changes the `throwOnError` assertion from a raw server object to a real `Error` with message and `cause.body`; `packages/opencode/test/server/sdk-error-shape.test.ts` adds focused regression coverage for that new contract. This is a replacement and strengthening, not a loss.
+- `packages/opencode/test/tool/read.test.ts` changes a read-permission expectation from an absolute path to a worktree-relative path and adds a dedicated worktree-relative regression case. The affected behavior remains covered.
+- Additional tests strengthen Kilo-sensitive HTTP API behavior, including `packages/opencode/test/server/httpapi-query-schema-drift.test.ts`, `packages/opencode/test/server/httpapi-promptasync-context.test.ts`, `packages/opencode/test/server/negative-tokens-regression.test.ts`, `packages/opencode/test/server/session-diff-missing-patch.test.ts`, `packages/opencode/test/server/httpapi-session.test.ts`, `packages/opencode/test/server/session-messages.test.ts`, and `packages/opencode/test/session/schema-decoding.test.ts`.
+
+## Command outputs
+
+```text
+$ git diff --diff-filter=D --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d
+(no output)
+
+$ git diff --name-status 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- <focused test and fixture globs> | wc -l
+27
+
+$ git diff --diff-filter=A --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- <focused test and fixture globs> | wc -l
+10
+
+$ git diff --diff-filter=M --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- <focused test and fixture globs> | wc -l
+17
+
+$ git diff --diff-filter=D --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- <focused test and fixture globs> | wc -l
+0
+
+$ git ls-tree -r --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 packages/opencode/test/kilocode | wc -l
+193
+
+$ git ls-tree -r --name-only 94fc42255c35827b197d97368d75d079242e9f4d packages/opencode/test/kilocode | wc -l
+193
+```
+
+## Limitations
+
+- This is a static, read-only coverage review. Tests were not executed.
+- The report assesses whether Kilo-specific coverage was removed or weakened. It does not validate production behavior, CI health, or whether all newly added tests pass.
+- The review checkout already contained unrelated untracked reports, `INFRASTRUCTURE_CHANGE.md` and `UNNECESSARY_MARKERS.md`; they were not modified.

--- a/UNNECESSARY_MARKERS.md
+++ b/UNNECESSARY_MARKERS.md
@@ -1,0 +1,102 @@
+# Unnecessary `kilocode_change` Marker Review
+
+## Scope and methodology
+
+Reviewed PR [#10822](https://github.com/Kilo-Org/kilocode/pull/10822) at snapshot `94fc42255c35827b197d97368d75d079242e9f4d`, relative to PR base snapshot `2f7f23deac683078a350014ec8a1a946aae46ce4`. The pristine upstream target reference was `/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/merge/.worktrees/opencode-merge/opencode`.
+
+The review used the repository reset-candidate classifier in dry-run mode, then intersected its findings with files changed by the reviewed PR. The classifier compares local files against transformed upstream `v1.14.46` (`d802b0a2`), strips `kilocode_change` markers for the `markers-only` bucket, and performs no writes under `--dry-run`. The single in-scope candidate was then checked with the one-file reset helper in dry-run mode and spot-checked against the pristine upstream reference.
+
+## Findings
+
+### Unnecessary marker in a PR-changed file
+
+- `packages/sdk/js/src/error-interceptor.ts`
+  - The reset-candidate scan classifies this file as `markers-only`.
+  - The one-file reset helper confirms that a dry-run reset would replace it with transformed upstream `v1.14.46`.
+  - A direct comparison against the pristine upstream target shows the only local differences are the expected Kilo branding transform (`opencode server` to `kilo server`) and the adjacent `// kilocode_change` comment. Because branding transforms already produce the local `kilo server` text automatically, the marker itself is stale and can be removed by resetting the file to transformed upstream.
+
+## Notable non-findings
+
+- The full dry-run scan reported three `markers-only` files, but only `packages/sdk/js/src/error-interceptor.ts` changed in PR #10822. The other two candidates are outside this review's allowed conclusion scope:
+  - `packages/opencode/src/cli/cmd/run/permission.shared.ts`
+  - `packages/opencode/src/cli/cmd/tui/component/error-component.tsx`
+- The reviewed PR changes 181 files. This report intentionally does not treat the scan's `small-diff`, `cosmetic-only`, `identical`, or skipped buckets as unnecessary-marker findings. The task was limited to marker-only drift with no actual difference to transformed upstream.
+- No uncertain in-scope cases remain after the dry-run reset verification and pristine-upstream spot-check.
+
+## Commands run and summarized outputs
+
+```bash
+git status --short && git rev-parse HEAD
+```
+
+- Confirmed the review checkout started clean and `HEAD` was exactly `94fc42255c35827b197d97368d75d079242e9f4d`.
+
+```bash
+git diff --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d
+```
+
+- Listed the files changed by the reviewed PR for scope restriction.
+
+```bash
+git diff --stat 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d && git diff --name-only 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d | wc -l
+```
+
+- Summarized the reviewed PR as 181 changed files, with 5,028 insertions and 2,498 deletions.
+
+```bash
+bun run script/upstream/find-reset-candidates.ts --dry-run
+```
+
+- Compared shared local files against transformed upstream `v1.14.46` (`d802b0a2`) without writing files.
+- Reported 724 candidates after skipping 324 non-code assets and 1,524 config-protected files.
+- Bucket summary: 3 `markers-only`, 1 `cosmetic-only`, 158 `small-diff`, 281 `large-diff`, 132 `identical`, 147 `upstream-missing`, and 2 `local-missing`.
+- The three `markers-only` entries were `packages/opencode/src/cli/cmd/run/permission.shared.ts`, `packages/opencode/src/cli/cmd/tui/component/error-component.tsx`, and `packages/sdk/js/src/error-interceptor.ts`.
+
+```bash
+bun run script/upstream/reset-to-upstream.ts --help
+```
+
+- Confirmed the one-file helper usage and that `--dry-run` shows the reset action without writing the file.
+
+```bash
+bun run script/upstream/find-reset-candidates.ts packages/sdk/js/src/error-interceptor.ts --dry-run
+```
+
+- Re-ran the classifier scoped to the only PR-changed `markers-only` candidate.
+- Reported one candidate in the `markers-only` bucket and no other buckets.
+
+```bash
+bun run script/upstream/reset-to-upstream.ts packages/sdk/js/src/error-interceptor.ts --dry-run
+```
+
+- Reported: `[DRY-RUN] Would reset packages/sdk/js/src/error-interceptor.ts to transformed upstream v1.14.46`.
+
+```bash
+git diff --unified=20 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d -- packages/sdk/js/src/error-interceptor.ts
+```
+
+- Confirmed the reviewed PR introduced `packages/sdk/js/src/error-interceptor.ts` locally, including the stale marker next to the branded server-error text.
+
+```bash
+git diff --no-index --unified=20 "/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/merge/.worktrees/opencode-merge/opencode/packages/sdk/js/src/error-interceptor.ts" "/Users/marius/Documents/git/kilocode/.worktrees/opencode-merges/v1.14.46/review/packages/sdk/js/src/error-interceptor.ts"
+```
+
+- Spot-checked the local file against pristine upstream. The direct raw-upstream diff showed `opencode server` versus `kilo server` plus the adjacent marker. The classifier's transformed-upstream comparison correctly reduces this to marker-only drift.
+
+```bash
+git grep -l kilocode_change 94fc42255c35827b197d97368d75d079242e9f4d -- $(git diff --name-only --diff-filter=ACMR 2f7f23deac683078a350014ec8a1a946aae46ce4 94fc42255c35827b197d97368d75d079242e9f4d)
+```
+
+- Listed marker-bearing files changed in the reviewed PR as an additional scope check. The list includes intentional Kilo drift and Kilo-owned paths, so it was not used as a standalone finding source.
+
+```bash
+git status --short
+```
+
+- Confirmed the dry-run review commands left the checkout unchanged before this report was written.
+
+## Limitations
+
+- `find-reset-candidates.ts` intentionally skips non-code assets, config-protected files, oversized files, upstream-missing files, and local-missing files. Those skips are not evidence of unnecessary markers.
+- The report restricts findings to files changed between the supplied PR base and reviewed snapshots, as requested. Marker-only drift elsewhere in the branch is noted only when the classifier surfaced it and is not attributed to PR #10822.
+- Direct pristine-upstream comparison is raw upstream, while reset decisions use repository branding transforms. The one-file dry-run reset verification is the authoritative check for the flagged file.


### PR DESCRIPTION
The OpenCode v1.14.46 synchronization needs a focused human review before merge. These reports capture static audits against the reviewed snapshot and keep review findings separate from the upstream-sync implementation branch.

The highest-priority finding is a likely workspace-routing regression across Kilo-only HttpApi endpoints after upstream removed global OpenAPI query injection. The reports also flag the newly merged OpenCode-branded customization skill, one stale marker candidate, a disabled structured sync-error test, and infrastructure items that need confirmation.

Included reports:
- `BROKEN_PIPELINE_CHAINS.md`
- `KILOCODE_CHANGE_MARKERS.md`
- `UNNECESSARY_MARKERS.md`
- `OPENCODE_MENTIONS.md`
- `INFRASTRUCTURE_CHANGE.md`
- `TESTS.md`