### PR TITLE
ux(cli): change `/copy` command to copy last message

### DIFF
--- a/.changeset/copy-command-scope.md
+++ b/.changeset/copy-command-scope.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Make `/copy` copy the latest agent response and use `/copy-session` for session transcripts.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -90,7 +90,8 @@ For detailed help on every command and subcommand, see the [CLI Command Referenc
 | `/compact` | `/summarize` | Compact/summarize session |
 | `/undo` | - | Undo previous message |
 | `/redo` | - | Redo message |
-| `/copy` | - | Copy session transcript |
+| `/copy` | - | Copy latest agent response |
+| `/copy-session` | - | Copy session transcript |
 | `/export` | - | Export session transcript |
 | `/timestamps` | `/toggle-timestamps` | Show/hide timestamps |
 | `/thinking` | `/toggle-thinking` | Show/hide thinking blocks |

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -994,6 +994,11 @@ export function Session() {
       title: "Copy last assistant message",
       value: "messages.copy",
       category: "Session",
+      // kilocode_change start - /copy copies the latest assistant response
+      slash: {
+        name: "copy",
+      },
+      // kilocode_change end
       run: () => {
         const revertID = session()?.revert?.messageID
         const lastAssistantMessage = messages().findLast(
@@ -1051,7 +1056,7 @@ export function Session() {
       value: "session.copy",
       category: "Session",
       slash: {
-        name: "copy",
+        name: "copy-session", // kilocode_change - transcript copy moved off /copy
       },
       run: async () => {
         try {

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -303,8 +303,8 @@ Custom themes: place JSON files in `~/.config/kilo/themes/` or `.kilo/themes/`.
 | Compact/summarize | `<leader>c` | `/compact`, `/summarize` |
 | Undo message | `<leader>u` | `/undo` |
 | Redo | `<leader>r` | `/redo` |
-| Copy last response | `<leader>y` | — |
-| Copy transcript | — | `/copy` |
+| Copy last response | `<leader>y` | `/copy` |
+| Copy transcript | — | `/copy-session` |
 
 ### Agent & Model
 


### PR DESCRIPTION
## Issue

Closes #10928

## Context/Implementation

Renames the current `/copy` command to `/copy-session`, to clarify that its purpose is to copy the entire session transcript. Creates a new `/copy` command to copy only the most recent message. Markdown formatting is preserved, making this ideal for pasting to other locations such as Github and Discord.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Verify that `/copy` copies the most recent message from the agent
- Verify that `/copy-session` copies the entire session transcript
## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord