### PR TITLE
ci(jetbrains): run inside pre-built container, drop manual setup steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,8 @@ jobs:
   jetbrains:
     name: jetbrains
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/kilo-org/build/jetbrains:24.04
     defaults:
       run:
         shell: bash
@@ -116,20 +118,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Mark workspace as git-safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts
         working-directory: packages/kilo-jetbrains


### PR DESCRIPTION
## What

Updates the `jetbrains` job in `test.yml` to run inside `ghcr.io/kilo-org/build/jetbrains:24.04` and removes the three manual setup steps for Bun, Java 21, and Gradle.

## Why

The `jetbrains` image (added in #11306) already has all three pre-installed — Bun and Node from the `bun-node` base, Java 21 via apt-get, and Gradle 9.4.1 pre-cached in `GRADLE_USER_HOME`. Removing these setup steps from every CI run eliminates the time spent downloading and configuring them (Java 21 installs several hundred MB; Gradle downloads a ~150 MB zip).

## ⚠️ Depends on #11306

**Do not merge this until `ghcr.io/kilo-org/build/jetbrains:24.04` has been published.** That image is built and pushed by the `containers.yml` workflow when #11306 merges to `main`.

Built for [Mark IJbema](https://kilo-code.slack.com/archives/C0A4SA041DE/p1781613361325899?thread_ts=1781607732.829409&cid=C0A4SA041DE) by [Kilo for Slack](https://kilo.ai/slack)