### PR TITLE
feat(gateway): default autocomplete to Mercury Next Edit

### DIFF
--- a/.changeset/default-mercury-next-edit.md
+++ b/.changeset/default-mercury-next-edit.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": patch
+---
+
+Use Mercury Edit 2 Next Edit as the default autocomplete model.

--- a/packages/kilo-gateway/src/autocomplete.ts
+++ b/packages/kilo-gateway/src/autocomplete.ts
@@ -97,7 +97,7 @@ const models: AutocompleteModelDef[] = [
 export const AUTOCOMPLETE_MODELS: readonly AutocompleteModelDef[] = models
 
 export const DEFAULT_AUTOCOMPLETE_PROVIDER_ID: AutocompleteProviderID = "kilo"
-export const DEFAULT_AUTOCOMPLETE_MODEL_ID = "mistralai/codestral-2508"
+export const DEFAULT_AUTOCOMPLETE_MODEL_ID = "inception/mercury-next-edit"
 
 export const DEFAULT_AUTOCOMPLETE_MODEL: AutocompleteModelDef = (() => {
   const found = models.find(

--- a/packages/kilo-gateway/test/autocomplete.test.ts
+++ b/packages/kilo-gateway/test/autocomplete.test.ts
@@ -7,11 +7,14 @@ import {
 } from "../src/autocomplete"
 
 describe("DEFAULT_AUTOCOMPLETE_MODEL", () => {
-  test("resolves to an entry that exists in AUTOCOMPLETE_MODELS", () => {
+  test("resolves to Mercury Next Edit through Kilo Gateway", () => {
     const match = AUTOCOMPLETE_MODELS.find(
       (m) => m.providerID === DEFAULT_AUTOCOMPLETE_PROVIDER_ID && m.modelID === DEFAULT_AUTOCOMPLETE_MODEL_ID,
     )
+    expect(DEFAULT_AUTOCOMPLETE_PROVIDER_ID).toBe("kilo")
+    expect(DEFAULT_AUTOCOMPLETE_MODEL_ID).toBe("inception/mercury-next-edit")
     expect(match).toBeDefined()
     expect(DEFAULT_AUTOCOMPLETE_MODEL).toBe(match!)
+    expect(DEFAULT_AUTOCOMPLETE_MODEL.kind).toBe("edit")
   })
 })

--- a/packages/kilo-gateway/test/edit.test.ts
+++ b/packages/kilo-gateway/test/edit.test.ts
@@ -29,7 +29,14 @@ describe("Edit target resolution", () => {
       model: "mistralai/codestral-2508",
       url: "",
     })
-    expect(resolveEditTarget()).toMatchObject({ provider: "kilo", url: "" })
+  })
+
+  test("routes the default model to the gateway proxy", () => {
+    expect(resolveEditTarget()).toEqual({
+      provider: "kilo",
+      model: "inception/mercury-edit-2",
+      url: "https://api.kilo.ai/api/edit/completions",
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Change the Kilo Gateway autocomplete default from Codestral to Mercury Edit 2's Next Edit mode so new and fallback configurations use multi-line next-edit predictions and the jump-to-edit UX.