### PR TITLE
feat(agent-manager): add close others tab action

### DIFF
--- a/.changeset/close-other-tabs.md
+++ b/.changeset/close-other-tabs.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support closing other Agent Manager tabs from the tab context menu.

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "جلسة للقراءة فقط",
   "agentManager.session.noSessions": "لا توجد جلسات مفتوحة",
   "agentManager.tab.close": "إغلاق",
+  "agentManager.tab.closeOthers": "إغلاق الآخرين",
   "agentManager.tab.closeTab": "إغلاق علامة التبويب",
   "agentManager.tab.forkSession": "تفريع الجلسة",
   "agentManager.tab.terminal": "الطرفية",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Sessão somente leitura",
   "agentManager.session.noSessions": "Nenhuma sessão aberta",
   "agentManager.tab.close": "Fechar",
+  "agentManager.tab.closeOthers": "Fechar outras",
   "agentManager.tab.closeTab": "Fechar aba",
   "agentManager.tab.forkSession": "Bifurcar sessão",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Sesija samo za čitanje",
   "agentManager.session.noSessions": "Nema otvorenih sesija",
   "agentManager.tab.close": "Zatvori",
+  "agentManager.tab.closeOthers": "Zatvori ostale",
   "agentManager.tab.closeTab": "Zatvori karticu",
   "agentManager.tab.forkSession": "Razdvoji sesiju",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Skrivebeskyttet session",
   "agentManager.session.noSessions": "Ingen åbne sessioner",
   "agentManager.tab.close": "Luk",
+  "agentManager.tab.closeOthers": "Luk andre",
   "agentManager.tab.closeTab": "Luk fane",
   "agentManager.tab.forkSession": "Forgren session",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Schreibgeschützte Sitzung",
   "agentManager.session.noSessions": "Keine Sitzungen geöffnet",
   "agentManager.tab.close": "Schließen",
+  "agentManager.tab.closeOthers": "Andere schließen",
   "agentManager.tab.closeTab": "Tab schließen",
   "agentManager.tab.forkSession": "Sitzung verzweigen",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -50,6 +50,7 @@ export const dict = {
   "agentManager.session.noSessions": "No sessions open",
 
   "agentManager.tab.close": "Close",
+  "agentManager.tab.closeOthers": "Close Others",
   "agentManager.tab.closeTab": "Close tab",
   "agentManager.tab.forkSession": "Fork Session",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Sesión de solo lectura",
   "agentManager.session.noSessions": "No hay sesiones abiertas",
   "agentManager.tab.close": "Cerrar",
+  "agentManager.tab.closeOthers": "Cerrar otras",
   "agentManager.tab.closeTab": "Cerrar pestaña",
   "agentManager.tab.forkSession": "Bifurcar sesión",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Session en lecture seule",
   "agentManager.session.noSessions": "Aucune session ouverte",
   "agentManager.tab.close": "Fermer",
+  "agentManager.tab.closeOthers": "Fermer les autres",
   "agentManager.tab.closeTab": "Fermer l'onglet",
   "agentManager.tab.forkSession": "Dupliquer la session",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -50,6 +50,7 @@ export const dict = {
   "agentManager.session.noSessions": "Nessuna sessione aperta",
 
   "agentManager.tab.close": "Chiudi",
+  "agentManager.tab.closeOthers": "Chiudi le altre",
   "agentManager.tab.closeTab": "Chiudi scheda",
   "agentManager.tab.forkSession": "Forka sessione",
   "agentManager.tab.terminal": "Terminale",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "読み取り専用セッション",
   "agentManager.session.noSessions": "開いているセッションがありません",
   "agentManager.tab.close": "閉じる",
+  "agentManager.tab.closeOthers": "他を閉じる",
   "agentManager.tab.closeTab": "タブを閉じる",
   "agentManager.tab.forkSession": "セッションをフォーク",
   "agentManager.tab.terminal": "ターミナル",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "읽기 전용 세션",
   "agentManager.session.noSessions": "열린 세션 없음",
   "agentManager.tab.close": "닫기",
+  "agentManager.tab.closeOthers": "다른 탭 닫기",
   "agentManager.tab.closeTab": "탭 닫기",
   "agentManager.tab.forkSession": "세션 포크",
   "agentManager.tab.terminal": "터미널",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -50,6 +50,7 @@ export const dict = {
   "agentManager.session.noSessions": "Geen open sessies",
 
   "agentManager.tab.close": "Sluiten",
+  "agentManager.tab.closeOthers": "Andere sluiten",
   "agentManager.tab.closeTab": "Tabblad sluiten",
   "agentManager.tab.forkSession": "Sessie forken",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Skrivebeskyttet økt",
   "agentManager.session.noSessions": "Ingen åpne økter",
   "agentManager.tab.close": "Lukk",
+  "agentManager.tab.closeOthers": "Lukk andre",
   "agentManager.tab.closeTab": "Lukk fane",
   "agentManager.tab.forkSession": "Forgrein økt",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Sesja tylko do odczytu",
   "agentManager.session.noSessions": "Brak otwartych sesji",
   "agentManager.tab.close": "Zamknij",
+  "agentManager.tab.closeOthers": "Zamknij pozostałe",
   "agentManager.tab.closeTab": "Zamknij kartę",
   "agentManager.tab.forkSession": "Rozgałęź sesję",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "Сессия только для чтения",
   "agentManager.session.noSessions": "Нет открытых сессий",
   "agentManager.tab.close": "Закрыть",
+  "agentManager.tab.closeOthers": "Закрыть остальные",
   "agentManager.tab.closeTab": "Закрыть вкладку",
   "agentManager.tab.forkSession": "Ответвить сессию",
   "agentManager.tab.terminal": "Терминал",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "เซสชันอ่านอย่างเดียว",
   "agentManager.session.noSessions": "ไม่มีเซสชันที่เปิดอยู่",
   "agentManager.tab.close": "ปิด",
+  "agentManager.tab.closeOthers": "ปิดแท็บอื่น",
   "agentManager.tab.closeTab": "ปิดแท็บ",
   "agentManager.tab.forkSession": "แยกเซสชัน",
   "agentManager.tab.terminal": "เทอร์มินัล",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -50,6 +50,7 @@ export const dict = {
   "agentManager.session.noSessions": "Açık oturum yok",
 
   "agentManager.tab.close": "Kapat",
+  "agentManager.tab.closeOthers": "Diğerlerini kapat",
   "agentManager.tab.closeTab": "Sekmeyi kapat",
   "agentManager.tab.forkSession": "Oturumu Fork'la",
   "agentManager.tab.terminal": "Terminal",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -50,6 +50,7 @@ export const dict = {
   "agentManager.session.noSessions": "Немає відкритих сесій",
 
   "agentManager.tab.close": "Закрити",
+  "agentManager.tab.closeOthers": "Закрити інші",
   "agentManager.tab.closeTab": "Закрити вкладку",
   "agentManager.tab.forkSession": "Розгалужити сесію",
   "agentManager.tab.terminal": "Термінал",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "只读会话",
   "agentManager.session.noSessions": "没有打开的会话",
   "agentManager.tab.close": "关闭",
+  "agentManager.tab.closeOthers": "关闭其他标签页",
   "agentManager.tab.closeTab": "关闭标签页",
   "agentManager.tab.forkSession": "复制会话",
   "agentManager.tab.terminal": "终端",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -46,6 +46,7 @@ export const dict = {
   "agentManager.session.readonly": "唯讀工作階段",
   "agentManager.session.noSessions": "沒有開啟的工作階段",
   "agentManager.tab.close": "關閉",
+  "agentManager.tab.closeOthers": "關閉其他分頁",
   "agentManager.tab.closeTab": "關閉分頁",
   "agentManager.tab.forkSession": "複製工作階段",
   "agentManager.tab.terminal": "終端機",

--- a/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
@@ -52,6 +52,7 @@ export const SortableTab: Component<{
   onSelect: () => void
   onMiddleClick: (e: MouseEvent) => void
   onClose: () => void
+  onCloseOthers: () => void
   onFork?: () => void
 }> = (props) => {
   const { t } = useLanguage()
@@ -129,6 +130,10 @@ export const SortableTab: Component<{
                   ))}
                 </span>
               </Show>
+            </ContextMenu.Item>
+            <ContextMenu.Item onSelect={props.onCloseOthers}>
+              <Icon name="close" size="small" />
+              <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
           </ContextMenu.Content>
         </ContextMenu.Portal>

--- a/packages/kilo-vscode/webview-ui/agent-manager/tab-rendering.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/tab-rendering.tsx
@@ -74,6 +74,7 @@ export function renderTab(id: string, deps: TabRenderDeps): JSX.Element {
       onSelect: deps.activateTerminal,
       onMiddleClick: deps.terminalMiddleClick,
       onClose: deps.closeTerminal,
+      onCloseOthers: (target) => closeOthers(target, deps),
     })
   }
   if (id === deps.REVIEW_TAB_ID) return renderReviewTab(deps)
@@ -141,9 +142,30 @@ function renderSessionTab(s: SessionInfo, deps: TabRenderDeps): JSX.Element {
       }}
       onMiddleClick={(e: MouseEvent) => deps.sessionMiddleClick(s.id, e)}
       onClose={() => deps.sessionClose(s.id)}
+      onCloseOthers={() => closeOthers(s.id, deps)}
       onFork={pending ? undefined : () => deps.sessionFork(s.id)}
     />
   )
+}
+
+function closeOthers(target: string, deps: TabRenderDeps) {
+  for (const id of deps.tabIds()) {
+    if (id === target) continue
+    if (isTerminalTabId(id)) {
+      deps.closeTerminal(id)
+      continue
+    }
+    if (id === deps.REVIEW_TAB_ID) {
+      deps.closeReview()
+      continue
+    }
+    deps.sessionClose(id)
+  }
+  if (isTerminalTabId(target)) {
+    deps.activateTerminal(target)
+    return
+  }
+  deps.selectSessionTab(target, deps.isPending(target))
 }
 
 // Terminal-specific renderers (layer + add button) live in `./terminal/render.tsx`

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
@@ -33,6 +33,7 @@ export const SortableTerminalTab: Component<{
   onSelect: () => void
   onMiddleClick: (e: MouseEvent) => void
   onClose: (e: MouseEvent) => void
+  onCloseOthers: () => void
 }> = (props) => {
   const { t } = useLanguage()
   const sortable = createSortable(props.id)
@@ -98,6 +99,10 @@ export const SortableTerminalTab: Component<{
                   ))}
                 </span>
               </Show>
+            </ContextMenu.Item>
+            <ContextMenu.Item onSelect={props.onCloseOthers}>
+              <Icon name="close" size="small" />
+              <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
           </ContextMenu.Content>
         </ContextMenu.Portal>

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
@@ -22,6 +22,7 @@ export interface TerminalTabRenderDeps {
   onSelect: (id: string) => void
   onMiddleClick: (id: string, e: MouseEvent) => void
   onClose: (id: string) => void
+  onCloseOthers: (id: string) => void
 }
 
 /** Render the terminal entry inside the agent-manager tab bar `<For>`. */
@@ -43,6 +44,7 @@ export function renderTerminalTab(deps: TerminalTabRenderDeps): JSX.Element {
         e.stopPropagation()
         deps.onClose(deps.id)
       }}
+      onCloseOthers={() => deps.onCloseOthers(deps.id)}
     />
   )
 }


### PR DESCRIPTION
## Issue

No linked issue. Small Agent Manager tab context menu UX improvement requested directly.

## Context

Agent Manager tabs had a `Close` context menu item, but no way to quickly close every other tab in the current tab strip.

## Implementation

Adds `Close Others` immediately after `Close` in the session and terminal tab context menus. The action keeps the clicked tab active and closes other session, terminal, and review tabs in the same Agent Manager context. Adds localized labels for the existing Agent Manager dictionaries and a changeset for the user-facing extension change.

## Screenshots / Video

<img width="1190" height="766" alt="GIF Recording 2026-06-16 at 9 29 48 PM" src="https://github.com/user-attachments/assets/8faefd75-ccce-403b-b951-68e82b1a6301" />


## How to Test

### Manual/local verification

- Agent ran `bun run typecheck` from `packages/kilo-vscode`.
- Agent ran `bun run lint` from `packages/kilo-vscode`.

### Reviewer test steps

1. Open Agent Manager in the VS Code extension.
2. Open multiple Agent Manager tabs in the same context.
3. Right-click a session or terminal tab.
4. Confirm `Close Others` appears immediately after `Close`.
5. Select `Close Others` and confirm only the clicked tab remains active.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch