### PR TITLE
Prevent content shift on turn end

### DIFF
--- a/.changeset/stable-working-indicator.md
+++ b/.changeset/stable-working-indicator.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reduce chat layout movement when live output finishes and session actions appear.

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -97,25 +97,27 @@ export const WorkingIndicator: Component = () => {
   }
 
   return (
-    <Show when={session.status() !== "idle" && !blocked()}>
-      <div class="working-indicator">
-        <Spinner />
-        <span class="working-text">{statusText()}</span>
-        <Show when={elapsed() > 0}>
-          <span class="working-elapsed">{formatElapsed()}</span>
-        </Show>
-        <Show when={isRetrying()}>
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={handleCancelRetry}
-            class="working-cancel"
-            style={{ "font-weight": "600", color: "var(--vscode-errorForeground, #f85149)" }}
-          >
-            {language.t("ui.sessionTurn.cancel") || "Cancel"}
-          </Button>
-        </Show>
-      </div>
-    </Show>
+    <div class="working-indicator-slot">
+      <Show when={session.status() !== "idle" && !blocked()}>
+        <div class="working-indicator">
+          <Spinner />
+          <span class="working-text">{statusText()}</span>
+          <Show when={elapsed() > 0}>
+            <span class="working-elapsed">{formatElapsed()}</span>
+          </Show>
+          <Show when={isRetrying()}>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={handleCancelRetry}
+              class="working-cancel"
+              style={{ "font-weight": "600", color: "var(--vscode-errorForeground, #f85149)" }}
+            >
+              {language.t("ui.sessionTurn.cancel") || "Cancel"}
+            </Button>
+          </Show>
+        </div>
+      </Show>
+    </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -161,6 +161,12 @@
   color: var(--vscode-descriptionForeground);
 }
 
+.working-indicator-slot {
+  /* Offset the session actions appearing when work finishes. */
+  min-height: 10px;
+  flex-shrink: 0;
+}
+
 .working-text {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
Part of #10741 


## Why

Everytime a turn finished, the working indicator ("Considering next steps....") disappeared, and the Session actions (New Sessions, Move to Worktree...) appeared. These had different heights causing a visual jump in the conversation - See before video

## Implementation

Wrap the WorkingIndicator in a persistent slot container with a fixed min-height so that toggling between the spinner and session actions does not cause the chat content to jump. This stabilizes the scroll position when live output finishes.


## Screenshots / Video

Before


https://github.com/user-attachments/assets/1672f699-fcb5-4ca2-96c7-2b57ad973dee



After


https://github.com/user-attachments/assets/726e6e63-5249-421f-bbd1-fb2a34e8fe4e


## Testing

- Typecheck
- Unit tests pass
- Manual verification as shown above