### PR TITLE
fix: support unauthenticated OpenAI-compatible indexing

### DIFF
--- a/.changeset/allow-keyless-indexing.md
+++ b/.changeset/allow-keyless-indexing.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-indexing": patch
+"kilo-code": patch
+---
+
+Support unauthenticated OpenAI-compatible endpoints for codebase indexing without requiring a placeholder API key.

--- a/packages/kilo-docs/pages/customize/context/codebase-indexing.md
+++ b/packages/kilo-docs/pages/customize/context/codebase-indexing.md
@@ -64,7 +64,7 @@ You can also edit the `indexing` section in `kilo.jsonc` directly:
 |---|---|---|
 | **OpenAI** | API key | Default model: `text-embedding-3-small`. `text-embedding-3-large` for higher accuracy. |
 | **Ollama** | Local base URL | No API costs. Runs fully offline. |
-| **OpenAI-Compatible** | Base URL + API key | For self-hosted or third-party OpenAI-compatible endpoints. |
+| **OpenAI-Compatible** | Base URL + optional API key | For self-hosted or third-party OpenAI-compatible endpoints, including unauthenticated local servers. |
 | **Gemini** | Google AI API key | Supports `gemini-embedding-001` and other Gemini embedding models. |
 | **Mistral** | API key from [La Plateforme](https://console.mistral.ai/api-keys/) | Use a standard Mistral API key. The Codestral-specific keys from the [Mistral autocomplete setup guide](/docs/code-with-ai/features/autocomplete/mistral-setup) are **not** interchangeable — those only work for completion. |
 | **Vercel AI Gateway** | API key | Routes requests through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway). |
@@ -143,7 +143,7 @@ You can also edit the `indexing` section directly. This is the full shape of the
 |---|---|---|---|
 | **OpenAI** | `openai` | `{ apiKey }` | Default: `text-embedding-3-small`. |
 | **Ollama** | `ollama` | `{ baseUrl }` | No API costs. Runs fully offline. |
-| **OpenAI-Compatible** | `openai-compatible` | `{ baseUrl, apiKey }` | For self-hosted or third-party endpoints. |
+| **OpenAI-Compatible** | `openai-compatible` | `{ baseUrl, apiKey? }` | For self-hosted or third-party endpoints, including unauthenticated local servers. |
 | **Gemini** | `gemini` | `{ apiKey }` | Supports `gemini-embedding-001`. |
 | **Mistral** | `mistral` | `{ apiKey }` | Use a [La Plateforme](https://console.mistral.ai/api-keys/) key — the Codestral-specific keys from the [autocomplete setup guide](/docs/code-with-ai/features/autocomplete/mistral-setup) don't work for embeddings. |
 | **Vercel AI Gateway** | `vercel-ai-gateway` | `{ apiKey }` | Routes through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway). |

--- a/packages/kilo-indexing/src/indexing/config-manager.ts
+++ b/packages/kilo-indexing/src/indexing/config-manager.ts
@@ -57,7 +57,7 @@ export class CodeIndexConfigManager {
   private kiloOptions?: { apiKey: string; baseUrl?: string; organizationId?: string }
   private openAiOptions?: { apiKey: string }
   private ollamaOptions?: { baseUrl: string; modelId?: string }
-  private openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
+  private openAiCompatibleOptions?: { baseUrl: string; apiKey?: string }
   private geminiOptions?: { apiKey: string }
   private mistralOptions?: { apiKey: string }
   private vercelAiGatewayOptions?: { apiKey: string }
@@ -112,10 +112,9 @@ export class CodeIndexConfigManager {
     this.openAiOptions = input.openAiKey ? { apiKey: input.openAiKey } : undefined
     const url = input.ollamaBaseUrl ?? (input.embedderProvider === "ollama" ? "http://localhost:11434" : undefined)
     this.ollamaOptions = url ? { baseUrl: url, modelId: input.modelId } : undefined
-    this.openAiCompatibleOptions =
-      input.openAiCompatibleBaseUrl && input.openAiCompatibleApiKey
-        ? { baseUrl: input.openAiCompatibleBaseUrl, apiKey: input.openAiCompatibleApiKey }
-        : undefined
+    this.openAiCompatibleOptions = input.openAiCompatibleBaseUrl
+      ? { baseUrl: input.openAiCompatibleBaseUrl, apiKey: input.openAiCompatibleApiKey?.trim() || undefined }
+      : undefined
     this.geminiOptions = input.geminiApiKey ? { apiKey: input.geminiApiKey } : undefined
     this.mistralOptions = input.mistralApiKey ? { apiKey: input.mistralApiKey } : undefined
     this.vercelAiGatewayOptions = input.vercelAiGatewayApiKey ? { apiKey: input.vercelAiGatewayApiKey } : undefined
@@ -168,8 +167,7 @@ export class CodeIndexConfigManager {
       return !!(this.kiloOptions?.apiKey && this.modelId && this.currentModelDimension && hasStore)
     if (provider === "openai") return !!(this.openAiOptions?.apiKey && hasStore)
     if (provider === "ollama") return !!(this.ollamaOptions?.baseUrl && hasStore)
-    if (provider === "openai-compatible")
-      return !!(this.openAiCompatibleOptions?.baseUrl && this.openAiCompatibleOptions?.apiKey && hasStore)
+    if (provider === "openai-compatible") return !!(this.openAiCompatibleOptions?.baseUrl && hasStore)
     if (provider === "gemini") return !!(this.geminiOptions?.apiKey && hasStore)
     if (provider === "mistral") return !!(this.mistralOptions?.apiKey && hasStore)
     if (provider === "vercel-ai-gateway") return !!(this.vercelAiGatewayOptions?.apiKey && hasStore)

--- a/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
+++ b/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
@@ -42,7 +42,7 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
   private embeddingsClient: OpenAI
   private readonly defaultModelId: string
   private readonly baseUrl: string
-  private readonly apiKey: string
+  private readonly apiKey?: string
   private readonly isFullUrl: boolean
   private readonly maxItemTokens: number
   private readonly headers: Record<string, string>
@@ -61,13 +61,13 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
   /**
    * Creates a new OpenAI Compatible embedder
    * @param baseUrl The base URL for the OpenAI-compatible API endpoint
-   * @param apiKey The API key for authentication
+   * @param apiKey Optional API key for authentication
    * @param modelId Optional model identifier (defaults to "text-embedding-3-small")
    * @param maxItemTokens Optional maximum tokens per item (defaults to MAX_ITEM_TOKENS)
    */
   constructor(
     baseUrl: string,
-    apiKey: string,
+    apiKey?: string,
     modelId?: string,
     maxItemTokens?: number,
     options: OpenAICompatibleOptions = {},
@@ -75,18 +75,24 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
     if (!baseUrl) {
       throw new Error("Base URL is required for OpenAI-compatible embedder")
     }
-    if (!apiKey) {
-      throw new Error("API key is required for OpenAI-compatible embedder")
-    }
 
     this.baseUrl = baseUrl
-    this.apiKey = apiKey
+    this.apiKey = apiKey?.trim() || undefined
 
     try {
+      const defaults = new Headers(options.headers)
       this.embeddingsClient = new OpenAI({
         baseURL: baseUrl,
-        apiKey: apiKey,
+        apiKey: this.apiKey ?? "EMPTY",
         defaultHeaders: options.headers,
+        fetch: this.apiKey
+          ? undefined
+          : async (input, init) => {
+              const headers = new Headers(init?.headers)
+              if (!defaults.has("authorization")) headers.delete("authorization")
+              if (!defaults.has("api-key")) headers.delete("api-key")
+              return globalThis.fetch(input, { ...init, headers })
+            },
       })
     } catch (error) {
       throw error instanceof Error ? error : new Error(String(error))
@@ -213,10 +219,12 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
       headers: {
         "Content-Type": "application/json",
         ...this.headers,
-        // Azure OpenAI uses 'api-key' header, while OpenAI uses 'Authorization'
-        // We'll try 'api-key' first for Azure compatibility
-        "api-key": this.apiKey,
-        Authorization: `Bearer ${this.apiKey}`,
+        ...(this.apiKey
+          ? {
+              "api-key": this.apiKey,
+              Authorization: `Bearer ${this.apiKey}`,
+            }
+          : {}),
       },
       body: JSON.stringify({
         input: batchTexts,

--- a/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
+++ b/packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts
@@ -79,24 +79,20 @@ export class OpenAICompatibleEmbedder implements IEmbedder {
     this.baseUrl = baseUrl
     this.apiKey = apiKey?.trim() || undefined
 
-    try {
-      const defaults = new Headers(options.headers)
-      this.embeddingsClient = new OpenAI({
-        baseURL: baseUrl,
-        apiKey: this.apiKey ?? "EMPTY",
-        defaultHeaders: options.headers,
-        fetch: this.apiKey
-          ? undefined
-          : async (input, init) => {
-              const headers = new Headers(init?.headers)
-              if (!defaults.has("authorization")) headers.delete("authorization")
-              if (!defaults.has("api-key")) headers.delete("api-key")
-              return globalThis.fetch(input, { ...init, headers })
-            },
-      })
-    } catch (error) {
-      throw error instanceof Error ? error : new Error(String(error))
-    }
+    const defaults = new Headers(options.headers)
+    this.embeddingsClient = new OpenAI({
+      baseURL: baseUrl,
+      apiKey: this.apiKey ?? "EMPTY",
+      defaultHeaders: options.headers,
+      fetch: this.apiKey
+        ? undefined
+        : async (input, init) => {
+            const headers = new Headers(init?.headers)
+            if (!defaults.has("authorization")) headers.delete("authorization")
+            if (!defaults.has("api-key")) headers.delete("api-key")
+            return globalThis.fetch(input, { ...init, headers: Object.fromEntries(headers) })
+          },
+    })
 
     this.defaultModelId = modelId || getDefaultModelId("openai-compatible")
     // Cache the URL type check for performance

--- a/packages/kilo-indexing/src/indexing/interfaces/config.ts
+++ b/packages/kilo-indexing/src/indexing/interfaces/config.ts
@@ -17,7 +17,7 @@ export interface CodeIndexConfig {
   kiloOptions?: { apiKey: string; baseUrl?: string; organizationId?: string }
   openAiOptions?: { apiKey: string }
   ollamaOptions?: { baseUrl: string; modelId?: string }
-  openAiCompatibleOptions?: { baseUrl: string; apiKey: string }
+  openAiCompatibleOptions?: { baseUrl: string; apiKey?: string }
   geminiOptions?: { apiKey: string }
   mistralOptions?: { apiKey: string }
   vercelAiGatewayOptions?: { apiKey: string }

--- a/packages/kilo-indexing/src/indexing/service-factory.ts
+++ b/packages/kilo-indexing/src/indexing/service-factory.ts
@@ -85,8 +85,7 @@ export class CodeIndexServiceFactory {
       return new CodeIndexOllamaEmbedder(config.ollamaOptions.baseUrl, config.modelId, config.modelDimension)
     }
     if (provider === "openai-compatible") {
-      if (!config.openAiCompatibleOptions?.baseUrl || !config.openAiCompatibleOptions?.apiKey)
-        throw new Error("OpenAI-compatible base URL and API key are required.")
+      if (!config.openAiCompatibleOptions?.baseUrl) throw new Error("OpenAI-compatible base URL is required.")
       return new OpenAICompatibleEmbedder(
         config.openAiCompatibleOptions.baseUrl,
         config.openAiCompatibleOptions.apiKey,

--- a/packages/kilo-indexing/test/kilocode/indexing/config-manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/config-manager.test.ts
@@ -26,6 +26,34 @@ describe("CodeIndexConfigManager", () => {
     expect(cfg.getConfig().ollamaOptions?.baseUrl).toBe("http://localhost:11434")
   })
 
+  test("configures an OpenAI-compatible endpoint without an API key", () => {
+    const cfg = new CodeIndexConfigManager(
+      createInput({
+        embedderProvider: "openai-compatible",
+        openAiKey: undefined,
+        openAiCompatibleBaseUrl: "http://localhost:1234/v1",
+      }),
+    )
+
+    expect(cfg.isFeatureConfigured).toBe(true)
+    expect(cfg.getConfig().openAiCompatibleOptions).toEqual({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: undefined,
+    })
+  })
+
+  test("requires a base URL for an OpenAI-compatible endpoint", () => {
+    const cfg = new CodeIndexConfigManager(
+      createInput({
+        embedderProvider: "openai-compatible",
+        openAiKey: undefined,
+        openAiCompatibleApiKey: "sk-test",
+      }),
+    )
+
+    expect(cfg.isFeatureConfigured).toBe(false)
+  })
+
   test("defaults vector store to LanceDB when omitted", () => {
     const cfg = new CodeIndexConfigManager(createInput({ vectorStoreProvider: undefined }))
 
@@ -140,6 +168,19 @@ describe("CodeIndexConfigManager", () => {
       )
 
       expect(result.requiresRestart).toBe(true)
+    })
+
+    test("requires restart when OpenAI-compatible auth is added or removed", () => {
+      const input = createInput({
+        embedderProvider: "openai-compatible",
+        openAiKey: undefined,
+        openAiCompatibleBaseUrl: "http://localhost:1234/v1",
+      })
+      const cfg = new CodeIndexConfigManager(input)
+
+      expect(cfg.loadConfiguration({ ...input, openAiCompatibleApiKey: "sk-test" }).requiresRestart).toBe(true)
+      expect(cfg.loadConfiguration(input).requiresRestart).toBe(true)
+      expect(cfg.loadConfiguration(input).requiresRestart).toBe(false)
     })
 
     test("requires restart when Kilo auth changes", () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
@@ -706,6 +706,7 @@ describe("OpenAICompatibleEmbedder", () => {
 
           const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined
           const headers = new Headers(init?.headers)
+          expect(init?.headers).not.toBeInstanceOf(Headers)
           expect(headers.get("authorization")).toBeNull()
           expect(headers.get("api-key")).toBeNull()
           expect(headers.get("x-fixture")).toBe("present")

--- a/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/embedders/openai-compatible.test.ts
@@ -63,10 +63,10 @@ describe("OpenAICompatibleEmbedder", () => {
       )
     })
 
-    test("should throw error when apiKey is missing", () => {
-      expect(() => new OpenAICompatibleEmbedder(testBaseUrl, "", testModelId)).toThrow(
-        "API key is required for OpenAI-compatible embedder",
-      )
+    test("should create embedder without an API key", () => {
+      embedder = new OpenAICompatibleEmbedder(testBaseUrl, "", testModelId)
+
+      expect(embedder).toBeDefined()
     })
 
     test("should throw error when both baseUrl and apiKey are missing", () => {
@@ -647,6 +647,68 @@ describe("OpenAICompatibleEmbedder", () => {
           expect(mockEmbeddingsCreate).toHaveBeenCalled()
           expect(mockFetch).not.toHaveBeenCalled()
           expect(baseResult.embeddings[0]).toEqual([0.4, 0.5, 0.6])
+        })
+
+        test("should omit auth headers for a keyless full endpoint", async () => {
+          const embedder = new OpenAICompatibleEmbedder(azureUrl, undefined, testModelId)
+          const base64String = createBase64Embedding([0.1, 0.2, 0.3])
+          mockFetch.mockResolvedValue(
+            createMockResponse({
+              data: [{ embedding: base64String }],
+              usage: { prompt_tokens: 1, total_tokens: 1 },
+            }) as any,
+          )
+
+          await embedder.createEmbeddings(["test"])
+
+          const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined
+          const headers = new Headers(init?.headers)
+          expect(headers.get("authorization")).toBeNull()
+          expect(headers.get("api-key")).toBeNull()
+        })
+
+        test("should preserve custom headers for a keyless full endpoint", async () => {
+          const embedder = new OpenAICompatibleEmbedder(azureUrl, undefined, testModelId, undefined, {
+            headers: { Authorization: "Custom token", "x-fixture": "present" },
+          })
+          const base64String = createBase64Embedding([0.1, 0.2, 0.3])
+          mockFetch.mockResolvedValue(
+            createMockResponse({
+              data: [{ embedding: base64String }],
+              usage: { prompt_tokens: 1, total_tokens: 1 },
+            }) as any,
+          )
+
+          await embedder.createEmbeddings(["test"])
+
+          const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined
+          const headers = new Headers(init?.headers)
+          expect(headers.get("authorization")).toBe("Custom token")
+          expect(headers.get("x-fixture")).toBe("present")
+        })
+
+        test("should omit generated SDK auth headers when no key is configured", async () => {
+          let request: ((input: string | URL | Request, init?: RequestInit) => Promise<Response>) | undefined
+          setOpenAIConstructorHook((config) => {
+            request = config.fetch
+          })
+          new OpenAICompatibleEmbedder(baseUrl, undefined, testModelId)
+          mockFetch.mockResolvedValue(new Response())
+
+          if (!request) throw new Error("Missing OpenAI-compatible fetch adapter")
+          await request("https://api.example.com/v1/embeddings", {
+            headers: {
+              Authorization: "Bearer EMPTY",
+              "api-key": "EMPTY",
+              "x-fixture": "present",
+            },
+          })
+
+          const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined
+          const headers = new Headers(init?.headers)
+          expect(headers.get("authorization")).toBeNull()
+          expect(headers.get("api-key")).toBeNull()
+          expect(headers.get("x-fixture")).toBe("present")
         })
 
         test.each([

--- a/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { CodeIndexManager } from "../../../src/indexing/manager"
 import type { IndexingConfigInput } from "../../../src/indexing/config-manager"
 import type { IndexingTelemetryEvent, IndexingTelemetryTrigger } from "../../../src/indexing/interfaces/telemetry"
@@ -98,6 +101,65 @@ describe("CodeIndexManager", () => {
     expect(mgr.isFeatureConfigured).toBe(false)
     expect(mgr.getCurrentStatus().systemStatus).toBe("Standby")
     expect(mgr.getCurrentStatus().message).toContain("not configured")
+  })
+
+  test("initializes an unauthenticated OpenAI-compatible endpoint without auth headers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kilo-keyless-indexing-"))
+    const workspace = join(root, "workspace")
+    const cache = join(root, "cache")
+    const requests: Array<{ authorization: string | null; apiKey: string | null }> = []
+    await Bun.write(join(workspace, ".gitkeep"), "")
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        requests.push({
+          authorization: req.headers.get("authorization"),
+          apiKey: req.headers.get("api-key"),
+        })
+        return Response.json({
+          object: "list",
+          data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }],
+          model: "fixture-model",
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        })
+      },
+    })
+
+    try {
+      const script = `
+        import { CodeIndexManager } from "./src/indexing/manager.ts"
+        import { normalizeIndexingStatus } from "./src/status.ts"
+        const mgr = new CodeIndexManager(${JSON.stringify(workspace)}, ${JSON.stringify(cache)})
+        try {
+          await mgr.initialize({
+            enabled: true,
+            embedderProvider: "openai-compatible",
+            vectorStoreProvider: "lancedb",
+            modelId: "fixture-model",
+            modelDimension: 3,
+            openAiCompatibleBaseUrl: ${JSON.stringify(`http://127.0.0.1:${server.port}/v1`)},
+          })
+          if (!mgr.isInitialized) throw new Error("Manager did not initialize")
+          if (normalizeIndexingStatus(mgr).state === "Disabled") throw new Error("Indexing remained disabled")
+        } finally {
+          await mgr.dispose()
+        }
+      `
+      const child = Bun.spawn([process.execPath, "-e", script], {
+        cwd: process.cwd(),
+        stdout: "pipe",
+        stderr: "pipe",
+        windowsHide: true,
+      })
+      const [exit, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
+      if (exit !== 0) throw new Error(stderr)
+
+      expect(requests).toEqual([{ authorization: null, apiKey: null }])
+    } finally {
+      server.stop(true)
+      await rm(root, { recursive: true, force: true })
+    }
   })
 
   test("cancels active indexing when configuration is removed", async () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
@@ -147,12 +147,20 @@ describe("CodeIndexManager", () => {
         }
       `
       const child = Bun.spawn([process.execPath, "-e", script], {
-        cwd: process.cwd(),
+        cwd: join(import.meta.dir, "../../.."),
         stdout: "pipe",
         stderr: "pipe",
         windowsHide: true,
       })
-      const [exit, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
+      const gate = Promise.withResolvers<never>()
+      const timeout = setTimeout(() => {
+        child.kill()
+        gate.reject(new Error("Indexing subprocess timed out"))
+      }, 10_000)
+      const [exit, stderr] = await Promise.race([
+        Promise.all([child.exited, new Response(child.stderr).text()]),
+        gate.promise,
+      ]).finally(() => clearTimeout(timeout))
       if (exit !== 0) throw new Error(stderr)
 
       expect(requests).toEqual([{ authorization: null, apiKey: null }])

--- a/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
@@ -29,6 +29,16 @@ describe("CodeIndexServiceFactory", () => {
     setOpenAIConstructorHook(undefined)
   })
 
+  test("creates an OpenAI-compatible embedder without an API key", () => {
+    const factory = createFactory({
+      embedderProvider: "openai-compatible",
+      openAiKey: undefined,
+      openAiCompatibleBaseUrl: "http://localhost:1234/v1",
+    })
+
+    expect(factory.createEmbedder().embedderInfo).toEqual({ name: "openai-compatible" })
+  })
+
   test("uses default LanceDB directory when config is unset", () => {
     const factory = createFactory({ vectorStoreProvider: "lancedb", lancedbVectorStoreDirectory: undefined })
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/IndexingTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/IndexingTab.tsx
@@ -70,7 +70,7 @@ function providerFields(provider: ProviderId | undefined): Array<{ key: string; 
   if (provider === "openai-compatible") {
     return [
       { key: "baseUrl", label: "Base URL", placeholder: "https://api.example.com/v1" },
-      { key: "apiKey", label: "API Key", placeholder: "sk-..." },
+      { key: "apiKey", label: "API Key (optional)", placeholder: "sk-..." },
     ]
   }
   if (provider === "gemini") return [{ key: "apiKey", label: "API Key", placeholder: "AI..." }]

--- a/packages/opencode/src/kilocode/components/dialog-indexing.tsx
+++ b/packages/opencode/src/kilocode/components/dialog-indexing.tsx
@@ -59,7 +59,7 @@ const PROVIDER_FIELDS: Record<EmbeddingProvider, ProviderFieldDef[]> = {
   ollama: [{ key: "baseUrl", label: "Base URL", placeholder: "http://localhost:11434" }],
   "openai-compatible": [
     { key: "baseUrl", label: "Base URL", placeholder: "https://api.example.com/v1" },
-    { key: "apiKey", label: "API Key", placeholder: "sk-...", sensitive: true },
+    { key: "apiKey", label: "API Key (optional)", placeholder: "sk-...", sensitive: true },
   ],
   gemini: [{ key: "apiKey", label: "API Key", placeholder: "AI...", sensitive: true }],
   mistral: [{ key: "apiKey", label: "API Key", placeholder: "...", sensitive: true }],


### PR DESCRIPTION
OpenAI-compatible indexing currently treats the API key as required configuration. Endpoints that intentionally do not require authentication therefore remain unconfigured and surface `IDX Disabled`; entering an arbitrary placeholder only works because it passes the truthiness check and the endpoint ignores the generated credentials.

Make authentication optional while keeping the base URL required. Keyless requests omit both `Authorization` and `api-key`, authenticated requests keep their existing behavior, and explicitly configured custom headers remain intact. The VS Code and CLI settings now identify the field as optional, and the indexing documentation describes unauthenticated local servers as supported.

This is compatible with #11182: shared Agent Manager worktree indexes will reuse the same main-workspace indexing engine, including a keyless OpenAI-compatible configuration, without changing the index ownership model introduced there.

Fixes #11208
Related to #11182