### PR TITLE
fix(vscode): correct changeset package name

### DIFF
--- a/.changeset/terminal-integrated-font.md
+++ b/.changeset/terminal-integrated-font.md
@@ -1,5 +1,5 @@
 ---
-"kilo-vscode": patch
+"kilo-code": patch
 ---
 
 Agent Manager terminals now use `terminal.integrated.fontFamily` and `terminal.integrated.fontSize` (including Nerd Font glyphs) instead of the editor font.


### PR DESCRIPTION
## Summary

The `terminal-integrated-font` changeset referenced the VS Code package by its directory name, `kilo-vscode`, instead of its workspace package name, `kilo-code`. This caused the v7.3.43 pre-release publish job to fail during `changeset version`; correcting the name allows the release workflow to consume the changeset.