### PR TITLE
fix(gateway): support Friendli JSON schemas

### DIFF
--- a/.changeset/fix-friendli-json-schemas.md
+++ b/.changeset/fix-friendli-json-schemas.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": patch
+---
+
+Support JSON schemas with `oneOf` when routing chat completions through Friendli.

--- a/packages/kilo-gateway/src/chat-completions.ts
+++ b/packages/kilo-gateway/src/chat-completions.ts
@@ -1,0 +1,47 @@
+function record(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input)
+}
+
+function endpoint(input: string | URL | Request) {
+  const raw = input instanceof Request ? input.url : input.toString()
+  const path = (() => {
+    try {
+      return new URL(raw).pathname
+    } catch {
+      return raw.split(/[?#]/, 1)[0]
+    }
+  })()
+  return path.endsWith("/chat/completions")
+}
+
+function rewrite(input: unknown): number {
+  if (Array.isArray(input)) return input.reduce((count, item) => count + rewrite(item), 0)
+  if (!record(input)) return 0
+
+  const count = Object.values(input).reduce((total, value) => total + rewrite(value), 0)
+  if (!("oneOf" in input)) return count
+
+  const value = input.oneOf
+  delete input.oneOf
+  input.anyOf = value
+  return count + 1
+}
+
+export function sanitizeChatCompletionsBody(input: string | URL | Request, body: BodyInit | null | undefined) {
+  if (!endpoint(input)) return body
+  if (typeof body !== "string") return body
+
+  const data = (() => {
+    try {
+      return JSON.parse(body) as unknown
+    } catch {
+      return undefined
+    }
+  })()
+  if (!record(data)) return body
+  if (!record(data.provider)) return body
+  if (!Array.isArray(data.provider.order)) return body
+  if (!data.provider.order.some((item) => typeof item === "string" && item.toLowerCase() === "friendli")) return body
+  if (rewrite(data) === 0) return body
+  return JSON.stringify(data)
+}

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -10,6 +10,7 @@ import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
 import { ANONYMOUS_API_KEY } from "./api/constants.js"
 import { resolveKiloOpenRouterBaseUrl } from "./api/url.js"
 import { sanitizeResponsesBody } from "./responses.js"
+import { sanitizeChatCompletionsBody } from "./chat-completions.js"
 
 export function buildRequestHeaders(defaultHeaders: Record<string, string>, requestHeaders?: HeadersInit): Headers {
   const headers = new Headers(defaultHeaders)
@@ -55,7 +56,8 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const originalFetch = options.fetch ?? fetch
   const wrappedFetch = async (input: string | URL | Request, init?: RequestInit) => {
     const headers = buildRequestHeaders(customHeaders, init?.headers)
-    const body = sanitizeResponsesBody(input, init?.body)
+    const chat = sanitizeChatCompletionsBody(input, init?.body)
+    const body = sanitizeResponsesBody(input, chat)
 
     // Add authorization if API key exists
     if (apiKey) {

--- a/packages/kilo-gateway/test/chat-completions.test.ts
+++ b/packages/kilo-gateway/test/chat-completions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizeChatCompletionsBody } from "../src/chat-completions"
+
+describe("Chat completions request sanitization", () => {
+  test("rewrites nested oneOf schemas when Friendli is ordered", () => {
+    const body = JSON.stringify({
+      provider: { order: ["Anthropic", "Friendli"] },
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "weather",
+            parameters: {
+              type: "object",
+              properties: {
+                location: {
+                  oneOf: [
+                    { type: "string" },
+                    {
+                      type: "object",
+                      properties: { coordinates: { oneOf: [{ type: "string" }, { type: "array" }] } },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: { schema: { oneOf: [{ type: "string" }, { type: "number" }] } },
+      },
+    })
+
+    const result = sanitizeChatCompletionsBody("https://api.kilo.ai/api/openrouter/chat/completions", body)
+    const data = JSON.parse(result as string)
+
+    expect(JSON.stringify(data)).not.toContain('"oneOf"')
+    expect(data.tools[0].function.parameters.properties.location.anyOf).toHaveLength(2)
+    expect(data.tools[0].function.parameters.properties.location.anyOf[1].properties.coordinates.anyOf).toHaveLength(2)
+    expect(data.response_format.json_schema.schema.anyOf).toHaveLength(2)
+  })
+
+  test("matches Friendli case-insensitively", () => {
+    const body = JSON.stringify({
+      provider: { order: ["friendli"] },
+      tools: [{ function: { parameters: { oneOf: [{ type: "string" }] } } }],
+    })
+    const result = sanitizeChatCompletionsBody("/api/openrouter/chat/completions?stream=true", body)
+    const data = JSON.parse(result as string)
+
+    expect(data.tools[0].function.parameters.oneOf).toBeUndefined()
+    expect(data.tools[0].function.parameters.anyOf).toHaveLength(1)
+  })
+
+  test("leaves schemas unchanged when Friendli is not ordered", () => {
+    const body = JSON.stringify({
+      provider: { order: ["Anthropic"] },
+      tools: [{ function: { parameters: { oneOf: [{ type: "string" }] } } }],
+    })
+
+    expect(sanitizeChatCompletionsBody("https://api.kilo.ai/api/openrouter/chat/completions", body)).toBe(body)
+  })
+
+  test("leaves non-chat requests unchanged", () => {
+    const body = JSON.stringify({ provider: { order: ["Friendli"] }, schema: { oneOf: [] } })
+
+    expect(sanitizeChatCompletionsBody("https://api.kilo.ai/api/openrouter/responses", body)).toBe(body)
+  })
+
+  test("leaves invalid JSON unchanged", () => {
+    const body = "not json"
+
+    expect(sanitizeChatCompletionsBody("https://api.kilo.ai/api/openrouter/chat/completions", body)).toBe(body)
+  })
+})


### PR DESCRIPTION
## Summary

Rewrite `oneOf` schema keywords to `anyOf` in serialized chat completions requests when Friendli appears in `provider.order`. This keeps tool and structured-output schemas compatible with Friendli while leaving other providers and endpoints unchanged.