### PR TITLE
fix(cli): prefix generated plan filenames with timestamp

### DIFF
--- a/.changeset/plan-timestamp-prefix.md
+++ b/.changeset/plan-timestamp-prefix.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore session timestamp prefixes for generated plan filenames while preserving descriptive model-chosen names.

--- a/packages/opencode/src/kilocode/session/native-plan-prompt.txt
+++ b/packages/opencode/src/kilocode/session/native-plan-prompt.txt
@@ -22,7 +22,7 @@ Your job is to gather context, challenge assumptions, resolve design questions, 
 
 - You may create and edit plan Markdown files only.
 - Follow the latest Plan File reminder for the target plan location.
-- Prefer `.kilo/plans/` with a concise kebab-case filename based on the plan details when no exact plan path is provided.
+- If no exact plan file path is provided, follow the latest Plan File reminder for the directory and generated filename pattern.
 - Use repo-root `plans/`, `.plans/`, or `.opencode/plans/` only when requested or required by the repo/client and your permissions allow it.
 - Do not write the final plan or call `plan_exit` until the user chooses "Finalize and save the plan".
 - After final approval, write the final plan to the chosen plan file, then call `plan_exit` with the saved plan path.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -287,12 +287,13 @@ export namespace KiloSessionPrompt {
     const file = input.messages ? PlanFile.latest(input.messages) : undefined
     const saved = PlanFile.resolve(file, ctx)
     const target = saved ?? plan
+    const time = input.session.time.created
     const dir = path.dirname(target)
     if (saved && !(await Filesystem.exists(target))) await ensurePlanDir(dir)
 
     const info = saved
       ? `The current saved plan file is ${target}. Read and edit this file when refining the plan.`
-      : `Use the plan path specified by the user or project instructions when present and permissions allow it. If none is specified, create a plan in ${dir} using a concise kebab-case filename based on the plan details.`
+      : `Use any exact plan file path from user or project instructions unchanged. If only a directory is specified, create the plan there; otherwise create it in ${dir}. For generated filenames, use ${time}-<concise-kebab-case-suffix>.md, choosing the suffix from the plan details, for example ${time}-database-cache-plan.md.`
     const body = [
       "## Plan File",
       info,

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -681,9 +681,9 @@ describe("plan_exit detection", () => {
 
       const part = user.parts.at(-1)
       const text = part?.type === "text" ? part.text : ""
-      expect(text).toContain("Use the plan path specified by the user or project instructions")
+      expect(text).toContain(`${session.time.created}-<concise-kebab-case-suffix>.md`)
+      expect(text).toContain(`${session.time.created}-database-cache-plan.md`)
       expect(text).toContain("plans/ or .plans/")
-      expect(text).toContain("If none is specified")
       expect(text).not.toContain(Session.plan(session, Instance.current))
     }))
 
@@ -733,8 +733,7 @@ describe("plan_exit detection", () => {
       const text = content(user)
       expect(text).toContain("The current saved plan file is")
       expect(text.replaceAll(path.sep, "/")).toContain(".plans/fix.md")
-      expect(text).toContain("Read and edit this file when refining the plan")
-      expect(text).toContain("experienced technical leader")
+      expect(text).not.toContain(`${session.time.created}-<concise-kebab-case-suffix>.md`)
       expect(text).not.toContain("No plan file exists yet")
     }))
 
@@ -771,8 +770,7 @@ describe("plan_exit detection", () => {
 
       const part = user.parts.at(-1)
       const text = part?.type === "text" ? part.text : ""
-      expect(text).toContain("Use the plan path specified by the user or project instructions")
-      expect(text).toContain("If none is specified")
+      expect(text).toContain(`${session.time.created}-<concise-kebab-case-suffix>.md`)
       expect(text).toContain("plans/ or .plans/")
       expect(text).not.toContain("Default to")
       expect(text).not.toContain("A fallback plan file exists")


### PR DESCRIPTION
## Issue

Fixes #10987

## Context

Generated plan files lost their timestamp prefix, which regressed natural chronological sorting in editors that sort file explorers by name. This PR restores timestamp-prefixed generated plan filenames without forcing the whole filename from `Session.plan`.

Exact user/project file paths still remain unchanged. When the user or project gives only a plan directory, or gives no plan path, the reminder now tells the model to use the real session timestamp as the prefix and choose a concise kebab-case suffix from the plan details.

## Implementation

The Kilo-owned plan reminder now includes `session.time.created` as the required prefix pattern for generated filenames, while keeping saved `plan_exit` paths as the refinement target. The native plan prompt was updated to defer to that latest reminder so exact paths, directory-only paths, and default plan locations are handled consistently.

This intentionally does not compute or force the final `Session.plan` path into the prompt, because that would lose the model-selected descriptive suffix.

## Screenshots / Video

### CLI
<img width="1658" height="198" alt="Screenshot 2026-06-15 at 15 49 47" src="https://github.com/user-attachments/assets/0d592391-5987-4441-8256-910cde4a2912" />

### Extension
<img width="389" height="798" alt="Screenshot 2026-06-15 at 16 17 32" src="https://github.com/user-attachments/assets/caf095be-53e4-4a1b-a504-bb01921f0570" />

## How to Test

### Manual/local verification

- Agen: `bun test ./test/kilocode/plan-exit-detection.test.ts` from `packages/opencode`.
- Agent: `bun run typecheck` from `packages/opencode`.
- Agent: push hook ran `bun turbo typecheck` successfully.

### Reviewer test steps

1. Start a native plan or Architect planning turn without an exact plan file path.
2. Confirm the injected Plan File reminder tells the model to use `<session timestamp>-<concise-kebab-case-suffix>.md` for generated filenames.
3. Provide an exact plan file path and confirm the reminder says not to add or change a timestamp prefix.
4. Refine a session with an existing `plan_exit` path and confirm that saved path is reused unchanged.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
