### PR TITLE
feat(vscode): align chat content in readable lane

### DIFF
--- a/.changeset/readable-agent-chat.md
+++ b/.changeset/readable-agent-chat.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Keep conversations readable across the sidebar, editor tabs, and Agent Manager by aligning messages, tool output, and the composer in one centered lane.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a645eecb71442d1ffde6febbcaa67054d1e048ea7f24b7e6837b3a2bb635aea
+size 51100

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-420-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-420-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99b5a627c2ee9ab5e5241284040c67310f9aa5ba6f7ee701c53b3b7d36426ffb
+size 41062

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-agent-manager-completed-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-agent-manager-completed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba55764c944231be2cd47c839d3a46c4bbdcb0a3060a1d8aa3ed7d391a34d722
-size 14749
+oid sha256:2f68c0170973f6c39a86968888d0041569f7a1403c780ca6783be4cef8b0a771
+size 13160

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-idle-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-idle-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7eede94f30f617eab9435e21861f2d56b85bdf347c94f1acfdedef0be65ee77
-size 16452
+oid sha256:cd6334875ae3c633396b90ffbcbd53e5567668e430c8ca97a4c1cc8bc30a0585
+size 17933

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-readable-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-readable-1280-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95f83279f09c34994294cef4a33c9007d6a7b7e84f553558edf6bdac62711216
+size 37558

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-readable-420-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-readable-420-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f419ed4b9435f9a01c94dca80ef5b252cc108ccbb0e4d7ba978acf0fbf02bbe4
+size 32635

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-with-messages-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-with-messages-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e929c1f6dd90495d14edea552acfd2f1a3a609d1c3713651f5e11f40aac19309
-size 8120
+oid sha256:7294cf96505d165a74609912f17be2da7318ea43517dc329370e31d60aa835fe
+size 9900

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-with-pending-question-empty-input-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/chat-view-with-pending-question-empty-input-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8476ecb49183dbfed9be2924a8aa4622e8b95eb098c50609b986f9b8eb6cfe2d
-size 14390
+oid sha256:bcfda7763cad7ffe65419b579478aadec6577ad27d564098855b95d731cff470
+size 15882

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/welcome-with-switcher-and-notification-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/welcome-with-switcher-and-notification-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2cdb6dfc9a907b8ff98bb1982f324efa6d19e4ee98f9f690b8adbc2a0a163de
-size 28994
+oid sha256:f0c612b61586c3f71b468e49c0ceab2ac2b8ef630d9e8aee1db63b2e6d7a74c7
+size 32345

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/bash-with-permission-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/bash-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb1a94508ea38454e26d3fcc9449cf11ebecd1a5adcbda029ec3db4e45f2d06e
-size 15121
+oid sha256:1b090ba2b647fb0e61704a4a660a86a8e0c7dd713e57f139e1e2f4ee40ff3f7f
+size 14912

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/glob-with-permission-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/glob-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:52722d7eeca414000bac9be9e25a842acf162bbf939bbe603221017bbe37a0ee
-size 13477
+oid sha256:06f350812896990ce1107febc2efd0d41f3c1bd3d8cde0b040375d65efb7e916
+size 15093

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-apply-patch-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-apply-patch-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97728b91ed1c92556abfde08824b91536e87cc7afa4d121bb5b1b488946c1d05
-size 26009
+oid sha256:7fb38259ed94186bf8ff0da4ec9f4d58702ab0aa3878fc43e4767259d54ec287
+size 25031

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-bash-many-rules-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-bash-many-rules-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ebc03aa35f29a8f5ddfd841fc691b187c440348190e16d3be33de85b151ac193
-size 17886
+oid sha256:6f7e685eee7798085c2f68e3909b97c5cdef4610a5172ac29ec990e02d164e43
+size 17881

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-edit-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-edit-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b8e9f6e0b9a9a62efc9b1e807936049c7627674ba241239dfd777698f951acc
-size 21820
+oid sha256:34b3e9e7f100d3d2a2169a86b094ad297e91d7b43bac99337aee7a15140cc5ab
+size 20254

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0268de1b89b0af37f0eca8eb4c6244b9d49c1665b92c4402432d8efa0615e0a9
-size 15590
+oid sha256:3653478ce14db3c366bf189a138903cdfd7ffed95f4b67cfd1884c7132882a5b
+size 17204

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-heredoc-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-heredoc-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bea86246a569ca4373ba9a17515a0366c0a78643aaed85bcb5cc663467335806
-size 22382
+oid sha256:0924ae39054fd6d77470a299faf68734866fde1cb4c1cbfbcfd2a1910020685b
+size 22369

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-subagent-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-subagent-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d038d117b50c8e71fdddc507af5fa123d823d2b575565ef1aa68f7623c7d04c
-size 12814
+oid sha256:a3628bbbd1acb7c17f4a04a486a7a1467f9b088163a463b70b6928c35a76e0e3
+size 12815

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-todo-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-todo-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34965c1e34d6186515fd826abc43d68d74e53484e40b4b1ff04b7b9d82a6f94f
-size 13291
+oid sha256:0243f8bb7de6e22600bc98e71cb27c97e102edb84f37b5f952392cc4aa911ed7
+size 14915

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-websearch-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-websearch-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62fbc073856f73a4b25deceef1e0af3e711ec413ef4b9ec2e300fef8d98dc538
-size 13113
+oid sha256:f4e06b7fcc2a6f356760a3babc289f7ed7b163af5466c3e152c86339574d7181
+size 14737

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-write-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-write-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2113bfbfbfa54af9cb7d94724edbb361a48bf3501270d7e692df9e4b6752d4ed
-size 14222
+oid sha256:65cc0b394668b06390c4882e1b0137d48da0e2c673057ecae3dd2be2c3715a63
+size 15821

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/question-above-chatbox-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/question-above-chatbox-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c5223aa923783e200838f744eba2b5adc4aae18575412bb05f32606f2a5c823e
-size 16857
+oid sha256:e5b64674aaceb051ba48bf7db489845f50c8bd7f65a108685dda5243103c735a
+size 18477

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/todo-write-with-permission-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/todo-write-with-permission-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a35c54af1c6d5f89fefcb651ef45deb127e1862f848560183abe206f99223ae
-size 14179
+oid sha256:99f328f5169276d97c51d182185a920e8b45ecd0f3c699a64ce8e1fc7ad6196d
+size 15361

--- a/packages/kilo-vscode/tests/visual-regression.spec.mts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.mts
@@ -86,10 +86,9 @@ for (const story of stories) {
       test.info().annotations.push({ type: "docs", description: ref })
     }
 
-    // Narrow stories (IDs ending in "-200") use a 200px viewport
-    // The "-200" suffix comes from the export name convention (e.g. Default200, WithThinking200)
-    const narrow = story.id.endsWith("-200")
-    await page.setViewportSize({ width: narrow ? 200 : 420, height: 720 })
+    // Width-suffixed stories cover layouts outside the default sidebar viewport.
+    const width = story.id.endsWith("-200") ? 200 : story.id.endsWith("-1280") ? 1280 : 420
+    await page.setViewportSize({ width, height: 720 })
 
     await page.goto(
       `/iframe.html?id=${story.id}&viewMode=story&globals=colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern`,

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts
@@ -87,9 +87,9 @@ for (const story of stories) {
       test.info().annotations.push({ type: "docs", description: ref })
     }
 
-    // Narrow stories (IDs ending in "-200") use a 200px viewport
-    const narrow = story.id.endsWith("-200")
-    await page.setViewportSize({ width: narrow ? 200 : 420, height: 720 })
+    // Width-suffixed stories cover layouts outside the default sidebar viewport.
+    const width = story.id.endsWith("-200") ? 200 : story.id.endsWith("-1280") ? 1280 : 420
+    await page.setViewportSize({ width, height: 720 })
 
     await page.goto(
       `/iframe.html?id=${story.id}&viewMode=story&globals=colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern`,

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -5,11 +5,16 @@
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { StoryProviders } from "./StoryProviders"
+import { StoryProviders, defaultMockData, mockSessionValue } from "./StoryProviders"
 import { FileTree } from "../../diff-viewer/FileTree"
 import { DiffPanel } from "../../agent-manager/DiffPanel"
 import { FullScreenDiffView } from "../../diff-viewer/FullScreenDiffView"
 import { WorktreeItem } from "../../agent-manager/WorktreeItem"
+import { ChatView } from "../components/chat/ChatView"
+import { registerVscodeToolOverrides } from "../components/chat/VscodeToolOverrides"
+import { SessionContext } from "../context/session"
+import { ServerContext } from "../context/server"
+import { WorktreeModeProvider } from "../context/worktree-mode"
 import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Icon } from "@kilocode/kilo-ui/icon"
@@ -20,6 +25,8 @@ import type { WorktreeFileDiff, WorktreeState, WorktreeGitStats, PRStatus } from
 import type { ReviewComment } from "../../diff-viewer/review-comments"
 import "../../agent-manager/agent-manager.css"
 import "../../agent-manager/agent-manager-review.css"
+
+registerVscodeToolOverrides()
 
 // ---------------------------------------------------------------------------
 // Shared mock data
@@ -116,6 +123,139 @@ const meta: Meta = {
 }
 export default meta
 type Story = StoryObj
+
+// ---------------------------------------------------------------------------
+// Wide chat layout
+// ---------------------------------------------------------------------------
+
+const chatSessionID = "story-agent-manager-chat"
+const chatUserID = "story-agent-manager-user"
+const chatAssistantID = "story-agent-manager-assistant"
+const chatTime = 1_718_000_000_000
+const chatDiff = {
+  file: "webview-ui/src/styles/chat-layout.css",
+  status: "modified" as const,
+  additions: 12,
+  deletions: 4,
+  before: ".chat-view {\n  display: flex;\n}\n",
+  after: ".chat-view {\n  display: flex;\n  container: chat / inline-size;\n}\n",
+}
+const chatMessages = [
+  {
+    id: chatUserID,
+    sessionID: chatSessionID,
+    role: "user",
+    createdAt: new Date(chatTime).toISOString(),
+    time: { created: chatTime },
+    summary: { diffs: [chatDiff] },
+  },
+  {
+    id: chatAssistantID,
+    sessionID: chatSessionID,
+    role: "assistant",
+    parentID: chatUserID,
+    createdAt: new Date(chatTime + 1000).toISOString(),
+    time: { created: chatTime + 1000, completed: chatTime + 5000 },
+    modelID: "anthropic/claude-sonnet-4-6",
+    providerID: "kilo",
+    mode: "default",
+    agent: "code",
+    path: { cwd: "/project", root: "/project" },
+  },
+]
+const chatParts = {
+  [chatUserID]: [
+    {
+      id: "story-agent-manager-user-text",
+      sessionID: chatSessionID,
+      messageID: chatUserID,
+      type: "text",
+      text: "Make the full-screen Agent Manager conversation easier to scan without squeezing tool output or diffs.",
+    },
+  ],
+  [chatAssistantID]: [
+    {
+      id: "story-agent-manager-assistant-text",
+      sessionID: chatSessionID,
+      messageID: chatAssistantID,
+      type: "text",
+      text: "The transcript now follows a centered 78 character reading lane. Long explanations share one consistent left edge, so the eye can move between turns without crossing the entire editor.\n\nTool output and the composer use the same lane, keeping every conversation element aligned.",
+    },
+    {
+      id: "story-agent-manager-bash",
+      sessionID: chatSessionID,
+      messageID: chatAssistantID,
+      type: "tool",
+      callID: "story-agent-manager-bash-call",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "bun run test:unit", description: "Run focused Agent Manager tests" },
+        output: "18 tests passed\n0 tests failed",
+        title: "Run focused Agent Manager tests",
+        metadata: {},
+        time: { start: chatTime + 2000, end: chatTime + 4000 },
+      },
+    },
+  ],
+}
+const chatData = {
+  ...defaultMockData,
+  message: { [chatSessionID]: chatMessages },
+  part: chatParts,
+}
+const chatServer = {
+  connectionState: () => "connected" as const,
+  serverInfo: () => undefined,
+  extensionVersion: () => "1.0.0",
+  errorMessage: () => undefined,
+  errorDetails: () => undefined,
+  isConnected: () => true,
+  profileData: () => null,
+  deviceAuth: () => ({ status: "idle" as const }),
+  startLogin: () => undefined,
+  goToLogin: () => undefined,
+  vscodeLanguage: () => "en",
+  languageOverride: () => undefined,
+  workspaceDirectory: () => "/project",
+  gitInstalled: () => true,
+}
+
+function renderChat() {
+  const session = {
+    ...mockSessionValue({ id: chatSessionID, status: "idle", closeReason: "completed" }),
+    messages: () => chatMessages,
+    visibleMessages: () => chatMessages,
+    userMessages: () => chatMessages.filter((message) => message.role === "user"),
+    getParts: (id: string) => chatParts[id as keyof typeof chatParts] ?? [],
+    worktreeStats: () => ({ files: 3, additions: 32, deletions: 8 }),
+  }
+  return (
+    <StoryProviders data={chatData} sessionID={chatSessionID} status="idle" noPadding>
+      <ServerContext.Provider value={chatServer}>
+        <SessionContext.Provider value={session as any}>
+          <WorktreeModeProvider>
+            <div class="am-chat-wrapper" style={{ height: "100vh" }}>
+              <ChatView onForkSession={() => undefined} />
+            </div>
+          </WorktreeModeProvider>
+        </SessionContext.Provider>
+      </ServerContext.Provider>
+    </StoryProviders>
+  )
+}
+
+export const ReadableChat1280: Story = {
+  name: "Chat - readable wide editor",
+  parameters: { layout: "fullscreen" },
+  render: renderChat,
+}
+
+export const ReadableChat420: Story = {
+  name: "Chat - constrained editor",
+  parameters: { layout: "fullscreen" },
+  render: renderChat,
+}
 
 // ---------------------------------------------------------------------------
 // FileTree

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -396,6 +396,13 @@ const spacingParts = {
   ],
   [toolAssistantID]: [
     {
+      id: "part-text-spacing-001",
+      sessionID: SESSION_ID,
+      messageID: toolAssistantID,
+      type: "text",
+      text: "The conversation stays in one centered reading lane so longer explanations remain easy to scan. Tool output, prose, and the composer share the same left and right edges in a wide editor tab.",
+    },
+    {
       id: "part-bash-spacing-001",
       sessionID: SESSION_ID,
       messageID: toolAssistantID,
@@ -435,6 +442,41 @@ const spacingData = {
   ...defaultMockData,
   message: { [SESSION_ID]: spacingMessages },
   part: spacingParts,
+}
+const readableMessages = [spacingMessages[0], spacingMessages[3]]
+const readableData = {
+  ...defaultMockData,
+  message: { [SESSION_ID]: readableMessages },
+  part: spacingParts,
+}
+
+function renderReadableChat(status: "idle" | "busy" = "idle") {
+  const session = {
+    ...mockSessionValue({ id: SESSION_ID, status, closeReason: status === "idle" ? "completed" : undefined }),
+    messages: () => readableMessages,
+    visibleMessages: () => readableMessages,
+    userMessages: () => readableMessages.filter((message) => message?.role === "user"),
+    getParts: (id: string) => spacingParts[id as keyof typeof spacingParts] ?? [],
+  }
+  return (
+    <StoryProviders data={readableData} sessionID={SESSION_ID} status={status} noPadding>
+      <SessionContext.Provider value={session as any}>
+        <div style={{ height: "100vh", display: "flex", "flex-direction": "column" }}>
+          <ChatView />
+        </div>
+      </SessionContext.Provider>
+    </StoryProviders>
+  )
+}
+
+export const ChatViewReadable1280: Story = {
+  name: "ChatView - readable editor tab",
+  render: renderReadableChat,
+}
+
+export const ChatViewReadable420: Story = {
+  name: "ChatView - readable busy sidebar",
+  render: () => renderReadableChat("busy"),
 }
 
 export const MessageListToolToQueuedUserSpacing: Story = {

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -17,6 +17,10 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  container: chat / inline-size;
+  --chat-readable-width: 78ch;
+  --chat-gutter: clamp(16px, 4cqi, 48px);
+  --chat-scrollbar-width: 10px;
 }
 
 .chat-messages-wrapper {
@@ -50,7 +54,8 @@
   height: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 12px 16px;
+  padding: 12px var(--chat-gutter, 16px);
+  scrollbar-gutter: stable;
 }
 
 .message-list-loading {
@@ -96,6 +101,7 @@
   min-height: 100%;
   flex-direction: column;
   gap: 12px;
+  margin-inline: calc(var(--chat-scrollbar-width, 10px) / 2) calc(var(--chat-scrollbar-width, 10px) / -2);
 }
 
 .message-list-content-empty {
@@ -217,6 +223,51 @@
 
 .vscode-session-turn-diffs {
   width: 100%;
+}
+
+/* Treat every chat host as a readable document. User messages, assistant
+   prose, tool calls, diffs, and the composer all share one centered lane. */
+.chat-view .vscode-session-turn-user,
+.chat-view .vscode-session-turn-diffs,
+.chat-view .error-card,
+.chat-view [data-component="tool-part-wrapper"] {
+  width: 100%;
+  max-width: var(--chat-readable-width);
+  margin-inline: auto;
+}
+
+.chat-view .message-list-content > .revert-banner,
+.chat-view .message-list-content > [data-component="question-dock"],
+.chat-view .message-list-content > .working-indicator-slot,
+.chat-view .message-list-content > .vscode-session-turn[role="status"],
+.chat-view .message-list-content > [data-component="suggest-bar"] {
+  width: calc(100% - 8px);
+  max-width: var(--chat-readable-width);
+  margin-inline: auto;
+}
+
+.chat-view .prompt-input-container,
+.chat-view .new-task-button-wrapper {
+  box-sizing: border-box;
+  width: min(
+    calc(100% - var(--chat-gutter) - var(--chat-gutter) - var(--chat-scrollbar-width) - 8px),
+    var(--chat-readable-width)
+  );
+  margin-inline: auto;
+}
+
+.chat-view .chat-input > .startup-error-banner,
+.chat-view .chat-input > [data-component="permission-shortcuts"] {
+  box-sizing: border-box;
+  width: min(
+    calc(100% - var(--chat-gutter) - var(--chat-gutter) - var(--chat-scrollbar-width) - 8px),
+    var(--chat-readable-width)
+  );
+  margin-inline: auto;
+}
+
+.chat-view .chat-input > [data-component="permission-shortcuts"] > [data-component="dock-prompt"] {
+  margin-inline: 0;
 }
 
 .vscode-session-turn-diffs-trigger {


### PR DESCRIPTION
Wide editor surfaces currently stretch conversation content across the available panel, while tool calls, reasoning, messages, and the composer can land on different horizontal edges. In narrow sidebar views, the transcript scrollbar also makes those margins look uneven.

This introduces one responsive reading lane for the sidebar, editor chat tabs, and Agent Manager. Messages, reasoning, tool output, diffs, busy states, permission prompts, and the composer now stay aligned, with scrollbar compensation preserving visually equal margins. Wide and constrained visual stories cover the shared behavior across chat hosts.

<img width="1181" height="1210" alt="file-a58fac1456d839167484b9ed15ec8769" src="https://github.com/user-attachments/assets/168872ef-5a38-4202-83cf-a4eb145ae523" />
<img width="484" height="1166" alt="file-a45083f63e52fa2f51d82181472513fa" src="https://github.com/user-attachments/assets/09a3d6d9-bc2f-4adf-8011-8b82d9635383" />
<img width="1313" height="1228" alt="file-d70d86e88c36dd28e8e04bffd029b444" src="https://github.com/user-attachments/assets/ba28a8ae-91ac-4142-8b7f-123e8cd435f0" />
