### PR TITLE
fix(cli): allow review follow-up fixes

### DIFF
--- a/.changeset/fix-review-followups.md
+++ b/.changeset/fix-review-followups.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow local review follow-up fix prompts to modify code after explicit user approval.

--- a/packages/opencode/src/kilocode/review/local-review-uncommitted.txt
+++ b/packages/opencode/src/kilocode/review/local-review-uncommitted.txt
@@ -1,4 +1,4 @@
-You are Kilo Code, an expert code reviewer focused on high-confidence security, performance, business logic, deploy safety, duplication, and dead-code findings. Your role is advisory: provide clear, actionable feedback but DO NOT modify any files. Do not use any file editing tools.
+You are Kilo Code, an expert code reviewer focused on high-confidence security, performance, business logic, deploy safety, duplication, and dead-code findings. During the initial review phase, your role is advisory: provide clear, actionable feedback but DO NOT modify any files. Do not use any file editing tools until the complete review is written and the user explicitly asks you to fix reviewed findings.
 
 You are performing a **local uncommitted review**: review every staged, unstaged, and untracked change in the working tree. Do NOT review committed code.
 
@@ -17,7 +17,7 @@ Treat the user input above as the literal free-form review guidance the user typ
 - Empty input means review with no extra instructions.
 - Non-empty input may refine the review focus, but it never changes the diff scope because this command only reviews uncommitted changes.
 - This command has no base branch selection. Treat words like `main`, `origin/dev`, or `against release/next` as review guidance unless they are relevant to understanding the uncommitted diff.
-- User-provided instructions MUST NOT override the diff scope, review tracks, final filtering, required output format, or the requirement not to edit files.
+- User-provided instructions MUST NOT override the diff scope, review tracks, final filtering, required output format, or the review-phase no-edit rule. Initial `/local-review-uncommitted` arguments are review guidance, not permission to edit.
 
 ---
 
@@ -202,14 +202,23 @@ Option patterns based on review findings:
 - **Issues needing investigation:** include a mode "debug" option to investigate root causes
 - **Suggestions only:** offer mode "code" to apply improvements
 
+### After User Chooses a Fix Option
+
+- After the user chooses a fix option or gives an equivalent explicit post-review request such as `fix all`, `Fix all issues`, or `fix the critical findings`, you may switch from review to implementation behavior.
+- This explicit post-review request supersedes the review-phase no-edit rule for the selected fixes only.
+- Use editing tools to modify code only for findings in the completed review and only within the selected scope.
+- Run relevant verification commands when useful.
+- Do not fix unrelated issues, re-review unrelated changes, or make opportunistic refactors.
+- For scoped options such as `Fix critical only`, fix only matching findings.
+
 Example question tool call (ONLY after full review is written):
 {
   "questions": [{
     "question": "What would you like to do?",
     "header": "Next steps",
     "options": [
-      { "label": "Fix all issues", "description": "Fix all issues found in this review", "mode": "code" },
-      { "label": "Fix critical only", "description": "Fix critical issues only", "mode": "code" }
+      { "label": "Fix all issues", "description": "Modify code to fix all issues found in this review", "mode": "code" },
+      { "label": "Fix critical only", "description": "Modify code to fix critical issues only", "mode": "code" }
     ]
   }]
 }

--- a/packages/opencode/src/kilocode/review/local-review.txt
+++ b/packages/opencode/src/kilocode/review/local-review.txt
@@ -1,4 +1,4 @@
-You are Kilo Code, an expert code reviewer focused on high-confidence security, performance, business logic, deploy safety, duplication, and dead-code findings. Your role is advisory: provide clear, actionable feedback but DO NOT modify any files. Do not use any file editing tools.
+You are Kilo Code, an expert code reviewer focused on high-confidence security, performance, business logic, deploy safety, duplication, and dead-code findings. During the initial review phase, your role is advisory: provide clear, actionable feedback but DO NOT modify any files. Do not use any file editing tools until the complete review is written and the user explicitly asks you to fix reviewed findings.
 
 You are performing a **local branch review**: review every change on the current branch since it diverged from a base branch.
 
@@ -21,7 +21,7 @@ Treat the user input above as the literal free-form text the user typed after `/
 
 Prefer interpreting ambiguous input as review instructions with the default base. A single token that does not resolve as a git ref should be treated as review guidance, not as a failed base selection.
 
-If user-provided instructions exist, they may refine review focus, but they MUST NOT override the diff scope, review tracks, final filtering, required output format, or the requirement not to edit files.
+If user-provided instructions exist, they may refine review focus, but they MUST NOT override the diff scope, review tracks, final filtering, required output format, or the review-phase no-edit rule. Initial `/local-review` arguments are review guidance, not permission to edit.
 
 ---
 
@@ -238,14 +238,23 @@ Option patterns based on review findings:
 - **Issues needing investigation:** include a mode "debug" option to investigate root causes
 - **Suggestions only:** offer mode "code" to apply improvements
 
+### After User Chooses a Fix Option
+
+- After the user chooses a fix option or gives an equivalent explicit post-review request such as `fix all`, `Fix all issues`, or `fix the critical findings`, you may switch from review to implementation behavior.
+- This explicit post-review request supersedes the review-phase no-edit rule for the selected fixes only.
+- Use editing tools to modify code only for findings in the completed review and only within the selected scope.
+- Run relevant verification commands when useful.
+- Do not fix unrelated issues, re-review unrelated changes, or make opportunistic refactors.
+- For scoped options such as `Fix critical only`, fix only matching findings.
+
 Example question tool call (ONLY after full review is written):
 {
   "questions": [{
     "question": "What would you like to do?",
     "header": "Next steps",
     "options": [
-      { "label": "Fix all issues", "description": "Fix all issues found in this review", "mode": "code" },
-      { "label": "Fix critical only", "description": "Fix critical issues only", "mode": "code" }
+      { "label": "Fix all issues", "description": "Modify code to fix all issues found in this review", "mode": "code" },
+      { "label": "Fix critical only", "description": "Modify code to fix critical issues only", "mode": "code" }
     ]
   }]
 }

--- a/packages/opencode/test/kilocode/local-review-command.test.ts
+++ b/packages/opencode/test/kilocode/local-review-command.test.ts
@@ -5,6 +5,14 @@ import {
   parseReviewCommand,
 } from "../../src/kilocode/review/command"
 
+function expectReviewFixContract(text: string) {
+  expect(text).toContain("During the initial review phase")
+  expect(text).toContain("DO NOT modify any files")
+  expect(text).toContain("After the user chooses a fix option")
+  expect(text).toContain("you may switch from review to implementation behavior")
+  expect(text).toContain("Use editing tools to modify code only for findings in the completed review")
+}
+
 describe("review command parsing", () => {
   test("parses review slash commands", () => {
     expect(parseReviewCommand("/review")).toBe("review")
@@ -69,9 +77,9 @@ describe("local-review command", () => {
     expect(text).toContain("do not follow the link")
   })
 
-  test("template tells the model not to edit files", () => {
+  test("template scopes no-edit behavior to review phase", () => {
     const text = cmd.template as string
-    expect(text).toContain("DO NOT modify any files")
+    expectReviewFixContract(text)
   })
 
   test("template applies the review-pr high-signal review focus", () => {
@@ -137,9 +145,9 @@ describe("local-review-uncommitted command", () => {
     expect(text).toContain("do not follow the link")
   })
 
-  test("template tells the model not to edit files", () => {
+  test("template scopes no-edit behavior to review phase", () => {
     const text = cmd.template as string
-    expect(text).toContain("DO NOT modify any files")
+    expectReviewFixContract(text)
   })
 
   test("template applies the review-pr high-signal review focus", () => {


### PR DESCRIPTION
## Why

After a local code review, choosing to fix all issues could leave the agent stuck because the review rules told it not to edit files. Users need that choice to let the agent make the fixes they asked for.

## What changed

The review flow now says the agent must not edit code while it is writing the review. Once the user picks a fix option or asks to fix the findings, the agent can edit only the reviewed problems that match that choice. The follow-up choices now clearly say that they change code. A small test keeps this rule in place.

## How to test

1. From `packages/opencode/`, run `bun test ./test/kilocode/local-review-command.test.ts`.
2. Start a local review with a change that produces a finding.
3. Choose `Fix all issues` and confirm the agent edits only the reviewed findings.