### PR TITLE
fix(agent-manager): avoid blocked native autofocus

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -396,7 +396,6 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                 <div class="prompt-input-ghost-wrapper am-prompt-input-ghost-wrapper">
                   <textarea
                     ref={textareaRef}
-                    autofocus
                     class="prompt-input am-prompt-input"
                     placeholder={t(
                       isMac


### PR DESCRIPTION
Opening the Configure Worktree modal caused Chromium to report \`Blocked autofocusing on a <textarea> element in a cross-origin subframe.\` The prompt textarea declared native \`autofocus\`, which VS Code webviews cannot honor because they run in a cross-origin iframe.

Remove the native attribute and rely on the dialog's existing imperative focus routine. The prompt still receives focus, including delayed retries and restored-prompt caret placement, without triggering the blocked-autofocus warning.