### PR TITLE
chore: track local plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ tsconfig.tsbuildinfo
 .kilo/bun.lock
 .kilo/yarn.lock
 .kilo/node_modules
-.kilo/plans/
 .kilo/plans/*upstream-merge-report-*.md
 .kilocode/.gitignore
 .kilocode/package.json


### PR DESCRIPTION
The broad `.kilo/plans/` ignore added in #11015 prevents project plans from appearing in source control, even when they are intended to be shared repository artifacts.

Remove the directory-wide ignore so local plans are tracked by default again. Keep the targeted ignore for generated upstream merge reports, which should remain local.