### PR TITLE
docs: clarify checkpoint behavior without Git

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
@@ -360,7 +360,7 @@ Operations are queued to prevent concurrent Git operations that might corrupt re
 
 ## Git Installation
 
-Checkpoints require Git to be installed on your system.
+Checkpoints require Git to be installed on your system. If Git is unavailable or the workspace is not a Git repository, Kilo skips checkpoints automatically; you do not need to disable them manually.
 
 ### macOS
 


### PR DESCRIPTION
The checkpoint docs stated that Git is required but did not explain what happens when it is unavailable, which could imply that snapshots must be disabled manually.

Clarify that Kilo automatically skips checkpoints when Git is unavailable or the workspace is not a Git repository, so no configuration action is needed.