### PR TITLE
fix(kilo-docs): use stable DeepSeek links

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/deepseek.md
+++ b/packages/kilo-docs/pages/ai-providers/deepseek.md
@@ -8,11 +8,11 @@ sidebar_label: DeepSeek
 
 Kilo Code supports accessing models through the DeepSeek API, including `deepseek-chat` and `deepseek-reasoner`.
 
-**Website:** [https://platform.deepseek.com/](https://platform.deepseek.com/)
+**Website:** [DeepSeek API documentation](https://api-docs.deepseek.com/)
 
 ## Getting an API Key
 
-1.  **Sign Up/Sign In:** Go to the [DeepSeek Platform](https://platform.deepseek.com/). Create an account or sign in.
+1.  **Sign Up/Sign In:** Go to the [DeepSeek API keys page](https://platform.deepseek.com/api_keys). Create an account or sign in.
 2.  **Navigate to API Keys:** Find your API keys in the [API keys](https://platform.deepseek.com/api_keys) section of the platform.
 3.  **Create a Key:** Click "Create new API key". Give your key a descriptive name (e.g., "Kilo Code").
 4.  **Copy the Key:** **Important:** Copy the API key _immediately_. You will not be able to see it again. Store it securely.


### PR DESCRIPTION
DeepSeek's platform root returns HTTP 202 to the documentation link checker, causing the Check Links workflow to fail even though the site remains available.

Use the stable API documentation as the provider website and send setup readers directly to the API keys page. This fixes the specific failing URL without broadening accepted status codes for every documentation link, as proposed in #11016.