### PR TITLE
fix(vscode): preserve chat mentions after submit and revert

### DIFF
--- a/.changeset/mentions-stay-active.md
+++ b/.changeset/mentions-stay-active.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep file and folder mentions active after sending chat messages, remove them atomically after reverting, and focus restored prompts for immediate editing.

--- a/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildFileAttachments,
   buildMentionResults,
   filterMentionResults,
+  getBackspaceMentionRemovalRange,
   getMentionRemovalRange,
   isCursorAtMentionEnd,
   findMentionRange,
@@ -221,6 +222,35 @@ describe("buildFileAttachments", () => {
     expect(result[0]!.mime).toBe("text/plain")
     expect(result[0]!.url).toContain("file://")
     expect(result[0]!.url).toContain("src/foo.ts")
+    expect(result[0]!.source).toEqual({
+      type: "file",
+      path: "src/foo.ts",
+      text: { value: "@src/foo.ts", start: 6, end: 17 },
+    })
+  })
+
+  it("tracks source offsets after prefixed text", () => {
+    const paths = new Set(["plans/tsql-migration.md"])
+    const result = buildFileAttachments("review\n\nread @plans/tsql-migration.md", paths, "/workspace")
+    expect(result).toHaveLength(1)
+    expect(result[0]!.source?.text).toEqual({ value: "@plans/tsql-migration.md", start: 13, end: 37 })
+  })
+
+  it("tracks folder mention source offsets", () => {
+    const paths = new Set(["rf-adf/"])
+    const result = buildFileAttachments("inspect @rf-adf/", paths, "/workspace")
+    expect(result).toHaveLength(1)
+    expect(result[0]!.source).toEqual({
+      type: "file",
+      path: "rf-adf/",
+      text: { value: "@rf-adf/", start: 8, end: 16 },
+    })
+  })
+
+  it("skips partial mention matches", () => {
+    const paths = new Set(["foo.ts"])
+    const result = buildFileAttachments("ignore @foo.tsx", paths, "/workspace")
+    expect(result).toEqual([])
   })
 
   it("skips paths not in text", () => {
@@ -298,6 +328,26 @@ describe("getMentionRemovalRange", () => {
     const paths = new Set(["foo.ts"])
     const result = getMentionRemovalRange(text, 13, paths)
     expect(result).toEqual({ start: 6, end: 13 })
+  })
+})
+
+describe("getBackspaceMentionRemovalRange", () => {
+  it("removes a mention when the cursor is directly at the end", () => {
+    const text = "Hi @foo.ts"
+    const paths = new Set(["foo.ts"])
+    expect(getBackspaceMentionRemovalRange(text, text.length, paths)).toEqual({ start: 3, end: 10 })
+  })
+
+  it("removes a mention and its separator when the cursor is after the separator", () => {
+    const text = "Hi @foo.ts "
+    const paths = new Set(["foo.ts"])
+    expect(getBackspaceMentionRemovalRange(text, text.length, paths)).toEqual({ start: 3, end: 11 })
+  })
+
+  it("does not remove a mention when the cursor is after later whitespace", () => {
+    const text = "Hi @foo.ts  "
+    const paths = new Set(["foo.ts"])
+    expect(getBackspaceMentionRemovalRange(text, text.length, paths)).toBeNull()
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
@@ -129,6 +129,25 @@ describe("useFileMention", () => {
     dispose.fn?.()
   })
 
+  it("seedFromText handles folder mentions ending with a slash", () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    mention.seedFromText("Hi to @packages/kilo-docs/.kilocode/")
+
+    expect(mention.mentionedPaths().has("packages/kilo-docs/.kilocode/")).toBe(true)
+
+    dispose.fn?.()
+  })
+
   it("seedFromText ignores text without @mentions", () => {
     const ctx = {
       postMessage: () => {},

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -386,14 +386,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
   })
 
+  const setTextareaValue = (value: string, focus = false) => {
+    if (!textareaRef) return
+    textareaRef.value = value
+    adjustHeight()
+    if (!focus) return
+    textareaRef.focus()
+    textareaRef.setSelectionRange(value.length, value.length)
+  }
+
   const unsubscribe = vscode.onMessage((message) => {
     if (message.type === "setChatBoxMessage") {
       setText(message.text)
       mention.seedFromText(message.text)
-      if (textareaRef) {
-        textareaRef.value = message.text
-        adjustHeight()
-      }
+      setTextareaValue(message.text, message.focus)
     }
 
     if (message.type === "appendChatBoxMessage") {
@@ -782,7 +788,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     )
       return
 
-    const mentionFiles = mention.parseFileAttachments(draft)
+    const mentionFiles = mention.parseFileAttachments(message)
     const imgFiles = imgs.map((img) => ({ mime: img.mime, url: img.dataUrl, filename: img.filename }))
     const pendingId = props.pendingSessionID ?? session.draftSessionID()
     const id = sid()

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -2343,7 +2343,7 @@ export const SessionProvider: ParentComponent = (props) => {
         .filter((p) => p.type === "text" && !(p as { synthetic?: boolean }).synthetic)
         .map((p) => (p as { text: string }).text ?? "")
         .join("")
-      if (text) window.postMessage({ type: "setChatBoxMessage", text }, "*")
+      if (text) window.postMessage({ type: "setChatBoxMessage", text, focus: true }, "*")
     }
     vscode.postMessage({ type: "revertSession", sessionID: id, messageID, partID })
   }

--- a/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
@@ -121,6 +121,17 @@ export function getMentionRemovalRange(
   return null
 }
 
+export function getBackspaceMentionRemovalRange(
+  text: string,
+  cursor: number,
+  paths: Set<string>,
+): { start: number; end: number } | null {
+  const char = text[cursor - 1]
+  const position = char && /\s/.test(char) ? cursor - 1 : cursor
+  if (!isCursorAtMentionEnd(text, position, paths)) return null
+  return getMentionRemovalRange(text, position, paths)
+}
+
 /**
  * Check whether the cursor sits immediately after a known mention.
  */
@@ -166,6 +177,19 @@ export function findMentionRange(
   return null
 }
 
+function findPathMention(text: string, path: string): { value: string; start: number; end: number } | undefined {
+  // A path is represented once in mentionedPaths, so use its first mention as
+  // the single inline source offset for the attachment.
+  const value = `@${path}`
+  const pattern = new RegExp(`(^|\\s)${escape(value)}(?=\\s|$)`)
+  const match = pattern.exec(text)
+  if (!match) return undefined
+
+  const prefix = match[1] ?? ""
+  const start = match.index + prefix.length
+  return { value, start, end: start + value.length }
+}
+
 /**
  * Build FileAttachment objects from currently mentioned paths in the text.
  */
@@ -177,12 +201,21 @@ export function buildFileAttachments(
   const result: FileAttachment[] = []
   const dir = workspaceDir.replaceAll("\\", "/")
   for (const path of mentionedPaths) {
-    if (text.includes(`@${path}`)) {
-      const abs = path.startsWith("/") ? path : `${dir}/${path}`
-      const url = new URL("file://")
-      url.pathname = abs.startsWith("/") ? abs : `/${abs}`
-      result.push({ mime: "text/plain", url: url.href })
-    }
+    const mention = findPathMention(text, path)
+    if (!mention) continue
+
+    const abs = path.startsWith("/") ? path : `${dir}/${path}`
+    const url = new URL("file://")
+    url.pathname = abs.startsWith("/") ? abs : `/${abs}`
+    result.push({
+      mime: "text/plain",
+      url: url.href,
+      source: {
+        type: "file",
+        path,
+        text: mention,
+      },
+    })
   }
   return result
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -7,13 +7,19 @@ import {
   buildFileAttachments,
   buildMentionResults,
   filterMentionResults,
-  isCursorAtMentionEnd,
-  getMentionRemovalRange,
+  getBackspaceMentionRemovalRange,
   findMentionRange,
   type MentionResult,
 } from "./file-mention-utils"
 
 const FILE_SEARCH_DEBOUNCE_MS = 150
+
+function pathToken(raw: string): string | undefined {
+  const path = raw.replace(/^@/, "")
+  if (!path) return undefined
+  if (!path.includes("/") && !path.includes(".")) return undefined
+  return path
+}
 
 interface VSCodeContext {
   postMessage: (message: WebviewMessage) => void
@@ -251,14 +257,9 @@ export function useFileMention(
     const cursor = textarea.selectionStart ?? 0
     if (textarea.selectionStart !== textarea.selectionEnd) return false
 
-    const charBefore = val[cursor - 1]
-    if (charBefore !== " " && charBefore !== "\n") return false
-    if (!isCursorAtMentionEnd(val, cursor - 1, mentionedPaths())) return false
-
-    // Cursor is on the space right after a mention — remove the entire
-    // mention + trailing space in one step via execCommand so the change
-    // lands on the browser's native undo stack.
-    const range = getMentionRemovalRange(val, cursor - 1, mentionedPaths())
+    // Remove the whole mention whether the cursor is directly after the token
+    // or after the single separator space inserted by mention selection.
+    const range = getBackspaceMentionRemovalRange(val, cursor, mentionedPaths())
     if (!range) return false
 
     e.preventDefault()
@@ -317,10 +318,9 @@ export function useFileMention(
   }
 
   const seedFromText = (text: string) => {
-    const re = /@([\w./-]+\.[\w]+|[\w.-]+\/[\w./-]+)/g
-    let m: RegExpExecArray | null
-    while ((m = re.exec(text))) {
-      knownPaths.add(m[1])
+    for (const match of text.matchAll(/(^|\s)@(\S+)/g)) {
+      const path = pathToken(match[2] ?? "")
+      if (path) knownPaths.add(path)
     }
     syncMentionedPaths(text)
   }

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -237,6 +237,7 @@ export interface ActionMessage {
 export interface SetChatBoxMessage {
   type: "setChatBoxMessage"
   text: string
+  focus?: boolean
 }
 
 export interface AppendChatBoxMessage {


### PR DESCRIPTION
## Issue

No linked issue; fixes user-reported VS Code chat mention behavior.

## Context

File and folder mentions in submitted user messages were degrading into plain text because their attachment metadata did not preserve the original mention text offsets. This also affected reverted messages: mentions could become editable as plain text at the cursor boundary, and reverted prompts did not automatically focus the textarea for immediate editing.

## Implementation

File and folder mention attachments now include `source.text` metadata with the original `@mention` value and offsets, matching the behavior already used by `@terminal`. The prompt submission path computes those offsets from the final submitted message text so rendered chat messages can keep mentions active.

The mention deletion flow now treats a cursor directly after a mention as atomic, even when there is no trailing separator space. Reverted text seeding was also tightened so folder mentions ending in `/` are recognized correctly.

Reverting a user message now restores the prompt text with an opt-in focus flag, so the prompt textarea focuses and places the cursor at the end without changing other restore flows.

## Screenshots / Video

N/A. Behavior-only webview interaction change; no layout or visual design changes.

| before | after |
|---|---|
| N/A | N/A |

## How to Test

### Manual/local verification

- Human verified that file/folder mentions remain active after submitting a user message.
- Human verified that reverting a sent user message restores active mentions into the prompt.
- Human verified that Backspace removes a restored final mention atomically.
- Human verified that the prompt textarea receives focus immediately after revert.

### Reviewer test steps

1. In the VS Code extension chat, type a message containing a file or folder mention, for example `Hi to @packages/kilo-docs/.kilocode/`.
2. Send the message.
3. Confirm the mention remains highlighted/clickable in the submitted user message.
4. Revert the user message.
5. Confirm the prompt textarea is focused and the restored mention is active.
6. Place the cursor directly after the final character of the mention and press Backspace.
7. Confirm the entire mention is removed atomically instead of deleting one character at a time.

### Blocked checks and substitute verification

- No blocked checks.

Agent-executed verification:
- `bun test tests/unit/file-mention-utils.test.ts tests/unit/use-file-mention.test.ts`
- `bun run check-types:webview`
- `bun run lint`

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.