### PR TITLE
fix(cli): prevent subagents asking questions

### DIFF
--- a/.changeset/prevent-subagent-questions.md
+++ b/.changeset/prevent-subagent-questions.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Prevent task subagents from asking questions that users cannot answer from the parent session.

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -61,7 +61,11 @@ export namespace KiloTask {
 
   /** Extra permission rules appended to subagent sessions */
   export function permissions(rules: Permission.Ruleset): Permission.Ruleset {
-    return [{ permission: "task", pattern: "*", action: "deny" }, ...rules]
+    return [
+      { permission: "task", pattern: "*", action: "deny" },
+      { permission: "question", pattern: "*", action: "deny" },
+      ...rules,
+    ]
   }
 
   export function merge(...rulesets: Permission.Ruleset[]): Permission.Ruleset {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -247,6 +247,7 @@ export const TaskTool = Tool.define(
           variant, // kilocode_change
           agent: next.name,
           tools: {
+            question: false, // kilocode_change - subagents cannot prompt the user directly
             ...(canTodo ? {} : { todowrite: false }),
             ...(canTask ? {} : { task: false }),
             ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -155,7 +155,7 @@ describe("Kilo task nesting", () => {
     ),
   )
 
-  it.live("disables nested task tool even when global task permission allows it", () =>
+  it.live("disables nested task and question tools even when global permissions allow them", () =>
     provideTmpdirInstance(
       () =>
         Effect.gen(function* () {
@@ -186,10 +186,16 @@ describe("Kilo task nesting", () => {
 
           const child = yield* sessions.get(result.metadata.sessionId)
           expect(seen?.tools?.task).toBe(false)
+          expect(seen?.tools?.question).toBe(false)
           expect(child.permission).toEqual(
             expect.arrayContaining([
               {
                 permission: "task",
+                pattern: "*",
+                action: "deny",
+              },
+              {
+                permission: "question",
                 pattern: "*",
                 action: "deny",
               },
@@ -200,6 +206,7 @@ describe("Kilo task nesting", () => {
         config: {
           permission: {
             task: "allow",
+            question: "allow",
           },
         },
       },

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -484,6 +484,7 @@ describe("tool.task", () => {
         )
         // kilocode_change end
         expect(seen?.tools).toEqual({
+          question: false, // kilocode_change - subagents cannot prompt the user directly
           todowrite: false,
           task: false, // kilocode_change - Kilo disallows nested subagents
           bash: false,


### PR DESCRIPTION
Task subagents can inherit or be configured with access to the interactive question tool, but those questions belong to the child session and are not reliably answerable from the parent conversation. This leaves the child task waiting indefinitely in both the VS Code sidebar and Agent Manager.

Disable the question tool at the task-spawn boundary and persist a matching deny rule on child sessions. Applying the restriction after configured agent permissions ensures global and custom-agent overrides cannot re-enable interactive questions for task subagents, while primary sessions retain normal question support.