### PR TITLE
fix(cli): reject unsupported webfetch images

### DIFF
--- a/.changeset/calm-icons-fetch.md
+++ b/.changeset/calm-icons-fetch.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent unsupported images fetched from the web from causing provider request errors.

--- a/.changeset/calm-icons-fetch.md
+++ b/.changeset/calm-icons-fetch.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Prevent unsupported images fetched from the web from causing provider request errors.
+Prevent icon images fetched from the web from causing provider request errors.

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -108,7 +108,7 @@ export const WebFetchTool = Tool.define(
           const contentType = response.headers["content-type"] || ""
           const mime = contentType.split(";")[0]?.trim().toLowerCase() || ""
           const title = `${url} (${contentType})` // kilocode_change
-
+          if (isIconMimeType(mime)) throw new Error(`Unsupported image format: ${mime}`) // kilocode_change
           if (isImageAttachment(mime)) {
             const base64Content = Buffer.from(arrayBuffer).toString("base64")
             return {
@@ -124,16 +124,6 @@ export const WebFetchTool = Tool.define(
               ],
             }
           }
-
-          // kilocode_change start
-          if (isIconMimeType(mime)) {
-            return {
-              title,
-              output: `Unsupported image format: ${mime}.`,
-              metadata: {},
-            }
-          }
-          // kilocode_change end
 
           const content = new TextDecoder().decode(arrayBuffer)
 

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -125,6 +125,16 @@ export const WebFetchTool = Tool.define(
             }
           }
 
+          // kilocode_change start
+          if (mime.startsWith("image/") && mime !== "image/svg+xml") {
+            return {
+              title,
+              output: `Unsupported image format: ${mime}. Supported formats are JPEG, PNG, GIF, and WebP.`,
+              metadata: {},
+            }
+          }
+          // kilocode_change end
+
           const content = new TextDecoder().decode(arrayBuffer)
 
           // Handle content based on requested format and actual content type

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import * as Tool from "./tool"
 import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
-import { isImageAttachment } from "@/util/media"
+import { isIconMimeType, isImageAttachment } from "@/util/media" // kilocode_change
 import { normalizeUrls } from "@/kilocode/util/url" // kilocode_change
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
@@ -126,12 +126,7 @@ export const WebFetchTool = Tool.define(
           }
 
           // kilocode_change start
-          if (
-            mime.startsWith("image/") &&
-            !isImageAttachment(mime) &&
-            mime !== "image/svg+xml" &&
-            mime !== "image/vnd.fastbidsheet"
-          ) {
+          if (isIconMimeType(mime)) {
             return {
               title,
               output: `Unsupported image format: ${mime}.`,

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -126,10 +126,15 @@ export const WebFetchTool = Tool.define(
           }
 
           // kilocode_change start
-          if (mime.startsWith("image/") && mime !== "image/svg+xml") {
+          if (
+            mime.startsWith("image/") &&
+            !isImageAttachment(mime) &&
+            mime !== "image/svg+xml" &&
+            mime !== "image/vnd.fastbidsheet"
+          ) {
             return {
               title,
-              output: `Unsupported image format: ${mime}. Supported formats are JPEG, PNG, GIF, and WebP.`,
+              output: `Unsupported image format: ${mime}.`,
               metadata: {},
             }
           }

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -10,8 +10,12 @@ export function isMedia(mime: string) {
 }
 
 // kilocode_change start
+export function isIconMimeType(mime: string) {
+  return icons.has(mime)
+}
+
 export function isImageAttachment(mime: string) {
-  return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet" && !icons.has(mime)
+  return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet" && !isIconMimeType(mime)
 }
 // kilocode_change end
 

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -9,7 +9,7 @@ export function isMedia(mime: string) {
 }
 
 export function isImageAttachment(mime: string) {
-  return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
+  return ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(mime) // kilocode_change
 }
 
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -1,4 +1,5 @@
 const startsWith = (bytes: Uint8Array, prefix: number[]) => prefix.every((value, index) => bytes[index] === value)
+const icons = new Set(["image/vnd.microsoft.icon", "image/x-icon", "image/x-ico", "image/ico", "image/icon"]) // kilocode_change
 
 export function isPdfAttachment(mime: string) {
   return mime === "application/pdf"
@@ -8,9 +9,11 @@ export function isMedia(mime: string) {
   return mime.startsWith("image/") || isPdfAttachment(mime)
 }
 
+// kilocode_change start
 export function isImageAttachment(mime: string) {
-  return ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(mime) // kilocode_change
+  return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet" && !icons.has(mime)
 }
+// kilocode_change end
 
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png"

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -91,9 +91,9 @@ describe("tool.webfetch", () => {
         await WithInstance.provide({
           directory: projectRoot,
           fn: async () => {
-            const result = await exec({ url: new URL("/favicon.ico", url).toString(), format: "markdown" })
-            expect(result.output).toContain(`Unsupported image format: ${mime}`)
-            expect(result.attachments).toBeUndefined()
+            await expect(exec({ url: new URL("/favicon.ico", url).toString(), format: "markdown" })).rejects.toThrow(
+              `Unsupported image format: ${mime}`,
+            )
           },
         })
       },

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -82,6 +82,25 @@ describe("tool.webfetch", () => {
     )
   })
 
+  // kilocode_change start
+  test("rejects unsupported image attachments", async () => {
+    const bytes = new Uint8Array([0, 0, 1, 0])
+    await withFetch(
+      () => new Response(bytes, { status: 200, headers: { "content-type": "image/x-icon" } }),
+      async (url) => {
+        await WithInstance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const result = await exec({ url: new URL("/favicon.ico", url).toString(), format: "markdown" })
+            expect(result.output).toContain("Unsupported image format: image/x-icon")
+            expect(result.attachments).toBeUndefined()
+          },
+        })
+      },
+    )
+  })
+  // kilocode_change end
+
   test("keeps text responses as text output", async () => {
     await withFetch(
       () =>

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -83,16 +83,49 @@ describe("tool.webfetch", () => {
   })
 
   // kilocode_change start
-  test("rejects unsupported image attachments", async () => {
+  test.each(["image/x-icon", "image/vnd.microsoft.icon"])("rejects %s attachments", async (mime) => {
     const bytes = new Uint8Array([0, 0, 1, 0])
     await withFetch(
-      () => new Response(bytes, { status: 200, headers: { "content-type": "image/x-icon" } }),
+      () => new Response(bytes, { status: 200, headers: { "content-type": mime } }),
       async (url) => {
         await WithInstance.provide({
           directory: projectRoot,
           fn: async () => {
             const result = await exec({ url: new URL("/favicon.ico", url).toString(), format: "markdown" })
-            expect(result.output).toContain("Unsupported image format: image/x-icon")
+            expect(result.output).toContain(`Unsupported image format: ${mime}`)
+            expect(result.attachments).toBeUndefined()
+          },
+        })
+      },
+    )
+  })
+
+  test("returns non-icon image responses as file attachments", async () => {
+    const bytes = new Uint8Array([0, 0, 0, 0])
+    await withFetch(
+      () => new Response(bytes, { status: 200, headers: { "content-type": "image/avif" } }),
+      async (url) => {
+        await WithInstance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const result = await exec({ url: new URL("/image.avif", url).toString(), format: "markdown" })
+            expect(result.output).toBe("Image fetched successfully")
+            expect(result.attachments?.[0].mime).toBe("image/avif")
+          },
+        })
+      },
+    )
+  })
+
+  test("keeps fastbidsheet responses as text output", async () => {
+    await withFetch(
+      () => new Response("sheet", { status: 200, headers: { "content-type": "image/vnd.fastbidsheet" } }),
+      async (url) => {
+        await WithInstance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const result = await exec({ url: new URL("/sheet", url).toString(), format: "text" })
+            expect(result.output).toBe("sheet")
             expect(result.attachments).toBeUndefined()
           },
         })


### PR DESCRIPTION
## Summary

Exclude ICO MIME variants from images returned as `webfetch` attachments so they cannot reach vision providers that reject icon containers. Other image formats remain attachments, while SVG and FastBidSheet responses retain their existing text behavior.

This prevents provider-level invalid request errors for fetched icons without introducing a restrictive image-format allowlist.