### PR TITLE
fix(kilo-docs): accept HTTP 202 links

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -10,6 +10,7 @@ exclude_path = ["node_modules"]
 
 accept = [
   "200",
+  "202",
   "403",
   "429",
   "301",

--- a/packages/kilo-docs/pages/ai-providers/deepseek.md
+++ b/packages/kilo-docs/pages/ai-providers/deepseek.md
@@ -8,11 +8,11 @@ sidebar_label: DeepSeek
 
 Kilo Code supports accessing models through the DeepSeek API, including `deepseek-chat` and `deepseek-reasoner`.
 
-**Website:** [DeepSeek API documentation](https://api-docs.deepseek.com/)
+**Website:** [https://platform.deepseek.com/](https://platform.deepseek.com/)
 
 ## Getting an API Key
 
-1.  **Sign Up/Sign In:** Go to the [DeepSeek API keys page](https://platform.deepseek.com/api_keys). Create an account or sign in.
+1.  **Sign Up/Sign In:** Go to the [DeepSeek Platform](https://platform.deepseek.com/). Create an account or sign in.
 2.  **Navigate to API Keys:** Find your API keys in the [API keys](https://platform.deepseek.com/api_keys) section of the platform.
 3.  **Create a Key:** Click "Create new API key". Give your key a descriptive name (e.g., "Kilo Code").
 4.  **Copy the Key:** **Important:** Copy the API key _immediately_. You will not be able to see it again. Store it securely.


### PR DESCRIPTION
## Summary

Accept HTTP 202 responses in the docs link checker. DeepSeek's platform endpoints now return `202 Accepted` to GitHub Actions runners despite remaining valid user-facing links, which caused the `Check Links` workflow to fail.

## Problem

Some valid links were returning HTTP 202 response codes on occasion instead of HTTP 200. These are in general valid links and do work, for example:

Errors in pages/ai-providers/deepseek.md

    [202] https://platform.deepseek.com/ | Rejected status code: 202 Accepted (configurable with "accept" option)
    [202] https://platform.deepseek.com/api_keys | Rejected status code: 202 Accepted (configurable with "accept" option)

This was causing false positives. We should just accept 202's since they are valid HTTP response codes that indicate "success": https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/202
