### PR TITLE
fix(cli): consolidate TUI notifications

### DIFF
--- a/.changeset/quiet-kilo-attention.md
+++ b/.changeset/quiet-kilo-attention.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent duplicate CLI attention alerts and route Kilo prompts through the configurable notification system.

--- a/packages/kilo-docs/pages/automate/extending/plugins.md
+++ b/packages/kilo-docs/pages/automate/extending/plugins.md
@@ -452,26 +452,11 @@ For tools that don't need the full plugin context, drop them in a `tool/` or `to
 
 ## Examples
 
-### Send a notification when a session finishes
+### Configure CLI completion notifications
 
-```ts
-// .kilo/plugin/notify.ts
-import type { Plugin } from "@kilocode/plugin"
+The CLI has built-in attention alerts for session completion, errors, and prompts that need input. You do not need a plugin or platform-specific notification command.
 
-const Notify: Plugin = async ({ $ }) => ({
-  event: async ({ event }) => {
-    if (event.type === "session.idle") {
-      await $`osascript -e 'display notification "Session complete!" with title "Kilo"'`
-    }
-  },
-})
-
-export default { id: "notify", server: Notify }
-```
-
-{% callout type="tip" %}
-The VS Code extension already emits system notifications when a session finishes or errors — this plugin is for the raw CLI / TUI.
-{% /callout %}
+Enable notifications and sounds in `kilo console` under **Settings > CLI > Notifications**, or configure the `attention` section of `tui.json`. See [CLI Notifications and Sounds](/docs/code-with-ai/platforms/cli#cli-notifications-and-sounds) for configuration and custom sound overrides.
 
 ### Block reads of `.env` files
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
@@ -904,6 +904,8 @@ Options:
 
 ## kilo console
 
+Open Kilo Console to manage CLI configuration, including **Settings > CLI > Notifications**. See [CLI Notifications and Sounds](/docs/code-with-ai/platforms/cli#cli-notifications-and-sounds) for the equivalent `tui.json` settings and custom sound overrides.
+
 ```
 open the local Kilo Console
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -152,7 +152,59 @@ Configuration is managed through:
 
 - `/connect` command for provider setup (interactive)
 - Config files in **`~/.config/kilo/`**: use **`kilo.jsonc`** for provider, model, permission, and **MCP** settings. Restart the CLI after editing. See [Using MCP in Kilo Code](/docs/automate/mcp/using-in-kilo-code) for MCP config format.
+- **`tui.jsonc`** for terminal UI settings such as notifications, sounds, themes, and keybindings
 - `kilo auth` for credential management
+
+## CLI Notifications and Sounds
+
+CLI attention alerts are disabled by default. Enable and configure them in either of these ways:
+
+- Run `kilo console`, open your project, then go to **Settings > CLI > Notifications**.
+- Edit the TUI configuration directly. Use `~/.config/kilo/tui.jsonc` (or `tui.json`) for global settings, or `.kilo/tui.json` (or `tui.jsonc`) for project settings.
+
+The Console exposes the attention, desktop notification, sound, and volume controls. The equivalent TUI configuration is:
+
+```json
+{
+  "attention": {
+    "enabled": true,
+    "notifications": true,
+    "sound": true,
+    "volume": 0.4
+  }
+}
+```
+
+- `enabled` is the master switch. When it is `false`, no attention notifications or sounds are delivered.
+- `notifications` requests a desktop notification when the terminal is not focused. Your terminal and operating system decide whether the notification is displayed.
+- `sound` enables the built-in attention sounds. Sounds can play while the terminal is focused.
+- `volume` accepts a value from `0` to `1`.
+
+### Custom Sounds
+
+To replace individual sounds, add file paths under `attention.sounds`:
+
+```json
+{
+  "attention": {
+    "enabled": true,
+    "sound": true,
+    "volume": 0.4,
+    "sounds": {
+      "question": "./sounds/question.mp3",
+      "permission": "./sounds/permission.mp3",
+      "error": "./sounds/error.mp3",
+      "done": "./sounds/done.mp3"
+    }
+  }
+}
+```
+
+Supported sound names are `default`, `question`, `permission`, `error`, `done`, and `subagent_done`. Relative paths are resolved from the directory containing the TUI configuration file. If an override cannot be loaded, Kilo falls back to the active sound pack and then the built-in `opencode.default` pack.
+
+The `attention.sound_pack` setting selects a sound pack registered by a TUI plugin. Setting an arbitrary pack name does not install or load a pack. Per-event file overrides remain the simplest way to customize sounds without a plugin.
+
+There is no notification slash command or command-palette toggle. Use Kilo Console or `tui.json` / `tui.jsonc` so all attention behavior is controlled by the same configuration.
 
 ## Slash Commands
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -776,17 +776,6 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           dialog.clear()
         },
       },
-      // kilocode_change start - expose the existing terminal notification preference in the command palette
-      {
-        name: "app.toggle.notifications",
-        title: kv.get("bell_enabled", true) ? "Disable notifications" : "Enable notifications",
-        category: "System",
-        run: () => {
-          kv.set("bell_enabled", !kv.get("bell_enabled", true))
-          dialog.clear()
-        },
-      },
-      // kilocode_change end
       {
         name: "app.toggle.animations",
         title: kv.get("animations_enabled", true) ? "Disable animations" : "Enable animations",

--- a/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
@@ -3,6 +3,7 @@ import HomeTips from "../feature-plugins/home/tips"
 // kilocode_change start
 import HomeNews from "@/kilocode/plugins/home-news"
 import HomeOnboarding from "@/kilocode/plugins/home-onboarding"
+import KiloAttention from "@/kilocode/plugins/attention"
 import KiloHomeFooter from "@/kilocode/plugins/home-footer"
 import KiloSidebarFooter from "@/kilocode/plugins/sidebar-footer"
 import KiloSidebarBackgroundProcesses from "@/kilocode/plugins/sidebar-background-processes"
@@ -33,6 +34,7 @@ export function internalTuiPlugins(flags: Pick<RuntimeFlags.Info, "experimentalE
   return [
     HomeNews, // kilocode_change
     HomeOnboarding, // kilocode_change
+    KiloAttention, // kilocode_change
     KiloHomeFooter, // kilocode_change
     KiloSidebarFooter, // kilocode_change
     KiloSidebarBackgroundProcesses, // kilocode_change

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -97,7 +97,6 @@ import { splitDiffHunks } from "@/kilocode/tui/diff"
 import { session as banner } from "@/kilocode/cli/logo"
 
 import { formatMarkdownTables } from "../../util/markdown"
-import { bell } from "@/kilocode/bell"
 import { submitFeedback } from "@/kilocode/cli/cmd/tui/feedback"
 // kilocode_change end
 import { getScrollAcceleration } from "../../util/scroll"
@@ -258,6 +257,7 @@ export function Session() {
       blockingSuggestions().length > 0 ||
       network().length > 0,
   )
+  // kilocode_change end
 
   const pending = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant" && !x.time.completed)?.id
@@ -266,45 +266,6 @@ export function Session() {
   const lastAssistant = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant")
   })
-
-  createEffect(
-    on(
-      () => [route.sessionID, sync.data.session_status?.[route.sessionID]?.type] as const,
-      ([id, type], prev) => {
-        if (!prev || prev[0] !== id) return
-        if (prev[1] && prev[1] !== "idle" && type === "idle" && bellEnabled()) bell()
-      },
-    ),
-  )
-
-  createEffect(
-    on(
-      () => [route.sessionID, permissions().length] as const,
-      ([id, len], prev) => {
-        if (!prev || prev[0] !== id) return
-        if (len > prev[1] && bellEnabled()) bell()
-      },
-    ),
-  )
-  createEffect(
-    on(
-      () => [route.sessionID, questions().length] as const,
-      ([id, len], prev) => {
-        if (!prev || prev[0] !== id) return
-        if (len > prev[1] && bellEnabled()) bell()
-      },
-    ),
-  )
-  createEffect(
-    on(
-      () => [route.sessionID, suggestions().length + network().length] as const,
-      ([id, len], prev) => {
-        if (!prev || prev[0] !== id) return
-        if (len > prev[1] && bellEnabled()) bell()
-      },
-    ),
-  )
-  // kilocode_change end
 
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
@@ -317,7 +278,6 @@ export function Session() {
   const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
-  const [bellEnabled, _setBellEnabled] = kv.signal("bell_enabled", true) // kilocode_change - terminal bell toggle (toggled via kv.set in app.tsx command)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
   const wide = createMemo(() => dimensions().width > 120)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -3,7 +3,7 @@ import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
 import { GenerateCommand } from "./cli/cmd/generate"
 import * as Log from "@opencode-ai/core/util/log"
-import { ConsoleCommand } from "./cli/cmd/account"
+// import { ConsoleCommand } from "./cli/cmd/account" // kilocode_change - reserve `kilo console` for local settings
 import { ProvidersCommand } from "./cli/cmd/providers"
 import { AgentCommand } from "./cli/cmd/agent"
 import { UpgradeCommand } from "./cli/cmd/upgrade"
@@ -40,6 +40,7 @@ import { Heap } from "./cli/heap"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 import { isRecord } from "@/util/record"
+import { KiloConsoleCommand } from "@/kilocode/cli/cmd/console" // kilocode_change
 
 const processMetadata = ensureProcessMetadata("main")
 
@@ -162,7 +163,8 @@ const cli = yargs(args)
   .command(RunCommand)
   .command(GenerateCommand)
   .command(DebugCommand)
-  .command(ConsoleCommand)
+  // .command(ConsoleCommand) // kilocode_change - reserve `kilo console` for local settings
+  .command(KiloConsoleCommand) // kilocode_change
   .command(ProvidersCommand)
   .command(AgentCommand)
   .command(UpgradeCommand)

--- a/packages/opencode/src/kilocode/bell.ts
+++ b/packages/opencode/src/kilocode/bell.ts
@@ -1,6 +1,0 @@
-// kilocode_change - new file
-export function bell() {
-  if (process.stdout.isTTY) {
-    process.stdout.write("\x07")
-  }
-}

--- a/packages/opencode/src/kilocode/plugins/attention.ts
+++ b/packages/opencode/src/kilocode/plugins/attention.ts
@@ -1,0 +1,53 @@
+import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@kilocode/plugin/tui"
+
+const id = "internal:kilo-attention"
+
+function notify(api: TuiPluginApi, sessionID: string, message: string) {
+  const session = api.state.session.get(sessionID)
+  void api.attention.notify({
+    title: session?.title,
+    message,
+    notification: session?.parentID ? false : { when: "blurred" },
+    sound: { name: "question", when: "always" },
+  })
+}
+
+const tui: TuiPlugin = async (api) => {
+  const suggestions = new Set<string>()
+  const network = new Set<string>()
+
+  api.event.on("suggestion.shown", (event) => {
+    if (suggestions.has(event.properties.id)) return
+    suggestions.add(event.properties.id)
+    notify(api, event.properties.sessionID, "Suggestion needs input")
+  })
+
+  api.event.on("suggestion.accepted", (event) => {
+    suggestions.delete(event.properties.requestID)
+  })
+
+  api.event.on("suggestion.dismissed", (event) => {
+    suggestions.delete(event.properties.requestID)
+  })
+
+  api.event.on("session.network.asked", (event) => {
+    if (network.has(event.properties.id)) return
+    network.add(event.properties.id)
+    notify(api, event.properties.sessionID, "Network connection needs input")
+  })
+
+  api.event.on("session.network.replied", (event) => {
+    network.delete(event.properties.requestID)
+  })
+
+  api.event.on("session.network.rejected", (event) => {
+    network.delete(event.properties.requestID)
+  })
+}
+
+const plugin: TuiPluginModule & { id: string } = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -317,7 +317,9 @@ Custom themes: place JSON files in `~/.config/kilo/themes/` or `.kilo/themes/`.
 
 ### Display Toggles (via Ctrl+P)
 
-Toggle notifications, Toggle animations, Toggle diff wrapping, Toggle sidebar (`<leader>b`), Toggle thinking (`/thinking`), Toggle tool details, Toggle timestamps (`/timestamps`), Toggle scrollbar, Toggle header, Toggle code concealment (`<leader>h`).
+Toggle animations, Toggle diff wrapping, Toggle sidebar (`<leader>b`), Toggle thinking (`/thinking`), Toggle tool details, Toggle timestamps (`/timestamps`), Toggle scrollbar, Toggle header, Toggle code concealment (`<leader>h`).
+
+Notification settings are managed through `kilo console` under **Settings > CLI > Notifications**, or through `attention` in `tui.json` / `tui.jsonc`. There is no notification slash command or command-palette toggle.
 
 ### System
 

--- a/packages/opencode/test/kilocode/cli/cmd/tui/attention.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/attention.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test"
+import Attention from "@/kilocode/plugins/attention"
+import type { Event, Session, SessionNetworkWait, SuggestionRequest } from "@kilocode/sdk/v2"
+import type { TuiAttentionNotifyInput } from "@kilocode/plugin/tui"
+import { createTuiPluginApi } from "../../../../fixture/tui-plugin"
+
+async function setup() {
+  const notifications: TuiAttentionNotifyInput[] = []
+  const handlers = new Map<Event["type"], ((event: Event) => void)[]>()
+  const session = (id: string, title: string, parentID?: string): Session => ({
+    id,
+    title,
+    slug: id,
+    projectID: "project",
+    directory: "/workspace",
+    ...(parentID && { parentID }),
+    version: "0.0.0-test",
+    time: { created: 0, updated: 0 },
+  })
+  const sessions: Record<string, Session> = {
+    session: session("session", "Demo session"),
+    subagent: session("subagent", "Subagent session", "session"),
+  }
+
+  await Attention.tui(
+    createTuiPluginApi({
+      attention: {
+        async notify(input) {
+          notifications.push(input)
+          return { ok: true, notification: true, sound: true }
+        },
+      },
+      event: {
+        on: <Type extends Event["type"]>(type: Type, handler: (event: Extract<Event, { type: Type }>) => void) => {
+          const list = handlers.get(type) ?? []
+          const wrapped = handler as (event: Event) => void
+          list.push(wrapped)
+          handlers.set(type, list)
+          return () => {
+            handlers.set(
+              type,
+              (handlers.get(type) ?? []).filter((item) => item !== wrapped),
+            )
+          }
+        },
+      },
+      state: {
+        session: {
+          get: (sessionID: string) => sessions[sessionID],
+        },
+      },
+    }),
+    undefined,
+    {} as never,
+  )
+
+  return {
+    notifications,
+    emit(event: Event) {
+      for (const handler of handlers.get(event.type) ?? []) handler(event)
+    },
+  }
+}
+
+function suggestion(id: string, sessionID = "session"): SuggestionRequest {
+  return {
+    id,
+    sessionID,
+    text: "Review the changes",
+    actions: [{ label: "Review", prompt: "/local-review-uncommitted" }],
+  }
+}
+
+function wait(id: string, sessionID = "session"): SessionNetworkWait {
+  return {
+    id,
+    sessionID,
+    message: "Network connection failed",
+    restored: false,
+    time: { created: 0 },
+  }
+}
+
+const suggestionNotification: TuiAttentionNotifyInput = {
+  title: "Demo session",
+  message: "Suggestion needs input",
+  notification: { when: "blurred" },
+  sound: { name: "question", when: "always" },
+}
+
+const networkNotification: TuiAttentionNotifyInput = {
+  title: "Demo session",
+  message: "Network connection needs input",
+  notification: { when: "blurred" },
+  sound: { name: "question", when: "always" },
+}
+
+describe("Kilo attention TUI plugin", () => {
+  test("requests upstream attention for suggestions and network prompts", async () => {
+    const harness = await setup()
+
+    harness.emit({ id: "event-1", type: "suggestion.shown", properties: suggestion("suggestion-1") })
+    harness.emit({ id: "event-2", type: "session.network.asked", properties: wait("network-1") })
+
+    expect(harness.notifications).toEqual([suggestionNotification, networkNotification])
+  })
+
+  test("dedupes pending prompts until they are resolved", async () => {
+    const harness = await setup()
+
+    harness.emit({ id: "event-1", type: "suggestion.shown", properties: suggestion("suggestion-1") })
+    harness.emit({ id: "event-2", type: "suggestion.shown", properties: suggestion("suggestion-1") })
+    harness.emit({
+      id: "event-3",
+      type: "suggestion.dismissed",
+      properties: { sessionID: "session", requestID: "suggestion-1" },
+    })
+    harness.emit({ id: "event-4", type: "suggestion.shown", properties: suggestion("suggestion-1") })
+
+    harness.emit({ id: "event-5", type: "session.network.asked", properties: wait("network-1") })
+    harness.emit({ id: "event-6", type: "session.network.asked", properties: wait("network-1") })
+    harness.emit({
+      id: "event-7",
+      type: "session.network.replied",
+      properties: { sessionID: "session", requestID: "network-1" },
+    })
+    harness.emit({ id: "event-8", type: "session.network.asked", properties: wait("network-1") })
+
+    expect(harness.notifications).toEqual([
+      suggestionNotification,
+      suggestionNotification,
+      networkNotification,
+      networkNotification,
+    ])
+  })
+
+  test("uses sound-only attention for subagent prompts", async () => {
+    const harness = await setup()
+
+    harness.emit({
+      id: "event-1",
+      type: "suggestion.shown",
+      properties: suggestion("suggestion-1", "subagent"),
+    })
+    harness.emit({
+      id: "event-2",
+      type: "session.network.asked",
+      properties: wait("network-1", "subagent"),
+    })
+
+    expect(harness.notifications).toEqual([
+      {
+        title: "Subagent session",
+        message: "Suggestion needs input",
+        notification: false,
+        sound: { name: "question", when: "always" },
+      },
+      {
+        title: "Subagent session",
+        message: "Network connection needs input",
+        notification: false,
+        sound: { name: "question", when: "always" },
+      },
+    ])
+  })
+})

--- a/packages/opencode/test/kilocode/help.test.ts
+++ b/packages/opencode/test/kilocode/help.test.ts
@@ -174,6 +174,14 @@ describe("generateCommandTable", () => {
 })
 
 describe("commands.ts stays in sync with index.ts", () => {
+  test("registers the local Kilo Console instead of the upstream account console", async () => {
+    const index = await Bun.file(path.resolve(import.meta.dir, "../../src/index.ts")).text()
+    const registered = [...index.matchAll(/^\s*\.command\((\w+)\)/gm)].map((match) => match[1]!)
+
+    expect(registered).toContain("KiloConsoleCommand")
+    expect(registered).not.toContain("ConsoleCommand")
+  })
+
   test("every .command() in index.ts has an entry in the commands array", async () => {
     const index = await Bun.file(path.resolve(import.meta.dir, "../../src/index.ts")).text()
     const barrel = await Bun.file(path.resolve(import.meta.dir, "../../src/kilocode/commands.ts")).text()

--- a/packages/opencode/test/kilocode/server/tui-config.test.ts
+++ b/packages/opencode/test/kilocode/server/tui-config.test.ts
@@ -85,6 +85,53 @@ describe("TUI config routes", () => {
     expect(saved).toEqual({ theme: "nord" })
   })
 
+  test("patches attention config without dropping advanced notification settings", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(
+          path.join(cfg, "tui.json"),
+          JSON.stringify(
+            {
+              attention: {
+                enabled: false,
+                sound_pack: "custom.pack",
+                sounds: { question: "./question.mp3" },
+              },
+            },
+            null,
+            2,
+          ),
+        )
+      },
+    })
+
+    const response = await Server.Default().app.request("/tui/config?scope=project", {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        "x-kilo-directory": tmp.path,
+      },
+      body: JSON.stringify({
+        attention: { enabled: true, notifications: false, sound: true, volume: 0.25 },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const saved = await Bun.file(path.join(tmp.path, ".kilo", "tui.json")).json()
+    expect(saved).toEqual({
+      attention: {
+        enabled: true,
+        notifications: false,
+        sound: true,
+        volume: 0.25,
+        sound_pack: "custom.pack",
+        sounds: { question: "./question.mp3" },
+      },
+    })
+  })
+
   test("emits global.config.updated when patching TUI config so open TUIs hot-reload", async () => {
     await using tmp = await tmpdir()
 


### PR DESCRIPTION
The Kilo terminal bell path overlaps with OpenCode's attention plugin, causing duplicate completion and prompt alerts while leaving a command palette toggle that controls only legacy terminal bell behavior.

This removes the legacy bell effects, state, utility, and toggle so upstream attention becomes the single notification transport. A small Kilo-owned TUI plugin forwards suggestion and network prompt events to `api.attention.notify()`, preserving Kilo-specific prompts without duplicating upstream notification logic.

Attention remains disabled by default and continues to be configured through `tui.json` or `kilo console` Settings > CLI > Notifications. Saving the console settings preserves advanced sound pack and per-event sound configuration.


Also made this support the kilo console:

<img width="1215" height="342" alt="file-e502bced737239dd2649b977c3e5b0a1" src="https://github.com/user-attachments/assets/daae787a-6d06-4d61-ac77-e56dd00e9301" />
