### PR TITLE
perf(vscode): virtualize bounded transcript rows

### DIFF
--- a/.changeset/fast-agent-transcripts.md
+++ b/.changeset/fast-agent-transcripts.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Keep large Agent Manager transcripts responsive by mounting only viewport-visible conversation rows.
+Keep large chat transcripts responsive by mounting only viewport-visible conversation rows.

--- a/.changeset/fast-agent-transcripts.md
+++ b/.changeset/fast-agent-transcripts.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep large Agent Manager transcripts responsive by mounting only viewport-visible conversation rows.

--- a/packages/kilo-vscode/tests/unit/task-timeline-tooltip.test.ts
+++ b/packages/kilo-vscode/tests/unit/task-timeline-tooltip.test.ts
@@ -19,12 +19,20 @@ describe("TaskTimeline delegated tooltip contract", () => {
     expect(src).not.toMatch(/<Tooltip\b/)
   })
 
-  it("keeps bar labels and renders one delegated portal tooltip", () => {
-    expect(src).toMatch(/data-tip=\{bar\(\)\.tip\}/)
-    expect(src).toMatch(/role="img"/)
-    expect(src).toMatch(/aria-label=\{bar\(\)\.tip\}/)
-    expect(src).toMatch(/if \(!bar \|\| !ref\?\.contains\(bar\)\) return hideTip\(\)/)
+  it("delegates SVG hit testing to one portal tooltip", () => {
+    expect(src).toMatch(/hit\(layout\(\)\.items, e\.clientX - rect\.left \+ ref\.scrollLeft\)/)
+    expect(src).toMatch(/const bar = bars\(\)\[idx\]/)
+    expect(src).toMatch(/text: bar\.tip/)
     expect(src).toMatch(/<Portal>/)
     expect(src).toMatch(/class="task-timeline-tooltip"/)
+  })
+
+  it("keeps accessibility and bar overlays bounded", () => {
+    expect(src).toMatch(/data-timeline-count=\{bars\(\)\.length\}/)
+    expect(src).toMatch(/tabIndex=\{0\}/)
+    expect(src).toMatch(/aria-label=\{aria\(\)\}/)
+    expect(src).toMatch(/<For each=\{layout\(\)\.paths\}>/)
+    expect(src).not.toMatch(/<Index\b/)
+    expect(src).not.toMatch(/data-tip=/)
   })
 })

--- a/packages/kilo-vscode/tests/unit/timeline-geometry.test.ts
+++ b/packages/kilo-vscode/tests/unit/timeline-geometry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test"
+import { geometry, hit, navigate } from "../../webview-ui/src/utils/timeline/geometry"
+
+describe("timeline geometry", () => {
+  const bars = [
+    { bg: "blue", width: 3, height: 4 },
+    { bg: "red", width: 5, height: 8 },
+    { bg: "blue", width: 2, height: 6 },
+  ]
+
+  it("preserves visual positions while grouping paths by color", () => {
+    const result = geometry(bars, 10)
+
+    expect(result.width).toBe(13)
+    expect(result.items.map((item) => [item.idx, item.x])).toEqual([
+      [0, 0],
+      [1, 4],
+      [2, 10],
+    ])
+    expect(result.paths).toHaveLength(2)
+    expect(result.paths.map((path) => path.bg)).toEqual(["blue", "red"])
+    expect(result.paths[0]!.d).toContain("M0,10")
+    expect(result.paths[0]!.d).toContain("M10,10")
+    expect(result.paths[1]!.d).toContain("M4,10")
+  })
+
+  it("hit tests bars but not their gaps", () => {
+    const items = geometry(bars, 10).items
+
+    expect(hit(items, 0)).toBe(0)
+    expect(hit(items, 2.99)).toBe(0)
+    expect(hit(items, 3)).toBe(-1)
+    expect(hit(items, 4)).toBe(1)
+    expect(hit(items, 12)).toBe(-1)
+  })
+
+  it("navigates in visual order with bounded endpoints", () => {
+    expect(navigate(-1, 3, "ArrowRight")).toBe(0)
+    expect(navigate(1, 3, "ArrowLeft")).toBe(0)
+    expect(navigate(2, 3, "ArrowRight")).toBe(2)
+    expect(navigate(1, 3, "Home")).toBe(0)
+    expect(navigate(1, 3, "End")).toBe(2)
+    expect(navigate(1, 3, "Escape")).toBe(1)
+    expect(navigate(0, 0, "ArrowRight")).toBe(-1)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/transcript-cache.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-cache.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "bun:test"
+import type { CacheSnapshot } from "virtua"
+import {
+  getMeasurement,
+  getScroll,
+  layoutFingerprint,
+  resetTranscriptCaches,
+  resolveAnchor,
+  rowFingerprint,
+  setMeasurement,
+  setScroll,
+} from "../../webview-ui/src/components/chat/transcript-cache"
+
+const snapshot = (id: number) => ({ id }) as unknown as CacheSnapshot
+const layout = layoutFingerprint({ width: 800, ratio: 2, font: "Kilo Sans", size: "13px", line: "20px" })
+
+describe("transcript measurement cache", () => {
+  beforeEach(resetTranscriptCaches)
+
+  it("returns a cache only for the exact row and layout fingerprints", () => {
+    const keys = rowFingerprint(["a", "bc"])
+    const cache = snapshot(1)
+    setMeasurement("session", keys, layout, cache)
+
+    expect(getMeasurement("session", keys, layout)).toBe(cache)
+    expect(getMeasurement("session", rowFingerprint(["a", "bd"]), layout)).toBeUndefined()
+    expect(getMeasurement("session", keys, layout)).toBeUndefined()
+  })
+
+  it("invalidates a measurement when layout changes", () => {
+    const keys = rowFingerprint(["row"])
+    setMeasurement("session", keys, layout, snapshot(1))
+    const changed = layoutFingerprint({ width: 801, ratio: 2, font: "Kilo Sans", size: "13px", line: "20px" })
+
+    expect(getMeasurement("session", keys, changed)).toBeUndefined()
+    expect(getMeasurement("session", keys, layout)).toBeUndefined()
+  })
+
+  it("uses collision-safe row and layout fingerprints", () => {
+    expect(rowFingerprint(["a|b", "c"])).not.toBe(rowFingerprint(["a", "b|c"]))
+    expect(layoutFingerprint({ width: 80, ratio: 1, font: "a|b", size: "c", line: "d" })).not.toBe(
+      layoutFingerprint({ width: 80, ratio: 1, font: "a", size: "b|c", line: "d" }),
+    )
+  })
+
+  it("evicts the least recently used measurement after 16 sessions", () => {
+    const keys = rowFingerprint(["row"])
+    for (let i = 0; i < 16; i += 1) setMeasurement(`s${i}`, keys, layout, snapshot(i))
+    expect(getMeasurement("s0", keys, layout)).toBeDefined()
+    setMeasurement("s16", keys, layout, snapshot(16))
+
+    expect(getMeasurement("s1", keys, layout)).toBeUndefined()
+    expect(getMeasurement("s0", keys, layout)).toBeDefined()
+  })
+})
+
+describe("transcript scroll cache", () => {
+  beforeEach(resetTranscriptCaches)
+
+  it("stores bottom-follow and anchored positions independently from measurements", () => {
+    setMeasurement("a", rowFingerprint(["row"]), layout, snapshot(1))
+    setScroll("a", { type: "bottom" })
+    setScroll("b", { type: "anchor", key: "row-2", offset: 37 })
+
+    expect(getScroll("a")).toEqual({ type: "bottom" })
+    expect(getScroll("b")).toEqual({ type: "anchor", key: "row-2", offset: 37 })
+  })
+
+  it("resolves an anchor after prepended rows shift its index", () => {
+    const state = { type: "anchor", key: "stable", offset: 19 } as const
+    expect(resolveAnchor(state, ["stable", "tail"])).toEqual({ index: 0, offset: 19 })
+    expect(resolveAnchor(state, ["older-1", "older-2", "stable", "tail"])).toEqual({ index: 2, offset: 19 })
+    expect(resolveAnchor(state, ["other"])).toBeUndefined()
+    expect(resolveAnchor({ type: "bottom" }, ["stable"])).toBeUndefined()
+  })
+
+  it("evicts the least recently used scroll state after 50 sessions", () => {
+    for (let i = 0; i < 50; i += 1) setScroll(`s${i}`, { type: "bottom" })
+    expect(getScroll("s0")).toEqual({ type: "bottom" })
+    setScroll("s50", { type: "anchor", key: "row", offset: 4 })
+
+    expect(getScroll("s1")).toBeUndefined()
+    expect(getScroll("s0")).toEqual({ type: "bottom" })
+    expect(getScroll("s50")).toEqual({ type: "anchor", key: "row", offset: 4 })
+  })
+})

--- a/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "bun:test"
+import { messageTurns } from "../../webview-ui/src/context/session-queue"
+import { partitionRows, transcriptRows } from "../../webview-ui/src/context/transcript-rows"
+import type { Message, Part } from "../../webview-ui/src/types/messages"
+
+const base = {
+  sessionID: "session",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  time: { created: 1 },
+}
+
+const user = (id: string, opts: Partial<Message> = {}): Message => ({ ...base, id, role: "user", ...opts })
+const assistant = (id: string, parentID: string, opts: Partial<Message> = {}): Message => ({
+  ...base,
+  id,
+  parentID,
+  role: "assistant",
+  ...opts,
+})
+const part = (id: string, messageID: string): Part => ({ id, messageID, type: "text", text: id })
+const lookup = (values: Record<string, Part[]>) => (id: string) => values[id] ?? []
+
+describe("transcriptRows", () => {
+  it("preserves turn order across user, bounded assistant, diff, and error rows", () => {
+    const u1 = user("u1", { summary: { diffs: [{ file: "a.ts" }] } })
+    const a1 = assistant("a1", "u1")
+    const a2 = assistant("a2", "u1", { error: { name: "ProviderError" } })
+    const u2 = user("u2")
+    const a3 = assistant("a3", "u2")
+    const parts = {
+      u1: [part("up1", "u1")],
+      a1: Array.from({ length: 10 }, (_, i) => part(`p${i}`, "a1")),
+      a2: [part("p10", "a2")],
+      a3: [part("p11", "a3")],
+    }
+
+    const rows = transcriptRows(messageTurns([u1, a1, a2, u2, a3]), lookup(parts))
+
+    expect(rows.map((row) => `${row.turn}:${row.type}`)).toEqual([
+      "u1:user",
+      "u1:assistant",
+      "u1:assistant",
+      "u1:assistant",
+      "u1:diff",
+      "u1:error",
+      "u2:user",
+      "u2:assistant",
+    ])
+    expect(rows.filter((row) => row.type === "assistant").map((row) => row.parts.length)).toEqual([8, 2, 1, 1])
+  })
+
+  it("uses the configured bound and keeps an empty assistant renderable", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const a2 = assistant("a2", "u1")
+    const rows = transcriptRows(
+      messageTurns([u1, a1, a2]),
+      lookup({ a1: Array.from({ length: 7 }, (_, i) => part(`p${i}`, "a1")) }),
+      { size: 3 },
+    )
+
+    expect(rows.filter((row) => row.type === "assistant").map((row) => row.parts.length)).toEqual([3, 3, 1, 0])
+  })
+
+  it("omits synthetic users for partial turns and carries row metadata", () => {
+    const a1 = assistant("a1", "u1")
+    const rows = transcriptRows(messageTurns([a1]), lookup({ a1: [part("p1", "a1")] }), {
+      queued: new Set(["u1"]),
+      live: new Set(["u1"]),
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ type: "assistant", turn: "u1", partial: true, queued: true, live: true })
+  })
+
+  it("places only the first visible non-abort error after diffs", () => {
+    const u1 = user("u1", { summary: { diffs: [{ file: "a.ts" }] } })
+    const a1 = assistant("a1", "u1", { error: { name: "MessageAbortedError" } })
+    const a2 = assistant("a2", "u1", { error: { name: "HiddenError" } })
+    const a3 = assistant("a3", "u1", { error: { name: "ShownError" } })
+    const rows = transcriptRows(messageTurns([u1, a1, a2, a3]), lookup({}), { hidden: (id) => id === "a2" })
+
+    expect(rows.slice(-2).map((row) => row.type)).toEqual(["diff", "error"])
+    expect(rows.at(-1)).toMatchObject({ type: "error", message: a3, error: a3.error })
+  })
+
+  it("keeps keys stable when older turns are prepended and parts are appended", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const parts = Array.from({ length: 8 }, (_, i) => part(`p${i}`, "a1"))
+    const current = transcriptRows(messageTurns([u1, a1]), lookup({ a1: parts }))
+    const older = user("u0")
+    const next = transcriptRows(messageTurns([older, u1, a1]), lookup({ a1: [...parts, part("p8", "a1")] }))
+
+    expect(next.find((row) => row.type === "user" && row.turn === "u1")?.key).toBe(current[0]?.key)
+    expect(next.find((row) => row.type === "assistant" && row.parts[0]?.id === "p0")?.key).toBe(current[1]?.key)
+  })
+
+  it("reuses unchanged rows across prepend and append updates", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const u2 = user("u2")
+    const p1 = part("p1", "a1")
+    const first = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [p1] }))
+    const u0 = user("u0")
+    const a2 = assistant("a2", "u2")
+    const second = transcriptRows(messageTurns([u0, u1, a1, u2, a2]), lookup({ a1: [p1] }), {}, first)
+
+    expect(second[1]).toBe(first[0])
+    expect(second[2]).toBe(first[1])
+    expect(second[3]).not.toBe(first[2])
+    expect(second[4]).not.toBe(first[2])
+  })
+
+  it("selects the last real assistant text part as the copy target", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const a2 = assistant("a2", "u1")
+    const synthetic: Part = { ...part("p2", "a2"), synthetic: true }
+    const blank: Part = { ...part("p3", "a2"), text: " " }
+    const rows = transcriptRows(
+      messageTurns([u1, a1, a2]),
+      lookup({ a1: [part("p1", "a1")], a2: [synthetic, blank] }),
+    )
+
+    expect(rows.filter((row) => row.type === "assistant").map((row) => row.copy)).toEqual(["p1", "p1"])
+  })
+
+  it("keeps compaction replies ordered under the compacted turn and respects revert turns", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const u2 = user("u2", {
+      parts: [{ id: "compact", messageID: "u2", type: "compaction", auto: false }],
+    })
+    const a2 = assistant("a2", "u1")
+    const u3 = user("u3")
+    const turns = messageTurns([u1, a1, u2, a2, u3], "u3")
+    const rows = transcriptRows(turns, (id) => (id === "u2" ? u2.parts ?? [] : []))
+
+    expect(rows.map((row) => `${row.turn}:${row.message.id}`)).toEqual([
+      "u1:u1",
+      "u1:a1",
+      "u2:u2",
+      "u2:a2",
+    ])
+  })
+
+  it("replaces only rows whose data or metadata changed", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const p1 = part("p1", "a1")
+    const first = transcriptRows(messageTurns([u1, a1]), lookup({ a1: [p1] }))
+    const changed = { ...p1, text: "changed" }
+    const second = transcriptRows(messageTurns([u1, a1]), lookup({ a1: [changed] }), {}, first)
+
+    expect(second[0]).toBe(first[0])
+    expect(second[1]).not.toBe(first[1])
+
+    const live = transcriptRows(messageTurns([u1, a1]), lookup({ a1: [changed] }), { live: new Set(["u1"]) }, second)
+    expect(live[0]).not.toBe(second[0])
+    expect(live[1]).not.toBe(second[1])
+  })
+})
+
+describe("partitionRows", () => {
+  it("pins only a bounded live suffix and virtualizes completed history", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const u2 = user("u2")
+    const a2 = assistant("a2", "u2")
+    const parts = Array.from({ length: 18 }, (_, i) => part(`p${i}`, "a2"))
+    const rows = transcriptRows(messageTurns([u1, a1, u2, a2]), lookup({ a1: [part("old", "a1")], a2: parts }), {
+      live: new Set(["u2"]),
+    })
+    const result = partitionRows(rows)
+
+    expect(result.keep).toEqual([result.virtual.length - 2, result.virtual.length - 1])
+    expect(result.keep.map((idx) => result.virtual[idx]).every((row) => row?.live && row.turn === "u2")).toBe(true)
+    expect(
+      result.keep
+        .flatMap((idx) => {
+          const row = result.virtual[idx]
+          return row?.type === "assistant" ? row.parts : []
+        })
+        .map((item) => item.id),
+    ).toEqual(["p8", "p9", "p10", "p11", "p12", "p13", "p14", "p15", "p16", "p17"])
+    expect(result.virtual.some((row) => row.turn === "u1")).toBe(true)
+    expect(result.virtual.some((row) => row.turn === "u2" && row.type === "user")).toBe(true)
+  })
+
+  it("returns completed live metadata to virtual history after queue handoff", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const u2 = user("u2")
+    const first = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [part("p1", "a1")] }), {
+      live: new Set(["u1"]),
+      queued: new Set(["u2"]),
+    })
+    const active = partitionRows(first)
+    expect(active.keep).toEqual([0, 1])
+    expect(active.keep.map((idx) => active.virtual[idx]?.turn)).toEqual(["u1", "u1"])
+    expect(active.queued.map((row) => row.turn)).toEqual(["u2"])
+
+    const second = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [part("p1", "a1")] }), {
+      live: new Set(["u2"]),
+    })
+    const handed = partitionRows(second)
+
+    expect(handed.keep.map((idx) => handed.virtual[idx]?.turn)).toEqual(["u2"])
+    expect(handed.virtual.filter((row) => row.turn === "u1")).toHaveLength(2)
+  })
+
+  it("keeps queued rows in visual order inside virtual data", () => {
+    const u1 = user("u1")
+    const u2 = user("u2")
+    const rows = transcriptRows(messageTurns([u1, u2]), lookup({}), {
+      live: new Set(["u1"]),
+      queued: new Set(["u2"]),
+    })
+    const result = partitionRows(rows)
+
+    expect(result.virtual.map((row) => row.turn)).toEqual(["u1"])
+    expect(result.keep).toEqual([0])
+    expect(result.queued.map((row) => row.turn)).toEqual(["u2"])
+    expect(result.queued[0]).toMatchObject({ type: "user", queued: true })
+  })
+})

--- a/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
@@ -118,10 +118,7 @@ describe("transcriptRows", () => {
     const a2 = assistant("a2", "u1")
     const synthetic: Part = { ...part("p2", "a2"), synthetic: true }
     const blank: Part = { ...part("p3", "a2"), text: " " }
-    const rows = transcriptRows(
-      messageTurns([u1, a1, a2]),
-      lookup({ a1: [part("p1", "a1")], a2: [synthetic, blank] }),
-    )
+    const rows = transcriptRows(messageTurns([u1, a1, a2]), lookup({ a1: [part("p1", "a1")], a2: [synthetic, blank] }))
 
     expect(rows.filter((row) => row.type === "assistant").map((row) => row.copy)).toEqual(["p1", "p1"])
   })
@@ -135,14 +132,9 @@ describe("transcriptRows", () => {
     const a2 = assistant("a2", "u1")
     const u3 = user("u3")
     const turns = messageTurns([u1, a1, u2, a2, u3], "u3")
-    const rows = transcriptRows(turns, (id) => (id === "u2" ? u2.parts ?? [] : []))
+    const rows = transcriptRows(turns, (id) => (id === "u2" ? (u2.parts ?? []) : []))
 
-    expect(rows.map((row) => `${row.turn}:${row.message.id}`)).toEqual([
-      "u1:u1",
-      "u1:a1",
-      "u2:u2",
-      "u2:a2",
-    ])
+    expect(rows.map((row) => `${row.turn}:${row.message.id}`)).toEqual(["u1:u1", "u1:a1", "u2:u2", "u2:a2"])
   })
 
   it("replaces only rows whose data or metadata changed", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -110,6 +110,7 @@ function matchToolRequest<T extends { tool?: { callID: string; messageID: string
 
 interface AssistantMessageProps {
   message: SDKAssistantMessage
+  parts?: SDKPart[]
   showAssistantCopyPartID?: string | null
   feedback?: MessageFeedbackControls
 }
@@ -177,7 +178,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const open = createMemo(() => config().terminal_command_display !== "collapsed")
 
   const parts = createMemo(() => {
-    const stored = data.store.part?.[props.message.id]
+    const stored = props.parts ?? data.store.part?.[props.message.id]
     if (!stored) return []
     return (stored as SDKPart[]).filter((part) => isRenderable(part))
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -20,23 +20,32 @@ import { useLanguage } from "../../context/language"
 import { recentSessions } from "../../context/session-utils"
 import { formatRelativeDate } from "../../utils/date"
 import { FeedbackDialog } from "./FeedbackDialog"
-import { VscodeSessionTurn } from "./VscodeSessionTurn"
+import { TranscriptRowView } from "./TranscriptRow"
 import { RevertBanner } from "./RevertBanner"
 import { AccountSwitcher } from "../shared/AccountSwitcher"
 import { KiloNotifications } from "./KiloNotifications"
 import { WorkingIndicator } from "../shared/WorkingIndicator"
 import { TurnOutcome } from "../shared/TurnOutcome"
 import { QuestionDock } from "./QuestionDock"
-import { Virtualizer } from "virtua/solid"
+import { Virtualizer, type VirtualizerHandle } from "virtua/solid"
 import { SuggestBar } from "./SuggestBar"
+import {
+  getMeasurement,
+  getScroll,
+  layoutFingerprint,
+  resolveAnchor,
+  rowFingerprint,
+  setMeasurement,
+  setScroll,
+} from "./transcript-cache"
 import {
   activeUserMessageID as getActiveUserMessageID,
   messageTurns,
-  partitionTurns,
   queuedUserMessageIDs,
   stableMessageTurns,
   type MessageTurn,
 } from "../../context/session-queue"
+import { partitionRows, transcriptRows, type TranscriptRow } from "../../context/transcript-rows"
 import type { QuestionRequest, SuggestionRequest } from "../../types/messages"
 
 const KiloLogo = (): JSX.Element => {
@@ -88,7 +97,8 @@ export const MessageList: Component<MessageListProps> = (props) => {
   })
 
   const [scrollEl, setScrollEl] = createSignal<HTMLElement>()
-  const positions = new Map<string, { top: number; userScrolled: boolean }>()
+  const [virtualizer, setVirtualizer] = createSignal<VirtualizerHandle>()
+  const [layout, setLayout] = createSignal("")
 
   const boundary = () => session.revert()?.messageID
   const turns = createMemo((prev: MessageTurn[] | undefined) =>
@@ -107,45 +117,55 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const queuedIDs = createMemo(
     () => new Set(queuedUserMessageIDs(session.messages(), session.statusInfo(), (msg) => session.getParts(msg.id))),
   )
-  const [held, setHeld] = createSignal<{ sid: string; ids: Set<string> }>()
-  createEffect(() => {
-    const id = activeUserID()
-    const sid = session.currentSessionID()
-    const paused = autoScroll.userScrolled()
-    if (!sid || (!id && !paused)) {
-      setHeld(undefined)
-      return
-    }
-    if (!id) return
-    if (!paused) {
-      setHeld({ sid, ids: new Set([id]) })
-      return
-    }
-    setHeld((prev) => {
-      if (prev?.sid === sid && prev.ids.has(id)) return prev
-      const ids = prev?.sid === sid ? new Set(prev.ids) : new Set<string>()
-      ids.add(id)
-      return { sid, ids }
-    })
-  })
-  const directIDs = createMemo(() => {
-    const item = held()
-    const ids = item && item.sid === session.currentSessionID() ? new Set(item.ids) : new Set<string>()
+  const rows = createMemo((prev: TranscriptRow[] | undefined) => {
     const active = activeUserID()
-    if (active) ids.add(active)
-    return ids
+    return transcriptRows(
+      turns(),
+      (msg) => session.getParts(msg),
+      {
+        queued: queuedIDs(),
+        live: new Set(active ? [active] : []),
+        hidden: session.isErrorHidden,
+      },
+      prev,
+    )
   })
-  // Keep the growing live turn out of Virtua. Resizing a tall virtual item while
-  // the user reads within it makes Virtua compensate scrollTop as if earlier
-  // content moved, dragging the viewport downward during streaming. Preserve
-  // direct-rendered tail turns while paused so completion and queue handoffs do
-  // not move a turn being read back into the virtualized history.
-  const partition = createMemo(() => partitionTurns(turns(), directIDs(), queuedIDs()))
+  const partition = createMemo(() => partitionRows(rows()))
+  const keys = createMemo(() => partition().virtual.map((row) => row.key))
+  const fingerprint = createMemo(() => rowFingerprint(keys()))
+  const measurement = createMemo(() => {
+    const id = session.currentSessionID()
+    const token = layout()
+    if (!id || !token || session.loading() || keys().length === 0) return undefined
+    return getMeasurement(id, fingerprint(), token)
+  })
 
-  const save = (id: string | undefined) => {
+  let active = { id: session.currentSessionID(), keys: keys(), fingerprint: fingerprint() }
+  createEffect(() => {
+    const id = session.currentSessionID()
+    const current = keys()
+    const value = fingerprint()
+    if (!id || session.loading() || active.id !== id) return
+    active = { id, keys: current, fingerprint: value }
+  })
+
+  const save = (id: string | undefined, saved = active) => {
     const el = scrollEl()
-    if (!id || !el) return
-    positions.set(id, { top: el.scrollTop, userScrolled: autoScroll.userScrolled() })
+    if (!id || !el || saved.id !== id) return
+    const handle = virtualizer()
+    const token = layout()
+    if (handle && token && saved.keys.length > 0) {
+      setMeasurement(id, saved.fingerprint, token, handle.cache)
+    }
+    if (!autoScroll.userScrolled()) {
+      setScroll(id, { type: "bottom" })
+      return
+    }
+    if (!handle || saved.keys.length === 0) return
+    const index = handle.findStartIndex()
+    const key = saved.keys[index]
+    if (!key) return
+    setScroll(id, { type: "anchor", key, offset: handle.scrollOffset - handle.getItemOffset(index) })
   }
 
   const maybeLoadOlder = () => {
@@ -159,16 +179,44 @@ export const MessageList: Component<MessageListProps> = (props) => {
     maybeLoadOlder()
   }
 
+  let resize: ResizeObserver | undefined
+  const refreshLayout = () => {
+    const el = scrollEl()
+    if (!el) return
+    const style = getComputedStyle(el)
+    setLayout(
+      layoutFingerprint({
+        width: Math.round(el.clientWidth),
+        ratio: window.devicePixelRatio,
+        font: style.fontFamily,
+        size: style.fontSize,
+        line: style.lineHeight,
+      }),
+    )
+  }
   const setScrollRef = (el: HTMLElement | undefined) => {
+    resize?.disconnect()
     setScrollEl(el)
     autoScroll.scrollRef(el)
+    if (!el) return
+    refreshLayout()
+    resize = new ResizeObserver(refreshLayout)
+    resize.observe(el)
   }
+  window.addEventListener("resize", refreshLayout)
+  document.fonts?.addEventListener("loadingdone", refreshLayout)
+  onCleanup(() => {
+    resize?.disconnect()
+    window.removeEventListener("resize", refreshLayout)
+    document.fonts?.removeEventListener("loadingdone", refreshLayout)
+  })
 
   const [pendingRestore, setPendingRestore] = createSignal<string>()
 
   createEffect(
     on(session.currentSessionID, (id, prev) => {
       save(prev)
+      active = { id, keys: [], fingerprint: rowFingerprint([]) }
       setPendingRestore(id)
     }),
   )
@@ -185,9 +233,11 @@ export const MessageList: Component<MessageListProps> = (props) => {
         if (pendingRestore() !== id) return
         const el = scrollEl()
         if (!el) return
-        const pos = positions.get(id)
-        if (pos?.userScrolled) {
-          el.scrollTop = pos.top
+        const state = getScroll(id)
+        const anchor = resolveAnchor(state, keys())
+        const handle = virtualizer()
+        if (state?.type === "anchor" && anchor && handle) {
+          handle.scrollToIndex(anchor.index, { offset: anchor.offset })
           autoScroll.pause()
           maybeLoadOlder()
         } else {
@@ -262,28 +312,36 @@ export const MessageList: Component<MessageListProps> = (props) => {
                 {language.t("session.messages.loadEarlier")}
               </button>
             </Show>
-            <Show when={partition().virtual.length > 0 || partition().direct.length > 0}>
-              <div class="message-list-turns">
-                <Show when={scrollEl() && partition().virtual.length > 0}>
+            <Show when={partition().virtual.length > 0}>
+              <div
+                class="message-list-turns"
+                data-loaded-messages={session.messages().length}
+                data-row-count={partition().virtual.length}
+                data-queued-count={partition().queued.length}
+                data-kept-count={partition().keep.length}
+              >
+                <Show when={scrollEl()}>
                   <Virtualizer
+                    ref={setVirtualizer}
                     data={partition().virtual}
                     scrollRef={scrollEl()}
                     shift={session.messageMutation() === "prepend"}
-                    overscan={6}
+                    cache={measurement()}
+                    keepMounted={partition().keep}
+                    overscan={2}
                     itemSize={260}
                   >
-                    {(turn) => <VscodeSessionTurn turn={turn} onForkMessage={props.onForkMessage} />}
+                    {(row, index) => (
+                      <TranscriptRowView row={row} index={index()} onForkMessage={props.onForkMessage} />
+                    )}
                   </Virtualizer>
                 </Show>
-                <For each={partition().direct}>
-                  {(turn) => <VscodeSessionTurn turn={turn} onForkMessage={props.onForkMessage} />}
-                </For>
               </div>
             </Show>
             <Show when={boundary()}>
               <RevertBanner />
             </Show>
-            <For each={partition().queued}>{(turn) => <VscodeSessionTurn turn={turn} queued />}</For>
+            <For each={partition().queued}>{(row) => <TranscriptRowView row={row} />}</For>
             <WorkingIndicator />
             <TurnOutcome />
             <For each={props.questions?.()}>{(req) => <QuestionDock request={req} />}</For>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -1,21 +1,13 @@
 /**
- * TaskTimeline — horizontal strip of colored bars representing session activity.
- *
- * Each bar = one Part from assistant messages.
- * Color  = part type (read=blue, write=dark blue, tool=indigo, error=red, text=gray).
- * Width  = proportional to time between parts.
- * Height = proportional to content length.
- *
- * Interactions: drag scroll, mouse wheel, auto-scroll to latest.
- *
- * No virtualization needed: SolidJS <Index> creates each element once and
- * updates bindings in place (unlike React). Even 1000+ bars are fine.
+ * Horizontal session activity timeline rendered as color-grouped SVG paths.
+ * Pointer and keyboard interaction use the same pure bar geometry.
  */
 
-import { Component, Index, Show, createMemo, createEffect, createSignal, on, onCleanup } from "solid-js"
+import { Component, For, Show, createMemo, createEffect, createSignal, on, onCleanup } from "solid-js"
 import { Portal } from "solid-js/web"
 import { useSession } from "../../context/session"
 import { color, label } from "../../utils/timeline/colors"
+import { geometry, hit, navigate } from "../../utils/timeline/geometry"
 import { sizes, pinned, MAX_HEIGHT } from "../../utils/timeline/sizes"
 import type { Part, Message } from "../../types/messages"
 
@@ -56,7 +48,8 @@ export const TaskTimeline: Component = () => {
   let dragging = false
   let startX = 0
   let startScroll = 0
-  let tipBar: HTMLElement | undefined
+  const [hover, setHover] = createSignal(-1)
+  const [active, setActive] = createSignal(-1)
   const [tip, setTip] = createSignal<{ text: string; x: number; y: number }>()
 
   const messages = () => session.visibleMessages()
@@ -71,12 +64,20 @@ export const TaskTimeline: Component = () => {
   }
 
   const bars = createMemo(() => collect(messages(), allParts()))
+  const layout = createMemo(() => geometry(bars(), MAX_HEIGHT))
   const busy = () => session.status() === "busy"
+  const selected = () => {
+    const idx = active()
+    if (idx >= 0 && idx < bars().length) return idx
+    return bars().length - 1
+  }
+  const aria = () => {
+    const idx = selected()
+    const bar = bars()[idx]
+    if (!bar) return "Session activity timeline, no activity"
+    return `Session activity timeline, bar ${idx + 1} of ${bars().length}: ${bar.tip}`
+  }
 
-  // Reading scrollWidth and writing scrollLeft synchronously for every appended bar can
-  // force repeated layout during streamed part updates. Batch those appends behind one
-  // animation frame, after Solid has applied the current DOM updates. Only follow while
-  // pinned so inspecting earlier activity is not interrupted by incoming bars.
   let prev = 0
   let frame: number | undefined
   let follow = true
@@ -87,6 +88,7 @@ export const TaskTimeline: Component = () => {
     on(
       () => bars().length,
       (len) => {
+        if (active() >= len) setActive(len - 1)
         if (len > prev && ref && follow && frame === undefined) {
           frame = requestAnimationFrame(() => {
             frame = undefined
@@ -103,28 +105,32 @@ export const TaskTimeline: Component = () => {
   })
 
   const hideTip = () => {
-    tipBar = undefined
+    setHover(-1)
     setTip(undefined)
   }
 
   createEffect(on(bars, hideTip, { defer: true }))
 
-  const showTip = (e: PointerEvent) => {
-    if (dragging || !(e.target instanceof Element)) return
-    const bar = e.target.closest<HTMLElement>(".task-timeline-bar")
-    if (!bar || !ref?.contains(bar)) return hideTip()
-    if (bar === tipBar) return
-    const rect = bar.getBoundingClientRect()
-    tipBar = bar
+  const showTip = (idx: number) => {
+    const item = layout().items[idx]
+    const bar = bars()[idx]
+    if (!ref || !item || !bar) return hideTip()
+    const rect = ref.getBoundingClientRect()
     const margin = Math.min(160, window.innerWidth / 2)
+    setHover(idx)
     setTip({
-      text: bar.dataset.tip ?? "",
-      x: Math.max(margin, Math.min(window.innerWidth - margin, rect.left + rect.width / 2)),
-      y: rect.top,
+      text: bar.tip,
+      x: Math.max(margin, Math.min(window.innerWidth - margin, rect.left + item.x - ref.scrollLeft + item.width / 2)),
+      y: rect.top + MAX_HEIGHT - item.height,
     })
   }
 
-  // ── Drag scroll ──────────────────────────────────────────────────
+  const pointerIndex = (e: PointerEvent) => {
+    if (!ref) return -1
+    const rect = ref.getBoundingClientRect()
+    return hit(layout().items, e.clientX - rect.left + ref.scrollLeft)
+  }
+
   const onPointerDown = (e: PointerEvent) => {
     hideTip()
     if (!ref) return
@@ -137,24 +143,43 @@ export const TaskTimeline: Component = () => {
   }
 
   const onPointerMove = (e: PointerEvent) => {
-    if (!dragging || !ref) return showTip(e)
+    if (!ref) return
+    if (!dragging) {
+      const idx = pointerIndex(e)
+      if (idx === hover()) return
+      if (idx < 0) return hideTip()
+      return showTip(idx)
+    }
     ref.scrollLeft = startScroll - (e.clientX - startX)
   }
 
   const onPointerUp = (e: PointerEvent) => {
     if (!ref) return
     dragging = false
-    ref.releasePointerCapture(e.pointerId)
+    if (ref.hasPointerCapture(e.pointerId)) ref.releasePointerCapture(e.pointerId)
     ref.style.cursor = "grab"
     ref.style.userSelect = ""
   }
 
-  // ── Wheel → horizontal scroll ────────────────────────────────────
   const onWheel = (e: WheelEvent) => {
     hideTip()
     if (!ref) return
     e.preventDefault()
     ref.scrollLeft += e.deltaY || e.deltaX
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (!ref || !["ArrowLeft", "ArrowRight", "Home", "End"].includes(e.key)) return
+    e.preventDefault()
+    const idx = navigate(selected(), bars().length, e.key)
+    setActive(idx)
+    const item = layout().items[idx]
+    if (!item) return
+    const left = item.x
+    const right = item.x + item.width
+    if (left < ref.scrollLeft) ref.scrollLeft = left
+    if (right > ref.scrollLeft + ref.clientWidth) ref.scrollLeft = right - ref.clientWidth
+    showTip(idx)
   }
 
   createEffect(() => {
@@ -164,13 +189,37 @@ export const TaskTimeline: Component = () => {
     onCleanup(() => el.removeEventListener("wheel", onWheel))
   })
 
+  const overlay = (idx: number, pulse = false) => {
+    const item = layout().items[idx]
+    if (!item) return null
+    return (
+      <div
+        class="task-timeline-bar"
+        classList={{ "task-timeline-bar--active": pulse }}
+        aria-hidden="true"
+        style={{
+          left: `${item.x}px`,
+          width: `${item.width}px`,
+          height: `${item.height}px`,
+          "--timeline-color": item.bg,
+        }}
+      />
+    )
+  }
+
   return (
     <>
       <div class="task-timeline-outer">
         <div
           ref={ref}
           class="task-timeline"
+          data-timeline-count={bars().length}
+          role="img"
+          tabIndex={0}
+          aria-label={aria()}
           style={{ height: `${MAX_HEIGHT}px` }}
+          onKeyDown={onKeyDown}
+          onBlur={hideTip}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
@@ -178,34 +227,19 @@ export const TaskTimeline: Component = () => {
           onPointerLeave={hideTip}
           onScroll={onScroll}
         >
-          <Index each={bars()}>
-            {(bar) => {
-              const active = () => busy() && bar().idx === bars().length - 1
-              return (
-                <div
-                  class="task-timeline-bar"
-                  data-tip={bar().tip}
-                  role="img"
-                  aria-label={bar().tip}
-                  style={{
-                    width: `${bar().width}px`,
-                    height: `${MAX_HEIGHT}px`,
-                  }}
-                >
-                  <div
-                    class="task-timeline-bar-fill task-timeline-bar-fill--new"
-                    classList={{
-                      "task-timeline-bar-fill--active": active(),
-                    }}
-                    style={{
-                      background: bar().bg,
-                      height: `${(bar().height / MAX_HEIGHT) * 100}%`,
-                    }}
-                  />
-                </div>
-              )
-            }}
-          </Index>
+          <div class="task-timeline-content" style={{ width: `${layout().width}px`, height: `${MAX_HEIGHT}px` }}>
+            <svg
+              class="task-timeline-svg"
+              width={layout().width}
+              height={MAX_HEIGHT}
+              viewBox={`0 0 ${layout().width} ${MAX_HEIGHT}`}
+              aria-hidden="true"
+            >
+              <For each={layout().paths}>{(path) => <path d={path.d} fill={path.bg} />}</For>
+            </svg>
+            <Show when={hover() >= 0}>{overlay(hover())}</Show>
+            <Show when={busy() && bars().length > 0}>{overlay(bars().length - 1, true)}</Show>
+          </div>
         </div>
       </div>
       <Show when={tip()}>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -1,0 +1,131 @@
+import { type Component, Show, createEffect } from "solid-js"
+import { UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
+import { DiffChanges } from "@kilocode/kilo-ui/diff-changes"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { useI18n } from "@kilocode/kilo-ui/context/i18n"
+import type { AssistantMessage as SDKAssistantMessage, Part as SDKPart, SnapshotFileDiff } from "@kilocode/sdk/v2"
+import type { TranscriptRow } from "../../context/transcript-rows"
+import { useSession } from "../../context/session"
+import { useServer } from "../../context/server"
+import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
+import { useFeedback } from "../../context/feedback"
+import { AssistantMessage } from "./AssistantMessage"
+import { ErrorDisplay, type ErrorDisplayProps } from "./ErrorDisplay"
+
+interface TranscriptRowViewProps {
+  row: TranscriptRow
+  index?: number
+  onForkMessage?: (sessionId: string, messageId: string) => void
+}
+
+export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
+  const session = useSession()
+  const server = useServer()
+  const language = useLanguage()
+  const vscode = useVSCode()
+  const feedback = useFeedback()
+  const i18n = useI18n()
+
+  createEffect(() => session.hydrateParts([props.row.message.id]))
+
+  const open = () => vscode.postMessage({ type: "openChanges", turnId: props.row.message.id })
+
+  return (
+    <div
+      class="vscode-session-turn"
+      data-message={props.row.message.id}
+      data-row={props.row.type}
+      data-row-key={props.row.key}
+      data-row-index={props.index}
+      data-turn={props.row.turn}
+      data-live={props.row.live ? "" : undefined}
+    >
+      <Show when={props.row.type === "user" ? props.row : undefined}>
+        {(row) => (
+          <div
+            class="vscode-session-turn-user"
+            data-revert-disabled={row().answered && session.status() !== "idle" ? "" : undefined}
+            title={row().answered && session.status() !== "idle" ? language.t("revert.disabled.agentBusy") : undefined}
+          >
+            <UserMessageDisplay
+              message={row().message as unknown as Parameters<typeof UserMessageDisplay>[0]["message"]}
+              parts={row().parts as unknown as Parameters<typeof UserMessageDisplay>[0]["parts"]}
+              interrupted={row().interrupted}
+              queued={row().queued}
+              onFork={
+                props.onForkMessage
+                  ? () => props.onForkMessage?.(row().message.sessionID, row().message.id)
+                  : undefined
+              }
+              onRevert={
+                row().answered
+                  ? () => {
+                      if (session.status() !== "idle") return
+                      session.revertSession(row().message.id)
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        )}
+      </Show>
+
+      <Show when={props.row.type === "assistant" ? props.row : undefined}>
+        {(row) => (
+          <div class="vscode-session-turn-assistant">
+            <AssistantMessage
+              message={row().message as unknown as SDKAssistantMessage}
+              parts={row().parts as unknown as SDKPart[]}
+              showAssistantCopyPartID={row().copy}
+              feedback={{
+                enabled: feedback.telemetryEnabled(),
+                rating: feedback.getRating(row().message.id),
+                onRate: (next) =>
+                  feedback.rate({
+                    messageID: row().message.id,
+                    sessionID: row().message.sessionID,
+                    parentMessageID: row().message.parentID ?? "",
+                    providerID: row().message.providerID ?? row().message.model?.providerID ?? "",
+                    modelID: row().message.modelID ?? row().message.model?.modelID ?? "",
+                    variant: row().message.model?.variant,
+                    next,
+                  }),
+              }}
+            />
+          </div>
+        )}
+      </Show>
+
+      <Show when={props.row.type === "diff" ? props.row : undefined}>
+        {(row) => (
+          <Show when={server.gitInstalled()}>
+            <div class="vscode-session-turn-diffs" data-component="session-turn">
+              <button
+                type="button"
+                class="vscode-session-turn-diffs-trigger"
+                onClick={open}
+                aria-label={i18n.t("ui.sessionReview.change.modified")}
+              >
+                <span data-slot="session-turn-diffs-label">{i18n.t("ui.sessionReview.change.modified")}</span>
+                <span data-slot="session-turn-diffs-count">
+                  {row().diffs.length} {i18n.t(row().diffs.length === 1 ? "ui.common.file.one" : "ui.common.file.other")}
+                </span>
+                <span data-slot="session-turn-diffs-meta">
+                  <DiffChanges changes={row().diffs as SnapshotFileDiff[]} variant="bars" />
+                </span>
+                <span data-slot="session-turn-diffs-chevron" aria-hidden="true">
+                  <Icon name="chevron-right" size="small" />
+                </span>
+              </button>
+            </div>
+          </Show>
+        )}
+      </Show>
+
+      <Show when={props.row.type === "error" ? props.row : undefined}>
+        {(row) => <ErrorDisplay error={row().error as ErrorDisplayProps["error"]} onLogin={server.goToLogin} />}
+      </Show>
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -54,9 +54,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               interrupted={row().interrupted}
               queued={row().queued}
               onFork={
-                props.onForkMessage
-                  ? () => props.onForkMessage?.(row().message.sessionID, row().message.id)
-                  : undefined
+                props.onForkMessage ? () => props.onForkMessage?.(row().message.sessionID, row().message.id) : undefined
               }
               onRevert={
                 row().answered
@@ -109,7 +107,8 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               >
                 <span data-slot="session-turn-diffs-label">{i18n.t("ui.sessionReview.change.modified")}</span>
                 <span data-slot="session-turn-diffs-count">
-                  {row().diffs.length} {i18n.t(row().diffs.length === 1 ? "ui.common.file.one" : "ui.common.file.other")}
+                  {row().diffs.length}{" "}
+                  {i18n.t(row().diffs.length === 1 ? "ui.common.file.one" : "ui.common.file.other")}
                 </span>
                 <span data-slot="session-turn-diffs-meta">
                   <DiffChanges changes={row().diffs as SnapshotFileDiff[]} variant="bars" />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/transcript-cache.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/transcript-cache.ts
@@ -1,0 +1,85 @@
+import type { CacheSnapshot } from "virtua"
+
+const MEASUREMENT_LIMIT = 16
+const SCROLL_LIMIT = 50
+
+export interface LayoutMetrics {
+  width: number
+  ratio: number
+  font: string
+  size: string
+  line: string
+}
+
+export type ScrollState =
+  | { type: "bottom" }
+  | {
+      type: "anchor"
+      key: string
+      offset: number
+    }
+
+interface MeasurementState {
+  keys: string
+  layout: string
+  cache: CacheSnapshot
+}
+
+const measurements = new Map<string, MeasurementState>()
+const scrolls = new Map<string, ScrollState>()
+
+function touch<T>(cache: Map<string, T>, key: string, value: T, limit: number) {
+  cache.delete(key)
+  cache.set(key, value)
+  if (cache.size <= limit) return
+  const oldest = cache.keys().next().value
+  if (oldest !== undefined) cache.delete(oldest)
+}
+
+export function rowFingerprint(keys: readonly string[]) {
+  return keys.map((key) => `${key.length}:${key}`).join("|")
+}
+
+export function layoutFingerprint(metrics: LayoutMetrics) {
+  return [metrics.width, metrics.ratio, metrics.font, metrics.size, metrics.line]
+    .map((value) => `${String(value).length}:${value}`)
+    .join("|")
+}
+
+export function setMeasurement(id: string, keys: string, layout: string, cache: CacheSnapshot) {
+  touch(measurements, id, { keys, layout, cache }, MEASUREMENT_LIMIT)
+}
+
+export function getMeasurement(id: string, keys: string, layout: string) {
+  const value = measurements.get(id)
+  if (!value) return undefined
+  if (value.keys !== keys || value.layout !== layout) {
+    measurements.delete(id)
+    return undefined
+  }
+  touch(measurements, id, value, MEASUREMENT_LIMIT)
+  return value.cache
+}
+
+export function setScroll(id: string, state: ScrollState) {
+  touch(scrolls, id, state, SCROLL_LIMIT)
+}
+
+export function getScroll(id: string) {
+  const value = scrolls.get(id)
+  if (!value) return undefined
+  touch(scrolls, id, value, SCROLL_LIMIT)
+  return value
+}
+
+export function resolveAnchor(state: ScrollState | undefined, keys: readonly string[]) {
+  if (!state || state.type === "bottom") return undefined
+  const index = keys.indexOf(state.key)
+  if (index < 0) return undefined
+  return { index, offset: state.offset }
+}
+
+export function resetTranscriptCaches() {
+  measurements.clear()
+  scrolls.clear()
+}

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
@@ -70,10 +70,7 @@ function equal(a: TranscriptRow, b: TranscriptRow) {
   if (a.type !== b.type || !meta(a, b)) return false
   if (a.type === "user" && b.type === "user") {
     return (
-      a.message === b.message &&
-      same(a.parts, b.parts) &&
-      a.interrupted === b.interrupted &&
-      a.answered === b.answered
+      a.message === b.message && same(a.parts, b.parts) && a.interrupted === b.interrupted && a.answered === b.answered
     )
   }
   if (a.type === "assistant" && b.type === "assistant") {

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
@@ -1,0 +1,196 @@
+import type { Message, Part } from "../types/messages"
+import type { MessageTurn } from "./session-queue"
+
+interface TranscriptMeta {
+  turn: string
+  partial: boolean
+  queued: boolean
+  live: boolean
+}
+
+export interface TranscriptUserRow extends TranscriptMeta {
+  type: "user"
+  key: string
+  message: Message
+  parts: Part[]
+  interrupted: boolean
+  answered: boolean
+}
+
+export interface TranscriptAssistantRow extends TranscriptMeta {
+  type: "assistant"
+  key: string
+  message: Message
+  parts: Part[]
+  copy?: string
+}
+
+export interface TranscriptDiffRow extends TranscriptMeta {
+  type: "diff"
+  key: string
+  message: Message
+  diffs: unknown[]
+}
+
+export interface TranscriptErrorRow extends TranscriptMeta {
+  type: "error"
+  key: string
+  message: Message
+  error: NonNullable<Message["error"]>
+}
+
+export type TranscriptRow = TranscriptUserRow | TranscriptAssistantRow | TranscriptDiffRow | TranscriptErrorRow
+
+export interface TranscriptOptions {
+  size?: number
+  queued?: ReadonlySet<string>
+  live?: ReadonlySet<string>
+  hidden?: (id: string) => boolean
+}
+
+export interface TranscriptPartition {
+  virtual: TranscriptRow[]
+  keep: number[]
+  queued: TranscriptRow[]
+}
+
+function same<T>(a: T[], b: T[]) {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function meta(a: TranscriptRow, b: TranscriptRow) {
+  return a.turn === b.turn && a.partial === b.partial && a.queued === b.queued && a.live === b.live
+}
+
+function equal(a: TranscriptRow, b: TranscriptRow) {
+  if (a.type !== b.type || !meta(a, b)) return false
+  if (a.type === "user" && b.type === "user") {
+    return (
+      a.message === b.message &&
+      same(a.parts, b.parts) &&
+      a.interrupted === b.interrupted &&
+      a.answered === b.answered
+    )
+  }
+  if (a.type === "assistant" && b.type === "assistant") {
+    return a.message === b.message && same(a.parts, b.parts) && a.copy === b.copy
+  }
+  if (a.type === "diff" && b.type === "diff") {
+    return a.message === b.message && same(a.diffs, b.diffs)
+  }
+  if (a.type === "error" && b.type === "error") {
+    return a.message === b.message && a.error === b.error
+  }
+  return false
+}
+
+function diffs(msg: Message) {
+  if (!msg.summary || typeof msg.summary === "boolean") return []
+  return msg.summary.diffs ?? []
+}
+
+function copy(messages: Message[], getParts: (id: string) => Part[]) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const parts = getParts(messages[i]!.id)
+    for (let j = parts.length - 1; j >= 0; j -= 1) {
+      const part = parts[j]
+      if (part?.type !== "text" || part.synthetic || !part.text.trim()) continue
+      return part.id
+    }
+  }
+  return undefined
+}
+
+export function transcriptRows(
+  turns: MessageTurn[],
+  getParts: (id: string) => Part[],
+  opts: TranscriptOptions = {},
+  prev: TranscriptRow[] = [],
+): TranscriptRow[] {
+  const size = Math.max(1, Math.floor(opts.size ?? 8))
+  const rows: TranscriptRow[] = []
+
+  for (const turn of turns) {
+    const meta = {
+      turn: turn.id,
+      partial: turn.partial === true,
+      queued: opts.queued?.has(turn.id) === true,
+      live: opts.live?.has(turn.id) === true,
+    }
+    const copied = copy(turn.assistant, getParts)
+
+    if (!turn.partial) {
+      rows.push({
+        ...meta,
+        type: "user",
+        key: `${turn.id}:user`,
+        message: turn.user,
+        parts: getParts(turn.user.id),
+        interrupted: turn.assistant.some((msg) => msg.error?.name === "MessageAbortedError"),
+        answered: turn.assistant.length > 0,
+      })
+    }
+
+    for (const msg of turn.assistant) {
+      const parts = getParts(msg.id)
+      if (parts.length === 0) {
+        rows.push({
+          ...meta,
+          type: "assistant",
+          key: `${turn.id}:assistant:${msg.id}:empty`,
+          message: msg,
+          parts,
+          copy: copied,
+        })
+        continue
+      }
+      for (let start = 0; start < parts.length; start += size) {
+        const chunk = parts.slice(start, start + size)
+        rows.push({
+          ...meta,
+          type: "assistant",
+          key: `${turn.id}:assistant:${msg.id}:${chunk[0]!.id}`,
+          message: msg,
+          parts: chunk,
+          copy: copied,
+        })
+      }
+    }
+
+    const changes = diffs(turn.user)
+    if (changes.length > 0) {
+      rows.push({ ...meta, type: "diff", key: `${turn.id}:diff`, message: turn.user, diffs: changes })
+    }
+
+    const failed = turn.assistant.find(
+      (msg) => msg.error && msg.error.name !== "MessageAbortedError" && opts.hidden?.(msg.id) !== true,
+    )
+    if (failed?.error) {
+      rows.push({ ...meta, type: "error", key: `${turn.id}:error:${failed.id}`, message: failed, error: failed.error })
+    }
+  }
+
+  if (prev.length === 0) return rows
+  const prior = new Map(prev.map((row) => [row.key, row]))
+  return rows.map((row) => {
+    const old = prior.get(row.key)
+    return old && equal(old, row) ? old : row
+  })
+}
+
+export function partitionRows(rows: TranscriptRow[], limit = 2): TranscriptPartition {
+  const queued = rows.filter((row) => row.queued)
+  const virtual = rows.filter((row) => !row.queued)
+  const size = Math.max(0, Math.floor(limit))
+  const keep: number[] = []
+  for (let i = virtual.length - 1; i >= 0 && keep.length < size; i -= 1) {
+    const row = virtual[i]!
+    if (!row.live) break
+    keep.unshift(i)
+  }
+  return { virtual, keep, queued }
+}

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -121,8 +121,7 @@
 }
 
 .task-timeline {
-  display: flex;
-  align-items: flex-end;
+  position: relative;
   overflow-x: auto;
   overflow-y: hidden;
   cursor: grab;
@@ -130,37 +129,36 @@
   scrollbar-width: none; /* Firefox */
 }
 
+.task-timeline:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
 .task-timeline::-webkit-scrollbar {
   display: none;
 }
 
-.task-timeline-bar {
+.task-timeline-content {
   position: relative;
-  flex-shrink: 0;
-  margin-right: 1px;
-  overflow: hidden;
 }
 
-.task-timeline-bar-fill {
+.task-timeline-svg {
+  display: block;
+  overflow: visible;
+}
+
+.task-timeline-bar {
   position: absolute;
   bottom: 0;
-  left: 0;
-  right: 0;
+  box-sizing: border-box;
   border-radius: 2px 2px 0 0;
-  transition: opacity 0.15s;
-}
-
-.task-timeline-bar:hover .task-timeline-bar-fill {
+  background: var(--timeline-color);
   opacity: 0.7;
+  pointer-events: none;
 }
 
-/* Fade-in animation for new bars */
-.task-timeline-bar-fill--new {
-  animation: timeline-fade-in 0.3s ease-out;
-}
-
-/* Active (latest) bar pulse when session is busy */
-.task-timeline-bar-fill--active {
+.task-timeline-bar--active {
+  opacity: 1;
   animation: timeline-pulse 2s ease-in-out infinite 0.5s;
 }
 
@@ -170,18 +168,6 @@
   transform: translate(-50%, calc(-100% - 4px));
   white-space: normal;
   pointer-events: none;
-}
-
-@keyframes timeline-fade-in {
-  from {
-    opacity: 0;
-    transform: scaleY(0);
-    transform-origin: bottom;
-  }
-  to {
-    opacity: 1;
-    transform: scaleY(1);
-  }
 }
 
 @keyframes timeline-pulse {

--- a/packages/kilo-vscode/webview-ui/src/utils/timeline/geometry.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/timeline/geometry.ts
@@ -1,0 +1,73 @@
+export interface TimelineGeometryBar {
+  bg: string
+  width: number
+  height: number
+}
+
+export interface TimelineGeometryItem extends TimelineGeometryBar {
+  idx: number
+  x: number
+}
+
+export interface TimelineGeometry {
+  items: TimelineGeometryItem[]
+  paths: Array<{ bg: string; d: string }>
+  width: number
+}
+
+const shape = (x: number, width: number, height: number, max: number) => {
+  const y = max - height
+  const radius = Math.min(2, width / 2, height)
+  return `M${x},${max}V${y + radius}Q${x},${y} ${x + radius},${y}H${x + width - radius}Q${x + width},${y} ${x + width},${y + radius}V${max}Z`
+}
+
+export function geometry(bars: TimelineGeometryBar[], max: number, gap = 1): TimelineGeometry {
+  const paths = new Map<string, string[]>()
+  const items: TimelineGeometryItem[] = []
+  let x = 0
+
+  for (const [idx, bar] of bars.entries()) {
+    const item = { ...bar, idx, x }
+    items.push(item)
+    const path = paths.get(bar.bg) ?? []
+    path.push(shape(x, bar.width, bar.height, max))
+    paths.set(bar.bg, path)
+    x += bar.width + gap
+  }
+
+  return {
+    items,
+    paths: Array.from(paths, ([bg, parts]) => ({ bg, d: parts.join("") })),
+    width: x,
+  }
+}
+
+export function hit(items: TimelineGeometryItem[], x: number) {
+  let low = 0
+  let high = items.length - 1
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2)
+    const item = items[mid]!
+    if (x < item.x) {
+      high = mid - 1
+      continue
+    }
+    if (x >= item.x + item.width) {
+      low = mid + 1
+      continue
+    }
+    return item.idx
+  }
+
+  return -1
+}
+
+export function navigate(index: number, count: number, key: string) {
+  if (count === 0) return -1
+  if (key === "Home") return 0
+  if (key === "End") return count - 1
+  if (key === "ArrowLeft") return Math.max(0, index < 0 ? count - 1 : index - 1)
+  if (key === "ArrowRight") return Math.min(count - 1, index < 0 ? 0 : index + 1)
+  return index
+}


### PR DESCRIPTION
Kilo uses the same chat transcript renderer in the sidebar, editor tabs, and Agent Manager. Very large sessions currently virtualize whole user turns while keeping an active tail outside Virtua. A single turn can contain hundreds of tools and thousands of elements, so navigating or switching sessions may still mount most of a transcript even when only one small area intersects the viewport.

This introduces a viewport-first transcript model for every Kilo VS Code chat surface, based on the proven OpenCode desktop architecture. Complete turns are flattened into stable, bounded rows for user messages, assistant part groups, diffs, and errors. Virtua mounts only visible rows plus two rows of overscan, while `keepMounted` is limited to the genuinely active streaming rows. Completed history no longer has an unbounded direct tail.

The implementation preserves lazy `PartStash` hydration and adds exact session-keyed measurement and scroll caches. Cached heights are accepted only when the complete row-key and layout fingerprints match, and scroll state independently preserves bottom-follow or a row anchor plus intra-row offset. The task timeline is rendered as bounded grouped SVG paths instead of one DOM bar per activity, while retaining hover, drag, wheel, keyboard navigation, colors, active state, and accessible labeling.

## Measured impact

All comparisons used real Agent Manager sessions in a metadata-guarded shadow workspace, the exact Agent Manager `fake.html?id=<uuid>` frame, a 505 px transcript viewport, closed diff/review/terminal surfaces, stable source and target IDs, and multiple samples. The baseline is commit `f180658b99`.

### Heavy transcript DOM

The baseline heavy target had only one viewport-intersecting turn but retained:

| Signal | Baseline | Final representative session |
|---|---:|---:|
| Loaded transcript messages | 240 | 240 |
| Logical units | 12 complete turns | 245 bounded rows |
| Mounted transcript units | 12 turns | 3 rows |
| Direct unvirtualized units | 10 turns | 0 rows |
| Viewport-intersecting units | 1 turn | 1 row |
| Transcript pane elements | Thousands, with 13,292 elements in the full Agent Manager document | 179 |
| Tool part wrappers | 712 | 4 |
| Tool collapsibles | 449 | Bounded to mounted rows |
| Timeline activities | 791 | 791 |
| Timeline DOM descendants | About 1,582 | 9 |

The final viewport typically mounts 3 to 6 rows. A second session that previously exposed an unusually large offscreen row settled at 421 transcript elements and 15 tool wrappers after reducing overscan to two rows.

### Comparable CPU traces

For the same warmed source-to-heavy-target switch, the first bounded-row stage changed the trace distribution as follows:

| Metric | Baseline | Bounded rows | Change |
|---|---:|---:|---:|
| Longest switch task p50 | 379.8 ms | 43.3 ms | 88.6% lower |
| Longest switch task p95 | 418.0 ms | 45.9 ms | 89.0% lower |
| Longest switch task max | 427.5 ms | 46.2 ms | 89.2% lower |
| Full-capture script p50 | 2,290.5 ms | 934.6 ms | 59.2% lower |
| Full-capture style p50 | 59.5 ms | 28.5 ms | 52.2% lower |
| Full-capture layout p50 | 64.0 ms | 28.9 ms | 54.9% lower |
| Full-capture paint p50 | 17.7 ms | 15.9 ms | 10.3% lower |
| Chromium transient node delta | +13,818 | +492 | 96.4% lower |

The final strictly valid traced stage had no switch-overlapping main-thread task above 50 ms. Its three-stable-frame qualification was 95.0 ms p50, 99.1 ms p95, and 99.6 ms max, with work split across frames instead of one blocking task.

### Final warm activation latency

After reducing overscan to two rows, 30 repeated heavy worktree activations measured:

| Metric | Latency |
|---|---:|
| p50 | 25.7 ms |
| p95 | 33.8 ms |
| max | 38.6 ms |

All 30 samples activated the expected target. Compared with the previous three-row overscan stage, this is 26.1% lower at p50, 12.4% lower at p95, and 23.1% lower at max.

### Sessions within one worktree

Thirty direct switches from one 240-message session to each of two other 240-message tabs in the same worktree measured:

| Target | p50 | p95 | max | Mounted rows |
|---|---:|---:|---:|---:|
| Fork 1 | 20.9 ms | 24.8 ms | 28.8 ms | 7 |
| Fork 2 | 13.9 ms | 16.0 ms | 17.4 ms | 5 to 6 |

### Broad real-session traversal

A single traversal across 26 real worktrees representing 37 open session tabs produced:

| Metric | Result |
|---|---:|
| Activation p50 | 9.6 ms |
| Activation p95 | 45.1 ms |
| Activation max | 47.3 ms |
| Loaded messages per target | 16 to 240 |
| Logical rows per target | 16 to 263 |
| Mounted rows per target | 2 to 9 |

A separate repeated traversal of nine large sessions for 20 cycles, 180 switches total, kept mounted rows between 2 and 9 and produced 25.9 ms p50, 61.2 ms p95, and 96.2 ms max across sessions with very different visible content. Per-session p95 ranged from 17.8 ms to 77.8 ms, with the slower cases corresponding to heavier visible rows rather than retained transcript size.

### Memory signals

The 20-cycle traversal showed a cycle-end heap slope of approximately +0.04 MiB per cycle. Comparable cycle-end samples ranged from 144.5 to 310.3 MiB and ended at 176.0 MiB after starting at 228.0 MiB. A one-pass 26-worktree traversal ranged from 145.8 to 393.2 MiB and ended at 283.1 MiB. These process-wide figures are GC-sensitive, but the repeated traversal did not show unbounded cycle-over-cycle growth.

## Architecture details

- Stable row keys survive append, prepend, reconcile, queue handoff, compaction, and revert boundaries.
- Unchanged row object identities are reused to avoid unnecessary Solid and Virtua work.
- Assistant part rows are capped at eight parts, preventing historical rows from collecting hundreds of tool wrappers.
- Active streaming rows remain inside Virtua and use bounded `keepMounted` indexes rather than a direct tail.
- Measurement cache capacity is 16 sessions and requires exact row-key and layout fingerprints.
- Scroll cache capacity is 50 sessions and stores bottom-follow or stable row-anchor state independently of measurements.
- Timeline paths are grouped by color, with delegated hit testing and one bounded keyboard-accessible active representation.
- No session prefetch or data LRU is added. Current switching is already below the user-visible target, and adding eviction/prefetch would trade warm speed for memory complexity without measured need.

## Measurement limits

CPU profiler startup work was excluded from switch-task attribution. Captures with frame or document teardown were rejected. Direct activation measurements cover synchronous selection and render dispatch, while the stable-frame metric additionally waits for three unchanged animation frames. Streaming was not exercised with paid prompts; active-row pinning and queue handoff are covered deterministically, while real-session profiling used existing settled sessions.