### PR TITLE
fix(cli): trim whitespace from tool names before repair

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -344,7 +344,7 @@ const live: Layer.Layer<
           })
         },
         async experimental_repairToolCall(failed) {
-          const lower = failed.toolCall.toolName.toLowerCase()
+          const lower = failed.toolCall.toolName.trim().toLowerCase() // kilocode_change
           if (lower !== failed.toolCall.toolName && prepared.tools[lower]) {
             l.info("repairing tool call", {
               tool: failed.toolCall.toolName,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1904,4 +1904,100 @@ describe("session.llm.stream", () => {
       }),
     },
   )
+
+  // kilocode_change start
+  it.instance(
+    "repairs whitespace-padded tool names and executes the correct tool",
+    () =>
+      Effect.gen(function* () {
+        const fixture = loadFixture(alibabaQwenFixture.providerID, alibabaQwenFixture.modelID)
+        let toolExecuted = false
+
+        waitRequest(
+          "/chat/completions",
+          createEventResponse(
+            [
+              {
+                id: "chatcmpl-1",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    index: 0,
+                    delta: {
+                      role: "assistant",
+                      content: null,
+                      tool_calls: [{ index: 0, id: "call-1", type: "function", function: { name: " bash", arguments: "" } }],
+                    },
+                  },
+                ],
+              },
+              {
+                id: "chatcmpl-1",
+                object: "chat.completion.chunk",
+                choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: "{}" } }] } }],
+              },
+              {
+                id: "chatcmpl-1",
+                object: "chat.completion.chunk",
+                choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+              },
+            ],
+            true,
+          ),
+        )
+
+        const resolved = yield* Provider.use.getModel(
+          ProviderID.make(alibabaQwenFixture.providerID),
+          ModelID.make(fixture.model.id),
+        )
+        const sessionID = SessionID.make("session-test-repair")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-repair"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(alibabaQwenFixture.providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        yield* drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Run bash" }],
+          tools: {
+            bash: tool({
+              description: "Run bash",
+              inputSchema: z.object({}),
+              execute: async () => {
+                toolExecuted = true
+                return { output: "" }
+              },
+            }),
+          },
+        })
+
+        expect(toolExecuted).toBe(true)
+      }),
+    {
+      config: () => ({
+        enabled_providers: [alibabaQwenFixture.providerID],
+        provider: {
+          [alibabaQwenFixture.providerID]: {
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+  // kilocode_change end
 })


### PR DESCRIPTION
## Summary

Normalizes tool names with accidental leading or trailing whitespace before falling back to the invalid-tool repair path in `experimental_repairToolCall`.

## Changes

- `packages/opencode/src/session/llm.ts`: Add `.trim()` before `.toLowerCase()` in `experimental_repairToolCall` so whitespace-prefixed tool calls (e.g. `" read"`) are repaired to the correct tool name instead of being marked as `"invalid"`.

## Related

Fixes #10140