### PR TITLE
fix(cli): write strict JSON for MCP config

### DIFF
--- a/.changeset/clean-mcp-json.md
+++ b/.changeset/clean-mcp-json.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Write strict JSON when adding MCP servers to `kilo.json` configuration files.

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -17,6 +17,7 @@ import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import path from "path"
 import { Global } from "@opencode-ai/core/global"
 import { modify, applyEdits } from "jsonc-parser"
+import { KilocodeMcpConfig } from "@/kilocode/cli/cmd/mcp" // kilocode_change
 import { Filesystem } from "@/util/filesystem"
 import { Bus } from "../../bus"
 import { Effect } from "effect"
@@ -438,7 +439,7 @@ async function addMcpToConfig(name: string, mcpConfig: ConfigMCP.Info, configPat
   const edits = modify(text, ["mcp", name], mcpConfig, {
     formattingOptions: { tabSize: 2, insertSpaces: true },
   })
-  const result = applyEdits(text, edits)
+  const result = KilocodeMcpConfig.format(configPath, applyEdits(text, edits)) // kilocode_change
 
   await Filesystem.write(configPath, result)
 

--- a/packages/opencode/src/kilocode/cli/cmd/mcp.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/mcp.ts
@@ -1,0 +1,8 @@
+import { ConfigParse } from "@/config/parse"
+
+export namespace KilocodeMcpConfig {
+  export function format(file: string, input: string) {
+    if (file.endsWith(".jsonc")) return input
+    return JSON.stringify(ConfigParse.jsonc(input, file), null, 2)
+  }
+}

--- a/packages/opencode/test/kilocode/cli/cmd/mcp.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/mcp.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { KilocodeMcpConfig } from "@/kilocode/cli/cmd/mcp"
+
+const added = `{
+  "permission": {
+    "bash": "allow"
+  },
+  "mcp": {
+    "linear": {
+      "type": "remote",
+      "url": "https://mcp.linear.app/mcp",
+      "oauth": {}
+    }
+  },
+}`
+
+describe("KilocodeMcpConfig.format", () => {
+  test("writes strict JSON for kilo.json", () => {
+    const output = KilocodeMcpConfig.format("/tmp/kilo.json", added)
+
+    expect(JSON.parse(output)).toEqual({
+      permission: { bash: "allow" },
+      mcp: {
+        linear: {
+          type: "remote",
+          url: "https://mcp.linear.app/mcp",
+          oauth: {},
+        },
+      },
+    })
+    expect(output).not.toEndWith(",\n}")
+  })
+
+  test("preserves JSONC formatting for kilo.jsonc", () => {
+    expect(KilocodeMcpConfig.format("/tmp/kilo.jsonc", added)).toBe(added)
+  })
+})


### PR DESCRIPTION
## Summary
- Normalize `kilo.json` after `kilo mcp add` so JSONC-preserved trailing commas are stripped for strict JSON config files.
- Preserve existing JSONC formatting for `kilo.jsonc` targets.
- Add regression coverage for remote OAuth MCP config output.

This fixes reports where adding an MCP server could leave `kilo.json` rejected by strict JSON parsers such as `jq`.

<img width="3810" height="1918" alt="Pasted image" src="https://github.com/user-attachments/assets/a996a1c9-4175-4c0b-9f85-f4122a21a559" />
<img width="3810" height="1918" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/d934ef1a-c00e-417a-9537-244561ca410b" />
<img width="3810" height="1918" alt="Pasted image (3)" src="https://github.com/user-attachments/assets/00211135-80bd-403d-ae94-23ed5c9a13a7" />
<img width="3810" height="1918" alt="Pasted image (4)" src="https://github.com/user-attachments/assets/84f3375b-c8c1-405e-b79c-1493489f2ccc" />
<img width="3810" height="1918" alt="Pasted image (5)" src="https://github.com/user-attachments/assets/a075e459-b9fe-4e61-87a3-6e70a3dedc90" />

