### PR TITLE
fix: inject computed plan path directly into plan file naming instructions (#10987)

### DIFF
--- a/packages/opencode/src/kilocode/session/native-plan-prompt.txt
+++ b/packages/opencode/src/kilocode/session/native-plan-prompt.txt
@@ -22,7 +22,7 @@ Your job is to gather context, challenge assumptions, resolve design questions, 
 
 - You may create and edit plan Markdown files only.
 - Follow the latest Plan File reminder for the target plan location.
-- Prefer `.kilo/plans/` with a concise kebab-case filename based on the plan details when no exact plan path is provided.
+- Use the plan path from the Plan File reminder section exactly as provided.
 - Use repo-root `plans/`, `.plans/`, or `.opencode/plans/` only when requested or required by the repo/client and your permissions allow it.
 - Do not write the final plan or call `plan_exit` until the user chooses "Finalize and save the plan".
 - After final approval, write the final plan to the chosen plan file, then call `plan_exit` with the saved plan path.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -292,7 +292,7 @@ export namespace KiloSessionPrompt {
 
     const info = saved
       ? `The current saved plan file is ${target}. Read and edit this file when refining the plan.`
-      : `Use the plan path specified by the user or project instructions when present and permissions allow it. If none is specified, create a plan in ${dir} using a concise kebab-case filename based on the plan details.`
+      : `Use the plan path specified by the user or project instructions when present and permissions allow it. If none is specified, create the plan file at \`${target}\`.`
     const body = [
       "## Plan File",
       info,

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -684,7 +684,7 @@ describe("plan_exit detection", () => {
       expect(text).toContain("Use the plan path specified by the user or project instructions")
       expect(text).toContain("plans/ or .plans/")
       expect(text).toContain("If none is specified")
-      expect(text).not.toContain(Session.plan(session, Instance.current))
+      expect(text).toContain(Session.plan(session, Instance.current))
     }))
 
   test("native plan reminder reuses custom plan_exit path when refining", () =>


### PR DESCRIPTION
## Summary
- Fixes #10987: plan files sort chronologically by using session-computed timestamps
- Eliminates LLM timestamp hallucination risk by injecting the actual `Session.plan()` computed path directly into the prompt
- Plan mode uses `NATIVE_PLAN_PROMPT` which references the Plan File reminder section — that section already contains the computed `${target}` path from `Session.plan()`
- Updated `native-plan-prompt.txt` to remove the kebab-case filename suggestion and instead reference the computed path from the Plan File reminder

## What changed
- `packages/opencode/src/kilocode/session/prompt.ts`: Resolved merge conflict with upstream, keeping the upstream's simpler `add(NATIVE_PLAN_PROMPT)` approach while maintaining computed path injection in the fallback Plan File reminder block
- `packages/opencode/src/kilocode/session/native-plan-prompt.txt`: Changed line 25 from "Prefer .kilo/plans/ with a concise kebab-case filename" to "Use the plan path from the Plan File reminder section exactly as provided"
- `packages/opencode/test/kilocode/plan-exit-detection.test.ts`: Updated test assertion to expect the plan path in prompt text

## Reviewer context
The upstream refactored plan mode to use a static `NATIVE_PLAN_PROMPT` text file instead of an inline prompt. Both plan and architect modes now get the Plan File reminder (with computed `${target}` path) in a separate block. The plan file path is never hallucinated — it always comes from the session's computed plan path.