### PR TITLE
ci: extract JetBrains test workflow

### DIFF
--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -1,0 +1,109 @@
+# kilocode_change - new file
+name: test-jetbrains
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  changes:
+    name: detect JetBrains changes
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      jetbrains: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.jetbrains }}
+    steps:
+      - name: Checkout repository
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v6
+
+      - name: Detect JetBrains changes
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: Kilo-Org/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            jetbrains:
+              - '**'
+              - '!packages/kilo-vscode/**'
+              - '!packages/kilo-docs/**'
+
+  unit:
+    name: jetbrains
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.jetbrains == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run JetBrains unit tests
+        run: bun script/test-ci.ts
+        working-directory: packages/kilo-jetbrains
+
+      - name: Publish JetBrains unit reports
+        if: always()
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
+        with:
+          report_paths: packages/kilo-jetbrains/.artifacts/unit/junit.xml
+          check_name: "unit results (jetbrains)"
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload JetBrains unit artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-jetbrains-${{ github.run_attempt }}
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/kilo-jetbrains/.artifacts/unit/junit.xml
+
+  required:
+    name: result
+    needs:
+      - changes
+      - unit
+    if: always()
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Verify JetBrains jobs passed
+        run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "jetbrains=${{ needs.unit.result }}"
+          test "${{ needs.changes.result }}" = "success"
+          if [ "${{ needs.changes.outputs.jetbrains }}" = "true" ]; then
+            test "${{ needs.unit.result }}" = "success"
+          else
+            test "${{ needs.changes.outputs.jetbrains }}" = "false"
+            test "${{ needs.unit.result }}" = "skipped"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,28 +22,6 @@ env:
 
 jobs:
   # kilocode_change start
-  changes:
-    name: detect JetBrains changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      jetbrains: ${{ steps.filter.outputs.jetbrains }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Detect JetBrains changes
-        id: filter
-        uses: Kilo-Org/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
-        with:
-          predicate-quantifier: every
-          filters: |
-            jetbrains:
-              - '**'
-              - '!packages/kilo-vscode/**'
-              - '!packages/kilo-docs/**'
   unit:
     name: unit (${{ matrix.settings.name }})
     strategy:
@@ -131,55 +109,11 @@ jobs:
   # kilocode_change start
   jetbrains:
     name: jetbrains
-    needs: changes
-    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.jetbrains == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-
-      - name: Run JetBrains unit tests
-        run: bun script/test-ci.ts
-        working-directory: packages/kilo-jetbrains
-
-      - name: Publish JetBrains unit reports
-        if: always()
-        uses: mikepenz/action-junit-report@v6
-        with:
-          report_paths: packages/kilo-jetbrains/.artifacts/unit/junit.xml
-          check_name: "unit results (jetbrains)"
-          detailed_summary: true
-          include_time_in_summary: true
-          fail_on_failure: false
-
-      - name: Upload JetBrains unit artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: unit-jetbrains-${{ github.run_attempt }}
-          include-hidden-files: true
-          if-no-files-found: ignore
-          retention-days: 7
-          path: packages/kilo-jetbrains/.artifacts/unit/junit.xml
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: read
+    uses: ./.github/workflows/test-jetbrains.yml
   # kilocode_change end
 
   # kilocode_change start
@@ -187,22 +121,14 @@ jobs:
     name: test (linux)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
-      - changes
       - unit
       - jetbrains
     if: always()
     steps:
       - name: Verify upstream test jobs passed
         run: |
-          echo "changes=${{ needs.changes.result }}"
           echo "unit=${{ needs.unit.result }}"
           echo "jetbrains=${{ needs.jetbrains.result }}"
-          test "${{ needs.changes.result }}" = "success"
           test "${{ needs.unit.result }}" = "success"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ needs.changes.outputs.jetbrains }}" = "true" ]; then
-            test "${{ needs.jetbrains.result }}" = "success"
-          else
-            test "${{ needs.changes.outputs.jetbrains }}" = "false"
-            test "${{ needs.jetbrains.result }}" = "skipped"
-          fi
+          test "${{ needs.jetbrains.result }}" = "success"
   # kilocode_change end

--- a/script/check-workflows.ts
+++ b/script/check-workflows.ts
@@ -48,6 +48,7 @@ const active = new Set([
   "publish.yml",
   "smoke-test.yml",
   "source-check-links.yml",
+  "test-jetbrains.yml",
   "test-vscode.yml",
   "test.yml",
   "typecheck.yml",


### PR DESCRIPTION
## Issue

No linked issue; follow-up to #11293 requested directly.

## Context

JetBrains change detection, setup, execution, and reporting currently live inside the shared upstream `test.yml`. Keeping that Kilo-specific implementation in a dedicated workflow reduces upstream merge surface while retaining the required `test (linux)` gate.

## Implementation

Extract the JetBrains pipeline into a reusable `test-jetbrains.yml` workflow. The parent test workflow calls it as one job and still requires that call to succeed, so branch protection remains unchanged.

The reusable workflow owns change detection and has an always-running result job. Relevant changes and manual dispatches require successful JetBrains tests; VS Code-only and docs-only changes explicitly accept a skipped test job. Detection failures and test failures propagate through the reusable call and fail `test (linux)`.

## Screenshots / Video

N/A — CI-only change.

## How to Test

### Manual/local verification

- Agent ran Prettier checks for both workflows and the allowlist.
- Agent ran `actionlint` against `test.yml` and `test-jetbrains.yml`.
- Agent ran `bun run script/check-opencode-annotations.ts --base main` and `bun run script/check-workflows.ts`.
- Agent ran the upstream marker tool in dry-run mode and confirmed `test-jetbrains.yml` is a normalized Kilo-only workflow.

### Reviewer test steps

1. Confirm the PR runs the extracted JetBrains workflow and the parent `test (linux)` gate succeeds only after it completes.
2. Confirm a VS Code-only change skips the extracted unit job while its result job and parent `test (linux)` gate succeed.
3. Confirm manual dispatch bypasses path detection and always runs JetBrains tests.

### Blocked checks and substitute verification

- No checks are blocked. CI exercises the reusable workflow call and relevant-change path on this PR.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

GitHub: @markijbema