### PR TITLE
Skip pausing auto-scroll on question answer

### DIFF
--- a/.changeset/ignore-control-scroll-intent.md
+++ b/.changeset/ignore-control-scroll-intent.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-ui": patch
+"kilo-code": patch
+---
+
+Keep chat auto-scroll active when interacting with question answers and other controls.

--- a/packages/kilo-ui/src/hooks/auto-scroll.ts
+++ b/packages/kilo-ui/src/hooks/auto-scroll.ts
@@ -1,0 +1,11 @@
+export const isControl = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) return false
+  const editable = target.closest<HTMLElement>("[contenteditable]")
+  return !!target.closest("button, input, textarea, select") || !!editable?.isContentEditable
+}
+
+export const isNested = (target: EventTarget | null, root?: HTMLElement) => {
+  if (!(target instanceof Element)) return false
+  const nested = target.closest("[data-scrollable]")
+  return !!root && !!nested && nested !== root
+}

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -1,6 +1,7 @@
 import { createEffect, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
+import { isControl, isNested } from "./auto-scroll"
 
 const DEBOUNCE_MS = 100
 // Grace window after a real user interaction (wheel/pointer/key/touch) during
@@ -43,11 +44,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
   }
 
   const markUser = (e: Event) => {
-    if (e instanceof WheelEvent) {
-      const target = e.target instanceof Element ? e.target : undefined
-      const nested = target?.closest("[data-scrollable]")
-      if (scroll && nested && nested !== scroll) return
-    }
+    if (!(e instanceof WheelEvent) && isControl(e.target)) return
+    if (e instanceof WheelEvent && isNested(e.target, scroll)) return
     userInitiated = true
     lastInteraction = performance.now()
   }


### PR DESCRIPTION

Part of #10741 
Closes #10741

## Why

Answering a question (Clicking on the chat) was interpreted as an event that stopped scrolling (See before video)

## Implementation

Extract helper utilities to identify interactive elements (buttons, inputs, textareas, contenteditable) and nested scrollable containers. Skip pausing auto-scroll when the user interacts with form controls or question answer elements, preventing false positives that would stop the chat from following new content.

## Screenshots / Video

Before


https://github.com/user-attachments/assets/0c351e0c-00c1-44ab-b033-4ea5fe9b2a21



After


https://github.com/user-attachments/assets/67bbbb52-d3bd-4946-91ef-8ec72dace02c




## Testing

- Unit tests pass
- Manual verification as shown above
