### PR TITLE
test(cli): fix prompt queue message ID fixture

### DIFF
--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -609,7 +609,7 @@ describe("session prompt queue", () => {
     const result = await Effect.runPromise(
       KiloSessionPromptQueue.enqueue(
         sessionID,
-        MessageID.make("message_probe"),
+        MessageID.make("msg_probe"),
         Effect.succeed("work executed"),
         Effect.succeed("cancelled returned"),
       ),


### PR DESCRIPTION
The prompt queue memory-leak regression used a legacy `message_probe` fixture that no longer satisfies the branded `MessageID` schema. This makes the test fail deterministically on every retry and blocks both Linux and Windows CI.

Use the current `msg` prefix so the regression reaches the queue behavior it is intended to verify while retaining coverage for cancellation state cleanup.