### PR TITLE
feat: add OrcaRouter provider

### DIFF
--- a/.changeset/orcarouter-provider.md
+++ b/.changeset/orcarouter-provider.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add OrcaRouter as an OpenAI-compatible provider. Set `ORCAROUTER_API_KEY` to route requests through OrcaRouter; requests then carry Kilo Code attribution headers.

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -155,6 +155,17 @@ export function kiloCustomLoaders(dep: CustomDep): Record<string, CustomLoader> 
         autoload: false,
         options: { headers: DEFAULT_HEADERS },
       }),
+
+    // OrcaRouter is an OpenAI-compatible meta-router (catalog + api come from
+    // models.dev). Like the other meta-routers (openrouter, vercel, zenmux), it
+    // only needs Kilo attribution headers so OrcaRouter can attribute traffic to
+    // Kilo Code. autoload:false defers activation until the user provides
+    // ORCAROUTER_API_KEY (env detection is handled by the framework).
+    orcarouter: () =>
+      Effect.succeed({
+        autoload: false,
+        options: { headers: DEFAULT_HEADERS },
+      }),
   }
 }
 

--- a/packages/opencode/test/kilocode/orcarouter-headers.test.ts
+++ b/packages/opencode/test/kilocode/orcarouter-headers.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Env } from "../../src/env"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID } from "../../src/provider/schema"
+import { DEFAULT_HEADERS } from "../../src/kilocode/const"
+
+const it = testEffect(Layer.mergeAll(Provider.defaultLayer, Env.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+function withOrcaRouterKey<A, E, R>(self: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const env = yield* Env.Service
+    yield* env.set("ORCAROUTER_API_KEY", "test-api-key")
+    yield* Effect.addFinalizer(() => env.remove("ORCAROUTER_API_KEY"))
+    return yield* self
+  })
+}
+
+it.live("orcarouter provider includes Kilo Code attribution headers", () =>
+  provideTmpdirInstance(() =>
+    withOrcaRouterKey(
+      Provider.Service.use((provider) =>
+        Effect.gen(function* () {
+          const providers = yield* provider.list()
+          const headers = providers[ProviderID.make("orcarouter")].options.headers
+
+          expect(headers["HTTP-Referer"]).toBe(DEFAULT_HEADERS["HTTP-Referer"])
+          expect(headers["X-Title"]).toBe(DEFAULT_HEADERS["X-Title"])
+        }),
+      ),
+    ),
+  ),
+)
+
+it.live("orcarouter attribution headers can be overridden from config", () =>
+  provideTmpdirInstance((dir) =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://app.kilo.ai/config.json",
+            provider: {
+              orcarouter: {
+                options: {
+                  headers: {
+                    "X-Title": "Custom Title",
+                  },
+                },
+              },
+            },
+          }),
+        ),
+      )
+
+      return yield* withOrcaRouterKey(
+        Provider.Service.use((provider) =>
+          Effect.gen(function* () {
+            const providers = yield* provider.list()
+            const headers = providers[ProviderID.make("orcarouter")].options.headers
+
+            expect(headers["HTTP-Referer"]).toBe(DEFAULT_HEADERS["HTTP-Referer"])
+            expect(headers["X-Title"]).toBe("Custom Title")
+          }),
+        ),
+      )
+    }),
+  ),
+)

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -28920,6 +28920,71 @@
       }
     }
   },
+  "orcarouter": {
+    "id": "orcarouter",
+    "env": ["ORCAROUTER_API_KEY"],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.orcarouter.ai/v1",
+    "name": "OrcaRouter",
+    "doc": "https://docs.orcarouter.ai",
+    "models": {
+      "orcarouter/auto": {
+        "id": "orcarouter/auto",
+        "name": "OrcaRouter Auto",
+        "family": "auto",
+        "attachment": true,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2025-01-01",
+        "last_updated": "2026-05-14",
+        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "open_weights": false,
+        "cost": { "input": 0, "output": 0 },
+        "limit": { "context": 128000, "output": 16384 },
+        "provider": { "npm": "@ai-sdk/openai-compatible", "api": "https://api.orcarouter.ai/v1" }
+      },
+      "openai/gpt-5.5": {
+        "id": "openai/gpt-5.5",
+        "name": "GPT-5.5",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2025-12-01",
+        "release_date": "2026-04-23",
+        "last_updated": "2026-04-23",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "context_over_200k": { "input": 10, "output": 45, "cache_read": 1 }
+        },
+        "limit": { "context": 1050000, "input": 922000, "output": 128000 },
+        "provider": { "npm": "@ai-sdk/openai-compatible", "api": "https://api.orcarouter.ai/v1" }
+      },
+      "anthropic/claude-opus-4.7": {
+        "id": "anthropic/claude-opus-4.7",
+        "name": "Claude Opus 4.7",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 },
+        "limit": { "context": 1000000, "output": 128000 },
+        "provider": { "npm": "@ai-sdk/openai-compatible", "api": "https://api.orcarouter.ai/v1" }
+      }
+    }
+  },
   "openrouter": {
     "id": "openrouter",
     "env": ["OPENROUTER_API_KEY"],


### PR DESCRIPTION
## Issue

Fixes #10989

## Context

Adds OrcaRouter as a selectable provider. OrcaRouter (https://www.orcarouter.ai) is an
OpenAI-compatible meta-router that routes a single API key across 80+ upstream models
(OpenAI, Anthropic, Google, DeepSeek, xAI, Qwen, etc.) and exposes an adaptive `orcarouter/auto`
router.

OrcaRouter's catalog and API base already ship in the models.dev catalog this repo consumes
(provider id `orcarouter`, `api: https://api.orcarouter.ai/v1`, env `ORCAROUTER_API_KEY`), so this
PR does **not** embed any model definitions. The only client-side wiring needed is attribution
headers — the same treatment the other OpenAI-compatible meta-routers (openrouter, vercel,
zenmux, nvidia) already get.

Disclosure: I'm an engineer on the OrcaRouter team.

## Implementation

OrcaRouter is registered as a custom loader in `kiloCustomLoaders` (the Kilo-owned provider
module), mirroring the existing `opencode`/`openrouter`/`zenmux` entries:

- `autoload: false` — the provider activates once the user supplies `ORCAROUTER_API_KEY`
  (or auth). Provider id, env var, and base URL all come from the models.dev catalog entry;
  no catalog is embedded in this repo.
- It injects `DEFAULT_HEADERS` (`HTTP-Referer` / `X-Title` / `User-Agent`) so OrcaRouter can
  attribute traffic to Kilo Code. User-configured headers still take precedence via the normal
  provider-options merge.

No changes to shared upstream opencode files were required (the loader lives in
`src/kilocode/provider/provider.ts`, an annotation-exempt path).

**Scope note (pre-existing, not addressed here):** as with the other meta-routers, attribution
headers are injected on the env/auth activation path. Configuring a provider purely via
`opencode.json` `provider.<id>.options.apiKey` without the env var does not inject the default
headers, because the custom-loader pass runs before the config merge and `autoload: false`
providers are only merged once already loaded. This is existing cross-provider loader/config-merge
behavior (e.g. `nvidia` behaves identically) and is intentionally left out of this provider-addition
PR rather than changing provider-initialization semantics here.

## Screenshots / Video

N/A — no visual UI change (provider wiring only).

## How to Test

### Manual/local verification

- `ORCAROUTER_API_KEY=<key> bun dev` then `/models` lists OrcaRouter models (sourced live from
  models.dev); selecting one routes through `https://api.orcarouter.ai/v1` with the Kilo
  attribution headers.

### Reviewer test steps

1. From `packages/opencode/`: `bun test ./test/kilocode/orcarouter-headers.test.ts`
2. Confirm both cases pass: default attribution headers are present on env activation, and a
   config-supplied header overrides while `HTTP-Referer` is preserved.

### Blocked checks and substitute verification

- Full `bun turbo typecheck` includes `@kilocode/kilo-jetbrains`, which requires Java 21 (not
  available in my environment). Substitute: ran `bun run typecheck` scoped to `packages/opencode/`
  (the only package touched) — passes with no errors.

Evidence (all executed by the agent locally):
- `bun test ./test/kilocode/orcarouter-headers.test.ts` → 2 pass / 0 fail
- `bun test ./test/provider/models.test.ts ./test/provider/provider.test.ts ./test/kilocode/nvidia-headers.test.ts` → 80 pass / 0 fail (fixture change does not regress)
- `bun run typecheck` (packages/opencode) → no errors
- `bun run lint` → 0 errors
- `bun run script/check-opencode-annotations.ts` → pass

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

