### PR TITLE
Feature/git commit gen timeout

### DIFF
--- a/.changeset/easy-melons-drive.md
+++ b/.changeset/easy-melons-drive.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": major
+---
+
+Added the provider timeout to git commit message generation, defaults to old behaviour

--- a/.changeset/easy-melons-drive.md
+++ b/.changeset/easy-melons-drive.md
@@ -1,5 +1,5 @@
 ---
-"@kilocode/cli": major
+"@kilocode/cli": patch
 ---
 
 Added the provider timeout to git commit message generation, defaults to old behaviour

--- a/packages/opencode/src/kilocode/commit-message/generate.ts
+++ b/packages/opencode/src/kilocode/commit-message/generate.ts
@@ -13,7 +13,7 @@ const log = Log.create({ service: "commit-message" })
 // Default maximum time (ms) to wait for the LLM to produce a commit message before
 // aborting. Prevents the HTTP request from hanging indefinitely when the
 // provider is slow or the stream stalls (e.g. due to config state races).
-const DEFAUL_TIMEOUT_MS = 30_000
+const DEFAULT_TIMEOUT_MS = 30_000
 
 export const CommitMessageRuntime = {
   context(repoPath: string, selectedFiles?: string[]) {
@@ -29,14 +29,14 @@ export const CommitMessageRuntime = {
       ),
     )
   },
-  timeout() {
+  timeoutMs() {
     return AppRuntime.runPromise(
       Provider.Service.use((svc) =>
         Effect.gen(function* () {
           const ref = yield* svc.defaultModel()
           const provider = yield* svc.getProvider(ref.providerID)
           
-          return provider?.options?.timeout ?? DEFAUL_TIMEOUT_MS
+          return provider?.options?.timeout as number ?? DEFAULT_TIMEOUT_MS
         }),
       ),
     )
@@ -184,7 +184,8 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
   }
 
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), await CommitMessageRuntime.timeout())
+  const timeoutMs = await CommitMessageRuntime.timeoutMs()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
 
   try {
     const result = await CommitMessageRuntime.generate(
@@ -223,7 +224,7 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
     return { message: clean(result) }
   } catch (err) {
     if (controller.signal.aborted) {
-      throw new Error("Commit message generation timed out after 30 seconds")
+      throw new Error(`Commit message generation timed out after ${Math.round(timeoutMs / 1000)} seconds`)
     }
     const msg = err instanceof Error ? err.message : String(err)
     log.error("generation failed", { error: msg })

--- a/packages/opencode/src/kilocode/commit-message/generate.ts
+++ b/packages/opencode/src/kilocode/commit-message/generate.ts
@@ -10,6 +10,11 @@ import { getGitContext } from "./git-context"
 
 const log = Log.create({ service: "commit-message" })
 
+// Default maximum time (ms) to wait for the LLM to produce a commit message before
+// aborting. Prevents the HTTP request from hanging indefinitely when the
+// provider is slow or the stream stalls (e.g. due to config state races).
+const DEFAUL_TIMEOUT_MS = 30_000
+
 export const CommitMessageRuntime = {
   context(repoPath: string, selectedFiles?: string[]) {
     return getGitContext(repoPath, selectedFiles)
@@ -20,6 +25,18 @@ export const CommitMessageRuntime = {
         Effect.gen(function* () {
           const ref = yield* svc.defaultModel()
           return (yield* svc.getSmallModel(ref.providerID)) ?? (yield* svc.getModel(ref.providerID, ref.modelID))
+        }),
+      ),
+    )
+  },
+  timeout() {
+    return AppRuntime.runPromise(
+      Provider.Service.use((svc) =>
+        Effect.gen(function* () {
+          const ref = yield* svc.defaultModel()
+          const provider = yield* svc.getProvider(ref.providerID)
+          
+          return provider?.options?.timeout ?? DEFAUL_TIMEOUT_MS
         }),
       ),
     )
@@ -138,11 +155,6 @@ function clean(text: string): string {
   return result.trim()
 }
 
-// Maximum time (ms) to wait for the LLM to produce a commit message before
-// aborting. Prevents the HTTP request from hanging indefinitely when the
-// provider is slow or the stream stalls (e.g. due to config state races).
-const TIMEOUT_MS = 30_000
-
 export async function generateCommitMessage(request: CommitMessageRequest): Promise<CommitMessageResponse> {
   const ctx = await CommitMessageRuntime.context(request.path, request.selectedFiles)
   if (ctx.files.length === 0) {
@@ -172,7 +184,7 @@ export async function generateCommitMessage(request: CommitMessageRequest): Prom
   }
 
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  const timer = setTimeout(() => controller.abort(), await CommitMessageRuntime.timeout())
 
   try {
     const result = await CommitMessageRuntime.generate(


### PR DESCRIPTION
## Issue

Fixes #7523 

## Context

The git commit message generation had a hardcoded TIMEOUT_MS of 30 seconds. When providers were slow, or the context (overall changes) was long, it would fail. This uses the provider's timeout option, if provided, instead of the hardcoded timeout, which is only used as a fallback.

## Implementation

Moved from a hardcoded constant (TIMEOUT_MS = 30_000) to fetching the provider's configured timeout option via AppRuntime.runPromise(Provider.Service.use(...)).
Added a new CommitMessageRuntime.timeout() method that reads the provider timeout and falls back to the previous default of 30_000ms when not explicitly set.
The generateCommitMessage() function now calls await CommitMessageRuntime.timeout() instead of using the hardcoded constant, so each request respects the current provider configuration.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Opened a repo with staged changes and triggered commit message generation; confirmed it still works with default timeout behavior (30s) when provider has no explicit timeout configured.
- Set a custom timeout value in the provider config for a test provider and verified the commit generation respects that timeout instead of the hardcoded 30s.

-

### Reviewer test steps

- Open a repo with uncommitted changes
- Trigger git commit message generation
- Confirm the commit message is generated successfully within the expected time window
- Set timeout in your provider config to a non-default value and retest, confirm the new timeout is respected

-

### Blocked checks and substitute verification

No automated tests exist for this module; manual verification was performed as described above.

-

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

alfredomm
