### PR TITLE
fix(ui): restore pointer cursors for clickable controls

### DIFF
--- a/.changeset/bright-pointer-controls.md
+++ b/.changeset/bright-pointer-controls.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+---
+
+Show a pointer cursor for clickable controls and links in Kilo webviews.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -280,6 +280,8 @@ jobs:
         if: steps.storybook-cache-vscode.outputs.cache-hit != 'true'
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096 # kilocode_change
 
       - name: Generate baselines and enforce webview accessibility checks # kilocode_change
         run: bun run test:visual:update

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -280,8 +280,10 @@ jobs:
         if: steps.storybook-cache-vscode.outputs.cache-hit != 'true'
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
+        # kilocode_change start
         env:
-          NODE_OPTIONS: --max-old-space-size=4096 # kilocode_change
+          NODE_OPTIONS: --max-old-space-size=4096
+        # kilocode_change end
 
       - name: Generate baselines and enforce webview accessibility checks # kilocode_change
         run: bun run test:visual:update
@@ -289,6 +291,7 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_WORKERS: "4"
+          NODE_OPTIONS: --max-old-space-size=4096 # kilocode_change
 
       - name: Remove stale baselines for deleted stories
         run: |

--- a/packages/kilo-ui/src/styles/globals.css
+++ b/packages/kilo-ui/src/styles/globals.css
@@ -37,6 +37,21 @@
   --radius-xl: 6px;
 }
 
+/* ===== Interactive cursors ===== */
+
+:where(
+  button:not(:disabled),
+  a[href],
+  summary,
+  [role="button"]:not([aria-disabled="true"]),
+  [role="link"]:not([aria-disabled="true"]),
+  [role="menuitem"]:not([aria-disabled="true"]),
+  [role="option"]:not([aria-disabled="true"]),
+  [role="tab"]:not([aria-disabled="true"])
+) {
+  cursor: pointer;
+}
+
 /* ===== Scrollbar styling ===== */
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
Clickable controls in the webviews can render with the default cursor, making buttons and links difficult to distinguish from non-interactive content. The upstream desktop UI removed pointer cursors in commit `89b703c387` and made the default explicit in `6ba7c54bab`; neither change came through a pull request. Kilo PR #6663 restored the cursor component by component, but native and ARIA controls remained dependent on individual styles and new gaps kept appearing, especially in Agent Manager.

Apply one low-specificity semantic cursor rule for enabled buttons, links, summaries, and common ARIA controls. Using `:where()` keeps specialized states authoritative, so disabled controls and drag targets retain their existing cursors while all Kilo webviews get consistent clickable feedback.