### PR TITLE
fix(cli): refresh connected provider models

### DIFF
--- a/.changeset/fresh-provider-models.md
+++ b/.changeset/fresh-provider-models.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Refresh connected provider model lists when the models catalog updates.

--- a/packages/core/src/kilocode/models-refresh.ts
+++ b/packages/core/src/kilocode/models-refresh.ts
@@ -1,0 +1,15 @@
+import { Effect } from "effect"
+
+type Listener = () => Effect.Effect<void>
+
+const listeners = new Set<Listener>()
+
+export const notify = Effect.fn("ModelsRefresh.notify")(function* () {
+  yield* Effect.forEach([...listeners], (listener) => Effect.exit(listener()), { discard: true })
+})
+
+export const watch = (listener: Listener) =>
+  Effect.gen(function* () {
+    listeners.add(listener)
+    yield* Effect.addFinalizer(() => Effect.sync(() => listeners.delete(listener)))
+  })

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -7,6 +7,7 @@ import { Flock } from "./util/flock"
 import { Hash } from "./util/hash"
 import { AppFileSystem } from "./filesystem"
 import { InstallationChannel, InstallationVersion } from "./installation/version"
+import * as ModelsRefresh from "./kilocode/models-refresh" // kilocode_change
 
 export const CatalogModelStatus = Schema.Literals(["alpha", "beta", "deprecated"])
 export type CatalogModelStatus = typeof CatalogModelStatus.Type
@@ -206,6 +207,7 @@ export const layer: Layer.Layer<Service, never, Requirements> = Layer.effect(
           if (!force && (yield* fresh())) return
           yield* fetchAndWrite()
           yield* invalidate
+          yield* ModelsRefresh.notify() // kilocode_change
         }),
       ).pipe(
         Effect.tapCause((cause) =>

--- a/packages/opencode/src/kilocode/provider/models-refresh.ts
+++ b/packages/opencode/src/kilocode/provider/models-refresh.ts
@@ -1,0 +1,6 @@
+import { ScopedCache } from "effect"
+import * as Refresh from "@opencode-ai/core/kilocode/models-refresh"
+import type { InstanceState } from "@/effect/instance-state"
+
+export const watch = <A, E, R>(state: InstanceState<A, E, R>) =>
+  Refresh.watch(() => ScopedCache.invalidateAll(state.cache))

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -39,6 +39,7 @@ import {
   buildTimeoutSignal,
   REQUEST_TIMEOUT_MS,
 } from "@/kilocode/provider/provider"
+import * as ModelsRefresh from "@/kilocode/provider/models-refresh"
 // kilocode_change end
 
 const log = Log.create({ service: "provider" })
@@ -1554,6 +1555,7 @@ export const layer = Layer.effect(
         }
       }),
     )
+    yield* ModelsRefresh.watch(state) // kilocode_change
 
     const list = Effect.fn("Provider.list")(() => InstanceState.use(state, (s) => s.providers))
 

--- a/packages/opencode/test/kilocode/provider-model-refresh.test.ts
+++ b/packages/opencode/test/kilocode/provider-model-refresh.test.ts
@@ -1,0 +1,107 @@
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { mkdir, rm, utimes, writeFile } from "fs/promises"
+import path from "path"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Global } from "@opencode-ai/core/global"
+import { Hash } from "@opencode-ai/core/util/hash"
+import { ModelsDev } from "../../src/provider/models"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID } from "../../src/provider/schema"
+import { it } from "../lib/effect"
+
+const model = (id: string, name: string): ModelsDev.Model => ({
+  id,
+  name,
+  release_date: "2026-06-01",
+  attachment: false,
+  reasoning: false,
+  temperature: true,
+  tool_call: true,
+  limit: { context: 128000, output: 8192 },
+})
+
+const initial: Record<string, ModelsDev.Provider> = {
+  acme: {
+    id: "acme",
+    name: "Acme",
+    env: ["ACME_API_KEY"],
+    npm: "@ai-sdk/openai-compatible",
+    api: "https://api.acme.test/v1",
+    models: {
+      "acme-1": model("acme-1", "Acme One"),
+    },
+  },
+}
+
+const refreshed: Record<string, ModelsDev.Provider> = {
+  acme: {
+    ...initial.acme,
+    models: {
+      ...initial.acme.models,
+      "acme-2": model("acme-2", "Acme Two"),
+    },
+  },
+}
+
+it.instance(
+  "connected providers use refreshed models without instance disposal",
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.serve({
+          port: 0,
+          fetch(request) {
+            if (new URL(request.url).pathname !== "/api.json") return new Response("not found", { status: 404 })
+            return Response.json(refreshed)
+          },
+        }),
+      ),
+      (server) => Effect.sync(() => server.stop(true)),
+    )
+    const source = `http://127.0.0.1:${server.port}`
+    const file = path.join(Global.Path.cache, `models-${Hash.fast(source)}.json`)
+    const flags = {
+      source: Flag.KILO_MODELS_URL,
+      path: Flag.KILO_MODELS_PATH,
+      disabled: Flag.KILO_DISABLE_MODELS_FETCH,
+      key: process.env.ACME_API_KEY,
+    }
+
+    yield* Effect.acquireUseRelease(
+      Effect.promise(async () => {
+        Flag.KILO_MODELS_URL = source
+        Flag.KILO_MODELS_PATH = undefined
+        Flag.KILO_DISABLE_MODELS_FETCH = true
+        process.env.ACME_API_KEY = "test-key"
+        await mkdir(Global.Path.cache, { recursive: true })
+        await writeFile(file, JSON.stringify(initial))
+        const stale = new Date(Date.now() - 10 * 60 * 1000)
+        await utimes(file, stale, stale)
+      }),
+      () =>
+        Effect.gen(function* () {
+          const models = yield* ModelsDev.Service
+          const provider = yield* Provider.Service
+          const before = yield* provider.list()
+          expect(before[ProviderID.make("acme")]?.models["acme-1"]).toBeDefined()
+          expect(before[ProviderID.make("acme")]?.models["acme-2"]).toBeUndefined()
+
+          yield* models.refresh()
+
+          const after = yield* provider.list()
+          expect(after[ProviderID.make("acme")]?.models["acme-2"]).toBeDefined()
+        }).pipe(Effect.provide(Layer.merge(ModelsDev.defaultLayer, Provider.defaultLayer))),
+      () =>
+        Effect.promise(async () => {
+          Flag.KILO_MODELS_URL = flags.source
+          Flag.KILO_MODELS_PATH = flags.path
+          Flag.KILO_DISABLE_MODELS_FETCH = flags.disabled
+          if (flags.key === undefined) delete process.env.ACME_API_KEY
+          else process.env.ACME_API_KEY = flags.key
+          await rm(file, { force: true })
+        }),
+    )
+  }),
+  { config: { disabled_providers: ["kilo", "apertis"] } },
+)


### PR DESCRIPTION
Connected providers retain a directory-scoped provider snapshot after the models catalog updates, so newly available models remain hidden until the provider or process is reset.

Invalidate connected provider snapshots after a successful catalog refresh. The next provider lookup rebuilds the snapshot from the updated catalog while preserving the existing lazy initialization behavior. A regression test exercises the full catalog fetch and connected-provider lifecycle without requiring provider removal or process restart.

Closes #10882