### PR TITLE
revert(cli): re-enable session export

### DIFF
--- a/.changeset/restore-session-export.md
+++ b/.changeset/restore-session-export.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Re-enable free-model session and Git workspace data export.

--- a/packages/opencode/src/kilocode/bootstrap.ts
+++ b/packages/opencode/src/kilocode/bootstrap.ts
@@ -29,7 +29,6 @@ export namespace KilocodeBootstrap {
         yield* sessions.init()
         // kilocode_change start - session export bootstrap
         yield* Effect.gen(function* () {
-          if (!SessionExport.enabled) return
           const anon = yield* EffectBridge.fromPromise(() =>
             Identity.getMachineId().catch((err) => {
               log.warn("session export identity failed", { err })

--- a/packages/opencode/src/kilocode/session-export/session-export.ts
+++ b/packages/opencode/src/kilocode/session-export/session-export.ts
@@ -32,8 +32,6 @@ const instances = new Map<string, Instance>()
 
 const maxRespawns = 3
 
-export const enabled = false
-
 export const init = (opts: {
   agentVersion: string
   dbPath: string

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -392,8 +392,7 @@ const live: Layer.Layer<
       const opencodeProjectID = input.model.providerID.startsWith("opencode") ? instance.project.id : undefined
 
       // kilocode_change start - capture eligible session export request start
-      const exporting = SessionExport.enabled
-      const org = yield* exporting && isKilo && input.model.isFree === true
+      const org = yield* isKilo && input.model.isFree === true
         ? Effect.promise(() => getActiveOrg())
         : Effect.succeed({ type: "unknown" as const })
       const started = Date.now()
@@ -401,7 +400,7 @@ const live: Layer.Layer<
       const found = KiloSession.resolveRoot(input.sessionID)
       const root = parent ? (found === input.sessionID ? parent : found) : input.sessionID
       const exportable =
-        exporting && isKilo && input.model.isFree === true && org.type === "personal" && input.agent.name !== "title"
+        isKilo && input.model.isFree === true && org.type === "personal" && input.agent.name !== "title"
       if (exportable) {
         SessionExport.beforeRequest({
           input: { model: input.model, org },


### PR DESCRIPTION
## Summary

- Revert #10924 now that the temporary session-export shutdown can be lifted.
- Restore free-model session and Git workspace export startup and request capture.
- Add a new patch changeset because the reverted PR's original changeset has already been released.