### PR TITLE
fix(jetbrains): cap prompt input growth

### DIFF
--- a/.changeset/jetbrains-prompt-input-height.md
+++ b/.changeset/jetbrains-prompt-input-height.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Limit JetBrains prompt input growth to the session while preserving scrolling for long prompts.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
@@ -139,6 +139,7 @@ class PromptPanel(
             ed.scrollPane.background = style.editorScheme.defaultBackground
             ed.scrollPane.viewport.background = style.editorScheme.defaultBackground
             ed.settings.isUseSoftWraps = true
+            ed.settings.isPaintSoftWraps = false
             ed.settings.isAdditionalPageAtBottom = false
             ed.putUserData(PROMPT_ATTACHMENT_PASTE_HANDLER_KEY, PromptAttachmentPasteHandler { processPaste(it) })
             ed.scrollPane.verticalScrollBarPolicy =

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
@@ -5,6 +5,7 @@ import ai.kilocode.client.actions.SendPromptAction
 import ai.kilocode.client.actions.StopSessionAction
 import ai.kilocode.client.plugin.KiloBundle
 import ai.kilocode.client.session.ui.ReasoningPicker
+import ai.kilocode.client.session.ui.SessionRootPanel
 import ai.kilocode.client.session.model.PromptAttachment
 import ai.kilocode.client.session.model.PromptAttachmentExtractor
 import ai.kilocode.client.session.ui.style.SessionEditorStyle
@@ -58,6 +59,8 @@ import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.event.FocusAdapter
 import java.awt.event.FocusEvent
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.Future
@@ -67,6 +70,7 @@ import javax.swing.Icon
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.ScrollPaneConstants
+import javax.swing.SwingUtilities
 
 /**
  * Prompt input panel with a borderless IntelliJ editor text field and
@@ -113,6 +117,12 @@ class PromptPanel(
     private var autoApprove = false
     private var attachment = true
     private var submitting = false
+    private var root: SessionRootPanel? = null
+    private val resize = object : ComponentAdapter() {
+        override fun componentResized(e: ComponentEvent) {
+            syncEditorHeight()
+        }
+    }
 
     private val editor = PromptEditorTextField(project, this).apply {
         border = JBUI.Borders.empty()
@@ -131,6 +141,8 @@ class PromptPanel(
             ed.settings.isUseSoftWraps = true
             ed.settings.isAdditionalPageAtBottom = false
             ed.putUserData(PROMPT_ATTACHMENT_PASTE_HANDLER_KEY, PromptAttachmentPasteHandler { processPaste(it) })
+            ed.scrollPane.verticalScrollBarPolicy =
+                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED
             ed.scrollPane.horizontalScrollBarPolicy =
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
             installFileDrop(ed.contentComponent, "editor")
@@ -228,6 +240,7 @@ class PromptPanel(
         bar.add(button)
         shell.add(bar, BorderLayout.SOUTH)
         add(shell, BorderLayout.CENTER)
+        addComponentListener(resize)
         installFileDrop(shell, "shell")
         syncTooltip()
         syncAutoApprove()
@@ -337,10 +350,13 @@ class PromptPanel(
 
     override fun addNotify() {
         super.addNotify()
+        bindRoot()
         bindKeymap()
     }
 
     override fun removeNotify() {
+        root?.removeComponentListener(resize)
+        root = null
         bus?.disconnect()
         bus = null
         super.removeNotify()
@@ -352,6 +368,7 @@ class PromptPanel(
         val source = editor.text
         if (source.isBlank()) {
             editor.text = KiloBundle.message("prompt.action.enhance.description")
+            syncEditorHeight()
             focus()
             return
         }
@@ -368,6 +385,7 @@ class PromptPanel(
         syncEnhance()
         result.onSuccess {
             editor.text = it
+            syncEditorHeight()
             focus()
         }.onFailure {
             if (it is CancellationException) return@onFailure
@@ -437,6 +455,7 @@ class PromptPanel(
         attachments += item
         strip.add(item)
         LOG.debug { "kind=prompt-attachment add name=${item.name} mime=${item.mime} count=${attachments.size}" }
+        syncEditorHeight()
         onChange()
     }
 
@@ -444,6 +463,7 @@ class PromptPanel(
     private fun removeAttachment(item: PromptAttachment) {
         if (!attachments.removeIf { it.id == item.id }) return
         strip.remove(item)
+        syncEditorHeight()
         onChange()
     }
 
@@ -603,17 +623,50 @@ class PromptPanel(
 
     @RequiresEdt
     private fun syncEditorHeight() {
-        val count = ApplicationManager.getApplication().runReadAction<Int> { editor.document.lineCount }
-        val lines = (count + SessionUiStyle.View.Prompt.EDITOR_SPARE_LINES).coerceIn(
-            SessionUiStyle.View.Prompt.EDITOR_LINES,
-            SessionUiStyle.View.Prompt.EDITOR_MAX_LINES,
-        )
-        val height = style.editorFont.size * lines + JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
-        if (editor.preferredSize.height == height && editor.minimumSize.height == height) return
+        val before = editor.preferredSize.height
+        val lower = editor.minimumSize.height
+        editor.setPreferredSize(null)
+        editor.setMinimumSize(null)
+        editor.getEditor(false)?.let {
+            it.contentComponent.invalidate()
+            it.component.invalidate()
+            it.scrollPane.invalidate()
+        }
+        editor.invalidate()
+        editor.ensureWillComputePreferredSize()
+        val view = editor.getEditor(false)
+        val line = view?.lineHeight ?: editor.getFontMetrics(editor.font).height
+        val min = line * SessionUiStyle.View.Prompt.EDITOR_LINES + JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
+        val content = editor.preferredSize.height
+        val sessionCap = rootCap(min)
+        val height = minOf(content, sessionCap ?: content).coerceAtLeast(min)
+        if (before == height && lower == height) {
+            editor.preferredSize = JBDimension(0, height)
+            editor.minimumSize = JBDimension(0, height)
+            return
+        }
         editor.preferredSize = JBDimension(0, height)
         editor.minimumSize = JBDimension(0, height)
         revalidate()
         repaint()
+    }
+
+    @RequiresEdt
+    private fun rootCap(min: Int): Int? {
+        val root = root ?: return null
+        if (root.height <= 0) return null
+        val chrome = (shell.preferredSize.height - editor.preferredSize.height).coerceAtLeast(0)
+        return (root.height / 3 - chrome).coerceAtLeast(min)
+    }
+
+    @RequiresEdt
+    private fun bindRoot() {
+        val next = SwingUtilities.getAncestorOfClass(SessionRootPanel::class.java, this) as? SessionRootPanel
+        if (root === next) return
+        root?.removeComponentListener(resize)
+        root = next
+        root?.addComponentListener(resize)
+        syncEditorHeight()
     }
 
     private inner class SendButton : JButton(), UiDataProvider {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
@@ -65,8 +65,6 @@ object SessionUiStyle {
         /** Prompt input dimensions and chrome inside the session view. */
         object Prompt {
             const val EDITOR_LINES = 3
-            const val EDITOR_MAX_LINES = 8
-            const val EDITOR_SPARE_LINES = 1
             const val EDITOR_CHROME = 16
             const val SEND_BUTTON_SIZE = 24
             const val CORNER_ARC = 6

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/PromptEnhancerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/PromptEnhancerTest.kt
@@ -24,6 +24,18 @@ class PromptEnhancerTest : SessionControllerTestBase() {
         assertEquals("Use a focused implementation plan", result!!.getOrThrow())
     }
 
+    fun `test enhance prompt records telemetry`() {
+        val controller = controller()
+
+        edt { controller.enhancePrompt("make a plan") {} }
+        flush()
+
+        val click = appRpc.telemetry.single { it.event == "Prompt Enhance Clicked" }
+        assertEquals("short", click.properties["textLength"])
+        val done = appRpc.telemetry.single { it.event == "Prompt Enhanced" }
+        assertEquals("short", done.properties["textLength"])
+    }
+
     fun `test enhance prompt reports failure without changing session state`() {
         val controller = controller()
         rpc.enhanceThrows = IllegalStateException("provider unavailable")

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
@@ -34,6 +34,7 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import kotlinx.coroutines.CancellationException
 import java.awt.Container
+import java.awt.BorderLayout
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
@@ -44,11 +45,23 @@ import java.io.File
 import java.util.Base64
 import javax.imageio.ImageIO
 import javax.swing.JButton
+import javax.swing.JPanel
 import javax.swing.ImageIcon
+import javax.swing.ScrollPaneConstants
 import javax.swing.SwingUtilities
 
 @Suppress("UnstableApiUsage")
 class PromptPanelTest : BasePlatformTestCase() {
+    private val roots = mutableListOf<SessionRootPanel>()
+
+    override fun tearDown() {
+        try {
+            roots.asReversed().forEach { it.removeNotify() }
+            roots.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
 
     fun `test prompt input uses editor font settings`() {
         val style = SessionEditorStyle.current()
@@ -82,16 +95,113 @@ class PromptPanelTest : BasePlatformTestCase() {
         val editor = panel.defaultFocusedComponent as EditorTextField
         val min = editor.preferredSize.height
 
+        realize(panel, 260, 400)
         editor.text = "one\ntwo\nthree\nfour\nfive"
 
         assertTrue(editor.preferredSize.height > min)
     }
 
-    fun `test prompt editor shrinks when lines are removed`() {
+    fun `test prompt editor keeps three line minimum`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+
+        realize(panel, 260, 400)
+        val view = editor.getEditor(false)!!
+        val min = view.lineHeight * SessionUiStyle.View.Prompt.EDITOR_LINES +
+            JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
+
+        assertEquals(min, editor.preferredSize.height)
+    }
+
+    fun `test prompt editor grows when single line wraps`() {
         val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
         val editor = panel.defaultFocusedComponent as EditorTextField
         val min = editor.preferredSize.height
 
+        realize(panel, 180, 400)
+        editor.text = List(80) { "wrapped" }.joinToString(" ")
+        UIUtil.dispatchAllInvocationEvents()
+
+        assertTrue(editor.preferredSize.height > min)
+    }
+
+    fun `test enhanced prompt result resizes wrapped input`() {
+        var complete: ((Result<String>) -> Unit)? = null
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, done -> complete = done })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+        val min = editor.preferredSize.height
+        panel.setReady(true)
+        realize(panel, 180, 400)
+        editor.text = "draft"
+
+        enhanceButton(panel).doClick()
+        complete!!(Result.success(List(80) { "enhanced" }.joinToString(" ")))
+        UIUtil.dispatchAllInvocationEvents()
+
+        assertTrue(editor.preferredSize.height > min)
+    }
+
+    fun `test empty enhance explanation resizes wrapped input`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+        val min = editor.preferredSize.height
+        panel.setReady(true)
+        realize(panel, 80, 400)
+
+        enhanceButton(panel).doClick()
+        UIUtil.dispatchAllInvocationEvents()
+
+        assertTrue(editor.preferredSize.height > min)
+        assertEquals(KiloBundle.message("prompt.action.enhance.description"), editor.text)
+    }
+
+    fun `test prompt shell height is capped by session root`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+        val root = realize(panel, 260, 600)
+
+        editor.text = (1..40).joinToString("\n") { "line $it" }
+        root.doLayout()
+        panel.doLayout()
+        UIUtil.dispatchAllInvocationEvents()
+
+        val chrome = (panel.preferredSize.height - editor.preferredSize.height).coerceAtLeast(0)
+        assertTrue(editor.preferredSize.height <= root.height / 3 - chrome + 1)
+    }
+
+    fun `test attachment strip is included in session root cap`() {
+        val plain = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val attached = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        realize(plain, 260, 600)
+        realize(attached, 260, 600)
+        val plainEditor = plain.defaultFocusedComponent as EditorTextField
+        val attachedEditor = attached.defaultFocusedComponent as EditorTextField
+
+        plainEditor.text = (1..40).joinToString("\n") { "line $it" }
+        attached.addAttachmentForTest(PromptAttachment("a", "a.txt", "text/plain", "file:///tmp/a.txt"))
+        attachedEditor.text = (1..40).joinToString("\n") { "line $it" }
+        UIUtil.dispatchAllInvocationEvents()
+
+        assertTrue(attachedEditor.preferredSize.height < plainEditor.preferredSize.height)
+    }
+
+    fun `test prompt editor scroll policy keeps horizontal disabled`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        realize(panel, 180, 400)
+
+        val editor = (panel.defaultFocusedComponent as EditorTextField).getEditor(false)!!
+
+        assertEquals(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, editor.scrollPane.verticalScrollBarPolicy)
+        assertEquals(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER, editor.scrollPane.horizontalScrollBarPolicy)
+        assertTrue(editor.settings.isUseSoftWraps)
+    }
+
+    fun `test prompt editor shrinks when lines are removed`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+
+        realize(panel, 260, 400)
+        val min = editor.preferredSize.height
         editor.text = "one\ntwo\nthree\nfour\nfive"
         assertTrue(editor.preferredSize.height > min)
 
@@ -103,8 +213,9 @@ class PromptPanelTest : BasePlatformTestCase() {
     fun `test prompt editor shrinks after clear`() {
         val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
         val editor = panel.defaultFocusedComponent as EditorTextField
-        val min = editor.preferredSize.height
 
+        realize(panel, 260, 400)
+        val min = editor.preferredSize.height
         editor.text = "one\ntwo\nthree\nfour\nfive"
         assertTrue(editor.preferredSize.height > min)
 
@@ -606,6 +717,18 @@ class PromptPanelTest : BasePlatformTestCase() {
         }
         visit(root)
         return out
+    }
+
+    private fun realize(panel: PromptPanel, width: Int, height: Int): SessionRootPanel {
+        val root = SessionRootPanel()
+        root.setSize(width, height)
+        root.content.add(JPanel(BorderLayout()).apply { add(panel, BorderLayout.SOUTH) }, BorderLayout.CENTER)
+        root.addNotify()
+        root.doLayout()
+        panel.doLayout()
+        UIUtil.dispatchAllInvocationEvents()
+        roots.add(root)
+        return root
     }
 
     private fun createEditor(): Editor {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
@@ -194,6 +194,7 @@ class PromptPanelTest : BasePlatformTestCase() {
         assertEquals(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED, editor.scrollPane.verticalScrollBarPolicy)
         assertEquals(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER, editor.scrollPane.horizontalScrollBarPolicy)
         assertTrue(editor.settings.isUseSoftWraps)
+        assertFalse(editor.settings.isPaintSoftWraps)
     }
 
     fun `test prompt editor shrinks when lines are removed`() {


### PR DESCRIPTION
## Issue

No linked issue; reported from local JetBrains prompt UI testing.

## Context

The JetBrains prompt input could grow too tall for the session UI and showed soft-wrap glyphs inside the prompt editor. This keeps long prompts usable by capping prompt growth to the session area and relying on scrolling once the cap is reached.

## Implementation

The prompt editor now sizes from the realized editor preferred height instead of estimating wrapped line counts. It keeps a three-line minimum, caps growth to one third of the session root after accounting for prompt chrome, and resyncs height when the root, attachments, or enhanced prompt text changes.

Soft wrapping remains enabled, but soft-wrap sign painting is disabled for the prompt editor to avoid visible wrap markers in the input.

## Demo


https://github.com/user-attachments/assets/21fc754d-6587-4d0c-9051-89755df7f290


## How to Test

### Manual/local verification

- Agent ran `./gradlew :frontend:test --tests ai.kilocode.client.session.ui.PromptPanelTest` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew typecheck` from `packages/kilo-jetbrains/`.
- Push hook ran `bun turbo typecheck` successfully.

### Reviewer test steps

1. Launch the JetBrains plugin.
2. Enter a long prompt that wraps across many visual lines.
3. Confirm the prompt starts at three lines, grows from actual wrapped editor content, then scrolls instead of taking over the session.
4. Confirm soft-wrap glyphs are not painted in the prompt input.
5. Add and remove attachments and confirm the prompt height still respects the session cap.

### Blocked checks and substitute verification

- No relevant checks were blocked.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [ ] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch