### PR TITLE
Fix/websearch default exa

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@kilocode/kilo",
@@ -4472,7 +4471,7 @@
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
-    "xlsx": ["xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz", { "bin": { "xlsx": "./bin/xlsx.njs" } }, "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA=="],
+    "xlsx": ["xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz", { "bin": { "xlsx": "./bin/xlsx.njs" } }],
 
     "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 

--- a/packages/opencode/src/kilocode/tool/websearch.ts
+++ b/packages/opencode/src/kilocode/tool/websearch.ts
@@ -1,0 +1,15 @@
+// kilocode_change - new file
+import type { WebSearchProvider } from "../../tool/websearch"
+
+export namespace KiloWebSearch {
+  /**
+   * Default web search provider for built-in Kilo gateway sessions that do not
+   * pin a provider via the `KILO_WEBSEARCH_PROVIDER` override or the
+   * `KILO_ENABLE_EXA` / `KILO_ENABLE_PARALLEL` flags.
+   *
+   * Upstream opencode runs an even Exa/Parallel A/B split here; Kilo pins Exa.
+   */
+  export function defaultProvider(): WebSearchProvider {
+    return "exa"
+  }
+}

--- a/packages/opencode/src/tool/mcp-websearch.ts
+++ b/packages/opencode/src/tool/mcp-websearch.ts
@@ -1,5 +1,6 @@
 import { Duration, Effect, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { DEFAULT_HEADERS } from "../kilocode/const"
 
 export const EXA_URL = process.env.EXA_API_KEY
   ? `https://mcp.exa.ai/mcp?exaApiKey=${encodeURIComponent(process.env.EXA_API_KEY)}`
@@ -83,7 +84,7 @@ export const call = <F extends Schema.Struct.Fields>(
   Effect.gen(function* () {
     const request = yield* HttpClientRequest.post(url).pipe(
       HttpClientRequest.accept("application/json, text/event-stream"),
-      HttpClientRequest.setHeaders(headers ?? {}),
+      HttpClientRequest.setHeaders({ ...DEFAULT_HEADERS, ...headers }),
       HttpClientRequest.schemaBodyJson(McpRequest(args))({
         jsonrpc: "2.0" as const,
         id: 1 as const,

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -4,8 +4,8 @@ import * as Tool from "./tool"
 import * as McpWebSearch from "./mcp-websearch"
 import DESCRIPTION from "./websearch.txt"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import { KiloWebSearch } from "../kilocode/tool/websearch" // kilocode_change
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({ description: "Websearch query" }),
@@ -36,7 +36,7 @@ export function selectWebSearchProvider(
   if (flags.parallel) return "parallel"
   if (flags.exa) return "exa"
 
-  return Number.parseInt(checksum(sessionID) ?? "0", 36) % 2 === 0 ? "exa" : "parallel"
+  return KiloWebSearch.defaultProvider() // kilocode_change: pin Exa as the default instead of an even Exa/Parallel split
 }
 
 export function webSearchProviderLabel(provider: unknown) {

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
-import { parseResponse } from "../../src/tool/mcp-websearch"
+import { Effect, Layer, Schema } from "effect"
+import { FetchHttpClient, HttpClient } from "effect/unstable/http"
+import { call, parseResponse } from "../../src/tool/mcp-websearch"
+import { DEFAULT_HEADERS } from "../../src/kilocode/const"
 import { selectWebSearchProvider, webSearchModelName, webSearchProviderLabel } from "../../src/tool/websearch"
 import { ProviderID } from "../../src/provider/schema"
 import { webSearchEnabled } from "../../src/tool/registry"
@@ -71,6 +73,83 @@ describe("websearch provider", () => {
         },
       }),
     ).toBe("claude-opus-4.7")
+  })
+})
+
+describe("mcp-websearch headers", () => {
+  const Args = Schema.Struct({ query: Schema.String })
+
+  const okBody = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: { content: [{ type: "text", text: "ok" }] },
+  })
+
+  async function withServer(
+    handler: (req: Request) => Response | Promise<Response>,
+    fn: (url: string) => Promise<void>,
+  ) {
+    const server = Bun.serve({ port: 0, fetch: handler })
+    try {
+      await fn(server.url.toString())
+    } finally {
+      server.stop()
+    }
+  }
+
+  function runCall(url: string, extraHeaders?: Record<string, string>) {
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient
+        return yield* call(http, url, "web_search_exa", Args, { query: "test" }, "5 seconds", extraHeaders)
+      }).pipe(Effect.provide(FetchHttpClient.layer)),
+    )
+  }
+
+  test("Exa call includes Kilo-Code User-Agent", async () => {
+    let captured: Headers | undefined
+    await withServer(
+      (req) => {
+        captured = req.headers
+        return new Response(okBody, { status: 200 })
+      },
+      async (url) => {
+        await runCall(url)
+        expect(captured?.get("user-agent")).toBe(DEFAULT_HEADERS["User-Agent"])
+      },
+    )
+  })
+
+  test("Exa call includes HTTP-Referer and X-Title", async () => {
+    let captured: Headers | undefined
+    await withServer(
+      (req) => {
+        captured = req.headers
+        return new Response(okBody, { status: 200 })
+      },
+      async (url) => {
+        await runCall(url)
+        expect(captured?.get("http-referer")).toBe(DEFAULT_HEADERS["HTTP-Referer"])
+        expect(captured?.get("x-title")).toBe(DEFAULT_HEADERS["X-Title"])
+      },
+    )
+  })
+
+  test("caller-supplied headers override DEFAULT_HEADERS", async () => {
+    let captured: Headers | undefined
+    await withServer(
+      (req) => {
+        captured = req.headers
+        return new Response(okBody, { status: 200 })
+      },
+      async (url) => {
+        await runCall(url, { "User-Agent": "opencode/0.0.0", Authorization: "Bearer tok" })
+        expect(captured?.get("user-agent")).toBe("opencode/0.0.0")
+        expect(captured?.get("authorization")).toBe("Bearer tok")
+        // Base headers still present
+        expect(captured?.get("http-referer")).toBe(DEFAULT_HEADERS["HTTP-Referer"])
+      },
+    )
   })
 })
 

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -35,6 +35,18 @@ describe("websearch provider", () => {
     expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: true })).toBe("parallel")
   })
 
+  test("defaults to Exa when no provider is pinned", () => {
+    const original = process.env.KILO_WEBSEARCH_PROVIDER
+
+    try {
+      delete process.env.KILO_WEBSEARCH_PROVIDER
+      expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: false })).toBe("exa")
+    } finally {
+      if (original === undefined) delete process.env.KILO_WEBSEARCH_PROVIDER
+      else process.env.KILO_WEBSEARCH_PROVIDER = original
+    }
+  })
+
   test("is only enabled for kilo or explicit websearch provider flags", () => {
     // kilocode_change
     expect(webSearchEnabled(ProviderID.kilo, { exa: false, parallel: false })).toBe(true) // kilocode_change


### PR DESCRIPTION
## Issue

Fixes #

<!-- No upstream issue — internal Kilo change -->

## Context

Two related changes to the web search integration:

1. **Pin Exa as the default web search provider.** Upstream opencode runs a 50/50 Exa/Parallel A/B split based on a session ID checksum. Kilo pins Exa unconditionally so users get consistent behaviour regardless of session.

2. **Inject `DEFAULT_HEADERS` into MCP web search HTTP calls.** `User-Agent`, `HTTP-Referer`, and `X-Title` were not being sent on requests routed through the MCP websearch path. This ensures Kilo identifies itself correctly to downstream services (e.g. Exa) and is consistent with how other HTTP calls in the codebase behave.

## Implementation

For (1): replaced the `checksum(sessionID) % 2` branch in `selectWebSearchProvider` with a call to `KiloWebSearch.defaultProvider()` in `src/kilocode/tool/websearch.ts`, keeping the override flags (`KILO_ENABLE_EXA`, `KILO_ENABLE_PARALLEL`) intact.

For (2): changed `HttpClientRequest.setHeaders(headers ?? {})` to `HttpClientRequest.setHeaders({ ...DEFAULT_HEADERS, ...headers })` in `mcp-websearch.ts` so caller-supplied headers still take precedence over the defaults.

## Screenshots / Video

N/A — no visual changes.

| before | after |
|---|---|
| N/A | N/A |

## How to Test

### Manual/local verification

- Enabled web search and ran a query; confirmed Exa was used regardless of session ID.
- Confirmed `User-Agent`, `HTTP-Referer`, and `X-Title` headers appear in outgoing MCP websearch requests.

### Reviewer test steps

1. Run `bun test packages/opencode/test/tool/websearch.test.ts` — all tests including the new `mcp-websearch headers` suite should pass.
2. Enable web search in the extension and run a query; confirm the provider shown is Exa.

### Blocked checks and substitute verification

-

## Checklist

- [ ] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
