### PR TITLE
fix(cli): allow blocked clarification questions

### DIFF
--- a/.changeset/quiet-questions-clarify.md
+++ b/.changeset/quiet-questions-clarify.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow agents to ask one targeted clarification question when a task has no safe default.

--- a/packages/opencode/src/kilocode/soul.txt
+++ b/packages/opencode/src/kilocode/soul.txt
@@ -6,8 +6,8 @@ You are Kilo, a highly skilled software engineer with extensive knowledge in man
 - You accomplish tasks iteratively, breaking them down into clear steps and working through them methodically.
 - Do not ask for more information than necessary. Use the tools provided to accomplish the user's request efficiently and effectively.
 - You are STRICTLY FORBIDDEN from starting your messages with "Great", "Certainly", "Okay", "Sure". You should NOT be conversational in your responses, but rather direct and to the point. For example you should NOT say "Great, I've updated the CSS" but instead something like "I've updated the CSS". It is important you be clear and technical in your messages.
-- NEVER end your result with a question or request to engage in further conversation. Formulate the end of your result in a way that is final and does not require further input from the user.
-- The user may provide feedback, which you can use to make improvements and try again. But DO NOT continue in pointless back and forth conversations, i.e. don't end your responses with questions or offers for further assistance.
+- Do not end a completed result with a purely social follow-up question or offer for further assistance. If the task is genuinely blocked after checking available context and no safe default exists, ask one concise, targeted clarification question instead.
+- The user may provide feedback, which you can use to make improvements and try again. But DO NOT continue in pointless back and forth conversations or ask questions that only invite more conversation without advancing the task.
 
 # Code
 

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -13,6 +13,17 @@ import PROMPT_GPT55 from "../../src/session/prompt/kilocode-gpt-5.5.txt"
 import PROMPT_LING from "../../src/session/prompt/ling.txt"
 import PROMPT_TRINITY from "../../src/session/prompt/trinity.txt"
 
+describe("SystemPrompt.soul", () => {
+  test("distinguishes blocked clarification from social follow-up questions", () => {
+    const result = SystemPrompt.soul()
+    expect(result).toContain("Do not end a completed result with a purely social follow-up question")
+    expect(result).toContain(
+      "If the task is genuinely blocked after checking available context and no safe default exists, ask one concise, targeted clarification question instead.",
+    )
+    expect(result).not.toContain("NEVER end your result with a question")
+  })
+})
+
 describe("SystemPrompt.provider", () => {
   describe("model.prompt override", () => {
     test("anthropic prompt is selected when model.prompt is 'anthropic'", () => {


### PR DESCRIPTION
The global Kilo soul treated every trailing question as conversational drift, which conflicted with model-specific prompts and plan mode when missing information genuinely blocks safe progress.

Narrow the rule to completed-result social follow-ups while explicitly allowing one concise clarification after context has been checked and no safe default exists. This preserves autonomous execution and discourages permission-seeking without pushing agents toward arbitrary assumptions for materially ambiguous, destructive, or credential-dependent work.

The prompt contract is covered so the blocked-clarification exception cannot silently regress.

Fixes #11186