### PR TITLE
feat(gateway): detect incomplete responses

### DIFF
--- a/.changeset/detect-incomplete-responses.md
+++ b/.changeset/detect-incomplete-responses.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": minor
+---
+
+Expose a callback for detecting response bodies closed before they are fully consumed.

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -23,11 +23,18 @@ export function watchResponse(response: Response, incomplete?: (reason?: unknown
   if (!response.body || !incomplete) return response
 
   const reader = response.body.getReader()
+  let ended = false
+  const finish = (reason: unknown) => {
+    if (ended) return
+    ended = true
+    incomplete(reason)
+  }
   const body = new ReadableStream<Uint8Array>({
     async pull(controller) {
       await reader.read().then(
         (chunk) => {
           if (chunk.done) {
+            ended = true
             controller.close()
             return
           }
@@ -35,12 +42,14 @@ export function watchResponse(response: Response, incomplete?: (reason?: unknown
         },
         (reason) => {
           controller.error(reason)
-          incomplete(reason)
+          finish(reason)
         },
       )
     },
     async cancel(reason) {
-      await Promise.all([reader.cancel(reason), Promise.resolve().then(() => incomplete(reason))])
+      const canceled = reader.cancel(reason)
+      finish(reason)
+      await canceled
     },
   })
 

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -19,6 +19,44 @@ export function buildRequestHeaders(defaultHeaders: Record<string, string>, requ
   return headers
 }
 
+export function watchResponse(response: Response, incomplete?: (reason?: unknown) => void): Response {
+  if (!response.body || !incomplete) return response
+
+  const reader = response.body.getReader()
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      await reader.read().then(
+        (chunk) => {
+          if (chunk.done) {
+            controller.close()
+            return
+          }
+          controller.enqueue(chunk.value)
+        },
+        (reason) => {
+          controller.error(reason)
+          incomplete(reason)
+        },
+      )
+    },
+    async cancel(reason) {
+      await Promise.all([reader.cancel(reason), Promise.resolve().then(() => incomplete(reason))])
+    },
+  })
+
+  const watched = new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+  Object.defineProperties(watched, {
+    redirected: { value: response.redirected },
+    type: { value: response.type },
+    url: { value: response.url },
+  })
+  return watched
+}
+
 /**
  * Create a KiloCode provider instance
  *
@@ -62,11 +100,12 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
       headers.set("Authorization", `Bearer ${apiKey}`)
     }
 
-    return originalFetch(input, {
+    const response = await originalFetch(input, {
       ...init,
       headers,
       body,
     })
+    return watchResponse(response, options.onResponseIncomplete)
   }
 
   const sdkOptions = {

--- a/packages/kilo-gateway/src/types.ts
+++ b/packages/kilo-gateway/src/types.ts
@@ -101,6 +101,11 @@ export interface KiloProviderOptions {
   fetch?: typeof fetch
 
   /**
+   * Called when response body consumption is canceled or fails before reaching a clean end
+   */
+  onResponseIncomplete?: (reason?: unknown) => void
+
+  /**
    * Request timeout in milliseconds
    */
   timeout?: number | false

--- a/packages/kilo-gateway/test/provider.test.ts
+++ b/packages/kilo-gateway/test/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { buildRequestHeaders } from "../src/provider"
+import { buildRequestHeaders, watchResponse } from "../src/provider"
 
 describe("Kilo provider request headers", () => {
   test("request headers override provider defaults", () => {
@@ -19,5 +19,71 @@ describe("Kilo provider request headers", () => {
     expect(headers.get("x-kilocode-feature")).toBe("agent-manager")
     expect(headers.get("x-default-only")).toBe("kept")
     expect(headers.get("x-request-only")).toBe("kept-too")
+  })
+})
+
+describe("Kilo provider responses", () => {
+  test("reports a response closed before it is fully consumed", async () => {
+    const reasons: unknown[] = []
+    const upstream: unknown[] = []
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"))
+      },
+      cancel(reason) {
+        upstream.push(reason)
+      },
+    })
+    const response = watchResponse(new Response(source), (reason) => reasons.push(reason))
+    const reader = response.body!.getReader()
+
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe("partial")
+    await reader.cancel("stopped")
+
+    expect(reasons).toEqual(["stopped"])
+    expect(upstream).toEqual(["stopped"])
+  })
+
+  test("does not report a fully consumed response", async () => {
+    const reasons: unknown[] = []
+    const response = watchResponse(new Response("complete"), (reason) => reasons.push(reason))
+
+    expect(await response.text()).toBe("complete")
+    expect(reasons).toEqual([])
+  })
+
+  test("reports an upstream failure", async () => {
+    const failure = new Error("connection closed")
+    const reasons: unknown[] = []
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(failure)
+      },
+    })
+    const response = watchResponse(new Response(source), (reason) => reasons.push(reason))
+
+    await expect(response.text()).rejects.toBe(failure)
+    expect(reasons).toEqual([failure])
+  })
+
+  test("preserves response metadata", () => {
+    const original = new Response("body", {
+      status: 202,
+      statusText: "Accepted",
+      headers: { "x-test": "value" },
+    })
+    Object.defineProperties(original, {
+      redirected: { value: true },
+      type: { value: "cors" },
+      url: { value: "https://example.com/final" },
+    })
+    const response = watchResponse(original, () => {})
+
+    expect(response.status).toBe(202)
+    expect(response.statusText).toBe("Accepted")
+    expect(response.headers.get("x-test")).toBe("value")
+    expect(response.redirected).toBe(true)
+    expect(response.type).toBe("cors")
+    expect(response.url).toBe("https://example.com/final")
   })
 })


### PR DESCRIPTION
## Summary

Expose an optional gateway provider callback when response body consumption is canceled or fails before reaching a clean end. The response wrapper forwards cancellation upstream and preserves fetch response metadata, allowing clients to observe truncated streams without buffering them.