### PR TITLE
fix(cli): discover project skills in worktree sessions

### DIFF
--- a/.changeset/fix-worktree-project-skills.md
+++ b/.changeset/fix-worktree-project-skills.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Discover project-installed skills in Agent Manager worktree sessions.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -765,7 +765,7 @@ export const layer = Layer.effect(
         if (!Flag.KILO_DISABLE_PROJECT_CONFIG) {
           // kilocode_change start - also discover kilo.json project files
           for (const name of ["kilo", "opencode"] as const) {
-            for (const file of yield* ConfigPaths.files(name, ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
+            for (const file of yield* ConfigPaths.files(name, ctx.directory, ctx.project.worktree).pipe(Effect.orDie)) {
               yield* merge(
                 file,
                 yield* loadFile(file).pipe(
@@ -785,7 +785,7 @@ export const layer = Layer.effect(
         result.mode = result.mode || {}
         result.plugin = result.plugin || []
 
-        const directories = yield* ConfigPaths.directories(ctx.directory, ctx.worktree)
+        const directories = yield* ConfigPaths.directories(ctx.directory, ctx.project.worktree) // kilocode_change
 
         if (Flag.KILO_CONFIG_DIR) {
           log.debug("loading config from KILO_CONFIG_DIR", { path: Flag.KILO_CONFIG_DIR })

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -250,7 +250,7 @@ export const layer = Layer.effect(
     const global = yield* Global.Service
     const discovered = yield* InstanceState.make(
       Effect.fn("Skill.discovery")(function* (ctx) {
-        return yield* discoverSkills(config, discovery, fsys, global, ctx.directory, ctx.worktree)
+        return yield* discoverSkills(config, discovery, fsys, global, ctx.directory, ctx.project.worktree) // kilocode_change
       }),
     )
     const state = yield* InstanceState.make(

--- a/packages/opencode/test/kilocode/worktree-project-skills.test.ts
+++ b/packages/opencode/test/kilocode/worktree-project-skills.test.ts
@@ -1,0 +1,49 @@
+import { $ } from "bun"
+import { afterEach, describe, expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import path from "path"
+import { Skill } from "../../src/skill"
+import { disposeAllInstances, provideInstance, tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+afterEach(() => disposeAllInstances())
+
+describe("worktree project skills", () => {
+  it.live("discovers skills installed in the main repository", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir({ git: true })),
+      (tmp) =>
+        Effect.gen(function* () {
+          const dir = path.join(tmp.path, ".kilo", "worktrees", "feature")
+          yield* Effect.promise(() => $`git worktree add -b worktree-project-skills ${dir}`.cwd(tmp.path).quiet())
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(tmp.path, ".kilo", "skills", "project-skill", "SKILL.md"),
+              `---
+name: project-skill
+description: A skill installed in the main repository.
+---
+
+# Project Skill
+`,
+            ),
+          )
+
+          const list = yield* provideInstance(dir)(
+            Effect.gen(function* () {
+              const skill = yield* Skill.Service
+              return yield* skill.all()
+            }),
+          )
+
+          expect(list.find((item) => item.name === "project-skill")?.location).toBe(
+            path.join(tmp.path, ".kilo", "skills", "project-skill", "SKILL.md"),
+          )
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+})


### PR DESCRIPTION
Agent Manager worktree sessions use the linked worktree checkout as their backend request directory. Project configuration discovery also used that checkout as its upward traversal boundary, so it stopped before reaching the main repository's `.kilo` directory. As a result, worktree sessions could see global skills but not project-installed skills available in normal sidebar chat.

Use the Git project's shared repository root as the discovery boundary for project config directories and skills, while keeping the linked checkout as the active session and Git-operation directory. This restores project skill discovery without allowing worktree sessions to edit or execute against the main checkout.

This addresses the [Discord report](https://discord.com/channels/1349288496988160052/1458112753687593096/1511098815610884127). It is separate from #10806, which hardened concurrent Marketplace installation and missing workspace handling but did not change backend discovery from linked worktree directories. No matching GitHub issue was found.