### PR TITLE
fix(vscode): route questions through request directories

### DIFF
--- a/.changeset/route-worktree-questions.md
+++ b/.changeset/route-worktree-questions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Route question responses to the worktree where the question was created.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2815,6 +2815,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       getQuestionDirectory: (id: string) => this.connectionService.getQuestionDirectory(id),
       clearQuestionDirectory: (id: string) => this.connectionService.clearQuestionDirectory(id),
       getQuestionRevision: () => this.connectionService.getQuestionRevision(),
+      pruneQuestionDirectories: (active: Set<string>, dirs: Set<string>) =>
+        this.connectionService.pruneQuestionDirectories(active, dirs),
     }
   }
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2808,8 +2808,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       currentSessionId: this.currentSession?.id,
       trackedSessionIds: this.trackedSessionIds,
       sessionDirectories: this.sessionDirectories,
+      extraDirectories: this.opts.worktreeDirectories,
       postMessage: (msg: unknown) => this.postMessage(msg),
       getWorkspaceDirectory: (sid?: string) => this.getWorkspaceDirectory(sid),
+      recordQuestionDirectory: (id: string, dir: string) => this.connectionService.recordQuestionDirectory(id, dir),
+      getQuestionDirectory: (id: string) => this.connectionService.getQuestionDirectory(id),
+      clearQuestionDirectory: (id: string) => this.connectionService.clearQuestionDirectory(id),
+      getQuestionRevision: () => this.connectionService.getQuestionRevision(),
     }
   }
 

--- a/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
@@ -20,6 +20,7 @@ export interface QuestionContext {
   getQuestionDirectory(requestID: string): string | undefined
   clearQuestionDirectory(requestID: string): void
   getQuestionRevision(): number
+  pruneQuestionDirectories(active: Set<string>, dirs: Set<string>): void
 }
 
 interface QuestionRecovery {
@@ -71,6 +72,7 @@ export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promis
       ])
       const revision = ctx.getQuestionRevision()
       const seen = new Set<string>()
+      const scanned = new Set<string>()
       const failed = new Set<string>()
       const pending: Array<{ question: QuestionRequest; dir: string }> = []
       for (const dir of dirs) {
@@ -80,6 +82,7 @@ export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promis
           console.error(`[Kilo New] KiloProvider: Failed to fetch pending questions for ${dir}:`, error)
           continue
         }
+        scanned.add(dir)
         if (!data) continue
         for (const q of data) {
           if (seen.has(q.id)) continue
@@ -102,6 +105,7 @@ export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promis
           },
         })
       }
+      ctx.pruneQuestionDirectories(seen, scanned)
       return { seen, complete: failed.size === 0 }
     }
   } catch (error) {

--- a/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
@@ -6,15 +6,52 @@
  * No vscode dependency.
  */
 
-import type { KiloClient } from "@kilocode/sdk/v2/client"
+import type { KiloClient, QuestionRequest } from "@kilocode/sdk/v2/client"
 
-interface QuestionContext {
+export interface QuestionContext {
   readonly client: KiloClient | null
   readonly currentSessionId: string | undefined
   readonly trackedSessionIds: Set<string>
   readonly sessionDirectories: ReadonlyMap<string, string>
+  readonly extraDirectories?: () => string[]
   postMessage(msg: unknown): void
   getWorkspaceDirectory(sessionId?: string): string
+  recordQuestionDirectory(requestID: string, directory: string): void
+  getQuestionDirectory(requestID: string): string | undefined
+  clearQuestionDirectory(requestID: string): void
+  getQuestionRevision(): number
+}
+
+interface QuestionRecovery {
+  readonly seen: Set<string>
+  readonly complete: boolean
+}
+
+function isNotFoundError(error: unknown): boolean {
+  const record = (value: unknown) =>
+    value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
+  const obj = record(error)
+  if (!obj) return false
+
+  const cause = record(obj.cause)
+  const body = record(cause?.body)
+  return [obj, record(obj.data), cause, body, record(body?.data)].some(
+    (value) => value?.name === "NotFoundError" || value?._tag === "NotFound" || value?.status === 404,
+  )
+}
+
+function stale(ctx: QuestionContext, requestID: string): void {
+  ctx.clearQuestionDirectory(requestID)
+  ctx.postMessage({ type: "questionResolved", requestID })
+  void fetchAndSendPendingQuestions(ctx)
+}
+
+async function recover(ctx: QuestionContext, requestID: string): Promise<boolean> {
+  const result = await fetchAndSendPendingQuestions(ctx)
+  if (!result?.complete || result.seen.has(requestID)) return false
+  ctx.clearQuestionDirectory(requestID)
+  ctx.postMessage({ type: "questionResolved", requestID })
+  return true
 }
 
 /**
@@ -23,29 +60,49 @@ interface QuestionContext {
  * called after child-session sync and after SSE reconnects so missed
  * question.asked events don't leave the server blocked indefinitely.
  */
-export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promise<void> {
+export async function fetchAndSendPendingQuestions(ctx: QuestionContext): Promise<QuestionRecovery | undefined> {
   if (!ctx.client) return
   try {
-    const dirs = new Set<string>([ctx.getWorkspaceDirectory(), ...ctx.sessionDirectories.values()])
-    const seen = new Set<string>()
-    for (const dir of dirs) {
-      const { data } = await ctx.client.question.list({ directory: dir })
-      if (!data) continue
-      for (const q of data) {
-        if (seen.has(q.id)) continue
-        seen.add(q.id)
-        if (!ctx.trackedSessionIds.has(q.sessionID)) continue
+    for (;;) {
+      const dirs = new Set<string>([
+        ctx.getWorkspaceDirectory(),
+        ...ctx.sessionDirectories.values(),
+        ...(ctx.extraDirectories?.() ?? []),
+      ])
+      const revision = ctx.getQuestionRevision()
+      const seen = new Set<string>()
+      const failed = new Set<string>()
+      const pending: Array<{ question: QuestionRequest; dir: string }> = []
+      for (const dir of dirs) {
+        const { data, error } = await ctx.client.question.list({ directory: dir })
+        if (error) {
+          failed.add(dir)
+          console.error(`[Kilo New] KiloProvider: Failed to fetch pending questions for ${dir}:`, error)
+          continue
+        }
+        if (!data) continue
+        for (const q of data) {
+          if (seen.has(q.id)) continue
+          seen.add(q.id)
+          if (!ctx.trackedSessionIds.has(q.sessionID)) continue
+          pending.push({ question: q, dir })
+        }
+      }
+      if (ctx.getQuestionRevision() !== revision) continue
+      for (const item of pending) {
+        ctx.recordQuestionDirectory(item.question.id, item.dir)
         ctx.postMessage({
           type: "questionRequest",
           question: {
-            id: q.id,
-            sessionID: q.sessionID,
-            questions: q.questions,
-            blocking: q.blocking,
-            tool: q.tool,
+            id: item.question.id,
+            sessionID: item.question.sessionID,
+            questions: item.question.questions,
+            blocking: item.question.blocking,
+            tool: item.question.tool,
           },
         })
       }
+      return { seen, complete: failed.size === 0 }
     }
   } catch (error) {
     console.error("[Kilo New] KiloProvider: Failed to fetch pending questions:", error)
@@ -65,14 +122,19 @@ export async function handleQuestionReply(
   }
 
   const sid = sessionID ?? ctx.currentSessionId
+  const origin = ctx.getQuestionDirectory(requestID)
+  const dir = origin ?? ctx.getWorkspaceDirectory(sid)
 
   try {
-    await ctx.client.question.reply(
-      { requestID, answers, directory: ctx.getWorkspaceDirectory(sid) },
-      { throwOnError: true },
-    )
+    await ctx.client.question.reply({ requestID, answers, directory: dir }, { throwOnError: true })
+    ctx.clearQuestionDirectory(requestID)
     return true
   } catch (error) {
+    if (isNotFoundError(error) && origin) {
+      stale(ctx, requestID)
+      return false
+    }
+    if (isNotFoundError(error) && (await recover(ctx, requestID))) return false
     console.error("[Kilo New] KiloProvider: Failed to reply to question:", error)
     ctx.postMessage({ type: "questionError", requestID })
     return false
@@ -91,11 +153,19 @@ export async function handleQuestionReject(
   }
 
   const sid = sessionID ?? ctx.currentSessionId
+  const origin = ctx.getQuestionDirectory(requestID)
+  const dir = origin ?? ctx.getWorkspaceDirectory(sid)
 
   try {
-    await ctx.client.question.reject({ requestID, directory: ctx.getWorkspaceDirectory(sid) }, { throwOnError: true })
+    await ctx.client.question.reject({ requestID, directory: dir }, { throwOnError: true })
+    ctx.clearQuestionDirectory(requestID)
     return true
   } catch (error) {
+    if (isNotFoundError(error) && origin) {
+      stale(ctx, requestID)
+      return false
+    }
+    if (isNotFoundError(error) && (await recover(ctx, requestID))) return false
     console.error("[Kilo New] KiloProvider: Failed to reject question:", error)
     ctx.postMessage({ type: "questionError", requestID })
     return false

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -21,9 +21,11 @@ function isNotFound(err: unknown) {
   if (!err || typeof err !== "object") return false
   const obj = err as Record<string, unknown>
   if (obj.name === "NotFoundError") return true
+  if (obj._tag === "NotFound") return true
   if (obj.status === 404) return true
   if (obj.data && typeof obj.data === "object") {
-    return (obj.data as Record<string, unknown>).name === "NotFoundError"
+    const data = obj.data as Record<string, unknown>
+    return data.name === "NotFoundError" || data._tag === "NotFound"
   }
   return false
 }
@@ -69,6 +71,8 @@ export class KiloConnectionService {
   private readonly clearPendingPromptsListeners: Set<ClearPendingPromptsListener> = new Set()
   private readonly directoryProviders: Set<DirectoryProvider> = new Set()
   private readonly permissionDirectories: Map<string, string> = new Map()
+  private readonly questionDirectories: Map<string, string> = new Map()
+  private questionRevision = 0
 
   /**
    * Shared mapping used to resolve session scope for events that don't reliably include a sessionID.
@@ -270,6 +274,26 @@ export class KiloConnectionService {
     }
   }
 
+  recordQuestionDirectory(requestID: string, directory: string): void {
+    if (!requestID || !directory) {
+      return
+    }
+    this.questionDirectories.set(requestID, directory)
+  }
+
+  getQuestionDirectory(requestID: string): string | undefined {
+    return this.questionDirectories.get(requestID)
+  }
+
+  clearQuestionDirectory(requestID: string): void {
+    this.questionDirectories.delete(requestID)
+    this.questionRevision += 1
+  }
+
+  getQuestionRevision(): number {
+    return this.questionRevision
+  }
+
   /**
    * Subscribe to notification dismiss events broadcast from any KiloProvider. Returns unsubscribe function.
    */
@@ -429,7 +453,7 @@ export class KiloConnectionService {
       if (qs) {
         for (const q of qs) {
           const { error } = await this.client.question.reject({ requestID: q.id, directory: dir })
-          if (error) throw new Error(`Failed to reject question ${q.id}: ${String(error)}`)
+          if (error && !isNotFound(error)) throw new Error(`Failed to reject question ${q.id}: ${String(error)}`)
         }
       }
       await drainSuggestions(this.client, dir)
@@ -516,6 +540,8 @@ export class KiloConnectionService {
     this.directoryProviders.clear()
     this.messageSessionIdsByMessageId.clear()
     this.permissionDirectories.clear()
+    this.questionDirectories.clear()
+    this.questionRevision += 1
     this.focused.clear()
     this.opened.clear()
     if (this.debounceTimer) {
@@ -595,6 +621,8 @@ export class KiloConnectionService {
     this.config = null
     this.info = null
     this.permissionDirectories.clear()
+    this.questionDirectories.clear()
+    this.questionRevision += 1
   }
 
   private handleServerExit(code: number | null): void {
@@ -647,6 +675,7 @@ export class KiloConnectionService {
     sse.onEvent((event, directory) => {
       if (this.sseClient !== sse) return
       this.handlePermissionEvent(event, directory)
+      this.handleQuestionEvent(event, directory)
       for (const listener of this.eventListeners) {
         listener(event, directory)
       }
@@ -700,6 +729,17 @@ export class KiloConnectionService {
     }
     if (event.type === "permission.replied") {
       this.clearPermissionDirectory(event.properties.requestID)
+    }
+  }
+
+  private handleQuestionEvent(event: SSEPayload, directory?: string): void {
+    if (event.type === "question.asked" && directory) {
+      this.questionRevision += 1
+      this.recordQuestionDirectory(event.properties.id, directory)
+      return
+    }
+    if (event.type === "question.replied" || event.type === "question.rejected") {
+      this.clearQuestionDirectory(event.properties.requestID)
     }
   }
 }

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -287,11 +287,21 @@ export class KiloConnectionService {
 
   clearQuestionDirectory(requestID: string): void {
     this.questionDirectories.delete(requestID)
+    // A resolved request must invalidate an in-flight recovery scan so stale list data cannot repost it.
     this.questionRevision += 1
   }
 
   getQuestionRevision(): number {
     return this.questionRevision
+  }
+
+  pruneQuestionDirectories(active: Set<string>, dirs: Set<string>): void {
+    const size = this.questionDirectories.size
+    for (const [id, dir] of this.questionDirectories) {
+      if (active.has(id) || !dirs.has(dir)) continue
+      this.questionDirectories.delete(id)
+    }
+    if (this.questionDirectories.size !== size) this.questionRevision += 1
   }
 
   /**

--- a/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
@@ -37,12 +37,14 @@ describe("KiloConnectionService question routing", () => {
       "/tmp/worktree",
     )
     expect(service.getQuestionDirectory("que_test")).toBe("/tmp/worktree")
+    expect(service.getQuestionRevision()).toBe(1)
 
     handler.handleQuestionEvent({
       type: "question.replied",
       properties: { requestID: "que_test", sessionID: "ses_test", answers: [] },
     })
     expect(service.getQuestionDirectory("que_test")).toBeUndefined()
+    expect(service.getQuestionRevision()).toBe(2)
 
     service.recordQuestionDirectory("que_rejected", "/tmp/worktree")
     handler.handleQuestionEvent({
@@ -50,5 +52,20 @@ describe("KiloConnectionService question routing", () => {
       properties: { requestID: "que_rejected", sessionID: "ses_test" },
     })
     expect(service.getQuestionDirectory("que_rejected")).toBeUndefined()
+    expect(service.getQuestionRevision()).toBe(3)
+  })
+
+  test("prunes stale origins only for successfully scanned directories", () => {
+    const service = new KiloConnectionService({} as any)
+    service.recordQuestionDirectory("que_active", "/tmp/scanned")
+    service.recordQuestionDirectory("que_stale", "/tmp/scanned")
+    service.recordQuestionDirectory("que_unknown", "/tmp/failed")
+
+    service.pruneQuestionDirectories(new Set(["que_active"]), new Set(["/tmp/scanned"]))
+
+    expect(service.getQuestionDirectory("que_active")).toBe("/tmp/scanned")
+    expect(service.getQuestionDirectory("que_stale")).toBeUndefined()
+    expect(service.getQuestionDirectory("que_unknown")).toBe("/tmp/failed")
+    expect(service.getQuestionRevision()).toBe(1)
   })
 })

--- a/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { KiloConnectionService } from "../../src/services/cli-backend/connection-service"
+
+describe("KiloConnectionService question routing", () => {
+  test("ignores stale NotFoundError rejects while draining questions", async () => {
+    const service = new KiloConnectionService({} as any)
+    const client = {
+      permission: {
+        list: async () => ({ data: [] }),
+      },
+      question: {
+        list: async () => ({ data: [{ id: "que_test" }] }),
+        reject: async () => ({ error: { _tag: "NotFound" } }),
+      },
+      suggestion: {
+        list: async () => ({ data: [] }),
+      },
+      network: {
+        list: async () => ({ data: [] }),
+      },
+    }
+
+    ;(service as any).client = client
+    ;(service as any).directoryProviders.add(() => ["/tmp/workspace"])
+
+    await expect(service.drainPendingPrompts()).resolves.toBeUndefined()
+  })
+
+  test("records and clears request origins from SSE events", () => {
+    const service = new KiloConnectionService({} as any)
+    const handler = service as unknown as {
+      handleQuestionEvent(event: unknown, directory?: string): void
+    }
+
+    handler.handleQuestionEvent(
+      { type: "question.asked", properties: { id: "que_test", sessionID: "ses_test", questions: [] } },
+      "/tmp/worktree",
+    )
+    expect(service.getQuestionDirectory("que_test")).toBe("/tmp/worktree")
+
+    handler.handleQuestionEvent({
+      type: "question.replied",
+      properties: { requestID: "que_test", sessionID: "ses_test", answers: [] },
+    })
+    expect(service.getQuestionDirectory("que_test")).toBeUndefined()
+
+    service.recordQuestionDirectory("que_rejected", "/tmp/worktree")
+    handler.handleQuestionEvent({
+      type: "question.rejected",
+      properties: { requestID: "que_rejected", sessionID: "ses_test" },
+    })
+    expect(service.getQuestionDirectory("que_rejected")).toBeUndefined()
+  })
+})

--- a/packages/kilo-vscode/tests/unit/question-handler.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-handler.test.ts
@@ -31,6 +31,7 @@ function ctx(
     pending?: Record<string, QuestionRequest[]>
     errors?: { list?: Record<string, unknown>; reply?: unknown; reject?: unknown }
     changeOnList?: string
+    removeOnList?: string
   } = {},
 ) {
   const messages: unknown[] = []
@@ -41,6 +42,7 @@ function ctx(
   const dirs = opts.dirs ?? new Map<string, string>()
   let revision = 0
   let changed = false
+  const removed = new Set<string>()
   const client = {
     question: {
       list: async (args: { directory?: string }) => {
@@ -52,7 +54,12 @@ function ctx(
         }
         const error = opts.errors?.list?.[dir]
         if (error) return { data: undefined, error }
-        return { data: opts.pending?.[dir] ?? [] }
+        const data = opts.pending?.[dir] ?? []
+        if (opts.removeOnList !== dir) return { data }
+        if (removed.has(dir)) return { data: [] }
+        removed.add(dir)
+        revision += 1
+        return { data }
       },
       reply: async (args: unknown) => {
         replies.push(args)
@@ -81,6 +88,14 @@ function ctx(
       revision += 1
     },
     getQuestionRevision: () => revision,
+    pruneQuestionDirectories: (active, scanned) => {
+      const size = questionDirs.size
+      for (const [id, dir] of questionDirs) {
+        if (active.has(id) || !scanned.has(dir)) continue
+        questionDirs.delete(id)
+      }
+      if (questionDirs.size !== size) revision += 1
+    },
   }
   return { fake, messages, queries, replies, rejects, questionDirs }
 }
@@ -262,17 +277,28 @@ describe("question recovery", () => {
       pending: { "/workspace": [item] },
       changeOnList: "/workspace",
     })
-    questionDirs.set("req-new", "/workspace")
 
     await fetchAndSendPendingQuestions(fake)
 
     expect(queries).toEqual(["/workspace", "/workspace"])
     expect(messages).toContainEqual({ type: "questionRequest", question: item })
-    expect(questionDirs.get("req-new")).toBe("/workspace")
     expect(questionDirs.get("req-missed")).toBe("/workspace")
   })
 
-  it("preserves cached routes when recovery is incomplete", async () => {
+  it("does not repost a question resolved during recovery", async () => {
+    const item = pending("req-resolved", "ses-root")
+    const { fake, messages, queries } = ctx({
+      pending: { "/workspace": [item] },
+      removeOnList: "/workspace",
+    })
+
+    await fetchAndSendPendingQuestions(fake)
+
+    expect(queries).toEqual(["/workspace", "/workspace"])
+    expect(messages).toEqual([])
+  })
+
+  it("prunes scanned routes while preserving routes from failed directories", async () => {
     const dir = "/workspace/.kilo/worktrees/failing"
     const error = new Error("temporary failure")
     const { fake, questionDirs } = ctx({
@@ -287,7 +313,7 @@ describe("question recovery", () => {
     await fetchAndSendPendingQuestions(fake)
     spy.mockRestore()
 
-    expect(questionDirs.get("workspace-stale")).toBe("/workspace")
+    expect(questionDirs.has("workspace-stale")).toBe(false)
     expect(questionDirs.get("worktree-pending")).toBe(dir)
   })
 })

--- a/packages/kilo-vscode/tests/unit/question-handler.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-handler.test.ts
@@ -1,104 +1,293 @@
-import { describe, expect, it } from "bun:test"
-import type { KiloClient } from "@kilocode/sdk/v2/client"
-import { handleQuestionReject, handleQuestionReply } from "../../src/kilo-provider/handlers/question"
+import { describe, expect, it, spyOn } from "bun:test"
+import type { QuestionRequest } from "@kilocode/sdk/v2/client"
+import {
+  fetchAndSendPendingQuestions,
+  handleQuestionReject,
+  handleQuestionReply,
+  type QuestionContext,
+} from "../../src/kilo-provider/handlers/question"
+
+function pending(id: string, sessionID: string): QuestionRequest {
+  return {
+    id,
+    sessionID,
+    questions: [
+      {
+        header: "Continue",
+        question: "What next?",
+        options: [{ label: "Continue", description: "Keep going" }],
+      },
+    ],
+    blocking: false,
+    tool: undefined,
+  }
+}
+
+function ctx(
+  opts: {
+    tracked?: string[]
+    dirs?: Map<string, string>
+    extra?: string[]
+    pending?: Record<string, QuestionRequest[]>
+    errors?: { list?: Record<string, unknown>; reply?: unknown; reject?: unknown }
+    changeOnList?: string
+  } = {},
+) {
+  const messages: unknown[] = []
+  const queries: string[] = []
+  const replies: unknown[] = []
+  const rejects: unknown[] = []
+  const questionDirs = new Map<string, string>()
+  const dirs = opts.dirs ?? new Map<string, string>()
+  let revision = 0
+  let changed = false
+  const client = {
+    question: {
+      list: async (args: { directory?: string }) => {
+        const dir = args.directory ?? ""
+        queries.push(dir)
+        if (opts.changeOnList === dir && !changed) {
+          changed = true
+          revision += 1
+        }
+        const error = opts.errors?.list?.[dir]
+        if (error) return { data: undefined, error }
+        return { data: opts.pending?.[dir] ?? [] }
+      },
+      reply: async (args: unknown) => {
+        replies.push(args)
+        if (opts.errors?.reply) throw opts.errors.reply
+        return { data: true }
+      },
+      reject: async (args: unknown) => {
+        rejects.push(args)
+        if (opts.errors?.reject) throw opts.errors.reject
+        return { data: true }
+      },
+    },
+  } as unknown as QuestionContext["client"]
+  const fake: QuestionContext = {
+    client,
+    currentSessionId: "ses-root",
+    trackedSessionIds: new Set(opts.tracked ?? ["ses-root"]),
+    sessionDirectories: dirs,
+    extraDirectories: () => opts.extra ?? [],
+    postMessage: (msg) => messages.push(msg),
+    getWorkspaceDirectory: (sessionID) => dirs.get(sessionID ?? "") ?? "/workspace",
+    recordQuestionDirectory: (id, dir) => questionDirs.set(id, dir),
+    getQuestionDirectory: (id) => questionDirs.get(id),
+    clearQuestionDirectory: (id) => {
+      questionDirs.delete(id)
+      revision += 1
+    },
+    getQuestionRevision: () => revision,
+  }
+  return { fake, messages, queries, replies, rejects, questionDirs }
+}
 
 describe("question handlers", () => {
-  it("routes replies using the question session when provided", async () => {
-    const calls: Array<Record<string, unknown>> = []
-    const client = {
-      question: {
-        reply: async (input: Record<string, unknown>) => {
-          calls.push(input)
-          return true
-        },
-        reject: async () => true,
-      },
-    } as unknown as KiloClient
+  it("routes replies through the recorded request directory", async () => {
+    const { fake, replies, questionDirs } = ctx({
+      tracked: ["ses-worktree"],
+      dirs: new Map([["ses-worktree", "/workspace/.kilo/worktrees/current"]]),
+    })
+    questionDirs.set("req-1", "/workspace/.kilo/worktrees/origin")
 
-    const ok = await handleQuestionReply(
-      {
-        client,
-        currentSessionId: "ses-root",
-        postMessage() {},
-        getWorkspaceDirectory(sessionId) {
-          return sessionId ? `/repo/${sessionId}` : "/repo"
-        },
-      },
-      "req-1",
-      [["Start new session"]],
-      "ses-worktree",
-    )
+    const ok = await handleQuestionReply(fake, "req-1", [["Continue"]], "ses-worktree")
 
     expect(ok).toBe(true)
-    expect(calls).toEqual([
+    expect(replies).toEqual([
       {
         requestID: "req-1",
-        answers: [["Start new session"]],
-        directory: "/repo/ses-worktree",
+        answers: [["Continue"]],
+        directory: "/workspace/.kilo/worktrees/origin",
       },
     ])
+    expect(questionDirs.has("req-1")).toBe(false)
   })
 
-  it("falls back to the current session when no question session is provided", async () => {
-    const calls: Array<Record<string, unknown>> = []
-    const client = {
-      question: {
-        reply: async (input: Record<string, unknown>) => {
-          calls.push(input)
-          return true
-        },
-        reject: async () => true,
-      },
-    } as unknown as KiloClient
+  it("routes rejects through the recorded request directory", async () => {
+    const { fake, rejects, questionDirs } = ctx({
+      tracked: ["ses-worktree"],
+      dirs: new Map([["ses-worktree", "/workspace/.kilo/worktrees/current"]]),
+    })
+    questionDirs.set("req-2", "/workspace/.kilo/worktrees/origin")
 
-    const ok = await handleQuestionReply(
-      {
-        client,
-        currentSessionId: "ses-root",
-        postMessage() {},
-        getWorkspaceDirectory(sessionId) {
-          return sessionId ? `/repo/${sessionId}` : "/repo"
-        },
-      },
-      "req-2",
-      [["Continue here"]],
-    )
+    const ok = await handleQuestionReject(fake, "req-2", "ses-worktree")
 
     expect(ok).toBe(true)
-    expect(calls[0]?.directory).toBe("/repo/ses-root")
+    expect(rejects).toEqual([{ requestID: "req-2", directory: "/workspace/.kilo/worktrees/origin" }])
+    expect(questionDirs.has("req-2")).toBe(false)
   })
 
-  it("routes rejects using the question session when provided", async () => {
-    const calls: Array<Record<string, unknown>> = []
-    const client = {
-      question: {
-        reply: async () => true,
-        reject: async (input: Record<string, unknown>) => {
-          calls.push(input)
-          return true
-        },
-      },
-    } as unknown as KiloClient
+  it("falls back to the question session directory when no request route is known", async () => {
+    const { fake, replies } = ctx({
+      tracked: ["ses-worktree"],
+      dirs: new Map([["ses-worktree", "/workspace/.kilo/worktrees/current"]]),
+    })
 
-    const ok = await handleQuestionReject(
-      {
-        client,
-        currentSessionId: "ses-root",
-        postMessage() {},
-        getWorkspaceDirectory(sessionId) {
-          return sessionId ? `/repo/${sessionId}` : "/repo"
-        },
-      },
-      "req-3",
-      "ses-worktree",
-    )
+    const ok = await handleQuestionReply(fake, "req-3", [["Continue"]], "ses-worktree")
 
     expect(ok).toBe(true)
-    expect(calls).toEqual([
+    expect(replies).toEqual([
       {
         requestID: "req-3",
-        directory: "/repo/ses-worktree",
+        answers: [["Continue"]],
+        directory: "/workspace/.kilo/worktrees/current",
       },
     ])
+  })
+
+  it("removes a stale question when the backend reports it missing", async () => {
+    const error = new Error("Question request not found", {
+      cause: { status: 404, body: { name: "NotFoundError" } },
+    })
+    const { fake, messages, questionDirs } = ctx({ errors: { reply: error } })
+    questionDirs.set("req-stale", "/workspace/.kilo/worktrees/origin")
+
+    const ok = await handleQuestionReply(fake, "req-stale", [["Continue"]], "ses-root")
+
+    expect(ok).toBe(false)
+    expect(questionDirs.has("req-stale")).toBe(false)
+    expect(messages).toContainEqual({ type: "questionResolved", requestID: "req-stale" })
+  })
+
+  it("keeps fallback-directory 404s retryable while recovering the request route", async () => {
+    const error = new Error("Question request not found", {
+      cause: { status: 404, body: { name: "NotFoundError" } },
+    })
+    const dir = "/workspace/.kilo/worktrees/origin"
+    const { fake, messages, questionDirs } = ctx({
+      tracked: ["ses-root"],
+      extra: [dir],
+      pending: { [dir]: [pending("req-misrouted", "ses-root")] },
+      errors: { reply: error },
+    })
+    const spy = spyOn(console, "error").mockImplementation(() => {})
+
+    const ok = await handleQuestionReply(fake, "req-misrouted", [["Continue"]], "ses-root")
+    spy.mockRestore()
+
+    expect(ok).toBe(false)
+    expect(messages).not.toContainEqual({ type: "questionResolved", requestID: "req-misrouted" })
+    expect(messages).toContainEqual({ type: "questionError", requestID: "req-misrouted" })
+    expect(questionDirs.get("req-misrouted")).toBe(dir)
+  })
+
+  it("removes a fallback question when recovery confirms it is stale", async () => {
+    const error = new Error("Question request not found", {
+      cause: { status: 404, body: { _tag: "NotFound" } },
+    })
+    const { fake, messages } = ctx({ errors: { reject: error } })
+
+    const ok = await handleQuestionReject(fake, "req-stale", "ses-root")
+
+    expect(ok).toBe(false)
+    expect(messages).toContainEqual({ type: "questionResolved", requestID: "req-stale" })
+    expect(messages).not.toContainEqual({ type: "questionError", requestID: "req-stale" })
+  })
+
+  it("keeps fallback questions retryable when recovery is incomplete", async () => {
+    const error = new Error("Question request not found", {
+      cause: { status: 404, body: { _tag: "NotFound" } },
+    })
+    const dir = "/workspace/.kilo/worktrees/failing"
+    const { fake, messages } = ctx({
+      extra: [dir],
+      errors: { list: { [dir]: new Error("temporary failure") }, reply: error },
+    })
+    const spy = spyOn(console, "error").mockImplementation(() => {})
+
+    const ok = await handleQuestionReply(fake, "req-unknown", [["Continue"]], "ses-root")
+    spy.mockRestore()
+
+    expect(ok).toBe(false)
+    expect(messages).toContainEqual({ type: "questionError", requestID: "req-unknown" })
+    expect(messages).not.toContainEqual({ type: "questionResolved", requestID: "req-unknown" })
+  })
+
+  it("keeps non-404 failures retryable", async () => {
+    const error = new Error("Internal server error", {
+      cause: { status: 500, body: { name: "InternalServerError" } },
+    })
+    const { fake, messages, questionDirs } = ctx({ errors: { reject: error } })
+    const spy = spyOn(console, "error").mockImplementation(() => {})
+    questionDirs.set("req-error", "/workspace/.kilo/worktrees/origin")
+
+    const ok = await handleQuestionReject(fake, "req-error", "ses-root")
+    spy.mockRestore()
+
+    expect(ok).toBe(false)
+    expect(questionDirs.get("req-error")).toBe("/workspace/.kilo/worktrees/origin")
+    expect(messages).toContainEqual({ type: "questionError", requestID: "req-error" })
+  })
+})
+
+describe("question recovery", () => {
+  it("records the directory that owns each recovered question", async () => {
+    const dir = "/workspace/.kilo/worktrees/late"
+    const { fake, queries, messages, questionDirs } = ctx({
+      tracked: ["ses-worktree"],
+      extra: [dir],
+      pending: { [dir]: [pending("req-1", "ses-worktree")] },
+    })
+
+    await fetchAndSendPendingQuestions(fake)
+
+    expect(queries).toEqual(["/workspace", dir])
+    expect(questionDirs.get("req-1")).toBe(dir)
+    expect(messages).toContainEqual({
+      type: "questionRequest",
+      question: pending("req-1", "ses-worktree"),
+    })
+  })
+
+  it("deduplicates recovered questions across directories", async () => {
+    const item = pending("req-1", "ses-worktree")
+    const dir = "/workspace/.kilo/worktrees/feature"
+    const { fake, messages } = ctx({
+      tracked: ["ses-worktree"],
+      dirs: new Map([["ses-worktree", dir]]),
+      pending: { "/workspace": [item], [dir]: [item] },
+    })
+
+    await fetchAndSendPendingQuestions(fake)
+
+    expect(messages).toHaveLength(1)
+  })
+
+  it("retries a recovery snapshot invalidated by a newer question event", async () => {
+    const item = pending("req-missed", "ses-root")
+    const { fake, messages, queries, questionDirs } = ctx({
+      pending: { "/workspace": [item] },
+      changeOnList: "/workspace",
+    })
+    questionDirs.set("req-new", "/workspace")
+
+    await fetchAndSendPendingQuestions(fake)
+
+    expect(queries).toEqual(["/workspace", "/workspace"])
+    expect(messages).toContainEqual({ type: "questionRequest", question: item })
+    expect(questionDirs.get("req-new")).toBe("/workspace")
+    expect(questionDirs.get("req-missed")).toBe("/workspace")
+  })
+
+  it("preserves cached routes when recovery is incomplete", async () => {
+    const dir = "/workspace/.kilo/worktrees/failing"
+    const error = new Error("temporary failure")
+    const { fake, questionDirs } = ctx({
+      tracked: ["ses-worktree"],
+      dirs: new Map([["ses-worktree", dir]]),
+      errors: { list: { [dir]: error } },
+    })
+    const spy = spyOn(console, "error").mockImplementation(() => {})
+    questionDirs.set("workspace-stale", "/workspace")
+    questionDirs.set("worktree-pending", dir)
+
+    await fetchAndSendPendingQuestions(fake)
+    spy.mockRestore()
+
+    expect(questionDirs.get("workspace-stale")).toBe("/workspace")
+    expect(questionDirs.get("worktree-pending")).toBe(dir)
   })
 })


### PR DESCRIPTION
Question requests are owned by the backend instance directory where they were created, but Agent Manager replies derived the target directory from mutable session state. Worktree changes, child-session adoption, and recovered prompts could therefore send a valid question response to another instance and receive a 404.

This change preserves each question's authoritative SSE directory in the shared connection service and uses that route for replies and dismissals. Pending-question recovery now scans all active Agent Manager directories, retains the directory that returned each request, and retries if question events invalidate a scan. Missing requests are only dismissed after a complete recovery confirms they are stale, while incomplete recovery remains retryable.

The prompt drain path also accepts both legacy and Effect `NotFound` response shapes so concurrent question resolution does not block destructive configuration operations.

Fixes #11157