### PR TITLE
perf(agent-manager): overlap MCP startup with worktree creation

### DIFF
--- a/.changeset/warm-agent-manager-mcp.md
+++ b/.changeset/warm-agent-manager-mcp.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start MCP servers while Agent Manager worktree sessions initialize to reduce the delay before the first response.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -35,6 +35,7 @@ import { diffSummary as localDiffSummary, diffFile as localDiffFile } from "./lo
 import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
 import { stopSessionProcesses } from "../kilo-provider/background-process"
 
+import { startSession } from "./mcp-warmup"
 import { buildKeybindingMap } from "./format-keybinding"
 import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
 import { Semaphore } from "./semaphore"
@@ -810,9 +811,11 @@ export class AgentManagerProvider implements Disposable {
     })
 
     try {
-      const { data: session } = await client.session.create(
-        { directory: worktreePath, platform: PLATFORM },
-        { throwOnError: true },
+      const { data: session } = await startSession(
+        client,
+        worktreePath,
+        () => client.session.create({ directory: worktreePath, platform: PLATFORM }, { throwOnError: true }),
+        (...args) => this.log(...args),
       )
       return session
     } catch (error) {

--- a/packages/kilo-vscode/src/agent-manager/mcp-warmup.ts
+++ b/packages/kilo-vscode/src/agent-manager/mcp-warmup.ts
@@ -1,0 +1,15 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+
+type Client = Pick<KiloClient, "mcp">
+type Log = (...args: unknown[]) => void
+
+async function warm(client: Client, dir: string, log: Log): Promise<void> {
+  log(`[MCPWarmup] Starting for ${dir}`)
+  await client.mcp.status({ directory: dir }, { throwOnError: true })
+  log(`[MCPWarmup] Completed for ${dir}`)
+}
+
+export function startSession<T>(client: Client, dir: string, create: () => Promise<T>, log: Log): Promise<T> {
+  void warm(client, dir, log).catch((err) => log(`[MCPWarmup] Failed for ${dir}:`, err))
+  return create()
+}

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -163,6 +163,16 @@ describe("Agent Manager Provider Messages", () => {
     expect(body).toContain("agentManager.sessionAdded")
   })
 
+  it("warms MCP before creating every new worktree session", () => {
+    const body = getMethodBody("createSessionInWorktree")
+    const warmup = body.indexOf("startSession(")
+    const create = body.indexOf("client.session.create(")
+
+    expect(warmup).toBeGreaterThanOrEqual(0)
+    expect(create).toBeGreaterThanOrEqual(0)
+    expect(warmup).toBeLessThan(create)
+  })
+
   it("state-mutating messages wait for state initialization", () => {
     const body = getMethodBody("shouldWaitForState")
     const messages = [

--- a/packages/kilo-vscode/tests/unit/agent-manager-mcp-warmup.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-mcp-warmup.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test"
+import { startSession } from "../../src/agent-manager/mcp-warmup"
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve))
+}
+
+describe("Agent Manager MCP warmup", () => {
+  it("starts MCP status for the worktree directory before session creation", async () => {
+    const calls: unknown[][] = []
+    const client = {
+      mcp: {
+        status: (input: unknown, opts: unknown) => {
+          calls.push(["warm", input, opts])
+          return Promise.resolve({ data: {} })
+        },
+      },
+    }
+
+    const result = await startSession(
+      client as never,
+      "/repo/.kilo/worktrees/feature",
+      async () => {
+        calls.push(["session"])
+        return "created"
+      },
+      () => {},
+    )
+
+    expect(result).toBe("created")
+    expect(calls[0]).toEqual(["warm", { directory: "/repo/.kilo/worktrees/feature" }, { throwOnError: true }])
+    expect(calls[1]).toEqual(["session"])
+  })
+
+  it("does not wait for MCP warmup before creating the session", async () => {
+    const calls: string[] = []
+    const warmup = new Promise<unknown>(() => {})
+    const client = {
+      mcp: {
+        status: () => {
+          calls.push("warm")
+          return warmup
+        },
+      },
+    }
+
+    const result = await startSession(
+      client as never,
+      "/repo/.kilo/worktrees/feature",
+      async () => {
+        calls.push("session")
+        return "created"
+      },
+      () => {},
+    )
+
+    expect(result).toBe("created")
+    expect(calls).toEqual(["warm", "session"])
+  })
+
+  it("logs and contains MCP warmup failures", async () => {
+    const logs: unknown[][] = []
+    const client = {
+      mcp: {
+        status: () => {
+          throw new Error("connection failed")
+        },
+      },
+    }
+
+    const result = await startSession(
+      client as never,
+      "/repo/.kilo/worktrees/feature",
+      async () => "created",
+      (...args) => logs.push(args),
+    )
+    await tick()
+
+    expect(result).toBe("created")
+    expect(logs[0]).toEqual(["[MCPWarmup] Starting for /repo/.kilo/worktrees/feature"])
+    expect(logs[1]?.[0]).toBe("[MCPWarmup] Failed for /repo/.kilo/worktrees/feature:")
+    expect(logs[1]?.[1]).toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
Cold Agent Manager worktree sessions currently initialize MCP servers only after worktree setup, session creation, and snapshot tracking. That makes MCP connection time a separate serial stage immediately before the first model request, even though MCP initialization does not depend on snapshot completion.

This change starts a directory-scoped MCP status request as soon as worktree setup finishes, before the CLI session is created. Session creation and the initial prompt continue without awaiting that request. The existing `mcp.tools()` call remains the synchronization point before model dispatch, so tool resolution still waits if initialization is genuinely unfinished.

The warmup lives in the shared Agent Manager worktree-session creation path. This covers normal New Worktree creation, configured and multi-version creation, imported worktrees, and Agent Manager tool-created worktrees without duplicating orchestration. It does not initialize MCP for unrelated directories or during extension startup. Warmup failures are caught and logged, so they cannot reject worktree/session creation or become unhandled promise rejections.

Observed cold-flow difference in the same repository and modal flow:

| Stage | Before | After | Difference |
|---|---:|---:|---:|
| MCP/tool resolution after snapshot | 1.356s | 0.106s | 1.250s less serial work (92%) |
| Provider dispatch to first backend delta | 1.304s | 1.323s | Effectively unchanged |
| Modal submit to first rendered token | 11.642s | 12.144s | 0.502s slower in this sample |

The end-to-end sample varied because worktree/session setup and snapshot tracking were slower in the after run. Backend ordering confirms the intended optimization independently of that variance: MCP discovery and client creation moved into snapshot initialization, completed about 4.5 seconds before snapshot tracking finished, and no longer occupied the serial `resolveTools()` stage.

This deliberately does not change snapshot behavior or shared CLI code. Snapshot startup remains the dominant cold-worktree cost and can be optimized independently, while this change ensures MCP initialization is already overlapped rather than becoming the next serial bottleneck.
