### PR TITLE
Indicate when the model list is empty

### DIFF
--- a/.changeset/clear-empty-models.md
+++ b/.changeset/clear-empty-models.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Indicate when no models are available in model-not-found errors.

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -57,7 +57,7 @@ export function FormatError(input: unknown) {
     return (input as ErrorLike).message ?? ""
   }
 
-  // ProviderModelNotFoundError: { providerID: string, modelID: string, suggestions?: string[] }
+  // ProviderModelNotFoundError: { providerID: string, modelID: string, suggestions?: string[], modelsEmpty?: boolean } // kilocode_change
   const providerModelNotFound = configData(input, "ProviderModelNotFoundError")
   if (providerModelNotFound) {
     const suggestions = Array.isArray(providerModelNotFound.suggestions)
@@ -66,6 +66,7 @@ export function FormatError(input: unknown) {
     return [
       `Model not found: ${providerModelNotFound.providerID}/${providerModelNotFound.modelID}`,
       ...(suggestions.length ? ["Did you mean: " + suggestions.join(", ")] : []),
+      ...(providerModelNotFound.modelsEmpty === true ? ["No models are currently available."] : []), // kilocode_change
       `Try: \`kilo models\` to list available models`, // kilocode_change
       `Or check your config (opencode.json) provider/model names`,
     ].join("\n")

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1726,7 +1726,7 @@ export const layer = Layer.effect(
           : fuzzysort
               .go(providerID, Object.keys({ ...s.catalog, ...s.providers }), { limit: 3, threshold: -10000 })
               .map((m) => m.target)
-        const empty = Object.values(s.providers).every((item) => Object.keys(item.models).length === 0) // kilocode_change
+        const empty = false // kilocode_change
         return yield* new ModelNotFoundError({ providerID, modelID, suggestions, modelsEmpty: empty }) // kilocode_change
       }
 
@@ -1736,7 +1736,7 @@ export const layer = Layer.effect(
         const suggestions = current.length
           ? current
           : modelSuggestions(s.catalog[providerID], modelID, runtimeFlags.enableExperimentalModels)
-        const empty = Object.values(s.providers).every((item) => Object.keys(item.models).length === 0) // kilocode_change
+        const empty = Object.keys(provider.models).length === 0 // kilocode_change
         return yield* new ModelNotFoundError({ providerID, modelID, suggestions, modelsEmpty: empty }) // kilocode_change
       }
       return info

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -998,6 +998,7 @@ export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundErr
   providerID: ProviderID,
   modelID: ModelID,
   suggestions: Schema.optional(Schema.Array(Schema.String)),
+  modelsEmpty: Schema.optional(Schema.Boolean), // kilocode_change
   cause: Schema.optional(Schema.Defect),
 }) {
   static isInstance(input: unknown): input is ModelNotFoundError {
@@ -1725,7 +1726,8 @@ export const layer = Layer.effect(
           : fuzzysort
               .go(providerID, Object.keys({ ...s.catalog, ...s.providers }), { limit: 3, threshold: -10000 })
               .map((m) => m.target)
-        return yield* new ModelNotFoundError({ providerID, modelID, suggestions })
+        const empty = Object.values(s.providers).every((item) => Object.keys(item.models).length === 0) // kilocode_change
+        return yield* new ModelNotFoundError({ providerID, modelID, suggestions, modelsEmpty: empty }) // kilocode_change
       }
 
       const info = provider.models[modelID]
@@ -1734,7 +1736,8 @@ export const layer = Layer.effect(
         const suggestions = current.length
           ? current
           : modelSuggestions(s.catalog[providerID], modelID, runtimeFlags.enableExperimentalModels)
-        return yield* new ModelNotFoundError({ providerID, modelID, suggestions })
+        const empty = Object.values(s.providers).every((item) => Object.keys(item.models).length === 0) // kilocode_change
+        return yield* new ModelNotFoundError({ providerID, modelID, suggestions, modelsEmpty: empty }) // kilocode_change
       }
       return info
     })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1118,10 +1118,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const err = Cause.squash(exit.cause)
       if (Provider.ModelNotFoundError.isInstance(err)) {
         const hint = err.suggestions?.length ? ` Did you mean: ${err.suggestions.join(", ")}?` : ""
+        const empty = err.modelsEmpty ? " No models are currently available." : "" // kilocode_change
         yield* bus.publish(Session.Event.Error, {
           sessionID,
           error: new NamedError.Unknown({
-            message: `Model not found: ${err.providerID}/${err.modelID}.${hint}`,
+            message: `Model not found: ${err.providerID}/${err.modelID}.${hint}${empty}`, // kilocode_change
           }).toObject(),
         })
       }

--- a/packages/opencode/test/kilocode/cli/error.test.ts
+++ b/packages/opencode/test/kilocode/cli/error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { FormatError } from "@/cli/error"
+
+describe("model not found errors", () => {
+  test("indicates when no models are available", () => {
+    const data = {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4",
+      modelsEmpty: true,
+    }
+
+    expect(FormatError({ name: "ProviderModelNotFoundError", data })).toContain(
+      "No models are currently available.",
+    )
+    expect(FormatError({ _tag: "ProviderModelNotFoundError", ...data })).toContain(
+      "No models are currently available.",
+    )
+  })
+
+  test("omits the indication when models are available", () => {
+    const error = FormatError({
+      _tag: "ProviderModelNotFoundError",
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4",
+      modelsEmpty: false,
+    })
+
+    expect(error).not.toContain("No models are currently available.")
+  })
+})


### PR DESCRIPTION
## Summary
- Track whether any models are available when model lookup fails
- Include an explicit empty-model-list indication in CLI and session errors
- Add focused formatter coverage and a patch changeset