### PR TITLE
fix(cli): acknowledge all-interface bindings in kilo console

### DIFF
--- a/.changeset/console-bind-acknowledgment.md
+++ b/.changeset/console-bind-acknowledgment.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Acknowledge all-interface bindings in `kilo console`: print the LAN-reachable console URLs when bound to 0.0.0.0, and warn when an already-running daemon keeps a different binding than requested.

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -1,3 +1,4 @@
+import os from "os"
 import open from "open"
 import { cmd } from "@/cli/cmd/cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
@@ -6,6 +7,28 @@ import { Daemon } from "@/kilocode/daemon/daemon"
 
 function publicUrl(state: Daemon.State) {
   return new URL("/console", state.url).toString()
+}
+
+export function wildcard(hostname: string) {
+  return hostname === "0.0.0.0" || hostname === "::"
+}
+
+export function covers(state: { hostname: string; port: number }, opts: { hostname: string; port: number }) {
+  if (opts.port !== 0 && opts.port !== state.port) return false
+  if (wildcard(state.hostname)) return true
+  return state.hostname === opts.hostname
+}
+
+export function addresses(
+  interfaces: Record<
+    string,
+    { address: string; family: string; internal: boolean }[] | undefined
+  > = os.networkInterfaces(),
+) {
+  return Object.values(interfaces)
+    .flatMap((list) => list ?? [])
+    .filter((item) => item.family === "IPv4" && !item.internal)
+    .map((item) => item.address)
 }
 
 function browserUrl(state: Daemon.State) {
@@ -45,10 +68,24 @@ export const KiloConsoleCommand = cmd({
     const state = result.state
     if (!state) throw new Error("Kilo daemon did not provide connection state")
 
+    if (result.reused && !covers(state, opts)) {
+      const requested = `${opts.hostname}${opts.port ? `:${opts.port}` : ""}`
+      console.warn(
+        `Kilo daemon is already running on ${state.hostname}:${state.port}; requested ${requested} was not applied.`,
+      )
+      console.warn(
+        `Run \`kilo daemon restart --hostname ${opts.hostname}${opts.port ? ` --port ${opts.port}` : ""}\` to rebind.`,
+      )
+    }
+
     const url = publicUrl(state)
     await launch(browserUrl(state)).catch((err) => {
       console.warn(`Could not open browser automatically: ${err instanceof Error ? err.message : String(err)}`)
     })
     console.log(`Kilo Console: ${url}`)
+    if (wildcard(state.hostname)) {
+      console.log(`Bound to all interfaces (${state.hostname})`)
+      for (const item of addresses()) console.log(`  http://${item}:${state.port}/console`)
+    }
   },
 })

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -27,7 +27,8 @@ export function addresses(
 ) {
   return Object.values(interfaces)
     .flatMap((list) => list ?? [])
-    .filter((item) => item.family === "IPv4" && !item.internal)
+    // Skip internal and Docker bridge networks (typically 172.x.x.x), matching web.ts
+    .filter((item) => item.family === "IPv4" && !item.internal && !item.address.startsWith("172."))
     .map((item) => item.address)
 }
 

--- a/packages/opencode/test/kilocode/cli/cmd/console.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/console.test.ts
@@ -26,7 +26,7 @@ describe("console command", () => {
     expect(covers({ hostname: "127.0.0.1", port: 4097 }, { hostname: "127.0.0.1", port: 0 })).toBe(true)
   })
 
-  test("addresses lists external IPv4 addresses only", () => {
+  test("addresses lists external IPv4 addresses only, skipping Docker bridge networks", () => {
     const fake = {
       lo: [
         { address: "127.0.0.1", family: "IPv4", internal: true },
@@ -36,6 +36,7 @@ describe("console command", () => {
         { address: "192.168.1.7", family: "IPv4", internal: false },
         { address: "fe80::1", family: "IPv6", internal: false },
       ],
+      docker0: [{ address: "172.17.0.1", family: "IPv4", internal: false }],
       down: undefined,
     }
     expect(addresses(fake)).toStrictEqual(["192.168.1.7"])

--- a/packages/opencode/test/kilocode/cli/cmd/console.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/console.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { addresses, covers, wildcard } from "../../../../src/kilocode/cli/cmd/console"
+
+describe("console command", () => {
+  test("wildcard detects all-interface bindings", () => {
+    expect(wildcard("0.0.0.0")).toBe(true)
+    expect(wildcard("::")).toBe(true)
+    expect(wildcard("127.0.0.1")).toBe(false)
+    expect(wildcard("192.168.1.7")).toBe(false)
+  })
+
+  test("covers accepts a wildcard daemon for any requested hostname", () => {
+    expect(covers({ hostname: "0.0.0.0", port: 4097 }, { hostname: "127.0.0.1", port: 0 })).toBe(true)
+    expect(covers({ hostname: "0.0.0.0", port: 4097 }, { hostname: "0.0.0.0", port: 4097 })).toBe(true)
+  })
+
+  test("covers rejects a loopback daemon for a wildcard request", () => {
+    expect(covers({ hostname: "127.0.0.1", port: 4097 }, { hostname: "0.0.0.0", port: 0 })).toBe(false)
+  })
+
+  test("covers rejects an explicit port mismatch", () => {
+    expect(covers({ hostname: "0.0.0.0", port: 4097 }, { hostname: "0.0.0.0", port: 10000 })).toBe(false)
+  })
+
+  test("covers ignores port when any port was requested", () => {
+    expect(covers({ hostname: "127.0.0.1", port: 4097 }, { hostname: "127.0.0.1", port: 0 })).toBe(true)
+  })
+
+  test("addresses lists external IPv4 addresses only", () => {
+    const fake = {
+      lo: [
+        { address: "127.0.0.1", family: "IPv4", internal: true },
+        { address: "::1", family: "IPv6", internal: true },
+      ],
+      eth0: [
+        { address: "192.168.1.7", family: "IPv4", internal: false },
+        { address: "fe80::1", family: "IPv6", internal: false },
+      ],
+      down: undefined,
+    }
+    expect(addresses(fake)).toStrictEqual(["192.168.1.7"])
+  })
+})


### PR DESCRIPTION


When `kilo console --hostname 0.0.0.0` binds all interfaces, the command only printed the loopback console URL, leaving users unable to discover the LAN address. It also silently reused an already-running daemon even when the requested hostname or port differed from the active binding.

Print the all-interface acknowledgment with reachable LAN console URLs, and warn with a `kilo daemon restart` hint when a reused daemon does not satisfy the requested binding.

Fixes #11027

## Issue

When `kilo console --hostname 0.0.0.0` binds all interfaces, the command only printed the loopback console URL, leaving users unable to discover the LAN address they actually wanted to share. It also silently reused an already-running daemon even when the requested hostname or port differed from the active binding, so a user asking for `0.0.0.0` could be handed back a loopback-only daemon with no indication their flag was ignored.

This change makes `kilo console` acknowledge the binding it actually got: it prints the LAN-reachable console URLs on a wildcard bind, and warns (with a `kilo daemon restart` hint) when a reused daemon doesn't satisfy the requested binding.

## Implementation

Three small pure helpers were added to `console.ts` so the logic is testable without spinning up a daemon:

- `wildcard(hostname)` — true for `0.0.0.0` / `::`.
- `covers(state, opts)` — whether an already-running daemon's binding satisfies the requested `hostname`/`port` (a wildcard daemon covers any host; port `0` means "any port").
- `addresses(interfaces?)` — external IPv4 addresses from `os.networkInterfaces()`, injectable for tests.

Behavior in the command body:

- If the daemon was `reused` and does **not** `covers()` the requested options, warn that the requested binding wasn't applied and print a `kilo daemon restart --hostname … [--port …]` hint.
- After printing the console URL, if the active binding is a wildcard, print `Bound to all interfaces (…)` followed by each `http://<lan-ip>:<port>/console`.

No behavior changes for the normal loopback case. The helpers are exported purely so the unit tests can exercise them directly.

## Screenshot

<img width="1920" height="1080" alt="Screenshot (528)" src="https://github.com/user-attachments/assets/aae0ad58-db96-47ab-87a8-28dd26d602d9" />


## How to Test

### Manual/local verification

- `bun test packages/opencode/test/kilocode/cli/cmd/console.test.ts` — the new unit tests pass (executed by the author), covering `wildcard`, `covers` (wildcard match, loopback-vs-wildcard rejection, port mismatch, any-port), and `addresses` (external IPv4 only).

### Reviewer test steps

1. Run `kilo console --hostname 0.0.0.0` with no daemon already running.
2. Confirm the output prints `Bound to all interfaces (0.0.0.0)` followed by one `http://<lan-ip>:<port>/console` line per external IPv4 interface.
3. With that wildcard daemon still running, run `kilo console --hostname 127.0.0.1` — confirm no spurious warning (a wildcard daemon covers loopback).
4. Stop the daemon, start a loopback-only one (`kilo console --hostname 127.0.0.1`), then run `kilo console --hostname 0.0.0.0` — confirm the warning prints and suggests `kilo daemon restart --hostname 0.0.0.0`.

### Blocked checks and substitute verification

- `bun turbo typecheck` could not complete locally: the `@kilocode/kilo-jetbrains` Gradle task fails on Windows with `java.io.IOException: Unable to delete directory …\.gradle\caches\…\transforms\…` (a daemon holds the transform jars open). This is unrelated to this change, which touches only `packages/opencode`. Substitute verification: the affected package typechecked cleanly and the new `console.test.ts` suite passes locally.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: `sivaram9230`