### PR TITLE
fix(vscode): preserve Explorer after window reload

### DIFF
--- a/.changeset/steady-sidebar-reload.md
+++ b/.changeset/steady-sidebar-reload.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the Explorer and other primary sidebar views open when VS Code reloads while Kilo Code is hidden.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -500,7 +500,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private setSidebarVisible(visible: boolean): void {
     this.setStreamVisibility(visible)
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)
-    this.opts.onSidebarVisibilityChange?.(visible)
   }
 
   /** Resolve a WebviewPanel for displaying Kilo in an editor tab. */

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -29,7 +29,6 @@ let shuttingDown = false
 const RESTORE_KEY = "kilo.workbench.restore"
 
 type RestoreState = {
-  sidebar?: boolean
   agentManager?: boolean
 }
 
@@ -50,10 +49,8 @@ export function activate(context: vscode.ExtensionContext) {
   // Create shared connection service (one server for all webviews)
   const connectionService = new KiloConnectionService(context)
   let restore = context.workspaceState.get<RestoreState>(RESTORE_KEY) ?? {}
-  const closeSidebar = restore.sidebar === false
   const remember = (patch: RestoreState) => {
     const next = { ...restore, ...patch }
-    if (shuttingDown && patch.sidebar === false) next.sidebar = restore.sidebar
     if (shuttingDown && patch.agentManager === false) next.agentManager = restore.agentManager
     restore = next
     void context.workspaceState.update(RESTORE_KEY, restore)
@@ -124,9 +121,7 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   // Create the provider with shared service
-  const provider = new KiloProvider(context.extensionUri, connectionService, context, {
-    onSidebarVisibilityChange: (visible) => remember({ sidebar: visible }),
-  })
+  const provider = new KiloProvider(context.extensionUri, connectionService, context)
   provider.setRemoteService(remoteService)
 
   // Register the webview view provider for the sidebar.
@@ -136,7 +131,6 @@ export function activate(context: vscode.ExtensionContext) {
       webviewOptions: { retainContextWhenHidden: true },
     }),
   )
-  if (closeSidebar) void vscode.commands.executeCommand("workbench.action.closeSidebar")
 
   // Ensure Agent Manager navigation keybindings work when a VS Code terminal has focus.
   // The terminal intercepts all keystrokes unless the command is listed in

--- a/packages/kilo-vscode/src/kilo-provider/options.ts
+++ b/packages/kilo-vscode/src/kilo-provider/options.ts
@@ -4,6 +4,5 @@ export type KiloProviderOptions = {
   snapshotInitialization?: "wait"
   slimEditMetadata?: boolean
   tabTitle?: (title: string) => void
-  onSidebarVisibilityChange?: (visible: boolean) => void
   worktreeDirectories?: () => string[]
 }

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -16,7 +16,6 @@ const PKG_JSON_FILE = path.join(ROOT, "package.json")
 const SRC_DIR = path.join(ROOT, "src")
 const EXTENSION_FILE = path.join(ROOT, "src/extension.ts")
 const KILO_PROVIDER_FILE = path.join(ROOT, "src/KiloProvider.ts")
-const KILO_PROVIDER_OPTIONS_FILE = path.join(ROOT, "src/kilo-provider/options.ts")
 
 function sliceBlock(source: string, start: number): string {
   const open = source.indexOf("{", start)
@@ -103,28 +102,6 @@ describe("Extension — package.json command sync", () => {
       bad,
       `Commands without "kilo-code.new." prefix — use the namespaced form:\n` + bad.map((b) => `  - ${b}`).join("\n"),
     ).toEqual([])
-  })
-})
-
-describe("Extension — sidebar visibility", () => {
-  const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
-  const provider = fs.readFileSync(KILO_PROVIDER_FILE, "utf-8")
-  const options = fs.readFileSync(KILO_PROVIDER_OPTIONS_FILE, "utf-8")
-
-  it("does not close or track the primary sidebar during workbench restore", () => {
-    const restore = ext.indexOf("type RestoreState")
-    expect(restore, "RestoreState must exist for Agent Manager restoration").toBeGreaterThan(-1)
-
-    expect(ext).not.toContain("workbench.action.closeSidebar")
-    expect(ext).not.toContain("onSidebarVisibilityChange")
-    expect(sliceBlock(ext, restore)).not.toContain("sidebar")
-    expect(provider).not.toContain("onSidebarVisibilityChange")
-    expect(options).not.toContain("onSidebarVisibilityChange")
-  })
-
-  it("keeps live Kilo sidebar visibility handling", () => {
-    expect(provider).toContain("this.setStreamVisibility(visible)")
-    expect(provider).toContain('vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)')
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -16,6 +16,7 @@ const PKG_JSON_FILE = path.join(ROOT, "package.json")
 const SRC_DIR = path.join(ROOT, "src")
 const EXTENSION_FILE = path.join(ROOT, "src/extension.ts")
 const KILO_PROVIDER_FILE = path.join(ROOT, "src/KiloProvider.ts")
+const KILO_PROVIDER_OPTIONS_FILE = path.join(ROOT, "src/kilo-provider/options.ts")
 
 function sliceBlock(source: string, start: number): string {
   const open = source.indexOf("{", start)
@@ -102,6 +103,28 @@ describe("Extension — package.json command sync", () => {
       bad,
       `Commands without "kilo-code.new." prefix — use the namespaced form:\n` + bad.map((b) => `  - ${b}`).join("\n"),
     ).toEqual([])
+  })
+})
+
+describe("Extension — sidebar visibility", () => {
+  const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
+  const provider = fs.readFileSync(KILO_PROVIDER_FILE, "utf-8")
+  const options = fs.readFileSync(KILO_PROVIDER_OPTIONS_FILE, "utf-8")
+
+  it("does not close or track the primary sidebar during workbench restore", () => {
+    const restore = ext.indexOf("type RestoreState")
+    expect(restore, "RestoreState must exist for Agent Manager restoration").toBeGreaterThan(-1)
+
+    expect(ext).not.toContain("workbench.action.closeSidebar")
+    expect(ext).not.toContain("onSidebarVisibilityChange")
+    expect(sliceBlock(ext, restore)).not.toContain("sidebar")
+    expect(provider).not.toContain("onSidebarVisibilityChange")
+    expect(options).not.toContain("onSidebarVisibilityChange")
+  })
+
+  it("keeps live Kilo sidebar visibility handling", () => {
+    expect(provider).toContain("this.setStreamVisibility(visible)")
+    expect(provider).toContain('vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)')
   })
 })
 


### PR DESCRIPTION
## Summary
- stop treating hidden Kilo view state as closed primary-sidebar state
- let VS Code restore Explorer and other primary sidebar views without Kilo closing them after activation
- add a regression guard while preserving Kilo's live visibility context and stream handling

Kilo previously persisted `WebviewView.visible` as sidebar state, then ran the global `workbench.action.closeSidebar` command during startup when Kilo itself was hidden. This closed Explorer shortly after a window reload even though the primary sidebar was meant to remain open.

### Before
https://github.com/user-attachments/assets/549ee5ed-90d5-4c8b-881f-7815f7855de1

### After

https://github.com/user-attachments/assets/5127e631-fd0a-4144-bb82-87cd4323b5a7


