### PR TITLE
feat(cli): warn when --port is outside discovery range

### DIFF
--- a/.changeset/feat-cli-port-discovery-warning.md
+++ b/.changeset/feat-cli-port-discovery-warning.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Warn when `kilo console` or `kilo daemon` is invoked with an explicit `--port` outside the discovery range (4097–4116).

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -3,6 +3,7 @@ import { cmd } from "@/cli/cmd/cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Daemon } from "@/kilocode/daemon/daemon"
+import { warnPort } from "@/kilocode/cli/port-warning"
 
 function publicUrl(state: Daemon.State) {
   return new URL("/console", state.url).toString()
@@ -41,6 +42,7 @@ export const KiloConsoleCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   handler: async (args) => {
     const opts = await AppRuntime.runPromise(resolveNetworkOptions(args))
+    warnPort(opts.port)
     const result = await Daemon.start(opts)
     const state = result.state
     if (!state) throw new Error("Kilo daemon did not provide connection state")

--- a/packages/opencode/src/kilocode/cli/cmd/daemon.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/daemon.ts
@@ -3,6 +3,7 @@ import { cmd } from "@/cli/cmd/cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Daemon } from "@/kilocode/daemon/daemon"
+import { warnPort } from "@/kilocode/cli/port-warning"
 
 function withJson<T>(yargs: Argv<T>) {
   return yargs.option("json", {
@@ -60,6 +61,7 @@ const StartCommand = cmd({
   builder: (yargs) => withJson(withNetworkOptions(yargs)),
   handler: async (args) => {
     const opts = await AppRuntime.runPromise(resolveNetworkOptions(args))
+    warnPort(opts.port)
     const result = await Daemon.start(opts)
     if (args.json) {
       print(result, true)
@@ -99,6 +101,7 @@ const RestartCommand = cmd({
   builder: (yargs) => withJson(withNetworkOptions(yargs)),
   handler: async (args) => {
     const opts = await AppRuntime.runPromise(resolveNetworkOptions(args))
+    warnPort(opts.port)
     const result = await Daemon.restart(opts)
     if (args.json) {
       print(result, true)

--- a/packages/opencode/src/kilocode/cli/port-warning.ts
+++ b/packages/opencode/src/kilocode/cli/port-warning.ts
@@ -1,0 +1,11 @@
+import { Daemon } from "@/kilocode/daemon/daemon"
+
+export function warnPort(port: number) {
+  if (port === 0) return
+  if (port < Daemon.PortRange.start || port > Daemon.PortRange.end) {
+    console.warn(
+      `\x1B[33mPort ${port} is outside the recommended daemon discovery range (${Daemon.PortRange.start}-${Daemon.PortRange.end}). ` +
+        `The console will work, but auto-discovery may not find this server.\x1B[0m`,
+    )
+  }
+}


### PR DESCRIPTION
## Issue

## Context

When `kilo console --port <port>` or `kilo daemon start/restart --port <port>` is called with an explicit port outside the daemon discovery range (4097–4116), the daemon still starts successfully but Kilo's browser auto-discovery only scans that 20-port window. This means later manual launches or dev-mode auto-connect can silently fail to find the daemon, leaving the user with no feedback about why the console can't connect.

The fix is to print a non-fatal yellow warning when an explicit port is passed outside that range, while still allowing the command to succeed normally.

## Implementation

I added a small shared helper in a Kilo-owned path (`packages/opencode/src/kilocode/cli/port-warning.ts`) so the change avoids touching upstream shared files and doesn't require `kilocode_change` markers.

The helper `warnIfPortOutsideDiscoveryRange(port)`:
- Skips the check when `port === 0` (auto-pick mode).
- Reads the range from `Daemon.PortRange` (`4097`–`4116`).
- Emits a yellow `console.warn` when the explicit port is out of range.

I then called this helper from:
- `packages/opencode/src/kilocode/cli/cmd/console.ts`: after resolving network options and before `Daemon.start()`.
- `packages/opencode/src/kilocode/cli/cmd/daemon.ts`: in both the `start` and `restart` handlers.

The warning is informational only; the command starts the daemon and opens the console as normal.

## Screenshots / Video

<img width="1779" height="360" alt="WindowsTerminal_ObyVryMH1u" src="https://github.com/user-attachments/assets/b26c2554-3d51-4578-aabb-22b6d44ba4b6" />

## How to Test

Manual/local verification:
- `kilo daemon stop && kilo console --port 4097` → no warning.
- `kilo daemon stop && kilo console --port 4321` → yellow warning, then console opens.
- `kilo daemon stop && kilo console --port 0` → no warning (auto-pick).
- `kilo daemon stop && kilo daemon start --port 5000` → yellow warning.
- `kilo daemon stop && kilo daemon restart --port 5000` → yellow warning.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18