### PR TITLE
Rename Mercury autocomplete model labels

### DIFF
--- a/.changeset/rename-mercury-autocomplete-labels.md
+++ b/.changeset/rename-mercury-autocomplete-labels.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Rename Mercury autocomplete model labels to distinguish FIM and Next Edit modes.

--- a/packages/kilo-gateway/src/autocomplete.ts
+++ b/packages/kilo-gateway/src/autocomplete.ts
@@ -39,7 +39,7 @@ const models: AutocompleteModelDef[] = [
   {
     id: "kilo/inception/mercury-edit-2",
     modelID: "inception/mercury-edit-2",
-    label: "Mercury Edit 2",
+    label: "Mercury Edit 2 (FIM)",
     providerID: "kilo",
     provider: "Kilo Gateway",
     requestModel: "inception/mercury-edit-2",
@@ -51,7 +51,7 @@ const models: AutocompleteModelDef[] = [
     // users who want multi-line next-edit predictions with the jump-to-edit UX.
     id: "kilo/inception/mercury-next-edit",
     modelID: "inception/mercury-next-edit",
-    label: "Mercury Next Edit",
+    label: "Mercury Edit 2 (Next Edit)",
     providerID: "kilo",
     provider: "Kilo Gateway",
     requestModel: "inception/mercury-edit-2",
@@ -71,7 +71,7 @@ const models: AutocompleteModelDef[] = [
   {
     id: "inception/mercury-edit-2",
     modelID: "mercury-edit-2",
-    label: "Mercury Edit 2",
+    label: "Mercury Edit 2 (FIM)",
     providerID: "inception",
     provider: "Inception",
     requestModel: "mercury-edit-2",
@@ -80,11 +80,11 @@ const models: AutocompleteModelDef[] = [
   },
   {
     // Same wire-level model as `mercury-edit-2`, but routed through the
-    // Mercury Next Edit endpoint instead of FIM. Picked by users who want
+    // Mercury Edit 2 (Next Edit) endpoint instead of FIM. Picked by users who want
     // multi-line next-edit predictions with the jump-to-edit UX.
     id: "inception/mercury-next-edit",
     modelID: "mercury-next-edit",
-    label: "Mercury Next Edit",
+    label: "Mercury Edit 2 (Next Edit)",
     providerID: "inception",
     provider: "Inception",
     requestModel: "mercury-edit-2",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -856,11 +856,11 @@
           ],
           "enumDescriptions": [
             "Codestral via Kilo Gateway",
-            "Mercury Edit 2 via Kilo Gateway",
-            "Mercury Next Edit (multi-line edit predictions with jump-to-edit UX) via Kilo Gateway",
+            "Mercury Edit 2 (FIM) via Kilo Gateway",
+            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
             "Codestral via your connected Mistral provider API key",
             "Mercury Edit 2 (FIM) via your connected Inception provider API key",
-            "Mercury Next Edit (multi-line edit predictions with jump-to-edit UX) via your connected Inception provider API key"
+            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key"
           ],
           "description": "Model to use for inline autocomplete suggestions. If unset, the recommended default is used."
         },


### PR DESCRIPTION
## Summary
- Rename Mercury autocomplete labels to distinguish FIM and Next Edit modes.
- Keep VS Code settings descriptions aligned with the selector labels.