### PR TITLE
fix(vscode): hide unfinished todo warnings

### DIFF
--- a/.changeset/calm-todos-rest.md
+++ b/.changeset/calm-todos-rest.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Hide turn outcome warnings caused only by unfinished to-dos.

--- a/packages/kilo-vscode/tests/unit/session-outcome.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-outcome.test.ts
@@ -26,17 +26,17 @@ describe("terminal", () => {
     expect(terminal({ reason: "completed", messages: [message("stop")], todos: [] })).toBeUndefined()
   })
 
-  it("warns when a completed turn leaves to-dos unfinished", () => {
+  it("hides completed turns with unfinished to-dos", () => {
     expect(
       terminal({ reason: "completed", messages: [message("stop")], todos: [todo("completed"), todo("pending")] }),
-    ).toEqual({ kind: "incomplete", tone: "warning", finish: "stop", remaining: 1 })
+    ).toBeUndefined()
   })
 
   it("treats cancelled to-dos as terminal rather than remaining work", () => {
     expect(terminal({ reason: "completed", messages: [message("stop")], todos: [todo("cancelled")] })).toBeUndefined()
   })
 
-  it("surfaces response limit and unknown model finishes before generic incomplete status", () => {
+  it("surfaces response limit and unknown model finishes with unfinished to-dos", () => {
     expect(terminal({ reason: "completed", messages: [message("length")], todos: [todo("pending")] })?.kind).toBe(
       "limit",
     )

--- a/packages/kilo-vscode/webview-ui/src/context/session-outcome.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-outcome.ts
@@ -32,6 +32,5 @@ export function terminal(input: Input): TerminalState | undefined {
   if (finish === "unknown") return { kind: "unknown", tone: "warning", finish, remaining }
   if (finish === "content-filter") return { kind: "filtered", tone: "warning", finish, remaining }
   if (finish === "other") return { kind: "unexpected", tone: "warning", finish, remaining }
-  if (remaining > 0) return { kind: "incomplete", tone: "warning", finish, remaining }
   return undefined
 }


### PR DESCRIPTION
A normal turn can end while its todo list still contains pending work, but that state alone does not indicate a failed or abnormal response. Showing a warning for every such turn creates noise and conflates todo bookkeeping with model or session failures.

Hide outcome cards caused only by unfinished todos. Interrupted turns, response limits, missing or unexpected finish reasons, content-filter stops, and unrendered errors continue to surface through the existing warning and error cards.

This supersedes #11136, which suppresses only interrupted outcomes with unfinished todos. The broader rule is that todo state should not determine whether any turn outcome warning appears.