### PR TITLE
fix(cli): restore permission override tests

### DIFF
--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -99,7 +99,7 @@ test("system utility agents ignore per-agent permission allows", async () => {
     },
   })
 
-  await WithInstance.provide({
+  await provideTestInstance({
     directory: tmp.path,
     fn: async () => {
       const title = await load(tmp.path, (svc) => svc.get("title"))
@@ -131,7 +131,7 @@ test("system utility agents deny tools after configured name override", async ()
     },
   })
 
-  await WithInstance.provide({
+  await provideTestInstance({
     directory: tmp.path,
     fn: async () => {
       const title = await load(tmp.path, (svc) => svc.get("title"))


### PR DESCRIPTION
## Summary
- Replace the accidental `WithInstance.provide` calls in the permission override tests with the existing `provideTestInstance` fixture.
- Restores the failing CLI typecheck and Windows unit test on `main`.

## Validation
- `bun test ./test/kilocode/agent-permission-overrides.test.ts`
- `bun run typecheck`