### PR TITLE
fix(cli): clean up slow snapshot progress

### DIFF
--- a/.changeset/calm-snapshot-spinner.md
+++ b/.changeset/calm-snapshot-spinner.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent snapshot initialization progress from blocking conversations after the slow repository prompt.

--- a/packages/opencode/src/kilocode/snapshot/track.ts
+++ b/packages/opencode/src/kilocode/snapshot/track.ts
@@ -77,7 +77,7 @@ interface SessionPartAPI {
 }
 
 type SessionRuntime = {
-  runPromise: <A>(fn: (svc: SessionPartAPI) => Effect.Effect<A>) => Promise<A>
+  runPromise: <A>(fn: (svc: SessionPartAPI) => Effect.Effect<A>, options?: Effect.RunOptions) => Promise<A>
 }
 
 export namespace KiloSnapshotTrack {
@@ -131,6 +131,8 @@ export namespace KiloSnapshotTrack {
     disabledForSession: boolean
     /** Guard prompt display until a continued snapshot successfully produces a hash. */
     asked: boolean
+    /** Identify the invocation that currently owns the slow-repository prompt. */
+    owner?: symbol
   }
 
   export const makeState = (): State => ({
@@ -153,33 +155,21 @@ export namespace KiloSnapshotTrack {
     readonly ask: (input: { sessionID: SessionID }) => Promise<Answer>
     /** Persist `"snapshot": false` to the project config without disposing the instance. */
     readonly persistDisable: () => Promise<void>
-    /**
-     * Publish a synthetic "initializing snapshot…" message part on the given
-     * assistant message so the UI (TUI + webview) renders it in the chat
-     * scrollback. Returns the opaque handle the caller passes to `updateProgress`
-     * / `endProgress`. Returning `undefined` means "no target" — the caller
-     * should then skip the progress indicator entirely.
-     */
-    readonly startProgress: (input: {
-      sessionID: SessionID
-      messageID: MessageID
-      text: string
-    }) => Promise<ProgressHandle | undefined>
+    /** Publish the synthetic progress part allocated by the wrapper. */
+    readonly startProgress: (input: { handle: ProgressHandle; text: string }, signal?: AbortSignal) => Promise<void>
     /** Update the visible text on the in-flight progress part. */
-    readonly updateProgress: (input: { handle: ProgressHandle; text: string }) => Promise<void>
+    readonly updateProgress: (input: { handle: ProgressHandle; text: string }, signal?: AbortSignal) => Promise<void>
     /** Remove the progress part so the chat stays clean once the snapshot is done. */
-    readonly endProgress: (input: { handle: ProgressHandle }) => Promise<void>
+    readonly endProgress: (input: { handle: ProgressHandle }, signal?: AbortSignal) => Promise<void>
   }
 
-  /**
-   * Opaque handle returned by `startProgress`. The production hook stores the
-   * published text-part coordinates; tests store whatever they need to verify
-   * the lifecycle.
-   */
+  /** Coordinates and lifecycle state for one synthetic progress part. */
   export type ProgressHandle = {
     readonly sessionID: SessionID
     readonly messageID: MessageID
     readonly partID: PartID
+    started: boolean
+    ended: boolean
   }
 
   export interface WrapInput {
@@ -202,6 +192,8 @@ export namespace KiloSnapshotTrack {
      * tiny value so the delay is actually observable within a test run.
      */
     readonly progressDelayMs?: number
+    /** Override the progress removal timeout for tests. */
+    readonly progressCleanupTimeoutMs?: number
   }
 
   /**
@@ -211,6 +203,9 @@ export namespace KiloSnapshotTrack {
    * the user gets a clear in-chat reason for the wait.
    */
   const PROGRESS_DELAY_MS = 500
+  const PROGRESS_CLEANUP_TIMEOUT_MS = 1_000
+  const PROGRESS_CLEANUP_RETRY_MS = 50
+  const PROGRESS_CLEANUP_ATTEMPTS = 3
 
   /**
    * Runs `inner` with a timeout + slow-repo prompt flow. Returns the snapshot
@@ -223,11 +218,24 @@ export namespace KiloSnapshotTrack {
       const hooks = input.hooks ?? defaultHooks
       const timeoutMs = input.timeoutMs ?? TIMEOUT_MS
       const progressDelayMs = input.progressDelayMs ?? PROGRESS_DELAY_MS
+      const cleanupTimeoutMs = input.progressCleanupTimeoutMs ?? PROGRESS_CLEANUP_TIMEOUT_MS
 
       // The progress part is only published when we have both a session and
       // a target message. Background/non-turn callers skip the indicator.
-      const canShowProgress = !!(input.sessionID && input.messageID)
-      let handle: ProgressHandle | undefined
+      const handle: ProgressHandle | undefined =
+        input.sessionID && input.messageID
+          ? {
+              sessionID: input.sessionID,
+              messageID: input.messageID,
+              partID: PartIDSchema.ascending(),
+              started: false,
+              ended: false,
+            }
+          : undefined
+      const owner = Symbol()
+      let cleared = false
+      let removal: Promise<void> | undefined
+      let reset = false
       let frameIdx = 0
 
       const nextFrameText = () => {
@@ -236,17 +244,54 @@ export namespace KiloSnapshotTrack {
         return formatProgress(PROGRESS_INITIALIZING, frame)
       }
 
-      const clearProgress = () =>
-        Effect.gen(function* () {
-          if (!handle) return
-          const h = handle
-          handle = undefined
-          yield* Effect.promise(() =>
-            hooks.endProgress({ handle: h }).catch((err) => {
-              log.warn("failed to clear snapshot progress part", { err })
-            }),
-          )
+      const removeProgress = async (force: boolean) => {
+        if (!handle || (cleared && !force)) return
+        for (let attempt = 0; attempt < PROGRESS_CLEANUP_ATTEMPTS; attempt += 1) {
+          if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, PROGRESS_CLEANUP_RETRY_MS))
+          const ctl = new AbortController()
+          const timeout = Promise.withResolvers<false>()
+          const timer = setTimeout(() => {
+            ctl.abort()
+            timeout.resolve(false)
+          }, cleanupTimeoutMs)
+          const removed = await Promise.race([
+            hooks
+              .endProgress({ handle }, ctl.signal)
+              .then(() => true as const)
+              .catch((err) => {
+                log.warn("failed to clear snapshot progress part", { err })
+                return false as const
+              }),
+            timeout.promise,
+          ])
+          clearTimeout(timer)
+          if (!removed) continue
+          cleared = true
+          return
+        }
+        log.warn("snapshot progress part remained after cleanup retries")
+      }
+
+      const settleProgress = async (work: () => Promise<void>, warning: string) => {
+        const settled = await work()
+          .then(() => true)
+          .catch((err) => {
+            log.warn(warning, { err })
+            return false
+          })
+        if (handle?.ended) await removeProgress(true)
+        return settled
+      }
+
+      const clearProgress = () => {
+        if (handle) handle.ended = true
+        if (!handle?.started || removal) return Effect.void
+        return Effect.sync(() => {
+          removal = removeProgress(false).finally(() => {
+            removal = undefined
+          })
         })
+      }
 
       // Delay the "Initializing snapshot…" indicator so fast snapshots never
       // flash a misleading line in the chat. The fiber:
@@ -255,127 +300,129 @@ export namespace KiloSnapshotTrack {
       //   3. Enters an animation loop that advances a frame every
       //      SPINNER_INTERVAL_MS. The loop runs in the same fiber so
       //      interrupting `progressFiber` stops everything.
-      const progressFiber = canShowProgress
+      const progressFiber = handle
         ? yield* Effect.forkChild(
             Effect.gen(function* () {
               yield* Effect.sleep(Duration.millis(Math.min(progressDelayMs, timeoutMs)))
-              if (!input.sessionID || !input.messageID) return
-              const started = yield* Effect.promise(async () => {
-                try {
-                  return await hooks.startProgress({
-                    sessionID: input.sessionID!,
-                    messageID: input.messageID!,
-                    text: nextFrameText(),
-                  })
-                } catch (err) {
-                  log.warn("failed to publish snapshot progress part", { err })
-                  return undefined
-                }
-              })
-              if (!started) return
-              handle = started
+              handle.started = true
+              const started = yield* Effect.promise((signal) =>
+                settleProgress(
+                  () => hooks.startProgress({ handle, text: nextFrameText() }, signal),
+                  "failed to publish snapshot progress part",
+                ),
+              )
+              if (!started || handle.ended) return
               while (true) {
                 yield* Effect.sleep(Duration.millis(SPINNER_INTERVAL_MS))
-                if (!handle) return
+                if (handle.ended) return
                 const text = nextFrameText()
-                const h = handle
-                yield* Effect.promise(() =>
-                  hooks.updateProgress({ handle: h, text }).catch((err) => {
-                    log.warn("failed to advance snapshot spinner frame", { err })
-                  }),
+                yield* Effect.promise((signal) =>
+                  settleProgress(
+                    () => hooks.updateProgress({ handle, text }, signal),
+                    "failed to advance snapshot spinner frame",
+                  ),
                 )
               }
             }),
           )
         : undefined
 
-      const fiber = yield* Effect.forkChild(input.inner)
-      const quick = yield* Fiber.join(fiber).pipe(
-        Effect.timeoutOption(Duration.millis(timeoutMs)),
-        Effect.catch((err) => {
-          log.warn("snapshot track failed", { err })
-          return Effect.succeed({ _tag: "Some" as const, value: undefined as string | undefined })
-        }),
+      const stopProgress = Effect.gen(function* () {
+        if (progressFiber) yield* Fiber.interrupt(progressFiber)
+        yield* clearProgress()
+      })
+
+      return yield* Effect.acquireUseRelease(
+        Effect.forkDetach(input.inner),
+        (fiber) => {
+          const cancelSnapshot = Fiber.interrupt(fiber).pipe(Effect.forkDetach, Effect.asVoid)
+          const cleanup = Effect.gen(function* () {
+            yield* stopProgress
+            if (input.state.owner !== owner) return
+            if (reset) input.state.asked = false
+            input.state.owner = undefined
+          })
+          return Effect.gen(function* () {
+            const quick = yield* Fiber.join(fiber).pipe(
+              Effect.timeoutOption(Duration.millis(timeoutMs)),
+              Effect.catch((err) => {
+                log.warn("snapshot track failed", { err })
+                return Effect.succeed({ _tag: "Some" as const, value: undefined as string | undefined })
+              }),
+            )
+            if (quick._tag === "Some") return quick.value
+
+            // Timed out. Keep the existing "Initializing snapshot…" indicator
+            // animating so the user still sees live progress while the slow-repo
+            // dialog is visible. The progress fiber is only torn down once we've
+            // decided whether to keep waiting, disable, or skip below.
+
+            // Managed products such as Agent Manager expect concurrent snapshot
+            // initialization and cannot stop started turns for an inline question.
+            // Retain the snapshot baseline, but wait silently after the threshold.
+            if (input.snapshotInitialization === "wait") {
+              log.info("snapshot track slow; waiting without question")
+              return yield* Fiber.join(fiber).pipe(
+                Effect.catch((err) => {
+                  log.warn("snapshot track failed while waiting without question", { err })
+                  return Effect.succeed(undefined as string | undefined)
+                }),
+              )
+            }
+
+            // Slow path. No target session to prompt against, or we've already
+            // prompted through this service scope — skip silently.
+            if (!input.sessionID || input.state.asked || input.state.owner) {
+              log.warn("snapshot track slow; skipping for this service scope", { timeoutMs })
+              if (!input.state.owner) input.state.disabledForSession = true
+              yield* cancelSnapshot
+              yield* stopProgress
+              return undefined
+            }
+            input.state.asked = true
+            input.state.owner = owner
+
+            const sessionID = input.sessionID
+            const answer = yield* Effect.promise(() => hooks.ask({ sessionID }))
+
+            if (answer === "continue") {
+              log.info("user chose to keep waiting for snapshot; joining fiber")
+              const finished = yield* Fiber.join(fiber).pipe(
+                Effect.catch((err) => {
+                  log.warn("snapshot track failed after user continue", { err })
+                  return Effect.succeed(undefined as string | undefined)
+                }),
+              )
+              // Reset `asked` only when the snapshot actually succeeded. That way a
+              // future slow turn (e.g. a new massive worktree gets added) still
+              // surfaces the dialog instead of silently disabling snapshots on a
+              // user who just explicitly said "keep them on". If the fiber failed
+              // (finished === undefined), we leave `asked` sticky to avoid prompt
+              // spam on a repo that repeatedly errors.
+              if (finished) reset = true
+              return finished
+            }
+
+            input.state.disabledForSession = true
+            yield* cancelSnapshot
+            yield* stopProgress
+
+            if (answer === "disable") {
+              log.info("user chose to disable snapshot for this project")
+              yield* Effect.promise(() =>
+                hooks.persistDisable().catch((err) => {
+                  log.error("failed to persist snapshot:false to project config", { err })
+                }),
+              )
+            } else {
+              log.info("user dismissed snapshot prompt; disabling for this service scope only")
+            }
+
+            return undefined
+          }).pipe(Effect.ensuring(cleanup))
+        },
+        (fiber) => Fiber.interrupt(fiber).pipe(Effect.forkDetach, Effect.asVoid),
       )
-      if (quick._tag === "Some") {
-        if (progressFiber) yield* Fiber.interrupt(progressFiber)
-        yield* clearProgress()
-        return quick.value
-      }
-
-      // Timed out. Keep the existing "Initializing snapshot…" indicator
-      // animating so the user still sees live progress while the slow-repo
-      // dialog is visible. The progress fiber is only torn down once we've
-      // decided whether to keep waiting, disable, or skip below.
-
-      // Managed products such as Agent Manager expect concurrent snapshot
-      // initialization and cannot stop started turns for an inline question.
-      // Retain the snapshot baseline, but wait silently after the threshold.
-      if (input.snapshotInitialization === "wait") {
-        log.info("snapshot track slow; waiting without question")
-        const finished = yield* Fiber.join(fiber).pipe(
-          Effect.catch((err) => {
-            log.warn("snapshot track failed while waiting without question", { err })
-            return Effect.succeed(undefined as string | undefined)
-          }),
-        )
-        if (progressFiber) yield* Fiber.interrupt(progressFiber)
-        yield* clearProgress()
-        return finished
-      }
-
-      // Slow path. No target session to prompt against, or we've already
-      // prompted through this service scope — skip silently.
-      if (!input.sessionID || input.state.asked) {
-        log.warn("snapshot track slow; skipping for this service scope", { timeoutMs })
-        input.state.disabledForSession = true
-        yield* Fiber.interrupt(fiber)
-        if (progressFiber) yield* Fiber.interrupt(progressFiber)
-        yield* clearProgress()
-        return undefined
-      }
-      input.state.asked = true
-
-      const sessionID = input.sessionID
-      const answer = yield* Effect.promise(() => hooks.ask({ sessionID }))
-
-      if (answer === "continue") {
-        log.info("user chose to keep waiting for snapshot; joining fiber")
-        const finished = yield* Fiber.join(fiber).pipe(
-          Effect.catch((err) => {
-            log.warn("snapshot track failed after user continue", { err })
-            return Effect.succeed(undefined as string | undefined)
-          }),
-        )
-        if (progressFiber) yield* Fiber.interrupt(progressFiber)
-        yield* clearProgress()
-        // Reset `asked` only when the snapshot actually succeeded. That way a
-        // future slow turn (e.g. a new massive worktree gets added) still
-        // surfaces the dialog instead of silently disabling snapshots on a
-        // user who just explicitly said "keep them on". If the fiber failed
-        // (finished === undefined), we leave `asked` sticky to avoid prompt
-        // spam on a repo that repeatedly errors.
-        if (finished) input.state.asked = false
-        return finished
-      }
-
-      yield* Fiber.interrupt(fiber)
-      if (progressFiber) yield* Fiber.interrupt(progressFiber)
-      input.state.disabledForSession = true
-
-      if (answer === "disable") {
-        log.info("user chose to disable snapshot for this project")
-        yield* Effect.promise(() =>
-          hooks.persistDisable().catch((err) => {
-            log.error("failed to persist snapshot:false to project config", { err })
-          }),
-        )
-      } else {
-        log.info("user dismissed snapshot prompt; disabling for this service scope only")
-      }
-
-      yield* clearProgress()
-      return undefined
     })
 
   // ── Default hooks (production wiring) ──────────────────────────────────
@@ -411,22 +458,10 @@ export namespace KiloSnapshotTrack {
   })
 
   export const defaultHooks: Hooks = {
-    async startProgress(input) {
-      const partID = PartIDSchema.ascending()
-      try {
-        const rt = await sessionRuntime()
-        await rt.runPromise((svc) => svc.updatePart(progressPart({ ...input, partID })))
-        return { sessionID: input.sessionID, messageID: input.messageID, partID }
-      } catch (err) {
-        log.warn("failed to publish snapshot progress part", { err })
-        return undefined
-      }
-    },
-
-    async updateProgress(input) {
-      try {
-        const rt = await sessionRuntime()
-        await rt.runPromise((svc) =>
+    async startProgress(input, signal) {
+      const rt = await sessionRuntime()
+      await rt.runPromise(
+        (svc) =>
           svc.updatePart(
             progressPart({
               sessionID: input.handle.sessionID,
@@ -435,25 +470,37 @@ export namespace KiloSnapshotTrack {
               text: input.text,
             }),
           ),
-        )
-      } catch (err) {
-        log.warn("failed to update snapshot progress part", { err })
-      }
+        { signal },
+      )
     },
 
-    async endProgress(input) {
-      try {
-        const rt = await sessionRuntime()
-        await rt.runPromise((svc) =>
+    async updateProgress(input, signal) {
+      const rt = await sessionRuntime()
+      await rt.runPromise(
+        (svc) =>
+          svc.updatePart(
+            progressPart({
+              sessionID: input.handle.sessionID,
+              messageID: input.handle.messageID,
+              partID: input.handle.partID,
+              text: input.text,
+            }),
+          ),
+        { signal },
+      )
+    },
+
+    async endProgress(input, signal) {
+      const rt = await sessionRuntime()
+      await rt.runPromise(
+        (svc) =>
           svc.removePart({
             sessionID: input.handle.sessionID,
             messageID: input.handle.messageID,
             partID: input.handle.partID,
           }),
-        )
-      } catch (err) {
-        log.warn("failed to remove snapshot progress part", { err })
-      }
+        { signal },
+      )
     },
 
     async ask(input) {

--- a/packages/opencode/test/kilocode/command-timeout.test.ts
+++ b/packages/opencode/test/kilocode/command-timeout.test.ts
@@ -164,7 +164,6 @@ shell.instance(
         },
       )
 
-      expect(result.output).toContain("started")
       expect(result.output).toContain("environment timeout 500 ms")
       expect(result.output).toContain("You're running in a sandbox.")
       expect(result.output).not.toContain("retry with a larger timeout")

--- a/packages/opencode/test/kilocode/snapshot-track-timeout.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-track-timeout.test.ts
@@ -6,8 +6,9 @@
 
 import { describe, expect, test } from "bun:test"
 import { Duration, Effect } from "effect"
-import type { MessageID, SessionID, PartID } from "../../src/session/schema"
+import type { MessageID, SessionID } from "../../src/session/schema"
 import { KiloSnapshotTrack } from "../../src/kilocode/snapshot/track"
+import { awaitWithTimeout } from "../lib/effect"
 
 const SESSION = "ses_test" as SessionID
 const MESSAGE = "msg_test" as MessageID
@@ -42,7 +43,6 @@ const makeHooks = (
   answer: KiloSnapshotTrack.Answer | Promise<KiloSnapshotTrack.Answer>,
 ): { hooks: KiloSnapshotTrack.Hooks; calls: Calls } => {
   const calls: Calls = { ask: 0, persist: 0, progress: [] }
-  let counter = 0
   const hooks: KiloSnapshotTrack.Hooks = {
     async ask() {
       calls.ask += 1
@@ -53,12 +53,6 @@ const makeHooks = (
     },
     async startProgress(input) {
       calls.progress.push({ kind: "start", text: input.text })
-      counter += 1
-      return {
-        sessionID: input.sessionID,
-        messageID: input.messageID,
-        partID: `prt_${counter}` as PartID,
-      }
     },
     async updateProgress(input) {
       calls.progress.push({ kind: "update", text: input.text })
@@ -161,6 +155,53 @@ describe("KiloSnapshotTrack.wrap", () => {
     expect(calls.persist).toBe(1)
     expect(state.disabledForSession).toBe(true)
     expect(state.asked).toBe(true)
+  })
+
+  test("disable starts snapshot cancellation before config persistence finishes", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const cancelled = Promise.withResolvers<void>()
+    const persisting = Promise.withResolvers<void>()
+    const persist = Promise.withResolvers<void>()
+    const { hooks: base } = makeHooks("disable")
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async persistDisable() {
+        await base.persistDisable()
+        persisting.resolve()
+        await persist.promise
+      },
+    }
+    const inner = Effect.never.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          cancelled.resolve()
+        }),
+      ),
+    )
+
+    const run = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner,
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 10,
+        progressDelayMs: 2,
+      }),
+    )
+
+    await persisting.promise
+    await Effect.runPromise(
+      awaitWithTimeout(
+        Effect.promise(() => cancelled.promise),
+        "snapshot cancellation did not start before config persistence finished",
+        Duration.millis(200),
+      ),
+    )
+    persist.resolve()
+
+    expect(await run).toBeUndefined()
   })
 
   test('timeout + "dismissed" interrupts and disables, but does NOT persist', async () => {
@@ -312,6 +353,82 @@ describe("KiloSnapshotTrack.wrap", () => {
     expect(state.disabledForSession).toBe(false)
   })
 
+  test("concurrent timeout does not override an active continue choice", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const answer = Promise.withResolvers<KiloSnapshotTrack.Answer>()
+    const asked = Promise.withResolvers<void>()
+    const { hooks, calls } = makeHooks(answer.promise)
+    const firstHooks: KiloSnapshotTrack.Hooks = {
+      ...hooks,
+      async ask(input) {
+        asked.resolve()
+        return hooks.ask(input)
+      },
+    }
+
+    const first = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: slowInner(80, "first-hash"),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks: firstHooks,
+        timeoutMs: 20,
+        progressDelayMs: 5,
+      }),
+    )
+    await asked.promise
+    answer.resolve("continue")
+
+    const second = await Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: hangInner(),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 20,
+        progressDelayMs: 5,
+      }),
+    )
+
+    expect(second).toBeUndefined()
+    expect(await first).toBe("first-hash")
+    expect(calls.ask).toBe(1)
+    expect(state.disabledForSession).toBe(false)
+    expect(state.asked).toBe(false)
+    expect(state.owner).toBeUndefined()
+  })
+
+  test("cleanup does not clear a newer prompt owner", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const replacement = Symbol()
+    const { hooks: base } = makeHooks("continue")
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async endProgress(input) {
+        state.owner = replacement
+        await base.endProgress(input)
+      },
+    }
+
+    const result = await Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: slowInner(80, "continued-hash"),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 20,
+        progressDelayMs: 2,
+      }),
+    )
+
+    expect(result).toBe("continued-hash")
+    expect(state.owner).toBe(replacement)
+    expect(state.asked).toBe(true)
+  })
+
   test("continue path keeps `asked` sticky when the fiber finished with no hash", async () => {
     const state = KiloSnapshotTrack.makeState()
     const { hooks, calls } = makeHooks("continue")
@@ -426,6 +543,36 @@ describe("KiloSnapshotTrack progress indicator", () => {
     }
   })
 
+  test("failed progress publication does not start update retries", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const { hooks: base } = makeHooks("continue")
+    let updates = 0
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async startProgress() {
+        throw new Error("session service unavailable")
+      },
+      async updateProgress() {
+        updates += 1
+      },
+    }
+
+    const result = await Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: slowInner(300, "hash"),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 1_000,
+        progressDelayMs: 2,
+      }),
+    )
+
+    expect(result).toBe("hash")
+    expect(updates).toBe(0)
+  })
+
   test("timed-out path keeps the initializing label (no text escalation)", async () => {
     const state = KiloSnapshotTrack.makeState()
     const { hooks, calls } = makeHooks("continue")
@@ -471,6 +618,195 @@ describe("KiloSnapshotTrack progress indicator", () => {
         progressDelayMs: 5,
       }),
     )
+
+    expect(calls.progress.at(-1)).toEqual({ kind: "end" })
+  })
+
+  test.each(["disable", "dismissed"] as const)("%s path does not wait for snapshot cleanup", async (answer) => {
+    const state = KiloSnapshotTrack.makeState()
+    const { hooks, calls } = makeHooks(answer)
+    const cleaning = Promise.withResolvers<void>()
+    const cleanup = Promise.withResolvers<void>()
+    const inner = Effect.never.pipe(
+      Effect.ensuring(
+        Effect.promise(async () => {
+          cleaning.resolve()
+          await cleanup.promise
+        }),
+      ),
+    )
+
+    const run = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner,
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 20,
+        progressDelayMs: 2,
+      }),
+    )
+    const completed = await Effect.runPromise(
+      awaitWithTimeout(
+        Effect.promise(() => run),
+        "snapshot wrapper waited for cleanup",
+      ).pipe(
+        Effect.as(true),
+        Effect.catch(() => Effect.succeed(false)),
+      ),
+    )
+    const last = calls.progress.at(-1)
+
+    cleanup.resolve()
+    await run
+    await cleaning.promise
+
+    expect(completed).toBe(true)
+    expect(last).toEqual({ kind: "end" })
+  })
+
+  test("stalled progress removal does not block completion and is retried", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const { hooks: base, calls } = makeHooks("continue")
+    const started = Promise.withResolvers<void>()
+    const ended = Promise.withResolvers<void>()
+    const snapshot = Promise.withResolvers<string | undefined>()
+    let attempts = 0
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async startProgress(input) {
+        await base.startProgress(input)
+        started.resolve()
+      },
+      async endProgress(input, signal) {
+        attempts += 1
+        if (attempts === 3) {
+          await base.endProgress(input)
+          ended.resolve()
+          return
+        }
+        await new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("stalled removal")), { once: true })
+        })
+      },
+    }
+
+    const run = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: Effect.promise(() => snapshot.promise),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 1_000,
+        progressDelayMs: 2,
+        progressCleanupTimeoutMs: 5,
+      }),
+    )
+
+    await started.promise
+    snapshot.resolve("hash")
+    const result = await Effect.runPromise(
+      awaitWithTimeout(
+        Effect.promise(() => run),
+        "snapshot wrapper waited for progress removal",
+      ),
+    )
+    await Effect.runPromise(
+      awaitWithTimeout(
+        Effect.promise(() => ended.promise),
+        "snapshot progress removal was not retried",
+      ),
+    )
+
+    expect(result).toBe("hash")
+    expect(attempts).toBe(3)
+    expect(calls.progress.at(-1)).toEqual({ kind: "end" })
+  })
+
+  test("pending progress publication is removed after the snapshot finishes", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const { hooks: base, calls } = makeHooks("continue")
+    const started = Promise.withResolvers<void>()
+    const publish = Promise.withResolvers<void>()
+    const ended = Promise.withResolvers<void>()
+    const snapshot = Promise.withResolvers<string | undefined>()
+    let ends = 0
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async startProgress(input) {
+        calls.progress.push({ kind: "start", text: input.text })
+        started.resolve()
+        await publish.promise
+      },
+      async endProgress(input) {
+        await base.endProgress(input)
+        ends += 1
+        if (ends === 2) ended.resolve()
+      },
+    }
+
+    const run = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: Effect.promise(() => snapshot.promise),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 1_000,
+        progressDelayMs: 2,
+      }),
+    )
+
+    await started.promise
+    snapshot.resolve("hash")
+    expect(await run).toBe("hash")
+    publish.resolve()
+    await ended.promise
+
+    expect(calls.progress.at(-1)).toEqual({ kind: "end" })
+  })
+
+  test("in-flight progress updates cannot recreate a removed indicator", async () => {
+    const state = KiloSnapshotTrack.makeState()
+    const { hooks: base, calls } = makeHooks("continue")
+    const updating = Promise.withResolvers<void>()
+    const update = Promise.withResolvers<void>()
+    const ended = Promise.withResolvers<void>()
+    const snapshot = Promise.withResolvers<string | undefined>()
+    let ends = 0
+    const hooks: KiloSnapshotTrack.Hooks = {
+      ...base,
+      async updateProgress(input) {
+        updating.resolve()
+        await update.promise
+        calls.progress.push({ kind: "update", text: input.text })
+      },
+      async endProgress(input) {
+        await base.endProgress(input)
+        ends += 1
+        if (ends === 2) ended.resolve()
+      },
+    }
+
+    const run = Effect.runPromise(
+      KiloSnapshotTrack.wrap({
+        inner: Effect.promise(() => snapshot.promise),
+        state,
+        sessionID: SESSION,
+        messageID: MESSAGE,
+        hooks,
+        timeoutMs: 1_000,
+        progressDelayMs: 2,
+      }),
+    )
+
+    await updating.promise
+    snapshot.resolve("hash")
+    expect(await run).toBe("hash")
+    update.resolve()
+    await ended.promise
 
     expect(calls.progress.at(-1)).toEqual({ kind: "end" })
   })


### PR DESCRIPTION
Slow snapshot initialization can leave an `Initializing snapshot...` part in the conversation after the user answers the warning. Promise-backed progress writes can settle after removal and recreate the synthetic part, while Disable or Dismiss can remain coupled to slow snapshot cleanup.

This change gives each progress part an explicit lifecycle, makes session writes cancellation-aware, and retries bounded asynchronous removal so late writes are removed again without blocking the turn. Snapshot cancellation now starts immediately for Disable and Dismiss, and prompt ownership is tokenized so concurrent slow tracks cannot overwrite one another.

Fixes #11282