### PR TITLE
perf(vscode): coalesce task timeline performance optimization

### DIFF
--- a/.changeset/calm-timeline-follow.md
+++ b/.changeset/calm-timeline-follow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the Agent Manager task timeline in place while reviewing earlier activity, and resume following updates from the latest bar.

--- a/.changeset/calm-timeline-follow.md
+++ b/.changeset/calm-timeline-follow.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Keep the Agent Manager task timeline in place while reviewing earlier activity, and resume following updates from the latest bar.
+Keep task timelines in place while reviewing earlier activity across Kilo chat surfaces, and resume following updates from the latest bar.

--- a/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-sizes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { sizes, MAX_HEIGHT } from "../../webview-ui/src/utils/timeline/sizes"
+import { sizes, pinned, MAX_HEIGHT } from "../../webview-ui/src/utils/timeline/sizes"
 import type { Part, TextPart, ToolPart, StepFinishPart } from "../../webview-ui/src/types/messages"
 
 function mkText(text: string): TextPart {
@@ -88,5 +88,11 @@ describe("timeline sizes", () => {
     for (const bar of result) {
       expect(Number.isInteger(bar.height)).toBe(true)
     }
+  })
+
+  it("detects whether scrolling should follow new bars", () => {
+    expect(pinned({ scrollLeft: 100, scrollWidth: 200, clientWidth: 100 })).toBe(true)
+    expect(pinned({ scrollLeft: 88, scrollWidth: 200, clientWidth: 100 })).toBe(true)
+    expect(pinned({ scrollLeft: 87, scrollWidth: 200, clientWidth: 100 })).toBe(false)
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -73,7 +73,10 @@ export const TaskTimeline: Component = () => {
   const bars = createMemo(() => collect(messages(), allParts()))
   const busy = () => session.status() === "busy"
 
-  // Auto-scroll to the latest bar when new bars appear while preserving manual scroll position.
+  // Reading scrollWidth and writing scrollLeft synchronously for every appended bar can
+  // force repeated layout during streamed part updates. Batch those appends behind one
+  // animation frame, after Solid has applied the current DOM updates. Only follow while
+  // pinned so inspecting earlier activity is not interrupted by incoming bars.
   let prev = 0
   let frame: number | undefined
   let follow = true

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -16,7 +16,7 @@ import { Component, Index, Show, createMemo, createEffect, createSignal, on, onC
 import { Portal } from "solid-js/web"
 import { useSession } from "../../context/session"
 import { color, label } from "../../utils/timeline/colors"
-import { sizes, MAX_HEIGHT } from "../../utils/timeline/sizes"
+import { sizes, pinned, MAX_HEIGHT } from "../../utils/timeline/sizes"
 import type { Part, Message } from "../../types/messages"
 
 export interface TimelineBar {
@@ -73,19 +73,31 @@ export const TaskTimeline: Component = () => {
   const bars = createMemo(() => collect(messages(), allParts()))
   const busy = () => session.status() === "busy"
 
-  // Auto-scroll to the latest bar when new bars appear
+  // Auto-scroll to the latest bar when new bars appear while preserving manual scroll position.
   let prev = 0
+  let frame: number | undefined
+  let follow = true
+  const onScroll = () => {
+    if (ref) follow = pinned(ref)
+  }
   createEffect(
     on(
       () => bars().length,
       (len) => {
-        if (len > prev && ref) {
-          ref.scrollLeft = ref.scrollWidth
+        if (len > prev && ref && follow && frame === undefined) {
+          frame = requestAnimationFrame(() => {
+            frame = undefined
+            if (!ref || !follow) return
+            ref.scrollLeft = ref.scrollWidth
+          })
         }
         prev = len
       },
     ),
   )
+  onCleanup(() => {
+    if (frame !== undefined) cancelAnimationFrame(frame)
+  })
 
   const hideTip = () => {
     tipBar = undefined
@@ -161,6 +173,7 @@ export const TaskTimeline: Component = () => {
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
           onPointerLeave={hideTip}
+          onScroll={onScroll}
         >
           <Index each={bars()}>
             {(bar) => {

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
@@ -26,6 +26,7 @@ export interface TimelineScroll {
   clientWidth: number
 }
 
+/** Keep following updates when the viewport is within one bar of the right edge. */
 export function pinned(scroll: TimelineScroll, slack = BAR_W): boolean {
   return scroll.scrollWidth - scroll.clientWidth - scroll.scrollLeft <= slack
 }

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/sizes.ts
@@ -20,6 +20,16 @@ export interface BarSize {
   content: number
 }
 
+export interface TimelineScroll {
+  scrollLeft: number
+  scrollWidth: number
+  clientWidth: number
+}
+
+export function pinned(scroll: TimelineScroll, slack = BAR_W): boolean {
+  return scroll.scrollWidth - scroll.clientWidth - scroll.scrollLeft <= slack
+}
+
 // ── Content length ───────────────────────────────────────────────────
 
 function content(part: Part): number {


### PR DESCRIPTION
The shared Kilo chat `TaskTimeline` is used across Agent Manager, sidebar chat, and editor conversations. During streamed responses it previously reacted to every appended bar by synchronously reading `scrollWidth` and writing `scrollLeft` inside Solid's reactive update chain.

That read/write pair can force layout before the browser has finished applying the current DOM updates. Bursts of incoming parts can repeat the work several times before one paint. It also pulled the viewport to the newest bar while someone was scrolling through earlier activity.

## Durable behavior

- Coalesce appended-bar scrolling into one `requestAnimationFrame` callback after the current DOM updates settle.
- Follow incoming activity only while the viewport is within one bar of the right edge.
- Preserve manual scroll position while earlier activity is being inspected.
- Resume following automatically after returning to the right edge.
- Preserve tooltip placement, drag and wheel scrolling, bar sizing, labels, and accessibility.

## Why this target

Agent Manager was used as the realistic high-concurrency benchmark because it can stream one foreground transcript while multiple background sessions remain active. The result applies to the shared timeline component on every Kilo chat surface.

The initial 40-second profile used three concurrent sessions. Each built and exercised an isolated dependency-free Node project with bash commands, reads, writes, edits, tests, and CLI execution. The pointer remained outside the timeline, and synthetic `sessionUpdated` flooding was not used.

| Webview event | Count |
|---|---:|
| `partUpdated` | 412 |
| `messageCreated` | 198 |
| `sessionStatus` | 100 |
| `partsUpdated` | 62 |
| `sessionUpdated` | 50 |
| `permissionRequest` / `permissionResolved` | 18 / 18 |

The synchronous TaskTimeline auto-scroll effect was the leading identifiable application frame. The larger `getBoundingClientRect` cost was not attributed to timeline tooltips because no tooltip hover occurred during capture.

## Controlled result

The before/after replay ran the same 36 specified tool operations across three concurrent sessions. Both runs settled to the same relevant active-transcript inventory: 23 tool wrappers, 13 collapsibles, 12 closed tools, 1 open tool, 27 timeline bars, and 2 markdown roots.

Rendering-event volume was 319 before and 296 after. The normalized column accounts for that difference using `partUpdated`, `messageCreated`, `sessionStatus`, `sessionUpdated`, and `partsUpdated` events.

| Metric | Before | After | Raw change | Per-event change |
|---|---:|---:|---:|---:|
| TaskTimeline CPU self-time | 20.320 ms | 2.959 ms | -85.4% | -84.3% |
| Chromium script duration | 572.925 ms | 457.614 ms | -20.1% | -13.9% |
| Style recalculation | 1231.066 ms | 968.152 ms | -21.4% | -15.2% |
| Layout duration | 141.659 ms | 117.196 ms | -17.3% | -10.8% |
| Trace script group | 3773.61 ms | 2815.37 ms | -25.4% | -19.6% |
| Trace layout group | 1365.87 ms | 1081.03 ms | -20.9% | -14.7% |
| Trace paint group | 1302.15 ms | 1049.99 ms | -19.4% | -13.1% |
| Longest task | 76.64 ms | 55.52 ms | -27.6% | n/a |

The code comments retain the causal explanation so future timeline changes preserve the animation-frame batching and right-edge pinning behavior.