### PR TITLE
fix(cli): isolate release target builds

### DIFF
--- a/.changeset/fix-darwin-cli-startup.md
+++ b/.changeset/fix-darwin-cli-startup.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Prevent the macOS Apple Silicon CLI from failing to start because of malformed bundled exports.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -161,6 +161,30 @@ jobs:
           name: kilo-vscode
           path: packages/kilo-vscode/out
 
+  # kilocode_change start - execute the cross-compiled Apple Silicon binary before publishing it
+  validate-darwin-arm64:
+    name: Validate CLI (darwin-arm64)
+    needs: build-cli
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: kilo-cli.tar.zst
+          path: /tmp
+          skip-decompress: true
+
+      - name: Unpack CLI dist
+        run: |
+          mkdir -p dist
+          tar --zstd -xf /tmp/kilo-cli.tar.zst -C dist
+
+      - name: Run CLI smoke test
+        run: |
+          test "$(uname -m)" = "arm64"
+          ./dist/@kilocode/cli-darwin-arm64/bin/kilo --version
+          ./dist/@kilocode/cli-darwin-arm64/bin/kilo --help >/dev/null
+  # kilocode_change end
   # kilocode_change start
   # Run smoke tests against CLI assets uploaded to the draft GitHub release
   # before publishing the release and package artifacts.
@@ -181,6 +205,7 @@ jobs:
       - version
       - build-cli
       - build-vscode
+      - validate-darwin-arm64 # kilocode_change
       - smoke-test
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -185,6 +185,42 @@ jobs:
           ./dist/@kilocode/cli-darwin-arm64/bin/kilo --version
           ./dist/@kilocode/cli-darwin-arm64/bin/kilo --help >/dev/null
   # kilocode_change end
+
+  # kilocode_change start - execute native Linux x64 and arm64 binaries before publishing them
+  validate-linux:
+    name: Validate CLI (linux-${{ matrix.arch }})
+    needs: build-cli
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+            uname: x86_64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            uname: aarch64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: kilo-cli.tar.zst
+          path: /tmp
+          skip-decompress: true
+
+      - name: Unpack CLI dist
+        run: |
+          mkdir -p dist
+          tar --zstd -xf /tmp/kilo-cli.tar.zst -C dist
+
+      - name: Run CLI smoke test
+        run: |
+          test "$(uname -m)" = "${{ matrix.uname }}"
+          ./dist/@kilocode/cli-linux-${{ matrix.arch }}/bin/kilo --version
+          ./dist/@kilocode/cli-linux-${{ matrix.arch }}/bin/kilo --help >/dev/null
+  # kilocode_change end
+
   # kilocode_change start
   # Run smoke tests against CLI assets uploaded to the draft GitHub release
   # before publishing the release and package artifacts.
@@ -206,6 +242,7 @@ jobs:
       - build-cli
       - build-vscode
       - validate-darwin-arm64 # kilocode_change
+      - validate-linux # kilocode_change
       - smoke-test
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,7 +183,6 @@ jobs:
         run: |
           test "$(uname -m)" = "arm64"
           ./dist/@kilocode/cli-darwin-arm64/bin/kilo --version
-          ./dist/@kilocode/cli-darwin-arm64/bin/kilo --help >/dev/null
   # kilocode_change end
 
   # kilocode_change start - execute native Linux x64 and arm64 binaries before publishing them
@@ -218,7 +217,6 @@ jobs:
         run: |
           test "$(uname -m)" = "${{ matrix.uname }}"
           ./dist/@kilocode/cli-linux-${{ matrix.arch }}/bin/kilo --version
-          ./dist/@kilocode/cli-linux-${{ matrix.arch }}/bin/kilo --help >/dev/null
   # kilocode_change end
 
   # kilocode_change start

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -193,6 +193,14 @@ const allTargets: {
   },
 ]
 
+// kilocode_change start - isolate target builds because repeated Bun.build calls can corrupt shared chunks
+const arg = process.argv.find((item) => item.startsWith("--target="))
+const value = arg?.slice("--target=".length)
+const selection = value !== undefined && /^(0|[1-9]\d*)$/.test(value) ? Number(value) : -1
+const isolated = selection >= 0 && selection < allTargets.length
+if (arg !== undefined && !isolated) throw new Error(`Invalid isolated build target: ${arg}`)
+// kilocode_change end
+
 const targets = singleFlag
   ? allTargets.filter((item) => {
       if (item.os !== process.platform || item.arch !== process.arch) {
@@ -213,10 +221,12 @@ const targets = singleFlag
       return true
     })
   : allTargets
+if (isolated) targets.splice(0, targets.length, allTargets[selection]!) // kilocode_change - select one target in child
 
-await $`rm -rf dist` // kilocode_change
-
-const kiloConsoleDist = await buildKiloConsole() // kilocode_change
+// kilocode_change start - isolated children reuse the parent's prepared output tree
+if (!isolated) await $`rm -rf dist`
+const kiloConsoleDist = isolated ? path.resolve(dir, "../kilo-console/dist") : await buildKiloConsole()
+// kilocode_change end
 
 const binaries: Record<string, string> = {}
 if (!skipInstall) {
@@ -234,6 +244,15 @@ for (const item of targets) {
   ]
     .filter(Boolean)
     .join("-")
+
+  // kilocode_change start - isolate Bun's shared-chunk state between cross-platform targets
+  if (!isolated && targets.length > 1) {
+    await $`${process.execPath} run script/build.ts --target=${allTargets.indexOf(item)} --skip-install`
+    binaries[name] = Script.version
+    continue
+  }
+  // kilocode_change end
+
   console.log(`building ${name}`)
   await $`mkdir -p dist/${name}/bin`
 
@@ -346,6 +365,8 @@ for (const item of targets) {
   )
   binaries[name] = Script.version
 }
+
+if (isolated) process.exit(0) // kilocode_change - isolated target children leave archive upload to parent
 
 if (Script.release) {
   const archives: string[] = [] // kilocode_change


### PR DESCRIPTION
## What changed

- Build each CLI release target in a fresh Bun subprocess while preserving minification and code splitting.
- Keep the parent build responsible for dependency installation, output cleanup, Kilo Console generation, archive creation, and release upload.
- Gate publishing on executing the exact packaged macOS arm64, Linux x64, and Linux arm64 CLI artifacts on native runners.

## Root cause

Incorrect root cause, we will unwind the split build changes but keep the kilo CLI arch --version tests which are valuable.