### PR TITLE
fix(cli): recover from empty provider streams

### DIFF
--- a/.changeset/retry-empty-streams.md
+++ b/.changeset/retry-empty-streams.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Recover from empty provider streams and surface partial stream failures instead of silently ending the agent turn.

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -25,6 +25,8 @@ export namespace KiloSessionProcessor {
     "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
   export const PROVIDER_FINISH_ERROR_MESSAGE =
     "The provider ended the response with an error before returning details. Start a new message to retry; Kilo will compact the oversized conversation first if needed."
+  export const EMPTY_PROVIDER_RESPONSE_MESSAGE = "The provider stream ended before returning any output."
+  export const INCOMPLETE_PROVIDER_RESPONSE_MESSAGE = "The provider stream ended before returning completion details."
 
   export function reviewTelemetry(command: string | undefined): ReviewTelemetry | undefined {
     if (!isReviewCommand(command)) return
@@ -207,6 +209,20 @@ export namespace KiloSessionProcessor {
     }
     log.warn("length stop", { messageID: input.msg.id })
     return OUTPUT_LENGTH_WARNING
+  }
+
+  export function incompleteResponseError(input: {
+    finish: string
+    output: number
+    step: { reasoning: boolean; text: boolean; tool: boolean }
+  }) {
+    if (input.finish !== "other" || input.output !== 0) return
+    const partial = input.step.reasoning || input.step.text || input.step.tool
+    log.warn("incomplete provider response", { partial, tool: input.step.tool })
+    return new MessageV2.APIError({
+      message: partial ? INCOMPLETE_PROVIDER_RESPONSE_MESSAGE : EMPTY_PROVIDER_RESPONSE_MESSAGE,
+      isRetryable: !partial,
+    })
   }
 
   export function providerFinishError(msg: MessageV2.Assistant) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -83,6 +83,7 @@ interface ProcessorContext extends Input {
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
   stepStart: number // kilocode_change
+  stepPart: PartID | undefined // kilocode_change
   step: { reasoning: boolean; text: boolean; tool: boolean } // kilocode_change
 }
 
@@ -143,17 +144,20 @@ export const layer: Layer.Layer<
         reasoningMap: {},
         telemetry: input.telemetry, // kilocode_change
         stepStart: 0, // kilocode_change
+        stepPart: undefined, // kilocode_change
         step: { reasoning: false, text: false, tool: false }, // kilocode_change
       }
       let aborted = false
       const ac = new AbortController() // kilocode_change — abort controller for offline handler
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
 
-      const parse = (e: unknown) =>
-        MessageV2.fromError(e, {
+      const parse = (e: unknown) => {
+        if (e instanceof MessageV2.APIError) return e.toObject() // kilocode_change
+        return MessageV2.fromError(e, {
           providerID: input.model.providerID,
           aborted,
         })
+      }
 
       const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {
         const done = ctx.toolcalls[toolCallID]?.done
@@ -529,13 +533,15 @@ export const layer: Layer.Layer<
                 timestamp: DateTime.makeUnsafe(Date.now()),
               })
             }
+            const id = PartID.ascending() // kilocode_change
             yield* session.updatePart({
-              id: PartID.ascending(),
+              id, // kilocode_change
               messageID: ctx.assistantMessage.id,
               sessionID: ctx.sessionID,
               snapshot: ctx.snapshot,
               type: "step-start",
             })
+            ctx.stepPart = id // kilocode_change
             return
 
           case "finish-step": {
@@ -562,6 +568,23 @@ export const layer: Layer.Layer<
               elapsed: Math.round(performance.now() - (ctx.stepStart || performance.now())),
               telemetry: ctx.telemetry,
             })
+            const err = KiloSessionProcessor.incompleteResponseError({
+              finish: value.finishReason,
+              output: usage.tokens.output,
+              step: ctx.step,
+            })
+            if (err) {
+              if (err.data.isRetryable && ctx.stepPart) {
+                yield* session.removePart({
+                  sessionID: ctx.sessionID,
+                  messageID: ctx.assistantMessage.id,
+                  partID: ctx.stepPart,
+                })
+              }
+              ctx.stepPart = undefined
+              return yield* Effect.fail(err)
+            }
+            ctx.stepPart = undefined
             // kilocode_change end
             if (!ctx.assistantMessage.summary) {
               // TODO(v2): Temporary dual-write while migrating session messages to v2 events.

--- a/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-empty-tool-calls.test.ts
@@ -264,6 +264,186 @@ describe("session processor empty tool-calls", () => {
     ),
   )
 
+  it.live("retries empty provider responses before ending the turn", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "other",
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "text-start", id: "text", providerMetadata: undefined } as LLM.Event,
+            { type: "text-delta", id: "text", text: "Recovered response", providerMetadata: undefined } as LLM.Event,
+            { type: "text-end", id: "text", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "stop",
+              usage: usage(),
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          const result = yield* handle.process(input)
+          expect(result).toBe("continue")
+          expect(handle.message.finish).toBe("stop")
+          expect(handle.message.error).toBeUndefined()
+          const parts = MessageV2.parts(msg.id)
+          expect(parts.some((part) => part.type === "text" && part.text === "Recovered response")).toBe(true)
+          expect(parts.filter((part) => part.type === "step-start")).toHaveLength(1)
+          expect(parts.some((part) => part.type === "step-finish" && part.reason === "other")).toBe(false)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("surfaces partial provider responses without retrying", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const test = yield* TestLLM
+          const processors = yield* SessionProcessor.Service
+          const session = yield* Session.Service
+
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "text-start", id: "text", providerMetadata: undefined } as LLM.Event,
+            { type: "text-delta", id: "text", text: "Partial response", providerMetadata: undefined } as LLM.Event,
+            { type: "text-end", id: "text", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "other",
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+          yield* test.reply(
+            { type: "start" },
+            { type: "start-step" } as LLM.Event,
+            { type: "text-start", id: "retry", providerMetadata: undefined } as LLM.Event,
+            { type: "text-delta", id: "retry", text: "Unexpected retry", providerMetadata: undefined } as LLM.Event,
+            { type: "text-end", id: "retry", providerMetadata: undefined } as LLM.Event,
+            {
+              type: "finish-step",
+              finishReason: "stop",
+              usage: usage(),
+              providerMetadata: undefined,
+            } as LLM.Event,
+            { type: "finish" } as LLM.Event,
+          )
+
+          const chat = yield* session.create({})
+          const parent = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: chat.id,
+            agent: "code",
+            model: ref,
+            time: { created: Date.now() },
+          })
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            sessionID: chat.id,
+            parentID: parent.id,
+            mode: "code",
+            agent: "code",
+            path: { cwd: path.resolve(dir), root: path.resolve(dir) },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ref.modelID,
+            providerID: ref.providerID,
+            time: { created: Date.now() },
+          }
+          yield* session.updateMessage(msg)
+
+          const mdl = model()
+          const handle = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: chat.id,
+            model: mdl,
+          })
+          const input: LLM.StreamInput = {
+            user: parent as MessageV2.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: { name: "code", mode: "primary", permission: [], options: {} } as any,
+            system: [],
+            messages: [],
+            tools: {},
+          }
+
+          const result = yield* handle.process(input)
+          expect(result).toBe("stop")
+          expect(handle.message.finish).toBeUndefined()
+          expect(handle.message.error?.name).toBe("APIError")
+          if (handle.message.error?.name !== "APIError") return
+          expect(handle.message.error.data.isRetryable).toBe(false)
+          expect(handle.message.error.data.message).toBe(KiloSessionProcessor.INCOMPLETE_PROVIDER_RESPONSE_MESSAGE)
+          const texts = MessageV2.parts(msg.id).filter((part): part is MessageV2.TextPart => part.type === "text")
+          expect(texts.map((part) => part.text)).toEqual(["Partial response"])
+        }),
+      { git: true },
+    ),
+  )
+
   it.effect("treats provider finish errors without details as retryable API errors", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
## Summary
- Retry provider streams that end without producing output instead of silently ending the agent turn.
- Surface partial stream failures without retrying and preserve the structured provider error.
- Remove failed-attempt step markers before retrying so recovered responses do not pollute future model context.