### PR TITLE
Prevent false auto-scroll pauses from programmatic scroll events

### DIFF
--- a/.changeset/user-driven-auto-scroll.md
+++ b/.changeset/user-driven-auto-scroll.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-ui": patch
+"kilo-code": patch
+---
+
+Keep chat auto-scroll following after programmatic or layout-driven scroll position changes.

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -22,7 +22,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let stopTimer: ReturnType<typeof setTimeout> | undefined
   let cleanup: (() => void) | undefined
   let userInitiated = false
-  let lastScrollTop: number | undefined
   let lastInteraction = 0
 
   const threshold = () => options.bottomThreshold ?? 10
@@ -65,7 +64,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // `scrollTop` assignment bypasses any CSS `scroll-behavior: smooth`.
     el.scrollTop = el.scrollHeight
-    lastScrollTop = el.scrollTop
   }
 
   const scrollToBottom = (force: boolean) => {
@@ -124,21 +122,17 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     if (distance < threshold()) {
       if (store.userScrolled) setStore("userScrolled", false)
-      lastScrollTop = el.scrollTop
       return
     }
 
     if (!store.userScrolled && !byUser) {
-      // virtua fires programmatic scroll events as it measures virtualized
-      // items. Don't let those snap the view back to the bottom while the
-      // user is mid-gesture — the wheel event fires before the scroll event,
-      // so `recentlyInteracted()` is reliable here.
-      if (el.scrollTop < (lastScrollTop ?? el.scrollTop) || recentlyInteracted()) {
+      // Only explicit user input can pause following. Treat unclassified
+      // scroll events from virtualization or layout changes as programmatic.
+      if (recentlyInteracted()) {
         stop()
       } else {
         scrollToBottomNow("auto")
       }
-      lastScrollTop = el.scrollTop
       return
     }
 
@@ -224,7 +218,6 @@ export function createAutoScroll(options: AutoScrollOptions) {
         cleanup = undefined
       }
 
-      lastScrollTop = undefined
       scroll = el
 
       if (!el) return


### PR DESCRIPTION
Part of https://github.com/Kilo-Org/kilocode/issues/10741

## Why

Auto-scrolling to the bottom of the chat can break as new LLM content is streamed.

The auto-scroll logic used scrollTop to calculate whether to stop scrolling (If decreased, must mean the user scrolled up, so stop following)

But scrollTop can decrease because content above resized, virtualization remeasured messages, or the browser adjusted the layout—not only because the user scrolled upward. Treating every decrease as user intent could incorrectly stop auto-follow, leaving users behind the latest output.

## Implementation

Removed lastScrollTop tracking and the comparison that inferred user intent from upward position changes. Auto-scroll now pauses only after recent explicit user input. Unclassified scroll events are treated as programmatic or layout-driven, so the view returns to the latest content.


## Screenshots / Video


Before

https://github.com/user-attachments/assets/eaa2103c-f7f0-4d63-be29-296744208c2c

After

https://github.com/user-attachments/assets/533a412b-74ea-4e05-86e7-78dc28550780

## Testing

- As shown above
- Unit tests pass

