### PR TITLE
fix(cli): restore subagent isolation in session forks

### DIFF
--- a/.changeset/isolate-forked-subagents.md
+++ b/.changeset/isolate-forked-subagents.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep subagent sessions isolated when forking sessions through editor clients.

--- a/packages/opencode/src/kilocode/server/httpapi/session-fork.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/session-fork.ts
@@ -1,3 +1,4 @@
+import { remapChildren } from "@/kilocode/session/fork"
 import { SessionID } from "@/session/schema"
 import { ForkPayload } from "@/server/routes/instance/httpapi/groups/session"
 import { Effect, Schema } from "effect"
@@ -15,19 +16,24 @@ export namespace KiloSessionHttpApi {
     request: HttpServerRequest.HttpServerRequest
   }
 
-  export function forkRaw<A, E, R>(fork: (ctx: Input) => Effect.Effect<A, E, R>) {
+  export function forkRaw<A extends { id: SessionID }, E, R>(fork: (ctx: Input) => Effect.Effect<A, E, R>) {
     return Effect.fn("KiloSessionHttpApi.forkRaw")(function* (ctx: Raw) {
       const body = yield* Effect.orDie(ctx.request.text)
-      if (body.trim().length === 0) return yield* fork({ params: ctx.params, payload: {} })
+      const payload = yield* Effect.gen(function* () {
+        if (body.trim().length === 0) return {}
 
-      const json = yield* Effect.try({
-        try: () => JSON.parse(body) as unknown,
-        catch: () => new HttpApiError.BadRequest({}),
+        const json = yield* Effect.try({
+          try: () => JSON.parse(body) as unknown,
+          catch: () => new HttpApiError.BadRequest({}),
+        })
+        return yield* Schema.decodeUnknownEffect(ForkPayload)(json).pipe(
+          Effect.mapError(() => new HttpApiError.BadRequest({})),
+        )
       })
-      const payload = yield* Schema.decodeUnknownEffect(ForkPayload)(json).pipe(
-        Effect.mapError(() => new HttpApiError.BadRequest({})),
-      )
-      return yield* fork({ params: ctx.params, payload })
+      const session = yield* fork({ params: ctx.params, payload })
+      const remapped = new Map<string, SessionID>([[ctx.params.sessionID, session.id]])
+      yield* remapChildren(session.id, remapped).pipe(Effect.orDie)
+      return session
     })
   }
 }

--- a/packages/opencode/src/kilocode/session/fork.ts
+++ b/packages/opencode/src/kilocode/session/fork.ts
@@ -23,7 +23,10 @@ function childID(part: MessageV2.Part): string | undefined {
  * child session references, causing SSE events and permission prompts to bleed
  * across sessions.
  */
-export function remapChildren(sid: SessionID): Effect.Effect<void, Session.NotFound, Session.Service> {
+export function remapChildren(
+  sid: SessionID,
+  remapped = new Map<string, SessionID>(),
+): Effect.Effect<void, Session.NotFound, Session.Service> {
   return Effect.gen(function* () {
     const sessions = yield* Session.Service
     const msgs = yield* sessions.messages({ sessionID: sid })
@@ -36,14 +39,13 @@ export function remapChildren(sid: SessionID): Effect.Effect<void, Session.NotFo
     }
     if (refs.length === 0) return
 
-    const remapped = new Map<string, SessionID>()
     for (const ref of refs) {
       if (remapped.has(ref.child)) continue
       const exists = yield* sessions.get(SessionID.make(ref.child)).pipe(Effect.orElseSucceed(() => undefined))
       if (!exists) continue
       const forked = yield* sessions.fork({ sessionID: SessionID.make(ref.child) })
-      yield* remapChildren(forked.id)
       remapped.set(ref.child, forked.id)
+      yield* remapChildren(forked.id, remapped)
     }
 
     if (remapped.size === 0) return

--- a/packages/opencode/src/kilocode/session/index.ts
+++ b/packages/opencode/src/kilocode/session/index.ts
@@ -410,7 +410,8 @@ export const kiloSessionFork = fn(
       Effect.gen(function* () {
         const sessions = yield* Session.Service
         const session = yield* sessions.fork(input)
-        yield* KiloSession.remapChildren(session.id)
+        const remapped = new Map<string, SessionID>([[input.sessionID, session.id]])
+        yield* KiloSession.remapChildren(session.id, remapped)
         return session
       }),
     )

--- a/packages/opencode/test/kilocode/session-fork-remap.test.ts
+++ b/packages/opencode/test/kilocode/session-fork-remap.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { createKiloClient } from "@kilocode/sdk/v2/client"
 import { WithInstance } from "../../src/project/with-instance"
+import { Server } from "../../src/server/server"
 import { Session } from "../../src/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -121,12 +123,20 @@ describe("Session.fork child session remapping", () => {
             }),
           )
 
-          // Fork the parent session
-          const forked = await Session.fork({ sessionID: parent.id })
+          // Exercise the SDK and HTTP route used by Agent Manager.
+          const client = createKiloClient({
+            baseUrl: "http://localhost",
+            directory: tmp.path,
+            fetch: ((request: Request) => Server.Default().app.fetch(request)) as unknown as typeof fetch,
+          })
+          const { data: forked } = await client.session.fork(
+            { sessionID: parent.id, directory: tmp.path },
+            { throwOnError: true },
+          )
           expect(forked.id).not.toBe(parent.id)
 
           // Check that the forked session's task part references a DIFFERENT child session
-          const forkedMsgs = await sessions.messages({ sessionID: forked.id })
+          const forkedMsgs = await sessions.messages({ sessionID: SessionID.make(forked.id) })
           const parts = forkedMsgs.flatMap((m) => m.parts)
           const tools = parts.filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
 
@@ -229,6 +239,114 @@ describe("Session.fork child session remapping", () => {
           // Verify grandchild content was copied
           const gcMsgs = await sessions.messages({ sessionID: SessionID.make(forkedGrandchildID) })
           expect(gcMsgs).toHaveLength(1)
+        },
+      })
+    },
+    { timeout: 30000 },
+  )
+
+  test(
+    "self-referential task metadata remaps to the forked session",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const parent = await sessions.create({ title: "parent" })
+          const msg = await userMsg(parent.id)
+          await sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: msg,
+            sessionID: parent.id,
+            type: "text",
+            text: "self task",
+          } as MessageV2.TextPart)
+          const asst = await asstMsg(parent.id, msg)
+          await sessions.updatePart(
+            taskPart({
+              messageID: asst,
+              sessionID: parent.id,
+              childSessionID: parent.id,
+            }),
+          )
+
+          const forked = await Session.fork({ sessionID: parent.id })
+          const msgs = await sessions.messages({ sessionID: forked.id })
+          const tools = msgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+
+          expect(tools).toHaveLength(1)
+          const meta = (tools[0].state as unknown as { metadata: { sessionId: string } }).metadata
+          expect(meta.sessionId).toBe(forked.id)
+        },
+      })
+    },
+    { timeout: 30000 },
+  )
+
+  test(
+    "cyclic task metadata remaps each session once",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await WithInstance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const parent = await sessions.create({ title: "parent" })
+          const child = await sessions.create({ parentID: parent.id, title: "child" })
+
+          const parentMsg = await userMsg(parent.id)
+          await sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: parentMsg,
+            sessionID: parent.id,
+            type: "text",
+            text: "call child",
+          } as MessageV2.TextPart)
+          const parentAsst = await asstMsg(parent.id, parentMsg)
+          await sessions.updatePart(
+            taskPart({
+              messageID: parentAsst,
+              sessionID: parent.id,
+              childSessionID: child.id,
+            }),
+          )
+
+          const childMsg = await userMsg(child.id)
+          await sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: childMsg,
+            sessionID: child.id,
+            type: "text",
+            text: "call parent",
+          } as MessageV2.TextPart)
+          const childAsst = await asstMsg(child.id, childMsg)
+          await sessions.updatePart(
+            taskPart({
+              messageID: childAsst,
+              sessionID: child.id,
+              childSessionID: parent.id,
+            }),
+          )
+
+          const forked = await Session.fork({ sessionID: parent.id })
+          const msgs = await sessions.messages({ sessionID: forked.id })
+          const tools = msgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+          const id = (tools[0].state as unknown as { metadata: { sessionId: SessionID } }).metadata.sessionId
+
+          expect(id).not.toBe(child.id)
+          const copy = await sessions.get(SessionID.make(id))
+          expect(copy.id).toBe(id)
+
+          const childMsgs = await sessions.messages({ sessionID: copy.id })
+          const childTools = childMsgs
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "tool" && p.tool === "task") as MessageV2.ToolPart[]
+          const back = (childTools[0].state as unknown as { metadata: { sessionId: string } }).metadata.sessionId
+
+          expect(back).toBe(forked.id)
         },
       })
     },


### PR DESCRIPTION
Session forks can retain task-part references to the source session's subagent sessions. Continuing a copied task then runs the original child session, so activity, permission prompts, and state can leak between the source and fork. This affects every editor flow using the generated SDK fork endpoint, including the sidebar, Agent Manager LOCAL sessions, Agent Manager worktrees, and Continue in Worktree.

The isolation behavior originally introduced in #8956 regressed in two migrations:

- `daaa2e5911` introduced the Effect HttpApi lifecycle handler and called the raw `Session.Service.fork()` operation directly. That bypassed the Kilo wrapper responsible for cloning and remapping task child sessions.
- `e4c9b4363e` converted the remapper to Effect services but lost the graph-wide source-to-copy map, its root seed, and the cyclic-session regression coverage. Self-references and cycles were no longer safely remapped.

This restores isolation at the shared server boundary used by editor clients. The HTTP fork wrapper now remaps task child-session references after creating the root fork, while direct CLI forks retain the same behavior. A single graph-wide map is seeded with the source and copied roots, reused through recursive child forks, and used to rewrite task metadata. This makes each referenced subagent independent, deduplicates repeated references, and terminates self-referential or cyclic graphs.

Regression coverage now exercises the generated SDK against the real HTTP route used by Agent Manager, and restores nested, self-referential, and cyclic session graph cases. A patch changeset records the restored user-facing behavior.