### PR TITLE
ci: fix Gradle wrapper cache hash in jetbrains container

### DIFF
--- a/packages/containers/jetbrains/Dockerfile
+++ b/packages/containers/jetbrains/Dockerfile
@@ -23,7 +23,14 @@ ENV GRADLE_USER_HOME=/gradle-home
 
 RUN set -euo pipefail; \
     url="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"; \
-    hash=$(echo -n "${url}" | md5sum | cut -d' ' -f1); \
+    hash=$(python3 -c '
+import hashlib, sys
+n = int.from_bytes(hashlib.md5(sys.argv[1].encode()).digest(), "big")
+c = "0123456789abcdefghijklmnopqrstuvwxyz"
+r = ""
+while n: r, n = c[n % 36] + r, n // 36
+print(r)
+' "${url}"); \
     dir="/gradle-home/wrapper/dists/gradle-${GRADLE_VERSION}-bin/${hash}"; \
     mkdir -p "${dir}"; \
     curl -fsSL "${url}" -o "${dir}/gradle-${GRADLE_VERSION}-bin.zip"; \


### PR DESCRIPTION
The Gradle wrapper determines the local cache directory name from the BigInteger representation of the distribution URL's MD5 digest in **base 36** (via Java's `BigInteger(1, md5bytes).toString(36)`). The initial Dockerfile used `md5sum | cut`, which produces a **hex** digest — a different encoding — so the wrapper always fell through to re-downloading the zip on every CI run.

This replaces the hash computation with a Python one-liner that matches Gradle's algorithm exactly.

Built for [Mark IJbema](https://kilo-code.slack.com/archives/C0A4SA041DE/p1781613361325899?thread_ts=1781607732.829409&cid=C0A4SA041DE) by [Kilo for Slack](https://kilo.ai/slack)