### PR TITLE
fix(ui): fix KaTeX math rendering (SVG glyphs and layout styles)

### DIFF
--- a/.changeset/fix-katex-math-rendering.md
+++ b/.changeset/fix-katex-math-rendering.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix KaTeX math rendering in VS Code sidebar — square root symbols and other SVG glyphs now render correctly, and inline layout styles are preserved.

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1015,7 +1015,7 @@ it.live(
 // Cancel semantics
 
 it.live(
-    "cancel interrupts loop and resolves with an assistant message",
+  "cancel interrupts loop and resolves with an assistant message",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -1039,7 +1039,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  10_000, // kilocode_change: 3_000 was too tight for Windows CI runners
+  10_000, // kilocode_change: 3_000 was too tight for Windows CI
 )
 
 unix(
@@ -1221,7 +1221,7 @@ it.live(
 )
 
 it.live(
-    "cancel with queued callers resolves all cleanly",
+  "cancel with queued callers resolves all cleanly",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -1246,7 +1246,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  10_000, // kilocode_change: 3_000 was too tight for Windows CI runners
+  10_000, // kilocode_change: 3_000 was too tight for Windows CI
 )
 
 // Queue semantics

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1015,7 +1015,7 @@ it.live(
 // Cancel semantics
 
 it.live(
-  "cancel interrupts loop and resolves with an assistant message",
+    "cancel interrupts loop and resolves with an assistant message",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -1039,7 +1039,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  10_000, // kilocode_change: 3_000 was too tight for Windows CI runners
 )
 
 unix(
@@ -1221,7 +1221,7 @@ it.live(
 )
 
 it.live(
-  "cancel with queued callers resolves all cleanly",
+    "cancel with queued callers resolves all cleanly",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
@@ -1246,7 +1246,7 @@ it.live(
       }),
       { git: true, config: providerCfg },
     ),
-  3_000,
+  10_000, // kilocode_change: 3_000 was too tight for Windows CI runners
 )
 
 // Queue semantics

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -294,13 +294,15 @@ export function Markdown(
             }
           }
 
-          // kilocode_change start: flush KaTeX slots before yielding so concurrent
-          // blocks in this Promise.all don't contaminate each other's math.
-          // marked.parse() is synchronous for the JS parser path, so slots are
-          // fully populated before the first await below.
+          // kilocode_change start: flush KaTeX slots at the right time for each parser path.
+          // JS parser (default): marked.parse() is synchronous — flush immediately before the
+          // first await so concurrent Promise.all blocks don't contaminate each other's slots.
+          // Native parser (no current callers): marked.parse() returns a Promise — slots are
+          // populated inside the async resolve, so flush after awaiting.
           const raw = marked.parse(block.src)
-          const slots = flushKatexSlots()
+          const syncSlots = raw instanceof Promise ? null : flushKatexSlots()
           const next = await Promise.resolve(raw)
+          const slots = syncSlots ?? flushKatexSlots()
           // kilocode_change end
           const sanitized = sanitize(next) // kilocode_change
           const safe = resolveMath(sanitized, slots) // kilocode_change: inject pre-sanitized KaTeX

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -1,5 +1,5 @@
 import { useMarked } from "../context/marked"
-import { deferredHighlight, fnv1a } from "../context/marked" // kilocode_change
+import { deferredHighlight, fnv1a, flushKatexSlots } from "../context/marked" // kilocode_change
 import { useI18n } from "../context/i18n"
 import DOMPurify from "dompurify"
 import morphdom from "morphdom"
@@ -41,8 +41,20 @@ const config = {
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
   ADD_TAGS: ["svg", "path"],
-  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns"],
+  ADD_ATTR: ["d", "viewBox", "preserveAspectRatio", "xmlns", "data-kilo-math"], // kilocode_change: preserve KaTeX placeholders
 }
+
+// kilocode_change start: replace KaTeX placeholders inserted by renderKatex() in marked.tsx
+// with the pre-sanitized KaTeX HTML that was stored during marked.parse().
+// This runs after the main restrictive DOMPurify pass, so user content never
+// passes through a permissive sanitizer — only KaTeX-generated output does.
+const MATH_RE = /<span\s[^>]*data-kilo-math="(\d+)"[^>]*><\/span>/g
+
+function resolveMath(html: string, slots: string[]): string {
+  if (slots.length === 0) return html
+  return html.replace(MATH_RE, (_, i) => slots[parseInt(i)] ?? "")
+}
+// kilocode_change end
 
 const iconPaths = {
   copy: '<path d="M6.2513 6.24935V2.91602H17.0846V13.7493H13.7513M13.7513 6.24935V17.0827H2.91797V6.24935H13.7513Z" stroke="currentColor" stroke-linecap="round"/>',
@@ -282,8 +294,16 @@ export function Markdown(
             }
           }
 
-          const next = await Promise.resolve(marked.parse(block.src))
-          const safe = sanitize(next)
+          // kilocode_change start: flush KaTeX slots before yielding so concurrent
+          // blocks in this Promise.all don't contaminate each other's math.
+          // marked.parse() is synchronous for the JS parser path, so slots are
+          // fully populated before the first await below.
+          const raw = marked.parse(block.src)
+          const slots = flushKatexSlots()
+          const next = await Promise.resolve(raw)
+          // kilocode_change end
+          const sanitized = sanitize(next) // kilocode_change
+          const safe = resolveMath(sanitized, slots) // kilocode_change: inject pre-sanitized KaTeX
           if (key && hash) touch(key, { hash, html: safe })
           return { key: `${base}:${index}`, hash, html: safe, mode: block.mode } // kilocode_change
         }),

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -9,6 +9,7 @@ import katex from "katex"
 // kilocode_change start: import types for double-dollar math extension
 import type { MarkedExtension, TokenizerAndRendererExtension } from "marked"
 // kilocode_change end
+import DOMPurify from "dompurify" // kilocode_change: pre-sanitize KaTeX output before main DOMPurify pass
 import { bundledLanguages, type BundledLanguage } from "shiki"
 import { parseFilePath } from "../file-path" // kilocode_change
 import { createSimpleContext } from "./helper"
@@ -29,17 +30,54 @@ const BLOCK = /^\$\$\n((?:\\[^]|[^\\])+?)\n\$\$(?:\n|$)/
 const INLINE = /^\$\$(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\$\$/
 // kilocode_change end
 
+// kilocode_change start: pre-sanitized KaTeX slot system.
+//
+// KaTeX output contains SVG elements (for √ and other glyphs) and inline style
+// attributes (for precise layout positioning). We pre-sanitize KaTeX output with
+// a dedicated permissive DOMPurify config immediately after rendering, store the
+// result indexed in katexSlots, and return a placeholder span that the main
+// restrictive DOMPurify pass can safely pass through. After the main sanitize
+// in markdown.tsx, the placeholder is replaced with the pre-sanitized KaTeX HTML.
+//
+// This keeps user-controlled content and KaTeX content fully separated through
+// the sanitization pipeline: user HTML never passes through a permissive
+// sanitizer, and KaTeX HTML is never exposed to the restrictive one.
+
+const katexSanitizeConfig = {
+  USE_PROFILES: { html: true, mathMl: true, svg: true },
+  ADD_ATTR: ["style", "d", "viewBox", "preserveAspectRatio", "xmlns"],
+  FORBID_TAGS: ["script"],
+  FORBID_CONTENTS: ["script"],
+}
+
+// Populated synchronously during marked.parse() (which is synchronous for the
+// JS parser path). Always call flushKatexSlots() before the first await after
+// marked.parse() to avoid cross-block contamination under Promise.all.
+const katexSlots: string[] = []
+
+function renderKatex(text: string, display: boolean): string {
+  const raw = katex.renderToString(text, { displayMode: display, throwOnError: false })
+  const safe =
+    typeof window !== "undefined" && DOMPurify.isSupported ? DOMPurify.sanitize(raw, katexSanitizeConfig) : raw
+  const idx = katexSlots.length
+  katexSlots.push(safe)
+  return `<span data-kilo-math="${idx}"></span>`
+}
+
+/** Drain and return all KaTeX slots collected during the most recent marked.parse() call. */
+export function flushKatexSlots(): string[] {
+  return katexSlots.splice(0)
+}
+// kilocode_change end
+
 function renderMathInText(text: string): string {
   let result = text
 
   // Display math: $$...$$
   const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
-  result = result.replace(displayMathRegex, (_, math) => {
+  result = result.replace(displayMathRegex, (_, math) => { // kilocode_change
     try {
-      return katex.renderToString(math, {
-        displayMode: true,
-        throwOnError: false,
-      })
+      return renderKatex(math, true) // kilocode_change
     } catch {
       return `$$${math}$$`
     }
@@ -333,7 +371,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
               }
             },
             renderer(token) {
-              return `${katex.renderToString(token.text, { displayMode: true, throwOnError: false })}\n`
+              return `${renderKatex(token.text, true)}\n` // kilocode_change
             },
           } satisfies TokenizerAndRendererExtension,
           {
@@ -355,7 +393,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
               }
             },
             renderer(token) {
-              return katex.renderToString(token.text, { displayMode: true, throwOnError: false })
+              return renderKatex(token.text, true) // kilocode_change
             },
           } satisfies TokenizerAndRendererExtension,
         ],


### PR DESCRIPTION
## What

Fixes broken KaTeX math rendering in the VS Code sidebar — square root symbols (√) and other SVG glyphs were missing, and layout was broken because inline styles were stripped.

Closes #7905

## Why

DOMPurify's restrictive config strips both SVG elements (KaTeX uses SVG paths for glyphs like √) and inline `style` attributes (KaTeX uses these for precise layout positioning).

## How

Instead of relaxing DOMPurify's global config or using the nonce-based `node.closest()` approach from #9786 (which markijbema raised concerns about being too broad), this reimplementation **fully separates KaTeX content from user content** through the sanitization pipeline:

1. **`renderKatex()` in `marked.tsx`**: After KaTeX renders a math expression, we immediately pre-sanitize the output with a dedicated DOMPurify config (`USE_PROFILES: { svg: true }`, `ADD_ATTR: ["style", ...]`). The pre-sanitized HTML is stored in `katexSlots[]` and a lightweight placeholder `<span data-kilo-math="N">` is returned instead.

2. **`markdown.tsx` render loop**: After `marked.parse()` (which is synchronous and fully populates `katexSlots`), we call `flushKatexSlots()` before the first `await` — this prevents cross-block contamination when `Promise.all` processes multiple markdown blocks concurrently.

3. **After the main DOMPurify pass**: `resolveMath()` replaces placeholders with the pre-sanitized KaTeX HTML. User content never passes through a permissive sanitizer; KaTeX content never passes through the restrictive one.

This directly addresses markijbema's concern from #9786: the `style` attributes we preserve are always from KaTeX's own output (sanitized separately), never from user-supplied HTML.