### PR TITLE
fix(docs): update Composio toolkits link

### DIFF
--- a/packages/kilo-docs/pages/kiloclaw/development-tools/composio.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/composio.md
@@ -8,7 +8,7 @@ description: "Connect Composio to your KiloClaw agent to access hundreds of tool
 Connect Composio to your KiloClaw agent to instantly unlock access to 250+ tool integrations — from Salesforce and HubSpot to Notion, Jira, and beyond. Composio is a platform that handles the authentication and connection details for each service, so your agent can use them without you having to set up each one individually.
 
 {% callout type="info" title="Tip" %}
-Browse the full list of tools Composio supports at [composio.dev/tools](https://composio.dev/tools). If a tool you need is listed there, you can connect it to KiloClaw through Composio in minutes.
+Browse the full list of toolkits Composio supports at [composio.dev/toolkits](https://composio.dev/toolkits). If a toolkit you need is listed there, you can connect it to KiloClaw through Composio in minutes.
 {% /callout %}
 
 ## Prerequisites


### PR DESCRIPTION
## What

Replace the removed `composio.dev/tools` URL with the current `composio.dev/toolkits` page and align the surrounding terminology.

## Why

The old URL returns 404 and causes the documentation link checker to fail.