### PR TITLE
fix(vscode): remove diff viewer corner artifacts

### DIFF
--- a/.changeset/fix-diff-viewer-corners.md
+++ b/.changeset/fix-diff-viewer-corners.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove stray rounded corners between files in the Changes diff viewer.

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1872,9 +1872,10 @@ body.am-wt-dragging-active * {
   --sticky-accordion-top: 0px;
 }
 
-/* Ensure accordion headers always span full panel width */
+/* Ensure virtualized accordion rows span the panel without per-row rounded corners. */
 .am-diff-content [data-component="accordion"],
 .am-review-diff-content [data-component="accordion"] {
+  --radius-lg: 0;
   width: 100% !important;
   align-items: stretch !important;
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1875,7 +1875,6 @@ body.am-wt-dragging-active * {
 /* Ensure virtualized accordion rows span the panel without per-row rounded corners. */
 .am-diff-content [data-component="accordion"],
 .am-review-diff-content [data-component="accordion"] {
-  --radius-lg: 0;
   width: 100% !important;
   align-items: stretch !important;
 }
@@ -1888,6 +1887,13 @@ body.am-wt-dragging-active * {
 .am-review-diff-content [data-slot="accordion-trigger"] {
   width: 100% !important;
   align-self: stretch !important;
+}
+
+.am-diff-content [data-slot="accordion-trigger"],
+.am-review-diff-content [data-slot="accordion-trigger"],
+.am-diff-content [data-slot="accordion-content"],
+.am-review-diff-content [data-slot="accordion-content"] {
+  border-radius: 0 !important;
 }
 
 .am-diff-content [data-slot="accordion-item"][data-file-path],


### PR DESCRIPTION
Virtualized diff rows are wrapped individually, which causes each accordion item to inherit first- and last-item corner radii. Those radii leave visible notches along file boundaries and the full-screen review divider.

Scope the accordion radius token to zero within inline and full-screen diff review surfaces. This keeps the file stack visually continuous while preserving rounded accordions elsewhere.

<img width="108" height="76" alt="dyn-f82f2fa253abf5f26c5d43fd3b037c56" src="https://github.com/user-attachments/assets/fb7d8a1b-2406-4f0f-ad47-6f224435fde8" />
<img width="81" height="73" alt="dyn-59b4ad50bc63661c24762054fbff8695" src="https://github.com/user-attachments/assets/0ccb07c1-d57a-4f84-bd78-3d263530225a" />
