### PR TITLE
feat(cli): add Kilo Console Beta tip to TUI tips array

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -278,6 +278,7 @@ const TIPS: Tip[] = [
   "Use {highlight}/connect{/highlight} with Kilo Gateway for curated, tested models", // kilocode_change
   "Commit your project's {highlight}AGENTS.md{/highlight} file to Git for team sharing",
   "Use {highlight}/review{/highlight} to review uncommitted changes, branches, or PRs",
+  "{highlight}Try Kilo Console (Beta){/highlight} — Manage git worktrees, sessions, and all CLI settings from a browser-based UI. How to install: {highlight}https://blog.kilo.ai/p/kilo-console-beta-is-live?utm_source=kilo-cli&utm_medium=notifications&utm_campaign=cli-tips{/highlight}", // kilocode_change
   (shortcuts) => `Use ${commandText("/help", shortcuts.helpShow())} to show the help dialog`,
   "Use {highlight}/rename{/highlight} to rename the current session",
   ...(process.platform === "win32"


### PR DESCRIPTION
## Summary

Adds a new tip to the CLI TUI home screen tips array promoting Kilo Console (Beta).

The tip surfaces the headline \"Try Kilo Console (Beta)\", a short description of what it offers (managing git worktrees, sessions, and CLI settings from a browser UI), and a link to the install blog post with UTM tracking parameters.

The entry is marked with `// kilocode_change` as required.

---
<environment_details>
Current time: 2026-06-15T14:50:12+00:00
Working directory: /workspace/9d278969-5453-4ae3-a51f-a8d2274a7b56/575ff40e-59a5-4385-ac4f-afee4520b2f0/sessions/agent_90146b93-ec4d-4fd4-84f9-a3aa2dee4832
Workspace root folder: /workspace/9d278969-5453-4ae3-a51f-a8d2274a7b56/575ff40e-59a5-4385-ac4f-afee4520b2f0/sessions/agent_90146b93-ec4d-4fd4-84f9-a3aa2dee4832
</environment_details>