### PR TITLE
fix(cli): ensure kilo mcp add always writes valid JSON to .json config files

### DIFF
--- a/.changeset/fix-mcp-add-invalid-json.md
+++ b/.changeset/fix-mcp-add-invalid-json.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix `kilo mcp add` writing invalid JSON to `kilo.json` config files

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -16,7 +16,7 @@ import { Installation } from "../../installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import path from "path"
 import { Global } from "@opencode-ai/core/global"
-import { modify, applyEdits } from "jsonc-parser"
+import { modify, applyEdits, parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
 import { Bus } from "../../bus"
 import { Effect } from "effect"
@@ -434,11 +434,21 @@ async function addMcpToConfig(name: string, mcpConfig: ConfigMCP.Info, configPat
     text = await Filesystem.readText(configPath)
   }
 
-  // Use jsonc-parser to modify while preserving comments
-  const edits = modify(text, ["mcp", name], mcpConfig, {
-    formattingOptions: { tabSize: 2, insertSpaces: true },
-  })
-  const result = applyEdits(text, edits)
+  let result: string
+  if (configPath.endsWith(".jsonc")) {
+    // For .jsonc files, use jsonc-parser to modify while preserving comments
+    const edits = modify(text, ["mcp", name], mcpConfig, {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    })
+    result = applyEdits(text, edits)
+  } else {
+    // For .json files, parse (tolerating any JSONC like trailing commas) and
+    // re-serialize with JSON.stringify to always produce valid JSON output.
+    const parsed: Record<string, unknown> = parseJsonc(text) ?? {}
+    if (typeof parsed.mcp !== "object" || parsed.mcp === null) parsed.mcp = {}
+    ;(parsed.mcp as Record<string, unknown>)[name] = mcpConfig
+    result = JSON.stringify(parsed, null, 2)
+  }
 
   await Filesystem.write(configPath, result)
 


### PR DESCRIPTION
## Summary

- `kilo mcp add` used `jsonc-parser`'s `modify`+`applyEdits` for all config files, which preserves existing JSONC features (trailing commas, comments) in the file content
- When a `kilo.json` file already contained JSONC features (e.g. from manual editing), the output file would retain them, making it invalid strict JSON that `jq` and the runtime reject
- Fix: for `.json` files, parse the existing content with `jsonc-parser.parse` (which tolerates JSONC) and re-serialize with `JSON.stringify` to always produce valid JSON; for `.jsonc` files, keep the existing comment-preserving `modify`+`applyEdits` path

This mirrors the pattern already used by `Config.updateGlobal` in `config.ts`, which distinguishes `.json` vs `.jsonc` files when writing.

Built for [Florian Hines](https://kilo-code.slack.com/archives/C09GD7US2UB/p1780622538294539?thread_ts=1780621732.053919&cid=C09GD7US2UB) by [Kilo for Slack](https://kilo.ai/slack)