### PR TITLE
fix(cli): improve guidelines for `kilo agent create`

### DIFF
--- a/packages/opencode/src/agent/generate.txt
+++ b/packages/opencode/src/agent/generate.txt
@@ -33,33 +33,17 @@ When a user describes what they want an agent to do, you will:
 
 6 **Example agent descriptions**:
 
-- in the 'whenToUse' field of the JSON object, you should include examples of when this agent should be used.
-- examples should be of the form:
-  - <example>
-      Context: The user is creating a code-review agent that should be called after a logical chunk of code is written.
-      user: "Please write a function that checks if a number is prime"
-      assistant: "Here is the relevant function: "
-      <function call omitted for brevity only for this example>
-      <commentary>
-      Since the user is greeting, use the Task tool to launch the greeting-responder agent to respond with a friendly joke. 
-      </commentary>
-      assistant: "Now let me use the code-reviewer agent to review the code"
-    </example>
-  - <example>
-      Context: User is creating an agent to respond to the word "hello" with a friendly jok.
-      user: "Hello"
-      assistant: "I'm going to use the Task tool to launch the greeting-responder agent to respond with a friendly joke"
-      <commentary>
-      Since the user is greeting, use the greeting-responder agent to respond with a friendly joke. 
-      </commentary>
-    </example>
-- If the user mentioned or implied that the agent should be used proactively, you should include examples of this.
-- NOTE: Ensure that in the examples, you are making the assistant use the Agent tool and not simply respond directly to the task.
+- in the 'whenToUse' field of the JSON object, you should include a description of when the agent should be used. Include the following:
+  - Trigger conditions, not just capability. Anthropic's guidance: "Reviews code for security issues before commits" routes better than "security expert." Name the situation, not the persona.
+  - When to invoke, phrased actively. "Use immediately after writing or modifying code," "Use when analyzing data," "Use proactively when encountering any issues." The phrase use proactively (or the community convention MUST BE USED for…) measurably increases auto-delegation — the main agent otherwise tends to do tasks itself rather than spawn.
+  - Input signal. What should be true when this fires? "errors, test failures, and unexpected behavior" / "after code changes" / "before commits" — these cue Claude to match against the current context, not just the verb.
+  - Avoid generic role nouns. "frontend-engineer," "security expert," "backend specialist" are weak signals because they overlap with almost any task.
+- A good description will be 1-3 sentences on average, but there is no hard length limit. Ensure the description is complete enough to guide an agent on when to use it, but do not unnecessarily pad the length.
 
 Your output must be a valid JSON object with exactly these fields:
 {
 "identifier": "A unique, descriptive identifier using lowercase letters, numbers, and hyphens (e.g., 'code-reviewer', 'api-docs-writer', 'test-generator')",
-"whenToUse": "A precise, actionable description starting with 'Use this agent when...' that clearly defines the triggering conditions and use cases. Ensure you include examples as described above.",
+"whenToUse": "A precise, actionable description starting with 'Use this agent when...' that clearly defines the triggering conditions and use cases.",
 "systemPrompt": "The complete system prompt that will govern the agent's behavior, written in second person ('You are...', 'You will...') and structured for maximum clarity and effectiveness"
 }
 


### PR DESCRIPTION
Reopens #9410

## Context

Currently the `kilo agent create` command generates extremely long agent descriptions. This is because the system prompt for the `generate` agent tells it to include multiple verbose examples of when the agent should be used. This is unnecessary and increases system context bloat without improving the parent agent's ability to choose a subagent.

## Implementation

This change updates the system prompt to exclude the guidance about examples, and instead includes official guidance from Anthropic's documentation on best practices for agent descriptions.

## Example Output

Before:

```md
---
description: >-
  Use this agent when automated tests need to be executed and their results
  analyzed. This includes running unit tests, integration tests, end-to-end
  tests, or any test suite, then interpreting pass/fail outcomes, diagnosing
  failures, and providing actionable insights.


  <example>

  Context: The user has just finished implementing a new feature and wants to
  verify nothing is broken.

  user: "I just added the new authentication middleware. Can you make sure
  everything still works?"

  assistant: "I'll use the Task tool to launch the test-executor agent to run
  the test suite and analyze the results."

  <commentary>

  Since the user wants to verify their changes haven't broken anything, use the
  test-executor agent to run tests and analyze outcomes.

  </commentary>

  </example>


  <example>

  Context: The user is debugging a failing CI pipeline.

  user: "The CI is red but I can't tell which tests are actually failing."

  assistant: "Let me use the test-executor agent to run the tests locally and
  break down exactly what's failing and why."

  <commentary>

  The user needs test execution with detailed failure analysis, which is the
  test-executor agent's specialty.

  </commentary>

  </example>


  <example>

  Context: Proactive use after code changes.

  user: "I refactored the payment processing module to use the new API."

  assistant: "I've noted the refactoring. Now I'll use the test-executor agent
  to run the relevant tests and confirm the refactor didn't introduce
  regressions."

  <commentary>

  After significant code changes, proactively use the test-executor agent to
  validate correctness.

  </commentary>

  </example>
mode: subagent
---
You are an elite Test Execution and Analysis Specialist with deep expertise in...
```

After:
```md
---
description: >-
  Use this agent when automated tests need to be executed and their results
  analyzed. This includes running unit tests, integration tests, end-to-end
  tests, or full test suites, as well as re-running failed tests and providing
  concise summaries of outcomes. The agent should be invoked after code changes
  that warrant verification, when explicitly asked to run tests, or proactively
  after implementing new features or fixes.
mode: subagent
---
You are an elite Test Execution Specialist with deep expertise in...
```

## Get in Touch

ExpedientFalcon on Discord

