### PR TITLE
feat(ui): parse file-path candidates with line and column suffixes

### DIFF
--- a/packages/kilo-ui/src/file-path.ts
+++ b/packages/kilo-ui/src/file-path.ts
@@ -1,40 +1,44 @@
-// Matches text that looks like a file path:
-// - Unix: /foo/bar.ts, ./foo.ts, ../foo.ts, foo.ts
-// - Windows drive: C:\foo\bar.ts, C:/foo/bar.ts
-// - Windows UNC: \\server\share\file.ts
-// Supports optional :line or :line:col suffix.
-const FILE_PATH_UNIX_RE =
-  /^((?:\/|\.\.?\/)?(?:[a-zA-Z0-9_@-][a-zA-Z0-9_@./-]*\/)*[a-zA-Z0-9_@.-]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
-const FILE_PATH_WIN_RE = /^((?:[a-zA-Z]:[/\\]|\\\\)(?:[^\\/]+[/\\])*[^\\/]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
-
 /**
- * Parse an inline code span into a file path with optional line/column.
- * Returns undefined when the text does not look like a file reference.
- *
- * Handles Unix paths (`/foo/bar.ts`, `./foo.ts`, `foo.ts`),
- * Windows drive paths (`C:\foo\bar.ts`), and UNC paths (`\\server\share\file.ts`).
+ * Strip an optional :line[-endline][:col] suffix from a code span.
+ * Returns the candidate file path and optional line/column numbers.
  */
-export function parseFilePath(text: string): { path: string; line?: number; column?: number } | undefined {
-  if (text.includes("://")) return undefined
-  if (text.includes(" ")) return undefined
-  const match = FILE_PATH_UNIX_RE.exec(text) ?? FILE_PATH_WIN_RE.exec(text)
-  if (!match) return undefined
-  return {
-    path: match[1],
-    line: match[2] ? parseInt(match[2], 10) : undefined,
-    column: match[3] ? parseInt(match[3], 10) : undefined,
-  }
+export function extractSuffix(text: string): { candidate: string; line?: number; column?: number } {
+  // Try :line:col first, then :line (with optional -endline range)
+  const m3 = /^(.+):(\d+)(?:-\d+)?:(\d+)$/.exec(text)
+  if (m3) return { candidate: m3[1], line: +m3[2], column: +m3[3] }
+  const m2 = /^(.+):(\d+)(?:-\d+)?$/.exec(text)
+  if (m2) return { candidate: m2[1], line: +m2[2] }
+  return { candidate: text }
 }
 
-const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
+/**
+ * Normalize a candidate path for filesystem validation.
+ * Ensures the path has a ./ prefix if it's a bare relative path,
+ * so the extension can stat-check it against the workspace root.
+ */
+export function normalizeCandidatePath(path: string): string {
+  if (path.startsWith("./") || path.startsWith("../") || path.startsWith("/")) return path
+  // Windows absolute paths (C:\...) — leave as-is
+  if (/^[a-zA-Z]:[/\\]/.test(path)) return path
+  // Windows UNC paths (\\server\...) — leave as-is
+  if (path.startsWith("\\\\")) return path
+  // Strip a/b diff prefixes
+  const stripped = path.replace(/^[ab]\//, "")
+  return `./${stripped}`
+}
+
+// Matches a URI scheme but NOT a Windows drive letter (single char followed by colon).
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]+:/
 
 /**
- * Extract a file path from a markdown link href, or return undefined
- * when the href is a URL, anchor, scheme, or otherwise not a file reference.
+ * Extract a file path (with optional line/column) from a markdown link href,
+ * or return undefined when the href is a URL, anchor, scheme, or otherwise
+ * not a file reference.
  *
- * Strips `#fragment` and `?query` suffixes before returning the path.
+ * Strips `#fragment` and `?query` suffixes, then parses an optional
+ * `:line` or `:line:column` suffix from the remaining path.
  */
-export function extractFilePathFromHref(href: string): string | undefined {
+export function extractFilePathFromHref(href: string): { path: string; line?: number; column?: number } | undefined {
   if (!href) return undefined
   // Handle file:// URLs — extract the path component and decode it
   if (href.startsWith("file://")) {
@@ -50,7 +54,7 @@ export function extractFilePathFromHref(href: string): string | undefined {
         decoded.charCodeAt(0) === 47 /* / */ &&
         decoded.charCodeAt(2) === 58 /* : */ &&
         ((c1 >= 65 && c1 <= 90) /* A-Z */ || (c1 >= 97 && c1 <= 122)) /* a-z */
-      return isWindowsDrive ? decoded.slice(1) : decoded
+      return { path: isWindowsDrive ? decoded.slice(1) : decoded }
     } catch {
       return undefined
     }
@@ -62,7 +66,8 @@ export function extractFilePathFromHref(href: string): string | undefined {
   // Strip fragment and query before treating as file path
   const cleaned = href.replace(/[#?].*$/, "")
   if (!cleaned) return undefined
-  // Must look like a file path (has a dot for extension)
-  if (!cleaned.includes(".")) return undefined
-  return cleaned
+  // Strip a/b diff prefixes, parse :line[:col] suffix
+  const stripped = cleaned.replace(/^[ab]\//, "")
+  const { candidate, line, column } = extractSuffix(stripped)
+  return { path: candidate, line, column }
 }

--- a/packages/ui/src/file-path.test.ts
+++ b/packages/ui/src/file-path.test.ts
@@ -1,189 +1,170 @@
 // kilocode_change - new file
 import { describe, expect, it } from "bun:test"
-import { parseFilePath, extractFilePathFromHref } from "./file-path"
+import { extractSuffix, normalizeCandidatePath, extractFilePathFromHref } from "./file-path"
 
-describe("parseFilePath", () => {
-  describe("Unix paths", () => {
-    it("bare filename", () => {
-      expect(parseFilePath("foo.ts")).toEqual({ path: "foo.ts", line: undefined, column: undefined })
-    })
-
-    it("relative path", () => {
-      expect(parseFilePath("src/index.ts")).toEqual({ path: "src/index.ts", line: undefined, column: undefined })
-    })
-
-    it("dot-relative path", () => {
-      expect(parseFilePath("./src/foo.ts")).toEqual({ path: "./src/foo.ts", line: undefined, column: undefined })
-    })
-
-    it("parent-relative path", () => {
-      expect(parseFilePath("../lib/bar.ts")).toEqual({ path: "../lib/bar.ts", line: undefined, column: undefined })
-    })
-
-    it("absolute path", () => {
-      expect(parseFilePath("/Users/dev/project/main.ts")).toEqual({
-        path: "/Users/dev/project/main.ts",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("with line number", () => {
-      expect(parseFilePath("src/foo.ts:42")).toEqual({ path: "src/foo.ts", line: 42, column: undefined })
-    })
-
-    it("with line and column", () => {
-      expect(parseFilePath("src/foo.ts:42:10")).toEqual({ path: "src/foo.ts", line: 42, column: 10 })
-    })
-
-    it("deeply nested path", () => {
-      expect(parseFilePath("packages/ui/src/context/marked.tsx")).toEqual({
-        path: "packages/ui/src/context/marked.tsx",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("path with @ scope", () => {
-      expect(parseFilePath("@scope/pkg/index.js")).toEqual({
-        path: "@scope/pkg/index.js",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("dotfile with path", () => {
-      expect(parseFilePath("src/.eslintrc.json")).toEqual({
-        path: "src/.eslintrc.json",
-        line: undefined,
-        column: undefined,
-      })
-    })
+describe("extractSuffix", () => {
+  it("no suffix", () => {
+    expect(extractSuffix("src/foo.ts")).toEqual({ candidate: "src/foo.ts" })
   })
 
-  describe("Windows paths", () => {
-    it("drive letter with backslash", () => {
-      expect(parseFilePath("C:\\Users\\dev\\file.ts")).toEqual({
-        path: "C:\\Users\\dev\\file.ts",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("drive letter with forward slash", () => {
-      expect(parseFilePath("C:/Users/dev/file.ts")).toEqual({
-        path: "C:/Users/dev/file.ts",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("lowercase drive", () => {
-      expect(parseFilePath("d:\\projects\\app.tsx")).toEqual({
-        path: "d:\\projects\\app.tsx",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("UNC path", () => {
-      expect(parseFilePath("\\\\server\\share\\file.ts")).toEqual({
-        path: "\\\\server\\share\\file.ts",
-        line: undefined,
-        column: undefined,
-      })
-    })
-
-    it("Windows path with line number", () => {
-      expect(parseFilePath("C:\\src\\file.ts:12")).toEqual({ path: "C:\\src\\file.ts", line: 12, column: undefined })
-    })
-
-    it("Windows path with line and column", () => {
-      expect(parseFilePath("C:\\src\\file.ts:12:5")).toEqual({ path: "C:\\src\\file.ts", line: 12, column: 5 })
-    })
+  it("line only", () => {
+    expect(extractSuffix("src/foo.ts:42")).toEqual({ candidate: "src/foo.ts", line: 42 })
   })
 
-  describe("rejects non-paths", () => {
-    it("URL with protocol", () => {
-      expect(parseFilePath("https://example.com/path.html")).toBeUndefined()
-    })
+  it("line and column", () => {
+    expect(extractSuffix("src/foo.ts:42:10")).toEqual({ candidate: "src/foo.ts", line: 42, column: 10 })
+  })
 
-    it("text with spaces", () => {
-      expect(parseFilePath("not a path.ts")).toBeUndefined()
-    })
+  it("line range (extracts start line)", () => {
+    expect(extractSuffix("src/index.ts:1-30")).toEqual({ candidate: "src/index.ts", line: 1 })
+  })
 
-    it("bare word without extension", () => {
-      expect(parseFilePath("README")).toBeUndefined()
-    })
+  it("line range with column", () => {
+    expect(extractSuffix("src/index.ts:10-21:5")).toEqual({ candidate: "src/index.ts", line: 10, column: 5 })
+  })
 
-    it("empty string", () => {
-      expect(parseFilePath("")).toBeUndefined()
-    })
+  it("bare word", () => {
+    expect(extractSuffix("LICENSE")).toEqual({ candidate: "LICENSE" })
+  })
 
-    it("file:// URL", () => {
-      expect(parseFilePath("file:///foo/bar.ts")).toBeUndefined()
-    })
+  it("dotfile", () => {
+    expect(extractSuffix(".gitignore")).toEqual({ candidate: ".gitignore" })
+  })
 
-    it("just a number", () => {
-      expect(parseFilePath("42")).toBeUndefined()
-    })
+  it("Windows drive path with line", () => {
+    expect(extractSuffix("C:\\src\\file.ts:12")).toEqual({ candidate: "C:\\src\\file.ts", line: 12 })
+  })
 
-    it("path without extension", () => {
-      expect(parseFilePath("src/Makefile")).toBeUndefined()
-    })
+  it("path with @ scope", () => {
+    expect(extractSuffix("@scope/pkg/index.js:5")).toEqual({ candidate: "@scope/pkg/index.js", line: 5 })
+  })
+
+  it("empty string", () => {
+    expect(extractSuffix("")).toEqual({ candidate: "" })
+  })
+})
+
+describe("normalizeCandidatePath", () => {
+  it("bare filename gets ./ prefix", () => {
+    expect(normalizeCandidatePath("LICENSE")).toBe("./LICENSE")
+  })
+
+  it("bare relative path gets ./ prefix", () => {
+    expect(normalizeCandidatePath("src/foo.ts")).toBe("./src/foo.ts")
+  })
+
+  it("dotfile gets ./ prefix", () => {
+    expect(normalizeCandidatePath(".gitignore")).toBe("./.gitignore")
+  })
+
+  it("./ prefix preserved", () => {
+    expect(normalizeCandidatePath("./LICENSE")).toBe("./LICENSE")
+  })
+
+  it("../ prefix preserved", () => {
+    expect(normalizeCandidatePath("../lib/bar.ts")).toBe("../lib/bar.ts")
+  })
+
+  it("absolute unix path preserved", () => {
+    expect(normalizeCandidatePath("/usr/bin/env")).toBe("/usr/bin/env")
+  })
+
+  it("Windows drive path preserved", () => {
+    expect(normalizeCandidatePath("C:\\src\\file.ts")).toBe("C:\\src\\file.ts")
+  })
+
+  it("UNC path preserved", () => {
+    expect(normalizeCandidatePath("\\\\server\\share")).toBe("\\\\server\\share")
+  })
+
+  it("strips a/ diff prefix", () => {
+    expect(normalizeCandidatePath("a/src/app.ts")).toBe("./src/app.ts")
+  })
+
+  it("strips b/ diff prefix", () => {
+    expect(normalizeCandidatePath("b/src/app.ts")).toBe("./src/app.ts")
+  })
+
+  it("Windows forward-slash drive path preserved", () => {
+    expect(normalizeCandidatePath("C:/src/file.ts")).toBe("C:/src/file.ts")
+  })
+
+  it("single letter not treated as diff prefix", () => {
+    // "c/foo" should NOT strip "c/" — only "a/" and "b/" are diff prefixes
+    expect(normalizeCandidatePath("c/foo.ts")).toBe("./c/foo.ts")
   })
 })
 
 describe("extractFilePathFromHref", () => {
   describe("accepts file-like hrefs", () => {
     it("bare filename", () => {
-      expect(extractFilePathFromHref("AGENTS.md")).toBe("AGENTS.md")
+      expect(extractFilePathFromHref("AGENTS.md")).toEqual({ path: "AGENTS.md" })
     })
 
     it("relative path", () => {
-      expect(extractFilePathFromHref("src/foo.ts")).toBe("src/foo.ts")
+      expect(extractFilePathFromHref("src/foo.ts")).toEqual({ path: "src/foo.ts" })
     })
 
     it("dot-relative path", () => {
-      expect(extractFilePathFromHref("./README.md")).toBe("./README.md")
+      expect(extractFilePathFromHref("./README.md")).toEqual({ path: "./README.md" })
     })
 
     it("parent-relative path", () => {
-      expect(extractFilePathFromHref("../docs/guide.md")).toBe("../docs/guide.md")
-    })
-
-    it("path with multiple extensions", () => {
-      expect(extractFilePathFromHref("config.test.ts")).toBe("config.test.ts")
-    })
-
-    it("file:// URL on Unix", () => {
-      expect(extractFilePathFromHref("file:///foo/bar.ts")).toBe("/foo/bar.ts")
-    })
-
-    it("file:// URL with Windows drive", () => {
-      expect(extractFilePathFromHref("file:///C:/Users/dev/file.ts")).toBe("C:/Users/dev/file.ts")
-    })
-
-    it("file:// URL with encoded characters", () => {
-      expect(extractFilePathFromHref("file:///foo%20bar/baz.ts")).toBe("/foo bar/baz.ts")
+      expect(extractFilePathFromHref("../docs/guide.md")).toEqual({ path: "../docs/guide.md" })
     })
   })
 
-  describe("strips fragments and queries", () => {
+  describe("file:// URLs return the decoded path", () => {
+    it("file:// URL on Unix", () => {
+      expect(extractFilePathFromHref("file:///foo/bar.ts")).toEqual({ path: "/foo/bar.ts" })
+    })
+
+    it("file:// URL with Windows drive", () => {
+      expect(extractFilePathFromHref("file:///C:/Users/dev/file.ts")).toEqual({ path: "C:/Users/dev/file.ts" })
+    })
+
+    it("file:// URL with encoded characters", () => {
+      expect(extractFilePathFromHref("file:///foo%20bar/baz.ts")).toEqual({ path: "/foo bar/baz.ts" })
+    })
+  })
+
+  describe("extracts line and column", () => {
+    it("path with line", () => {
+      expect(extractFilePathFromHref("src/foo.ts:42")).toEqual({ path: "src/foo.ts", line: 42 })
+    })
+
+    it("path with line and column", () => {
+      expect(extractFilePathFromHref("src/foo.ts:42:10")).toEqual({ path: "src/foo.ts", line: 42, column: 10 })
+    })
+
+    it("path with line range", () => {
+      expect(extractFilePathFromHref("src/index.ts:1-30")).toEqual({ path: "src/index.ts", line: 1 })
+    })
+
+    it("Windows path with line and column", () => {
+      expect(extractFilePathFromHref("C:\\src\\file.ts:12:5")).toEqual({
+        path: "C:\\src\\file.ts",
+        line: 12,
+        column: 5,
+      })
+    })
+  })
+
+  describe("strips fragments, queries, and diff prefixes", () => {
     it("strips #fragment", () => {
-      expect(extractFilePathFromHref("AGENTS.md#worktrees")).toBe("AGENTS.md")
+      expect(extractFilePathFromHref("AGENTS.md#worktrees")).toEqual({ path: "AGENTS.md" })
     })
 
     it("strips ?query", () => {
-      expect(extractFilePathFromHref("README.md?plain=1")).toBe("README.md")
+      expect(extractFilePathFromHref("README.md?plain=1")).toEqual({ path: "README.md" })
     })
 
-    it("strips both fragment and query", () => {
-      expect(extractFilePathFromHref("docs/guide.md?v=2#section")).toBe("docs/guide.md")
+    it("strips a/ prefix", () => {
+      expect(extractFilePathFromHref("a/src/app.ts")).toEqual({ path: "src/app.ts" })
     })
 
-    it("strips fragment from path with directory", () => {
-      expect(extractFilePathFromHref("src/foo.ts#L42")).toBe("src/foo.ts")
+    it("strips b/ prefix with line", () => {
+      expect(extractFilePathFromHref("b/src/app.ts:42")).toEqual({ path: "src/app.ts", line: 42 })
     })
   })
 
@@ -217,30 +198,26 @@ describe("extractFilePathFromHref", () => {
     })
   })
 
-  describe("rejects anchors and non-file values", () => {
+  describe("rejects anchors and empty", () => {
     it("pure anchor", () => {
       expect(extractFilePathFromHref("#section")).toBeUndefined()
-    })
-
-    it("anchor with nested path", () => {
-      expect(extractFilePathFromHref("#/some/path")).toBeUndefined()
     })
 
     it("empty string", () => {
       expect(extractFilePathFromHref("")).toBeUndefined()
     })
+  })
 
-    it("no extension (bare word)", () => {
-      expect(extractFilePathFromHref("README")).toBeUndefined()
+  describe("Windows drive letter not treated as scheme", () => {
+    it("C: drive path accepted", () => {
+      expect(extractFilePathFromHref("C:\\Users\\dev\\file.ts")).toEqual({ path: "C:\\Users\\dev\\file.ts" })
     })
 
-    it("directory-only path (no extension)", () => {
-      expect(extractFilePathFromHref("src/components/")).toBeUndefined()
-    })
-
-    it("fragment-only after stripping resolves to empty", () => {
-      // href is "#foo" — starts with # so rejected
-      expect(extractFilePathFromHref("#foo.md")).toBeUndefined()
+    it("D: drive path with line", () => {
+      expect(extractFilePathFromHref("D:\\projects\\app.tsx:10")).toEqual({
+        path: "D:\\projects\\app.tsx",
+        line: 10,
+      })
     })
   })
 })

--- a/packages/ui/src/file-path.ts
+++ b/packages/ui/src/file-path.ts
@@ -1,42 +1,46 @@
 // kilocode_change - new file
 
-// Matches text that looks like a file path:
-// - Unix: /foo/bar.ts, ./foo.ts, ../foo.ts, foo.ts
-// - Windows drive: C:\foo\bar.ts, C:/foo/bar.ts
-// - Windows UNC: \\server\share\file.ts
-// Supports optional :line or :line:col suffix.
-const FILE_PATH_UNIX_RE =
-  /^((?:\/|\.\.?\/)?(?:[a-zA-Z0-9_@-][a-zA-Z0-9_@./-]*\/)*[a-zA-Z0-9_@.-]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
-const FILE_PATH_WIN_RE = /^((?:[a-zA-Z]:[/\\]|\\\\)(?:[^\\/]+[/\\])*[^\\/]+\.[a-zA-Z0-9]+)(?::(\d+)(?::(\d+))?)?$/
-
 /**
- * Parse an inline code span into a file path with optional line/column.
- * Returns undefined when the text does not look like a file reference.
- *
- * Handles Unix paths (`/foo/bar.ts`, `./foo.ts`, `foo.ts`),
- * Windows drive paths (`C:\foo\bar.ts`), and UNC paths (`\\server\share\file.ts`).
+ * Strip an optional :line[-endline][:col] suffix from a code span.
+ * Returns the candidate file path and optional line/column numbers.
  */
-export function parseFilePath(text: string): { path: string; line?: number; column?: number } | undefined {
-  if (text.includes("://")) return undefined
-  if (text.includes(" ")) return undefined
-  const match = FILE_PATH_UNIX_RE.exec(text) ?? FILE_PATH_WIN_RE.exec(text)
-  if (!match) return undefined
-  return {
-    path: match[1],
-    line: match[2] ? parseInt(match[2], 10) : undefined,
-    column: match[3] ? parseInt(match[3], 10) : undefined,
-  }
+export function extractSuffix(text: string): { candidate: string; line?: number; column?: number } {
+  // Try :line:col first, then :line (with optional -endline range)
+  const m3 = /^(.+):(\d+)(?:-\d+)?:(\d+)$/.exec(text)
+  if (m3) return { candidate: m3[1], line: +m3[2], column: +m3[3] }
+  const m2 = /^(.+):(\d+)(?:-\d+)?$/.exec(text)
+  if (m2) return { candidate: m2[1], line: +m2[2] }
+  return { candidate: text }
 }
 
-const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/
+/**
+ * Normalize a candidate path for filesystem validation.
+ * Ensures the path has a ./ prefix if it's a bare relative path,
+ * so the extension can stat-check it against the workspace root.
+ */
+export function normalizeCandidatePath(path: string): string {
+  if (path.startsWith("./") || path.startsWith("../") || path.startsWith("/")) return path
+  // Windows absolute paths (C:\...) — leave as-is
+  if (/^[a-zA-Z]:[/\\]/.test(path)) return path
+  // Windows UNC paths (\\server\...) — leave as-is
+  if (path.startsWith("\\\\")) return path
+  // Strip a/b diff prefixes
+  const stripped = path.replace(/^[ab]\//, "")
+  return `./${stripped}`
+}
+
+// Matches a URI scheme but NOT a Windows drive letter (single char followed by colon).
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]+:/
 
 /**
- * Extract a file path from a markdown link href, or return undefined
- * when the href is a URL, anchor, scheme, or otherwise not a file reference.
+ * Extract a file path (with optional line/column) from a markdown link href,
+ * or return undefined when the href is a URL, anchor, scheme, or otherwise
+ * not a file reference.
  *
- * Strips `#fragment` and `?query` suffixes before returning the path.
+ * Strips `#fragment` and `?query` suffixes, then parses an optional
+ * `:line` or `:line:column` suffix from the remaining path.
  */
-export function extractFilePathFromHref(href: string): string | undefined {
+export function extractFilePathFromHref(href: string): { path: string; line?: number; column?: number } | undefined {
   if (!href) return undefined
   // Handle file:// URLs — extract the path component and decode it
   if (href.startsWith("file://")) {
@@ -52,7 +56,7 @@ export function extractFilePathFromHref(href: string): string | undefined {
         decoded.charCodeAt(0) === 47 /* / */ &&
         decoded.charCodeAt(2) === 58 /* : */ &&
         ((c1 >= 65 && c1 <= 90) /* A-Z */ || (c1 >= 97 && c1 <= 122)) /* a-z */
-      return isWindowsDrive ? decoded.slice(1) : decoded
+      return { path: isWindowsDrive ? decoded.slice(1) : decoded }
     } catch {
       return undefined
     }
@@ -64,7 +68,8 @@ export function extractFilePathFromHref(href: string): string | undefined {
   // Strip fragment and query before treating as file path
   const cleaned = href.replace(/[#?].*$/, "")
   if (!cleaned) return undefined
-  // Must look like a file path (has a dot for extension)
-  if (!cleaned.includes(".")) return undefined
-  return cleaned
+  // Strip a/b diff prefixes, parse :line[:col] suffix
+  const stripped = cleaned.replace(/^[ab]\//, "")
+  const { candidate, line, column } = extractSuffix(stripped)
+  return { path: candidate, line, column }
 }


### PR DESCRIPTION
## Issue

Re-split of #10340 per maintainer feedback (no separate tracking issue exists). Part 1 of 3.

**Stack (review/merge in order):** #11217 (this PR) → #11218 → #11219

## Context

First slice of the clickable-file-links work from #10340, rebased onto current `main` and split into smaller reviewable pieces as requested. This PR only changes the **path-parsing layer**: turning inline code / link hrefs into structured `{ path, line, column }` candidates that a later slice validates against the filesystem.

## Implementation

- Replaces the regex `parseFilePath` (a "does this look like a file?" matcher) with two small helpers: `extractSuffix` (strips `:line` / `:line:col` / `:start-end` suffixes) and `normalizeCandidatePath` (adds a `./` prefix to bare relative paths, strips `a/`+`b/` diff prefixes, leaves absolute/Windows/UNC paths alone).
- `extractFilePathFromHref` now returns `{ path, line, column }` instead of a bare string, and preserves `file://` decoding and Windows-drive handling.
- Both copies are updated: `packages/ui/src/file-path.ts` (shared opencode path, keeps its `kilocode_change` marker) and `packages/kilo-ui/src/file-path.ts` (Kilo-only).
- Detection intentionally shifts to "extract a candidate, let the filesystem confirm it" — confirmation lands in the dependent slices.

## Screenshots / Video

N/A — no user-visible change in this slice.

## How to Test

### Manual/local verification

- N/A (pure parsing module; covered by unit tests below).

### Reviewer test steps

1. From `packages/ui/`: `bun test src/file-path.test.ts`
2. Confirm 48 tests pass across `extractSuffix`, `normalizeCandidatePath`, and `extractFilePathFromHref`.

### Blocked checks and substitute verification

- A standalone `typecheck` of just this slice fails on purpose: its consumers (`marked.tsx`, `message-part.tsx`) are updated in the dependent UI PR (#11219). The full stack typechecks/tests/builds green. Substitute verification: ran this module's unit tests directly — agent-executed, 48 pass.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (the changeset lives in #11219, which carries the user-facing behavior)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
