### PR TITLE
fix(cli): prevent tests from deleting session database

### DIFF
--- a/packages/opencode/test/fixture/db.ts
+++ b/packages/opencode/test/fixture/db.ts
@@ -1,12 +1,13 @@
-import { rm } from "fs/promises"
 import { Database } from "@/storage/db"
 import { disposeAllInstances } from "./fixture"
 
 export async function resetDatabase() {
+  // kilocode_change start
+  // Closing the in-memory connection clears shared test state. Never reset a
+  // disk-backed database because this helper can run without the test preload.
+  const path = Database.getPath()
+  if (path !== ":memory:") throw new Error(`Refusing to reset non-test database: ${path}`)
+  // kilocode_change end
   await disposeAllInstances().catch(() => undefined)
   Database.close()
-  const dbPath = Database.getPath()
-  await rm(dbPath, { force: true }).catch(() => undefined)
-  await rm(`${dbPath}-wal`, { force: true }).catch(() => undefined)
-  await rm(`${dbPath}-shm`, { force: true }).catch(() => undefined)
 }

--- a/packages/opencode/test/kilocode/database-reset-safety.test.ts
+++ b/packages/opencode/test/kilocode/database-reset-safety.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import path from "path"
+import { resetDatabase } from "../fixture/db"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.resolve(import.meta.dir, "..")
+const paths = [/\bDatabase\.getPath\s*\(/, /\bDatabase\.Path\b/, /kilo\.db(?:-wal|-shm)?/]
+const removals = [/\b(?:rm|rmSync|unlink|unlinkSync)\s*\(/, /\bBun\.file\s*\([^)]*\)\.delete\s*\(/]
+
+function dangerous(source: string) {
+  return paths.some((pattern) => pattern.test(source)) && removals.some((pattern) => pattern.test(source))
+}
+
+// Root cause of the session loss this protects against:
+//
+// 1. test/server/httpapi-sdk.test.ts was run from a directory where Bun did not
+//    load the package bunfig.toml. test/preload.ts was therefore not applied,
+//    so KILO_DB was not set to :memory:.
+// 2. The test process inherited KILO_DISABLE_CHANNEL_DB=true from the VS Code
+//    extension. Database.getPath() therefore returned the real shared database
+//    at ~/.local/share/kilo/kilo.db.
+// 3. The upstream resetDatabase() helper deleted kilo.db, kilo.db-wal, and
+//    kilo.db-shm. The test then recreated the database and inserted its
+//    identifiable "parent" and "child" sessions.
+// 4. Conversations stored only in the deleted database were lost. Git
+//    worktrees, branches, and .kilo/agent-manager.json survived because they are
+//    stored separately.
+//
+// Keep both the runtime guard and this source scan so a misconfigured test run
+// fails safely instead of deleting a developer's sessions again.
+describe("test database safety", () => {
+  test("recognizes destructive database cleanup", () => {
+    expect(dangerous("const file = Database.getPath()\nawait rm(file, { force: true })")).toBe(true)
+  })
+
+  test("preserves the resolved database when the in-memory preload is missing", async () => {
+    // Use a disposable sentinel inside the test's temporary directory, never a
+    // user database. This simulates a disk-backed KILO_DB and verifies that the
+    // reset helper rejects it before cleanup can run.
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "sessions.db")
+    const previous = Flag.KILO_DB
+    await Bun.write(file, "preserve me")
+    Flag.KILO_DB = file
+
+    try {
+      await expect(resetDatabase()).rejects.toThrow(`Refusing to reset non-test database: ${file}`)
+      expect(await Bun.file(file).text()).toBe("preserve me")
+    } finally {
+      Flag.KILO_DB = previous
+    }
+  })
+
+  test("forbids direct database file deletion in tests", async () => {
+    const violations: string[] = []
+    const files = new Bun.Glob("**/*.{ts,tsx,js,mjs,cjs}").scan({ cwd: root, absolute: true })
+
+    for await (const file of files) {
+      if (file === import.meta.path) continue
+      const source = await Bun.file(file).text()
+      if (!dangerous(source)) continue
+      violations.push(path.relative(root, file))
+    }
+
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
The shared database reset fixture could delete the real local Kilo session database when a test was launched without the package test preload. This is destructive because the fixture removed the resolved SQLite database together with its WAL and SHM files, while treating test-runner configuration as its only safety boundary. A missed preload could therefore permanently remove every conversation stored only in the shared database.

The complete failure requires all of these conditions:

1. A database-resetting test, specifically `packages/opencode/test/server/httpapi-sdk.test.ts` in the observed incident, is run from a directory where Bun does not discover `packages/opencode/bunfig.toml`.
2. Because that Bun configuration is not loaded, `packages/opencode/test/preload.ts` is not applied and `KILO_DB=:memory:` is never set.
3. The test process inherits `KILO_DISABLE_CHANNEL_DB=true`. The managed VS Code backend adds that variable in `packages/kilo-vscode/src/services/cli-backend/server-manager.ts` so extension contexts use one shared session database.
4. With no `KILO_DB` override, `Database.getPath()` in `packages/opencode/src/storage/db.ts` honors the inherited channel setting and resolves to `~/.local/share/kilo/kilo.db`.
5. `resetDatabase()` in `packages/opencode/test/fixture/db.ts` closes the client and unlinks that resolved path, `kilo.db-wal`, and `kilo.db-shm`. The helper runs from both the `afterEach` cleanup and the default-versus-raw server parity reset in `httpapi-sdk.test.ts`.
6. The test opens a new database at the same path. Its session lifecycle scenario creates the identifiable `parent` and `child` sessions, leaving a valid but nearly empty replacement database.

At that point, conversations stored only in the previous SQLite database are gone. Agent Manager worktrees, git branches, and `.kilo/agent-manager.json` remain because they are stored separately, which makes the UI look as though its sessions disappeared while the worktree metadata still exists.

The unsafe helper originated in upstream OpenCode PR [#15120](https://github.com/anomalyco/opencode/pull/15120), where tests used a temporary disk-backed XDG data directory and deleting the database was intended to reset state. Upstream PRs [#24836](https://github.com/anomalyco/opencode/pull/24836) and [#24853](https://github.com/anomalyco/opencode/pull/24853) expanded the SDK route and parity coverage that invokes this reset, including the `parent` and `child` lifecycle scenario. Kilo later switched package tests to an in-memory database, so filesystem deletion was no longer required.

Kilo PR [#11031](https://github.com/Kilo-Org/kilocode/pull/11031) adapted the fixture from the former static database path to `Database.getPath()`. Kilo PR [#11087](https://github.com/Kilo-Org/kilocode/pull/11087) intentionally added `KILO_DISABLE_CHANNEL_DB=true` to the managed VS Code server environment to restore one shared session database across extension contexts. Each change was reasonable in isolation, but together they allowed a test process that missed its preload to resolve the cleanup target to the real shared database.

This change removes every filesystem deletion from `resetDatabase()`. The fixture now accepts only the exact `:memory:` database, then disposes shared instances and closes the in-memory SQLite connection. Closing that connection clears its contents and resets the lazy client, so the next test still receives a clean database. Any disk-backed path fails before disposal or closure, regardless of the current directory or inherited environment.

A Kilo-owned regression test documents the incident and enforces both safety boundaries. It points `KILO_DB` at a disposable sentinel file and proves the reset is rejected without changing the file. It also scans the test tree for direct deletion code combined with `Database.getPath()`, `Database.Path`, or a `kilo.db` path, so the removed database, WAL, and SHM cleanup cannot be reintroduced elsewhere. The existing HTTP API SDK coverage remains unchanged.