### PR TITLE
fix(vscode): remove stale speech-to-text setting

### DIFF
--- a/.changeset/remove-stale-speech-setting.md
+++ b/.changeset/remove-stale-speech-setting.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the obsolete speech-to-text enabled setting while preserving provider-based availability and model selection.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -893,11 +893,6 @@
           "default": false,
           "description": "Enable chat textarea autocomplete"
         },
-        "kilo-code.new.speechToText.enabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable experimental speech-to-text voice input in prompt fields. Uses your Kilo account through the Kilo Gateway."
-        },
         "kilo-code.new.speechToText.model": {
           "type": "string",
           "description": "Model to use for experimental speech-to-text voice input. Requires Kilo Gateway."


### PR DESCRIPTION
The extension manifest still exposes `kilo-code.new.speechToText.enabled`, but speech input availability now comes from the connected Kilo provider and profile. Leaving the unused setting visible suggests that it controls behavior when no runtime code reads it.

Remove the obsolete enabled setting from VS Code configuration contributions. Keep `kilo-code.new.speechToText.model` intact so model selection and the current provider-based availability behavior remain unchanged.