### PR TITLE
fix(cli): prevent Bun ESM splitter crash and fix Alpine musl validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,6 +207,11 @@ jobs:
             alpine:3.22 \
             sh -c '
               set -eu
+              # kilocode_change start - Bun musl binaries link against libstdc++ and libgcc_s
+              # (GCC C++ runtime). Alpine does not ship these by default; they are available
+              # as optional packages and must be installed for any Bun-compiled musl binary to run.
+              apk add --no-cache libstdc++ libgcc
+              # kilocode_change end
               binary="/dist/$PACKAGE/bin/kilo"
               "$binary" --version
               root="$(mktemp -d)"

--- a/packages/opencode/src/kilocode/compat/morphsdk.ts
+++ b/packages/opencode/src/kilocode/compat/morphsdk.ts
@@ -1,0 +1,42 @@
+import { createRequire } from "module"
+
+// Force Bun to load @morphllm/morphsdk/tools/warp-grep/client via its self-contained
+// CJS bundle instead of the pre-split ESM barrel.
+//
+// WHY THIS EXISTS
+// ---------------
+// @morphllm/morphsdk ships a pre-split ESM distribution:
+//   dist/tools/warp_grep/client.js  (805 bytes, barrel)
+//     └─ imports from ../../chunk-P7G3CJB2.js
+//     └─ side-effects ../../chunk-63VHBANJ.js ... (12 more chunks, 52 total)
+//
+// When Bun bundles the CLI with `splitting: true + minify: true`, it merges
+// these external pre-split chunks into its own chunk graph. Bun 1.3.14 intermittently
+// generates invalid minified ESM in that process:
+//
+//   SyntaxError: Exported binding 'G9' needs to refer to a top-level declared variable.
+//
+// The error is non-deterministic (Bun's parallel bundler uses different orderings
+// per run), so the build sometimes succeeds and sometimes fails on Windows x64.
+//
+// The CJS bundle (client.cjs, ~2300 lines) is fully self-contained with no external
+// chunk imports. `createRequire` lets Bun inline the CJS module directly without
+// running it through the ESM splitter.
+//
+// HOW TO DETECT THIS FOR FUTURE DEPS
+// -----------------------------------
+// If a new dependency causes `SyntaxError: Exported binding '...' needs to refer to
+// a top-level declared variable` in release builds, check whether its ESM entry point
+// is a barrel that re-imports from internal `chunk-*.js` files:
+//
+//   head -5 node_modules/<pkg>/dist/index.js
+//     → imports { ... } from "./chunk-XYZ123.js"  ← pre-split ESM
+//
+// If so, add a CJS bridge here and re-export from it instead of importing the package
+// directly. Always verify there is a `.cjs` (or CJS `main`) alternative.
+const req = createRequire(import.meta.url)
+
+// Type-cast via the package's own .d.ts so callers get full type safety.
+const mod = req("@morphllm/morphsdk/tools/warp-grep/client") as typeof import("@morphllm/morphsdk/tools/warp-grep/client")
+
+export const WarpGrepClient = mod.WarpGrepClient

--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
-import { WarpGrepClient } from "@morphllm/morphsdk/tools/warp-grep/client" // kilocode_change
+import { WarpGrepClient } from "@/kilocode/compat/morphsdk" // kilocode_change
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"


### PR DESCRIPTION
## Issue

Fixes intermittent publish failures in `Validate CLI (windows-x64)` and persistent failures in `Validate CLI (alpine-x64)` / `Validate CLI (alpine-arm64)` — visible in https://github.com/Kilo-Org/kilocode/actions/runs/27028001871.

## Context

Two independent issues introduced by the v1.14.33 upstream merge (which added `@morphllm/morphsdk`) and the new all-architecture validation jobs.

**1. Intermittent `SyntaxError: Exported binding 'G9'` on Windows x64**

`@morphllm/morphsdk` ships its ESM entry for `./tools/warp-grep/client` as a 805-byte barrel that re-exports from 13 internal `chunk-*.js` files (52 pre-split chunks total). When Bun 1.3.14 bundles the CLI with `splitting: true + minify: true`, it tries to merge those external pre-split chunks into its own chunk graph. Bun 1.3.14's splitter intermittently generates invalid minified ESM during this process:

```
SyntaxError: Exported binding 'G9' needs to refer to a top-level declared variable.
```

This is non-deterministic — Bun's parallel bundler uses different variable orderings per run, so some builds succeed and others fail. The dependency was added in v1.14.33 (May 6) but only surfaced after bumping Bun from 1.3.13 → 1.3.14 (June 3, PR #10884), which made the splitter more aggressive with external chunks.

All 40+ other third-party packages imported by `packages/opencode/src/` were scanned — morphsdk is the only one with pre-split ESM.

**2. Persistent `Error loading shared library libstdc++.so.6` on Alpine**

Bun's musl compilation target (`bun-linux-{arch}-musl`) is not fully static. It still links against `libstdc++.so.6` and `libgcc_s.so.1` (GCC C++ runtime). Alpine base does not ship these by default — they are optional packages available via `apk`. The validation container was running the binary without them.

## Implementation

**morphsdk fix**: Added `packages/opencode/src/kilocode/compat/morphsdk.ts`, a thin CJS bridge using `createRequire(import.meta.url)` to force Bun to load the self-contained CJS bundle (`client.cjs`, ~2300 lines) rather than the pre-split ESM barrel. Types are preserved via `typeof import(...)` cast against the package's own `.d.ts`. `warpgrep.ts` now imports `WarpGrepClient` from the compat wrapper instead of directly from morphsdk.

The compat file includes a comment explaining how to detect this pattern for future third-party dependencies (look for ESM entry files that re-import from `chunk-*.js` internal files).

**Alpine fix**: Added `apk add --no-cache libstdc++ libgcc` at the start of the Alpine Docker smoke test. This matches the runtime requirement any Alpine user of the CLI would also need to satisfy.

## Screenshots / Video

| before | after |
|---|---|
| N/A — CI-only fix | N/A — CI-only fix |

## How to Test

### Manual/local verification

- `bun run typecheck` from `packages/opencode/` — passes
- `bun run script/check-opencode-annotations.ts` — passes
- `bun run script/check-workflows.ts` — passes
- Pre-push `bun turbo typecheck` — all 17 packages pass

### Reviewer test steps

1. Trigger the publish workflow after merging — both `Validate CLI (windows-x64)` and `Validate CLI (alpine-*)` should now pass consistently.
2. Review `packages/opencode/src/kilocode/compat/morphsdk.ts` — the comment documents the detection pattern for future pre-split ESM dependencies.

### Blocked checks and substitute verification

- Local Windows x64 binary smoke test cannot run (no Wine/Windows available); the fix targets Bun's bundler behavior which only manifests building for Windows on a Linux host.
- Alpine binary smoke test cannot run locally without the dist artifact; substitute: confirmed `apk add --no-cache libstdc++ libgcc` succeeds on `alpine:3.22` in Docker.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — CI-only, no changeset needed
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.