### PR TITLE
test(jetbrains): make session timeout tests deterministic

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/SessionSidePanelManagerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/SessionSidePanelManagerTest.kt
@@ -39,9 +39,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import java.awt.event.ActionEvent
 import javax.swing.JLabel
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.Timer
 
 @Suppress("UnstableApiUsage")
 class SessionSidePanelManagerTest : BasePlatformTestCase() {
@@ -221,7 +223,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         manager.openSession(session("ses_1"))
         val first = active(manager)
         manager.openSession(session("ses_2"))
-        settle { first !in ui }
+        expire(manager, first)
 
         assertFalse(ui.contains(first))
         assertEquals(listOf("/test" to "ses_1", "/test" to "ses_2"), created)
@@ -234,7 +236,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         manager.openSession(session("ses_1"))
         val first = active(manager)
         manager.openSession(session("ses_2"))
-        settle { first !in ui }
+        expire(manager, first)
         manager.openSession(session("ses_1"))
 
         assertNotSame(first, active(manager))
@@ -255,7 +257,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
             flow.emit(ChatEventDto.MessageUpdated("ses_1", msg("msg_hidden", "ses_1", "assistant")))
             flow.emit(ChatEventDto.PartDelta("ses_1", "msg_hidden", "txt_hidden", "text", "stale"))
         }
-        settle { first !in ui }
+        expire(manager, first)
         manager.openSession(session("ses_1"))
         val second = active(manager)
         settle()
@@ -588,7 +590,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
             first.controller().model.setState(SessionState.AwaitingPermission(permission("ses_1")))
         }
         manager.openSession(session("ses_2"))
-        settle { first !in ui }
+        expire(manager, first)
 
         assertFalse(ui.contains(first))
         assertEquals(emptyMap<String, SessionActivityKind>(), manager.activity())
@@ -603,7 +605,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
             first.controller().model.setState(SessionState.Busy("running"))
         }
         manager.openSession(session("ses_2"))
-        settle { first !in ui }
+        expire(manager, first)
 
         assertFalse(ui.contains(first))
     }
@@ -614,7 +616,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         manager.openSession(session("ses_1"))
         val first = active(manager)
         manager.openSession(session("ses_2"))
-        settle { first !in ui }
+        expire(manager, first)
 
         assertFalse(ui.contains(first))
         assertEquals(emptyMap<String, SessionActivityKind>(), manager.activity())
@@ -698,19 +700,19 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         method.invoke(manager)
     }
 
+    private fun expire(manager: SessionSidePanelManager, ui: JPanel) {
+        val field = SessionSidePanelManager::class.java.getDeclaredField("timers")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val timers = field.get(manager) as Map<JPanel, Timer>
+        val timer = requireNotNull(timers[ui]) { "Expected an inactive session disposal timer" }
+        timer.stop()
+        timer.actionListeners.single().actionPerformed(ActionEvent(timer, ActionEvent.ACTION_PERFORMED, "expire"))
+    }
+
     private fun settle() = kotlinx.coroutines.runBlocking {
         repeat(5) {
             kotlinx.coroutines.delay(100)
-            com.intellij.openapi.application.ApplicationManager.getApplication().invokeAndWait {
-                com.intellij.util.ui.UIUtil.dispatchAllInvocationEvents()
-            }
-        }
-    }
-
-    private fun settle(done: () -> Boolean) = kotlinx.coroutines.runBlocking {
-        repeat(50) {
-            if (done()) return@runBlocking
-            kotlinx.coroutines.delay(20)
             com.intellij.openapi.application.ApplicationManager.getApplication().invokeAndWait {
                 com.intellij.util.ui.UIUtil.dispatchAllInvocationEvents()
             }


### PR DESCRIPTION
## What changed

The inactive-session timeout tests now retrieve the `javax.swing.Timer` scheduled by `SessionSidePanelManager`, stop it, and invoke its real action listener directly. This replaces the test helper that repeatedly slept and called `UIUtil.dispatchAllInvocationEvents()` while waiting for disposal.

Production code and timeout behavior are unchanged.

## Why this is needed

These tests run on the IntelliJ test framework's event dispatch thread (EDT). The previous polling helper used `runBlocking` on that thread, then periodically called `UIUtil.dispatchAllInvocationEvents()`:

- `runBlocking` prevents the EDT from processing Swing events normally while the test waits.
- `UIUtil.dispatchAllInvocationEvents()` dispatches only `InvocationEvent` instances and removes other queued AWT events.
- A Swing `Timer` posts an `ActionEvent`, so the helper could remove the timer event without executing its listener.
- Whether the timer fired before the polling helper blocked the EDT depended on scheduling and CI load.

This explains why different tests in the same timeout group failed intermittently. In the observed failures, each test took approximately 1.05 seconds, matching exhaustion of the 50 x 20ms polling loop rather than the configured 10ms timeout.

## Why this solution

The tests are intended to verify what `SessionSidePanelManager` does when its inactive-session timer expires, not Swing's wall-clock timer implementation. Triggering the timer's registered listener directly:

- executes the actual callback created by production code;
- verifies that switching away scheduled a timer for the expected session UI;
- removes dependence on wall-clock timing, runner load, and nested EDT event pumping;
- fails immediately with a clear message if no timer was scheduled;
- keeps production APIs and implementation unchanged.

The test stops the timer before invoking the listener so it cannot fire again later and leak work into another test.

Reflection is limited to the test helper and matches existing tests in this class, which already inspect private controller state and invoke private manager methods. A production scheduler abstraction would provide cleaner injection, but would require changing production code solely to control this test boundary.

## Validation

- `./gradlew :frontend:test --tests 'ai.kilocode.client.session.SessionSidePanelManagerTest'`
- Full JetBrains CI test job passes.