### PR TITLE
fix(cli): restore Kilo CLI initialization after upstream merge

### DIFF
--- a/.changeset/restore-kilo-cli-commands.md
+++ b/.changeset/restore-kilo-cli-commands.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore Kilo branding, fork-specific CLI commands, and CLI lifecycle initialization after upstream merges.

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -40,7 +40,7 @@ import { Heap } from "./cli/heap"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process"
 import { isRecord } from "@/util/record"
-import { KiloConsoleCommand } from "@/kilocode/cli/cmd/console" // kilocode_change
+import { KiloCli } from "@/kilocode/cli/setup" // kilocode_change
 
 const processMetadata = ensureProcessMetadata("main")
 
@@ -68,9 +68,9 @@ function show(out: string) {
   process.stderr.write(out)
 }
 
-const cli = yargs(args)
+let cli = yargs(args) // kilocode_change
   .parserConfiguration({ "populate--": true })
-  .scriptName("opencode")
+  .scriptName("kilo") // kilocode_change
   .wrap(100)
   .help("help", "show help")
   .alias("help", "h")
@@ -116,6 +116,8 @@ const cli = yargs(args)
       process_role: processMetadata.processRole,
       run_id: processMetadata.runID,
     })
+
+    await KiloCli.bootstrap() // kilocode_change - env tagging, telemetry init, legacy auth migration
 
     const marker = path.join(Global.Path.data, "kilo.db")
     if (!(await Filesystem.exists(marker))) {
@@ -163,8 +165,7 @@ const cli = yargs(args)
   .command(RunCommand)
   .command(GenerateCommand)
   .command(DebugCommand)
-  // .command(ConsoleCommand) // kilocode_change - reserve `kilo console` for local settings
-  .command(KiloConsoleCommand) // kilocode_change
+  // kilocode_change - upstream account console intentionally not registered; KiloConsole is added by KiloCli.register
   .command(ProvidersCommand)
   .command(AgentCommand)
   .command(UpgradeCommand)
@@ -180,6 +181,11 @@ const cli = yargs(args)
   .command(SessionCommand)
   .command(PluginCommand)
   .command(DbCommand)
+
+// kilocode_change start - register Kilo-specific commands after the upstream chain
+cli = KiloCli.register(cli)
+cli = cli
+  // kilocode_change end
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||
@@ -245,6 +251,8 @@ try {
   }
   process.exitCode = 1
 } finally {
+  await KiloCli.shutdown() // kilocode_change - telemetry/session-export shutdown + instance disposal
+
   // Some subprocesses don't react properly to SIGTERM and similar signals.
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -1,0 +1,80 @@
+import type { Argv } from "yargs"
+import { Global } from "@opencode-ai/core/global"
+import { InstallationBuildKind, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { Telemetry } from "@kilocode/kilo-telemetry"
+import { migrateLegacyKiloAuth, ENV_FEATURE, ENV_VERSION } from "@kilocode/kilo-gateway"
+import { AppRuntime } from "@/effect/app-runtime"
+import { Config } from "@/config/config"
+import { Auth } from "@/auth"
+import { InstanceRuntime } from "@/project/instance-runtime"
+import { SessionExport } from "@/kilocode/session-export"
+import { createHelpCommand } from "@/kilocode/help-command"
+import { KiloConsoleCommand } from "@/kilocode/cli/cmd/console"
+import { RollCallCommand } from "@/kilocode/cli/cmd/roll-call"
+import { ProfileCommand } from "@/kilocode/cli/cmd/profile"
+import { DaemonCommand } from "@/kilocode/cli/cmd/daemon"
+import { DevSetupCommand, DevAliasCommand } from "@/kilocode/cli/dev-setup"
+import { RemoteCommand } from "@/cli/cmd/remote"
+import { ConfigCommand as ConfigCLICommand } from "@/cli/cmd/config"
+
+// All Kilo-specific CLI customization lives here so the shared upstream entrypoint
+// (src/index.ts) only needs a handful of thin call-sites behind kilocode_change markers.
+// This keeps index.ts close to upstream and reduces merge conflicts on every sync.
+export namespace KiloCli {
+  // Register only the Kilo-specific commands. Upstream commands stay in index.ts's chain so
+  // upstream merges that add or remove commands keep working without touching this file.
+  export function register<T>(cli: Argv<T>): Argv<T> {
+    cli
+      .command(KiloConsoleCommand)
+      .command(RollCallCommand)
+      .command(ProfileCommand)
+      .command(RemoteCommand)
+      .command(DaemonCommand)
+      .command(ConfigCLICommand)
+    if (InstallationBuildKind !== "release") cli.command(DevSetupCommand).command(DevAliasCommand)
+    // Safe self-reference: `cli` is a typed parameter and yargs `.command()` returns the same
+    // instance, so the help command can resolve the fully-built root at handler time. This also
+    // sidesteps the self-referential type error the old inline registration hit in index.ts.
+    cli.command(createHelpCommand(() => cli))
+    return cli
+  }
+
+  // Runs from the upstream `.middleware`, before any command handler. Env tagging is additive so
+  // it never has to modify upstream's own env assignments.
+  export async function bootstrap(): Promise<void> {
+    if (!process.env[ENV_FEATURE]) process.env[ENV_FEATURE] = process.argv.includes("serve") ? "unknown" : "cli"
+    if (!process.env[ENV_VERSION]) process.env[ENV_VERSION] = InstallationVersion
+    process.env.KILO = "1"
+
+    const cfg = await AppRuntime.runPromise(Config.Service.use((c) => c.getGlobal()))
+    await Telemetry.init({
+      dataPath: Global.Path.data,
+      version: InstallationVersion,
+      enabled: cfg.experimental?.openTelemetry !== false,
+    })
+
+    // Migrate legacy Kilo CLI auth (~/.kilocode/cli/config.json) into auth.json if present.
+    await migrateLegacyKiloAuth(
+      async () => (await AppRuntime.runPromise(Auth.Service.use((s) => s.get("kilo")))) !== undefined,
+      async (auth) => AppRuntime.runPromise(Auth.Service.use((s) => s.set("kilo", auth))),
+    )
+
+    const auth = await AppRuntime.runPromise(Auth.Service.use((s) => s.get("kilo")))
+    if (auth) {
+      const token = auth.type === "oauth" ? auth.access : auth.key
+      const account = auth.type === "oauth" ? auth.accountId : undefined
+      await Telemetry.updateIdentity(token, account)
+    }
+
+    Telemetry.trackCliStart()
+  }
+
+  // Runs from the `finally` block on every exit path.
+  export async function shutdown(): Promise<void> {
+    const code = typeof process.exitCode === "number" ? process.exitCode : undefined
+    Telemetry.trackCliExit(code)
+    await SessionExport.shutdown()
+    await Telemetry.shutdown()
+    await InstanceRuntime.disposeAllInstances() // safety net (no-op if already disposed)
+  }
+}

--- a/packages/opencode/test/kilocode/help.test.ts
+++ b/packages/opencode/test/kilocode/help.test.ts
@@ -173,18 +173,38 @@ describe("generateCommandTable", () => {
   })
 })
 
-describe("commands.ts stays in sync with index.ts", () => {
-  test("registers the local Kilo Console instead of the upstream account console", async () => {
-    const index = await Bun.file(path.resolve(import.meta.dir, "../../src/index.ts")).text()
-    const registered = [...index.matchAll(/^\s*\.command\((\w+)\)/gm)].map((match) => match[1]!)
+describe("Kilo CLI customizations are wired into index.ts", () => {
+  const file = (rel: string) => Bun.file(path.resolve(import.meta.dir, rel)).text()
+  const INDEX = "../../src/index.ts"
+  const SETUP = "../../src/kilocode/cli/setup.ts"
+  const BARREL = "../../src/kilocode/commands.ts"
 
-    expect(registered).toContain("KiloConsoleCommand")
-    expect(registered).not.toContain("ConsoleCommand")
+  test("CLI is branded `kilo`, not `opencode`", async () => {
+    const index = await file(INDEX)
+    expect(index).toContain('.scriptName("kilo")')
+    expect(index).not.toContain('.scriptName("opencode")')
+  })
+
+  test("index.ts invokes the KiloCli integration points", async () => {
+    // These thin call-sites are the only wiring between upstream index.ts and the Kilo
+    // customizations in setup.ts. If a future upstream merge drops them, every Kilo command
+    // and the telemetry/lifecycle hooks silently disappear — exactly the regression this guards.
+    const index = await file(INDEX)
+    expect(index).toContain("KiloCli.register(")
+    expect(index).toContain("KiloCli.bootstrap(")
+    expect(index).toContain("KiloCli.shutdown(")
+  })
+
+  test("registers the local Kilo Console instead of the upstream account console", async () => {
+    const index = await file(INDEX)
+    const setup = await file(SETUP)
+    expect(setup).toContain("KiloConsoleCommand")
+    expect(index).not.toContain(".command(ConsoleCommand)")
   })
 
   test("every .command() in index.ts has an entry in the commands array", async () => {
-    const index = await Bun.file(path.resolve(import.meta.dir, "../../src/index.ts")).text()
-    const barrel = await Bun.file(path.resolve(import.meta.dir, "../../src/kilocode/commands.ts")).text()
+    const index = await file(INDEX)
+    const barrel = await file(BARREL)
 
     // Match uncommented .command(XxxCommand) calls in index.ts
     const registered = [...index.matchAll(/^\s*\.command\((\w+)\)/gm)].map((m) => m[1]!)
@@ -196,6 +216,34 @@ describe("commands.ts stays in sync with index.ts", () => {
     const entries = [...arrayMatch![1]!.matchAll(/\b(\w+Command)\b/g)].map((m) => m[1]!)
 
     const missing = registered.filter((name) => !entries.includes(name))
+    expect(missing).toEqual([])
+  })
+
+  test("every barrel command is registered in index.ts or setup.ts", async () => {
+    // Reverse direction of the test above: every source-of-truth command must actually be
+    // runnable. The merge dropped `daemon`/`profile`/`remote`/`config` from index.ts while the
+    // barrel still listed them — this catches that.
+    const index = await file(INDEX)
+    const setup = await file(SETUP)
+    const barrel = await file(BARREL)
+
+    const registered = new Set(
+      [...index.matchAll(/\.command\((\w+)\)/g), ...setup.matchAll(/\.command\((\w+)\)/g)].map((m) => m[1]!),
+    )
+
+    const arrayMatch = barrel.match(/export const commands\s*=\s*\[([\s\S]*?)\]/)
+    expect(arrayMatch).toBeTruthy()
+    // Strip comments first — the array body contains a comment mentioning `AuthCommand`.
+    const body = arrayMatch![1]!.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "")
+    const entries = [...body.matchAll(/\b(\w+Command)\b/g)].map((m) => m[1]!)
+
+    // Not registered as a bare `.command(Ident)`:
+    //  ConsoleCommand    → replaced by KiloConsoleCommand
+    //  CompletionCommand → provided by yargs `.completion(...)`
+    //  HelpCommand       → registered via createHelpCommand(() => cli)
+    //  (DevSetup/DevAlias enter the array via `...dev`, so they aren't scraped here)
+    const except = new Set(["ConsoleCommand", "CompletionCommand", "HelpCommand"])
+    const missing = entries.filter((name) => !except.has(name) && !registered.has(name))
     expect(missing).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Restore `kilo` branding and fork-specific commands such as `daemon`, `profile`, `remote`, `config`, `roll-call`, the local Console, and extended help.
- Reintroduce Kilo CLI environment tagging, telemetry/auth initialization, session-export cleanup, and instance disposal through a fork-isolated `KiloCli` setup module.
- Harden CLI tests so future upstream merges fail when branding changes, integration hooks disappear, or the documented command barrel drifts from runtime registration.
- Add a patch changeset for the restored CLI behavior.

## Why
The latest upstream merge reset the shared CLI entrypoint close to OpenCode defaults. That left the generated command reference intact while the runtime binary used `opencode` branding and omitted Kilo-only commands and lifecycle hooks.

The implementation keeps Kilo-specific behavior under `src/kilocode/cli/setup.ts` and limits the shared `src/index.ts` changes to small `kilocode_change` integration points, reducing conflicts in future upstream syncs.

## Dependency
This is a stacked PR based on #10866 so its diff contains only the CLI restoration work from this session.