### PR TITLE
ci: raise VS Code Storybook heap limit

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -211,6 +211,10 @@ jobs:
     name: Visual Regression (kilo-vscode webview)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
+    # kilocode_change start
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+    # kilocode_change end
 
     steps:
       - name: Checkout (internal)
@@ -280,8 +284,6 @@ jobs:
         if: steps.storybook-cache-vscode.outputs.cache-hit != 'true'
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
-        env:
-          NODE_OPTIONS: --max-old-space-size=4096 # kilocode_change
 
       - name: Generate baselines and enforce webview accessibility checks # kilocode_change
         run: bun run test:visual:update

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -280,6 +280,8 @@ jobs:
         if: steps.storybook-cache-vscode.outputs.cache-hit != 'true'
         run: bun run build-storybook
         working-directory: packages/kilo-vscode
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096 # kilocode_change
 
       - name: Generate baselines and enforce webview accessibility checks # kilocode_change
         run: bun run test:visual:update


### PR DESCRIPTION
## Summary
Raise the Node heap limit to 4 GB for the VS Code webview visual-regression job.

The workflow consistently reached the end of Vite's 5,799-module transform and then aborted at Node's default ~2 GB heap limit before screenshot comparison. The first CI experiment scoped the override only to `Build Storybook`: that step passed, then Playwright's independently started Storybook web server hit the same heap limit. The job-level override covers both Storybook processes while remaining isolated from the separate kilo-ui job.

This same failure occurred twice on #10879 and on an unrelated VS Code PR, so it is not caused by a particular visual change.

## Validation
- Workflow allowlist check passes.
- Shared-file annotation check passes.
- Visual Regression (kilo-vscode webview) passes end to end: https://github.com/Kilo-Org/kilocode/actions/runs/27150186977/job/80138844193
- Visual Regression (kilo-ui) remains unaffected and passes: https://github.com/Kilo-Org/kilocode/actions/runs/27150186977/job/80138844242