### PR TITLE
fix(cli): resolve morphsdk client.cjs via exported subpath

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -292,11 +292,15 @@ for (const item of targets) {
   // pre-split ESM barrel (client.js) whose 52 chunk-*.js side-imports make the ESM splitter emit
   // invalid minified output: SyntaxError: Exported binding 'G9' needs to refer to a top-level...
   // Redirecting onResolve to client.cjs (2300-line self-contained CJS bundle) bypasses the splitter.
+  // require.resolve uses the package's "require" condition, which maps the warp-grep/client
+  // subpath straight to client.cjs. The deep dist path is not an exported subpath, so resolving
+  // it directly throws "Cannot find module" — go through the public specifier instead.
+  const morphsdkCjs = require.resolve("@morphllm/morphsdk/tools/warp-grep/client")
   const morphsdkCjsPlugin: import("bun").BunPlugin = {
     name: "morphsdk-cjs",
     setup(build) {
       build.onResolve({ filter: /^@morphllm\/morphsdk\/tools\/warp-grep\/client$/ }, () => ({
-        path: require.resolve("@morphllm/morphsdk/dist/tools/warp_grep/client.cjs"),
+        path: morphsdkCjs,
       }))
     },
   }

--- a/packages/opencode/src/kilocode/compat/morphsdk.ts
+++ b/packages/opencode/src/kilocode/compat/morphsdk.ts
@@ -14,7 +14,10 @@
 //
 // FIX: script/build.ts adds a morphsdkCjsPlugin (onResolve) that redirects this module
 // specifier to client.cjs — a fully self-contained CJS bundle (~2300 lines, no chunk-*.js
-// imports). The plugin runs at bundle time before the ESM splitter is invoked.
+// imports). The plugin runs at bundle time before the ESM splitter is invoked. It resolves
+// client.cjs via require.resolve("@morphllm/morphsdk/tools/warp-grep/client") (the package's
+// "require" export condition); the raw dist/.../client.cjs path is not an exported subpath
+// and throws "Cannot find module".
 //
 // HOW TO DETECT THIS FOR FUTURE DEPS
 // ------------------------------------


### PR DESCRIPTION
## Issue

Follow-up to #10956. The `build-cli` job still fails on `cli-linux-x64` (and every target), now with a different error:

```
error: ResolveMessage: Cannot find module '@morphllm/morphsdk/dist/tools/warp_grep/client.cjs'
    at .../src/kilocode/compat/morphsdk.ts:0
```

See https://github.com/Kilo-Org/kilocode/actions/runs/27034802261/job/79796129695.

## Root cause

The `morphsdkCjsPlugin` added in #10956 resolved the CJS bundle with:

```ts
require.resolve("@morphllm/morphsdk/dist/tools/warp_grep/client.cjs")
```

`@morphllm/morphsdk` declares an `"exports"` map in its `package.json`. Once `"exports"` is present, Node/Bun gate **all** subpath access through it — the raw `./dist/tools/warp_grep/client.cjs` path is not a listed subpath, so resolution throws `Cannot find module` even though the file exists on disk. This aborts `Bun.build()` before any binary is produced.

## Fix

Resolve through the package's public specifier instead:

```ts
require.resolve("@morphllm/morphsdk/tools/warp-grep/client")
```

`require.resolve` uses the package's `"require"` export condition, which maps `./tools/warp-grep/client` straight to `client.cjs`. The resolved absolute path is then handed to the plugin's `onResolve`, so the ESM-splitter bypass behaves exactly as #10956 intended. The resolve is hoisted out of the per-target loop since it's constant.

## How to verify

`build-cli` (all targets) should pass without the `Cannot find module` or the original `SyntaxError: Exported binding 'G9' ...`.

Verified locally from `packages/opencode/`:
- `bun run script/build.ts --single --skip-install` — compiles `@kilocode/cli-linux-x64` with **no** morphsdk resolve or `SyntaxError` (the exact CI failure is gone). The local smoke-test `exit 139` is a pre-existing Nix-host segfault in Bun's compiled-binary bootstrap (crashes right after `execve`, before any JS runs) and is unrelated to this change; it does not occur on CI's Ubuntu runners.
- `bun run typecheck` passes.
- `bun run script/check-opencode-annotations.ts` passes.

No changeset needed — CI-only build fix.