### PR TITLE
ci: add jetbrains container image and fix containers.yml trigger

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,7 +3,7 @@ name: containers
 on:
   push:
     branches:
-      - dev
+      - main
     paths:
       - packages/containers/**
       - .github/workflows/containers.yml

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,7 +3,7 @@ name: containers
 on:
   push:
     branches:
-      - main
+      - main # kilocode_change
     paths:
       - packages/containers/**
       - .github/workflows/containers.yml

--- a/packages/containers/README.md
+++ b/packages/containers/README.md
@@ -8,6 +8,7 @@ Images
 
 - `base`: Ubuntu 24.04 with common build tools and utilities
 - `bun-node`: `base` plus Bun and Node.js 24
+- `jetbrains`: `bun-node` plus Java 21 and the pre-cached Gradle distribution
 - `rust`: `bun-node` plus Rust (stable, minimal profile)
 - `tauri-linux`: `rust` plus Tauri Linux build dependencies
 - `publish`: `bun-node` plus Docker CLI and AUR tooling

--- a/packages/containers/jetbrains/Dockerfile
+++ b/packages/containers/jetbrains/Dockerfile
@@ -1,0 +1,35 @@
+# kilocode_change start
+ARG REGISTRY=ghcr.io/kilo-org
+FROM ${REGISTRY}/build/bun-node:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GRADLE_VERSION=9.4.1
+
+# Install Java 21 (apt handles multi-arch automatically)
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openjdk-21-jdk-headless \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create a stable /usr/lib/jvm/java-21 symlink that works on amd64 and arm64
+RUN java_home="$(dirname "$(dirname "$(readlink -f "$(which java)")")")" \
+  && ln -nfs "${java_home}" /usr/lib/jvm/java-21
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21
+
+# Pre-download the exact Gradle distribution used by the wrapper so CI jobs
+# skip the download entirely.  GRADLE_USER_HOME is set to a location that any
+# user (including the GitHub Actions runner) can read.
+ENV GRADLE_USER_HOME=/gradle-home
+
+RUN set -euo pipefail; \
+    url="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"; \
+    hash=$(echo -n "${url}" | md5sum | cut -d' ' -f1); \
+    dir="/gradle-home/wrapper/dists/gradle-${GRADLE_VERSION}-bin/${hash}"; \
+    mkdir -p "${dir}"; \
+    curl -fsSL "${url}" -o "${dir}/gradle-${GRADLE_VERSION}-bin.zip"; \
+    unzip -q "${dir}/gradle-${GRADLE_VERSION}-bin.zip" -d "${dir}"; \
+    touch "${dir}/gradle-${GRADLE_VERSION}-bin.zip.ok"; \
+    rm "${dir}/gradle-${GRADLE_VERSION}-bin.zip"; \
+    java -version; \
+    "${dir}/gradle-${GRADLE_VERSION}/bin/gradle" --version
+# kilocode_change end

--- a/packages/containers/script/build.ts
+++ b/packages/containers/script/build.ts
@@ -17,7 +17,7 @@ const manager = pkg.packageManager ?? ""
 const bun = manager.startsWith("bun@") ? manager.slice(4) : ""
 if (!bun) throw new Error("packageManager must be bun@<version>")
 
-const images = ["base", "bun-node", "rust", "tauri-linux", "publish"]
+const images = ["base", "bun-node", "jetbrains", "rust", "tauri-linux", "publish"] // kilocode_change
 
 const setup = async () => {
   if (!push) return


### PR DESCRIPTION
## What

- Adds `packages/containers/jetbrains/Dockerfile` — a new image extending `bun-node` with Java 21 (via apt-get, multi-arch safe) and Gradle 9.4.1 pre-cached in `GRADLE_USER_HOME` so the Gradle wrapper skips the network download entirely.
- Registers the new image in `build.ts` and `README`.
- Fixes `containers.yml`: branch trigger was `dev` but should be `main`, so images are actually published from the default branch on every relevant push.

## Why

The `containers.yml` workflow was set to trigger on `dev`, which means the pipeline was never running automatically. Images were being published manually via `workflow_dispatch`. This PR corrects the trigger and adds the `jetbrains` image needed to speed up the JetBrains CI job.

## Merge order

This PR must be merged **first**. Once merged, `containers.yml` will automatically build and push `ghcr.io/kilo-org/build/jetbrains:24.04`.

A follow-up PR will update `test.yml` to use the new container and drop the manual Bun/Java/Gradle setup steps — but it can only be merged **after** this image is available.

Built for [Mark IJbema](https://kilo-code.slack.com/archives/C0A4SA041DE/p1781613361325899?thread_ts=1781607732.829409&cid=C0A4SA041DE) by [Kilo for Slack](https://kilo.ai/slack)