### PR TITLE
fix(cli): show indexing warnings as TUI notifications

### DIFF
--- a/.changeset/quiet-qdrant-warnings.md
+++ b/.changeset/quiet-qdrant-warnings.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show Qdrant indexing compatibility warnings as TUI notifications instead of writing over the terminal interface.

--- a/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
@@ -23,6 +23,7 @@ import { isKiloError, showKiloErrorToast } from "@/kilocode/kilo-errors"
 import { registerKiloCommands } from "@/kilocode/kilo-commands"
 import { initializeTUIDependencies } from "@kilocode/kilo-gateway/tui"
 import { DialogProcessList } from "@/kilocode/cli/cmd/tui/component/dialog-process-list"
+import { useIndexingWarnings } from "@/kilocode/cli/cmd/tui/indexing-warning"
 
 // Re-export so upstream can render the route without importing directly
 export { KiloClawView } from "@/kilocode/claw/view"
@@ -154,6 +155,8 @@ export function init() {
   const sdk = useSDK()
   const toast = useToast()
   const dialog = useDialog()
+
+  useIndexingWarnings()
 
   // Inject TUI dependencies for kilo-gateway
   initializeTUIDependencies({

--- a/packages/opencode/src/kilocode/cli/cmd/tui/indexing-warning.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/indexing-warning.ts
@@ -1,0 +1,52 @@
+import { createEffect, onCleanup } from "solid-js"
+import { useProject } from "@tui/context/project"
+import { useSDK } from "@tui/context/sdk"
+import { useToast } from "@tui/ui/toast"
+import { Warning as IndexingWarningEvent } from "@/kilocode/indexing-event"
+import { indexingWarningKey, type IndexingWarning } from "@/kilocode/indexing-warning"
+
+export function useIndexingWarnings() {
+  const sdk = useSDK()
+  const toast = useToast()
+  const project = useProject()
+  const seen = new Set<string>()
+  const state = { scope: "" }
+  const show = (warning: IndexingWarning) => {
+    const key = indexingWarningKey(warning)
+    if (seen.has(key)) return
+    seen.add(key)
+    toast.show({
+      title: "Qdrant Compatibility Warning",
+      message: warning.message,
+      variant: "warning",
+      duration: 10000,
+    })
+  }
+
+  onCleanup(
+    sdk.event.on("event", (event) => {
+      if (event.payload.type !== IndexingWarningEvent.type) return
+      if (event.workspace !== undefined && event.workspace !== project.workspace.current()) return
+      const directory = project.instance.directory() || sdk.directory
+      if (directory && event.directory !== directory) return
+      show(event.payload.properties)
+    }),
+  )
+  createEffect(() => {
+    const workspace = project.workspace.current()
+    const directory = project.instance.directory() || sdk.directory || ""
+    const scope = `${workspace ?? ""}\u0000${directory}`
+    if (state.scope !== scope) {
+      state.scope = scope
+      seen.clear()
+    }
+    void sdk.client.indexing
+      .warnings({ workspace })
+      .then((response) => {
+        if (project.workspace.current() !== workspace) return
+        if ((project.instance.directory() || sdk.directory || "") !== directory) return
+        for (const warning of response.data ?? []) show(warning)
+      })
+      .catch(() => undefined)
+  })
+}

--- a/packages/opencode/src/kilocode/indexing-event.ts
+++ b/packages/opencode/src/kilocode/indexing-event.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect"
 import { INDEXING_STATUS_STATES } from "@kilocode/kilo-indexing/status"
 import { BusEvent } from "@/bus/bus-event"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
+import { INDEXING_WARNING_CODES } from "./indexing-warning"
 
 export const IndexingStatusState = Schema.Literals(INDEXING_STATUS_STATES).annotate({
   identifier: "IndexingStatusState",
@@ -21,3 +22,10 @@ export const Event = BusEvent.define(
     status: IndexingStatusInfo,
   }),
 )
+
+export const IndexingWarningInfo = Schema.Struct({
+  code: Schema.Literals(INDEXING_WARNING_CODES),
+  message: Schema.String,
+}).annotate({ identifier: "IndexingWarning" })
+
+export const Warning = BusEvent.define("indexing.warning", IndexingWarningInfo)

--- a/packages/opencode/src/kilocode/indexing-warning.ts
+++ b/packages/opencode/src/kilocode/indexing-warning.ts
@@ -1,0 +1,23 @@
+export const INDEXING_WARNING_CODES = ["qdrant.version-incompatible", "qdrant.version-unavailable"] as const
+
+export type IndexingWarning = {
+  code: (typeof INDEXING_WARNING_CODES)[number]
+  message: string
+}
+
+const incompatible =
+  /^Client version .+ is incompatible with server version .+\. Major versions should match and minor version difference must not exceed 1\. Set checkCompatibility=false to skip version check\.$/
+const detail = " Major versions should match and minor version difference must not exceed 1."
+const unavailable =
+  /^Failed to obtain server version\. Unable to check client-server compatibility\. Set checkCompatibility=false to skip version check\.$/
+
+export function parseQdrantWarning(value: unknown): IndexingWarning | undefined {
+  if (typeof value !== "string") return undefined
+  if (incompatible.test(value)) return { code: "qdrant.version-incompatible", message: value.replace(detail, "") }
+  if (unavailable.test(value)) return { code: "qdrant.version-unavailable", message: value }
+  return undefined
+}
+
+export function indexingWarningKey(warning: IndexingWarning): string {
+  return `${warning.code}\u0000${warning.message}`
+}

--- a/packages/opencode/src/kilocode/indexing-worker-client.ts
+++ b/packages/opencode/src/kilocode/indexing-worker-client.ts
@@ -5,7 +5,8 @@ import type {
 } from "@kilocode/kilo-indexing/engine"
 import type { IndexingStatus } from "@kilocode/kilo-indexing/status"
 import { withTimeout } from "@/util/timeout"
-import type { Message, Request, Result } from "./indexing-worker-protocol"
+import type { Log, Message, Request, Result } from "./indexing-worker-protocol"
+import type { IndexingWarning } from "./indexing-warning"
 
 declare global {
   const KILO_INDEXING_WORKER_PATH: string
@@ -15,6 +16,8 @@ export namespace IndexingWorker {
   export type Hooks = {
     status(status: IndexingStatus): void
     telemetry(event: IndexingTelemetryEvent): void
+    warning(warning: IndexingWarning): void
+    log(event: Log): void
     failure(err: unknown): void
   }
 
@@ -56,6 +59,8 @@ export namespace IndexingWorker {
         if (stopping || stopped) return
         if (message.event === "status") hooks.status(message.data)
         if (message.event === "telemetry") hooks.telemetry(message.data)
+        if (message.event === "warning") hooks.warning(message.data)
+        if (message.event === "log") hooks.log(message.data)
         return
       }
 

--- a/packages/opencode/src/kilocode/indexing-worker-protocol.ts
+++ b/packages/opencode/src/kilocode/indexing-worker-protocol.ts
@@ -4,6 +4,7 @@ import type {
   VectorStoreSearchResult,
 } from "@kilocode/kilo-indexing/engine"
 import type { IndexingStatus } from "@kilocode/kilo-indexing/status"
+import type { IndexingWarning } from "./indexing-warning"
 
 export type InitInput = {
   directory: string
@@ -23,8 +24,15 @@ export type Result =
   | { type: "result"; id: number; method: "dispose"; ok: true; value: undefined }
   | { type: "result"; id: number; method: Request["method"]; ok: false; error: string }
 
+export type Log = {
+  level: "debug" | "info" | "warn" | "error"
+  message: string
+}
+
 export type Event =
   | { type: "event"; event: "status"; data: IndexingStatus }
   | { type: "event"; event: "telemetry"; data: IndexingTelemetryEvent }
+  | { type: "event"; event: "warning"; data: IndexingWarning }
+  | { type: "event"; event: "log"; data: Log }
 
 export type Message = Result | Event

--- a/packages/opencode/src/kilocode/indexing-worker.ts
+++ b/packages/opencode/src/kilocode/indexing-worker.ts
@@ -1,6 +1,7 @@
-import { CodeIndexManager } from "@kilocode/kilo-indexing/engine"
-import { normalizeIndexingStatus } from "@kilocode/kilo-indexing/status"
-import type { Request, Result, Event } from "./indexing-worker-protocol"
+import type { CodeIndexManager } from "@kilocode/kilo-indexing/engine"
+import { format } from "node:util"
+import type { Request, Result, Event, Log } from "./indexing-worker-protocol"
+import { parseQdrantWarning } from "./indexing-warning"
 
 let manager: CodeIndexManager | undefined
 let progress: { dispose(): void } | undefined
@@ -9,6 +10,20 @@ let telemetry: { dispose(): void } | undefined
 function send(message: Result | Event) {
   postMessage(message)
 }
+
+function write(level: Log["level"], args: unknown[]) {
+  const message = format(...args)
+  send({ type: "event", event: "log", data: { level, message } })
+  if (level !== "warn") return
+  const warning = parseQdrantWarning(message)
+  if (warning) send({ type: "event", event: "warning", data: warning })
+}
+
+console.debug = (...args) => write("debug", args)
+console.info = (...args) => write("info", args)
+console.log = (...args) => write("info", args)
+console.warn = (...args) => write("warn", args)
+console.error = (...args) => write("error", args)
 
 function dispose() {
   progress?.dispose()
@@ -22,16 +37,20 @@ function dispose() {
 async function init(request: Extract<Request, { method: "init" }>) {
   dispose()
   if (request.input.lancedbPath) process.env.KILO_LANCEDB_PATH = request.input.lancedbPath
-  const next = new CodeIndexManager(request.input.directory, request.input.root)
+  const [engine, status] = await Promise.all([
+    import("@kilocode/kilo-indexing/engine"),
+    import("@kilocode/kilo-indexing/status"),
+  ])
+  const next = new engine.CodeIndexManager(request.input.directory, request.input.root)
   manager = next
   progress = next.onProgressUpdate.on(() => {
-    send({ type: "event", event: "status", data: normalizeIndexingStatus(next) })
+    send({ type: "event", event: "status", data: status.normalizeIndexingStatus(next) })
   })
   telemetry = next.onTelemetry.on((data) => {
     send({ type: "event", event: "telemetry", data })
   })
   await next.initialize(request.input.config)
-  send({ type: "result", id: request.id, method: "init", ok: true, value: normalizeIndexingStatus(next) })
+  send({ type: "result", id: request.id, method: "init", ok: true, value: status.normalizeIndexingStatus(next) })
 }
 
 onmessage = async (event: MessageEvent<Request>) => {

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -15,7 +15,8 @@ import { makeRuntime } from "@/effect/run-service"
 import { registerDisposer } from "@/effect/instance-registry"
 import { Global } from "@opencode-ai/core/global"
 import * as Log from "@opencode-ai/core/util/log"
-import { Event as IndexingEvent } from "./indexing-event"
+import { Event as IndexingEvent, Warning as IndexingWarningEvent } from "./indexing-event"
+import { indexingWarningKey, type IndexingWarning } from "./indexing-warning"
 import { IndexingWorker } from "./indexing-worker-client"
 import { LanceDBRuntime } from "./lancedb" // kilocode_change
 import { indexingWithKiloDefault, resolveKiloIndexingAuth, type KiloIndexingAuth } from "./indexing-auth" // kilocode_change
@@ -196,6 +197,7 @@ export namespace KiloIndexing {
     engine?: IndexingWorker.Driver
     initialized?: boolean
     current(): Status
+    warnings(): IndexingWarning[]
     publish(): Promise<void>
     dispose(): Promise<void>
   }
@@ -210,6 +212,7 @@ export namespace KiloIndexing {
   }
 
   export const Event = IndexingEvent
+  export const Warning = IndexingWarningEvent
 
   const cache = new Map<string, Cache>()
 
@@ -220,6 +223,7 @@ export namespace KiloIndexing {
 
     return {
       current,
+      warnings: () => [],
       publish,
       async dispose() {},
     }
@@ -254,6 +258,7 @@ export namespace KiloIndexing {
     const merged = indexingWithKiloDefault({ ...global, ...cfg.indexing }, auth)
     const cfgInput = await model(enrichKilo(input(merged, global), auth), auth)
     const box = { status: pending() }
+    const warnings = new Map<string, IndexingWarning>()
     const current = () => box.status
     let disposed = false
 
@@ -276,8 +281,22 @@ export namespace KiloIndexing {
       if (disposed) return
       trackTelemetry(event)
     })
+    const warning = Instance.bind((item: IndexingWarning) => {
+      if (disposed) return
+      const key = indexingWarningKey(item)
+      if (warnings.has(key)) return
+      warnings.set(key, item)
+      void Bus.publish(Warning, item).catch((err) => {
+        log.error("failed to publish indexing warning", { err, workspacePath: dir })
+      })
+    })
+    const output = Instance.bind((event: Parameters<IndexingWorker.Hooks["log"]>[0]) => {
+      if (disposed) return
+      log[event.level](event.message, { source: "worker", workspacePath: dir })
+    })
     const base: Entry = {
       current,
+      warnings: () => [...warnings.values()],
       publish,
       async dispose() {
         if (disposed) return
@@ -309,7 +328,7 @@ export namespace KiloIndexing {
     const err = await LanceDBRuntime.ensure(cfgInput.vectorStoreProvider)
       .then(async () => {
         if (hit.disposed) return
-        const engine = IndexingWorker.create(dir, root, { status, telemetry, failure })
+        const engine = IndexingWorker.create(dir, root, { status, telemetry, warning, log: output, failure })
         base.engine = engine
         box.status = await engine.init(cfgInput)
         base.initialized = true
@@ -392,6 +411,10 @@ export namespace KiloIndexing {
 
   export async function current(): Promise<Status> {
     return (await hit().ready).current()
+  }
+
+  export async function warnings(): Promise<IndexingWarning[]> {
+    return (await hit().ready).warnings()
   }
 
   export function ready(): boolean {

--- a/packages/opencode/src/kilocode/server/httpapi/groups/indexing.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/indexing.ts
@@ -1,5 +1,6 @@
+import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { IndexingStatusInfo } from "@/kilocode/indexing-event"
+import { IndexingStatusInfo, IndexingWarningInfo } from "@/kilocode/indexing-event"
 import { Authorization } from "@/server/routes/instance/httpapi/middleware/authorization"
 import { InstanceContextMiddleware } from "@/server/routes/instance/httpapi/middleware/instance-context"
 import {
@@ -8,12 +9,13 @@ import {
 } from "@/server/routes/instance/httpapi/middleware/workspace-routing"
 import { described } from "@/server/routes/instance/httpapi/groups/metadata"
 
-export { IndexingStatusInfo, IndexingStatusState } from "@/kilocode/indexing-event"
+export { IndexingStatusInfo, IndexingStatusState, IndexingWarningInfo } from "@/kilocode/indexing-event"
 
 const root = "/indexing"
 
 export const IndexingPaths = {
   status: `${root}/status`,
+  warnings: `${root}/warnings`,
 } as const
 
 export const IndexingApi = HttpApi.make("indexing")
@@ -28,6 +30,16 @@ export const IndexingApi = HttpApi.make("indexing")
             identifier: "indexing.status",
             summary: "Get indexing status",
             description: "Retrieve the current code indexing status for the active project.",
+          }),
+        ),
+        HttpApiEndpoint.get("warnings", IndexingPaths.warnings, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(IndexingWarningInfo), "Indexing warnings"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "indexing.warnings",
+            summary: "Get indexing warnings",
+            description: "Retrieve code indexing warnings for the active project.",
           }),
         ),
       )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/indexing.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/indexing.ts
@@ -10,7 +10,11 @@ export const indexingHandlers = HttpApiBuilder.group(InstanceHttpApi, "indexing"
       const current = yield* EffectBridge.fromPromise(() => mod.KiloIndexing.current())
       return current
     })
+    const warnings = Effect.fn("IndexingHttpApi.warnings")(function* () {
+      const mod = yield* Effect.promise(() => import("@/kilocode/indexing"))
+      return yield* EffectBridge.fromPromise(() => mod.KiloIndexing.warnings())
+    })
 
-    return handlers.handle("status", status)
+    return handlers.handle("status", status).handle("warnings", warnings)
   }),
 )

--- a/packages/opencode/test/kilocode/indexing-startup.test.ts
+++ b/packages/opencode/test/kilocode/indexing-startup.test.ts
@@ -161,6 +161,73 @@ describe("indexing startup degradation", () => {
     }
   })
 
+  test("retains and deduplicates indexing warnings for TUI replay", async () => {
+    const warning = {
+      code: "qdrant.version-incompatible" as const,
+      message:
+        "Client version 1.17.0 is incompatible with server version 1.14.1. Set checkCompatibility=false to skip version check.",
+    }
+    const events: (typeof warning)[] = []
+
+    IndexingWorker.override((_directory, _root, hooks) => ({
+      async init() {
+        hooks.log({ level: "warn", message: warning.message })
+        hooks.warning(warning)
+        hooks.warning(warning)
+        return {
+          state: "Standby",
+          message: "Indexing paused.",
+          processedFiles: 0,
+          totalFiles: 0,
+          percent: 0,
+        }
+      },
+      async search() {
+        return []
+      },
+      async dispose() {},
+    }))
+
+    await using tmp = await tmpdir({ git: true, config: cfg })
+    process.env["KILO_CONFIG_DIR"] = tmp.path
+    const on = (data: { directory?: string; payload?: { type?: string; properties?: typeof warning } }) => {
+      if (data.directory !== tmp.path) return
+      if (data.payload?.type !== KiloIndexing.Warning.type) return
+      if (data.payload.properties) events.push(data.payload.properties)
+    }
+    GlobalBus.on("event", on)
+
+    try {
+      const app = Server.Default().app
+      await app.request("/config", {
+        headers: {
+          "x-kilo-directory": tmp.path,
+        },
+      })
+
+      const list = await (async () => {
+        for (const _ of Array.from({ length: 100 })) {
+          const response = await app.request("/indexing/warnings", {
+            headers: {
+              "x-kilo-directory": tmp.path,
+            },
+          })
+          expect(response.status).toBe(200)
+          const body = (await response.json()) as (typeof warning)[]
+          if (body.length > 0) return body
+          await new Promise((resolve) => setTimeout(resolve, 10))
+        }
+        throw new Error("indexing warning was not retained")
+      })()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(list).toEqual([warning])
+      expect(events).toEqual([warning])
+    } finally {
+      GlobalBus.off("event", on)
+    }
+  })
+
   test("reports routes as in progress while initialization is in flight", async () => {
     await using tmp = await tmpdir({ git: true, config: cfg })
     process.env["KILO_CONFIG_DIR"] = tmp.path

--- a/packages/opencode/test/kilocode/indexing-warning.test.ts
+++ b/packages/opencode/test/kilocode/indexing-warning.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { indexingWarningKey, parseQdrantWarning } from "../../src/kilocode/indexing-warning"
+
+describe("parseQdrantWarning", () => {
+  test("classifies incompatible Qdrant versions", () => {
+    const message =
+      "Client version 1.17.0 is incompatible with server version 1.14.1. Major versions should match and minor version difference must not exceed 1. Set checkCompatibility=false to skip version check."
+
+    expect(parseQdrantWarning(message)).toEqual({
+      code: "qdrant.version-incompatible",
+      message:
+        "Client version 1.17.0 is incompatible with server version 1.14.1. Set checkCompatibility=false to skip version check.",
+    })
+  })
+
+  test("classifies unavailable Qdrant versions", () => {
+    const message =
+      "Failed to obtain server version. Unable to check client-server compatibility. Set checkCompatibility=false to skip version check."
+
+    expect(parseQdrantWarning(message)).toEqual({
+      code: "qdrant.version-unavailable",
+      message,
+    })
+  })
+
+  test("ignores unrelated warnings and non-string values", () => {
+    expect(parseQdrantWarning("Api key is used with unsecure connection.")).toBeUndefined()
+    expect(parseQdrantWarning(new Error("warning"))).toBeUndefined()
+  })
+})
+
+test("indexingWarningKey includes the warning code and message", () => {
+  expect(indexingWarningKey({ code: "qdrant.version-unavailable", message: "warning" })).toBe(
+    "qdrant.version-unavailable\u0000warning",
+  )
+})

--- a/packages/opencode/test/kilocode/indexing-worker.test.ts
+++ b/packages/opencode/test/kilocode/indexing-worker.test.ts
@@ -8,6 +8,8 @@ test("runs indexing engine requests in its worker", async () => {
   const engine = IndexingWorker.create(tmp.path, tmp.path, {
     status() {},
     telemetry() {},
+    warning() {},
+    log() {},
     failure(err) {
       failures.push(err)
     },

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -129,6 +129,7 @@ export const kiloScenarios: Scenario[] = [
     }))
     .json(200, (body) => check(body === null, "missing worktree diff detail should return null")),
   http.protected.get("/indexing/status", "indexing.status").json(200, object),
+  http.protected.get("/indexing/warnings", "indexing.warnings").json(200, array),
   http.protected.get("/kilo/profile", "kilo.profile").probe({ path: "/path" }).status(401),
   http.protected.get("/kilo/modes", "kilo.modes").json(200, (body) => {
     object(body)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -86,6 +86,7 @@ import type {
   GlobalUpgradeErrors,
   GlobalUpgradeResponses,
   IndexingStatusResponses,
+  IndexingWarningsResponses,
   InstanceDisposeResponses,
   KiloAudioTranscriptionsErrors,
   KiloAudioTranscriptionsResponses,
@@ -6087,6 +6088,36 @@ export class Indexing extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<IndexingStatusResponses, unknown, ThrowOnError>({
       url: "/indexing/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get indexing warnings
+   *
+   * Retrieve code indexing warnings for the active project.
+   */
+  public warnings<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<IndexingWarningsResponses, unknown, ThrowOnError>({
+      url: "/indexing/warnings",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -14,6 +14,7 @@ export type Event =
   | EventTuiSessionSelect
   | EventKilocodeAgentManagerStart
   | EventIndexingStatus
+  | EventIndexingWarning
   | EventServerInstanceDisposed
   | EventFileEdited
   | EventFileWatcherUpdated
@@ -181,6 +182,11 @@ export type IndexingStatus = {
   processedFiles: number
   totalFiles: number
   percent: number
+}
+
+export type IndexingWarning = {
+  code: "qdrant.version-incompatible" | "qdrant.version-unavailable"
+  message: string
 }
 
 export type QuestionOption = {
@@ -890,6 +896,7 @@ export type GlobalEvent = {
     | EventTuiSessionSelect
     | EventKilocodeAgentManagerStart
     | EventIndexingStatus
+    | EventIndexingWarning
     | EventServerInstanceDisposed
     | EventFileEdited
     | EventFileWatcherUpdated
@@ -2747,6 +2754,12 @@ export type EventIndexingStatus = {
   properties: {
     status: IndexingStatus
   }
+}
+
+export type EventIndexingWarning = {
+  id: string
+  type: "indexing.warning"
+  properties: IndexingWarning
 }
 
 export type EventServerInstanceDisposed = {
@@ -8248,6 +8261,25 @@ export type IndexingStatusResponses = {
 }
 
 export type IndexingStatusResponse = IndexingStatusResponses[keyof IndexingStatusResponses]
+
+export type IndexingWarningsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/indexing/warnings"
+}
+
+export type IndexingWarningsResponses = {
+  /**
+   * Indexing warnings
+   */
+  200: Array<IndexingWarning>
+}
+
+export type IndexingWarningsResponse = IndexingWarningsResponses[keyof IndexingWarningsResponses]
 
 export type KiloProfileData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10979,6 +10979,54 @@
         ]
       }
     },
+    "/indexing/warnings": {
+      "get": {
+        "tags": ["indexing"],
+        "operationId": "indexing.warnings",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indexing warnings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexingWarning"
+                  },
+                  "description": "Indexing warnings"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve code indexing warnings for the active project.",
+        "summary": "Get indexing warnings",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.indexing.warnings({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/kilo/profile": {
       "get": {
         "tags": ["kilo"],
@@ -14161,9 +14209,6 @@
       "Event": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/EventServerInstanceDisposed"
-          },
-          {
             "$ref": "#/components/schemas/EventServerConnected"
           },
           {
@@ -14171,6 +14216,30 @@
           },
           {
             "$ref": "#/components/schemas/EventGlobalConfigUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.prompt.append"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.command.execute"
+          },
+          {
+            "$ref": "#/components/schemas/EventTuiToastShow1"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.session.select"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
+          },
+          {
+            "$ref": "#/components/schemas/EventIndexingStatus"
+          },
+          {
+            "$ref": "#/components/schemas/EventIndexingWarning"
+          },
+          {
+            "$ref": "#/components/schemas/EventServerInstanceDisposed"
           },
           {
             "$ref": "#/components/schemas/EventFileEdited"
@@ -14192,18 +14261,6 @@
           },
           {
             "$ref": "#/components/schemas/EventLspUpdated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.prompt.append"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.command.execute"
-          },
-          {
-            "$ref": "#/components/schemas/EventTuiToastShow1"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.session.select"
           },
           {
             "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -14282,9 +14339,6 @@
           },
           {
             "$ref": "#/components/schemas/EventProjectUpdated"
-          },
-          {
-            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
           },
           {
             "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -14417,9 +14471,6 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-          },
-          {
-            "$ref": "#/components/schemas/EventIndexingStatus"
           }
         ]
       },
@@ -14499,6 +14550,183 @@
             "$ref": "#/components/schemas/WellKnownAuth"
           }
         ]
+      },
+      "Event.tui.prompt.append": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.prompt.append"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.command.execute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.command.execute"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "command": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "session.list",
+                      "session.new",
+                      "session.share",
+                      "session.interrupt",
+                      "session.compact",
+                      "session.page.up",
+                      "session.page.down",
+                      "session.line.up",
+                      "session.line.down",
+                      "session.half.page.up",
+                      "session.half.page.down",
+                      "session.first",
+                      "session.last",
+                      "prompt.clear",
+                      "prompt.submit",
+                      "agent.cycle"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.toast.show": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.toast.show"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string",
+                "enum": ["info", "success", "warning", "error"]
+              },
+              "duration": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["message", "variant"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.session.select": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.select"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "description": "Session ID to navigate to"
+              }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "IndexingStatusState": {
+        "type": "string",
+        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
+      },
+      "IndexingStatus": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/IndexingStatusState"
+          },
+          "message": {
+            "type": "string"
+          },
+          "processedFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "percent": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        },
+        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
+        "additionalProperties": false
+      },
+      "IndexingWarning": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": ["qdrant.version-incompatible", "qdrant.version-unavailable"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
       },
       "QuestionOption": {
         "type": "object",
@@ -14636,139 +14864,6 @@
           }
         },
         "required": ["sessionID", "requestID"],
-        "additionalProperties": false
-      },
-      "Event.tui.prompt.append": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.prompt.append"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "text": {
-                "type": "string"
-              }
-            },
-            "required": ["text"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.command.execute": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.command.execute"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "command": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "enum": [
-                      "session.list",
-                      "session.new",
-                      "session.share",
-                      "session.interrupt",
-                      "session.compact",
-                      "session.page.up",
-                      "session.page.down",
-                      "session.line.up",
-                      "session.line.down",
-                      "session.half.page.up",
-                      "session.half.page.down",
-                      "session.first",
-                      "session.last",
-                      "prompt.clear",
-                      "prompt.submit",
-                      "agent.cycle"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.toast.show": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.toast.show"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              },
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"]
-              },
-              "duration": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "required": ["message", "variant"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.session.select": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.session.select"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "description": "Session ID to navigate to"
-              }
-            },
-            "required": ["sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
       "SessionNetworkWait": {
@@ -16644,36 +16739,6 @@
         "required": ["text"],
         "additionalProperties": false
       },
-      "IndexingStatusState": {
-        "type": "string",
-        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
-      },
-      "IndexingStatus": {
-        "type": "object",
-        "properties": {
-          "state": {
-            "$ref": "#/components/schemas/IndexingStatusState"
-          },
-          "message": {
-            "type": "string"
-          },
-          "processedFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "totalFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "percent": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
-          }
-        },
-        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
-        "additionalProperties": false
-      },
       "GlobalEvent": {
         "type": "object",
         "properties": {
@@ -16689,9 +16754,6 @@
           "payload": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/EventServerInstanceDisposed"
-              },
-              {
                 "$ref": "#/components/schemas/EventServerConnected"
               },
               {
@@ -16699,6 +16761,30 @@
               },
               {
                 "$ref": "#/components/schemas/EventGlobalConfigUpdated"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.prompt.append"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.command.execute"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.toast.show"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.session.select"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexingStatus"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexingWarning"
+              },
+              {
+                "$ref": "#/components/schemas/EventServerInstanceDisposed"
               },
               {
                 "$ref": "#/components/schemas/EventFileEdited"
@@ -16720,18 +16806,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventLspUpdated"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.prompt.append"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.command.execute"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.toast.show"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.session.select"
               },
               {
                 "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -16810,9 +16884,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventProjectUpdated"
-              },
-              {
-                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
               },
               {
                 "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -16945,9 +17016,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-              },
-              {
-                "$ref": "#/components/schemas/EventIndexingStatus"
               },
               {
                 "$ref": "#/components/schemas/SyncEventMessageUpdated"
@@ -22268,30 +22336,6 @@
         "required": ["type", "name", "id", "seq", "aggregateID", "data"],
         "additionalProperties": false
       },
-      "EventServerInstanceDisposed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["server.instance.disposed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "directory": {
-                "type": "string"
-              }
-            },
-            "required": ["directory"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
       "EventServerConnected": {
         "type": "object",
         "properties": {
@@ -22341,6 +22385,125 @@
           "properties": {
             "type": "object",
             "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeAgent_managerStart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.agent_manager.start"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string"
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["worktree", "local"]
+              },
+              "versions": {
+                "type": "boolean"
+              },
+              "tasks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prompt": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "branchName": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 20
+              }
+            },
+            "required": ["requestID", "sessionID", "mode", "tasks"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventIndexingStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.status"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/IndexingStatus"
+              }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventIndexingWarning": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.warning"]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/IndexingWarning"
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventServerInstanceDisposed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["server.instance.disposed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string"
+              }
+            },
+            "required": ["directory"],
+            "additionalProperties": false
           }
         },
         "required": ["id", "type", "properties"],
@@ -23206,60 +23369,6 @@
           },
           "properties": {
             "$ref": "#/components/schemas/Project"
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventKilocodeAgent_managerStart": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["kilocode.agent_manager.start"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "requestID": {
-                "type": "string"
-              },
-              "sessionID": {
-                "type": "string"
-              },
-              "mode": {
-                "type": "string",
-                "enum": ["worktree", "local"]
-              },
-              "versions": {
-                "type": "boolean"
-              },
-              "tasks": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "prompt": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "branchName": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "minItems": 1,
-                "maxItems": 20
-              }
-            },
-            "required": ["requestID", "sessionID", "mode", "tasks"],
-            "additionalProperties": false
           }
         },
         "required": ["id", "type", "properties"],
@@ -24814,30 +24923,6 @@
               }
             },
             "required": ["timestamp", "sessionID", "text"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventIndexingStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["indexing.status"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "status": {
-                "$ref": "#/components/schemas/IndexingStatus"
-              }
-            },
-            "required": ["status"],
             "additionalProperties": false
           }
         },


### PR DESCRIPTION
## Issue

No linked issue was provided. This fixes a CLI TUI rendering regression reported directly: indexing dependency warnings could write over the terminal interface.

## Context

The code-indexing worker can emit Qdrant client compatibility warnings during startup. Because those warnings were written directly through `console.warn`, they rendered above the active TUI and corrupted its layout. The warning remains important, so this routes worker output into Kilo logging while promoting Qdrant compatibility warnings into the existing top-right TUI notification area.

## Implementation

The indexing worker installs console interception before dynamically loading the indexing engine, ensuring dependency output is forwarded as structured worker log events rather than printed into the terminal. Known Qdrant compatibility warnings are additionally classified, shortened for display, retained per indexing instance, deduplicated, and published as `indexing.warning` events.

The TUI subscribes through a dedicated indexing-warning hook and replays retained warnings through a generated `GET /indexing/warnings` SDK endpoint so startup warnings are not missed before the UI mounts. The hook preserves workspace and directory filtering and deduplicates live events against replayed warnings.

## Screenshots / Video

### Before
<img width="3810" height="1918" alt="image" src="https://github.com/user-attachments/assets/d3fd9ede-45c3-49ed-b5d3-03e4f04e744e" />

### After
<img width="3810" height="1918" alt="After" src="https://github.com/user-attachments/assets/4c8355f8-4ab1-4a2d-a12f-36126aeea3f6" />


## How to Test

### Manual/local verification

- Agent: ran the focused indexing regression suite with `bun test ./test/kilocode/indexing-warning.test.ts ./test/kilocode/indexing-worker.test.ts ./test/kilocode/indexing-startup.test.ts` from `packages/opencode/`; all 19 tests passed.
- Agent: ran `bun run test:httpapi` from `packages/opencode/`; route coverage, auth, and Effect modes passed, including `GET /indexing/warnings`.
- Agent: ran SDK typecheck, repository lint, Prettier checks, generated-artifact validation, annotation validation, Promise-facade validation, markdown-table validation, and `git diff --check`; all completed successfully.

### Reviewer test steps

1. Start a Qdrant server whose minor version differs from the bundled Qdrant client by more than one, such as server `1.14.1` with client `1.17.0`.
2. Enable code indexing and open the CLI TUI.
3. Confirm the TUI layout remains intact and the top-right notification area shows the shortened Qdrant compatibility warning.
4. Confirm the full original worker warning remains available in Kilo logs.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [X] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [X] I personally reviewed the diff and can explain the changes, including any AI-assisted work.