### PR TITLE
fix(cli): temporarily disable session export

### DIFF
--- a/.changeset/quiet-session-export.md
+++ b/.changeset/quiet-session-export.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Temporarily disable free-model session and Git workspace data export.

--- a/packages/opencode/src/kilocode/bootstrap.ts
+++ b/packages/opencode/src/kilocode/bootstrap.ts
@@ -29,6 +29,7 @@ export namespace KilocodeBootstrap {
         yield* sessions.init()
         // kilocode_change start - session export bootstrap
         yield* Effect.gen(function* () {
+          if (!SessionExport.enabled) return
           const anon = yield* EffectBridge.fromPromise(() =>
             Identity.getMachineId().catch((err) => {
               log.warn("session export identity failed", { err })

--- a/packages/opencode/src/kilocode/session-export/session-export.ts
+++ b/packages/opencode/src/kilocode/session-export/session-export.ts
@@ -32,6 +32,8 @@ const instances = new Map<string, Instance>()
 
 const maxRespawns = 3
 
+export const enabled = false
+
 export const init = (opts: {
   agentVersion: string
   dbPath: string

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -392,7 +392,8 @@ const live: Layer.Layer<
       const opencodeProjectID = input.model.providerID.startsWith("opencode") ? instance.project.id : undefined
 
       // kilocode_change start - capture eligible session export request start
-      const org = yield* isKilo && input.model.isFree === true
+      const exporting = SessionExport.enabled
+      const org = yield* exporting && isKilo && input.model.isFree === true
         ? Effect.promise(() => getActiveOrg())
         : Effect.succeed({ type: "unknown" as const })
       const started = Date.now()
@@ -400,7 +401,7 @@ const live: Layer.Layer<
       const found = KiloSession.resolveRoot(input.sessionID)
       const root = parent ? (found === input.sessionID ? parent : found) : input.sessionID
       const exportable =
-        isKilo && input.model.isFree === true && org.type === "personal" && input.agent.name !== "title"
+        exporting && isKilo && input.model.isFree === true && org.type === "personal" && input.agent.name !== "title"
       if (exportable) {
         SessionExport.beforeRequest({
           input: { model: input.model, org },


### PR DESCRIPTION
## Summary

Temporarily disable free-model session export, including Git workspace state capture, while preserving the implementation for a later rollout.

The production bootstrap and request path share a single hardcoded `SessionExport.enabled` flag. Keeping the flag off prevents worker startup, queued uploads, Git scanning, organization lookup, and response-stream buffering; re-enabling the capability is a one-line change.