### PR TITLE
fix: clarify free model training disclosure

### DIFF
--- a/.changeset/brain-circuit-data-disclosure.md
+++ b/.changeset/brain-circuit-data-disclosure.md
@@ -1,6 +1,8 @@
 ---
+"@kilocode/cli": patch
+"@kilocode/kilo-jetbrains": patch
 "kilo-code": patch
 "@kilocode/kilo-ui": patch
 ---
 
-Use a brain circuit icon for free-model data collection disclosures.
+Clarify when free-model data may be used for training and identify it with a brain circuit icon.

--- a/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
+++ b/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
@@ -145,7 +145,7 @@ model.picker.no.matches=No matching models
 model.picker.favorite.add=Add to favorites
 model.picker.favorite.remove=Remove from favorites
 model.picker.free=Free
-model.picker.dataCollected=Data collected
+model.picker.dataCollected=Data may be used for training
 model.picker.reset=Reset model to default
 reasoning.picker.tooltip=Select reasoning effort
 

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -158,9 +158,9 @@ class ModelPickerTest : BasePlatformTestCase() {
 
         picker.setItems(listOf(item("auto", "Auto Free", "kilo", "Kilo", free = true)))
 
-        assertFalse(picker.text.contains("Data collected"))
+        assertFalse(picker.text.contains("Data may be used for training"))
         assertSame(ModelPickerIcons.DATA_COLLECTED, picker.icon)
-        assertEquals("Data collected", picker.toolTipText)
+        assertEquals("Data may be used for training", picker.toolTipText)
     }
 
     fun `test selected non-kilo free model does not indicate data collection`() {
@@ -282,7 +282,7 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertTrue(renderer.badgeVisible())
         assertEquals("Free", renderer.badgeText())
         assertTrue(renderer.warningVisible())
-        assertEquals("Data collected", renderer.warningTooltip())
+        assertEquals("Data may be used for training", renderer.warningTooltip())
     }
 
     fun `test renderer hides data collection warning for non-kilo free model`() {

--- a/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
@@ -98,12 +98,12 @@ describe("sanitizeName", () => {
 
 describe("freeDataLabel", () => {
   it("uses the data collection label without repeating free", () => {
-    expect(freeDataLabel("Free", "Data collected")).toBe("Data collected")
+    expect(freeDataLabel("Free", "Data may be used for training")).toBe("Data may be used for training")
   })
 })
 
 describe("isDataCollectedModel", () => {
-  it("only marks free Kilo Gateway models as data collected", () => {
+  it("only marks free Kilo Gateway models with the training disclosure", () => {
     expect(isDataCollectedModel({ providerID: KILO_GATEWAY_ID, isFree: true })).toBe(true)
     expect(isDataCollectedModel({ providerID: "openrouter", isFree: true })).toBe(false)
     expect(isDataCollectedModel({ providerID: KILO_GATEWAY_ID, isFree: false })).toBe(false)

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -174,7 +174,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "تم فصل {{provider}}",
   "provider.disconnect.toast.disconnected.description": "لم تعد نماذج {{provider}} متاحة.",
   "model.tag.free": "مجاني",
-  "model.tag.dataCollected": "يتم جمع البيانات",
+  "model.tag.dataCollected": "قد تُستخدم البيانات للتدريب",
   "model.tag.latest": "الأحدث",
   "model.group.recommended": "موصى به",
   "model.group.favorites": "المفضلة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} desconectado",
   "provider.disconnect.toast.disconnected.description": "Os modelos de {{provider}} não estão mais disponíveis.",
   "model.tag.free": "Grátis",
-  "model.tag.dataCollected": "Dados coletados",
+  "model.tag.dataCollected": "Os dados podem ser usados para treinamento",
   "model.tag.latest": "Mais recente",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -176,7 +176,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modeli više nisu dostupni.",
 
   "model.tag.free": "Besplatno",
-  "model.tag.dataCollected": "Podaci se prikupljaju",
+  "model.tag.dataCollected": "Podaci se mogu koristiti za obuku",
   "model.tag.latest": "Najnovije",
   "model.group.recommended": "Preporučeno",
   "model.group.favorites": "Favoriti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} frakoblet",
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke længere tilgængelige.",
   "model.tag.free": "Gratis",
-  "model.tag.dataCollected": "Data indsamles",
+  "model.tag.dataCollected": "Data kan bruges til træning",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalet",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -179,7 +179,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} getrennt",
   "provider.disconnect.toast.disconnected.description": "Die {{provider}}-Modelle sind nicht mehr verfügbar.",
   "model.tag.free": "Kostenlos",
-  "model.tag.dataCollected": "Daten erfasst",
+  "model.tag.dataCollected": "Daten können für das Training verwendet werden",
   "model.tag.latest": "Neueste",
   "model.group.recommended": "Empfohlen",
   "model.group.favorites": "Favoriten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -176,7 +176,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} models are no longer available.",
 
   "model.tag.free": "Free",
-  "model.tag.dataCollected": "Data collected",
+  "model.tag.dataCollected": "Data may be used for training",
   "model.tag.latest": "Latest",
   "model.group.recommended": "Recommended",
   "model.group.favorites": "Favorites",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -176,7 +176,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} desconectado",
   "provider.disconnect.toast.disconnected.description": "Los modelos de {{provider}} ya no están disponibles.",
   "model.tag.free": "Gratis",
-  "model.tag.dataCollected": "Datos recopilados",
+  "model.tag.dataCollected": "Los datos pueden utilizarse para entrenamiento",
   "model.tag.latest": "Último",
   "model.group.recommended": "Recomendado",
   "model.group.favorites": "Favoritos",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -177,7 +177,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} déconnecté",
   "provider.disconnect.toast.disconnected.description": "Les modèles {{provider}} ne sont plus disponibles.",
   "model.tag.free": "Gratuit",
-  "model.tag.dataCollected": "Données collectées",
+  "model.tag.dataCollected": "Les données peuvent être utilisées pour l’entraînement",
   "model.tag.latest": "Dernier",
   "model.group.recommended": "Recommandé",
   "model.group.favorites": "Favoris",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -151,7 +151,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} disconnesso",
   "provider.disconnect.toast.disconnected.description": "I modelli {{provider}} non sono più disponibili.",
   "model.tag.free": "Gratis",
-  "model.tag.dataCollected": "Dati raccolti",
+  "model.tag.dataCollected": "I dati possono essere utilizzati per l'addestramento",
   "model.tag.latest": "Più recente",
   "model.group.recommended": "Consigliati",
   "model.group.favorites": "Preferiti",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -174,7 +174,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}}が切断されました",
   "provider.disconnect.toast.disconnected.description": "{{provider}}のモデルは利用できなくなりました。",
   "model.tag.free": "無料",
-  "model.tag.dataCollected": "データ収集あり",
+  "model.tag.dataCollected": "データがトレーニングに使用される場合があります",
   "model.tag.latest": "最新",
   "model.group.recommended": "推奨",
   "model.group.favorites": "お気に入り",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -178,7 +178,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 연결 해제됨",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 모델을 더 이상 사용할 수 없습니다.",
   "model.tag.free": "무료",
-  "model.tag.dataCollected": "데이터 수집됨",
+  "model.tag.dataCollected": "데이터가 학습에 사용될 수 있습니다",
   "model.tag.latest": "최신",
   "model.group.recommended": "추천",
   "model.group.favorites": "즐겨찾기",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -176,7 +176,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modellen zijn niet langer beschikbaar.",
 
   "model.tag.free": "Gratis",
-  "model.tag.dataCollected": "Gegevens verzameld",
+  "model.tag.dataCollected": "Gegevens kunnen worden gebruikt voor training",
   "model.tag.latest": "Nieuwste",
   "model.group.recommended": "Aanbevolen",
   "model.group.favorites": "Favorieten",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -178,7 +178,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} frakoblet",
   "provider.disconnect.toast.disconnected.description": "Modeller fra {{provider}} er ikke lenger tilgjengelige.",
   "model.tag.free": "Gratis",
-  "model.tag.dataCollected": "Data samles inn",
+  "model.tag.dataCollected": "Data kan brukes til trening",
   "model.tag.latest": "Nyeste",
   "model.group.recommended": "Anbefalt",
   "model.group.favorites": "Favoritter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "Rozłączono {{provider}}",
   "provider.disconnect.toast.disconnected.description": "Modele {{provider}} nie są już dostępne.",
   "model.tag.free": "Darmowy",
-  "model.tag.dataCollected": "Dane zbierane",
+  "model.tag.dataCollected": "Dane mogą być wykorzystywane do trenowania",
   "model.tag.latest": "Najnowszy",
   "model.group.recommended": "Zalecane",
   "model.group.favorites": "Ulubione",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} отключён",
   "provider.disconnect.toast.disconnected.description": "Модели {{provider}} больше недоступны.",
   "model.tag.free": "Бесплатно",
-  "model.tag.dataCollected": "Данные собираются",
+  "model.tag.dataCollected": "Данные могут использоваться для обучения",
   "model.tag.latest": "Последняя",
   "model.group.recommended": "Рекомендуемые",
   "model.group.favorites": "Избранное",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "โมเดล {{provider}} ไม่พร้อมใช้งานอีกต่อไป",
 
   "model.tag.free": "ฟรี",
-  "model.tag.dataCollected": "มีการเก็บข้อมูล",
+  "model.tag.dataCollected": "ข้อมูลอาจถูกนำไปใช้ในการฝึก",
   "model.tag.latest": "ล่าสุด",
   "model.group.recommended": "แนะนำ",
   "model.group.favorites": "รายการโปรด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "{{provider}} modelleri artık kullanılabilir değil.",
 
   "model.tag.free": "Ücretsiz",
-  "model.tag.dataCollected": "Veri toplanır",
+  "model.tag.dataCollected": "Veriler eğitim için kullanılabilir",
   "model.tag.latest": "En yeni",
   "model.group.recommended": "Önerilen",
   "model.group.favorites": "Favoriler",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -176,7 +176,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.description": "Моделі {{provider}} більше недоступні.",
 
   "model.tag.free": "Безкоштовно",
-  "model.tag.dataCollected": "Дані збираються",
+  "model.tag.dataCollected": "Дані можуть використовуватися для навчання",
   "model.tag.latest": "Остання",
   "model.group.recommended": "Рекомендовані",
   "model.group.favorites": "Обране",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 已断开连接",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免费",
-  "model.tag.dataCollected": "已收集数据",
+  "model.tag.dataCollected": "数据可能会用于训练",
   "model.tag.latest": "最新",
   "model.group.recommended": "推荐",
   "model.group.favorites": "收藏夹",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -175,7 +175,7 @@ export const dict = {
   "provider.disconnect.toast.disconnected.title": "{{provider}} 已中斷連線",
   "provider.disconnect.toast.disconnected.description": "{{provider}} 模型已不再可用。",
   "model.tag.free": "免費",
-  "model.tag.dataCollected": "已收集資料",
+  "model.tag.dataCollected": "資料可能會用於訓練",
   "model.tag.latest": "最新",
   "model.group.recommended": "推薦",
   "model.group.favorites": "我的最愛",

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,6 +1,6 @@
 export const FreeModelDisclosure = {
   label: "May train",
-  panel: "Free - may train",
+  panel: "Free - data may be used for training",
   collectsData(model: { isFree?: boolean; api?: { npm?: string } }): boolean {
     return model.isFree === true && model.api?.npm === "@kilocode/kilo-gateway"
   },

--- a/packages/opencode/src/kilocode/components/free-model-disclosure.ts
+++ b/packages/opencode/src/kilocode/components/free-model-disclosure.ts
@@ -1,6 +1,6 @@
 export const FreeModelDisclosure = {
-  label: "Data collected",
-  panel: "Free - data collected",
+  label: "May train",
+  panel: "Free - may train",
   collectsData(model: { isFree?: boolean; api?: { npm?: string } }): boolean {
     return model.isFree === true && model.api?.npm === "@kilocode/kilo-gateway"
   },

--- a/packages/opencode/test/kilocode/free-model-disclosure.test.ts
+++ b/packages/opencode/test/kilocode/free-model-disclosure.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { FreeModelDisclosure } from "../../src/kilocode/components/free-model-disclosure"
 
 describe("FreeModelDisclosure", () => {
-  test("only Kilo Gateway free models collect data", () => {
+  test("uses compact CLI labels", () => {
+    expect(FreeModelDisclosure.label).toBe("May train")
+    expect(FreeModelDisclosure.panel).toBe("Free - may train")
+  })
+
+  test("only Kilo Gateway free models get the training disclosure", () => {
     expect(
       FreeModelDisclosure.collectsData({
         isFree: true,

--- a/packages/opencode/test/kilocode/free-model-disclosure.test.ts
+++ b/packages/opencode/test/kilocode/free-model-disclosure.test.ts
@@ -4,7 +4,7 @@ import { FreeModelDisclosure } from "../../src/kilocode/components/free-model-di
 describe("FreeModelDisclosure", () => {
   test("uses compact CLI labels", () => {
     expect(FreeModelDisclosure.label).toBe("May train")
-    expect(FreeModelDisclosure.panel).toBe("Free - may train")
+    expect(FreeModelDisclosure.panel).toBe("Free - data may be used for training")
   })
 
   test("only Kilo Gateway free models get the training disclosure", () => {


### PR DESCRIPTION
## Summary
- Clarify free Kilo Gateway model disclosures so editor clients state that data may be used for training.
- Use the compact `May train` wording in CLI picker rows where space is limited, while the wide CLI sidebar shows the expanded `Free - data may be used for training` disclosure.
- Keep localized VS Code copy, JetBrains tooltip coverage, CLI assertions, and release metadata aligned.

## Why
The previous `Data collected` label did not communicate the training implication clearly. This makes the disclosure more specific while preserving concise CLI picker rendering.