### PR TITLE
Support same-repo cloud session portability

### DIFF
--- a/.changeset/session-portability-checkpoints.md
+++ b/.changeset/session-portability-checkpoints.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Restore same-repo workspace changes when continuing cloud sessions locally.

--- a/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/cloud-session.ts
@@ -140,7 +140,7 @@ export async function handleImportAndSend(
     const result = await ctx.client.kilo.cloud.session.import(
       {
         sessionId: cloudSessionId,
-        directory: dir,
+        body_directory: dir,
       },
       { signal: AbortSignal.timeout(TIMEOUT) },
     )

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -392,7 +392,7 @@ export const RunCommand = effectCmd({
       async function session(sdk: KiloClient): Promise<SessionInfo | undefined> {
         // kilocode_change start - import cloud session before local lookup
         if (args.session && args["cloud-fork"]) {
-          const id = await importCloudSession(sdk, args.session).catch(() => undefined)
+          const id = await importCloudSession(sdk, args.session, directory ?? root).catch(() => undefined)
           if (!id) {
             UI.error("Failed to import session from cloud")
             process.exit(1)

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -89,7 +89,7 @@ export const AttachCommand = cmd({
           directory,
           headers,
         })
-        const id = await importCloudSession(sdk, args.session).catch(() => undefined)
+        const id = await importCloudSession(sdk, args.session, directory).catch(() => undefined)
         if (!id) {
           UI.error("Failed to import session from cloud")
           process.exitCode = 1

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -336,7 +336,7 @@ export const TuiThreadCommand = cmd({
             fetch: transport.fetch,
             directory: cwd,
           })
-          const id = await importCloudSession(sdk, args.session).catch(() => undefined)
+          const id = await importCloudSession(sdk, args.session, cwd).catch(() => undefined)
           if (!id) {
             UI.error("Failed to import session from cloud")
             shutdownAndExit({ reason: "cloud-fork-failed", code: 1 })

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -4,6 +4,7 @@ import { Provider } from "@/provider/provider"
 import { Session } from "@/session/session"
 import { SessionSummary } from "@/session/summary"
 import { KiloSession } from "@/kilocode/session"
+import { attachWorkspaceCheckpoint } from "@/kilocode/session-portability/git-checkpoint"
 import { SessionID } from "@/session/schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { MessageV2 } from "@/session/message-v2"
@@ -130,8 +131,8 @@ export namespace KiloSessions {
     fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
   }
 
-  function transport(info: Session.Info): SDK.Session {
-    return {
+  async function transport(info: Session.Info, opts?: { checkpoint?: boolean }): Promise<SDK.Session> {
+    const session = {
       ...info,
       summary: info.summary
         ? {
@@ -142,6 +143,8 @@ export namespace KiloSessions {
           }
         : undefined,
     }
+    if (!opts?.checkpoint) return session
+    return attachWorkspaceCheckpoint(session)
   }
 
   async function getClient(): Promise<Client | undefined> {
@@ -260,7 +263,7 @@ export namespace KiloSessions {
             if (!session) return
             await ingest.sync(sessionID, [
               { type: "kilo_meta", data: await meta(sessionID) },
-              { type: "session", data: transport(session) },
+              { type: "session", data: await transport(session) },
             ])
           })
           yield* watch(MessageV2.Event.Updated, async (evt) => {
@@ -278,9 +281,14 @@ export namespace KiloSessions {
           yield* watch(Session.Event.TurnOpen, (evt) =>
             ingest.sync(evt.properties.sessionID, [{ type: "session_open", data: {} }]),
           )
-          yield* watch(Session.Event.TurnClose, (evt) =>
-            ingest.sync(evt.properties.sessionID, [{ type: "session_close", data: { reason: evt.properties.reason } }]),
-          )
+          yield* watch(Session.Event.TurnClose, async (evt) => {
+            const sessionID = evt.properties.sessionID
+            const session = await Effect.runPromise(sessions.get(sessionID).pipe(Effect.orElseSucceed(() => null)))
+            await ingest.sync(sessionID, [
+              ...(session ? [{ type: "session" as const, data: await transport(session, { checkpoint: true }) }] : []),
+              { type: "session_close", data: { reason: evt.properties.reason } },
+            ])
+          })
 
           const sync = (evt: { properties: { sessionID: string } }) => {
             const sessionID = evt.properties.sessionID
@@ -696,7 +704,7 @@ export namespace KiloSessions {
       },
       {
         type: "session",
-        data: transport(session),
+        data: await transport(session, { checkpoint: true }),
       },
       ...messages.map((x) => ({
         type: "message" as const,

--- a/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
@@ -35,7 +35,7 @@ async function session(input: Input, daemon: DaemonClient.Connection) {
     directory: input.cwd,
     headers: daemon.headers,
   })
-  const id = await importCloudSession(client, input.args.session).catch(() => undefined)
+  const id = await importCloudSession(client, input.args.session, input.cwd).catch(() => undefined)
   if (id) return { ok: true as const, id }
 
   UI.error("Failed to import session from cloud")

--- a/packages/opencode/src/kilocode/cloud-session.ts
+++ b/packages/opencode/src/kilocode/cloud-session.ts
@@ -23,14 +23,22 @@ export async function importCloudSession(
     kilo: {
       cloud: {
         session: {
-          import: (params: { sessionId: string }) => Promise<{ data?: unknown }>
+          import: (params: {
+            sessionId: string
+            body_directory?: string
+            query_directory?: string
+          }) => Promise<{ data?: unknown }>
         }
       }
     }
   },
   sessionId: string,
+  directory?: string,
 ): Promise<string | undefined> {
-  const result = await client.kilo.cloud.session.import({ sessionId })
+  const result = await client.kilo.cloud.session.import({
+    sessionId,
+    ...(directory ? { body_directory: directory } : {}),
+  })
   const id = (result.data as Record<string, unknown>)?.id
   return typeof id === "string" ? id : undefined
 }

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
@@ -105,6 +105,7 @@ export const CloudSessions = Schema.Struct({
 
 export const CloudSessionImportBody = Schema.Struct({
   sessionId: Schema.String,
+  directory: Schema.optional(Schema.String),
 })
 
 const GroupEntry = Schema.Union([

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -32,6 +32,7 @@ import { Auth } from "@/auth"
 import { EffectBridge } from "@/effect/bridge"
 import { Bus } from "@/bus"
 import { Identifier } from "@/id/id"
+import { restoreCloudSessionWorkspace } from "@/kilocode/session-portability/git-checkpoint"
 import { Instance } from "@/project/instance"
 import { InstanceStore } from "@/project/instance-store"
 import { ModelCache } from "@/provider/model-cache"
@@ -440,6 +441,34 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       if (!fetched.ok) return jsonError(fetched.error, fetched.status)
       if (!fetched.data?.info?.id) return yield* Effect.fail(new HttpApiError.BadRequest({}))
 
+      const directory = ctx.payload.directory ?? Instance.directory
+      const workspace = yield* Effect.tryPromise({
+        try: () =>
+          restoreCloudSessionWorkspace({
+            info: fetched.data.info,
+            directory,
+            sessionID: fetched.data.info.id,
+          }),
+        catch: (err) => err,
+      }).pipe(
+        Effect.catch((err) =>
+          Effect.sync(() => {
+            log.warn("cloud session workspace restore failed", {
+              sessionID: fetched.data.info.id,
+              error: err instanceof Error ? err.message : String(err),
+            })
+            return { directory, result: { status: "skipped" as const, reason: "no_checkpoint" as const } }
+          }),
+        ),
+      )
+      if (workspace.result.status === "failed") {
+        log.warn("cloud session workspace restore did not complete", {
+          sessionID: fetched.data.info.id,
+          reason: workspace.result.reason,
+          error: workspace.result.error,
+        })
+      }
+
       const bridge = yield* EffectBridge.make()
       return yield* Effect.tryPromise({
         try: () =>
@@ -447,7 +476,10 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
             Effect.sync(() =>
               importSessionToDb(fetched.data, {
                 Database,
-                Instance,
+                Instance: {
+                  directory: workspace.directory,
+                  project: Instance.project,
+                },
                 SessionTable,
                 MessageTable,
                 PartTable,

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -206,10 +206,10 @@ export async function restoreCloudSessionWorkspace(input: {
 }
 
 async function commit(dir: string, sha: string) {
-  const hit = await run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] })
+  const hit = await run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1, 128] })
   if (hit.code === 0) return true
   await run(dir, ["fetch", "--all", "--quiet"], { env: { GIT_TERMINAL_PROMPT: "0" }, ok: [0, 1], timeout: 5000 })
-  return run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] }).then((out) => out.code === 0)
+  return run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1, 128] }).then((out) => out.code === 0)
 }
 
 async function uniqueBranch(dir: string, base: string) {

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -196,10 +196,10 @@ async function commit(dir: string, sha: string) {
 
 async function uniqueBranch(dir: string, base: string) {
   const clean = base.replace(/[^A-Za-z0-9/_-]/g, "-")
-  const pick = async (name: string): Promise<string> => {
+  const pick = async (name: string, attempt = 0): Promise<string> => {
     const hit = await run(dir, ["rev-parse", "--verify", `refs/heads/${name}`], { ok: [0, 1, 128] })
     if (hit.code !== 0) return name
-    return pick(`${clean}-${Date.now().toString(36)}`)
+    return pick(`${clean}-${attempt + 1}`, attempt + 1)
   }
   return pick(clean)
 }

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -4,6 +4,7 @@ import os from "node:os"
 import path from "node:path"
 
 export const WORKSPACE_CHECKPOINT_KEY = "kilocodeWorkspaceCheckpoint"
+export const WORKSPACE_CHECKPOINT_PATCH_LIMIT = 5 * 1024 * 1024
 
 export type WorkspaceCheckpoint = {
   version: 1
@@ -123,17 +124,22 @@ async function patch(dir: string, base: string) {
 
 export async function captureWorkspaceCheckpoint(input: {
   directory: string
+  maxPatchBytes?: number
   now?: () => number
 }): Promise<WorkspaceCheckpoint | undefined> {
   const dir = await root(input.directory)
   if (!dir) return undefined
   const base = await head(dir)
+  const diff = await patch(dir, base)
+  if (new TextEncoder().encode(diff).byteLength > (input.maxPatchBytes ?? WORKSPACE_CHECKPOINT_PATCH_LIMIT)) {
+    return undefined
+  }
   return {
     version: 1,
     ...(await remote(dir).then((gitUrl) => (gitUrl ? { gitUrl } : {}))),
     ...(await branch(dir).then((name) => (name ? { branch: name } : {}))),
     head: base,
-    patch: await patch(dir, base),
+    patch: diff,
     createdAt: input.now?.() ?? Date.now(),
   }
 }

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -24,9 +24,11 @@ type RunOptions = {
   env?: Record<string, string>
   ok?: number[]
   trim?: boolean
+  timeout?: number
 }
 
 async function run(dir: string, args: string[], opts: RunOptions = {}) {
+  let expired = false
   const proc = Bun.spawn(["git", ...args], {
     cwd: dir,
     stdin: opts.input ? "pipe" : undefined,
@@ -34,6 +36,12 @@ async function run(dir: string, args: string[], opts: RunOptions = {}) {
     stderr: "pipe",
     env: opts.env ? { ...process.env, ...opts.env } : undefined,
   })
+  const timeout = opts.timeout
+    ? setTimeout(() => {
+        expired = true
+        proc.kill()
+      }, opts.timeout)
+    : undefined
   if (opts.input && proc.stdin) {
     proc.stdin.write(opts.input)
     proc.stdin.end()
@@ -42,8 +50,11 @@ async function run(dir: string, args: string[], opts: RunOptions = {}) {
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
-  ])
+  ]).finally(() => {
+    if (timeout) clearTimeout(timeout)
+  })
   if (!(opts.ok ?? [0]).includes(code)) {
+    if (expired) throw new Error(`git ${args.join(" ")} timed out after ${opts.timeout}ms`)
     throw new Error(stderr.trim() || `git ${args.join(" ")} failed with ${code}`)
   }
   return { code, stdout: opts.trim === false ? stdout : stdout.trim(), stderr: stderr.trim() }
@@ -191,7 +202,7 @@ export async function restoreCloudSessionWorkspace(input: {
 async function commit(dir: string, sha: string) {
   const hit = await run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] })
   if (hit.code === 0) return true
-  await run(dir, ["fetch", "--all", "--quiet"], { ok: [0, 1] })
+  await run(dir, ["fetch", "--all", "--quiet"], { env: { GIT_TERMINAL_PROMPT: "0" }, ok: [0, 1], timeout: 5000 })
   return run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] }).then((out) => out.code === 0)
 }
 

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -1,0 +1,244 @@
+// kilocode_change - new file
+import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+export const WORKSPACE_CHECKPOINT_KEY = "kilocodeWorkspaceCheckpoint"
+
+export type WorkspaceCheckpoint = {
+  version: 1
+  gitUrl?: string
+  branch?: string
+  head: string
+  patch: string
+  createdAt: number
+}
+
+export type RestoreResult =
+  | { status: "restored"; directory: string }
+  | { status: "skipped"; reason: "not_git_repo" | "different_repo" | "missing_commit" | "no_checkpoint" }
+  | { status: "failed"; reason: "worktree_failed" | "patch_failed"; directory?: string; error: string }
+
+type RunOptions = {
+  input?: string
+  env?: Record<string, string>
+  ok?: number[]
+  trim?: boolean
+}
+
+async function run(dir: string, args: string[], opts: RunOptions = {}) {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: dir,
+    stdin: opts.input ? "pipe" : undefined,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: opts.env ? { ...process.env, ...opts.env } : undefined,
+  })
+  if (opts.input && proc.stdin) {
+    proc.stdin.write(opts.input)
+    proc.stdin.end()
+  }
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (!(opts.ok ?? [0]).includes(code)) {
+    throw new Error(stderr.trim() || `git ${args.join(" ")} failed with ${code}`)
+  }
+  return { code, stdout: opts.trim === false ? stdout : stdout.trim(), stderr: stderr.trim() }
+}
+
+export function normalizeGitUrl(raw: string | undefined) {
+  if (!raw) return undefined
+  const ssh = raw.match(/^git@([^:]+):(.+)$/)
+  if (ssh) {
+    const repo = ssh[2].split("?")[0].replace(/\.git$/, "").replace(/\/$/, "")
+    return `${ssh[1].toLowerCase()}/${repo}`
+  }
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "ssh:") return undefined
+    url.username = ""
+    url.password = ""
+    url.search = ""
+    url.hash = ""
+    const repo = url.pathname.replace(/^\//, "").replace(/\.git$/, "").replace(/\/$/, "")
+    if (!repo) return undefined
+    return `${url.hostname.toLowerCase()}/${repo}`
+  } catch {
+    return undefined
+  }
+}
+
+async function root(dir: string) {
+  return run(dir, ["rev-parse", "--show-toplevel"])
+    .then((out) => out.stdout)
+    .catch(() => undefined)
+}
+
+async function head(dir: string) {
+  return run(dir, ["rev-parse", "HEAD"]).then((out) => out.stdout)
+}
+
+async function branch(dir: string) {
+  return run(dir, ["branch", "--show-current"]).then((out) => out.stdout || undefined)
+}
+
+async function remote(dir: string) {
+  const origin = await run(dir, ["config", "--get", "remote.origin.url"], { ok: [0, 1] })
+  if (origin.stdout) return normalizeGitUrl(origin.stdout)
+  const names = await run(dir, ["remote"], { ok: [0, 1] })
+  const name = names.stdout.split(/\s+/).find(Boolean)
+  if (!name) return undefined
+  return run(dir, ["config", "--get", `remote.${name}.url`], { ok: [0, 1] }).then((out) => normalizeGitUrl(out.stdout))
+}
+
+async function patch(dir: string, base: string) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-index-"))
+  const idx = path.join(tmp, "index")
+  const env = { GIT_INDEX_FILE: idx }
+  try {
+    await run(dir, ["read-tree", base], { env })
+    await run(dir, ["add", "--all", "--", "."], { env })
+    return await run(dir, ["diff", "--cached", "--binary", "--full-index", base, "--"], { env, trim: false }).then(
+      (out) => out.stdout,
+    )
+  } finally {
+    await rm(tmp, { recursive: true, force: true })
+  }
+}
+
+export async function captureWorkspaceCheckpoint(input: {
+  directory: string
+  now?: () => number
+}): Promise<WorkspaceCheckpoint | undefined> {
+  const dir = await root(input.directory)
+  if (!dir) return undefined
+  const base = await head(dir)
+  return {
+    version: 1,
+    ...(await remote(dir).then((gitUrl) => (gitUrl ? { gitUrl } : {}))),
+    ...(await branch(dir).then((name) => (name ? { branch: name } : {}))),
+    head: base,
+    patch: await patch(dir, base),
+    createdAt: input.now?.() ?? Date.now(),
+  }
+}
+
+export async function attachWorkspaceCheckpoint<T extends { directory?: string }>(
+  input: T,
+  opts?: { now?: () => number },
+): Promise<T & { [WORKSPACE_CHECKPOINT_KEY]?: WorkspaceCheckpoint }> {
+  if (!input.directory) return { ...input }
+  const checkpoint = await captureWorkspaceCheckpoint({ directory: input.directory, now: opts?.now }).catch(
+    () => undefined,
+  )
+  if (!checkpoint) return { ...input }
+  return { ...input, [WORKSPACE_CHECKPOINT_KEY]: checkpoint }
+}
+
+function record(input: unknown): input is Record<string, unknown> {
+  return !!input && typeof input === "object" && !Array.isArray(input)
+}
+
+export function readWorkspaceCheckpoint(input: unknown): WorkspaceCheckpoint | undefined {
+  const item = record(input) ? input[WORKSPACE_CHECKPOINT_KEY] : undefined
+  if (!record(item)) return undefined
+  if (item.version !== 1) return undefined
+  if (typeof item.head !== "string") return undefined
+  if (typeof item.patch !== "string") return undefined
+  if (typeof item.createdAt !== "number") return undefined
+  return {
+    version: 1,
+    ...(typeof item.gitUrl === "string" ? { gitUrl: item.gitUrl } : {}),
+    ...(typeof item.branch === "string" ? { branch: item.branch } : {}),
+    head: item.head,
+    patch: item.patch,
+    createdAt: item.createdAt,
+  }
+}
+
+function clean(input: string) {
+  return input.replace(/[^A-Za-z0-9_-]/g, "-")
+}
+
+async function target(dir: string, sessionID: string) {
+  const base = (await root(dir)) ?? dir
+  return path.join(path.dirname(base), ".kilo-session-worktrees", `${clean(sessionID)}-${Date.now().toString(36)}`)
+}
+
+export async function restoreCloudSessionWorkspace(input: {
+  info: unknown
+  directory: string
+  sessionID: string
+  targetDirectory?: string
+}): Promise<{ directory: string; result: RestoreResult }> {
+  const checkpoint = readWorkspaceCheckpoint(input.info)
+  const result = await restoreWorkspaceCheckpoint({
+    directory: input.directory,
+    checkpoint,
+    targetDirectory: input.targetDirectory ?? (await target(input.directory, input.sessionID)),
+    branch: `kilo/session/${input.sessionID}`,
+  })
+  return {
+    directory: result.status === "restored" ? result.directory : input.directory,
+    result,
+  }
+}
+
+async function commit(dir: string, sha: string) {
+  const hit = await run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] })
+  if (hit.code === 0) return true
+  await run(dir, ["fetch", "--all", "--quiet"], { ok: [0, 1] })
+  return run(dir, ["cat-file", "-e", `${sha}^{commit}`], { ok: [0, 1] }).then((out) => out.code === 0)
+}
+
+async function uniqueBranch(dir: string, base: string) {
+  const clean = base.replace(/[^A-Za-z0-9/_-]/g, "-")
+  const pick = async (name: string): Promise<string> => {
+    const hit = await run(dir, ["rev-parse", "--verify", `refs/heads/${name}`], { ok: [0, 1, 128] })
+    if (hit.code !== 0) return name
+    return pick(`${clean}-${Date.now().toString(36)}`)
+  }
+  return pick(clean)
+}
+
+export async function restoreWorkspaceCheckpoint(input: {
+  directory: string
+  checkpoint: WorkspaceCheckpoint | undefined
+  targetDirectory: string
+  branch: string
+}): Promise<RestoreResult> {
+  if (!input.checkpoint) return { status: "skipped", reason: "no_checkpoint" }
+  const dir = await root(input.directory)
+  if (!dir) return { status: "skipped", reason: "not_git_repo" }
+
+  const url = await remote(dir)
+  if (input.checkpoint.gitUrl && url !== input.checkpoint.gitUrl) {
+    return { status: "skipped", reason: "different_repo" }
+  }
+
+  if (!(await commit(dir, input.checkpoint.head))) return { status: "skipped", reason: "missing_commit" }
+
+  const name = await uniqueBranch(dir, input.branch)
+  await mkdir(path.dirname(input.targetDirectory), { recursive: true })
+  const added = await run(dir, ["worktree", "add", "-b", name, input.targetDirectory, input.checkpoint.head], {
+    ok: [0, 1],
+  }).catch((err) => ({ code: 1, stderr: err instanceof Error ? err.message : String(err) }))
+  if (added.code !== 0) {
+    return { status: "failed", reason: "worktree_failed", error: added.stderr || "unable to create worktree" }
+  }
+
+  if (input.checkpoint.patch.trim()) {
+    const applied = await run(input.targetDirectory, ["apply", "--3way", "--whitespace=nowarn"], {
+      input: input.checkpoint.patch,
+      ok: [0, 1],
+    }).catch((err) => ({ code: 1, stderr: err instanceof Error ? err.message : String(err) }))
+    if (applied.code !== 0) {
+      return { status: "failed", reason: "patch_failed", directory: input.targetDirectory, error: applied.stderr }
+    }
+  }
+
+  return { status: "restored", directory: input.targetDirectory }
+}

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -204,6 +204,10 @@ async function uniqueBranch(dir: string, base: string) {
   return pick(clean)
 }
 
+async function removeWorktree(dir: string, target: string) {
+  await run(dir, ["worktree", "remove", "--force", target], { ok: [0, 1, 128] }).catch(() => undefined)
+}
+
 export async function restoreWorkspaceCheckpoint(input: {
   directory: string
   checkpoint: WorkspaceCheckpoint | undefined
@@ -236,6 +240,7 @@ export async function restoreWorkspaceCheckpoint(input: {
       ok: [0, 1],
     }).catch((err) => ({ code: 1, stderr: err instanceof Error ? err.message : String(err) }))
     if (applied.code !== 0) {
+      await removeWorktree(dir, input.targetDirectory)
       return { status: "failed", reason: "patch_failed", directory: input.targetDirectory, error: applied.stderr }
     }
   }

--- a/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
+++ b/packages/opencode/src/kilocode/session-portability/git-checkpoint.ts
@@ -100,6 +100,7 @@ async function patch(dir: string, base: string) {
   const env = { GIT_INDEX_FILE: idx }
   try {
     await run(dir, ["read-tree", base], { env })
+    // Respect normal gitignore rules so checkpoints do not carry ignored build outputs or secrets.
     await run(dir, ["add", "--all", "--", "."], { env })
     return await run(dir, ["diff", "--cached", "--binary", "--full-index", base, "--"], { env, trim: false }).then(
       (out) => out.stdout,

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -121,7 +121,7 @@ describe("workspace git checkpoints", () => {
       branch: "kilo-restore-patch-fail",
     })
 
-    expect(restored.status).toBe("failed")
+    if (restored.status !== "failed") throw new Error("expected restore to fail")
     expect(restored.reason).toBe("patch_failed")
     expect(await Bun.file(target).exists()).toBe(false)
     expect(await git(dir, ["worktree", "list", "--porcelain"])).not.toContain(target)

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -106,6 +106,27 @@ describe("workspace git checkpoints", () => {
     expect(restored).toEqual({ status: "skipped", reason: "different_repo" })
   })
 
+  test("removes the created worktree when patch apply fails", async () => {
+    const dir = await repo()
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })
+    const target = path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-patch-fail-")), "session")
+
+    const restored = await restoreWorkspaceCheckpoint({
+      directory: dir,
+      checkpoint: {
+        ...checkpoint!,
+        patch: "diff --git a/missing.txt b/missing.txt\n--- a/missing.txt\n+++ b/missing.txt\n@@ -1 +1 @@\n-old\n+new\n",
+      },
+      targetDirectory: target,
+      branch: "kilo-restore-patch-fail",
+    })
+
+    expect(restored.status).toBe("failed")
+    expect(restored.reason).toBe("patch_failed")
+    expect(await Bun.file(target).exists()).toBe(false)
+    expect(await git(dir, ["worktree", "list", "--porcelain"])).not.toContain(target)
+  })
+
   test("embeds a checkpoint in a session-shaped object without mutating the original", async () => {
     const dir = await repo()
     await writeFile(path.join(dir, "untracked.txt"), "new\n")

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -106,6 +106,24 @@ describe("workspace git checkpoints", () => {
     expect(restored).toEqual({ status: "skipped", reason: "different_repo" })
   })
 
+  test("skips restore when the checkpoint commit does not exist locally", async () => {
+    const dir = await repo()
+    await git(dir, ["remote", "remove", "origin"])
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })
+
+    const restored = await restoreWorkspaceCheckpoint({
+      directory: dir,
+      checkpoint: {
+        ...checkpoint!,
+        head: "0123456789012345678901234567890123456789",
+      },
+      targetDirectory: path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-missing-")), "session"),
+      branch: "kilo-restore-missing",
+    })
+
+    expect(restored).toEqual({ status: "skipped", reason: "missing_commit" })
+  })
+
   test("removes the created worktree when patch apply fails", async () => {
     const dir = await repo()
     const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -127,6 +127,25 @@ describe("workspace git checkpoints", () => {
     expect(await git(dir, ["worktree", "list", "--porcelain"])).not.toContain(target)
   })
 
+  test("uses a numbered branch suffix when the requested restore branch exists", async () => {
+    const dir = await repo()
+    await writeFile(path.join(dir, "untracked.txt"), "new\n")
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })
+    await git(dir, ["branch", "kilo-restore-collision"])
+    const target = path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-branch-collision-")), "session")
+
+    const restored = await restoreWorkspaceCheckpoint({
+      directory: dir,
+      checkpoint: checkpoint!,
+      targetDirectory: target,
+      branch: "kilo-restore-collision",
+    })
+
+    expect(restored).toEqual({ status: "restored", directory: target })
+    expect(await git(target, ["branch", "--show-current"])).toBe("kilo-restore-collision-1")
+    expect(await readFile(path.join(target, "untracked.txt"), "utf8")).toBe("new\n")
+  })
+
   test("embeds a checkpoint in a session-shaped object without mutating the original", async () => {
     const dir = await repo()
     await writeFile(path.join(dir, "untracked.txt"), "new\n")

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -1,0 +1,143 @@
+// kilocode_change - new file
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import {
+  attachWorkspaceCheckpoint,
+  captureWorkspaceCheckpoint,
+  normalizeGitUrl,
+  restoreCloudSessionWorkspace,
+  restoreWorkspaceCheckpoint,
+  WORKSPACE_CHECKPOINT_KEY,
+} from "../../../src/kilocode/session-portability/git-checkpoint"
+
+async function git(dir: string, args: string[], input?: string) {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: dir,
+    stdin: input ? "pipe" : undefined,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (input && proc.stdin) {
+    proc.stdin.write(input)
+    proc.stdin.end()
+  }
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
+  return stdout.trim()
+}
+
+async function repo() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-"))
+  await git(dir, ["init", "-b", "main"])
+  await git(dir, ["config", "user.email", "test@example.com"])
+  await git(dir, ["config", "user.name", "Test User"])
+  await git(dir, ["remote", "add", "origin", "git@github.com:Kilo-Org/kilocode.git"])
+  await writeFile(path.join(dir, "tracked.txt"), "base\n")
+  await mkdir(path.join(dir, "nested"))
+  await writeFile(path.join(dir, "nested", "keep.txt"), "keep\n")
+  await git(dir, ["add", "."])
+  await git(dir, ["commit", "-m", "initial"])
+  return dir
+}
+
+describe("workspace git checkpoints", () => {
+  test("normalizes common remote URL forms to the same repo key", () => {
+    expect(normalizeGitUrl("git@github.com:Kilo-Org/kilocode.git")).toBe("github.com/Kilo-Org/kilocode")
+    expect(normalizeGitUrl("https://token@github.com/Kilo-Org/kilocode.git?x=1")).toBe(
+      "github.com/Kilo-Org/kilocode",
+    )
+    expect(normalizeGitUrl("ssh://git@github.com/Kilo-Org/kilocode.git")).toBe("github.com/Kilo-Org/kilocode")
+  })
+
+  test("captures tracked and untracked dirty state and restores it into a separate worktree", async () => {
+    const dir = await repo()
+    const head = await git(dir, ["rev-parse", "HEAD"])
+    await writeFile(path.join(dir, "tracked.txt"), "base\nchanged\n")
+    await writeFile(path.join(dir, "untracked.txt"), "new\n")
+    await writeFile(path.join(dir, "nested", "new.txt"), "nested new\n")
+    await git(dir, ["rm", "nested/keep.txt"])
+
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })
+
+    expect(checkpoint?.head).toBe(head)
+    expect(checkpoint?.gitUrl).toBe("github.com/Kilo-Org/kilocode")
+    expect(checkpoint?.patch).toContain("tracked.txt")
+    expect(checkpoint?.patch).toContain("untracked.txt")
+    expect(checkpoint?.patch).toContain("nested/new.txt")
+    expect(checkpoint?.patch).toContain("nested/keep.txt")
+
+    const target = path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-restore-")), "session")
+    const restored = await restoreWorkspaceCheckpoint({
+      directory: dir,
+      checkpoint: checkpoint!,
+      targetDirectory: target,
+      branch: "kilo-restore-test",
+    })
+
+    expect(restored).toEqual({ status: "restored", directory: target })
+    if (restored.status !== "restored") throw new Error("expected restore to succeed")
+    expect(restored.directory).toBe(target)
+    expect(await readFile(path.join(target, "tracked.txt"), "utf8")).toBe("base\nchanged\n")
+    expect(await readFile(path.join(target, "untracked.txt"), "utf8")).toBe("new\n")
+    expect(await readFile(path.join(target, "nested", "new.txt"), "utf8")).toBe("nested new\n")
+    expect(await Bun.file(path.join(target, "nested", "keep.txt")).exists()).toBe(false)
+    expect(await readFile(path.join(dir, "tracked.txt"), "utf8")).toBe("base\nchanged\n")
+  })
+
+  test("skips restore when the current repo does not match the checkpoint remote", async () => {
+    const dir = await repo()
+    const other = await repo()
+    await git(other, ["remote", "set-url", "origin", "git@github.com:Kilo-Org/other.git"])
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir })
+
+    const restored = await restoreWorkspaceCheckpoint({
+      directory: other,
+      checkpoint: checkpoint!,
+      targetDirectory: path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-other-")), "session"),
+      branch: "kilo-restore-other",
+    })
+
+    expect(restored).toEqual({ status: "skipped", reason: "different_repo" })
+  })
+
+  test("embeds a checkpoint in a session-shaped object without mutating the original", async () => {
+    const dir = await repo()
+    await writeFile(path.join(dir, "untracked.txt"), "new\n")
+    const session = { id: "ses_123", directory: dir, title: "session" }
+
+    const next = await attachWorkspaceCheckpoint(session, { now: () => 123 })
+
+    expect(session).not.toHaveProperty(WORKSPACE_CHECKPOINT_KEY)
+    expect(next).toHaveProperty(WORKSPACE_CHECKPOINT_KEY)
+    expect(next[WORKSPACE_CHECKPOINT_KEY]?.createdAt).toBe(123)
+    expect(next[WORKSPACE_CHECKPOINT_KEY]?.patch).toContain("untracked.txt")
+  })
+
+  test("restores a cloud session workspace from the checkpoint embedded in session info", async () => {
+    const dir = await repo()
+    await writeFile(path.join(dir, "tracked.txt"), "base\nchanged\n")
+    await writeFile(path.join(dir, "untracked.txt"), "new\n")
+    const info = await attachWorkspaceCheckpoint({ id: "ses_source", directory: dir, title: "session" })
+    const peer = path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-peer-")), "peer")
+    await git(dir, ["worktree", "add", peer, "HEAD"])
+    const target = path.join(await mkdtemp(path.join(os.tmpdir(), "kilo-checkpoint-cloud-")), "session")
+
+    const restored = await restoreCloudSessionWorkspace({
+      info,
+      directory: peer,
+      targetDirectory: target,
+      sessionID: "ses_imported",
+    })
+
+    expect(restored.result).toEqual({ status: "restored", directory: target })
+    expect(restored.directory).toBe(target)
+    expect(await readFile(path.join(target, "tracked.txt"), "utf8")).toBe("base\nchanged\n")
+    expect(await readFile(path.join(target, "untracked.txt"), "utf8")).toBe("new\n")
+  })
+})

--- a/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
+++ b/packages/opencode/test/kilocode/session-portability/git-checkpoint.test.ts
@@ -159,6 +159,15 @@ describe("workspace git checkpoints", () => {
     expect(next[WORKSPACE_CHECKPOINT_KEY]?.patch).toContain("untracked.txt")
   })
 
+  test("skips checkpoints when the patch is over the size limit", async () => {
+    const dir = await repo()
+    await writeFile(path.join(dir, "large.txt"), "large patch\n")
+
+    const checkpoint = await captureWorkspaceCheckpoint({ directory: dir, maxPatchBytes: 8 })
+
+    expect(checkpoint).toBeUndefined()
+  })
+
   test("restores a cloud session workspace from the checkpoint embedded in session info", async () => {
     const dir = await repo()
     await writeFile(path.join(dir, "tracked.txt"), "base\nchanged\n")

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -6290,9 +6290,10 @@ export class Session4 extends HeyApiClient {
    */
   public import<ThrowOnError extends boolean = false>(
     parameters?: {
-      directory?: string
+      query_directory?: string
       workspace?: string
       sessionId?: string
+      body_directory?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6301,9 +6302,18 @@ export class Session4 extends HeyApiClient {
       [
         {
           args: [
-            { in: "query", key: "directory" },
+            {
+              in: "query",
+              key: "query_directory",
+              map: "directory",
+            },
             { in: "query", key: "workspace" },
             { in: "body", key: "sessionId" },
+            {
+              in: "body",
+              key: "body_directory",
+              map: "directory",
+            },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -8715,6 +8715,7 @@ export type KiloCloudSessionGetResponse = KiloCloudSessionGetResponses[keyof Kil
 export type KiloCloudSessionImportData = {
   body?: {
     sessionId: string
+    directory?: string
   }
   path?: never
   query?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -12364,6 +12364,9 @@
                 "properties": {
                   "sessionId": {
                     "type": "string"
+                  },
+                  "directory": {
+                    "type": "string"
                   }
                 },
                 "required": ["sessionId"],


### PR DESCRIPTION
## What changed

This adds same-repo workspace portability for cloud sessions. When a session syncs to the session ingest service, the CLI now attaches a lightweight git checkpoint to the session payload at full sync and turn close. The checkpoint records the repo identity, current HEAD, branch, timestamp, and a binary git patch of dirty workspace state, including tracked edits, deletions, and untracked files, without touching the user's real index.

When a cloud session is imported or forked locally, the import endpoint now accepts the caller's directory, checks whether it is the same git repo as the checkpoint, creates a new session worktree from the recorded commit, applies the dirty-state patch there, and imports the transcript against that restored directory. If the checkpoint is missing, the current directory is not a git repo, the repo does not match, or restore fails, the session import falls back to the existing behavior instead of blocking transcript import.

The directory context is wired through CLI cloud-fork entry points, the VS Code cloud-session handler, the import HTTP contract, and the generated SDK so extension-to-CLI and CLI-to-extension continuation have the same restore path.

## Why

Cloud sessions currently preserve the transcript but not the filesystem state that made the transcript meaningful. Continuing a session from another client in the same repo can land in the right conversation with the wrong files. This PR uses git as the portability boundary: fork the session into a separate worktree at the original commit, then replay the source workspace's dirty state into that worktree. That keeps the original workspace untouched and avoids cross-client concurrency control while making fork-and-continue practical.

## Verification

- `bun test ./test/kilocode/session-portability/git-checkpoint.test.ts` from `packages/opencode/`
- `bun test ./test/kilocode/kilo-sessions.test.ts` from `packages/opencode/`
- `bun test ./test/cloud-sessions.test.ts` from `packages/kilo-gateway/`
- `bun run typecheck` from `packages/opencode/`
- `bun run typecheck` from `packages/kilo-vscode/`
- `bun run typecheck` from `packages/sdk/js/`
- `bun run script/check-opencode-annotations.ts` from repo root
- `bun run check-kilocode-change` from `packages/kilo-vscode/`
