### PR TITLE
fix(cli): keep Console terminals in TUI mode

### DIFF
--- a/.changeset/keep-console-tui-open.md
+++ b/.changeset/keep-console-tui-open.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep new Kilo Console terminals open in the TUI on macOS.

--- a/packages/opencode/src/kilocode/pty/self-command.ts
+++ b/packages/opencode/src/kilocode/pty/self-command.ts
@@ -13,7 +13,7 @@ type Command = {
 }
 
 const names = new Set(["kilo", "kilocode"])
-const self = current()
+const self = command()
 
 function clean(input: string[]) {
   return input.filter((arg, index) => {
@@ -24,34 +24,38 @@ function clean(input: string[]) {
   })
 }
 
-function full(input: string) {
+function full(input: string, cwd: string) {
   if (path.isAbsolute(input)) return input
-  return path.resolve(process.cwd(), input)
+  return path.resolve(cwd, input)
 }
 
-function current(): Command {
-  const script = process.argv[1]
-  if (script && /\.(ts|js|mjs|cjs)$/.test(script)) {
-    const file = full(script)
+export function command(
+  proc = { argv: process.argv, execArgv: process.execArgv, execPath: process.execPath, cwd: process.cwd() },
+): Command {
+  const script = proc.argv[1]
+  const bundled = script?.startsWith("/$bunfs/") || (script ? /^[A-Za-z]:[\\/]~BUN[\\/]/.test(script) : false)
+  if (script && !bundled && /\.(ts|js|mjs|cjs)$/.test(script)) {
+    const file = full(script, proc.cwd)
     const dir = path.dirname(file)
-    const root = path.basename(dir) === "src" ? path.dirname(dir) : process.cwd()
-    return { command: full(process.execPath), args: [...clean(process.execArgv), file], cwd: root }
+    const root = path.basename(dir) === "src" ? path.dirname(dir) : proc.cwd
+    return { command: full(proc.execPath, proc.cwd), args: [...clean(proc.execArgv), file], cwd: root }
   }
-  return { command: full(process.execPath), args: [] }
+  return { command: full(proc.execPath, proc.cwd), args: [] }
 }
 
-export function resolve(input: Input): Input {
+export function resolve(input: Input, cmd = self): Input {
   if (!input.command || !names.has(input.command)) return input
   const args = input.args ?? []
-  const project = self.cwd && args.length === 0 && input.cwd ? [input.cwd] : []
+  const project = cmd.cwd && args.length === 0 && input.cwd ? [input.cwd] : []
   return {
     ...input,
-    command: self.command,
-    args: [...self.args, ...project, ...args],
-    cwd: self.cwd ?? input.cwd,
+    command: cmd.command,
+    args: [...cmd.args, ...project, ...args],
+    cwd: cmd.cwd ?? input.cwd,
   }
 }
 
 export const KiloPtySelfCommand = {
+  command,
   resolve,
 }

--- a/packages/opencode/test/kilocode/pty-self-command.test.ts
+++ b/packages/opencode/test/kilocode/pty-self-command.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { KiloPtySelfCommand } from "../../src/kilocode/pty/self-command"
+
+describe("pty self-command", () => {
+  test("does not forward bundled bun entrypoints", () => {
+    const proc = {
+      argv: ["/tmp/kilo", "/$bunfs/root/src/index.js"],
+      execArgv: ["--user-agent=kilo/test", "--use-system-ca", "--"],
+      execPath: "/tmp/kilo",
+      cwd: "/tmp",
+    }
+
+    const cmd = KiloPtySelfCommand.command(proc)
+    expect(cmd).toStrictEqual({ command: "/tmp/kilo", args: [] })
+    expect(
+      KiloPtySelfCommand.resolve({ command: "kilo", cwd: "/tmp/project" }, cmd),
+    ).toStrictEqual({ command: "/tmp/kilo", args: [], cwd: "/tmp/project" })
+    expect(
+      KiloPtySelfCommand.command({
+        ...proc,
+        argv: ["C:/tmp/kilo.exe", "B:/~BUN/root/src/index.js"],
+      }).args,
+    ).toStrictEqual([])
+    expect(
+      KiloPtySelfCommand.command({
+        ...proc,
+        argv: ["C:/tmp/kilo.exe", "b:\\~BUN\\root\\src\\index.js"],
+      }).args,
+    ).toStrictEqual([])
+  })
+
+  test("forwards source entrypoints", () => {
+    const cmd = KiloPtySelfCommand.command({
+      argv: ["/tmp/bun", "/tmp/kilo/src/index.ts"],
+      execArgv: ["--conditions=browser", "--cwd", "packages/opencode"],
+      execPath: "/tmp/bun",
+      cwd: "/tmp/kilo",
+    })
+    expect(cmd).toStrictEqual({
+      command: "/tmp/bun",
+      args: ["--conditions=browser", "/tmp/kilo/src/index.ts"],
+      cwd: "/tmp/kilo",
+    })
+    expect(
+      KiloPtySelfCommand.resolve({ command: "kilo", cwd: "/tmp/project" }, cmd),
+    ).toStrictEqual({
+      command: "/tmp/bun",
+      args: ["--conditions=browser", "/tmp/kilo/src/index.ts", "/tmp/project"],
+      cwd: "/tmp/kilo",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- recognize Bun's virtual bundled entrypoint when Kilo Console resolves its PTY self-command
- launch packaged Kilo binaries without forwarding the embedded script path, allowing the default TUI command to stay active
- preserve source-mode invocation behavior and cover packaged Unix, Windows, and development entrypoints

## Context
Packaged macOS binaries expose `/$bunfs/root/src/index.js` as `process.argv[1]`. The PTY resolver treated that virtual path as a source entrypoint and passed it back to the CLI, which selected CLI/help behavior and exited instead of opening the TUI.