### PR TITLE
test(cli): remove session cancellation timing races

### DIFF
--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -24,7 +24,7 @@ import type { Provider } from "@/provider/provider"
 import * as SessionProcessorModule from "../../src/session/processor"
 import { Snapshot } from "../../src/snapshot"
 import { ProviderTest } from "../fake/provider"
-import { awaitWithTimeout, testEffect } from "../lib/effect" // kilocode_change
+import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
 import { SyncEvent } from "@/sync"
@@ -1296,15 +1296,9 @@ describe("session.compaction.process", () => {
           .pipe(Effect.forkChild)
 
         yield* Deferred.await(ready).pipe(Effect.timeout("1 second"))
-        // kilocode_change start - Windows CI can take longer than 250ms to schedule interrupt finalizers
-        const exit = yield* awaitWithTimeout(
-          Effect.gen(function* () {
-            yield* Fiber.interrupt(fiber)
-            return yield* Fiber.await(fiber)
-          }),
-          "compaction did not stop after retry-backoff interrupt",
-          "2 seconds",
-        )
+        // kilocode_change start - avoid a scheduler-sensitive inner deadline on loaded CI runners
+        yield* Fiber.interrupt(fiber)
+        const exit = yield* Fiber.await(fiber)
         // kilocode_change end
 
         expect(Exit.isFailure(exit)).toBe(true)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1234,7 +1234,7 @@ it.live(
         const a = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
         yield* llm.wait(1)
         const b = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* Effect.yieldNow // kilocode_change - let the queued caller join without a wall-clock race
 
         yield* prompt.cancel(chat.id)
         const [exitA, exitB] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1287,7 +1287,7 @@ it.live(
         const a = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
         yield* llm.wait(1)
         const b = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* Effect.yieldNow // kilocode_change - let the queued caller join without a wall-clock race
         gate.resolve()
 
         const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
@@ -1692,7 +1692,7 @@ it.live(
         // kilocode_change end
 
         const loop = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* Effect.yieldNow // kilocode_change - give the queued loop a scheduler turn instead of a wall-clock window
 
         expect(yield* llm.calls).toBe(0)
 
@@ -1734,7 +1734,7 @@ it.live(
 
         const a = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
         const b = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-        yield* Effect.sleep(50)
+        yield* Effect.yieldNow // kilocode_change - give the queued loops a scheduler turn instead of a wall-clock window
 
         expect(yield* llm.calls).toBe(0)
 
@@ -1964,14 +1964,17 @@ unix(
       (_dir) =>
         Effect.gen(function* () {
           const { prompt, chat } = yield* boot()
+          const status = yield* SessionStatus.Service // kilocode_change
 
           const sh = yield* prompt
             .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
             .pipe(Effect.forkChild)
-          yield* Effect.sleep(50)
+          // kilocode_change start - wait for shell to actually be running before forking the queued loop
+          yield* waitFor("shell busy", status.get(chat.id).pipe(Effect.map((s) => (s.type === "busy" ? s : undefined))))
+          // kilocode_change end
 
           const loop = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-          yield* Effect.sleep(50)
+          yield* Effect.yieldNow // kilocode_change - give the queued loop a scheduler turn before cancelling
 
           yield* prompt.cancel(chat.id)
 
@@ -1997,11 +2000,14 @@ unix(
         (_dir) =>
           Effect.gen(function* () {
             const { prompt, chat } = yield* boot()
+            const status = yield* SessionStatus.Service // kilocode_change
 
             const a = yield* prompt
               .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
               .pipe(Effect.forkChild)
-            yield* Effect.sleep(50)
+            // kilocode_change start - wait for shell to actually be running before exercising the busy guard
+            yield* waitFor("shell busy", status.get(chat.id).pipe(Effect.map((s) => (s.type === "busy" ? s : undefined))))
+            // kilocode_change end
 
             const exit = yield* prompt
               .shell({ sessionID: chat.id, agent: "build", command: "echo hi" })


### PR DESCRIPTION
## Why

The Windows unit job in PR #10388 failed in two session cancellation tests even though the corresponding Linux job passed. Looking across recent failed workflows showed both failures were intermittent and strongly correlated with loaded Windows runners:

- `stops quickly when aborted during retry backoff` failed when interrupt cleanup exceeded an internal 2-second wall-clock deadline.
- `cancel with queued callers resolves all cleanly` previously failed at its whole-test timeout and still used a fixed 50 ms sleep to assume the second caller had joined the active run.

Neither deadline is part of the behavior these tests need to prove. They make correctness depend on how quickly CI schedules Effect fibers and finalizers. Workflow reruns frequently pass without code changes, while the underlying cancellation assertions remain stable.

## What changed

- Remove the inner timeout around compaction fiber interruption. The test still waits for the published retry status before interrupting, then verifies that the fiber exits through interruption. The outer test timeout still protects against a genuine deadlock.
- Replace `Effect.sleep(50)` with `Effect.yieldNow` before cancelling queued prompt callers. This gives the newly forked caller a scheduler turn without requiring it to complete within an arbitrary real-time window.

## Why this preserves coverage

The behavioral assertions are unchanged:

- retry backoff must be interruptible and terminate with an interrupt cause;
- both callers sharing a prompt run must resolve successfully after cancellation;
- both callers must receive the same assistant message.

This removes timing assumptions rather than weakening the expected cancellation semantics. The lower-level runner suite also covers queued cancellation using observable runner state, so the prompt integration test remains focused on end-to-end behavior.