### PR TITLE
feat: support subagent reasoning overrides

### DIFF
--- a/.changeset/bright-subagents-reason.md
+++ b/.changeset/bright-subagents-reason.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Support model-specific reasoning overrides for task subagents, including custom subagents with their own model and variant settings.

--- a/packages/kilo-vscode/tests/unit/settings-io.test.ts
+++ b/packages/kilo-vscode/tests/unit/settings-io.test.ts
@@ -168,12 +168,23 @@ describe("parseImport", () => {
   })
 
   it("preserves task subagent model and variant settings", () => {
-    const json = JSON.stringify({ subagent_model: "anthropic/claude-sonnet-4", subagent_variant: "high" })
+    const json = JSON.stringify({
+      subagent_model: "anthropic/claude-sonnet-4",
+      subagent_variant: "high",
+      subagent_variant_overrides: {
+        "anthropic/claude-sonnet-4": "max",
+        "openai/gpt-5": "xhigh",
+      },
+    })
     const result = parseImport(json)
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.config.subagent_model).toBe("anthropic/claude-sonnet-4")
       expect(result.config.subagent_variant).toBe("high")
+      expect(result.config.subagent_variant_overrides).toEqual({
+        "anthropic/claude-sonnet-4": "max",
+        "openai/gpt-5": "xhigh",
+      })
     }
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -1,4 +1,4 @@
-import { Component, For, createMemo } from "solid-js"
+import { Component, For, Show, createMemo } from "solid-js"
 import { Card } from "@kilocode/kilo-ui/card"
 import { useConfig } from "../../context/config"
 import { useLanguage } from "../../context/language"
@@ -36,15 +36,14 @@ const ModelsTab: Component = () => {
   }
 
   const subagentModel = createMemo(() => parseModelString(config().subagent_model ?? undefined))
-  const subagentVariants = createMemo(() => {
-    const model = provider.findModel(subagentModel())
-    return model?.variants ? Object.keys(model.variants) : []
-  })
+  const variantKey = createMemo(() => config().subagent_model ?? undefined)
+  const subagentVariants = createMemo(() => Object.keys(provider.findModel(subagentModel())?.variants ?? {}))
   const subagentVariant = createMemo(() => {
-    const list = subagentVariants()
-    if (list.length === 0) return undefined
-    const value = config().subagent_variant ?? undefined
-    return value && list.includes(value) ? value : undefined
+    const key = variantKey()
+    if (!key) return undefined
+    const value = config().subagent_variant_overrides?.[key]
+    if (value) return value
+    return config().subagent_model === key ? (config().subagent_variant ?? undefined) : undefined
   })
 
   function handleSubagentModelSelect(providerID: string, modelID: string) {
@@ -52,16 +51,20 @@ const ModelsTab: Component = () => {
       updateConfig({ subagent_model: null, subagent_variant: null })
       return
     }
-    const model = { providerID, modelID }
-    const variants = provider.findModel(model)?.variants
-    const list = variants ? Object.keys(variants) : []
-    const value = config().subagent_model === `${providerID}/${modelID}` ? config().subagent_variant : undefined
-    const variant = value && list.includes(value) ? value : list[0]
-    updateConfig({ subagent_model: `${providerID}/${modelID}`, subagent_variant: variant ?? null })
+    const value = `${providerID}/${modelID}`
+    updateConfig({
+      subagent_model: value,
+      ...(config().subagent_model === value ? {} : { subagent_variant: null }),
+    })
   }
 
-  function handleSubagentVariantSelect(value: string) {
-    updateConfig({ subagent_variant: value })
+  function updateSubagentVariant(value: string | null) {
+    const key = variantKey()
+    if (!key) return
+    updateConfig({
+      subagent_variant_overrides: { [key]: value },
+      ...(config().subagent_model === key ? { subagent_variant: null } : {}),
+    })
   }
 
   const allAgents = createMemo(() => session.agents())
@@ -124,7 +127,7 @@ const ModelsTab: Component = () => {
           title={language.t("settings.providers.subagentModel.title")}
           description={language.t("settings.providers.subagentModel.description")}
         >
-          <div style={{ display: "flex", "align-items": "center", gap: "8px", "flex-wrap": "wrap" }}>
+          <div style={{ display: "flex", "flex-direction": "column", "align-items": "flex-end", gap: "8px" }}>
             <ModelSelectorBase
               value={subagentModel()}
               onSelect={handleSubagentModelSelect}
@@ -134,12 +137,18 @@ const ModelsTab: Component = () => {
               label={language.t("settings.providers.subagentModel.title")}
               description={language.t("settings.providers.subagentModel.description")}
             />
-            <ThinkingSelectorBase
-              variants={subagentVariants()}
-              value={subagentVariant()}
-              onSelect={handleSubagentVariantSelect}
-              placement="bottom-start"
-            />
+            <Show when={subagentVariants().length > 0}>
+              <ThinkingSelectorBase
+                variants={subagentVariants()}
+                value={subagentVariant()}
+                onSelect={(value) => updateSubagentVariant(value)}
+                onClear={() => updateSubagentVariant(null)}
+                allowClear
+                clearLabel={language.t("settings.providers.notSet")}
+                placement="bottom-start"
+                globalTrigger={false}
+              />
+            </Show>
           </div>
         </SettingsRow>
         <SettingsRow

--- a/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
@@ -14,6 +14,7 @@ export const KNOWN_KEYS: ReadonlyArray<string> = [
   "small_model",
   "subagent_model",
   "subagent_variant",
+  "subagent_variant_overrides",
   "default_agent",
   "agent",
   "provider",

--- a/packages/kilo-vscode/webview-ui/src/styles/settings.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/settings.css
@@ -107,6 +107,11 @@
     & > * {
       max-width: 100%;
     }
+
+    [data-slot="popover-trigger"] {
+      min-width: 0;
+      max-width: 100%;
+    }
   }
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -116,6 +116,7 @@ export interface Config {
   small_model?: string | null
   subagent_model?: string | null
   subagent_variant?: string | null
+  subagent_variant_overrides?: Record<string, string | null> | null
   default_agent?: string | null
   agent?: Record<string, AgentConfig>
   provider?: Record<string, ProviderConfig>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -237,6 +237,12 @@ export const Info = Schema.Struct({
   subagent_variant: Schema.optional(Schema.NullOr(Schema.String)).annotate({
     description: "Default model variant for task-tool subagents when subagent_model is configured.",
   }),
+  subagent_variant_overrides: Schema.optional(
+    Schema.NullOr(Schema.Record(Schema.String, Schema.NullOr(Schema.String))),
+  ).annotate({
+    description:
+      "Model-specific variant overrides for task-tool subagents, keyed by provider/model. Valid overrides take precedence over saved, agent-specific, and inherited variants.",
+  }),
   default_agent: Schema.optional(Schema.NullOr(Schema.String)).annotate({
     description:
       "Default agent to use when none is specified. Must be a primary agent. Falls back to 'code' if not set or if the specified agent is invalid.",

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -84,6 +84,10 @@ export namespace KiloTask {
   type Saved = Model & { variant?: string }
   type Choice = { model: Model; variant?: string; sticky?: boolean; direct?: boolean }
 
+  function key(model: Model) {
+    return `${model.providerID}/${model.modelID}`
+  }
+
   function parse(value: string | null | undefined): Model | undefined {
     if (!value) return undefined
     const [providerID, ...parts] = value.split("/")
@@ -117,13 +121,14 @@ export namespace KiloTask {
   export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (input: {
     name: string
     agent: Pick<Agent.Info, "model" | "variant">
-    config: Pick<Config.Info, "subagent_model" | "subagent_variant">
+    config: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
     parent: Model
     variant?: string
     provider: Provider.Interface
   }) {
     const state = yield* saved(input.name)
     const cfg = parse(input.config.subagent_model)
+    const override = (model: Model) => input.config.subagent_variant_overrides?.[key(model)] ?? undefined
     const choices: Array<Choice | undefined> = [
       state
         ? {
@@ -138,7 +143,13 @@ export namespace KiloTask {
 
     for (const choice of choices) {
       if (!choice) continue
-      if (choice.direct) return { model: choice.model, variant: choice.variant }
+      if (choice.direct) {
+        const value = override(choice.model)
+        if (!value) return { model: choice.model, variant: choice.variant }
+        const full = yield* input.provider.getModel(choice.model.providerID, choice.model.modelID)
+        const variant = full.variants?.[value] ? value : choice.variant
+        return { model: choice.model, variant }
+      }
       const full = yield* input.provider.getModel(choice.model.providerID, choice.model.modelID).pipe(
         Effect.catchTag("ProviderModelNotFoundError", (err) =>
           Effect.sync(() => {
@@ -152,13 +163,21 @@ export namespace KiloTask {
         ),
       )
       if (!full) continue
-      const variant = choice.variant && full.variants?.[choice.variant] ? choice.variant : undefined
+      const fallback = choice.variant && full.variants?.[choice.variant] ? choice.variant : undefined
+      const value = override(choice.model)
+      const variant = value && full.variants?.[value] ? value : fallback
       return {
         model: choice.sticky && variant ? { ...choice.model, variant } : choice.model,
         variant,
       }
     }
 
-    return { model: input.parent, variant: input.variant }
+    const value = override(input.parent)
+    if (!value) return { model: input.parent, variant: input.variant }
+    const full = yield* input.provider
+      .getModel(input.parent.providerID, input.parent.modelID)
+      .pipe(Effect.catchTag("ProviderModelNotFoundError", () => Effect.succeed(undefined)))
+    const variant = full?.variants?.[value] ? value : input.variant
+    return { model: input.parent, variant }
   })
 }

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -234,6 +234,43 @@ describe("kilocode indexing config", () => {
   })
 })
 
+describe("subagent variant overrides", () => {
+  test("removes one model override without removing sibling models", () => {
+    const patch = decode({
+      subagent_variant_overrides: {
+        "anthropic/claude-sonnet-4-6": null,
+      },
+    })
+    const merged = KilocodeConfig.mergeConfig(
+      {
+        subagent_variant_overrides: {
+          "anthropic/claude-sonnet-4-6": "high",
+          "openai/gpt-5": "xhigh",
+        },
+      },
+      patch,
+    )
+
+    expect(patch.subagent_variant_overrides?.["anthropic/claude-sonnet-4-6"]).toBeNull()
+    expect(merged.subagent_variant_overrides).toEqual({ "openai/gpt-5": "xhigh" })
+  })
+
+  test("accepts a delete sentinel for the complete override map", () => {
+    const patch = decode({ subagent_variant_overrides: null })
+    const merged = KilocodeConfig.mergeConfig(
+      {
+        subagent_variant_overrides: {
+          "anthropic/claude-sonnet-4-6": "high",
+        },
+      },
+      patch,
+    )
+
+    expect(patch.subagent_variant_overrides).toBeNull()
+    expect(merged.subagent_variant_overrides).toBeUndefined()
+  })
+})
+
 describe("agent config", () => {
   test("accepts delete sentinels for agent model and variant overrides", () => {
     const patch = decode({ agent: { explore: { model: null, variant: null } } })

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -53,6 +53,7 @@ const cfg = {
 }
 
 const inherited = "thorough"
+const overrideVariant = "full"
 const savedVariant = "fast"
 const cfgVariant = "balanced"
 const sub = {
@@ -88,9 +89,10 @@ function custom(id: string, model: string, variants: string[] = []) {
 
 const catalog = {
   provider: {
-    "saved-provider": custom("saved-provider", "saved-model", [savedVariant]),
-    "config-provider": custom("config-provider", "config-model", [cfgVariant]),
-    "sub-provider": custom("sub-provider", "sub-model", [subVariant]),
+    "parent-provider": custom("parent-provider", "parent-model", [inherited, overrideVariant]),
+    "saved-provider": custom("saved-provider", "saved-model", [savedVariant, overrideVariant]),
+    "config-provider": custom("config-provider", "config-model", [cfgVariant, overrideVariant]),
+    "sub-provider": custom("sub-provider", "sub-model", [subVariant, overrideVariant]),
   },
 }
 
@@ -197,7 +199,7 @@ function run(input: {
   state?: unknown
   client?: string
   variant?: string
-  config?: Pick<Config.Info, "subagent_model" | "subagent_variant">
+  config?: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
 }) {
   return provideTmpdirInstance(
     () =>
@@ -360,6 +362,95 @@ describe("tool.task model resolution", () => {
           expect(result.variant).toEqual(cfgVariant)
           expect(result.model).toEqual(cfg)
           expect(result.metadataVariant).toEqual(cfgVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("model-specific override replaces an inherited parent variant", () =>
+    run({
+      agent: "worker",
+      variant: inherited,
+      config: { subagent_variant_overrides: { "parent-provider/parent-model": overrideVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.variant).toEqual(overrideVariant)
+          expect(result.model).toEqual(parent)
+          expect(result.metadataVariant).toEqual(overrideVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("model-specific override applies to a custom subagent model and variant", () =>
+    run({
+      agent: "pinned",
+      variant: inherited,
+      config: { subagent_variant_overrides: { "config-provider/config-model": overrideVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(cfg)
+          expect(result.variant).toEqual(overrideVariant)
+          expect(result.model).toEqual(cfg)
+          expect(result.metadataVariant).toEqual(overrideVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("model-specific override follows a saved custom subagent model", () =>
+    run({
+      agent: "worker",
+      state: { model: { worker: saved }, variant: { "saved-provider/saved-model": savedVariant } },
+      config: { subagent_variant_overrides: { "saved-provider/saved-model": overrideVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(saved)
+          expect(result.variant).toEqual(overrideVariant)
+          expect(result.model).toMatchObject({ ...saved, variant: overrideVariant })
+          expect(result.metadataVariant).toEqual(overrideVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("stale model-specific override preserves the resolved variant", () =>
+    run({
+      agent: "pinned",
+      variant: inherited,
+      config: { subagent_variant_overrides: { "config-provider/config-model": "gone" } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(cfg)
+          expect(result.variant).toEqual(cfgVariant)
+          expect(result.model).toEqual(cfg)
+          expect(result.metadataVariant).toEqual(cfgVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("unavailable configured subagent model falls back to the parent model override", () =>
+    run({
+      agent: "worker",
+      variant: inherited,
+      config: {
+        subagent_model: "missing-provider/missing-model",
+        subagent_variant: subVariant,
+        subagent_variant_overrides: { "parent-provider/parent-model": overrideVariant },
+      },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.variant).toEqual(overrideVariant)
+          expect(result.model).toEqual(parent)
+          expect(result.metadataVariant).toEqual(overrideVariant)
         }),
       ),
     ),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1332,6 +1332,9 @@ export type Config = {
   small_model?: string
   subagent_model?: string
   subagent_variant?: string
+  subagent_variant_overrides?: {
+    [key: string]: string
+  }
   default_agent?: string
   username?: string
   mode?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -18227,6 +18227,12 @@
           "subagent_variant": {
             "type": "string"
           },
+          "subagent_variant_overrides": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "default_agent": {
             "type": "string"
           },


### PR DESCRIPTION
The global subagent model setting previously coupled reasoning effort to a single legacy variant value, which could become invalid when models changed and could not safely account for custom subagents using different models.

This adds model-specific subagent variant overrides while keeping the settings UI focused on one model and one matching reasoning selector. The general subagent receives the selected model and reasoning effort, while custom subagents retain their own model and only receive an override when one exists and is valid for that exact model. Stale or incompatible variants fall back to the agent's resolved variant instead of crossing model boundaries.

The settings controls also constrain long model labels to their input column so names truncate rather than overlap adjacent content.

<img width="837" height="153" alt="file-eb2b53c39bea42f5aa9a9ded4dbd8ebf" src="https://github.com/user-attachments/assets/ae5f5f85-f71e-49e8-8d37-eef92472d1f8" />
<img width="851" height="357" alt="file-fc9aa0b11c00a659e64fbbd608d49bf7" src="https://github.com/user-attachments/assets/bef3ffcd-5c8e-43dd-a527-9a15bb9216f5" />
<img width="836" height="139" alt="file-47f834151cfba43986842a2fb9bb9491" src="https://github.com/user-attachments/assets/02268ec6-bcb7-49f3-b423-76167d3d7aa9" />
