### PR TITLE
fix(cli): respect Kilo env precedence

### DIFF
--- a/.changeset/env-overrides-config.md
+++ b/.changeset/env-overrides-config.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Ensure `KILO_*` credentials and config sources override persisted user configuration while preserving managed policy and explicit CLI argument precedence.

--- a/packages/kilo-docs/pages/contributing/architecture/cli-runtime.md
+++ b/packages/kilo-docs/pages/contributing/architecture/cli-runtime.md
@@ -252,14 +252,16 @@ Later sources override earlier values during instance config load:
 | 2 | Organization modes |
 | 3 | Auth-record `.well-known/opencode` remote config |
 | 4 | Global config files |
-| 5 | Explicit `KILO_CONFIG` file |
-| 6 | Project `kilo.json[c]` and `opencode.json[c]` files plus discovered config directories |
+| 5 | Project `kilo.json[c]` and `opencode.json[c]` files plus discovered config directories |
+| 6 | Explicit `KILO_CONFIG` file |
 | 7 | `KILO_CONFIG_DIR` directory |
 | 8 | `KILO_CONFIG_CONTENT` |
-| 9 | Active Kilo Cloud organization config |
-| 10 | Managed config directory |
-| 11 | macOS managed preferences |
-| 12 | Runtime flag-derived permission, tool, compaction, and plugin behavior |
+| 9 | Runtime environment overlays such as `KILO_PERMISSION`, `KILO_DISABLE_AUTOCOMPACT`, and `KILO_DISABLE_PRUNE` |
+| 10 | Active Kilo Cloud organization config |
+| 11 | Managed config directory |
+| 12 | macOS managed preferences |
+
+Environment-backed Kilo credentials and config sources override persisted user configuration. Managed organization and device policy remains authoritative. Explicit CLI arguments such as `--model`, `--agent`, `--port`, and `--hostname` are applied outside this config merge and override matching environment defaults without bypassing managed restrictions.
 
 Global config files load from `${Global.Path.config}`. Project updates prefer existing config files found in ancestor `.kilo`, `.kilocode`, or `.opencode` directories, then existing project root config files, then create `.kilo/kilo.json`. Global indexing settings can carry provider and storage defaults, but global `indexing.enabled` is stripped so project enablement remains local in effective instance config.
 

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -179,7 +179,9 @@ Agent configurations merge from lowest to highest priority:
 2. Global config (`~/.config/kilo/kilo.jsonc`)
 3. Project config (`kilo.jsonc` at project root)
 4. `.kilo/` / `.opencode/` directory configs and agent `.md` files
-5. Environment variable overrides (`KILO_CONFIG_CONTENT`)
+5. Environment variable overrides (`KILO_CONFIG`, `KILO_CONFIG_DIR`, and `KILO_CONFIG_CONTENT`)
+6. Explicit CLI arguments such as `--agent` and `--model` for matching environment defaults
+7. Managed Kilo Cloud organization and device restrictions
 
 When the same agent name appears at multiple levels, properties are merged (not replaced wholesale), so you can override just a model or temperature without redefining the entire agent.
 
@@ -415,7 +417,9 @@ Agent configurations merge from lowest to highest priority:
 2. Global config (`~/.config/kilo/kilo.jsonc`)
 3. Project config (`kilo.jsonc` at project root)
 4. `.kilo/` / `.opencode/` directory configs and agent `.md` files
-5. Environment variable overrides (`KILO_CONFIG_CONTENT`)
+5. Environment variable overrides (`KILO_CONFIG`, `KILO_CONFIG_DIR`, and `KILO_CONFIG_CONTENT`)
+6. Explicit CLI arguments such as `--agent` and `--model` for matching environment defaults
+7. Managed Kilo Cloud organization and device restrictions
 
 When the same agent name appears at multiple levels, properties are merged (not replaced wholesale), so you can override just a model or temperature without redefining the entire agent.
 

--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -22,6 +22,7 @@ import * as Log from "@opencode-ai/core/util/log"
 import { ConfigVariable } from "@/config/variable"
 import { Npm } from "@opencode-ai/core/npm"
 import { KilocodeDefaultPlugins } from "@/kilocode/config/default-plugins" // kilocode_change
+import { mergeEnvTuiConfig } from "@/kilocode/cli/cmd/tui/config/tui" // kilocode_change
 import type { DeepMutable } from "@opencode-ai/core/schema"
 import type { TuiAttentionSoundName } from "@kilocode/plugin/tui"
 import { FormatError, FormatUnknownError } from "@/cli/error"
@@ -208,19 +209,12 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     yield* mergeFile(acc, file)
   }
 
-  // 2. Explicit KILO_TUI_CONFIG override, if set.
-  if (Flag.KILO_TUI_CONFIG) {
-    const configFile = Flag.KILO_TUI_CONFIG
-    yield* mergeFile(acc, configFile)
-    log.debug("loaded custom tui config", { path: configFile })
-  }
-
-  // 3. Project tui files, applied root-first so the closest file wins.
+  // 2. Project tui files, applied root-first so the closest file wins.
   for (const file of projectFiles) {
     yield* mergeFile(acc, file)
   }
 
-  // 4. `.opencode` directories (and KILO_CONFIG_DIR) discovered while
+  // 3. `.opencode` directories (and KILO_CONFIG_DIR) discovered while
   // walking up the tree. Also returned below so callers can install plugin
   // dependencies from each location.
   // kilocode_change start - also load tui.json from .kilo/.kilocode
@@ -236,6 +230,12 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
       yield* mergeFile(acc, file)
     }
   }
+
+  yield* mergeEnvTuiConfig({
+    file: Flag.KILO_TUI_CONFIG,
+    merge: (file) => mergeFile(acc, file),
+    loaded: (file) => log.debug("loaded custom tui config", { path: file }),
+  }) // kilocode_change
 
   const keybinds = { ...acc.result.keybinds }
   if (process.platform === "win32") {

--- a/packages/opencode/src/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui.ts
@@ -209,6 +209,7 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     yield* mergeFile(acc, file)
   }
 
+  // kilocode_change start - order Kilo TUI config sources by precedence
   // 2. Project tui files, applied root-first so the closest file wins.
   for (const file of projectFiles) {
     yield* mergeFile(acc, file)
@@ -217,15 +218,13 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
   // 3. `.opencode` directories (and KILO_CONFIG_DIR) discovered while
   // walking up the tree. Also returned below so callers can install plugin
   // dependencies from each location.
-  // kilocode_change start - also load tui.json from .kilo/.kilocode
   const dirs = unique(directories).filter(
     (dir) =>
       dir.endsWith(".kilo") || dir.endsWith(".kilocode") || dir.endsWith(".opencode") || dir === Flag.KILO_CONFIG_DIR,
   )
-  // kilocode_change end
 
   for (const dir of dirs) {
-    // if (!dir.endsWith(".opencode") && dir !== Flag.KILO_CONFIG_DIR) continue // kilocode_change
+    // if (!dir.endsWith(".opencode") && dir !== Flag.KILO_CONFIG_DIR) continue
     for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {
       yield* mergeFile(acc, file)
     }
@@ -235,7 +234,8 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     file: Flag.KILO_TUI_CONFIG,
     merge: (file) => mergeFile(acc, file),
     loaded: (file) => log.debug("loaded custom tui config", { path: file }),
-  }) // kilocode_change
+  })
+  // kilocode_change end
 
   const keybinds = { ...acc.result.keybinds }
   if (process.platform === "win32") {

--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -1,24 +1,18 @@
 import { Bus } from "@/bus"
 import { Config } from "@/config/config"
 import { AppRuntime } from "@/effect/app-runtime"
-import { Flag } from "@opencode-ai/core/flag/flag"
 import { Installation } from "@/installation"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 
 export async function upgrade() {
-  const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.getGlobal()))
-  if (config.autoupdate === false || Flag.KILO_DISABLE_AUTOUPDATE) return
+  const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get())) // kilocode_change - include env and managed overlays
+  if (config.autoupdate === false) return // kilocode_change - env overlay is applied before managed config
   const method = await Installation.method()
   // kilocode_change start - only auto-upgrade for npm/pnpm/bun (we only publish @kilocode/cli via npm registry)
   if (method !== "npm" && method !== "pnpm" && method !== "bun") return
   // kilocode_change end
   const latest = await Installation.latest(method).catch(() => {})
   if (!latest) return
-
-  if (Flag.KILO_ALWAYS_NOTIFY_UPDATE) {
-    await Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
-    return
-  }
 
   if (InstallationVersion === latest) return
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -743,21 +743,6 @@ export const layer = Layer.effect(
 
         yield* merge(Global.Path.config, global, "global")
 
-        if (Flag.KILO_CONFIG) {
-          // kilocode_change start - capture KILO_CONFIG failures as warnings
-          yield* merge(
-            Flag.KILO_CONFIG,
-            yield* loadFile(Flag.KILO_CONFIG).pipe(
-              Effect.catchDefect((err: unknown) => {
-                caughtWarning(warnings, Flag.KILO_CONFIG!, err)
-                return Effect.succeed({} as Info)
-              }),
-            ),
-          )
-          // kilocode_change end
-          log.debug("loaded custom config", { path: Flag.KILO_CONFIG })
-        }
-
         if (!Flag.KILO_DISABLE_PROJECT_CONFIG) {
           // kilocode_change start - also discover kilo.json project files
           for (const name of ["kilo", "opencode"] as const) {
@@ -790,7 +775,16 @@ export const layer = Layer.effect(
         const deps: Fiber.Fiber<void, never>[] = []
 
         // kilocode_change start
+        const mergeEnvFile = () =>
+          KilocodeConfig.loadEnvConfig({
+            file: Flag.KILO_CONFIG,
+            load: loadFile,
+            merge: (source, config) => merge(source, config),
+            caught: (source, err) => caughtWarning(warnings, source, err),
+          })
+
         for (const dir of unique(directories)) {
+          if (dir === Flag.KILO_CONFIG_DIR) yield* mergeEnvFile()
           if (KilocodeConfig.isConfigDir(dir, Flag.KILO_CONFIG_DIR)) {
             for (const file of KilocodeConfig.ALL_CONFIG_FILES) {
               const source = path.join(dir, file)
@@ -849,6 +843,7 @@ export const layer = Layer.effect(
           const list = yield* Effect.promise(() => ConfigPlugin.load(dir))
           yield* mergePluginOrigins(dir, list)
         }
+        if (!Flag.KILO_CONFIG_DIR) yield* mergeEnvFile() // kilocode_change
 
         if (process.env.KILO_CONFIG_CONTENT) {
           // kilocode_change start - capture KILO_CONFIG_CONTENT parse failures as warnings
@@ -869,6 +864,19 @@ export const layer = Layer.effect(
           )
           // kilocode_change end
         }
+
+        // kilocode_change start - environment overlays beat local config but remain below managed policy
+        result = KilocodeConfig.applyEnvironment(result, {
+          apiKey: process.env.KILO_API_KEY,
+          organizationId: process.env.KILO_ORG_ID,
+          permission: Flag.KILO_PERMISSION,
+          autoShare: Flag.KILO_AUTO_SHARE,
+          disableAutoupdate: Flag.KILO_DISABLE_AUTOUPDATE,
+          notifyUpdate: Flag.KILO_ALWAYS_NOTIFY_UPDATE,
+          disableAutocompact: Flag.KILO_DISABLE_AUTOCOMPACT,
+          disablePrune: Flag.KILO_DISABLE_PRUNE,
+        })
+        // kilocode_change end
 
         const activeAccount = Option.getOrUndefined(
           yield* accountSvc.active().pipe(Effect.catch(() => Effect.succeed(Option.none()))),
@@ -943,10 +951,6 @@ export const layer = Layer.effect(
           })
         }
 
-        if (Flag.KILO_PERMISSION) {
-          result.permission = mergeDeep(result.permission ?? {}, JSON.parse(Flag.KILO_PERMISSION))
-        }
-
         if (result.tools) {
           const perms: Record<string, ConfigPermission.Action> = {}
           for (const [tool, enabled] of Object.entries(result.tools)) {
@@ -966,12 +970,6 @@ export const layer = Layer.effect(
           result.share = "auto"
         }
 
-        if (Flag.KILO_DISABLE_AUTOCOMPACT) {
-          result.compaction = { ...result.compaction, auto: false }
-        }
-        if (Flag.KILO_DISABLE_PRUNE) {
-          result.compaction = { ...result.compaction, prune: false }
-        }
         // kilocode_change start — inject Kilo default plugins into both plugin list and origins
         KilocodeDefaultPlugins.apply(result, { disabled: Flag.KILO_DISABLE_DEFAULT_PLUGINS, log })
         // kilocode_change end

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -3,7 +3,7 @@ export * as ConfigPaths from "./paths"
 import path from "path"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
-import { unique } from "remeda"
+import { orderConfigDirectories } from "@/kilocode/config/paths" // kilocode_change
 import * as Effect from "effect/Effect"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 
@@ -22,22 +22,24 @@ export const files = Effect.fn("ConfigPaths.projectFiles")(function* (
 
 export const directories = Effect.fn("ConfigPaths.directories")(function* (directory: string, worktree?: string) {
   const afs = yield* AppFileSystem.Service
-  return unique([
-    Global.Path.config,
-    ...(!Flag.KILO_DISABLE_PROJECT_CONFIG
-      ? yield* afs.up({
-          targets: [".kilocode", ".kilo", ".opencode"], // kilocode_change
-          start: directory,
-          stop: worktree,
-        })
-      : []),
-    ...(yield* afs.up({
-      targets: [".kilocode", ".kilo", ".opencode"], // kilocode_change
-      start: Global.Path.home,
-      stop: Global.Path.home,
-    })),
-    ...(Flag.KILO_CONFIG_DIR ? [Flag.KILO_CONFIG_DIR] : []),
-  ])
+  return orderConfigDirectories(
+    [
+      Global.Path.config,
+      ...(!Flag.KILO_DISABLE_PROJECT_CONFIG
+        ? yield* afs.up({
+            targets: [".kilocode", ".kilo", ".opencode"], // kilocode_change
+            start: directory,
+            stop: worktree,
+          })
+        : []),
+      ...(yield* afs.up({
+        targets: [".kilocode", ".kilo", ".opencode"], // kilocode_change
+        start: Global.Path.home,
+        stop: Global.Path.home,
+      })),
+    ],
+    Flag.KILO_CONFIG_DIR,
+  ) // kilocode_change
 })
 
 export function fileInDirectory(dir: string, name: string) {

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -4,6 +4,7 @@ import { Provider } from "@/provider/provider"
 import { Session } from "@/session/session"
 import { SessionSummary } from "@/session/summary"
 import { KiloSession } from "@/kilocode/session"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
 import { SessionID } from "@/session/schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { MessageV2 } from "@/session/message-v2"
@@ -106,13 +107,10 @@ export namespace KiloSessions {
   async function kilocodeToken() {
     return withInFlightCache(tokenKey, ttlMs, async () => {
       const auth = await runtime.runPromise((svc) => svc.get("kilo"))
-      if (auth?.type === "api" && auth.key.length > 0) return auth.key
-      if (auth?.type === "oauth" && auth.access.length > 0) return auth.access
-      if (auth?.type === "wellknown" && auth.token.length > 0) return auth.token
-
-      const key = process.env["KILO_API_KEY"]?.trim()
-      if (key) return key
-      return undefined
+      return resolveKiloCredentials({
+        env: { KILO_API_KEY: process.env.KILO_API_KEY, KILO_ORG_ID: process.env.KILO_ORG_ID },
+        auth,
+      }).token
     })
   }
 
@@ -793,13 +791,13 @@ export namespace KiloSessions {
   }
 
   async function getOrgId(): Promise<Uuid | undefined> {
-    const env = process.env["KILO_ORG_ID"]
-    if (isUuid(env)) return env
-
     return withInFlightCache(orgKey, ttlMs, async () => {
       const auth = await runtime.runPromise((svc) => svc.get("kilo"))
-      if (auth?.type === "oauth" && isUuid(auth.accountId)) return auth.accountId
-      return undefined
+      const org = resolveKiloCredentials({
+        env: { KILO_API_KEY: process.env.KILO_API_KEY, KILO_ORG_ID: process.env.KILO_ORG_ID },
+        auth,
+      }).organizationId
+      return isUuid(org) ? org : undefined
     })
   }
 

--- a/packages/opencode/src/kilocode/auth/credentials.ts
+++ b/packages/opencode/src/kilocode/auth/credentials.ts
@@ -1,0 +1,76 @@
+type Env = {
+  KILO_API_KEY?: string
+  KILO_ORG_ID?: string
+}
+
+type Provider = {
+  key?: unknown
+  options?: Record<string, unknown>
+}
+
+export type KiloCredentials = {
+  token?: string
+  organizationId?: string
+  baseUrl?: string
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+  return value as Record<string, unknown>
+}
+
+export function text(value: unknown): string | undefined {
+  if (typeof value !== "string") return
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function token(auth: unknown) {
+  const data = record(auth)
+  if (data.type === "api") return text(data.key)
+  if (data.type === "oauth") return text(data.access)
+  if (data.type === "wellknown") return text(data.token)
+  return
+}
+
+function org(auth: unknown) {
+  const data = record(auth)
+  if (data.type === "oauth") return text(data.accountId)
+  return
+}
+
+export function resolveKiloCredentials(input: {
+  env?: Env
+  config?: unknown
+  auth?: unknown
+  provider?: Provider
+  token?: unknown
+  organizationId?: unknown
+  baseUrl?: unknown
+}): KiloCredentials {
+  const env = input.env ?? {}
+  const config = record(input.config)
+  const options = record(record(config.provider).kilo)
+  const configured = record(options.options)
+  const provider = input.provider ?? {}
+  const state = record(provider.options)
+
+  return {
+    token:
+      text(env.KILO_API_KEY) ??
+      text(configured.apiKey) ??
+      text(configured.kilocodeToken) ??
+      text(input.token) ??
+      token(input.auth) ??
+      text(provider.key) ??
+      text(state.kilocodeToken) ??
+      text(state.apiKey),
+    organizationId:
+      text(env.KILO_ORG_ID) ??
+      text(configured.kilocodeOrganizationId) ??
+      text(input.organizationId) ??
+      org(input.auth) ??
+      text(state.kilocodeOrganizationId),
+    baseUrl: text(input.baseUrl) ?? text(configured.baseURL) ?? text(configured.baseUrl),
+  }
+}

--- a/packages/opencode/src/kilocode/auth/credentials.ts
+++ b/packages/opencode/src/kilocode/auth/credentials.ts
@@ -50,10 +50,10 @@ export function resolveKiloCredentials(input: {
 }): KiloCredentials {
   const env = input.env ?? {}
   const config = record(input.config)
-  const options = record(record(config.provider).kilo)
-  const configured = record(options.options)
-  const provider = input.provider ?? {}
-  const state = record(provider.options)
+  const entry = record(record(config.provider).kilo)
+  const configured = record(entry.options)
+  const source = input.provider ?? {}
+  const state = record(source.options)
 
   return {
     token:
@@ -62,7 +62,7 @@ export function resolveKiloCredentials(input: {
       text(configured.kilocodeToken) ??
       text(input.token) ??
       token(input.auth) ??
-      text(provider.key) ??
+      text(source.key) ??
       text(state.kilocodeToken) ??
       text(state.apiKey),
     organizationId:

--- a/packages/opencode/src/kilocode/cli/cmd/tui/config/tui.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/config/tui.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+
+export function mergeEnvTuiConfig(input: {
+  file?: string
+  merge: (file: string) => Effect.Effect<void>
+  loaded: (file: string) => void
+}) {
+  if (!input.file) return Effect.void
+  const file = input.file
+  return input.merge(file).pipe(Effect.tap(() => Effect.sync(() => input.loaded(file))))
+}

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -386,6 +386,84 @@ export namespace KilocodeConfig {
     log.info("migrated bash permission to allow for existing user", { path: target })
   }
 
+  export function applyEnvironment(
+    config: Config.Info,
+    input: {
+      apiKey?: string
+      organizationId?: string
+      permission?: string
+      autoShare: boolean
+      disableAutoupdate: boolean
+      notifyUpdate: boolean
+      disableAutocompact: boolean
+      disablePrune: boolean
+    },
+  ) {
+    const provider =
+      input.apiKey || input.organizationId
+        ? {
+            provider: {
+              kilo: {
+                options: {
+                  ...(input.apiKey ? { apiKey: input.apiKey } : {}),
+                  ...(input.organizationId ? { kilocodeOrganizationId: input.organizationId } : {}),
+                },
+              },
+            },
+          }
+        : {}
+    const indexing =
+      input.apiKey || input.organizationId
+        ? {
+            indexing: {
+              kilo: {
+                ...(input.apiKey ? { apiKey: input.apiKey } : {}),
+                ...(input.organizationId ? { organizationId: input.organizationId } : {}),
+              },
+            },
+          }
+        : {}
+    const autoupdate: false | "notify" | undefined = input.disableAutoupdate
+      ? false
+      : input.notifyUpdate
+        ? "notify"
+        : undefined
+    const overlay = {
+      ...provider,
+      ...indexing,
+      ...(input.permission ? { permission: JSON.parse(input.permission) } : {}),
+      ...(input.autoShare ? { share: "auto" as const } : {}),
+      ...(autoupdate !== undefined ? { autoupdate } : {}),
+      ...(input.disableAutocompact || input.disablePrune
+        ? {
+            compaction: {
+              ...(input.disableAutocompact ? { auto: false } : {}),
+              ...(input.disablePrune ? { prune: false } : {}),
+            },
+          }
+        : {}),
+    }
+    return mergeConfig(config, overlay)
+  }
+
+  export function loadEnvConfig(input: {
+    file?: string
+    load: (file: string) => Effect.Effect<Config.Info>
+    merge: (source: string, config: Config.Info) => Effect.Effect<void>
+    caught: (source: string, err: unknown) => void
+  }) {
+    if (!input.file) return Effect.void
+    const file = input.file
+    return input.load(file).pipe(
+      Effect.catchDefect((err) => {
+        input.caught(file, err)
+        return Effect.succeed({} as Config.Info)
+      }),
+      Effect.flatMap((config) => input.merge(file, config)),
+      Effect.tap(() => Effect.sync(() => log.debug("loaded custom config", { path: file }))),
+    )
+  }
+
   // ── Config merge utilities ───────────────────────────────────────────
 
   /** Recursively remove null values and drop objects left empty after removal. */

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -399,6 +399,7 @@ export namespace KilocodeConfig {
       disablePrune: boolean
     },
   ) {
+    const permission = parsePermission(input.permission)
     const provider =
       input.apiKey || input.organizationId
         ? {
@@ -431,7 +432,7 @@ export namespace KilocodeConfig {
     const overlay = {
       ...provider,
       ...indexing,
-      ...(input.permission ? { permission: JSON.parse(input.permission) } : {}),
+      ...permission,
       ...(input.autoShare ? { share: "auto" as const } : {}),
       ...(autoupdate !== undefined ? { autoupdate } : {}),
       ...(input.disableAutocompact || input.disablePrune
@@ -444,6 +445,16 @@ export namespace KilocodeConfig {
         : {}),
     }
     return mergeConfig(config, overlay)
+  }
+
+  function parsePermission(input?: string) {
+    if (!input) return {}
+    try {
+      return { permission: JSON.parse(input) }
+    } catch (err) {
+      log.warn("ignored invalid KILO_PERMISSION", { err })
+      return {}
+    }
   }
 
   export function loadEnvConfig(input: {

--- a/packages/opencode/src/kilocode/config/paths.ts
+++ b/packages/opencode/src/kilocode/config/paths.ts
@@ -1,0 +1,6 @@
+import { unique } from "remeda"
+
+export function orderConfigDirectories(dirs: string[], env?: string) {
+  const regular = env ? dirs.filter((dir) => dir !== env) : dirs
+  return unique([...regular, ...(env ? [env] : [])])
+}

--- a/packages/opencode/src/kilocode/config/sources.ts
+++ b/packages/opencode/src/kilocode/config/sources.ts
@@ -61,17 +61,20 @@ export namespace KilocodeConfigSources {
 
   export async function list(input: Input): Promise<Result> {
     const project = Flag.KILO_DISABLE_PROJECT_CONFIG ? [] : await projectSources(input)
-    const dirs = Flag.KILO_DISABLE_PROJECT_CONFIG ? [] : await configDirSources(input)
+    const dirs = await configDirSources(input)
+    const regular = dirs.filter((source) => source.scope !== "env")
+    const env = dirs.filter((source) => source.scope === "env")
     const sources = [
       ...wellknownSources(input.auth ?? {}),
       ...(await globalSources()),
-      ...(await envFileSources()),
       ...project,
-      ...dirs,
+      ...regular,
+      ...(await envFileSources()),
+      ...env,
       ...envContentSources(),
+      ...runtimeSources(),
       ...cloudSources(input.account),
       ...(await managedSources()),
-      ...runtimeSources(),
     ]
 
     return {
@@ -133,7 +136,9 @@ export namespace KilocodeConfigSources {
   }
 
   async function configDirSources(input: Input): Promise<Pending[]> {
-    const project = await Filesystem.findUp([...roots], input.directory, input.worktree)
+    const project = Flag.KILO_DISABLE_PROJECT_CONFIG
+      ? []
+      : await Filesystem.findUp([...roots], input.directory, input.worktree)
     const home = await Filesystem.findUp([...roots], Global.Path.home, Global.Path.home)
     const env = Flag.KILO_CONFIG_DIR ? [Flag.KILO_CONFIG_DIR] : []
     const dirs = unique([Global.Path.config, ...project, ...home, ...env]).filter((dir) =>
@@ -274,7 +279,12 @@ export namespace KilocodeConfigSources {
 
   function runtimeSources(): Pending[] {
     return [
+      runtimeSource("KILO_API_KEY", process.env.KILO_API_KEY, "Overrides persisted Kilo credentials."),
+      runtimeSource("KILO_ORG_ID", process.env.KILO_ORG_ID, "Overrides the persisted Kilo organization."),
       runtimeSource("KILO_PERMISSION", Flag.KILO_PERMISSION, "Runtime permission overlay."),
+      runtimeSource("KILO_AUTO_SHARE", process.env.KILO_AUTO_SHARE, "Enables automatic session sharing."),
+      runtimeSource("KILO_DISABLE_AUTOUPDATE", process.env.KILO_DISABLE_AUTOUPDATE, "Disables automatic updates."),
+      runtimeSource("KILO_ALWAYS_NOTIFY_UPDATE", process.env.KILO_ALWAYS_NOTIFY_UPDATE, "Uses update notifications."),
       runtimeSource("KILO_DISABLE_AUTOCOMPACT", process.env.KILO_DISABLE_AUTOCOMPACT, "Disables automatic compaction."),
       runtimeSource("KILO_DISABLE_PRUNE", process.env.KILO_DISABLE_PRUNE, "Disables tool-output pruning."),
     ].filter((item): item is Pending => item !== undefined)

--- a/packages/opencode/src/kilocode/indexing-auth.ts
+++ b/packages/opencode/src/kilocode/indexing-auth.ts
@@ -1,4 +1,5 @@
 import type { IndexingConfig } from "@kilocode/kilo-indexing/config"
+import { resolveKiloCredentials } from "./auth/credentials"
 
 type Auth = unknown
 
@@ -35,25 +36,6 @@ function record(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>
 }
 
-function text(value: unknown): string | undefined {
-  if (typeof value !== "string") return
-  const trimmed = value.trim()
-  return trimmed || undefined
-}
-
-function token(auth: Auth): string | undefined {
-  const data = record(auth)
-  if (data.type === "api") return text(data.key)
-  if (data.type === "oauth") return text(data.access)
-  return
-}
-
-function org(auth: Auth): string | undefined {
-  const data = record(auth)
-  if (data.type === "oauth") return text(data.accountId)
-  return
-}
-
 function value(input: unknown): boolean {
   if (input === undefined || input === null) return false
   if (typeof input === "string") return input.trim().length > 0
@@ -73,28 +55,22 @@ export function resolveKiloIndexingAuth(input: {
   env?: Env
 }): KiloIndexingAuth {
   const config = record(input.config)
-  const options = record(record(config.provider).kilo)
   const provider = input.provider ?? record(input.provider)
-  const providerOptions = record(provider.options)
-  const providerConfig = record(options.options)
   const kilo = record(record(config.indexing).kilo)
-  const env = input.env ?? process.env
+  const credentials = resolveKiloCredentials({
+    env: input.env,
+    config,
+    provider,
+    auth: input.auth,
+    token: kilo.apiKey,
+    organizationId: kilo.organizationId,
+    baseUrl: kilo.baseUrl,
+  })
 
   return {
-    apiKey:
-      text(kilo.apiKey) ??
-      text(providerConfig.apiKey) ??
-      token(input.auth) ??
-      text(provider.key) ??
-      text(providerOptions.kilocodeToken) ??
-      text(env.KILO_API_KEY),
-    baseUrl: text(kilo.baseUrl) ?? text(providerConfig.baseURL) ?? text(providerConfig.baseUrl),
-    organizationId:
-      text(kilo.organizationId) ??
-      text(providerConfig.kilocodeOrganizationId) ??
-      org(input.auth) ??
-      text(providerOptions.kilocodeOrganizationId) ??
-      text(env.KILO_ORG_ID),
+    apiKey: credentials.token,
+    baseUrl: credentials.baseUrl,
+    organizationId: credentials.organizationId,
   }
 }
 

--- a/packages/opencode/src/kilocode/provider/models.ts
+++ b/packages/opencode/src/kilocode/provider/models.ts
@@ -1,0 +1,38 @@
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
+
+export type KiloModelOptions = {
+  baseURL?: string
+  kilocodeOrganizationId?: string
+  kilocodeToken?: string
+}
+
+export function normalizeKiloBaseURL(baseURL: string | undefined, org: string | undefined) {
+  if (!baseURL) return undefined
+  const trimmed = baseURL.replace(/\/+$/, "")
+  if (org) {
+    if (trimmed.includes("/api/organizations/")) return trimmed
+    if (trimmed.endsWith("/api")) return `${trimmed}/organizations/${org}`
+    return `${trimmed}/api/organizations/${org}`
+  }
+  if (trimmed.includes("/openrouter")) return trimmed
+  if (trimmed.endsWith("/api")) return `${trimmed}/openrouter`
+  return `${trimmed}/api/openrouter`
+}
+
+export function resolveKiloModelOptions(input: { config?: unknown; auth?: unknown }) {
+  const credentials = resolveKiloCredentials(input)
+  const baseURL = normalizeKiloBaseURL(credentials.baseUrl, credentials.organizationId)
+  return {
+    ...(baseURL ? { baseURL } : {}),
+    ...(credentials.organizationId ? { kilocodeOrganizationId: credentials.organizationId } : {}),
+  }
+}
+
+export function mergeKiloModelOptions(
+  providerID: string,
+  resolved: KiloModelOptions,
+  options: KiloModelOptions,
+): KiloModelOptions {
+  if (providerID !== "kilo") return { ...resolved, ...options }
+  return { ...options, ...resolved }
+}

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -13,6 +13,7 @@ import { optionalOmitUndefined } from "@opencode-ai/core/schema"
 import { Effect, Schema } from "effect"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { mapValues, omit, pickBy } from "remeda"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
 
 /** Default timeout (ms) for provider HTTP requests (connection phase). */
 export const REQUEST_TIMEOUT_MS = 300_000 // 5 minutes
@@ -128,21 +129,13 @@ export function kiloCustomLoaders(dep: CustomDep): Record<string, CustomLoader> 
       }),
 
     kilo: Effect.fnUntraced(function* (input: any) {
-      const env = yield* dep.env()
-      const hasKey = yield* Effect.gen(function* () {
-        if (input.env.some((item: string) => env[item])) return true
-        if (yield* dep.auth(input.id)) return true
-        if ((yield* dep.config()).provider?.["kilo"]?.options?.apiKey) return true
-        return false
-      })
-
+      const auth = yield* dep.auth(input.id)
+      const config = yield* dep.config()
+      const credentials = resolveKiloCredentials({ auth, config, provider: input })
       const options: Record<string, string> = {}
-      if (env.KILO_ORG_ID) {
-        options.kilocodeOrganizationId = env.KILO_ORG_ID
-      }
-      if (!hasKey) {
-        options.apiKey = "anonymous"
-      }
+      if (credentials.token) options.kilocodeToken = credentials.token
+      if (credentials.organizationId) options.kilocodeOrganizationId = credentials.organizationId
+      if (!credentials.token) options.apiKey = "anonymous"
 
       return {
         autoload: Object.keys(input.models).length > 0,

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -75,7 +75,7 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const proxyAuth = Effect.fn("KiloGatewayHttpApi.proxyAuth")(function* () {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
+      const info = yield* auth.get("kilo").pipe(Effect.catch(() => Effect.succeed(undefined)))
       const cfg = yield* config.get()
       return { auth: info, ...resolveKiloCredentials({ config: cfg, auth: info }) }
     })

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -3,8 +3,6 @@ import {
   fetchCloudSession,
   fetchCloudSessionForImport,
   getCloudSessions,
-  getOrganizationId,
-  getToken,
   importSessionToDb,
 } from "@kilocode/kilo-gateway"
 import {
@@ -29,6 +27,7 @@ import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import * as Log from "@opencode-ai/core/util/log"
 import { Auth } from "@/auth"
+import { Config } from "@/config/config"
 import { EffectBridge } from "@/effect/bridge"
 import { Bus } from "@/bus"
 import { Identifier } from "@/id/id"
@@ -43,6 +42,7 @@ import { Storage } from "@/storage/storage"
 import { AudioTranscriptionsBody, ClawStatus, EditBody, FimBody } from "../groups/kilo-gateway"
 import { baseKey } from "../../../session-portability/cumulative-diff"
 import { extractSessionDiffs, restoreSessionDiffs } from "../../../session-portability/session-diff-restore"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
 
 const FIM_TIMEOUT_MS = 30_000
 const log = Log.create({ service: "kilo-gateway" })
@@ -58,6 +58,7 @@ function logError(route: string, err: unknown) {
 export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo", (handlers) =>
   Effect.gen(function* () {
     const auth = yield* Auth.Service
+    const config = yield* Config.Service
     const store = yield* InstanceStore.Service
     const cache = yield* ModelCache.Service
 
@@ -75,11 +76,8 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const proxyAuth = Effect.fn("KiloGatewayHttpApi.proxyAuth")(function* () {
       const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-      return {
-        auth: info,
-        token: getToken(info),
-        organizationId: getOrganizationId(info),
-      }
+      const cfg = yield* config.get()
+      return { auth: info, ...resolveKiloCredentials({ config: cfg, auth: info }) }
     })
 
     const modes = Effect.fn("KiloGatewayHttpApi.modes")(function* () {
@@ -103,7 +101,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
         return DIRECT_FIM_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
       })
 
-      if (target.provider === "kilo" && !info?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -181,7 +178,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
         if (item?.type === "api") return item.key
         return DIRECT_EDIT_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
       })
-      if (target.provider === "kilo" && !proxy?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -272,7 +268,6 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       payload: typeof AudioTranscriptionsBody.Type
     }) {
       const info = yield* proxyAuth()
-      if (!info.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
       if (!info.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const request = yield* HttpServerRequest.HttpServerRequest
@@ -299,14 +294,13 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const notifications = Effect.fn("KiloGatewayHttpApi.notifications")(function* () {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
-      const token = getToken(info)
-      if (!token) return []
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return []
 
       return yield* Effect.promise(() =>
         fetchKilocodeNotifications({
-          kilocodeToken: token,
-          kilocodeOrganizationId: getOrganizationId(info),
+          kilocodeToken: credentials.token,
+          kilocodeOrganizationId: credentials.organizationId,
         }),
       )
     })
@@ -332,16 +326,14 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const clawStatus = Effect.fn("KiloGatewayHttpApi.clawStatus")(function* () {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.ServiceUnavailable({})))
-      const token = getToken(info)
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
       const headers: Record<string, string> = {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${credentials.token}`,
         "Content-Type": "application/json",
       }
-      const org = getOrganizationId(info)
-      if (org) headers[HEADER_ORGANIZATIONID] = org
+      if (credentials.organizationId) headers[HEADER_ORGANIZATIONID] = credentials.organizationId
 
       return yield* Effect.tryPromise({
         try: async () => {
@@ -364,13 +356,13 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const clawChatCredentials = Effect.fn("KiloGatewayHttpApi.clawChatCredentials")(function* () {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-      const token = getToken(info)
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
-      const expires = info?.type === "oauth" ? info.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
+      const expires =
+        credentials.auth?.type === "oauth" ? credentials.auth.expires : Date.now() + 365 * 24 * 60 * 60 * 1000
       return {
-        token,
+        token: credentials.token,
         expiresAt: new Date(expires).toISOString(),
         kiloChatUrl: KILO_CHAT_URL,
         eventServiceUrl: KILO_EVENT_SERVICE_URL,
@@ -378,9 +370,9 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const cloudSessions = Effect.fn("KiloGatewayHttpApi.cloudSessions")(function* (ctx) {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
-      const token = getToken(info)
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const token = credentials.token
 
       const query = {
         ...ctx.query,
@@ -403,9 +395,9 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const cloudSession = Effect.fn("KiloGatewayHttpApi.cloudSession")(function* (ctx) {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-      const token = getToken(info)
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const token = credentials.token
 
       const result = yield* Effect.tryPromise({
         try: () => fetchCloudSession(token, ctx.params.id),
@@ -424,9 +416,9 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const cloudSessionImport = Effect.fn("KiloGatewayHttpApi.cloudSessionImport")(function* (ctx) {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-      const token = getToken(info)
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const credentials = yield* proxyAuth()
+      if (!credentials.token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      const token = credentials.token
 
       const fetched = yield* Effect.tryPromise({
         try: () => fetchCloudSessionForImport(token, ctx.payload.sessionId),

--- a/packages/opencode/src/kilocode/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/kilocode/server/routes/instance/httpapi/handlers/config.ts
@@ -1,0 +1,7 @@
+import { fetchDefaultModel } from "@kilocode/kilo-gateway"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
+
+export function fetchKiloDefaultModel(config: unknown, auth: unknown) {
+  const credentials = resolveKiloCredentials({ config, auth })
+  return fetchDefaultModel(credentials.token, credentials.organizationId)
+}

--- a/packages/opencode/src/kilocode/session-export/org-sources.ts
+++ b/packages/opencode/src/kilocode/session-export/org-sources.ts
@@ -1,7 +1,7 @@
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
 import { makeRuntime } from "@/effect/run-service"
-import { resolveKiloIndexingAuth } from "@/kilocode/indexing-auth"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
 
 export type OrgState = { type: "personal" } | { type: "org"; id: string } | { type: "unknown" }
 export type OrgSource = () => Promise<OrgState>
@@ -15,7 +15,7 @@ export async function getAuthOrgId(): Promise<OrgState> {
       config.runPromise((svc) => svc.get()),
       auth.runPromise((svc) => svc.get("kilo")),
     ])
-    const id = resolveKiloIndexingAuth({ config: cfg, auth: info }).organizationId
+    const id = resolveKiloCredentials({ config: cfg, auth: info }).organizationId
     if (id) return { type: "org", id }
     return { type: "personal" }
   } catch (err) {

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -374,7 +374,9 @@ Example: `~/.config/kilo/command/*.md` (modern global), `~/.kilocode/command/*.m
 
 | Variable | Description |
 |---|---|
-| `KILO_CONFIG` | Path to an additional config file (loaded after global) |
-| `KILO_CONFIG_DIR` | Path to an additional config directory (appended to search list) |
-| `KILO_CONFIG_CONTENT` | Inline JSON config string (high precedence, after project dirs) |
-| `KILO_DISABLE_PROJECT_CONFIG` | Skip all project-level config (files and directories) |
+| `KILO_CONFIG` | Config file that overrides global and project configuration |
+| `KILO_CONFIG_DIR` | Config directory that overrides project configuration and `KILO_CONFIG` |
+| `KILO_CONFIG_CONTENT` | Inline JSON config that overrides all user-controlled config files and directories |
+| `KILO_DISABLE_PROJECT_CONFIG` | Skip all project-level config while retaining explicit environment config sources |
+
+Managed Kilo Cloud organization config, managed directories, and macOS MDM policy override environment configuration. Explicit CLI arguments override matching environment defaults but do not bypass managed restrictions.

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -6,6 +6,8 @@ import { Config } from "../config/config"
 import { Auth } from "../auth"
 import type { Provider } from "@opencode-ai/core/models"
 import * as Log from "@opencode-ai/core/util/log"
+import { resolveKiloCredentials } from "@/kilocode/auth/credentials"
+import { mergeKiloModelOptions } from "@/kilocode/provider/models"
 
 type Models = Provider["models"]
 type KiloOptions = NonNullable<Parameters<typeof fetchKiloModels>[0]>
@@ -118,19 +120,10 @@ export const layer: Layer.Layer<
       const options: Options = {}
 
       if (providerID === "kilo") {
-        const item = config.provider?.[providerID]
-        if (item?.options?.apiKey) options.kilocodeToken = item.options.apiKey
-        if (item?.options?.kilocodeOrganizationId) options.kilocodeOrganizationId = item.options.kilocodeOrganizationId
-
         const info = yield* auth.get(providerID)
-        if (info?.type === "api") options.kilocodeToken = info.key
-        if (info?.type === "oauth") {
-          options.kilocodeToken = info.access
-          if (info.accountId) options.kilocodeOrganizationId = info.accountId
-        }
-
-        if (process.env.KILO_API_KEY) options.kilocodeToken = process.env.KILO_API_KEY
-        if (process.env.KILO_ORG_ID) options.kilocodeOrganizationId = process.env.KILO_ORG_ID
+        const credentials = resolveKiloCredentials({ config, auth: info })
+        if (credentials.token) options.kilocodeToken = credentials.token
+        if (credentials.organizationId) options.kilocodeOrganizationId = credentials.organizationId
         log.debug("auth options resolved", {
           providerID,
           hasToken: !!options.kilocodeToken,
@@ -173,7 +166,7 @@ export const layer: Layer.Layer<
           }),
         ),
       )
-      return yield* fetchModels(providerID, { ...resolved, ...options })
+      return yield* fetchModels(providerID, mergeKiloModelOptions(providerID, resolved, options))
     })
 
     const key = (providerID: string, options?: Options) => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -5,6 +5,7 @@ import { ModelCache } from "./model-cache"
 import * as Core from "@opencode-ai/core/models"
 import { Context, Effect, Layer } from "effect"
 import { AI_SDK_PROVIDERS, KILO_OPENROUTER_BASE, PROMPTS } from "@kilocode/kilo-gateway"
+import { resolveKiloModelOptions } from "@/kilocode/provider/models" // kilocode_change
 
 export const Model = Core.Model
 export type Model = Core.Model
@@ -16,19 +17,6 @@ export type CatalogModelStatus = Core.CatalogModelStatus
 export interface Interface extends Core.Interface {}
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ModelsDev") {}
-
-function baseURL(url: string | undefined, org: string | undefined) {
-  if (!url) return
-  const base = url.replace(/\/+$/, "")
-  if (org) {
-    if (base.includes("/api/organizations/")) return base
-    if (base.endsWith("/api")) return `${base}/organizations/${org}`
-    return `${base}/api/organizations/${org}`
-  }
-  if (base.includes("/openrouter")) return base
-  if (base.endsWith("/api")) return `${base}/openrouter`
-  return `${base}/api/openrouter`
-}
 
 export const layer: Layer.Layer<
   Service,
@@ -73,14 +61,8 @@ export const layer: Layer.Layer<
         return providers
       }
 
-      const opts = cfg.provider?.kilo?.options
       const info = yield* auth.get("kilo").pipe(Effect.catch(() => Effect.succeed(undefined)))
-      const org = opts?.kilocodeOrganizationId ?? (info?.type === "oauth" ? info.accountId : undefined)
-      const url = baseURL(opts?.baseURL, org)
-      const fetch = {
-        ...(url ? { baseURL: url } : {}),
-        ...(org ? { kilocodeOrganizationId: org } : {}),
-      }
+      const fetch = resolveKiloModelOptions({ config: cfg, auth: info }) // kilocode_change
       const models = yield* cache.fetch("kilo", fetch).pipe(Effect.catch(() => Effect.succeed({})))
       providers.kilo = {
         id: "kilo",

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -61,8 +61,9 @@ export const layer: Layer.Layer<
         return providers
       }
 
+      // kilocode_change start - resolve model fetch options from effective Kilo credentials
       const info = yield* auth.get("kilo").pipe(Effect.catch(() => Effect.succeed(undefined)))
-      const fetch = resolveKiloModelOptions({ config: cfg, auth: info }) // kilocode_change
+      const fetch = resolveKiloModelOptions({ config: cfg, auth: info })
       const models = yield* cache.fetch("kilo", fetch).pipe(Effect.catch(() => Effect.succeed({})))
       providers.kilo = {
         id: "kilo",
@@ -73,6 +74,7 @@ export const layer: Layer.Layer<
         models,
       }
       if (Object.keys(models).length === 0) yield* cache.refresh("kilo", fetch).pipe(Effect.ignore, Effect.forkDetach)
+      // kilocode_change end
       yield* addApertis()
       return providers
     })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -1,8 +1,8 @@
 import { Config } from "@/config/config"
 // kilocode_change start - preserve Kilo API default model overlay
-import { fetchDefaultModel } from "@kilocode/kilo-gateway"
 import { Auth } from "@/auth"
 import { ModelID, ProviderID } from "@/provider/schema"
+import { fetchKiloDefaultModel } from "@/kilocode/server/routes/instance/httpapi/handlers/config"
 // kilocode_change end
 import { Provider } from "@/provider/provider"
 import * as InstanceState from "@/effect/instance-state"
@@ -40,9 +40,8 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
       if (providers[ProviderID.kilo]) {
         const auth = yield* Auth.Service
         const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({}))) // kilocode_change
-        const token = info?.type === "oauth" ? info.access : info?.key
-        const organizationId = info?.type === "oauth" ? info.accountId : undefined
-        const model = yield* Effect.promise(() => fetchDefaultModel(token, organizationId))
+        const config = yield* configSvc.get()
+        const model = yield* Effect.promise(() => fetchKiloDefaultModel(config, info))
         if (model && providers[ProviderID.kilo]?.models[model]) defaults[ProviderID.kilo] = ModelID.make(model)
       }
       // kilocode_change end

--- a/packages/opencode/src/share/session.ts
+++ b/packages/opencode/src/share/session.ts
@@ -3,7 +3,6 @@ import { SessionID } from "@/session/schema"
 import { SyncEvent } from "@/sync"
 import { Effect, Layer, Scope, Context } from "effect"
 import { Config } from "@/config/config"
-import { RuntimeFlags } from "@/effect/runtime-flags"
 import { KiloSession } from "@/kilocode/session" // kilocode_change
 
 export interface Interface {
@@ -21,7 +20,6 @@ export const layer = Layer.effect(
     const session = yield* Session.Service
     const scope = yield* Scope.Scope
     const sync = yield* SyncEvent.Service
-    const flags = yield* RuntimeFlags.Service
 
     const share = Effect.fn("SessionShare.share")(function* (sessionID: SessionID) {
       const conf = yield* cfg.get()
@@ -40,7 +38,7 @@ export const layer = Layer.effect(
       const result = yield* session.create(input)
       if (result.parentID) return result
       const conf = yield* cfg.get()
-      if (!(flags.autoShare || conf.share === "auto")) return result
+      if (conf.share !== "auto") return result // kilocode_change - env overlay is applied before managed config
       yield* share(result.id).pipe(Effect.ignore, Effect.forkIn(scope))
       return result
     })
@@ -53,7 +51,6 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Session.defaultLayer),
   Layer.provide(Config.defaultLayer),
   Layer.provide(SyncEvent.defaultLayer),
-  Layer.provide(RuntimeFlags.defaultLayer),
 )
 
 export * as SessionShare from "./session"

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -412,28 +412,6 @@ it.instance("top-level keys in tui.json take precedence over nested tui key", ()
   ),
 )
 
-it.instance("project config takes precedence over KILO_TUI_CONFIG (matches KILO_CONFIG)", () =>
-  withCleanState(
-    Effect.gen(function* () {
-      const fs = yield* AppFileSystem.Service
-      const test = yield* TestInstance
-      const custom = path.join(test.directory, "custom-tui.json")
-      yield* fs.writeJson(path.join(test.directory, "tui.json"), { theme: "project", diff_style: "auto" })
-      yield* fs.writeJson(custom, { theme: "custom", diff_style: "stacked" })
-
-      yield* withEnv(
-        "KILO_TUI_CONFIG",
-        custom,
-        Effect.gen(function* () {
-          const config = yield* getTuiConfig(test.directory)
-          expect(config.theme).toBe("project")
-          expect(config.diff_style).toBe("auto")
-        }),
-      )
-    }),
-  ),
-)
-
 it.instance("merges keybind overrides across precedence layers", () =>
   withCleanState(
     Effect.gen(function* () {

--- a/packages/opencode/test/kilocode/auth/credentials.test.ts
+++ b/packages/opencode/test/kilocode/auth/credentials.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { resolveKiloCredentials } from "../../../src/kilocode/auth/credentials"
+
+describe("Kilo credential precedence", () => {
+  test("environment overrides config, stored auth, and provider state", () => {
+    const result = resolveKiloCredentials({
+      env: { KILO_API_KEY: " env-token ", KILO_ORG_ID: " env-org " },
+      config: {
+        provider: {
+          kilo: { options: { apiKey: "config-token", kilocodeOrganizationId: "config-org" } },
+        },
+      },
+      auth: { type: "oauth", access: "stored-token", accountId: "stored-org" },
+      provider: {
+        key: "provider-key",
+        options: { kilocodeToken: "provider-token", kilocodeOrganizationId: "provider-org" },
+      },
+      token: "feature-token",
+      organizationId: "feature-org",
+    })
+
+    expect(result).toEqual({ token: "env-token", organizationId: "env-org", baseUrl: undefined })
+  })
+
+  test("resolves token and organization independently", () => {
+    expect(
+      resolveKiloCredentials({
+        env: { KILO_ORG_ID: "env-org" },
+        config: { provider: { kilo: { options: { apiKey: "config-token" } } } },
+        auth: { type: "oauth", access: "stored-token", accountId: "stored-org" },
+      }),
+    ).toEqual({ token: "config-token", organizationId: "env-org", baseUrl: undefined })
+  })
+
+  test("effective provider config overrides feature-specific fallbacks", () => {
+    expect(
+      resolveKiloCredentials({
+        env: {},
+        config: {
+          provider: {
+            kilo: { options: { apiKey: "effective-token", kilocodeOrganizationId: "effective-org" } },
+          },
+        },
+        token: "feature-token",
+        organizationId: "feature-org",
+      }),
+    ).toMatchObject({ token: "effective-token", organizationId: "effective-org" })
+  })
+
+  test("falls back through API, OAuth, and well-known auth", () => {
+    expect(resolveKiloCredentials({ env: {}, auth: { type: "api", key: "api-token" } }).token).toBe("api-token")
+    expect(
+      resolveKiloCredentials({ env: {}, auth: { type: "oauth", access: "oauth-token", accountId: "oauth-org" } }),
+    ).toMatchObject({ token: "oauth-token", organizationId: "oauth-org" })
+    expect(resolveKiloCredentials({ env: {}, auth: { type: "wellknown", token: "wellknown-token" } }).token).toBe(
+      "wellknown-token",
+    )
+  })
+
+  test("ignores empty environment values", () => {
+    expect(
+      resolveKiloCredentials({
+        env: { KILO_API_KEY: " ", KILO_ORG_ID: "" },
+        auth: { type: "oauth", access: "stored-token", accountId: "stored-org" },
+      }),
+    ).toMatchObject({ token: "stored-token", organizationId: "stored-org" })
+  })
+})

--- a/packages/opencode/test/kilocode/cli/cmd/tui/config/tui.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/config/tui.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { TuiConfig } from "@/cli/cmd/tui/config/tui"
+import { CurrentWorkingDirectory } from "@/cli/cmd/tui/config/cwd"
+import { tmpdir } from "../../../../../fixture/fixture"
+
+const get = (directory: string) =>
+  Effect.runPromise(
+    TuiConfig.Service.use((svc) => svc.get()).pipe(
+      Effect.provide(TuiConfig.defaultLayer.pipe(Layer.provide(Layer.succeed(CurrentWorkingDirectory, directory)))),
+    ),
+  )
+
+afterEach(() => {
+  delete process.env.KILO_TUI_CONFIG
+})
+
+test("KILO_TUI_CONFIG overrides project config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "tui.json"), JSON.stringify({ theme: "project", diff_style: "auto" }))
+      const custom = path.join(dir, "custom-tui.json")
+      await Bun.write(custom, JSON.stringify({ theme: "custom", diff_style: "stacked" }))
+      process.env.KILO_TUI_CONFIG = custom
+    },
+  })
+
+  const config = await get(tmp.path)
+  expect(config.theme).toBe("custom")
+  expect(config.diff_style).toBe("stacked")
+})

--- a/packages/opencode/test/kilocode/config/env-precedence.test.ts
+++ b/packages/opencode/test/kilocode/config/env-precedence.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer, Option } from "effect"
+import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import path from "path"
+import fs from "fs/promises"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Account } from "../../../src/account/account"
+import { Auth } from "../../../src/auth"
+import { Config } from "../../../src/config/config"
+import { Env } from "../../../src/env"
+import { Npm } from "@opencode-ai/core/npm"
+import { WithInstance } from "../../../src/project/with-instance"
+import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
+
+const infra = CrossSpawnSpawner.defaultLayer.pipe(
+  Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
+)
+const account = Layer.mock(Account.Service)({
+  active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
+})
+const auth = Layer.mock(Auth.Service)({ all: () => Effect.succeed({}) })
+const npm = Layer.mock(Npm.Service)({
+  install: () => Effect.void,
+  add: () => Effect.die("not implemented"),
+  which: () => Effect.succeed(Option.none()),
+})
+const layer = Config.layer.pipe(
+  Layer.provide(EffectFlock.defaultLayer),
+  Layer.provide(AppFileSystem.defaultLayer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(auth),
+  Layer.provide(account),
+  Layer.provideMerge(infra),
+  Layer.provide(npm),
+)
+const load = () => Effect.runPromise(Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(layer)))
+
+const original = {
+  file: process.env.KILO_CONFIG,
+  dir: process.env.KILO_CONFIG_DIR,
+  content: process.env.KILO_CONFIG_CONTENT,
+  managed: process.env.KILO_TEST_MANAGED_CONFIG_DIR,
+  key: process.env.KILO_API_KEY,
+  org: process.env.KILO_ORG_ID,
+  flag: Flag.KILO_CONFIG,
+  compact: Flag.KILO_DISABLE_AUTOCOMPACT,
+  prune: Flag.KILO_DISABLE_PRUNE,
+  share: Flag.KILO_AUTO_SHARE,
+  update: Flag.KILO_DISABLE_AUTOUPDATE,
+  notify: Flag.KILO_ALWAYS_NOTIFY_UPDATE,
+}
+
+function restore() {
+  set("KILO_CONFIG", original.file)
+  set("KILO_CONFIG_DIR", original.dir)
+  set("KILO_CONFIG_CONTENT", original.content)
+  set("KILO_TEST_MANAGED_CONFIG_DIR", original.managed)
+  set("KILO_API_KEY", original.key)
+  set("KILO_ORG_ID", original.org)
+  Flag.KILO_CONFIG = original.flag
+  Flag.KILO_DISABLE_AUTOCOMPACT = original.compact
+  Flag.KILO_DISABLE_PRUNE = original.prune
+  Flag.KILO_AUTO_SHARE = original.share
+  Flag.KILO_DISABLE_AUTOUPDATE = original.update
+  Flag.KILO_ALWAYS_NOTIFY_UPDATE = original.notify
+}
+
+function set(key: keyof typeof process.env, value: string | undefined) {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
+
+afterEach(async () => {
+  restore()
+  await disposeAllInstances()
+})
+
+describe("KILO config precedence", () => {
+  test("environment config sources override project files in deterministic order", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "kilo.json"),
+          JSON.stringify({ username: "project", share: "disabled", autoupdate: false }),
+        )
+        await Bun.write(path.join(dir, "env.json"), JSON.stringify({ username: "env-file" }))
+        await fs.mkdir(path.join(dir, "env-dir"), { recursive: true })
+        await Bun.write(path.join(dir, "env-dir", "kilo.json"), JSON.stringify({ username: "env-dir" }))
+      },
+    })
+
+    const file = path.join(tmp.path, "env.json")
+    process.env.KILO_CONFIG = file
+    Flag.KILO_CONFIG = file
+    process.env.KILO_CONFIG_DIR = path.join(tmp.path, "env-dir")
+    process.env.KILO_CONFIG_CONTENT = JSON.stringify({ username: "env-content" })
+    process.env.KILO_API_KEY = "env-token"
+    process.env.KILO_ORG_ID = "env-org"
+    Flag.KILO_AUTO_SHARE = true
+    Flag.KILO_ALWAYS_NOTIFY_UPDATE = true
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.username).toBe("env-content")
+        expect(config.share).toBe("auto")
+        expect(config.autoupdate).toBe("notify")
+        expect(config.provider?.kilo?.options).toMatchObject({
+          apiKey: "env-token",
+          kilocodeOrganizationId: "env-org",
+        })
+      },
+    })
+  })
+
+  test("KILO_CONFIG_DIR overrides KILO_CONFIG and project files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "kilo.json"), JSON.stringify({ username: "project" }))
+        await Bun.write(path.join(dir, "env.json"), JSON.stringify({ username: "env-file" }))
+        await fs.mkdir(path.join(dir, "env-dir"), { recursive: true })
+        await Bun.write(path.join(dir, "env-dir", "kilo.json"), JSON.stringify({ username: "env-dir" }))
+      },
+    })
+
+    const file = path.join(tmp.path, "env.json")
+    process.env.KILO_CONFIG = file
+    Flag.KILO_CONFIG = file
+    process.env.KILO_CONFIG_DIR = path.join(tmp.path, "env-dir")
+    delete process.env.KILO_CONFIG_CONTENT
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => expect((await load()).username).toBe("env-dir"),
+    })
+  })
+
+  test("managed config remains stronger than environment config", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "managed"), { recursive: true })
+        await Bun.write(
+          path.join(dir, "managed", "kilo.json"),
+          JSON.stringify({
+            username: "managed",
+            share: "disabled",
+            autoupdate: false,
+            provider: {
+              kilo: { options: { apiKey: "managed-token", kilocodeOrganizationId: "managed-org" } },
+            },
+          }),
+        )
+      },
+    })
+
+    process.env.KILO_CONFIG_CONTENT = JSON.stringify({ username: "env-content" })
+    process.env.KILO_API_KEY = "env-token"
+    process.env.KILO_ORG_ID = "env-org"
+    process.env.KILO_TEST_MANAGED_CONFIG_DIR = path.join(tmp.path, "managed")
+    Flag.KILO_AUTO_SHARE = true
+    Flag.KILO_ALWAYS_NOTIFY_UPDATE = true
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.username).toBe("managed")
+        expect(config.share).toBe("disabled")
+        expect(config.autoupdate).toBe(false)
+        expect(config.provider?.kilo?.options).toMatchObject({
+          apiKey: "managed-token",
+          kilocodeOrganizationId: "managed-org",
+        })
+      },
+    })
+  })
+
+  test("managed compaction policy overrides runtime environment overlays", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "managed"), { recursive: true })
+        await Bun.write(
+          path.join(dir, "managed", "kilo.json"),
+          JSON.stringify({ compaction: { auto: true, prune: true } }),
+        )
+      },
+    })
+
+    Flag.KILO_DISABLE_AUTOCOMPACT = true
+    Flag.KILO_DISABLE_PRUNE = true
+    process.env.KILO_TEST_MANAGED_CONFIG_DIR = path.join(tmp.path, "managed")
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => expect((await load()).compaction).toMatchObject({ auto: true, prune: true }),
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/config/env-precedence.test.ts
+++ b/packages/opencode/test/kilocode/config/env-precedence.test.ts
@@ -52,6 +52,7 @@ const original = {
   share: Flag.KILO_AUTO_SHARE,
   update: Flag.KILO_DISABLE_AUTOUPDATE,
   notify: Flag.KILO_ALWAYS_NOTIFY_UPDATE,
+  permission: Flag.KILO_PERMISSION,
 }
 
 function restore() {
@@ -67,6 +68,7 @@ function restore() {
   Flag.KILO_AUTO_SHARE = original.share
   Flag.KILO_DISABLE_AUTOUPDATE = original.update
   Flag.KILO_ALWAYS_NOTIFY_UPDATE = original.notify
+  Flag.KILO_PERMISSION = original.permission
 }
 
 function set(key: keyof typeof process.env, value: string | undefined) {
@@ -198,6 +200,21 @@ describe("KILO config precedence", () => {
     await WithInstance.provide({
       directory: tmp.path,
       fn: async () => expect((await load()).compaction).toMatchObject({ auto: true, prune: true }),
+    })
+  })
+
+  test("ignores malformed KILO_PERMISSION overlays", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "kilo.json"), JSON.stringify({ permission: { bash: "ask" } }))
+      },
+    })
+
+    Flag.KILO_PERMISSION = "{malformed"
+
+    await WithInstance.provide({
+      directory: tmp.path,
+      fn: async () => expect((await load()).permission).toEqual({ bash: "ask" }),
     })
   })
 })

--- a/packages/opencode/test/kilocode/indexing-auth.test.ts
+++ b/packages/opencode/test/kilocode/indexing-auth.test.ts
@@ -34,6 +34,20 @@ describe("Kilo indexing auth resolution", () => {
     })
   })
 
+  test("prefers environment credentials over all persisted sources", () => {
+    expect(
+      resolveKiloIndexingAuth({
+        env: { KILO_API_KEY: "env-token", KILO_ORG_ID: "org_env" },
+        config: {
+          indexing: { kilo: { apiKey: "index-token", organizationId: "org_index" } },
+          provider: { kilo: { options: { apiKey: "config-token", kilocodeOrganizationId: "org_config" } } },
+        },
+        provider: { key: "provider-token", options: { kilocodeOrganizationId: "org_provider" } },
+        auth: { type: "oauth", access: "oauth-token", accountId: "org_oauth" },
+      }),
+    ).toEqual({ apiKey: "env-token", organizationId: "org_env", baseUrl: undefined })
+  })
+
   test("defaults to Kilo only when no provider or other embedder config is present", () => {
     const auth = { apiKey: "kilo-token" }
 

--- a/packages/opencode/test/kilocode/kilo-loader-auth.test.ts
+++ b/packages/opencode/test/kilocode/kilo-loader-auth.test.ts
@@ -161,7 +161,7 @@ it.effect("enables a paid catalog when config apiKey is present", () =>
   Effect.gen(function* () {
     const result = yield* load({ config: { provider: { kilo: { options: { apiKey: "test-key" } } } } })
     expect(result.autoload).toBe(true)
-    expect(result.options).toEqual({})
+    expect(result.options).toEqual({ kilocodeToken: "test-key" })
   }),
 )
 
@@ -169,6 +169,20 @@ it.effect("enables a paid catalog when auth exists", () =>
   Effect.gen(function* () {
     const result = yield* load({ auth: { type: "api", key: "test-key" } })
     expect(result.autoload).toBe(true)
-    expect(result.options).toEqual({})
+    expect(result.options).toEqual({ kilocodeToken: "test-key" })
+  }),
+)
+
+it.effect("prefers effective config credentials over stored auth", () =>
+  Effect.gen(function* () {
+    const result = yield* load({
+      auth: { type: "oauth", access: "stored-token", accountId: "stored-org" },
+      config: {
+        provider: {
+          kilo: { options: { apiKey: "config-token", kilocodeOrganizationId: "config-org" } },
+        },
+      },
+    })
+    expect(result.options).toEqual({ kilocodeToken: "config-token", kilocodeOrganizationId: "config-org" })
   }),
 )

--- a/packages/opencode/test/kilocode/kilo-sessions.test.ts
+++ b/packages/opencode/test/kilocode/kilo-sessions.test.ts
@@ -90,7 +90,7 @@ it.instance("bootstraps session ingest from KILO_API_KEY without stored auth", (
   )
 })
 
-it.instance("prefers stored auth over KILO_API_KEY for session ingest", () => {
+it.instance("prefers KILO_API_KEY over stored auth for session ingest", () => {
   const original = process.env.KILO_API_KEY
   const calls: string[] = []
   const fetch: typeof globalThis.fetch = Object.assign(
@@ -117,7 +117,7 @@ it.instance("prefers stored auth over KILO_API_KEY for session ingest", () => {
     const auth = yield* Auth.Service
     yield* auth.set("kilo", { type: "api", key: "stored-token" })
     yield* Effect.promise(() => KiloSessions.bootstrap("session-auth"))
-    expect(calls).toEqual(["Bearer stored-token", "Bearer stored-token"])
+    expect(calls).toEqual(["Bearer env-token", "Bearer env-token"])
   }).pipe(
     Effect.ensuring(
       Effect.gen(function* () {

--- a/packages/opencode/test/kilocode/model-cache-org.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-org.test.ts
@@ -10,13 +10,14 @@ import * as Log from "@opencode-ai/core/util/log"
 Log.init({ print: false })
 
 import { Auth } from "../../src/auth"
+import { Config } from "../../src/config/config"
 import { ModelCache } from "../../src/provider/model-cache"
 import { TestConfig } from "../fixture/config"
 import { testEffect } from "../lib/effect"
 
 type Options = Parameters<ModelCache.KiloModels["fetch"]>[0]
 
-function layer(info: Auth.Info | undefined, captured: Ref.Ref<Options | undefined>) {
+function layer(info: Auth.Info | undefined, captured: Ref.Ref<Options | undefined>, config: Config.Info = {}) {
   const auth = Layer.mock(Auth.Service)({
     get: (id) => Effect.succeed(id === "kilo" ? info : undefined),
   })
@@ -40,7 +41,7 @@ function layer(info: Auth.Info | undefined, captured: Ref.Ref<Options | undefine
   )
   return Layer.fresh(ModelCache.layer).pipe(
     Layer.provide(FetchHttpClient.layer),
-    Layer.provide(TestConfig.layer()),
+    Layer.provide(TestConfig.layer({ get: () => Effect.succeed(config) })),
     Layer.provide(auth),
     Layer.provide(models),
   )
@@ -62,6 +63,31 @@ it.live("model fetch uses accountId from OAuth auth as kilocodeOrganizationId", 
     expect(yield* Ref.get(captured)).toMatchObject({
       kilocodeToken: "test-oauth-token",
       kilocodeOrganizationId: "org-enterprise-123",
+    })
+  }),
+)
+
+it.live("effective config credentials override stored and caller model options", () =>
+  Effect.gen(function* () {
+    const captured = yield* Ref.make<Options | undefined>(undefined)
+    const info = new Auth.Oauth({
+      type: "oauth",
+      access: "stored-token",
+      refresh: "stored-refresh",
+      expires: Date.now() + 3600000,
+      accountId: "stored-org",
+    })
+    const config = {
+      provider: {
+        kilo: { options: { apiKey: "config-token", kilocodeOrganizationId: "config-org" } },
+      },
+    }
+    yield* ModelCache.Service.use((cache) =>
+      cache.fetch("kilo", { kilocodeToken: "caller-token", kilocodeOrganizationId: "caller-org" }),
+    ).pipe(Effect.provide(layer(info, captured, config)))
+    expect(yield* Ref.get(captured)).toMatchObject({
+      kilocodeToken: "config-token",
+      kilocodeOrganizationId: "config-org",
     })
   }),
 )

--- a/packages/opencode/test/kilocode/server/config-sources.test.ts
+++ b/packages/opencode/test/kilocode/server/config-sources.test.ts
@@ -31,6 +31,7 @@ const env = {
   KILO_CONFIG_DIR: process.env.KILO_CONFIG_DIR,
   KILO_DISABLE_PROJECT_CONFIG: process.env.KILO_DISABLE_PROJECT_CONFIG,
   KILO_TEST_MANAGED_CONFIG_DIR: process.env.KILO_TEST_MANAGED_CONFIG_DIR,
+  KILO_DISABLE_AUTOCOMPACT: process.env.KILO_DISABLE_AUTOCOMPACT,
   flagConfig: Flag.KILO_CONFIG,
 }
 
@@ -46,6 +47,7 @@ function restore() {
   set("KILO_CONFIG_DIR", env.KILO_CONFIG_DIR)
   set("KILO_DISABLE_PROJECT_CONFIG", env.KILO_DISABLE_PROJECT_CONFIG)
   set("KILO_TEST_MANAGED_CONFIG_DIR", env.KILO_TEST_MANAGED_CONFIG_DIR)
+  set("KILO_DISABLE_AUTOCOMPACT", env.KILO_DISABLE_AUTOCOMPACT)
   Flag.KILO_CONFIG = env.flagConfig
 }
 
@@ -103,15 +105,18 @@ describe("config source routes", () => {
     process.env.KILO_CONFIG_CONTENT = '{"username":"secret-inline-value"}'
     process.env.KILO_CONFIG_DIR = path.join(tmp.path, "extra")
     process.env.KILO_TEST_MANAGED_CONFIG_DIR = path.join(tmp.path, "managed")
+    process.env.KILO_DISABLE_AUTOCOMPACT = "1"
 
     const body = await sources(tmp.path)
     const inline = body.sources.find((source) => source.source === "KILO_CONFIG_CONTENT")
+    const runtime = body.sources.find((source) => source.source === "KILO_DISABLE_AUTOCOMPACT")
 
-    expect(order(body, envFile)).toBeLessThan(order(body, projectFile))
     expect(order(body, projectFile)).toBeLessThan(order(body, configFile))
-    expect(order(body, configFile)).toBeLessThan(order(body, extraFile))
+    expect(order(body, configFile)).toBeLessThan(order(body, envFile))
+    expect(order(body, envFile)).toBeLessThan(order(body, extraFile))
     expect(inline?.order).toBeGreaterThan(order(body, extraFile))
-    expect(inline?.order).toBeLessThan(order(body, managedFile))
+    expect(runtime?.order).toBeGreaterThan(inline!.order)
+    expect(runtime?.order).toBeLessThan(order(body, managedFile))
 
     expect(body.sources.find((source) => source.path === configFile)).toMatchObject({
       kind: "config-dir-file",

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -17,6 +17,7 @@ import {
   WorkspaceRoutingMiddleware,
 } from "../../../src/server/routes/instance/httpapi/middleware/workspace-routing"
 import { testEffect } from "../../lib/effect"
+import { TestConfig } from "../../fixture/config"
 
 const TestHttpApi = HttpApi.make("opencode-instance").addHttpApi(KiloGatewayApi)
 const auth = Layer.mock(Auth.Service)({
@@ -25,6 +26,19 @@ const auth = Layer.mock(Auth.Service)({
 const store = Layer.mock(InstanceStore.Service)({})
 const cache = Layer.mock(ModelCache.Service)({})
 const session = Layer.mock(Session.Service)({})
+const config = TestConfig.layer({
+  get: () =>
+    Effect.succeed({
+      provider: {
+        kilo: {
+          options: {
+            ...(process.env.KILO_API_KEY ? { apiKey: process.env.KILO_API_KEY } : {}),
+            ...(process.env.KILO_ORG_ID ? { kilocodeOrganizationId: process.env.KILO_ORG_ID } : {}),
+          },
+        },
+      },
+    }),
+})
 const passthroughAuthorization = Layer.succeed(
   Authorization,
   Authorization.of((effect) => effect),
@@ -48,6 +62,7 @@ const layer = HttpRouter.serve(
       passthroughInstanceContext,
       testWorkspaceRouting,
       auth,
+      config,
       store,
       cache,
       session,
@@ -57,14 +72,14 @@ const layer = HttpRouter.serve(
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 const it = testEffect(layer)
 
-function stub(run: () => Response | Promise<Response>) {
+function stub(run: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>) {
   // These tests run sequentially; scope the process-global override and delegate in-process server traffic.
   const original = globalThis.fetch
   const fetch: typeof globalThis.fetch = Object.assign(
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
       if (url.startsWith("http://127.0.0.1:")) return original(input, init)
-      return run()
+      return run(input, init)
     },
     { preconnect: original.preconnect },
   )
@@ -84,6 +99,34 @@ function post(path: string, body: Record<string, unknown>) {
 }
 
 describe("Kilo gateway HttpApi statuses", () => {
+  it.live("environment credentials override stored auth for operational routes", () => {
+    const key = process.env.KILO_API_KEY
+    const org = process.env.KILO_ORG_ID
+    process.env.KILO_API_KEY = "env-token"
+    process.env.KILO_ORG_ID = "env-org"
+
+    return Effect.gen(function* () {
+      yield* stub((_input, init) => {
+        const headers = new Headers(init?.headers)
+        expect(headers.get("Authorization")).toBe("Bearer env-token")
+        expect(headers.get("X-KiloCode-OrganizationId")).toBe("env-org")
+        return Response.json({ status: "running" })
+      })
+
+      const response = yield* HttpClient.get(KiloGatewayPaths.clawStatus)
+      expect(response.status).toBe(200)
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (key === undefined) delete process.env.KILO_API_KEY
+          else process.env.KILO_API_KEY = key
+          if (org === undefined) delete process.env.KILO_ORG_ID
+          else process.env.KILO_ORG_ID = org
+        }),
+      ),
+    )
+  })
+
   it.live("preserves cloud session list rate limits", () =>
     Effect.gen(function* () {
       yield* stub(() => new Response("rate limited", { status: 429 }))

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -23,6 +23,9 @@ const TestHttpApi = HttpApi.make("opencode-instance").addHttpApi(KiloGatewayApi)
 const auth = Layer.mock(Auth.Service)({
   get: () => Effect.succeed(new Auth.Api({ type: "api", key: "test-token" })),
 })
+const empty = Layer.mock(Auth.Service)({
+  get: () => Effect.fail(new Auth.AuthError({ message: "missing auth" })),
+})
 const store = Layer.mock(InstanceStore.Service)({})
 const cache = Layer.mock(ModelCache.Service)({})
 const session = Layer.mock(Session.Service)({})
@@ -53,23 +56,28 @@ const testWorkspaceRouting = Layer.succeed(
     effect.pipe(Effect.provideService(WorkspaceRouteContext, WorkspaceRouteContext.of({ directory: process.cwd() }))),
   ),
 )
-const layer = HttpRouter.serve(
-  HttpApiBuilder.layer(TestHttpApi).pipe(
-    Layer.provide(kiloGatewayHandlers),
-    Layer.provide(schemaErrorLayer),
-    Layer.provide([
-      passthroughAuthorization,
-      passthroughInstanceContext,
-      testWorkspaceRouting,
-      auth,
-      config,
-      store,
-      cache,
-      session,
-    ]),
-  ),
-  { disableListenLog: true, disableLogger: true },
-).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
+function serve(auth: Layer.Layer<Auth.Service>) {
+  return HttpRouter.serve(
+    HttpApiBuilder.layer(TestHttpApi).pipe(
+      Layer.provide(kiloGatewayHandlers),
+      Layer.provide(schemaErrorLayer),
+      Layer.provide([
+        passthroughAuthorization,
+        passthroughInstanceContext,
+        testWorkspaceRouting,
+        auth,
+        config,
+        store,
+        cache,
+        session,
+      ]),
+    ),
+    { disableListenLog: true, disableLogger: true },
+  ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
+}
+const layer = serve(auth)
+const envLayer = serve(empty)
+const env = testEffect(envLayer)
 const it = testEffect(layer)
 
 function stub(run: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>) {
@@ -99,6 +107,34 @@ function post(path: string, body: Record<string, unknown>) {
 }
 
 describe("Kilo gateway HttpApi statuses", () => {
+  env.live("uses environment credentials without stored auth", () => {
+    const key = process.env.KILO_API_KEY
+    const org = process.env.KILO_ORG_ID
+    process.env.KILO_API_KEY = "env-only-token"
+    process.env.KILO_ORG_ID = "env-only-org"
+
+    return Effect.gen(function* () {
+      yield* stub((_input, init) => {
+        const headers = new Headers(init?.headers)
+        expect(headers.get("Authorization")).toBe("Bearer env-only-token")
+        expect(headers.get("X-KiloCode-OrganizationId")).toBe("env-only-org")
+        return Response.json({ status: "running" })
+      })
+
+      const response = yield* HttpClient.get(KiloGatewayPaths.clawStatus)
+      expect(response.status).toBe(200)
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (key === undefined) delete process.env.KILO_API_KEY
+          else process.env.KILO_API_KEY = key
+          if (org === undefined) delete process.env.KILO_ORG_ID
+          else process.env.KILO_ORG_ID = org
+        }),
+      ),
+    )
+  })
+
   it.live("environment credentials override stored auth for operational routes", () => {
     const key = process.env.KILO_API_KEY
     const org = process.env.KILO_ORG_ID

--- a/packages/opencode/test/kilocode/session-export/org-signal.test.ts
+++ b/packages/opencode/test/kilocode/session-export/org-signal.test.ts
@@ -20,12 +20,6 @@ describe("getActiveOrg", () => {
     expect(await getActiveOrg()).toEqual({ type: "personal" })
   })
 
-  test("returns env value when KILO_ORG_ID is set", async () => {
-    setOrgSource(async () => ({ type: "org", id: "org_auth" }))
-    process.env.KILO_ORG_ID = "org_envvar"
-    expect(await getActiveOrg()).toEqual({ type: "org", id: "org_envvar" })
-  })
-
   test("returns auth-derived org id when env is absent", async () => {
     setOrgSource(async () => ({ type: "org", id: "org_auth" }))
     expect(await getActiveOrg()).toEqual({ type: "org", id: "org_auth" })


### PR DESCRIPTION
## Issue

No linked issue; this refactor was requested directly.

## Context

`KILO_*` runtime environment overrides were not consistently applied across config loading, provider credentials, model catalog requests, indexing auth, session export, and gateway status endpoints. This made persisted auth/config win in some paths while raw env won in others, and it risked bypassing managed policy in direct consumers.

## Implementation

Centralize Kilo credential resolution in Kilo-owned code and route direct consumers through effective config plus auth where possible. Move runtime env overlays before managed config so managed policy remains strongest, while explicit CLI args still win for command-level defaults. Add narrow shared-file seams for config path ordering, TUI env config ordering, provider model options, default model handling, update flags, and auto-share policy.

## Screenshots / Video

N/A, no visual changes.

## How to Test

### Manual/local verification

- Agent-executed: `bun test ./test/kilocode/auth/credentials.test.ts ./test/kilocode/config/env-precedence.test.ts ./test/kilocode/indexing-auth.test.ts ./test/kilocode/kilo-loader-auth.test.ts ./test/kilocode/model-cache-org.test.ts ./test/kilocode/kilo-sessions.test.ts ./test/kilocode/session-export/org-signal.test.ts ./test/kilocode/server/config-sources.test.ts ./test/kilocode/server/kilo-gateway-statuses.test.ts ./test/kilocode/cli/cmd/tui/config/tui.test.ts ./test/config/tui.test.ts` from `packages/opencode`
- Agent-executed: `bun run typecheck` from `packages/opencode`
- Agent-executed: `bun run script/check-opencode-annotations.ts`
- Agent-executed: `bun run script/check-opencode-promise-facades.ts`
- Agent-executed: `bun run script/check-md-table-padding.ts`
- Agent-executed: `git diff --check`
- Agent-executed by pre-push hook: `bun turbo typecheck`

### Reviewer test steps

1. Configure a persisted Kilo API key and org, then export different `KILO_API_KEY` and `KILO_ORG_ID` values.
2. Verify effective config, provider model loading, indexing auth, session export org lookup, and gateway status endpoints use the env credentials when no managed policy overrides them.
3. Add managed Kilo credential/share policy and verify it still wins over runtime env, including preventing auto-share when managed config disables sharing.
4. Start TUI with project TUI config plus `KILO_TUI_CONFIG` and verify the env TUI file is applied after regular config files.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A