### PR TITLE
fix: format provider rate limit errors

### DIFF
--- a/.changeset/clear-rate-limit-errors.md
+++ b/.changeset/clear-rate-limit-errors.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show a clear, retryable provider rate-limit error instead of raw response JSON in chat.

--- a/packages/kilo-vscode/tests/unit/errorUtils.test.ts
+++ b/packages/kilo-vscode/tests/unit/errorUtils.test.ts
@@ -28,6 +28,26 @@ describe("unwrapError", () => {
     const json = JSON.stringify({ message: "connection refused" })
     expect(unwrapError(`Error: ${json}`)).toBe("connection refused")
   })
+
+  it("formats empty provider rate-limit errors", () => {
+    const body = {
+      type: "error",
+      sequence_number: 2,
+      error: { type: "tokens", code: "rate_limit_exceeded", message: "", param: null },
+    }
+    const input = JSON.stringify({ message: JSON.stringify(body) })
+
+    expect(unwrapError(input)).toBe("Provider rate limit exceeded. Please try again shortly.")
+  })
+
+  it("preserves provider details when a rate-limit message is present", () => {
+    const input = JSON.stringify({
+      type: "error",
+      error: { type: "tokens", code: "rate_limit_exceeded", message: "Try again in 30 seconds." },
+    })
+
+    expect(unwrapError(input)).toBe("tokens: Try again in 30 seconds.")
+  })
 })
 
 describe("parseAssistantError", () => {

--- a/packages/kilo-vscode/webview-ui/src/utils/errorUtils.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/errorUtils.ts
@@ -1,45 +1,58 @@
 import type { AssistantMessage } from "@kilocode/sdk/v2"
 
-export function unwrapError(message: string): string {
-  const text = message.replace(/^Error:\s*/, "").trim()
-  const tryParse = (v: string) => {
-    try {
-      return JSON.parse(v) as unknown
-    } catch {
-      return undefined
-    }
+function parse(value: string) {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return undefined
   }
-  const read = (v: string) => {
-    const first = tryParse(v)
-    if (typeof first !== "string") return first
-    return tryParse(first.trim())
+}
+
+function read(value: string) {
+  const first = parse(value)
+  if (typeof first !== "string") return first
+  return parse(first.trim())
+}
+
+function detail(err: Record<string, unknown>) {
+  const type = typeof err.type === "string" ? err.type : undefined
+  const code = typeof err.code === "string" ? err.code : undefined
+  const msg = typeof err.message === "string" && err.message.trim() ? err.message : undefined
+  if (type && msg) return `${type}: ${msg}`
+  if (msg) return msg
+  if (code === "rate_limit_exceeded") return "Provider rate limit exceeded. Please try again shortly."
+  if (code) return code
+  return type
+}
+
+function format(value: unknown, depth: number): string | undefined {
+  if (depth > 3) return
+  if (typeof value === "string") {
+    const nested = read(value.trim())
+    return nested === undefined ? value : format(nested, depth + 1)
   }
-  let json = read(text)
-  if (json === undefined) {
-    const start = text.indexOf("{")
-    const end = text.lastIndexOf("}")
-    if (start !== -1 && end > start) json = read(text.slice(start, end + 1))
-  }
-  if (!json || typeof json !== "object" || Array.isArray(json)) return message
-  const rec = json as Record<string, unknown>
+  if (!value || typeof value !== "object" || Array.isArray(value)) return
+
+  const rec = value as Record<string, unknown>
   const err =
     rec.error && typeof rec.error === "object" && !Array.isArray(rec.error)
       ? (rec.error as Record<string, unknown>)
       : undefined
-  if (err) {
-    const type = typeof err.type === "string" ? err.type : undefined
-    const msg = typeof err.message === "string" ? err.message : undefined
-    if (type && msg) return `${type}: ${msg}`
-    if (msg) return msg
-    if (type) return type
-    const code = typeof err.code === "string" ? err.code : undefined
-    if (code) return code
-  }
-  const msg = typeof rec.message === "string" ? rec.message : undefined
-  if (msg) return msg
-  const reason = typeof rec.error === "string" ? rec.error : undefined
-  if (reason) return reason
-  return message
+  const message = err ? detail(err) : undefined
+  if (message) return message
+  if (typeof rec.message === "string" && rec.message.trim()) return format(rec.message, depth + 1)
+  if (typeof rec.error === "string" && rec.error.trim()) return rec.error
+}
+
+export function unwrapError(message: string): string {
+  const text = message.replace(/^Error:\s*/, "").trim()
+  const direct = read(text)
+  if (direct !== undefined) return format(direct, 0) ?? message
+
+  const start = text.indexOf("{")
+  const end = text.lastIndexOf("}")
+  if (start === -1 || end <= start) return message
+  return format(read(text.slice(start, end + 1)), 0) ?? message
 }
 
 const errorCodes = {

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -135,6 +135,18 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
         message: "Input exceeds context window of this model",
         responseBody,
       }
+    // kilocode_change start - normalize empty provider rate-limit stream errors
+    case "rate_limit_exceeded":
+      return {
+        type: "api_error",
+        message:
+          typeof body?.error?.message === "string" && body.error.message.trim()
+            ? body.error.message
+            : "Provider rate limit exceeded. Please try again shortly.",
+        isRetryable: true,
+        responseBody,
+      }
+    // kilocode_change end
     case "insufficient_quota":
       return {
         type: "api_error",

--- a/packages/opencode/test/kilocode/provider/error.test.ts
+++ b/packages/opencode/test/kilocode/provider/error.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { MessageV2 } from "@/session/message-v2"
+import { ProviderID } from "@/provider/schema"
+
+describe("provider stream errors", () => {
+  test("normalizes empty rate-limit messages", () => {
+    const body = {
+      type: "error",
+      sequence_number: 2,
+      error: {
+        type: "tokens",
+        code: "rate_limit_exceeded",
+        message: "",
+        param: null,
+      },
+    }
+    const result = MessageV2.fromError({ message: JSON.stringify(body) }, { providerID: ProviderID.make("openai") })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: "Provider rate limit exceeded. Please try again shortly.",
+        isRetryable: true,
+        responseBody: JSON.stringify(body),
+      },
+    })
+  })
+
+  test("preserves provider rate-limit messages", () => {
+    const body = {
+      type: "error",
+      error: {
+        type: "tokens",
+        code: "rate_limit_exceeded",
+        message: "Try again in 30 seconds.",
+      },
+    }
+    const result = MessageV2.fromError({ message: JSON.stringify(body) }, { providerID: ProviderID.make("openai") })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toBe(body.error.message)
+    expect(result.data.isRetryable).toBe(true)
+  })
+})


### PR DESCRIPTION
OpenAI Responses-compatible providers can emit in-stream `rate_limit_exceeded` events with an empty message. These errors currently fall through as unknown failures, causing the extension to expose nested raw response JSON even though the retry layer recognizes the same condition.

Normalize these events at the CLI provider boundary into retryable API errors, preserving provider-supplied messages and the original response while supplying a concise fallback when the message is empty. The extension also unwraps nested serialized errors defensively so existing or partially normalized session errors render the same readable result.

<img width="335" height="269" alt="file-2e1c4486024d7c1bf77bea0feabe4b48" src="https://github.com/user-attachments/assets/8b171c1f-6926-44ea-bb98-70a073985279" />
<img width="315" height="165" alt="dyn-fe68bdfcdb3c995ff9674e4f4a4641b3" src="https://github.com/user-attachments/assets/bc449a16-4b9f-44dd-afcc-cfb62fa835d7" />
