### PR TITLE
fix(cli): restore automatic session titles

### DIFF
--- a/.changeset/calm-titles-return.md
+++ b/.changeset/calm-titles-return.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore automatic session titles for models that require reasoning without assuming a supported effort level.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -26,6 +26,10 @@ import CODE_SWITCH from "@/session/prompt/code-switch.txt"
 export namespace KiloSessionPrompt {
   const modes = ["ask", "plan", "architect"]
 
+  export function titleID(sessionID: SessionID) {
+    return `title-${sessionID}`
+  }
+
   function mode(name: string) {
     return name.toLowerCase()
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1272,10 +1272,8 @@ export function smallOptions(model: Provider.Model) {
     model.providerID === "llmgateway" ||
     model.api.npm === "@kilocode/kilo-gateway" // kilocode_change
   ) {
-    if (model.api.id.includes("google")) {
-      return { reasoning: { enabled: false } }
-    }
-    return { reasoningEffort: "minimal" }
+    if (!model.capabilities.reasoning) return {} // kilocode_change - omit unsupported reasoning options
+    return { reasoning: { enabled: true } } // kilocode_change - use the model's supported default effort
   }
 
   if (model.providerID === "venice") {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -224,7 +224,7 @@ export const layer = Layer.effect(
           small: true,
           tools: {},
           model: mdl,
-          sessionID: input.session.id,
+          sessionID: KiloSessionPrompt.titleID(input.session.id), // kilocode_change - isolate title requests from the agent task
           retries: 2,
           messages: [{ role: "user", content: "Generate a title for this conversation:\n" }, ...msgs],
         })

--- a/packages/opencode/test/kilocode/session-title-generation.test.ts
+++ b/packages/opencode/test/kilocode/session-title-generation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import type { Model } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { SessionID } from "@/session/schema"
+import { KiloSessionPrompt } from "@/kilocode/session/prompt"
+
+function model(id: string, reasoning = true): Model {
+  return {
+    id: ModelID.make(id),
+    providerID: ProviderID.make("kilo"),
+    api: {
+      id,
+      url: "https://api.kilo.ai/api/openrouter",
+      npm: "@kilocode/kilo-gateway",
+    },
+    name: id,
+    capabilities: {
+      temperature: true,
+      reasoning,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: true, image: true, video: true, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 1.5, output: 9, cache: { read: 0.15, write: 0.08333 } },
+    limit: { context: 1_048_576, output: 65_536 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-05-19",
+  }
+}
+
+describe("session title generation", () => {
+  test("uses an isolated task ID", () => {
+    expect(KiloSessionPrompt.titleID(SessionID.make("ses_test"))).toBe("title-ses_test")
+  })
+
+  test("uses the model default for reasoning-capable small models", () => {
+    expect(ProviderTransform.smallOptions(model("google/gemini-3.5-flash"))).toEqual({
+      reasoning: { enabled: true },
+    })
+    expect(ProviderTransform.smallOptions(model("anthropic/claude-haiku-4.5"))).toEqual({
+      reasoning: { enabled: true },
+    })
+  })
+
+  test("omits reasoning options for models without reasoning support", () => {
+    expect(ProviderTransform.smallOptions(model("google/gemini-2.0-flash", false))).toEqual({})
+  })
+})

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3752,7 +3752,7 @@ describe("ProviderTransform.variants", () => {
   // kilocode_change start
   describe("ProviderTransform.smallOptions", () => {
     describe("@kilocode/kilo-gateway", () => {
-      test("claude models return reasoningEffort minimal", () => {
+      test("claude models use their default reasoning effort", () => {
         const model = createMockModel({
           id: "kilo/anthropic/claude-sonnet-4",
           providerID: "kilo",
@@ -3763,10 +3763,10 @@ describe("ProviderTransform.variants", () => {
           },
         })
         const result = ProviderTransform.smallOptions(model)
-        expect(result).toEqual({ reasoningEffort: "minimal" })
+        expect(result).toEqual({ reasoning: { enabled: true } })
       })
 
-      test("non-claude models use reasoningEffort format", () => {
+      test("non-claude models use their default reasoning effort", () => {
         const model = createMockModel({
           id: "kilo/openai/gpt-4",
           providerID: "kilo",
@@ -3777,10 +3777,10 @@ describe("ProviderTransform.variants", () => {
           },
         })
         const result = ProviderTransform.smallOptions(model)
-        expect(result).toEqual({ reasoningEffort: "minimal" })
+        expect(result).toEqual({ reasoning: { enabled: true } })
       })
 
-      test("google models disable reasoning", () => {
+      test("google models use their default reasoning effort", () => {
         const model = createMockModel({
           id: "kilo/google/gemini-2.0-flash",
           providerID: "kilo",
@@ -3791,7 +3791,7 @@ describe("ProviderTransform.variants", () => {
           },
         })
         const result = ProviderTransform.smallOptions(model)
-        expect(result).toEqual({ reasoning: { enabled: false } })
+        expect(result).toEqual({ reasoning: { enabled: true } })
       })
     })
   })


### PR DESCRIPTION
Automatic session titles can silently remain as timestamp placeholders when the configured `small_model` requires reasoning. The title request currently disables reasoning for Google models, so a model such as `kilo/google/gemini-3.5-flash` rejects it with HTTP 400: `Reasoning is mandatory for this endpoint and cannot be disabled.`

The title request also reuses the main session ID as its Kilo Gateway task ID. An upstream merge reverted the dedicated title ID, allowing the title request and main agent request to collide when they run concurrently.

Reproduction:

1. Configure `small_model` as `kilo/google/gemini-3.5-flash`.
2. Start a new session and send the first prompt.
3. Observe that the timestamp placeholder remains instead of being replaced by a generated title.
4. Inspect the CLI log and find the title request failing with the reasoning-mandatory HTTP 400. The title and main model requests also use the same `x-kilo-task` value based on the session ID.

This restores a dedicated `title-<sessionID>` task identity for title generation. Small requests now use model capabilities instead of model-name checks: non-reasoning models receive no reasoning option, while reasoning-capable models enable the provider-supported default without assuming that `minimal`, `low`, or another effort level exists.