### PR TITLE
fix(vscode): count pending submission time

### DIFF
--- a/packages/kilo-vscode/tests/unit/working-indicator.test.ts
+++ b/packages/kilo-vscode/tests/unit/working-indicator.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test"
+import { tracksElapsed } from "../../webview-ui/src/components/shared/working-indicator-utils"
+
+describe("tracksElapsed", () => {
+  it("tracks pending submissions before backend status arrives", () => {
+    expect(tracksElapsed("idle", true, 1)).toBe(true)
+  })
+
+  it("tracks active backend statuses", () => {
+    expect(tracksElapsed("busy", false, 1)).toBe(true)
+    expect(tracksElapsed("retry", false, 1)).toBe(true)
+    expect(tracksElapsed("offline", false, 1)).toBe(true)
+  })
+
+  it("stops for idle sessions and missing start times", () => {
+    expect(tracksElapsed("idle", false, 1)).toBe(false)
+    expect(tracksElapsed("busy", false, undefined)).toBe(false)
+    expect(tracksElapsed("idle", true, undefined)).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/WorkingIndicator.tsx
@@ -10,6 +10,7 @@ import { Button } from "@kilocode/kilo-ui/button"
 import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
+import { tracksElapsed } from "./working-indicator-utils"
 
 export const WorkingIndicator: Component = () => {
   const session = useSession()
@@ -23,7 +24,7 @@ export const WorkingIndicator: Component = () => {
     const since = session.busySince()
     const status = session.status()
 
-    if (status === "idle" || !since) {
+    if (!tracksElapsed(status, session.submitting(), since)) {
       setElapsed(0)
       return
     }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/working-indicator-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/working-indicator-utils.ts
@@ -1,0 +1,5 @@
+import type { SessionStatus } from "../../types/messages"
+
+export function tracksElapsed(status: SessionStatus, submitting: boolean, since: number | undefined): since is number {
+  return since !== undefined && (status !== "idle" || submitting)
+}


### PR DESCRIPTION
#11103 makes the first prompt and Thinking spinner appear immediately in a new Agent Manager Local tab. While that tab is still waiting for the backend to create its real session, however, the backend status remains idle. The elapsed indicator interpreted that idle status as inactive, so users could see a spinner with no timer for several seconds, followed by the timer suddenly appearing at a higher value once session creation finished.

Treat a pending submission as active for elapsed-time tracking. The timer now progresses visibly from the moment the prompt is sent and continues from the same start time when the pending tab is promoted to a real session, rather than appearing late or resetting during the handoff.

Follow-up to https://github.com/Kilo-Org/kilocode/pull/11103#discussion_r3394964575