### PR TITLE
docs(kilo-docs): clarify Mistral AI BYOK label

### DIFF
--- a/packages/kilo-docs/pages/getting-started/using-kilo-for-free.md
+++ b/packages/kilo-docs/pages/getting-started/using-kilo-for-free.md
@@ -65,7 +65,7 @@ By default, autocomplete routes through the Kilo provider and uses credits. If y
 
 ### How to Get It Free
 
-Add your own Mistral AI (Codestral) API key via **BYOK (Bring Your Own Key)** on the Kilo Gateway. Mistral offers a free tier for Codestral. When you configure a BYOK key, autocomplete requests use your key directly — at no cost on your Kilo balance.
+Add your own Mistral AI API key via **BYOK (Bring Your Own Key)** on the Kilo Gateway. Mistral offers a free tier for Codestral. When you configure a BYOK key, autocomplete requests use your key directly — at no cost on your Kilo balance.
 
 See the [Mistral Setup Guide](/docs/code-with-ai/features/autocomplete/mistral-setup) for step-by-step instructions.
 


### PR DESCRIPTION
## Summary

Update the free autocomplete documentation to refer to the Kilo Gateway BYOK provider as \"Mistral AI\" rather than \"Mistral AI (Codestral)\". Codestral remains identified as the model with an available free tier.