### PR TITLE
fix(cli): avoid repeat compaction from stale totals

### DIFF
--- a/.changeset/avoid-repeat-compactions.md
+++ b/.changeset/avoid-repeat-compactions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent unnecessary repeat auto-compactions when providers report inconsistent token totals.

--- a/packages/opencode/src/kilocode/session/overflow.ts
+++ b/packages/opencode/src/kilocode/session/overflow.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@/config/config"
 import type { Provider } from "@/provider/provider"
+import type { MessageV2 } from "@/session/message-v2"
 import { Token } from "@/util/token"
 import type { ModelMessage } from "ai"
 
@@ -24,6 +25,11 @@ export namespace KiloSessionOverflow {
       super("Outgoing context reached the automatic compaction threshold")
       this.name = "PreflightCompactionError"
     }
+  }
+
+  export function count(tokens: MessageV2.Assistant["tokens"]) {
+    const total = tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+    return total || tokens.total || 0
   }
 
   export function limit(input: { cfg: Config.Info; model: Provider.Model; usable: number }) {

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -21,8 +21,7 @@ export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistan
   if (input.cfg.compaction?.auto === false) return false
   if (input.model.limit.context === 0) return false
 
-  const count =
-    input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
+  const count = KiloSessionOverflow.count(input.tokens) // kilocode_change
   // kilocode_change start
   const cap = KiloSessionOverflow.limit({ cfg: input.cfg, model: input.model, usable: usable(input) })
   return count >= cap

--- a/packages/opencode/test/kilocode/session-overflow.test.ts
+++ b/packages/opencode/test/kilocode/session-overflow.test.ts
@@ -86,6 +86,27 @@ describe("Kilo auto-compaction threshold", () => {
 
     expect(isOverflow({ cfg: conf, model: mdl, tokens: tokens(150_000) })).toBe(false)
   })
+
+  test("uses normalized fields when the provider total disagrees", () => {
+    const conf = cfg({ threshold_percent: 75 })
+    const mdl = model({ context: 200_000, output: 32_000 })
+
+    expect(isOverflow({ cfg: conf, model: mdl, tokens: { ...tokens(80_000), total: 250_000 } })).toBe(false)
+  })
+
+  test("counts reasoning tokens", () => {
+    const conf = cfg({ threshold_percent: 75 })
+    const mdl = model({ context: 200_000, output: 32_000 })
+
+    expect(isOverflow({ cfg: conf, model: mdl, tokens: { ...tokens(149_999), reasoning: 1 } })).toBe(true)
+  })
+
+  test("falls back to provider total when normalized usage is unavailable", () => {
+    const conf = cfg({ threshold_percent: 75 })
+    const mdl = model({ context: 200_000, output: 32_000 })
+
+    expect(isOverflow({ cfg: conf, model: mdl, tokens: { ...tokens(0), total: 150_000 } })).toBe(true)
+  })
 })
 
 describe("Kilo request estimation", () => {


### PR DESCRIPTION
## Summary
- Use normalized token buckets, including reasoning tokens, for local auto-compaction threshold decisions.
- Fall back to provider-reported totals only when granular usage is unavailable, preserving recovery for providers that expose totals alone.
- Prevent an inconsistent provider total from causing an unnecessary immediate second compaction after context has already been reduced.

Closes #10888