### PR TITLE
fix(remote): use the session's own model for relayed messages, not the cloud's

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -49,9 +49,25 @@ function getRemotePromptInput() {
 // kilocode_change end
 function normalizeModel(model: string | undefined) {
   if (!model) return undefined
+  // "kilocode/xxx" is an alias for the kilo provider
+  if (model.startsWith("kilocode/")) {
+    return {
+      providerID: ProviderID.make("kilo"),
+      modelID: ModelID.make(model.slice("kilocode/".length)),
+    }
+  }
+  // "provider/model" — split on the first slash to respect the provider prefix
+  const slashIndex = model.indexOf("/")
+  if (slashIndex > 0) {
+    return {
+      providerID: ProviderID.make(model.slice(0, slashIndex)),
+      modelID: ModelID.make(model.slice(slashIndex + 1)),
+    }
+  }
+  // Bare model name — default to the kilo provider
   return {
     providerID: ProviderID.make("kilo"),
-    modelID: ModelID.make(model.startsWith("kilocode/") ? model.slice("kilocode/".length) : model),
+    modelID: ModelID.make(model),
   }
 }
 

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -9,7 +9,7 @@ import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { SessionID } from "@/session/schema"
 import { QuestionID } from "@/question/schema"
-import { ModelID, ProviderID } from "@/provider/schema"
+
 import * as Log from "@opencode-ai/core/util/log"
 import z from "zod"
 import { zodObject } from "@opencode-ai/core/effect-zod"
@@ -47,35 +47,14 @@ function getRemotePromptInput() {
   }))
 }
 // kilocode_change end
-function normalizeModel(model: string | undefined) {
-  if (!model) return undefined
-  // "kilocode/xxx" is an alias for the kilo provider
-  if (model.startsWith("kilocode/")) {
-    return {
-      providerID: ProviderID.make("kilo"),
-      modelID: ModelID.make(model.slice("kilocode/".length)),
-    }
-  }
-  // "provider/model" — split on the first slash to respect the provider prefix
-  const slashIndex = model.indexOf("/")
-  if (slashIndex > 0) {
-    return {
-      providerID: ProviderID.make(model.slice(0, slashIndex)),
-      modelID: ModelID.make(model.slice(slashIndex + 1)),
-    }
-  }
-  // Bare model name — default to the kilo provider
-  return {
-    providerID: ProviderID.make("kilo"),
-    modelID: ModelID.make(model),
-  }
-}
-
 function normalizePrompt(input: SessionPrompt.PromptInput & { model?: string }): SessionPrompt.PromptInput {
-  return {
-    ...input,
-    model: normalizeModel(input.model),
-  }
+  // Don't override the session's own model from the remote relay. The session
+  // already has a model configured, and the cloud app may mangle the provider
+  // prefix for unknown providers (e.g. sending "kilo/deepseek-v4-flash" when
+  // the session uses "opencode-go/deepseek-v4-flash"). Let the session's model
+  // resolution chain (input.model ?? ag.model ?? currentModel) handle it.
+  const { model: _model, ...rest } = input
+  return rest
 }
 
 export namespace RemoteSender {

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -9,7 +9,6 @@ import { Question } from "../../../src/question"
 import { QuestionID } from "../../../src/question/schema"
 import { Permission } from "../../../src/permission"
 import { PermissionID } from "../../../src/permission/schema"
-import { ModelID, ProviderID } from "../../../src/provider/schema"
 import { SessionID } from "../../../src/session/schema"
 import { Suggestion } from "../../../src/kilocode/suggestion" // kilocode_change
 
@@ -336,7 +335,7 @@ describe("RemoteSender", () => {
   })
 
   // kilocode_change start
-  test("send_message splits string model at the provider prefix", async () => {
+  test("send_message uses the session's own model, not the model string from the relay", async () => {
     const { conn, sent } = fakeConn()
     const calls: SessionPrompt.PromptInput[] = []
     const sender = RemoteSender.create({
@@ -350,7 +349,7 @@ describe("RemoteSender", () => {
 
     sender.handle({
       type: "command",
-      id: "req_model_string",
+      id: "req_model",
       command: "send_message",
       data: {
         sessionID: "ses_x",
@@ -361,46 +360,12 @@ describe("RemoteSender", () => {
 
     await new Promise((r) => setTimeout(r, 0))
 
-    expect(sent[0]).toEqual({ type: "response", id: "req_model_string", result: {} })
+    // The model from the cloud is stripped so the session uses its own model
+    expect(sent[0]).toEqual({ type: "response", id: "req_model", result: {} })
     expect(calls).toEqual([
       {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
-        model: { providerID: ProviderID.make("anthropic"), modelID: ModelID.make("claude-sonnet-4-20250514") },
-      },
-    ])
-  })
-
-  test("send_message keeps kilocode-prefixed model unchanged before internal conversion", async () => {
-    const { conn } = fakeConn()
-    const calls: SessionPrompt.PromptInput[] = []
-    const sender = RemoteSender.create({
-      conn,
-      directory: "/tmp/test",
-      log: nolog,
-      subscribe: fakeBus().subscribe,
-      provide: async <R>(input: { directory: string; init?: Effect.Effect<void>; fn: () => R }) => input.fn(),
-      prompt: prompts(calls),
-    })
-
-    sender.handle({
-      type: "command",
-      id: "req_model_kilocode",
-      command: "send_message",
-      data: {
-        sessionID: "ses_x",
-        parts: [{ type: "text", text: "hello" }],
-        model: "kilocode/gpt-5-mini",
-      },
-    })
-
-    await new Promise((r) => setTimeout(r, 0))
-
-    expect(calls).toEqual([
-      {
-        sessionID: SessionID.make("ses_x"),
-        parts: [{ type: "text", text: "hello" }],
-        model: { providerID: ProviderID.make("kilo"), modelID: ModelID.make("gpt-5-mini") },
       },
     ])
   })
@@ -432,40 +397,6 @@ describe("RemoteSender", () => {
     expect(sent[0].error).toContain("invalid send_message data")
   })
 
-  test("send_message correctly splits kilo-prefixed model", async () => {
-    const { conn, sent } = fakeConn()
-    const calls: SessionPrompt.PromptInput[] = []
-    const sender = RemoteSender.create({
-      conn,
-      directory: "/tmp/test",
-      log: nolog,
-      subscribe: fakeBus().subscribe,
-      provide: async <R>(input: { directory: string; init?: Effect.Effect<void>; fn: () => R }) => input.fn(),
-      prompt: prompts(calls),
-    })
-
-    sender.handle({
-      type: "command",
-      id: "req_model_kilo",
-      command: "send_message",
-      data: {
-        sessionID: "ses_x",
-        parts: [{ type: "text", text: "hello" }],
-        model: "kilo/gpt-5-mini",
-      },
-    })
-
-    await new Promise((r) => setTimeout(r, 0))
-
-    expect(sent[0]).toEqual({ type: "response", id: "req_model_kilo", result: {} })
-    expect(calls).toEqual([
-      {
-        sessionID: SessionID.make("ses_x"),
-        parts: [{ type: "text", text: "hello" }],
-        model: { providerID: ProviderID.make("kilo"), modelID: ModelID.make("gpt-5-mini") },
-      },
-    ])
-  })
   // kilocode_change end
 
   test("question_reply sends response after work completes", async () => {

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -336,7 +336,7 @@ describe("RemoteSender", () => {
   })
 
   // kilocode_change start
-  test("send_message normalizes string model without prefix", async () => {
+  test("send_message splits string model at the provider prefix", async () => {
     const { conn, sent } = fakeConn()
     const calls: SessionPrompt.PromptInput[] = []
     const sender = RemoteSender.create({
@@ -366,7 +366,7 @@ describe("RemoteSender", () => {
       {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
-        model: { providerID: ProviderID.make("kilo"), modelID: ModelID.make("anthropic/claude-sonnet-4-20250514") },
+        model: { providerID: ProviderID.make("anthropic"), modelID: ModelID.make("claude-sonnet-4-20250514") },
       },
     ])
   })
@@ -432,7 +432,7 @@ describe("RemoteSender", () => {
     expect(sent[0].error).toContain("invalid send_message data")
   })
 
-  test("send_message does not special-case kilo-prefixed model", async () => {
+  test("send_message correctly splits kilo-prefixed model", async () => {
     const { conn, sent } = fakeConn()
     const calls: SessionPrompt.PromptInput[] = []
     const sender = RemoteSender.create({
@@ -462,7 +462,7 @@ describe("RemoteSender", () => {
       {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
-        model: { providerID: ProviderID.make("kilo"), modelID: ModelID.make("kilo/gpt-5-mini") },
+        model: { providerID: ProviderID.make("kilo"), modelID: ModelID.make("gpt-5-mini") },
       },
     ])
   })


### PR DESCRIPTION
## Summary

The Cloud Agents web app has a model selector — this is necessary for **cloud-hosted sessions** where the LLM call runs on Kilo's infrastructure. However, for **local remote relay sessions**, this model selection is forwarded to the CLI and overrides the user's local model configuration with a value determined by the cloud app's model resolution logic.

This causes two problems:

1. **Wrong model**: For users with custom/third-party providers (e.g. `opencode-go/deepseek-v4-flash`), the cloud app doesn't recognize the provider and rewrites it to `kilo/deepseek-v4-flash`. The session then fails with `ModelNotFoundError` because that model doesn't exist in the Kilo Gateway catalog.

2. **Unexpected cost/behaviour**: Even for recognized providers, the cloud's model selection may pick a different model than what the user configured locally, potentially incurring unexpected costs or using a model the user didn't intend.

## Fix

The remote relay `send_message` handler now strips the model from incoming relay commands, letting the session use its own configured model. The session's model resolution chain (`input.model ?? ag.model ?? currentModel`) already handles this correctly — the issue was that the cloud's model took priority.

- Removed `normalizeModel()` — it was normalizing the model string from the cloud and overriding the session's model
- `normalizePrompt()` now drops the model from the relay input entirely

## Testing

All 35 tests in `remote-sender.test.ts` pass. The updated test verifies that the session's own model is used regardless of what model string the cloud sends.