### PR TITLE
fix(agent-manager): constrain assistant transcript width

### DIFF
--- a/.changeset/calm-tools-align.md
+++ b/.changeset/calm-tools-align.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager assistant messages and tool cards readable in wide editor panes.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/transcript-alignment-wide-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/transcript-alignment-wide-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec38462755ee4d6da1cffd0ae3240757cabc2c4b3fe87489357f769e381f30a3
+size 29321

--- a/packages/kilo-vscode/tests/visual-regression.spec.mts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.mts
@@ -86,10 +86,10 @@ for (const story of stories) {
       test.info().annotations.push({ type: "docs", description: ref })
     }
 
-    // Narrow stories (IDs ending in "-200") use a 200px viewport
-    // The "-200" suffix comes from the export name convention (e.g. Default200, WithThinking200)
+    // Width-specific stories use their suffix; all others use the sidebar viewport.
     const narrow = story.id.endsWith("-200")
-    await page.setViewportSize({ width: narrow ? 200 : 420, height: 720 })
+    const wide = story.id.endsWith("-wide")
+    await page.setViewportSize({ width: wide ? 1280 : narrow ? 200 : 420, height: 720 })
 
     await page.goto(
       `/iframe.html?id=${story.id}&viewMode=story&globals=colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern`,

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts
@@ -87,9 +87,10 @@ for (const story of stories) {
       test.info().annotations.push({ type: "docs", description: ref })
     }
 
-    // Narrow stories (IDs ending in "-200") use a 200px viewport
+    // Width-specific stories use their suffix; all others use the sidebar viewport.
     const narrow = story.id.endsWith("-200")
-    await page.setViewportSize({ width: narrow ? 200 : 420, height: 720 })
+    const wide = story.id.endsWith("-wide")
+    await page.setViewportSize({ width: wide ? 1280 : narrow ? 200 : 420, height: 720 })
 
     await page.goto(
       `/iframe.html?id=${story.id}&viewMode=story&globals=colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern`,

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1570,6 +1570,11 @@ body.am-wt-dragging-active * {
   position: relative;
 }
 
+.am-chat-wrapper [data-slot="session-turn-assistant"] {
+  align-self: flex-start;
+  max-width: 720px;
+}
+
 .am-readonly-banner {
   display: flex;
   align-items: center;

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -71,7 +71,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
 
       <Show when={props.row.type === "assistant" ? props.row : undefined}>
         {(row) => (
-          <div class="vscode-session-turn-assistant">
+          <div class="vscode-session-turn-assistant" data-slot="session-turn-assistant">
             <AssistantMessage
               message={row().message as unknown as SDKAssistantMessage}
               parts={row().parts as unknown as SDKPart[]}

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -5,14 +5,24 @@
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { StoryProviders } from "./StoryProviders"
+import type {
+  AssistantMessage as SDKAssistantMessage,
+  ReasoningPart,
+  TextPart,
+  ToolPart,
+  UserMessage,
+} from "@kilocode/sdk/v2"
+import { StoryProviders, defaultMockData } from "./StoryProviders"
 import { FileTree } from "../../diff-viewer/FileTree"
 import { DiffPanel } from "../../agent-manager/DiffPanel"
 import { FullScreenDiffView } from "../../diff-viewer/FullScreenDiffView"
 import { WorktreeItem } from "../../agent-manager/WorktreeItem"
+import { AssistantMessage } from "../components/chat/AssistantMessage"
+import { registerVscodeToolOverrides } from "../components/chat/VscodeToolOverrides"
 import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Icon } from "@kilocode/kilo-ui/icon"
+import { UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
 import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { createSignal, type JSX } from "solid-js"
@@ -20,6 +30,8 @@ import type { WorktreeFileDiff, WorktreeState, WorktreeGitStats, PRStatus } from
 import type { ReviewComment } from "../../diff-viewer/review-comments"
 import "../../agent-manager/agent-manager.css"
 import "../../agent-manager/agent-manager-review.css"
+
+registerVscodeToolOverrides()
 
 // ---------------------------------------------------------------------------
 // Shared mock data
@@ -116,6 +128,111 @@ const meta: Meta = {
 }
 export default meta
 type Story = StoryObj
+
+// ---------------------------------------------------------------------------
+// Transcript layout
+// ---------------------------------------------------------------------------
+
+const transcriptSessionID = "story-agent-manager-transcript"
+const transcriptUserID = "story-agent-manager-user"
+const transcriptAssistantID = "story-agent-manager-assistant"
+const transcriptNow = 1_700_000_000_000
+
+const transcriptUser: UserMessage = {
+  id: transcriptUserID,
+  sessionID: transcriptSessionID,
+  role: "user",
+  time: { created: transcriptNow },
+  agent: "default",
+  model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+}
+
+const transcriptAssistant: SDKAssistantMessage = {
+  id: transcriptAssistantID,
+  sessionID: transcriptSessionID,
+  role: "assistant",
+  parentID: transcriptUserID,
+  time: { created: transcriptNow + 1000, completed: transcriptNow + 5000 },
+  modelID: "claude-sonnet-4",
+  providerID: "anthropic",
+  mode: "default",
+  agent: "default",
+  path: { cwd: "/project", root: "/project" },
+  cost: 0.003,
+  tokens: { input: 400, output: 240, reasoning: 80, cache: { read: 0, write: 0 } },
+}
+
+const transcriptUserText: TextPart = {
+  id: "story-agent-manager-user-text",
+  sessionID: transcriptSessionID,
+  messageID: transcriptUserID,
+  type: "text",
+  text: "Verify the updated pull request and watch its checks to completion.",
+}
+
+const transcriptReasoning: ReasoningPart = {
+  id: "story-agent-manager-reasoning",
+  sessionID: transcriptSessionID,
+  messageID: transcriptAssistantID,
+  type: "reasoning",
+  text: "I will inspect the pull request state first, then follow the checks until they finish.",
+  time: { start: transcriptNow + 1000, end: transcriptNow + 1800 },
+}
+
+const transcriptTool: ToolPart = {
+  id: "story-agent-manager-tool",
+  sessionID: transcriptSessionID,
+  messageID: transcriptAssistantID,
+  type: "tool",
+  callID: "story-agent-manager-call",
+  tool: "bash",
+  state: {
+    status: "completed",
+    input: { command: "gh pr checks 11090 --watch", description: "Watch updated pull request checks" },
+    output: "build        pass   2m14s\nunit-tests   pass   3m08s\nwindows      pass   4m31s",
+    title: "Watch updated pull request checks",
+    metadata: {},
+    time: { start: transcriptNow + 2000, end: transcriptNow + 4800 },
+  },
+}
+
+const transcriptText: TextPart = {
+  id: "story-agent-manager-assistant-text",
+  sessionID: transcriptSessionID,
+  messageID: transcriptAssistantID,
+  type: "text",
+  text: "The pull request is mergeable and all required checks pass.",
+}
+
+const transcriptParts = [transcriptReasoning, transcriptTool, transcriptText]
+const transcriptData = {
+  ...defaultMockData,
+  message: { [transcriptSessionID]: [transcriptUser, transcriptAssistant] },
+  part: {
+    [transcriptUserID]: [transcriptUserText],
+    [transcriptAssistantID]: transcriptParts,
+  },
+}
+
+export const TranscriptAlignmentWide: Story = {
+  name: "Transcript - constrained assistant and right-aligned user",
+  render: () => (
+    <StoryProviders data={transcriptData} sessionID={transcriptSessionID} noPadding>
+      <div class="am-chat-wrapper" style={{ "max-height": "680px" }}>
+        <div class="message-list">
+          <div class="vscode-session-turn">
+            <div class="vscode-session-turn-user">
+              <UserMessageDisplay message={transcriptUser} parts={[transcriptUserText]} />
+            </div>
+            <div class="vscode-session-turn-assistant" data-slot="session-turn-assistant">
+              <AssistantMessage message={transcriptAssistant} parts={transcriptParts} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </StoryProviders>
+  ),
+}
 
 // ---------------------------------------------------------------------------
 // FileTree


### PR DESCRIPTION
Agent Manager transcripts can occupy the full editor width, making tool output and assistant reasoning difficult to scan on wide panes. User messages should retain their conversational right alignment without forcing assistant content to span the same width.

This constrains assistant turns, including reasoning and tool cards, to a responsive 720px left-aligned column in Agent Manager while leaving user messages right-aligned. It also adds a wide visual-regression scenario so the asymmetric alignment and width cap remain covered.