### PR TITLE
Maintain scroll position on container resize

### DIFF
--- a/.changeset/observe-chat-resize.md
+++ b/.changeset/observe-chat-resize.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-ui": patch
+"kilo-code": patch
+---
+
+Keep chat pinned to the latest output when the visible message area resizes without overriding an intentional scroll position.

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -28,6 +28,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
   const [store, setStore] = createStore({
     contentRef: undefined as HTMLElement | undefined,
+    scrollRef: undefined as HTMLElement | undefined,
     userScrolled: false,
   })
 
@@ -187,6 +188,20 @@ export function createAutoScroll(options: AutoScrollOptions) {
     },
   )
 
+  createResizeObserver(
+    () => store.scrollRef,
+    () => {
+      const el = scroll
+      if (!el) return
+      if (!canScroll(el)) {
+        if (store.userScrolled) setStore("userScrolled", false)
+        return
+      }
+      if (store.userScrolled || recentlyInteracted()) return
+      scrollToBottomNow("auto")
+    },
+  )
+
   createEffect(
     on(options.working, (working: boolean) => {
       settling = false
@@ -219,6 +234,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
       }
 
       scroll = el
+      setStore("scrollRef", el)
 
       if (!el) return
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -5,7 +5,7 @@
  * Main chat container that combines all chat components
  */
 
-import { type Component, Show, createEffect, createMemo, createSignal, on, onCleanup, onMount } from "solid-js"
+import { type Component, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
@@ -77,17 +77,6 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // Session is busy only because a question tool call is pending — prompt should behave as idle
   const questioning = () => isQuestioning(blocked(), familyQuestions().length)
   const dock = () => !props.readonly || !!permissionRequest()
-
-  // When a bottom-dock permission disappears while the session is busy,
-  // the scroll container grows taller. Dispatch a custom event so MessageList can
-  // resume auto-scroll.
-  createEffect(
-    on(blocked, (isBlocked, wasBlocked) => {
-      if (wasBlocked && !isBlocked && !idle()) {
-        window.dispatchEvent(new CustomEvent("resumeAutoScroll"))
-      }
-    }),
-  )
 
   onMount(() => {
     if (props.readonly) return

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -74,7 +74,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
     working: () => session.status() !== "idle",
   })
 
-  // Resume auto-scroll when a bottom-dock permission/question is dismissed
+  // Explicit output-producing actions resume auto-scroll before appending.
   const onResumeAutoScroll = () => autoScroll.resume()
   window.addEventListener("resumeAutoScroll", onResumeAutoScroll)
   onCleanup(() => window.removeEventListener("resumeAutoScroll", onResumeAutoScroll))


### PR DESCRIPTION

Part of #10741 

## Why

If the user had intentionally scrolled up before approving or rejecting a permission, handling that permission could unexpectedly move them to the bottom.


## Implementation

Replace the custom event approach for resuming auto-scroll when the permission dock disappears.

Instead, observe the scroll container's dimensions directly via createResizeObserver in the auto-scroll hook, eliminating the coupling between ChatView and MessageList through window events. The scroll ref is now tracked in the store to enable resize observation alongside the existing content observer.
## Screenshots / Video

Before


https://github.com/user-attachments/assets/f5267ab0-1e30-41cf-a98c-2ffe56572361



After


https://github.com/user-attachments/assets/7b7d9b2d-5cbf-462c-abc6-56decff80430


## Testing

- Unit tests pass
- Manual testing as shown above