### PR TITLE
ci: guard Kilo-only workflows in forks

### DIFF
--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -26,15 +26,18 @@ concurrency:
 
 jobs:
   call-valtown:
+    # kilocode_change start
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      github.repository == 'Kilo-Org/kilocode' &&
+      (github.event_name == 'workflow_dispatch' ||
       (
         github.event.pull_request.merged == true &&
         (
           startsWith(github.event.pull_request.title, 'feat:') ||
           startsWith(github.event.pull_request.title, 'feat(')
         )
-      )
+      ))
+    # kilocode_change end
 
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -28,15 +28,15 @@ jobs:
   call-valtown:
     # kilocode_change start
     if: >
-      github.repository == 'Kilo-Org/kilocode' &&
-      (github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_dispatch' ||
       (
+        github.repository == 'Kilo-Org/kilocode' &&
         github.event.pull_request.merged == true &&
         (
           startsWith(github.event.pull_request.title, 'feat:') ||
           startsWith(github.event.pull_request.title, 'feat(')
         )
-      ))
+      )
     # kilocode_change end
 
     runs-on: ubuntu-latest

--- a/.github/workflows/check-org-member.yml
+++ b/.github/workflows/check-org-member.yml
@@ -18,8 +18,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404 # kilocode_change
     outputs:
       is-member: ${{ steps.check.outputs['is-member'] }}
     steps:

--- a/.github/workflows/check-org-member.yml
+++ b/.github/workflows/check-org-member.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   check:
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       is-member: ${{ steps.check.outputs['is-member'] }}

--- a/.github/workflows/codeql-kotlin.yml
+++ b/.github/workflows/codeql-kotlin.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   analyze:
     name: Analyze (java-kotlin)
+    if: github.repository == 'Kilo-Org/kilocode'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/codeql-kotlin.yml
+++ b/.github/workflows/codeql-kotlin.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   analyze:
     name: Analyze (java-kotlin)
-    if: github.repository == 'Kilo-Org/kilocode'
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'Kilo-Org/kilocode'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: github.repository == 'Kilo-Org/kilocode'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    if: github.repository == 'Kilo-Org/kilocode'
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'Kilo-Org/kilocode'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       # kilocode_change start

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       # kilocode_change start

--- a/.github/workflows/disabled/duplicate-issues.yml.disabled
+++ b/.github/workflows/disabled/duplicate-issues.yml.disabled
@@ -118,7 +118,7 @@ jobs:
           Remember: post at most ONE comment combining all findings. If everything is fine, post nothing."
 
   recheck-compliance:
-    if: github.repository == 'Kilo-Org/kilocode' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance') # kilocode_change
+    if: github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance') # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/disabled/duplicate-issues.yml.disabled
+++ b/.github/workflows/disabled/duplicate-issues.yml.disabled
@@ -118,7 +118,7 @@ jobs:
           Remember: post at most ONE comment combining all findings. If everything is fine, post nothing."
 
   recheck-compliance:
-    if: github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance')
+    if: github.repository == 'Kilo-Org/kilocode' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance') # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     name: Build docs site
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,8 +13,7 @@ on:
 jobs:
   build:
     name: Build docs site
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404 # kilocode_change
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6 # kilocode_change

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,6 +134,7 @@ jobs:
   validate-cli-unix:
     name: Validate CLI (${{ matrix.target }})
     needs: build-cli
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -257,6 +258,7 @@ jobs:
   validate-cli-windows:
     name: Validate CLI (windows-${{ matrix.arch }})
     needs: build-cli
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:
@@ -389,6 +391,7 @@ jobs:
       - validate-cli-unix # kilocode_change
       - validate-cli-windows # kilocode_change
       - smoke-test
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6 # kilocode_change

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,7 +134,6 @@ jobs:
   validate-cli-unix:
     name: Validate CLI (${{ matrix.target }})
     needs: build-cli
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -258,9 +257,8 @@ jobs:
   validate-cli-windows:
     name: Validate CLI (windows-${{ matrix.arch }})
     needs: build-cli
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 20 # kilocode_change
     strategy:
       fail-fast: false
       matrix:
@@ -391,7 +389,6 @@ jobs:
       - validate-cli-unix # kilocode_change
       - validate-cli-windows # kilocode_change
       - smoke-test
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6 # kilocode_change

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -40,7 +40,6 @@ permissions:
 jobs:
   smoke-test:
     name: Smoke Test
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     env:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -40,6 +40,7 @@ permissions:
 jobs:
   smoke-test:
     name: Smoke Test
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     env:

--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   unit:
     name: unit tests
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
       run:

--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -21,8 +21,7 @@ on:
 jobs:
   unit:
     name: unit tests
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404 # kilocode_change
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,7 @@ jobs:
   unit:
     name: ${{ !matrix.settings.run && 'unit (unchanged)' || matrix.settings.total > 1 && format('unit ({0}, {1}/{2})', matrix.settings.os, matrix.settings.index, matrix.settings.total) || format('unit ({0})', matrix.settings.os) }}
     needs: changes
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    strategy:
+    strategy: # kilocode_change
       fail-fast: false
       matrix:
         settings: ${{ fromJSON(needs.changes.outputs.settings) }}
@@ -207,12 +206,12 @@ jobs:
   # kilocode_change start
   jetbrains:
     name: jetbrains
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     permissions:
       contents: read
       checks: write
       pull-requests: read
     uses: ./.github/workflows/test-jetbrains.yml
+  # kilocode_change end
 
   # kilocode_change start
   unit-required:
@@ -235,9 +234,9 @@ jobs:
       - unit
       - httpapi
       - jetbrains
-    if: github.repository == 'Kilo-Org/kilocode' && always() # kilocode_change
+    if: always()
     steps:
-      - name: Verify upstream test jobs passed
+      - name: Verify upstream test jobs passed # kilocode_change
         run: |
           echo "unit=${{ needs.unit.result }}"
           echo "httpapi=${{ needs.httpapi.result }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
   unit:
     name: ${{ !matrix.settings.run && 'unit (unchanged)' || matrix.settings.total > 1 && format('unit ({0}, {1}/{2})', matrix.settings.os, matrix.settings.index, matrix.settings.total) || format('unit ({0})', matrix.settings.os) }}
     needs: changes
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     strategy:
       fail-fast: false
       matrix:
@@ -206,12 +207,12 @@ jobs:
   # kilocode_change start
   jetbrains:
     name: jetbrains
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     permissions:
       contents: read
       checks: write
       pull-requests: read
     uses: ./.github/workflows/test-jetbrains.yml
-  # kilocode_change end
 
   # kilocode_change start
   unit-required:
@@ -234,7 +235,7 @@ jobs:
       - unit
       - httpapi
       - jetbrains
-    if: always()
+    if: github.repository == 'Kilo-Org/kilocode' && always() # kilocode_change
     steps:
       - name: Verify upstream test jobs passed
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,8 +10,7 @@ on:
 jobs:
   typecheck-js:
     name: typecheck-js
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404 # kilocode_change
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6 # kilocode_change
@@ -54,7 +53,7 @@ jobs:
   typecheck-jetbrains:
     name: typecheck-jetbrains
     needs: jetbrains-changes
-    if: github.repository == 'Kilo-Org/kilocode' && (github.event_name == 'workflow_dispatch' || needs.jetbrains-changes.outputs.jetbrains == 'true') # kilocode_change
+    if: github.event_name == 'workflow_dispatch' || needs.jetbrains-changes.outputs.jetbrains == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -85,7 +84,7 @@ jobs:
       - typecheck-js
       - jetbrains-changes
       - typecheck-jetbrains
-    if: github.repository == 'Kilo-Org/kilocode' && always() # kilocode_change
+    if: always()
     steps:
       - name: Verify typecheck jobs passed
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   typecheck-js:
     name: typecheck-js
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -53,7 +54,7 @@ jobs:
   typecheck-jetbrains:
     name: typecheck-jetbrains
     needs: jetbrains-changes
-    if: github.event_name == 'workflow_dispatch' || needs.jetbrains-changes.outputs.jetbrains == 'true'
+    if: github.repository == 'Kilo-Org/kilocode' && (github.event_name == 'workflow_dispatch' || needs.jetbrains-changes.outputs.jetbrains == 'true') # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -84,7 +85,7 @@ jobs:
       - typecheck-js
       - jetbrains-changes
       - typecheck-jetbrains
-    if: always()
+    if: github.repository == 'Kilo-Org/kilocode' && always() # kilocode_change
     steps:
       - name: Verify typecheck jobs passed
         run: |

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -12,8 +12,7 @@ permissions:
 jobs:
   check-paths:
     name: Check changed paths
-    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # kilocode_change
     outputs:
       matched: ${{ steps.filter.outputs.matched }}
       can_autocommit: ${{ steps.autocommit-check.outputs.can_autocommit }}
@@ -58,8 +57,8 @@ jobs:
 
   visual-regression:
     needs: check-paths
-    if: github.repository == 'Kilo-Org/kilocode' && needs.check-paths.outputs.matched == 'true' # kilocode_change
-    name: Visual Regression (kilo-ui)
+    if: needs.check-paths.outputs.matched == 'true'
+    name: Visual Regression (kilo-ui) # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
@@ -220,8 +219,8 @@ jobs:
 
   visual-regression-vscode:
     needs: check-paths
-    if: github.repository == 'Kilo-Org/kilocode' && needs.check-paths.outputs.matched == 'true' # kilocode_change
-    name: Visual Regression (kilo-vscode webview)
+    if: needs.check-paths.outputs.matched == 'true'
+    name: Visual Regression (kilo-vscode webview) # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     env:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   check-paths:
     name: Check changed paths
+    if: github.repository == 'Kilo-Org/kilocode' # kilocode_change
     runs-on: ubuntu-latest
     outputs:
       matched: ${{ steps.filter.outputs.matched }}
@@ -57,7 +58,7 @@ jobs:
 
   visual-regression:
     needs: check-paths
-    if: needs.check-paths.outputs.matched == 'true'
+    if: github.repository == 'Kilo-Org/kilocode' && needs.check-paths.outputs.matched == 'true' # kilocode_change
     name: Visual Regression (kilo-ui)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -219,7 +220,7 @@ jobs:
 
   visual-regression-vscode:
     needs: check-paths
-    if: needs.check-paths.outputs.matched == 'true'
+    if: github.repository == 'Kilo-Org/kilocode' && needs.check-paths.outputs.matched == 'true' # kilocode_change
     name: Visual Regression (kilo-vscode webview)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15

--- a/.github/workflows/watch-opencode-releases.yml
+++ b/.github/workflows/watch-opencode-releases.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-release:
-    if: github.repository == 'Kilo-Org/kilocode' && vars.OPENCODE_WATCH_ENABLED != 'false'
+    if: github.repository == 'Kilo-Org/kilocode' && vars.OPENCODE_WATCH_ENABLED != 'false' # kilocode_change
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/watch-opencode-releases.yml
+++ b/.github/workflows/watch-opencode-releases.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-release:
-    if: github.repository == 'Kilo-Org/kilocode' && vars.OPENCODE_WATCH_ENABLED != 'false' # kilocode_change
+    if: vars.OPENCODE_WATCH_ENABLED != 'false' && (github.event_name == 'workflow_dispatch' || github.repository == 'Kilo-Org/kilocode') # kilocode_change
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary
- Add canonical-repo job guards to workflows that depend on Kilo-only secrets, private resources, publishing credentials, CodeQL uploads, or Blacksmith runners.
- Prevent personal forks from running fork-local CI that cannot succeed outside `Kilo-Org/kilocode`.
- Keep upstream PR and canonical-repo CI behavior unchanged.

## Why
Forks currently trigger workflows that require Kilo-owned infrastructure or credentials. Those jobs fail or queue indefinitely in forks, creating noisy and unactionable CI failures for fork owners.

## Validation
- `bun run script/check-workflows.ts`
- `yq eval '.' .github/workflows/*.yml >/dev/null`
- `git diff --check`
- Pre-push hook: `bun turbo typecheck`

_gpt-5.5 on behalf of matt_