### PR TITLE
perf(cli): accelerate durable snapshot initialization

### DIFF
--- a/.changeset/fast-regular-snapshots.md
+++ b/.changeset/fast-regular-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Accelerate initial snapshots for regular Git sessions while preserving existing changes and asynchronously storing snapshots independently from the source repository.

--- a/packages/opencode/src/kilocode/snapshot/materialize.ts
+++ b/packages/opencode/src/kilocode/snapshot/materialize.ts
@@ -1,0 +1,228 @@
+import { Effect } from "effect"
+import path from "path"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import * as Log from "@opencode-ai/core/util/log"
+import { Hash } from "@opencode-ai/core/util/hash"
+
+export namespace KiloSnapshotMaterialize {
+  const log = Log.create({ service: "snapshot.materialize" })
+
+  interface Result {
+    readonly code: number
+    readonly text: string
+    readonly stderr: string
+  }
+
+  export type Git = (
+    cmd: string[],
+    opts?: { cwd?: string; env?: Record<string, string>; stdin?: string },
+  ) => Effect.Effect<Result>
+
+  export interface Input {
+    readonly gitdir: string
+    readonly git: Git
+    readonly fs: AppFileSystem.Interface
+  }
+
+  export const ref = (gitdir: string) => `refs/kilo/materialize/${Hash.fast(path.resolve(gitdir))}`
+  const snapshotRef = (hash: string, time = Date.now()) => `refs/kilo/snapshots/${time}/${hash}`
+
+  const pack = Effect.fnUntraced(function* (input: Input, dir: string, name: string, objects: string[]) {
+    if (!objects.length) return true
+    yield* input.fs.ensureDir(dir).pipe(Effect.catch(() => Effect.void))
+    const result = yield* input.git(["--git-dir", input.gitdir, "pack-objects", "--non-empty", path.join(dir, name)], {
+      stdin: `${objects.join("\n")}\n`,
+    })
+    if (result.code === 0 && result.text.trim()) return true
+    log.warn("failed to localize snapshot objects", { name, objects: objects.length, stderr: result.stderr })
+    return false
+  })
+
+  export const pin = Effect.fnUntraced(function* (input: Input, hash: string) {
+    const result = yield* input.git(["--git-dir", input.gitdir, "update-ref", snapshotRef(hash), hash])
+    if (result.code === 0) return true
+    log.warn("failed to pin snapshot", { hash, stderr: result.stderr })
+    return false
+  })
+
+  export const localize = Effect.fnUntraced(function* (
+    input: Input & { readonly staging: string; readonly seed: string },
+  ) {
+    const diff = yield* input.git([
+      "--git-dir",
+      input.gitdir,
+      "diff-index",
+      "--cached",
+      "--name-only",
+      "-z",
+      input.seed,
+    ])
+    if (diff.code !== 0) return false
+    const files = diff.text.split("\0").filter(Boolean)
+    if (!files.length) return true
+
+    const listed = yield* Effect.all(
+      Array.from({ length: Math.ceil(files.length / 500) }, (_, i) =>
+        input.git([
+          "--git-dir",
+          input.gitdir,
+          "ls-files",
+          "--stage",
+          "-z",
+          "--",
+          ...files.slice(i * 500, i * 500 + 500),
+        ]),
+      ),
+      { concurrency: 1 },
+    )
+    if (listed.some((item) => item.code !== 0)) return false
+    const objects = Array.from(
+      new Set(
+        listed.flatMap((item) =>
+          item.text.split("\0").flatMap((line) => {
+            const match = line.match(/^(\d+) ([0-9a-f]+) 0\t/)
+            if (!match || match[1] === "160000") return []
+            return [match[2]]
+          }),
+        ),
+      ),
+    )
+    return yield* pack(input, path.join(input.staging, "pack"), "changed", objects)
+  })
+
+  export const localizeTrees = Effect.fnUntraced(function* (input: Input & { readonly staging: string }, hash: string) {
+    const listed = yield* input.git(["--git-dir", input.gitdir, "ls-tree", "-r", "-t", "-z", hash])
+    if (listed.code !== 0) return false
+    const objects = Array.from(
+      new Set([
+        hash,
+        ...listed.text.split("\0").flatMap((line) => {
+          const match = line.match(/^\d+ tree ([0-9a-f]+)\t/)
+          return match ? [match[1]] : []
+        }),
+      ]),
+    )
+    return yield* pack(input, path.join(input.staging, "pack"), "trees", objects)
+  })
+
+  export const prune = Effect.fnUntraced(function* (input: Input, before: number) {
+    const result = yield* input.git([
+      "--git-dir",
+      input.gitdir,
+      "for-each-ref",
+      "--format=%(refname)",
+      "refs/kilo/snapshots",
+    ])
+    if (result.code !== 0) return false
+    const refs = result.text
+      .split("\n")
+      .map((item) => item.trim())
+      .filter((item) => {
+        const match = item.match(/^refs\/kilo\/snapshots\/(\d+)\/[0-9a-f]+$/)
+        if (!match) return false
+        const time = Number(match[1])
+        return Number.isSafeInteger(time) && time < before
+      })
+    if (!refs.length) return true
+    const removed = yield* input.git(["--git-dir", input.gitdir, "update-ref", "--stdin"], {
+      stdin: refs.map((item) => `delete ${item}`).join("\n") + "\n",
+    })
+    if (removed.code === 0) return true
+    log.warn("failed to prune snapshot pins", { refs: refs.length, stderr: removed.stderr })
+    return false
+  })
+
+  export const run = Effect.fnUntraced(function* (input: Input) {
+    const started = Date.now()
+    const alt = path.join(input.gitdir, "objects", "info", "alternates")
+    const hold = `${alt}.materializing`
+    if (!(yield* input.fs.exists(alt)) && (yield* input.fs.exists(hold))) yield* input.fs.rename(hold, alt)
+    if (!(yield* input.fs.exists(alt))) return false
+    const text = yield* input.fs.readFileString(alt)
+
+    const refs = yield* input.git([
+      "--git-dir",
+      input.gitdir,
+      "for-each-ref",
+      "--format=%(objectname)",
+      "refs/kilo/snapshots",
+    ])
+    if (refs.code !== 0) {
+      log.warn("failed to list snapshot pins", { stderr: refs.stderr })
+      return false
+    }
+    const roots = yield* Effect.gen(function* () {
+      const listed = Array.from(
+        new Set(
+          refs.text
+            .split("\n")
+            .map((item) => item.trim())
+            .filter(Boolean),
+        ),
+      )
+      if (listed.length) return listed
+      const tree = yield* input.git(["--git-dir", input.gitdir, "write-tree"])
+      const hash = tree.text.trim()
+      if (tree.code !== 0 || !hash) return []
+      if (!(yield* pin(input, hash))) return []
+      return [hash]
+    })
+    if (!roots.length) return false
+
+    const packed = yield* input.git(["--git-dir", input.gitdir, "repack", "-a", "-d", "--no-write-bitmap-index"])
+    if (packed.code !== 0) {
+      log.warn("failed to repack snapshot objects", { stderr: packed.stderr })
+      return false
+    }
+
+    const source = yield* Effect.gen(function* () {
+      const objects = text
+        .split("\n")
+        .map((item) => item.trim())
+        .find(Boolean)
+      if (!objects || path.basename(objects) !== "objects") return
+      const gitdir = path.dirname(objects)
+      const name = ref(input.gitdir)
+      const result = yield* input.git(["--git-dir", gitdir, "rev-parse", "--verify", name])
+      const hash = result.text.trim()
+      if (result.code !== 0 || !hash) return
+      return { gitdir, ref: name, hash }
+    })
+
+    const detached = yield* Effect.uninterruptible(
+      Effect.gen(function* () {
+        yield* input.fs.rename(alt, hold)
+        const connected = yield* input.git([
+          "--git-dir",
+          input.gitdir,
+          "fsck",
+          "--connectivity-only",
+          "--no-dangling",
+          "--no-reflogs",
+          "--no-progress",
+        ])
+        yield* input.fs.rename(hold, alt)
+        if (connected.code !== 0) {
+          log.warn("snapshot pack failed local connectivity check", { stderr: connected.stderr })
+          return false
+        }
+
+        if (source) {
+          const removed = yield* input.git(["--git-dir", source.gitdir, "update-ref", "-d", source.ref, source.hash])
+          if (removed.code !== 0) {
+            log.warn("failed to remove source snapshot pin", { stderr: removed.stderr })
+            return false
+          }
+        }
+        yield* input.fs.remove(alt)
+        yield* input.fs
+          .remove(path.join(input.gitdir, "seed-objects"), { recursive: true })
+          .pipe(Effect.catch(() => Effect.void))
+        return true
+      }),
+    )
+    if (!detached) return false
+    log.info("snapshot objects materialized", { roots: roots.length, duration: Date.now() - started })
+    return true
+  })
+}

--- a/packages/opencode/src/kilocode/snapshot/materialize.ts
+++ b/packages/opencode/src/kilocode/snapshot/materialize.ts
@@ -58,33 +58,18 @@ export namespace KiloSnapshotMaterialize {
       input.seed,
     ])
     if (diff.code !== 0) return false
-    const files = diff.text.split("\0").filter(Boolean)
-    if (!files.length) return true
+    const files = new Set(diff.text.split("\0").filter(Boolean))
+    if (!files.size) return true
 
-    const listed = yield* Effect.all(
-      Array.from({ length: Math.ceil(files.length / 500) }, (_, i) =>
-        input.git([
-          "--git-dir",
-          input.gitdir,
-          "ls-files",
-          "--stage",
-          "-z",
-          "--",
-          ...files.slice(i * 500, i * 500 + 500),
-        ]),
-      ),
-      { concurrency: 1 },
-    )
-    if (listed.some((item) => item.code !== 0)) return false
+    const listed = yield* input.git(["--git-dir", input.gitdir, "ls-files", "--stage", "-z"])
+    if (listed.code !== 0) return false
     const objects = Array.from(
       new Set(
-        listed.flatMap((item) =>
-          item.text.split("\0").flatMap((line) => {
-            const match = line.match(/^(\d+) ([0-9a-f]+) 0\t/)
-            if (!match || match[1] === "160000") return []
-            return [match[2]]
-          }),
-        ),
+        listed.text.split("\0").flatMap((line) => {
+          const match = line.match(/^(\d+) ([0-9a-f]+) 0\t(.*)$/)
+          if (!match || match[1] === "160000" || !files.has(match[3])) return []
+          return [match[2]]
+        }),
       ),
     )
     return yield* pack(input, path.join(input.staging, "pack"), "changed", objects)
@@ -113,7 +98,10 @@ export namespace KiloSnapshotMaterialize {
       "--format=%(refname)",
       "refs/kilo/snapshots",
     ])
-    if (result.code !== 0) return false
+    if (result.code !== 0) {
+      log.warn("failed to list snapshot pins for pruning", { stderr: result.stderr })
+      return false
+    }
     const refs = result.text
       .split("\n")
       .map((item) => item.trim())
@@ -137,7 +125,18 @@ export namespace KiloSnapshotMaterialize {
     const alt = path.join(input.gitdir, "objects", "info", "alternates")
     const hold = `${alt}.materializing`
     if (!(yield* input.fs.exists(alt)) && (yield* input.fs.exists(hold))) yield* input.fs.rename(hold, alt)
-    if (!(yield* input.fs.exists(alt))) return false
+    if (!(yield* input.fs.exists(alt))) {
+      yield* Effect.all(
+        [
+          input.fs.remove(`${alt}.seed`).pipe(Effect.catch(() => Effect.void)),
+          input.fs
+            .remove(path.join(input.gitdir, "seed-objects"), { recursive: true })
+            .pipe(Effect.catch(() => Effect.void)),
+        ],
+        { discard: true },
+      )
+      return false
+    }
     const text = yield* input.fs.readFileString(alt)
 
     const refs = yield* input.git([
@@ -169,6 +168,7 @@ export namespace KiloSnapshotMaterialize {
     })
     if (!roots.length) return false
 
+    // Without --local, repack copies all reachable objects from alternates into this repository.
     const packed = yield* input.git(["--git-dir", input.gitdir, "repack", "-a", "-d", "--no-write-bitmap-index"])
     if (packed.code !== 0) {
       log.warn("failed to repack snapshot objects", { stderr: packed.stderr })
@@ -189,10 +189,10 @@ export namespace KiloSnapshotMaterialize {
       return { gitdir, ref: name, hash }
     })
 
-    const detached = yield* Effect.uninterruptible(
-      Effect.gen(function* () {
-        yield* input.fs.rename(alt, hold)
-        const connected = yield* input.git([
+    const connected = yield* Effect.acquireUseRelease(
+      input.fs.rename(alt, hold),
+      () =>
+        input.git([
           "--git-dir",
           input.gitdir,
           "fsck",
@@ -200,28 +200,31 @@ export namespace KiloSnapshotMaterialize {
           "--no-dangling",
           "--no-reflogs",
           "--no-progress",
-        ])
-        yield* input.fs.rename(hold, alt)
-        if (connected.code !== 0) {
-          log.warn("snapshot pack failed local connectivity check", { stderr: connected.stderr })
-          return false
-        }
+        ]),
+      () => input.fs.rename(hold, alt).pipe(Effect.orDie),
+    )
 
-        if (source) {
-          const removed = yield* input.git(["--git-dir", source.gitdir, "update-ref", "-d", source.ref, source.hash])
-          if (removed.code !== 0) {
-            log.warn("failed to remove source snapshot pin", { stderr: removed.stderr })
-            return false
-          }
-        }
+    if (!(yield* input.fs.exists(alt))) return false
+    if (connected.code !== 0) {
+      log.warn("snapshot pack failed local connectivity check", { stderr: connected.stderr })
+      return false
+    }
+
+    if (source) {
+      const removed = yield* input.git(["--git-dir", source.gitdir, "update-ref", "-d", source.ref, source.hash])
+      if (removed.code !== 0) {
+        log.warn("failed to remove source snapshot pin", { stderr: removed.stderr })
+        return false
+      }
+    }
+    yield* Effect.uninterruptible(
+      Effect.gen(function* () {
         yield* input.fs.remove(alt)
         yield* input.fs
           .remove(path.join(input.gitdir, "seed-objects"), { recursive: true })
           .pipe(Effect.catch(() => Effect.void))
-        return true
       }),
     )
-    if (!detached) return false
     log.info("snapshot objects materialized", { roots: roots.length, duration: Date.now() - started })
     return true
   })

--- a/packages/opencode/src/kilocode/snapshot/seed.ts
+++ b/packages/opencode/src/kilocode/snapshot/seed.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect"
 import path from "path"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import * as Log from "@opencode-ai/core/util/log"
+import { KiloSnapshotMaterialize } from "./materialize"
 
 export namespace KiloSnapshotSeed {
   const log = Log.create({ service: "snapshot.seed" })
@@ -26,11 +27,14 @@ export namespace KiloSnapshotSeed {
     readonly fs: AppFileSystem.Interface
   }
 
+  export interface Source {
+    readonly gitdir: string
+    readonly staging: string
+    readonly hash: string
+  }
+
   export interface Output {
-    readonly seeded: boolean
-    readonly paths: number
-    readonly dropped: number
-    readonly reason?: string
+    readonly source?: Source
   }
 
   const list = (text: string) => text.split("\0").filter(Boolean)
@@ -42,20 +46,34 @@ export namespace KiloSnapshotSeed {
   export const seed = Effect.fnUntraced(function* (input: Input) {
     const started = Date.now()
     const alt = path.join(input.gitdir, "objects", "info", "alternates")
+    const temp = path.join(input.gitdir, "seed.index")
     const changed = { value: false }
+    const pinned = { gitdir: "", ref: "", hash: "" }
     const reset = Effect.fnUntraced(function* (reason: string, warn = false) {
+      const retained = { value: false }
+      if (pinned.hash) {
+        const removed = yield* input.git(["--git-dir", pinned.gitdir, "update-ref", "-d", pinned.ref, pinned.hash])
+        retained.value = removed.code !== 0
+      }
       if (changed.value) {
         const cleared = yield* input.git(snap(input, ["read-tree", "--empty"]), { cwd: input.dir })
         if (cleared.code !== 0) {
           yield* input.fs.remove(path.join(input.gitdir, "index")).pipe(Effect.catch(() => Effect.void))
         }
         yield* input.fs.remove(path.join(input.gitdir, "index.lock")).pipe(Effect.catch(() => Effect.void))
-        yield* input.fs.remove(alt).pipe(Effect.catch(() => Effect.void))
+        yield* input.fs.remove(temp).pipe(Effect.catch(() => Effect.void))
+        yield* input.fs.remove(`${temp}.lock`).pipe(Effect.catch(() => Effect.void))
+        if (!retained.value) {
+          yield* input.fs.remove(alt).pipe(Effect.catch(() => Effect.void))
+          yield* input.fs
+            .remove(path.join(input.gitdir, "seed-objects"), { recursive: true })
+            .pipe(Effect.catch(() => Effect.void))
+        }
       }
       const fields = { reason, duration: Date.now() - started }
       if (warn) log.warn("snapshot seed failed; using cold initialization", fields)
       if (!warn) log.info("snapshot seed skipped", fields)
-      return { seeded: false, paths: 0, dropped: 0, reason } satisfies Output
+      return {} satisfies Output
     })
 
     const attempt = Effect.gen(function* () {
@@ -92,32 +110,51 @@ export namespace KiloSnapshotSeed {
 
       const objects = path.join(common, "objects")
       if (!(yield* input.fs.exists(objects))) return yield* reset("source-objects")
-      // Borrow committed objects to keep the first turn fast. Durable materialization can happen off this critical path.
+      const staging = path.join(input.gitdir, "seed-objects")
+      yield* input.fs.ensureDir(staging)
+      // Borrow committed objects while writing dirty content into snapshot-owned staging.
       yield* input.fs.ensureDir(path.dirname(alt))
       changed.value = true
-      yield* input.fs.writeFileString(alt, `${objects}\n`)
+      yield* input.fs.writeFileString(alt, `${objects}\n${staging}\n`)
 
-      const tree = yield* input.git(["write-tree"], {
-        cwd: input.dir,
-        env: {
-          GIT_DIR: source,
-          GIT_WORK_TREE: input.worktree,
-          GIT_INDEX_FILE: index,
-          GIT_OBJECT_DIRECTORY: path.join(input.gitdir, "objects"),
-          GIT_ALTERNATE_OBJECT_DIRECTORIES: objects,
-        },
-      })
-      if (tree.code !== 0 || !tree.text.trim()) return yield* reset("write-tree", true)
+      // Normalize a private index copy so write-tree cannot mutate the user's index
+      // and the snapshot does not retain source-local index extensions.
+      yield* input.fs.copyFile(index, temp)
+      const env = {
+        GIT_DIR: source,
+        GIT_WORK_TREE: input.worktree,
+        GIT_INDEX_FILE: temp,
+      }
+      const normalized = yield* input.git(
+        ["update-index", "--no-split-index", "--no-fsmonitor", "--no-untracked-cache"],
+        { cwd: input.dir, env },
+      )
+      if (normalized.code !== 0) return yield* reset("normalize-index", true)
 
-      const read = yield* input.git(snap(input, ["read-tree", tree.text.trim()]), { cwd: input.dir })
+      const tree = yield* input.git(["write-tree"], { cwd: input.dir, env })
+      const hash = tree.text.trim()
+      if (tree.code !== 0 || !hash) return yield* reset("write-tree", true)
+
+      const ref = KiloSnapshotMaterialize.ref(input.gitdir)
+      const pin = yield* input.git(["--git-dir", common, "update-ref", ref, hash])
+      if (pin.code !== 0) return yield* reset("source-pin", true)
+      pinned.gitdir = common
+      pinned.ref = ref
+      pinned.hash = hash
+      const materialize = { gitdir: common, staging, hash }
+
+      // Discard source stat data and entry flags so reconciliation observes the
+      // filesystem under snapshot filter and line-ending semantics.
+      const read = yield* input.git(snap(input, ["read-tree", hash]), { cwd: input.dir })
       if (read.code !== 0) return yield* reset("read-tree", true)
+      yield* input.fs.remove(temp).pipe(Effect.catch(() => Effect.void))
 
       const tracked = yield* input.git(snap(input, ["ls-files", "-z", "--", "."]), { cwd: input.dir })
       if (tracked.code !== 0) return yield* reset("list", true)
       const files = list(tracked.text)
       if (!files.length) {
         log.info("snapshot seed complete", { paths: 0, dropped: 0, duration: Date.now() - started })
-        return { seeded: true, paths: 0, dropped: 0 } satisfies Output
+        return { source: materialize } satisfies Output
       }
 
       const ignored = yield* input.git(["-C", input.worktree, "check-ignore", "--no-index", "--stdin", "-z"], {
@@ -157,7 +194,7 @@ export namespace KiloSnapshotSeed {
         large: large.length,
         duration: Date.now() - started,
       })
-      return { seeded: true, paths: files.length, dropped: dropped.length } satisfies Output
+      return { source: materialize } satisfies Output
     })
 
     return yield* attempt.pipe(

--- a/packages/opencode/src/kilocode/snapshot/seed.ts
+++ b/packages/opencode/src/kilocode/snapshot/seed.ts
@@ -46,6 +46,7 @@ export namespace KiloSnapshotSeed {
   export const seed = Effect.fnUntraced(function* (input: Input) {
     const started = Date.now()
     const alt = path.join(input.gitdir, "objects", "info", "alternates")
+    const pending = `${alt}.seed`
     const temp = path.join(input.gitdir, "seed.index")
     const changed = { value: false }
     const pinned = { gitdir: "", ref: "", hash: "" }
@@ -63,6 +64,7 @@ export namespace KiloSnapshotSeed {
         yield* input.fs.remove(path.join(input.gitdir, "index.lock")).pipe(Effect.catch(() => Effect.void))
         yield* input.fs.remove(temp).pipe(Effect.catch(() => Effect.void))
         yield* input.fs.remove(`${temp}.lock`).pipe(Effect.catch(() => Effect.void))
+        yield* input.fs.remove(pending).pipe(Effect.catch(() => Effect.void))
         if (!retained.value) {
           yield* input.fs.remove(alt).pipe(Effect.catch(() => Effect.void))
           yield* input.fs
@@ -115,7 +117,8 @@ export namespace KiloSnapshotSeed {
       // Borrow committed objects while writing dirty content into snapshot-owned staging.
       yield* input.fs.ensureDir(path.dirname(alt))
       changed.value = true
-      yield* input.fs.writeFileString(alt, `${objects}\n${staging}\n`)
+      yield* input.fs.writeFileString(pending, `${objects}\n${staging}\n`)
+      yield* input.fs.rename(pending, alt)
 
       // Normalize a private index copy so write-tree cannot mutate the user's index
       // and the snapshot does not retain source-local index extensions.
@@ -198,6 +201,7 @@ export namespace KiloSnapshotSeed {
     })
 
     return yield* attempt.pipe(
+      Effect.onInterrupt(() => reset("interrupted", true).pipe(Effect.asVoid)),
       Effect.catch((err) => {
         log.warn("snapshot seed failed", { err })
         return reset("error", true)

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -1,4 +1,4 @@
-import { Cause, Duration, Effect, Layer, Schedule, Schema, Semaphore, Struct, Context } from "effect"
+import { Cause, Duration, Effect, Layer, Schedule, Schema, Semaphore, Struct, Context } from "effect" // kilocode_change
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { formatPatch, structuredPatch } from "diff"
 import path from "path"
@@ -6,16 +6,20 @@ import { AppProcess } from "@opencode-ai/core/process"
 import { InstanceState } from "@/effect/instance-state"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { Hash } from "@opencode-ai/core/util/hash"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock" // kilocode_change
 import { Config } from "@/config/config"
 import { Global } from "@opencode-ai/core/global"
 import * as Log from "@opencode-ai/core/util/log"
-import { Flag } from "@opencode-ai/core/flag/flag" // kilocode_change
-import { DiffFull } from "../kilocode/snapshot/diff-full" // kilocode_change
-import { KiloSnapshotTrack } from "../kilocode/snapshot/track" // kilocode_change
-import { KiloSnapshotSeed } from "../kilocode/snapshot/seed" // kilocode_change
-import type { MessageID, SessionID } from "../session/schema" // kilocode_change
-import { withStatics } from "@opencode-ai/core/schema" // kilocode_change
-import { zod } from "@opencode-ai/core/effect-zod" // kilocode_change
+// kilocode_change start
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { DiffFull } from "../kilocode/snapshot/diff-full"
+import { KiloSnapshotTrack } from "../kilocode/snapshot/track"
+import { KiloSnapshotSeed } from "../kilocode/snapshot/seed"
+import { KiloSnapshotMaterialize } from "../kilocode/snapshot/materialize"
+import type { MessageID, SessionID } from "../session/schema"
+import { withStatics } from "@opencode-ai/core/schema"
+import { zod } from "@opencode-ai/core/effect-zod"
+// kilocode_change end
 
 export const Patch = Schema.Struct({
   hash: Schema.String,
@@ -32,9 +36,11 @@ export const FileDiff = Schema.Struct({
   additions: Schema.Finite,
   deletions: Schema.Finite,
   status: Schema.optional(Schema.Literals(["added", "deleted", "modified"])),
+// kilocode_change start
 })
   .annotate({ identifier: "SnapshotFileDiff" })
-  .pipe(withStatics((s) => ({ zod: zod(s) }))) // kilocode_change
+  .pipe(withStatics((s) => ({ zod: zod(s) })))
+// kilocode_change end
 export type FileDiff = typeof FileDiff.Type
 
 // kilocode_change start - lightweight FileDiff without patch for session summaries
@@ -46,6 +52,7 @@ export type SummaryFileDiff = typeof SummaryFileDiff.Type
 
 const log = Log.create({ service: "snapshot" })
 const prune = "7.days"
+const retention = 7 * 24 * 60 * 60 * 1000 // kilocode_change
 const limit = 2 * 1024 * 1024
 const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
 const cfg = ["-c", "core.autocrlf=false", ...core]
@@ -79,13 +86,17 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Snapshot") {}
 
-export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProcess.Service | Config.Service> =
+// kilocode_change start
+type Requirements = AppFileSystem.Service | AppProcess.Service | Config.Service | EffectFlock.Service
+export const layer: Layer.Layer<Service, never, Requirements> =
+// kilocode_change end
   Layer.effect(
     Service,
     Effect.gen(function* () {
       const fs = yield* AppFileSystem.Service
       const appProcess = yield* AppProcess.Service
       const config = yield* Config.Service
+      const flock = yield* EffectFlock.Service // kilocode_change
       const locks = new Map<string, Semaphore.Semaphore>()
 
       const lock = (key: string) => {
@@ -168,12 +179,13 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             )
           })
 
-          const stage = Effect.fnUntraced(function* (files: string[]) {
+          const stage = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) { // kilocode_change
             if (!files.length) return
             const result = yield* git(
               [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
               {
                 cwd: state.directory,
+                env, // kilocode_change
                 stdin: feed(files),
               },
             )
@@ -187,7 +199,11 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
           const exists = (file: string) => fs.exists(file).pipe(Effect.orDie)
           const read = (file: string) => fs.readFileString(file).pipe(Effect.catch(() => Effect.succeed("")))
           const remove = (file: string) => fs.remove(file).pipe(Effect.catch(() => Effect.void))
-          const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
+          // kilocode_change start - serialize snapshot repositories across CLI and extension processes
+          const locked = <A, R>(fx: Effect.Effect<A, never, R>) =>
+            lock(state.gitdir).withPermits(1)(flock.withLock(fx, `snapshot:${state.gitdir}`).pipe(Effect.orDie))
+
+          // kilocode_change end
 
           const enabled = Effect.fnUntraced(function* () {
             if (state.vcs !== "git") return false
@@ -218,7 +234,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
           })
 
-          const add = Effect.fnUntraced(function* () {
+          const add = Effect.fnUntraced(function* (env?: Record<string, string>) { // kilocode_change
             yield* sync()
             const [diff, other] = yield* Effect.all(
               [
@@ -280,14 +296,37 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             const block = new Set(untracked.filter((item) => large.has(item)))
             yield* sync(Array.from(block))
             // Stage only the allowed candidate paths so snapshot updates stay scoped.
-            yield* stage(allow.filter((item) => !block.has(item)))
+            // kilocode_change start - initial seeded writes stay protected by the source pin
+            yield* stage(
+              allow.filter((item) => !block.has(item)),
+              env,
+            )
           })
+
+          const materialize = Effect.fnUntraced(function* () {
+            yield* locked(
+              KiloSnapshotMaterialize.run({ gitdir: state.gitdir, git, fs }).pipe(
+                Effect.catchCause((cause) => {
+                  log.error("snapshot materialization failed", { cause: Cause.pretty(cause) })
+                  return Effect.void
+                }),
+              ),
+            ).pipe(Effect.forkDetach, Effect.asVoid)
+          })
+          // kilocode_change end
 
           const cleanup = Effect.fnUntraced(function* () {
             return yield* locked(
               Effect.gen(function* () {
                 if (!(yield* enabled())) return
                 if (!(yield* exists(state.gitdir))) return
+                // kilocode_change start - retain snapshots for the same seven-day window as object pruning
+                const pruned = yield* KiloSnapshotMaterialize.prune(
+                  { gitdir: state.gitdir, git, fs },
+                  Date.now() - retention,
+                )
+                if (!pruned) return
+                // kilocode_change end
                 const result = yield* git(args(["gc", `--prune=${prune}`]), { cwd: state.directory })
                 if (result.code !== 0) {
                   log.warn("cleanup failed", {
@@ -306,6 +345,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
               Effect.gen(function* () {
                 if (!(yield* enabled())) return
                 const existed = yield* exists(state.gitdir)
+                const seeded: { value?: KiloSnapshotSeed.Output } = {} // kilocode_change
                 yield* fs.ensureDir(state.gitdir).pipe(Effect.orDie)
                 if (!existed) {
                   yield* git(["init"], {
@@ -315,23 +355,53 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
                   yield* git(["--git-dir", state.gitdir, "config", "core.longpaths", "true"])
                   yield* git(["--git-dir", state.gitdir, "config", "core.symlinks", "true"])
                   yield* git(["--git-dir", state.gitdir, "config", "core.fsmonitor", "false"])
-                  // kilocode_change start - seed new Agent Manager snapshots from the worktree index
-                  if (opts?.snapshotInitialization === "wait") {
-                    yield* KiloSnapshotSeed.seed({
-                      dir: state.directory,
-                      worktree: state.worktree,
-                      gitdir: state.gitdir,
-                      limit,
-                      git,
-                      fs,
-                    })
-                  }
+                  // kilocode_change start - seed all eligible new snapshots from the worktree index
+                  seeded.value = yield* KiloSnapshotSeed.seed({
+                    dir: state.directory,
+                    worktree: state.worktree,
+                    gitdir: state.gitdir,
+                    limit,
+                    git,
+                    fs,
+                  })
                   // kilocode_change end
                   log.info("initialized")
                 }
-                yield* add()
+                // kilocode_change start - pin every snapshot before background materialization
+                const seed = seeded.value?.source
+                const env = seed
+                  ? {
+                      GIT_OBJECT_DIRECTORY: seed.staging,
+                      GIT_ALTERNATE_OBJECT_DIRECTORIES: path.join(seed.gitdir, "objects"),
+                    }
+                  : undefined
+                yield* add(env)
+                if (
+                  seed &&
+                  !(yield* KiloSnapshotMaterialize.localize({
+                    gitdir: state.gitdir,
+                    git,
+                    fs,
+                    staging: seed.staging,
+                    seed: seed.hash,
+                  }))
+                )
+                  return
                 const result = yield* git(args(["write-tree"]), { cwd: state.directory })
                 const hash = result.text.trim()
+                if (result.code !== 0 || !hash) return
+                if (
+                  seed &&
+                  !(yield* KiloSnapshotMaterialize.localizeTrees(
+                    { gitdir: state.gitdir, git, fs, staging: seed.staging },
+                    hash,
+                  ))
+                )
+                  return
+                if (!(yield* KiloSnapshotMaterialize.pin({ gitdir: state.gitdir, git, fs }, hash))) return
+                const alt = path.join(state.gitdir, "objects", "info", "alternates")
+                if (yield* exists(alt)) yield* materialize()
+                // kilocode_change end
                 log.info("tracking", { hash, cwd: state.directory, git: state.gitdir })
                 return hash
               }),
@@ -769,6 +839,8 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | AppProce
             )
           })
 
+          yield* materialize() // kilocode_change - resume interrupted snapshot object materialization
+
           yield* cleanup().pipe(
             Effect.catchCause((cause) => {
               log.error("cleanup loop failed", { cause: Cause.pretty(cause) })
@@ -849,6 +921,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(AppProcess.defaultLayer),
   Layer.provide(AppFileSystem.defaultLayer),
   Layer.provide(Config.defaultLayer),
+  Layer.provide(EffectFlock.defaultLayer), // kilocode_change
 )
 
 export * as Snapshot from "."

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -181,14 +181,18 @@ export const layer: Layer.Layer<Service, never, Requirements> =
 
           const stage = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) { // kilocode_change
             if (!files.length) return
-            const result = yield* git(
-              [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
-              {
-                cwd: state.directory,
-                env, // kilocode_change
-                stdin: feed(files),
-              },
-            )
+            // kilocode_change start
+            // Seeded snapshots cover the worktree root, so a single pathspec avoids
+            // quadratic matching against every tracked path in very large repositories.
+            const cmd = env
+              ? ["add", "--all", "--sparse", "--", "."]
+              : ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"]
+            const result = yield* git([...cfg, ...args(cmd)], {
+              cwd: state.directory,
+              env,
+              stdin: env ? undefined : feed(files),
+            })
+            // kilocode_change end
             if (result.code === 0) return
             log.warn("failed to add snapshot files", {
               exitCode: result.code,

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -179,18 +179,24 @@ export const layer: Layer.Layer<Service, never, Requirements> =
             )
           })
 
-          const stage = Effect.fnUntraced(function* (files: string[], env?: Record<string, string>) { // kilocode_change
+          // kilocode_change start
+          const stage = Effect.fnUntraced(function* (
+            files: string[],
+            opts?: { env?: Record<string, string>; root?: boolean },
+          ) {
+          // kilocode_change end
             if (!files.length) return
             // kilocode_change start
-            // Seeded snapshots cover the worktree root, so a single pathspec avoids
+            // A new root snapshot covers the full worktree, so a single pathspec avoids
             // quadratic matching against every tracked path in very large repositories.
-            const cmd = env
+            const cmd = opts?.root
               ? ["add", "--all", "--sparse", "--", "."]
               : ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"]
+
             const result = yield* git([...cfg, ...args(cmd)], {
               cwd: state.directory,
-              env,
-              stdin: env ? undefined : feed(files),
+              env: opts?.env,
+              stdin: opts?.root ? undefined : feed(files),
             })
             // kilocode_change end
             if (result.code === 0) return
@@ -238,7 +244,7 @@ export const layer: Layer.Layer<Service, never, Requirements> =
             yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
           })
 
-          const add = Effect.fnUntraced(function* (env?: Record<string, string>) { // kilocode_change
+          const add = Effect.fnUntraced(function* (opts?: { env?: Record<string, string>; root?: boolean }) { // kilocode_change
             yield* sync()
             const [diff, other] = yield* Effect.all(
               [
@@ -303,7 +309,7 @@ export const layer: Layer.Layer<Service, never, Requirements> =
             // kilocode_change start - initial seeded writes stay protected by the source pin
             yield* stage(
               allow.filter((item) => !block.has(item)),
-              env,
+              opts,
             )
           })
 
@@ -376,7 +382,7 @@ export const layer: Layer.Layer<Service, never, Requirements> =
                       GIT_ALTERNATE_OBJECT_DIRECTORIES: path.join(seed.gitdir, "objects"),
                     }
                   : undefined
-                yield* add(env)
+                yield* add({ env, root: !existed && state.directory === state.worktree })
                 if (
                   seed &&
                   !(yield* KiloSnapshotMaterialize.localize({

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -36,7 +36,7 @@ export const FileDiff = Schema.Struct({
   additions: Schema.Finite,
   deletions: Schema.Finite,
   status: Schema.optional(Schema.Literals(["added", "deleted", "modified"])),
-// kilocode_change start
+  // kilocode_change start
 })
   .annotate({ identifier: "SnapshotFileDiff" })
   .pipe(withStatics((s) => ({ zod: zod(s) })))
@@ -89,7 +89,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Sn
 // kilocode_change start
 type Requirements = AppFileSystem.Service | AppProcess.Service | Config.Service | EffectFlock.Service
 export const layer: Layer.Layer<Service, never, Requirements> =
-// kilocode_change end
+  // kilocode_change end
   Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -304,14 +304,15 @@ export const layer: Layer.Layer<Service, never, Requirements> =
           })
 
           const materialize = Effect.fnUntraced(function* () {
-            yield* locked(
-              KiloSnapshotMaterialize.run({ gitdir: state.gitdir, git, fs }).pipe(
-                Effect.catchCause((cause) => {
-                  log.error("snapshot materialization failed", { cause: Cause.pretty(cause) })
-                  return Effect.void
-                }),
-              ),
-            ).pipe(Effect.forkDetach, Effect.asVoid)
+            yield* locked(KiloSnapshotMaterialize.run({ gitdir: state.gitdir, git, fs }).pipe(Effect.orDie)).pipe(
+              Effect.timeout("5 minutes"),
+              Effect.catchCause((cause) => {
+                log.error("snapshot materialization failed", { cause: Cause.pretty(cause) })
+                return Effect.void
+              }),
+              Effect.forkDetach,
+              Effect.asVoid,
+            )
           })
           // kilocode_change end
 
@@ -321,11 +322,7 @@ export const layer: Layer.Layer<Service, never, Requirements> =
                 if (!(yield* enabled())) return
                 if (!(yield* exists(state.gitdir))) return
                 // kilocode_change start - retain snapshots for the same seven-day window as object pruning
-                const pruned = yield* KiloSnapshotMaterialize.prune(
-                  { gitdir: state.gitdir, git, fs },
-                  Date.now() - retention,
-                )
-                if (!pruned) return
+                yield* KiloSnapshotMaterialize.prune({ gitdir: state.gitdir, git, fs }, Date.now() - retention)
                 // kilocode_change end
                 const result = yield* git(args(["gc", `--prune=${prune}`]), { cwd: state.directory })
                 if (result.code !== 0) {

--- a/packages/opencode/test/kilocode/snapshot-seed.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-seed.test.ts
@@ -126,6 +126,10 @@ test(
 
     expect(cold.value).toBeTruthy()
     expect(fast.value).toBe(cold.value)
+    const tree = await $`git --git-dir=${fast.gitdir} ls-tree -r --name-only ${fast.value!}`.text()
+    expect(tree).not.toContain("debug.log")
+    expect(tree).not.toContain("huge.bin")
+    expect(tree).not.toContain("tracked.log")
     await expect(fs.access(path.join(cold.gitdir, "objects", "info", "alternates"))).rejects.toThrow()
     const common = (await $`git rev-parse --path-format=absolute --git-common-dir`.cwd(seeded).text()).trim()
     expect(

--- a/packages/opencode/test/kilocode/snapshot-seed.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-seed.test.ts
@@ -14,7 +14,7 @@ import { disposeAllInstances, provideInstance, tmpdir } from "../fixture/fixture
 const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
 
 async function waitFor(check: () => Promise<boolean>, message: string) {
-  const deadline = Date.now() + 10_000
+  const deadline = Date.now() + 30_000
   while (Date.now() < deadline) {
     if (await check()) return
     await Bun.sleep(25)
@@ -28,14 +28,12 @@ function durable(snapshot: Snapshot.Interface) {
     const gitdir = path.join(Global.Path.data, "snapshot", Instance.project.id, Hash.fast(Instance.worktree))
     const alt = path.join(gitdir, "objects", "info", "alternates")
     yield* Effect.promise(() =>
-      waitFor(
-        () =>
-          fs.access(alt).then(
-            () => false,
-            () => true,
-          ),
-        "snapshot alternate was not removed after materialization",
-      ),
+      waitFor(async () => {
+        const pending = await Promise.all(
+          [alt, `${alt}.materializing`].map((file) => fs.access(file).then(() => true, () => false)),
+        )
+        return !pending.some(Boolean)
+      }, "snapshot alternate was not removed after materialization"),
     )
     return hash
   })

--- a/packages/opencode/test/kilocode/snapshot-seed.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-seed.test.ts
@@ -8,9 +8,38 @@ import { Hash } from "@opencode-ai/core/util/hash"
 import { Snapshot } from "../../src/snapshot"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
+import { KiloSnapshotMaterialize } from "../../src/kilocode/snapshot/materialize"
 import { disposeAllInstances, provideInstance, tmpdir } from "../fixture/fixture"
 
 const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
+
+async function waitFor(check: () => Promise<boolean>, message: string) {
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (await check()) return
+    await Bun.sleep(25)
+  }
+  throw new Error(message)
+}
+
+function durable(snapshot: Snapshot.Interface) {
+  return Effect.gen(function* () {
+    const hash = yield* snapshot.track()
+    const gitdir = path.join(Global.Path.data, "snapshot", Instance.project.id, Hash.fast(Instance.worktree))
+    const alt = path.join(gitdir, "objects", "info", "alternates")
+    yield* Effect.promise(() =>
+      waitFor(
+        () =>
+          fs.access(alt).then(
+            () => false,
+            () => true,
+          ),
+        "snapshot alternate was not removed after materialization",
+      ),
+    )
+    return hash
+  })
+}
 
 function run<A>(dir: string, body: (snapshot: Snapshot.Interface) => Effect.Effect<A>) {
   return Effect.runPromise(
@@ -33,6 +62,8 @@ async function setup(dir: string) {
   await Filesystem.write(path.join(dir, "deleted.txt"), "committed deleted\n")
   await Filesystem.write(path.join(dir, "tracked.log"), "tracked but ignored\n")
   await Filesystem.write(path.join(dir, "filtered.flt"), "committed filtered\n")
+  await Filesystem.write(path.join(dir, "assume.txt"), "committed assume\n")
+  await Filesystem.write(path.join(dir, "skip.txt"), "committed skip\n")
   await Filesystem.write(path.join(dir, "script.sh"), "#!/bin/sh\nexit 0\n")
   await Filesystem.write(path.join(dir, "huge.bin"), new Uint8Array(2 * 1024 * 1024 + 1))
   await Filesystem.write(path.join(dir, ".gitattributes"), "*.flt filter=snapshot-test\n")
@@ -47,9 +78,14 @@ async function dirty(dir: string) {
   await Filesystem.write(path.join(dir, "dirty.txt"), "user dirty\n")
   await Filesystem.write(path.join(dir, "staged.txt"), "user staged\n")
   await $`git add staged.txt`.cwd(dir).quiet()
+  await Filesystem.write(path.join(dir, "staged.txt"), "user unstaged over staged\n")
   await fs.rm(path.join(dir, "deleted.txt"))
   await Filesystem.write(path.join(dir, "untracked.txt"), "user untracked\n")
   await Filesystem.write(path.join(dir, "filtered.flt"), "user filtered\n")
+  await Filesystem.write(path.join(dir, "assume.txt"), "user hidden assume\n")
+  await Filesystem.write(path.join(dir, "skip.txt"), "user hidden skip\n")
+  await $`git update-index --assume-unchanged assume.txt`.cwd(dir).quiet()
+  await $`git update-index --skip-worktree skip.txt`.cwd(dir).quiet()
   await Filesystem.write(path.join(dir, "debug.log"), "ignored untracked\n")
   if (process.platform !== "win32") await fs.chmod(path.join(dir, "script.sh"), 0o755)
 }
@@ -59,7 +95,7 @@ afterEach(async () => {
 })
 
 test(
-  "Agent Manager cold seed matches full snapshot and preserves first-turn reset",
+  "regular cold seed matches full snapshot and preserves first-turn reset",
   async () => {
     await using source = await tmpdir({
       git: true,
@@ -68,33 +104,58 @@ test(
     await using root = await tmpdir()
     const seeded = path.join(root.path, "seeded")
     await $`git worktree add --quiet -b snapshot-seed-test ${seeded} HEAD`.cwd(source.path)
+    await $`git config extensions.worktreeConfig true`.cwd(source.path).quiet()
+    await $`git config --worktree core.sparseCheckout true`.cwd(source.path).quiet()
 
     await dirty(source.path)
     await dirty(seeded)
 
+    const index = (await $`git rev-parse --path-format=absolute --git-path index`.cwd(seeded).text()).trim()
+    const original = await fs.readFile(index)
     const cold = await run(source.path, (snapshot) => snapshot.track())
-    const fast = await run(seeded, (snapshot) => snapshot.track({ snapshotInitialization: "wait" }))
+    const fast = await run(seeded, durable)
 
     expect(cold.value).toBeTruthy()
     expect(fast.value).toBe(cold.value)
     await expect(fs.access(path.join(cold.gitdir, "objects", "info", "alternates"))).rejects.toThrow()
     const common = (await $`git rev-parse --path-format=absolute --git-common-dir`.cwd(seeded).text()).trim()
-    expect((await fs.readFile(path.join(fast.gitdir, "objects", "info", "alternates"), "utf8")).trim()).toBe(
-      path.join(common, "objects"),
-    )
+    expect(
+      (
+        await $`git --git-dir=${common} rev-parse --verify --quiet ${KiloSnapshotMaterialize.ref(fast.gitdir)}`
+          .nothrow()
+          .text()
+      ).trim(),
+    ).toBe("")
+    const dirtyHash = (await $`git hash-object untracked.txt`.cwd(seeded).text()).trim()
+    expect((await $`git --git-dir=${common} cat-file -e ${dirtyHash}`.nothrow()).exitCode).not.toBe(0)
+    expect(await fs.readFile(index)).toEqual(original)
+    expect((await $`git stash create`.cwd(seeded).text()).trim()).toBeTruthy()
 
     expect((await run(seeded, (snapshot) => snapshot.patch(fast.value!))).value.files).toEqual([])
 
     await Filesystem.write(path.join(seeded, "dirty.txt"), "assistant dirty\n")
+    await Filesystem.write(path.join(seeded, "staged.txt"), "assistant staged\n")
+    await Filesystem.write(path.join(seeded, "assume.txt"), "assistant assume\n")
+    await Filesystem.write(path.join(seeded, "skip.txt"), "assistant skip\n")
     await Filesystem.write(path.join(seeded, "untracked.txt"), "assistant untracked\n")
     await Filesystem.write(path.join(seeded, "created.txt"), "assistant created\n")
     const patch = (await run(seeded, (snapshot) => snapshot.patch(fast.value!))).value
     expect(patch.files).toEqual(
-      expect.arrayContaining([fwd(seeded, "dirty.txt"), fwd(seeded, "untracked.txt"), fwd(seeded, "created.txt")]),
+      expect.arrayContaining([
+        fwd(seeded, "dirty.txt"),
+        fwd(seeded, "staged.txt"),
+        fwd(seeded, "assume.txt"),
+        fwd(seeded, "skip.txt"),
+        fwd(seeded, "untracked.txt"),
+        fwd(seeded, "created.txt"),
+      ]),
     )
 
     await run(seeded, (snapshot) => snapshot.revert([patch]))
     expect(await fs.readFile(path.join(seeded, "dirty.txt"), "utf8")).toBe("user dirty\n")
+    expect(await fs.readFile(path.join(seeded, "staged.txt"), "utf8")).toBe("user unstaged over staged\n")
+    expect(await fs.readFile(path.join(seeded, "assume.txt"), "utf8")).toBe("user hidden assume\n")
+    expect(await fs.readFile(path.join(seeded, "skip.txt"), "utf8")).toBe("user hidden skip\n")
     expect(await fs.readFile(path.join(seeded, "untracked.txt"), "utf8")).toBe("user untracked\n")
     await expect(fs.access(path.join(seeded, "created.txt"))).rejects.toThrow()
     await expect(fs.access(path.join(seeded, "deleted.txt"))).rejects.toThrow()
@@ -102,18 +163,154 @@ test(
   { timeout: 15_000 },
 )
 
-test("Agent Manager seed falls back for sparse checkouts", async () => {
+test("regular seed preserves aged line endings and filtered worktree bytes", async () => {
+  await using source = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await $`git config core.autocrlf true`.cwd(dir).quiet()
+      await $`git config filter.snapshot-bytes.clean "tr a-z A-Z"`.cwd(dir).quiet()
+      await $`git config filter.snapshot-bytes.smudge "tr A-Z a-z"`.cwd(dir).quiet()
+      await $`git config filter.snapshot-bytes.required true`.cwd(dir).quiet()
+      await Filesystem.write(path.join(dir, ".gitattributes"), "crlf.txt text\nfiltered.flt filter=snapshot-bytes\n")
+      await Filesystem.write(path.join(dir, "crlf.txt"), "one\r\ntwo\r\n")
+      await Filesystem.write(path.join(dir, "filtered.flt"), "lower worktree\n")
+      await $`git add .`.cwd(dir).quiet()
+      await $`git commit -m bytes`.cwd(dir).quiet()
+    },
+  })
+  await using root = await tmpdir()
+  const seeded = path.join(root.path, "seeded-bytes")
+  await $`git worktree add --quiet -b snapshot-seed-bytes ${seeded} HEAD`.cwd(source.path)
+  await $`git config extensions.worktreeConfig true`.cwd(source.path).quiet()
+  await $`git config --worktree core.sparseCheckout true`.cwd(source.path).quiet()
+
+  const attrs = Buffer.from("crlf.txt text\nfiltered.flt filter=snapshot-bytes\n")
+  const crlf = Buffer.from("one\r\ntwo\r\n")
+  const filtered = Buffer.from("lower worktree\n")
+  const age = new Date(Date.now() - 10_000)
+  for (const dir of [source.path, seeded]) {
+    await fs.writeFile(path.join(dir, ".gitattributes"), attrs)
+    await fs.writeFile(path.join(dir, "crlf.txt"), crlf)
+    await fs.writeFile(path.join(dir, "filtered.flt"), filtered)
+    await fs.utimes(path.join(dir, ".gitattributes"), age, age)
+    await fs.utimes(path.join(dir, "crlf.txt"), age, age)
+    await fs.utimes(path.join(dir, "filtered.flt"), age, age)
+    await $`git add .gitattributes crlf.txt filtered.flt`.cwd(dir).quiet()
+    await $`git diff --cached --quiet HEAD`.cwd(dir).quiet()
+  }
+
+  const cold = await run(source.path, (snapshot) => snapshot.track())
+  const fast = await run(seeded, (snapshot) => snapshot.track())
+  expect(fast.value).toBe(cold.value)
+
+  for (const dir of [source.path, seeded]) {
+    await Filesystem.write(path.join(dir, "crlf.txt"), "assistant\n")
+    await Filesystem.write(path.join(dir, "filtered.flt"), "assistant\n")
+  }
+  const coldPatch = (await run(source.path, (snapshot) => snapshot.patch(cold.value!))).value
+  const fastPatch = (await run(seeded, (snapshot) => snapshot.patch(fast.value!))).value
+  await run(source.path, (snapshot) => snapshot.revert([coldPatch]))
+  await run(seeded, (snapshot) => snapshot.revert([fastPatch]))
+  expect(await fs.readFile(path.join(seeded, "crlf.txt"))).toEqual(
+    await fs.readFile(path.join(source.path, "crlf.txt")),
+  )
+  expect(await fs.readFile(path.join(seeded, "filtered.flt"))).toEqual(
+    await fs.readFile(path.join(source.path, "filtered.flt")),
+  )
+})
+
+test(
+  "regular primary checkout materializes a durable split-index snapshot",
+  async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: setup,
+    })
+    await dirty(tmp.path)
+    await $`git update-index --split-index`.cwd(tmp.path).quiet()
+    const index = (await $`git rev-parse --path-format=absolute --git-path index`.cwd(tmp.path).text()).trim()
+    const original = await fs.readFile(index)
+
+    const result = await run(tmp.path, durable)
+    expect(result.value).toBeTruthy()
+    const common = (await $`git rev-parse --path-format=absolute --git-common-dir`.cwd(tmp.path).text()).trim()
+    const alt = path.join(result.gitdir, "objects", "info", "alternates")
+    expect(await fs.readFile(index)).toEqual(original)
+
+    await fs.writeFile(alt, `${path.join(common, "objects")}\n`)
+    await fs.rename(alt, `${alt}.materializing`)
+    const sourceRef = KiloSnapshotMaterialize.ref(result.gitdir)
+    const sourceHash = (await $`git write-tree`.cwd(tmp.path).text()).trim()
+    await $`git --git-dir=${common} update-ref ${sourceRef} ${sourceHash}`.quiet()
+    await disposeAllInstances()
+    await run(tmp.path, (snapshot) =>
+      Effect.gen(function* () {
+        yield* snapshot.init()
+        yield* Effect.promise(() =>
+          waitFor(async () => {
+            const pending = await Promise.all(
+              [alt, `${alt}.materializing`].map((file) =>
+                fs.access(file).then(
+                  () => true,
+                  () => false,
+                ),
+              ),
+            )
+            const pinned = (
+              await $`git --git-dir=${common} rev-parse --verify --quiet ${sourceRef}`.nothrow().text()
+            ).trim()
+            return !pending.some(Boolean) && !pinned
+          }, "interrupted snapshot materialization did not resume"),
+        )
+      }),
+    )
+    expect((await $`git --git-dir=${common} rev-parse --verify --quiet ${sourceRef}`.nothrow().text()).trim()).toBe("")
+    expect((await run(tmp.path, (snapshot) => snapshot.patch(result.value!))).value.files).toEqual([])
+
+    const expired = `refs/kilo/snapshots/1/${result.value!}`
+    await $`git --git-dir=${result.gitdir} update-ref ${expired} ${result.value!}`.quiet()
+    await run(tmp.path, (snapshot) => snapshot.cleanup())
+    expect(
+      (await $`git --git-dir=${result.gitdir} rev-parse --verify --quiet ${expired}`.nothrow().text()).trim(),
+    ).toBe("")
+    expect((await $`git --git-dir=${result.gitdir} for-each-ref refs/kilo/snapshots`.text()).trim()).toContain(
+      result.value!,
+    )
+
+    await $`git --git-dir=${result.gitdir} gc --prune=now`.quiet()
+    const objects = path.join(common, "objects")
+    const hidden = path.join(common, "objects.hidden")
+    await fs.rename(objects, hidden)
+    try {
+      await $`git --git-dir=${result.gitdir} fsck --connectivity-only --no-dangling --no-reflogs`.quiet()
+      await $`git --git-dir=${result.gitdir} cat-file -e ${result.value!}^{tree}`.quiet()
+    } finally {
+      await fs.rename(hidden, objects)
+    }
+  },
+  { timeout: 15_000 },
+)
+
+test("regular seed falls back for sparse checkouts", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      await Filesystem.write(path.join(dir, "tracked.txt"), "tracked\n")
-      await $`git add tracked.txt`.cwd(dir).quiet()
+      await Filesystem.write(path.join(dir, "inside/tracked.txt"), "tracked\n")
+      await Filesystem.write(path.join(dir, "outside/tracked.txt"), "outside\n")
+      await $`git add .`.cwd(dir).quiet()
       await $`git commit -m tracked`.cwd(dir).quiet()
-      await $`git config core.sparseCheckout true`.cwd(dir).quiet()
+      await $`git sparse-checkout set --cone --sparse-index inside`.cwd(dir).quiet()
     },
   })
 
-  const result = await run(tmp.path, (snapshot) => snapshot.track({ snapshotInitialization: "wait" }))
+  const result = await run(tmp.path, (snapshot) => snapshot.track())
   expect(result.value).toBeTruthy()
   await expect(fs.access(path.join(result.gitdir, "objects", "info", "alternates"))).rejects.toThrow()
+
+  const file = path.join(tmp.path, "inside/tracked.txt")
+  await Filesystem.write(file, "assistant change\n")
+  const patch = (await run(tmp.path, (snapshot) => snapshot.patch(result.value!))).value
+  expect(patch.files).toEqual([fwd(file)])
+  await run(tmp.path, (snapshot) => snapshot.revert([patch]))
+  expect(await fs.readFile(file, "utf8")).toBe("tracked\n")
 })

--- a/packages/opencode/test/kilocode/snapshot-seed.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-seed.test.ts
@@ -30,7 +30,12 @@ function durable(snapshot: Snapshot.Interface) {
     yield* Effect.promise(() =>
       waitFor(async () => {
         const pending = await Promise.all(
-          [alt, `${alt}.materializing`].map((file) => fs.access(file).then(() => true, () => false)),
+          [alt, `${alt}.materializing`].map((file) =>
+            fs.access(file).then(
+              () => true,
+              () => false,
+            ),
+          ),
         )
         return !pending.some(Boolean)
       }, "snapshot alternate was not removed after materialization"),
@@ -126,6 +131,8 @@ test(
     ).toBe("")
     const dirtyHash = (await $`git hash-object untracked.txt`.cwd(seeded).text()).trim()
     expect((await $`git --git-dir=${common} cat-file -e ${dirtyHash}`.nothrow()).exitCode).not.toBe(0)
+    expect((await $`git --git-dir=${fast.gitdir} cat-file -e ${dirtyHash}`.nothrow()).exitCode).toBe(0)
+    await expect(fs.access(path.join(fast.gitdir, "seed-objects"))).rejects.toThrow()
     expect(await fs.readFile(index)).toEqual(original)
     expect((await $`git stash create`.cwd(seeded).text()).trim()).toBeTruthy()
 
@@ -275,6 +282,24 @@ test(
       result.value!,
     )
 
+    const locked = `refs/kilo/snapshots/2/${result.value!}`
+    await $`git --git-dir=${result.gitdir} update-ref ${locked} ${result.value!}`.quiet()
+    const lock = path.join(result.gitdir, `${locked}.lock`)
+    await Filesystem.write(lock, "")
+    const orphanFile = path.join(tmp.path, "orphan.txt")
+    await Filesystem.write(orphanFile, "old orphan\n")
+    const orphan = (await $`git --git-dir=${result.gitdir} hash-object -w ${orphanFile}`.text()).trim()
+    const loose = path.join(result.gitdir, "objects", orphan.slice(0, 2), orphan.slice(2))
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)
+    await fs.utimes(loose, old, old)
+    try {
+      await run(tmp.path, (snapshot) => snapshot.cleanup())
+      expect((await $`git --git-dir=${result.gitdir} rev-parse --verify ${locked}`.text()).trim()).toBe(result.value!)
+      expect((await $`git --git-dir=${result.gitdir} cat-file -e ${orphan}`.nothrow()).exitCode).not.toBe(0)
+    } finally {
+      await fs.rm(lock)
+    }
+
     await $`git --git-dir=${result.gitdir} gc --prune=now`.quiet()
     const objects = path.join(common, "objects")
     const hidden = path.join(common, "objects.hidden")
@@ -286,7 +311,7 @@ test(
       await fs.rename(hidden, objects)
     }
   },
-  { timeout: 15_000 },
+  { timeout: 30_000 },
 )
 
 test("regular seed falls back for sparse checkouts", async () => {

--- a/packages/opencode/test/kilocode/snapshot-seed.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-seed.test.ts
@@ -2,13 +2,17 @@ import { afterEach, expect, test } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { Global } from "@opencode-ai/core/global"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { AppProcess } from "@opencode-ai/core/process"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { Snapshot } from "../../src/snapshot"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
 import { KiloSnapshotMaterialize } from "../../src/kilocode/snapshot/materialize"
+import { KiloSnapshotSeed } from "../../src/kilocode/snapshot/seed"
 import { disposeAllInstances, provideInstance, tmpdir } from "../fixture/fixture"
 
 const fwd = (...parts: string[]) => path.join(...parts).replaceAll("\\", "/")
@@ -43,6 +47,8 @@ function durable(snapshot: Snapshot.Interface) {
     return hash
   })
 }
+
+const infra = Layer.mergeAll(AppProcess.defaultLayer, AppFileSystem.defaultLayer)
 
 function run<A>(dir: string, body: (snapshot: Snapshot.Interface) => Effect.Effect<A>) {
   return Effect.runPromise(
@@ -165,7 +171,7 @@ test(
     await expect(fs.access(path.join(seeded, "created.txt"))).rejects.toThrow()
     await expect(fs.access(path.join(seeded, "deleted.txt"))).rejects.toThrow()
   },
-  { timeout: 15_000 },
+  { timeout: 35_000 },
 )
 
 test("regular seed preserves aged line endings and filtered worktree bytes", async () => {
@@ -311,8 +317,134 @@ test(
       await fs.rename(hidden, objects)
     }
   },
-  { timeout: 30_000 },
+  { timeout: 35_000 },
 )
+
+test("interrupted seed removes borrowed state after source gc", async () => {
+  await using source = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Filesystem.write(path.join(dir, "tracked.txt"), "tracked\n")
+      await $`git add tracked.txt`.cwd(dir).quiet()
+      await $`git commit -m tracked`.cwd(dir).quiet()
+    },
+  })
+  await using root = await tmpdir()
+  const gitdir = path.join(root.path, "snapshot.git")
+  await $`git init --bare ${gitdir}`.quiet()
+  const index = (await $`git rev-parse --path-format=absolute --git-path index`.cwd(source.path).text()).trim()
+  const original = await fs.readFile(index)
+  const ref = KiloSnapshotMaterialize.ref(gitdir)
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const process = yield* AppProcess.Service
+      const fsys = yield* AppFileSystem.Service
+      const reached = yield* Deferred.make<void>()
+      const raw = (cmd: string[], opts?: { cwd?: string; env?: Record<string, string>; stdin?: string }) =>
+        process
+          .run(ChildProcess.make("git", cmd, { cwd: opts?.cwd, env: opts?.env, extendEnv: true }), {
+            stdin: opts?.stdin,
+          })
+          .pipe(
+            Effect.map((result) => ({
+              code: ChildProcessSpawner.ExitCode(result.exitCode),
+              text: result.stdout.toString("utf8"),
+              stderr: result.stderr.toString("utf8"),
+            })),
+            Effect.catch((err) =>
+              Effect.succeed({
+                code: ChildProcessSpawner.ExitCode(1),
+                text: "",
+                stderr: String(err),
+              }),
+            ),
+          )
+      const git = (cmd: string[], opts?: { cwd?: string; env?: Record<string, string>; stdin?: string }) => {
+        const read = cmd[1] === gitdir && cmd.includes("read-tree") && cmd.at(-1) !== "--empty"
+        if (read) return Deferred.succeed(reached, undefined).pipe(Effect.andThen(Effect.never))
+        return raw(cmd, opts)
+      }
+      const fiber = yield* KiloSnapshotSeed.seed({
+        dir: source.path,
+        worktree: source.path,
+        gitdir,
+        limit: 2 * 1024 * 1024,
+        git,
+        fs: fsys,
+      }).pipe(Effect.forkChild)
+      yield* Deferred.await(reached)
+
+      const hash = yield* Effect.promise(() => $`git --git-dir=${source.path}/.git rev-parse ${ref}`.text())
+      yield* Effect.promise(() => $`git gc --prune=now`.cwd(source.path).quiet())
+      yield* Effect.promise(() => $`git --git-dir=${source.path}/.git cat-file -e ${hash.trim()}^{tree}`.quiet())
+      yield* Fiber.interrupt(fiber)
+    }).pipe(Effect.provide(infra)),
+  )
+
+  expect(await fs.readFile(index)).toEqual(original)
+  expect((await $`git --git-dir=${source.path}/.git rev-parse --verify --quiet ${ref}`.nothrow().text()).trim()).toBe(
+    "",
+  )
+  for (const file of [
+    path.join(gitdir, "seed.index"),
+    path.join(gitdir, "seed.index.lock"),
+    path.join(gitdir, "objects", "info", "alternates"),
+    path.join(gitdir, "objects", "info", "alternates.seed"),
+    path.join(gitdir, "seed-objects"),
+  ]) {
+    await expect(fs.access(file)).rejects.toThrow()
+  }
+})
+
+test("regular seed falls back for subdirectory sessions", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Filesystem.write(path.join(dir, "root.txt"), "root\n")
+      await Filesystem.write(path.join(dir, "nested/tracked.txt"), "nested\n")
+      await $`git add .`.cwd(dir).quiet()
+      await $`git commit -m tracked`.cwd(dir).quiet()
+    },
+  })
+  const dir = path.join(tmp.path, "nested")
+  const result = await run(dir, (snapshot) => snapshot.track())
+  expect(result.value).toBeTruthy()
+  await expect(fs.access(path.join(result.gitdir, "objects", "info", "alternates"))).rejects.toThrow()
+  expect((await run(dir, (snapshot) => snapshot.patch(result.value!))).value.files).toEqual([])
+})
+
+test("regular seed falls back for unmerged indexes", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Filesystem.write(path.join(dir, "conflict.txt"), "base\n")
+      await $`git add conflict.txt`.cwd(dir).quiet()
+      await $`git commit -m base`.cwd(dir).quiet()
+      await $`git checkout -b other`.cwd(dir).quiet()
+      await Filesystem.write(path.join(dir, "conflict.txt"), "other\n")
+      await $`git commit -am other`.cwd(dir).quiet()
+      await $`git checkout -`.cwd(dir).quiet()
+      await Filesystem.write(path.join(dir, "conflict.txt"), "current\n")
+      await $`git commit -am current`.cwd(dir).quiet()
+      await $`git merge other`.cwd(dir).nothrow().quiet()
+    },
+  })
+  const before = await $`git ls-files --unmerged`.cwd(tmp.path).text()
+  expect(before).not.toBe("")
+
+  const result = await run(tmp.path, (snapshot) => snapshot.track())
+  expect(result.value).toBeTruthy()
+  await expect(fs.access(path.join(result.gitdir, "objects", "info", "alternates"))).rejects.toThrow()
+  expect(await $`git ls-files --unmerged`.cwd(tmp.path).text()).toBe(before)
+
+  const file = path.join(tmp.path, "conflict.txt")
+  const baseline = await fs.readFile(file, "utf8")
+  await Filesystem.write(file, "assistant\n")
+  const patch = (await run(tmp.path, (snapshot) => snapshot.patch(result.value!))).value
+  await run(tmp.path, (snapshot) => snapshot.revert([patch]))
+  expect(await fs.readFile(file, "utf8")).toBe(baseline)
+})
 
 test("regular seed falls back for sparse checkouts", async () => {
   await using tmp = await tmpdir({


### PR DESCRIPTION
Cold snapshot initialization for regular CLI and extension sessions scans the entire checkout, while the existing Agent Manager-only seeded path leaves snapshots dependent on the source repository's object database. That combination makes the first turn unnecessarily slow and prevents index seeding from safely becoming the default.

This change enables Git index seeding for every eligible new root snapshot repository. It normalizes a private index copy, reconciles the actual working tree, and preserves staged, unstaged, deleted, untracked, filtered, mode, and index-flag state without mutating the user's index. Unsupported layouts continue through the existing cold initialization path.

Returned snapshot trees are protected against source garbage collection before the first turn continues. Dirty blobs and final tree objects are localized immediately, then a serialized background job repacks the complete reachable graph into snapshot-owned storage, verifies connectivity without alternates, and removes the temporary source pin. Interrupted jobs resume from their on-disk state, and timestamped snapshot refs retain history for the existing seven-day cleanup window.

Closes #11069. The broader subdirectory and sparse-checkout expansion remains tracked by #11070.