### PR TITLE
build: migrate toolchain to Rust Bun canary

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -8,25 +8,35 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get baseline download URL
+    # kilocode_change start - pin the Rust Bun canary by immutable upstream revision.
+    - name: Get Bun download URL
       id: bun-url
       shell: bash
       run: |
-        if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          case "$RUNNER_OS" in
-            macOS)   OS=darwin ;;
-            Linux)   OS=linux ;;
-            Windows) OS=windows ;;
-          esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
-        fi
+        REVISION=$(node -p "require('./package.json').config.bunRevision")
+        case "$RUNNER_OS" in
+          macOS)   OS=darwin ;;
+          Linux)   OS=linux ;;
+          Windows) OS=windows ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   ARCH=x64-baseline ;;
+          ARM64) ARCH=aarch64 ;;
+        esac
+        echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+        echo "url=https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${REVISION}-canary/bun-${OS}-${ARCH}.zip" >> "$GITHUB_OUTPUT"
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
-        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Verify Bun revision
+      shell: bash
+      env:
+        EXPECTED_REVISION: ${{ steps.bun-url.outputs.revision }}
+      run: test "$(bun -e 'process.stdout.write(Bun.revision)')" = "$EXPECTED_REVISION"
+    # kilocode_change end
 
     - name: Get cache directory
       id: cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The Kilo Community is [on Discord](https://kilo.ai/discord).
 
 ## Prerequisites
 
-- **Bun 1.3.14+** — required for all packages.
+- **Bun 1.4.0 canary** - required for all packages. Until Bun 1.4 is stable, install the Rust implementation with `bun upgrade --canary`. CI, Nix, and build containers use the exact revision pinned in `package.json`.
 - **Java 21** — required by the JetBrains plugin. The root `bun turbo typecheck` and `bun turbo test:ci` commands include `@kilocode/kilo-jetbrains` and will fail without Java 21.
 
   The preferred way to install Java is via [SDKMAN](https://sdkman.io/install):
@@ -41,7 +41,7 @@ The Kilo Community is [on Discord](https://kilo.ai/discord).
 
 ## Developing Kilo CLI
 
-- **Requirements:** Bun 1.3.14+, Java 21 (see [Prerequisites](#prerequisites) above)
+- **Requirements:** Bun 1.4.0 canary, Java 21 (see [Prerequisites](#prerequisites) above)
 - Install dependencies and start the CLI from the repo root:
 
   ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -21,26 +21,26 @@
       devShells = forEachSystem (pkgs: {
         default =
           let
-            # Pin bun to the version declared in package.json (packageManager: "bun@1.3.14").
-            # The locked nixpkgs revision ships 1.3.11, so we fetch the official release directly.
+            # kilocode_change start - pin the Rust Bun canary by immutable upstream revision.
             bun =
               let
+                revision = "2ad419957431f1f4179f5376283b6639d8b81a7a";
                 sources = {
                   "aarch64-linux" = {
                     name = "bun-linux-aarch64";
-                    hash = "sha256-on/7Y6gxA3WDbg1vZorhf6jY0YuIw3yCHGUzGXOhmjs=";
+                    hash = "sha256-Pi/tmGlrAKH845Husi+2ole91vXCCf/LtsAKZdNEbfs=";
                   };
                   "x86_64-linux" = {
                     name = "bun-linux-x64";
-                    hash = "sha256-lR7iruhV8IWVruxiJSJqKY0/6oOj3NZGXAnLzN9+hI8=";
+                    hash = "sha256-SQjJ0q9hhj3b1RYCr1tea74H+2jdNVZdNOVWhlmWed4=";
                   };
                   "aarch64-darwin" = {
                     name = "bun-darwin-aarch64";
-                    hash = "sha256-2LliIYKK1vl6x6wKt+lYcjQa92MAHogD6CZ2UsJlJiA=";
+                    hash = "sha256-cgkmEFzxqC9OyUxPvSvRTGIiQSxeFUh2QpKNpzM1kTU=";
                   };
                   "x86_64-darwin" = {
                     name = "bun-darwin-x64";
-                    hash = "sha256-QYPfM3RiPlurMVxUfPoJdFM81FfYa3O2OfeoeXTNZjM=";
+                    hash = "sha256-8mL6wK84oc8Al8lfkowHnBE4Tr+KyOIqAgek3Vqm5eg=";
                   };
                 };
                 source =
@@ -49,9 +49,9 @@
               in
               pkgs.stdenv.mkDerivation rec {
                 pname = "bun";
-                version = "1.3.14";
+                version = "1.4.0-canary.1";
                 src = pkgs.fetchurl {
-                  url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/${source.name}.zip";
+                  url = "https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${revision}-canary/${source.name}.zip";
                   inherit (source) hash;
                 };
                 nativeBuildInputs = [
@@ -74,6 +74,7 @@
                   platforms = builtins.attrNames sources;
                 };
               };
+            # kilocode_change end
 
             kilo-dev = pkgs.writeShellScriptBin "kilo-dev" ''
               set -euo pipefail

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0-canary.1",
+  "config": {
+    "bunRevision": "2ad419957431f1f4179f5376283b6639d8b81a7a"
+  },
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:storybook": "bun --cwd packages/storybook storybook",

--- a/packages/containers/bun-node/Dockerfile
+++ b/packages/containers/bun-node/Dockerfile
@@ -6,7 +6,9 @@ FROM ${REGISTRY}/build/base:24.04
 SHELL ["/bin/bash", "-lc"]
 
 ARG NODE_VERSION=24.4.0
-ARG BUN_VERSION=1.3.14
+# kilocode_change start - pin the Rust Bun canary by immutable upstream revision.
+ARG BUN_REVISION=2ad419957431f1f4179f5376283b6639d8b81a7a
+# kilocode_change end
 
 ENV BUN_INSTALL=/opt/bun
 ENV PATH=/opt/bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -19,8 +21,18 @@ RUN set -euo pipefail; \
   | tar -xJf - -C /usr/local --strip-components=1; \
   corepack enable
 
+# kilocode_change start - use the exact Rust Bun artifact used by CI and Nix.
 RUN set -euo pipefail; \
-  curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"; \
+  arch=$(uname -m); \
+  bun_arch=x64; \
+  if [ "$arch" = "aarch64" ]; then bun_arch=aarch64; fi; \
+  curl -fsSL "https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${BUN_REVISION}-canary/bun-linux-${bun_arch}.zip" -o /tmp/bun.zip; \
+  unzip -q /tmp/bun.zip -d /tmp/bun; \
+  install -Dm755 "/tmp/bun/bun-linux-${bun_arch}/bun" /opt/bun/bin/bun; \
+  ln -s /opt/bun/bin/bun /opt/bun/bin/bunx; \
+  rm -rf /tmp/bun /tmp/bun.zip; \
+  test "$(bun -e 'process.stdout.write(Bun.revision)')" = "$BUN_REVISION"; \
   bun --version; \
   node --version; \
   npm --version
+# kilocode_change end

--- a/packages/containers/script/build.ts
+++ b/packages/containers/script/build.ts
@@ -13,9 +13,10 @@ const push = process.argv.includes("--push") || process.env.PUSH === "1"
 
 const root = path.join(rootDir, "package.json")
 const pkg = await Bun.file(root).json()
-const manager = pkg.packageManager ?? ""
-const bun = manager.startsWith("bun@") ? manager.slice(4) : ""
-if (!bun) throw new Error("packageManager must be bun@<version>")
+// kilocode_change start - install the same immutable Rust Bun revision as CI and Nix.
+const revision = pkg.config?.bunRevision ?? ""
+if (!revision) throw new Error("config.bunRevision must be set")
+// kilocode_change end
 
 const images = ["base", "bun-node", "jetbrains", "rust", "tauri-linux", "publish"] // kilocode_change
 
@@ -51,13 +52,15 @@ for (const name of images) {
   if (name === "bun-node") {
     if (push) {
       console.log(
-        `docker buildx build --platform ${platform} -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_VERSION=${bun} --push .`,
+        `docker buildx build --platform ${platform} -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_REVISION=${revision} --push .`, // kilocode_change
       )
-      await $`docker buildx build --platform ${platform} -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_VERSION=${bun} --push .`
+      await $`docker buildx build --platform ${platform} -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_REVISION=${revision} --push .` // kilocode_change
     }
     if (!push) {
-      console.log(`docker build -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_VERSION=${bun} .`)
-      await $`docker build -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_VERSION=${bun} .`
+      console.log(
+        `docker build -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_REVISION=${revision} .`,
+      ) // kilocode_change
+      await $`docker build -f ${file} -t ${image} --build-arg REGISTRY=${reg} --build-arg BUN_REVISION=${revision} .` // kilocode_change
     }
   }
   if (name !== "base" && name !== "bun-node") {

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -16,7 +16,7 @@ This document will help you set up your development environment and understand h
 Before you begin, make sure you have the following installed:
 
 1. **Git** - For version control
-2. **Bun 1.3.14+** - Required for installing dependencies and running scripts
+2. **Bun 1.4.0 canary** - Required for installing dependencies and running scripts. Until Bun 1.4 is stable, install the Rust implementation with `bun upgrade --canary`. CI, Nix, and build containers use the exact revision pinned in the root `package.json`.
 3. **Visual Studio Code** - Our recommended IDE for development
 4. **Java 21** - Required only when running JetBrains plugin checks or repo-level checks that include `@kilocode/kilo-jetbrains`
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -322,10 +322,10 @@ for (const item of targets) {
       KILO_VERSION: `'${Script.version}'`,
       KILO_MIGRATIONS: JSON.stringify(migrations),
       KILO_MODELS_DEV: generated.modelsData,
-      OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
-      KILO_WORKER_PATH: workerPath,
-      KILO_SESSION_EXPORT_WORKER_PATH: sessionExportWorkerPath, // kilocode_change
-      KILO_INDEXING_WORKER_PATH: indexingWorkerPath, // kilocode_change
+      OTUI_TREE_SITTER_WORKER_PATH: JSON.stringify(bunfsRoot + workerRelativePath), // kilocode_change
+      KILO_WORKER_PATH: JSON.stringify(workerPath), // kilocode_change
+      KILO_SESSION_EXPORT_WORKER_PATH: JSON.stringify(sessionExportWorkerPath), // kilocode_change
+      KILO_INDEXING_WORKER_PATH: JSON.stringify(indexingWorkerPath), // kilocode_change
       KILO_SANDBOX_MUTATION_WORKER_PATH: JSON.stringify(KiloSandboxWorker.filename), // kilocode_change
       KILO_CHANNEL: `'${Script.channel}'`,
       KILO_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",


### PR DESCRIPTION
Just for testing, keeping it here as reference PR


Bun's runtime core has moved from Zig to Rust, but Kilo still pins the Zig-based Bun 1.3 toolchain across local metadata, CI, Nix, and container builds. That prevents the repository from exercising Bun 1.4 compatibility and allows different setup paths to resolve different runtime builds.

This draft pins Bun 1.4.0-canary.1 at upstream revision `2ad419957431f1f4179f5376283b6639d8b81a7a`. CI, Nix, and build containers fetch immutable revision artifacts and verify the runtime revision instead of following the mutable canary tag. Contributor requirements identify the canary explicitly so the experimental toolchain is not mistaken for a stable release.

The Rust compiler also requires build-time define values to be valid JSON expressions. Worker paths are now JSON-encoded before standalone compilation so packaged Kilo binaries continue to build under Bun 1.4.

This remains a draft while Bun's Rust implementation is canary-only and its compatibility surface is still changing. The revision pin keeps evaluation reproducible until the stable release or a newer reviewed canary replaces it.