### PR TITLE
cli: skip automatic browser launch for kilo console on headless Linux

### DIFF
--- a/.changeset/fix-linux-display-detection.md
+++ b/.changeset/fix-linux-display-detection.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Skip automatic browser launch on Linux when no display is detected.

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -5,10 +5,7 @@ import { serverUrls } from "@/kilocode/cli/server-urls"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Daemon } from "@/kilocode/daemon/daemon"
 import { warnPort } from "@/kilocode/cli/port-warning"
-
-function publicUrl(state: Daemon.State) {
-  return new URL("/console", state.url).toString()
-}
+import { hasDisplay } from "@/kilocode/cli/cmd/tui/util/display"
 
 function browserUrl(state: Daemon.State) {
   const url = new URL("/console", state.url)
@@ -53,9 +50,13 @@ export const KiloConsoleCommand = cmd({
     const consoleLocal = `${urls.local}/console`
     const consoleNetwork = urls.network ? `${urls.network}/console` : undefined
 
-    await launch(browserUrl(state)).catch((err) => {
-      console.warn(`Could not open browser automatically: ${err instanceof Error ? err.message : String(err)}`)
-    })
+    if (hasDisplay()) {
+      await launch(browserUrl(state)).catch((err) => {
+        console.warn(`Could not open browser automatically: ${err instanceof Error ? err.message : String(err)}`)
+      })
+    } else {
+      console.warn("No display detected; open the Kilo Console URL manually")
+    }
     console.log("Kilo Console:")
     console.log(`  Local:   ${consoleLocal}`)
     if (consoleNetwork) console.log(`  Network: ${consoleNetwork}`)


### PR DESCRIPTION
## Issue

Closes #11025

## Context

On headless Linux machines, `kilo console` tries to open the default browser automatically, but `xdg-open` fails immediately when no X11/Wayland session is available. The user sees a confusing low-level warning like `Could not open browser automatically: Browser open failed with exit code 3`, even though the URL is still printed afterward. This change adds a headless check so the warning is replaced with a concise hint telling the user to open the URL manually and doesn't waste time waiting for the browser to launch, which it never does.

## Implementation

Added a small `hasDisplay()` helper in `packages/opencode/src/kilocode/cli/cmd/console.ts`. It returns `false` only when `process.platform === "linux"` and both `process.env.DISPLAY` and `process.env.WAYLAND_DISPLAY` are falsy. The `open()` call is now conditional inside the `KiloConsoleCommand` handler:

- If a display is detected, the original `launch(browserUrl(state))` flow runs unchanged.
- If no display is detected, the code skips `open()` and emits a one-line `console.warn`.
- The public `Kilo Console: <url>` log runs unconditionally in both paths.

## Screenshots / Video

| before | after |
|---|---|
| <img width="760" height="63" alt="image" src="https://github.com/user-attachments/assets/8f29ef29-b594-4d17-9c3c-bad32f994125" /> | <img width="768" height="81" alt="WindowsTerminal_xMWALaZHkO" src="https://github.com/user-attachments/assets/13f7634f-80c2-436c-9ac3-d21b231922df" /> |

## How to Test

### Manual/local verification

- SSH in, run `kilo console`, and confirm the concise headless hint appears instead of the generic `open` failure.
- Confirm the `Kilo Console: <url>` line is still printed.
- On a normal desktop Linux session, confirm `kilo console` still attempts to open the browser automatically.

### Reviewer test steps

Run headlessly:
1. Run `kilo console`.
2. Verify no `Browser open failed with exit code` warning appears.
3. Verify a concise “No display detected” warning is printed alongside the URL.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18 