### PR TITLE
fix(vscode): keep HTTP status with error title

### DIFF
--- a/.changeset/keep-error-status-inline.md
+++ b/.changeset/keep-error-status-inline.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep HTTP status codes beside tool error titles when error details wrap.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/tool-errors-200-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/tool-errors-200-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3fb9398991f40c60fb16d73b05ba4dd85af3475928df65917fefb9af1c4aaf1
+size 7836

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/tool-errors-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/tool-errors-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8576fc52a9122900230f545f9b0886280251b3c636a7c2416432730c2844398
+size 8727

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -294,25 +294,26 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
     display: flex;
     flex: 1;
     flex-wrap: wrap;
-    align-items: start;
+    align-items: baseline;
     gap: 2px 8px;
     min-width: 0;
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-base);
+    font-style: normal;
+    line-height: var(--line-height-large);
+    letter-spacing: var(--letter-spacing-normal);
   }
 
   [data-slot="message-part-tool-error-heading"] {
     display: inline-flex;
     flex: none;
+    align-items: baseline;
     gap: 8px;
     white-space: nowrap;
   }
 
   [data-slot="message-part-tool-error-title"] {
-    font-family: var(--font-family-sans);
-    font-size: var(--font-size-base);
-    font-style: normal;
     font-weight: var(--font-weight-medium);
-    line-height: var(--line-height-large);
-    letter-spacing: var(--letter-spacing-normal);
     color: var(--text-on-critical-base);
     white-space: nowrap;
   }

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -292,8 +292,18 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
 
   [data-slot="message-part-tool-error-content"] {
     display: flex;
+    flex: 1;
+    flex-wrap: wrap;
     align-items: start;
+    gap: 2px 8px;
+    min-width: 0;
+  }
+
+  [data-slot="message-part-tool-error-heading"] {
+    display: inline-flex;
+    flex: none;
     gap: 8px;
+    white-space: nowrap;
   }
 
   [data-slot="message-part-tool-error-title"] {
@@ -307,11 +317,24 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
     white-space: nowrap;
   }
 
+  [data-slot="message-part-tool-error-code"] {
+    color: var(--text-on-critical-weak);
+  }
+
   [data-slot="message-part-tool-error-message"] {
     color: var(--text-on-critical-weak);
+    flex: 1 0 auto;
+    min-width: 0;
+    max-width: 100%;
     max-height: 240px;
     overflow-y: auto;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+}
+
+@media (max-width: 240px) {
+  [data-component="tool-error"] > [data-component="icon"] {
+    display: none;
   }
 }
 

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1240,6 +1240,10 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                 )
               }
               const [title, ...rest] = cleaned.split(": ")
+              const message = rest.join(": ")
+              const status = message.match(/^(\d{3})(?:\s+|$)/)
+              const code = status?.[1]
+              const detail = code ? message.slice(code.length).trimStart() : message
               return (
                 <Card variant="error">
                   <div data-component="tool-error">
@@ -1247,8 +1251,15 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                     <Switch>
                       <Match when={title && title.length < 30}>
                         <div data-slot="message-part-tool-error-content">
-                          <div data-slot="message-part-tool-error-title">{title}</div>
-                          <span data-slot="message-part-tool-error-message">{rest.join(": ")}</span>
+                          <div data-slot="message-part-tool-error-heading">
+                            <div data-slot="message-part-tool-error-title">{title}</div>
+                            <Show when={code}>
+                              <span data-slot="message-part-tool-error-code">{code}</span>
+                            </Show>
+                          </div>
+                          <Show when={detail}>
+                            <span data-slot="message-part-tool-error-message">{detail}</span>
+                          </Show>
                         </div>
                       </Match>
                       <Match when={true}>

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -215,6 +215,36 @@ const backgroundLogsCompleted: ToolPart = {
   },
 }
 
+const githubApiError: ToolPart = {
+  id: "part-github-error-001",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-github-error-001",
+  tool: "github-pr-search",
+  state: {
+    status: "error",
+    input: { query: "status-inline-self-test" },
+    error: "GitHub API error: 401 Unauthorized",
+    time: { start: now - 3000, end: now - 2500 },
+  },
+}
+
+const fileError: ToolPart = {
+  id: "part-file-error-001",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-file-error-001",
+  tool: "edit",
+  state: {
+    status: "error",
+    input: { filePath: "src/missing-file.tsx" },
+    error: "ENOENT: no such file or directory 'src/missing-file.tsx'",
+    time: { start: now - 2000, end: now - 1500 },
+  },
+}
+
 const textPart: TextPart = {
   id: "part-text-001",
   sessionID: SESSION_ID,
@@ -1190,6 +1220,30 @@ const mcpShort: ToolPart = {
     title: "Search issues",
     metadata: {},
     time: { start: now - 3000, end: now - 2800 },
+  },
+}
+
+export const ToolErrors: Story = {
+  name: "Tool Errors — HTTP and filesystem",
+  render: () => {
+    const data = dataWith([githubApiError, fileError])
+    return (
+      <StoryProviders data={data} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+export const ToolErrors200: Story = {
+  name: "Tool Errors — HTTP and filesystem (200px)",
+  render: () => {
+    const data = dataWith([githubApiError, fileError])
+    return (
+      <StoryProviders data={data} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
   },
 }
 


### PR DESCRIPTION
Tool errors currently treat the HTTP status and status text as one flexible message. In constrained sidebar layouts, that can place the status code away from the error title or split the status text mid-word, making errors such as `GitHub API error: 401 Unauthorized` difficult to scan.

This keeps a leading three-digit HTTP status grouped with the structured error title while allowing the descriptive status text to wrap independently. General tool errors retain their existing title/detail treatment, and very narrow layouts prioritize readable text over the decorative error icon.

The composite webview stories now cover both an HTTP error and a filesystem error at standard and narrow sidebar widths so future layout changes preserve the intended grouping and wrapping behavior.

Before:
<img width="559" height="112" alt="image" src="https://github.com/user-attachments/assets/af9a3970-8d18-4858-b05e-6d3a9ad62e3b" />


After:
<img width="458" height="85" alt="image" src="https://github.com/user-attachments/assets/c1ff2f22-e41c-467e-8e36-882476a59960" />
