### PR TITLE
fix(vscode): restore sessions after channel database regression

### DIFF
--- a/.changeset/share-vscode-session-database.md
+++ b/.changeset/share-vscode-session-database.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore persisted sessions across development extension branches and worktrees.

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -28,6 +28,10 @@ export function resolveIndexingEnv(folders: readonly WorkspaceFolderLike[] | und
   return { KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" }
 }
 
+export function resolveManagedServerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...env, KILO_DISABLE_CHANNEL_DB: "true" }
+}
+
 export class ServerManager {
   private instance: ServerInstance | null = null
   private startupPromise: Promise<ServerInstance> | null = null
@@ -108,7 +112,7 @@ export class ServerManager {
           NODE_USE_SYSTEM_CA: "1",
           ...(extraCaCerts && { NODE_EXTRA_CA_CERTS: extraCaCerts }),
           ...(!proxyStrictSSL && { NODE_TLS_REJECT_UNAUTHORIZED: "0" }),
-          ...process.env,
+          ...resolveManagedServerEnv(process.env),
           // VS Code's http.proxy / http.noProxy settings are not reflected in
           // process.env, so spawned children bypass the user's configured proxy
           // and fail behind corporate firewalls. Forward them as the standard

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "bun:test"
 import { parseServerPort } from "../../src/services/cli-backend/server-utils"
-import { resolveServerCwd, resolveIndexingEnv, toErrorMessage } from "../../src/services/cli-backend/server-manager"
+import {
+  resolveServerCwd,
+  resolveIndexingEnv,
+  resolveManagedServerEnv,
+  toErrorMessage,
+} from "../../src/services/cli-backend/server-manager"
 import {
   copyTreeSitterResources,
   resolveTreeSitterEnv,
@@ -176,5 +181,12 @@ describe("server workspace helpers", () => {
     expect(resolveIndexingEnv(undefined)).toEqual({ KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" })
     expect(resolveIndexingEnv([])).toEqual({ KILO_DISABLE_CODEBASE_INDEXING: "vscode-no-workspace" })
     expect(resolveIndexingEnv([{ uri: { fsPath: "/repo" } }])).toEqual({})
+  })
+
+  it("uses the shared database for the managed backend while preserving the environment", () => {
+    expect(resolveManagedServerEnv({ PATH: "/usr/bin", KILO_DISABLE_CHANNEL_DB: "false" })).toEqual({
+      PATH: "/usr/bin",
+      KILO_DISABLE_CHANNEL_DB: "true",
+    })
   })
 })


### PR DESCRIPTION
[PR #11031](https://github.com/Kilo-Org/kilocode/pull/11031) changed non-production CLI binaries to select a database from their installation channel. Its compatibility commit [6ecaaab48a](https://github.com/Kilo-Org/kilocode/commit/6ecaaab48a49f61b7cd6f32b2370fe821f24c49b) removed the prior Kilo override that always selected the shared `kilo.db`.

Channel-specific databases are useful for standalone CLI development, but they break the VS Code development extension. The extension bundles a branch-channel binary while Agent Manager keeps shared worktree and session IDs in the main checkout's `.kilo/agent-manager.json`. After #11031, those IDs were restored from shared state but looked up in `opencode-<channel>.db` instead of the `kilo.db` where the sessions exist, causing valid sessions to fail with `Session not found`.

This restores the extension's previous compatibility behavior at its owned backend spawn boundary. Every extension-managed `kilo serve` process receives `KILO_DISABLE_CHANNEL_DB=true`, so the sidebar, editor tabs, and Agent Manager resolve the same persisted sessions across branches and worktrees. Standalone CLI development keeps channel isolation, production behavior remains unchanged, and no session state or Agent Manager metadata is migrated or rewritten.