### PR TITLE
fix: improve auto close filter logic

### DIFF
--- a/.github/workflows/kilo-auto-close.yml
+++ b/.github/workflows/kilo-auto-close.yml
@@ -125,6 +125,15 @@ jobs:
                           createdAt
                         }
                       }
+                      reviewThreads(last: 100) {
+                        nodes {
+                          comments(last: 1) {
+                            nodes {
+                              createdAt
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -159,23 +168,35 @@ jobs:
 
             core.info(`Found ${allPrs.length} open pull requests`)
 
-            const stalePrs = allPrs.filter((pr) => {
-              const dates = [
-                new Date(pr.createdAt),
-                pr.commits.nodes[0] ? new Date(pr.commits.nodes[0].commit.committedDate) : null,
-                pr.comments.nodes[0] ? new Date(pr.comments.nodes[0].createdAt) : null,
-                pr.reviews.nodes[0] ? new Date(pr.reviews.nodes[0].createdAt) : null,
-              ].filter((d) => d !== null)
+            function entry(source, date) {
+              if (!date) return null
 
-              const lastActivity = dates.sort((a, b) => b.getTime() - a.getTime())[0]
+              return { source, date: new Date(date) }
+            }
 
-              if (!lastActivity || lastActivity > prCutoff) {
-                core.info(`PR #${pr.number} is fresh (last activity: ${lastActivity?.toISOString() || "unknown"})`)
-                return false
+            function latest(items) {
+              return items.filter(Boolean).sort((a, b) => b.date.getTime() - a.date.getTime())[0]
+            }
+
+            const stalePrs = allPrs.flatMap((pr) => {
+              const activity = latest([
+                entry("created", pr.createdAt),
+                entry("commit", pr.commits.nodes[0]?.commit.committedDate),
+                entry("comment", pr.comments.nodes[0]?.createdAt),
+                entry("review", pr.reviews.nodes[0]?.createdAt),
+                ...pr.reviewThreads.nodes.map((t) => entry("review comment", t.comments.nodes[0]?.createdAt)),
+              ])
+              const text = activity
+                ? `${activity.date.toISOString()} via ${activity.source}`
+                : "unknown"
+
+              if (!activity || activity.date > prCutoff) {
+                core.info(`PR #${pr.number} is fresh (last activity: ${text})`)
+                return []
               }
 
-              core.info(`PR #${pr.number} is STALE (last activity: ${lastActivity.toISOString()})`)
-              return true
+              core.info(`PR #${pr.number} is STALE (last activity: ${text})`)
+              return [{ ...pr, activity }]
             })
 
             core.info(`Found ${stalePrs.length} stale pull requests`)
@@ -194,7 +215,7 @@ jobs:
               const closeComment = `To stay organized pull requests are automatically closed after ${PR_DAYS_INACTIVE} days of inactivity. If the pull request is still relevant please open a new one.`
 
               if (dryRun) {
-                core.info(`[dry-run] Would close PR #${issue_number} from ${pr.author?.login || 'unknown'}: ${pr.title}`)
+                core.info(`[dry-run] Would close PR #${issue_number} from ${pr.author?.login || 'unknown'} (last activity: ${pr.activity.date.toISOString()} via ${pr.activity.source}): ${pr.title}`)
                 continue
               }
 
@@ -222,7 +243,7 @@ jobs:
                 )
 
                 closedPrCount++
-                core.info(`Closed PR #${issue_number} from ${pr.author?.login || 'unknown'}: ${pr.title}`)
+                core.info(`Closed PR #${issue_number} from ${pr.author?.login || 'unknown'} (last activity: ${pr.activity.date.toISOString()} via ${pr.activity.source}): ${pr.title}`)
 
                 // Delay before processing next PR
                 await sleep(prDelayMs)
@@ -272,7 +293,7 @@ jobs:
                   continue
                 }
 
-                staleIssues.push(issue)
+                staleIssues.push({ ...issue, activity: updated })
               }
 
               if (!stop) {
@@ -296,7 +317,7 @@ jobs:
               const closeComment = `To stay organized issues are automatically closed after ${ISSUE_DAYS_INACTIVE} days of no activity. If the issue is still relevant please open a new one.`
 
               if (dryRun) {
-                core.info(`[dry-run] Would close issue #${issue.number}: ${issue.title}`)
+                core.info(`[dry-run] Would close issue #${issue.number} (last activity: ${issue.activity.toISOString()} via updated): ${issue.title}`)
                 continue
               }
 
@@ -323,7 +344,7 @@ jobs:
                 )
 
                 closedIssueCount++
-                core.info(`Closed issue #${issue.number}: ${issue.title}`)
+                core.info(`Closed issue #${issue.number} (last activity: ${issue.activity.toISOString()} via updated): ${issue.title}`)
 
                 await sleep(issueDelayMs)
               } catch (error) {


### PR DESCRIPTION
## Context

Improve stale PR detection so review-thread comments count as PR activity before auto-closing.

## Implementation

Fetch PRs through GraphQL with commits, issue comments, reviews, and review-thread comments, then close only PRs whose latest activity is older than the cutoff. Keep issue closing on the existing oldest-updated scan.

## Screenshots / Video

N/A, workflow-only change.

## How to Test

### Manual/local verification

- Agent: `bun run script/check-workflows.ts` successfully.

### Reviewer test steps

1. Run the `kilo-auto-close` workflow with `dryRun: true`. 
2. Confirm PRs with recent review-thread comments are logged as fresh.
3. Confirm stale PRs and issues are only logged, not closed.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch