### PR TITLE
fix(cli): identify Kilo in LLM user agent

### DIFF
--- a/.changeset/fix-llm-user-agent.md
+++ b/.changeset/fix-llm-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Identify Kilo in provider request user-agent headers instead of OpenCode.

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -44,7 +44,7 @@ import { KiloSessionOverflow } from "@/kilocode/session/overflow"
 import { SessionExport } from "@/kilocode/session-export"
 import { getActiveOrg } from "@/kilocode/session-export/eligibility"
 // kilocode_change end
-import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import { USER_AGENT } from "@/installation" // kilocode_change
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import * as Option from "effect/Option"
@@ -491,12 +491,12 @@ const live: Layer.Layer<
                 "x-kilo-session": input.sessionID,
                 "x-kilo-request": input.user.id,
                 "x-kilo-client": flags.client,
-                "User-Agent": `opencode/${InstallationVersion}`,
+                "User-Agent": USER_AGENT, // kilocode_change
               }
             : {
                 "x-session-affinity": input.sessionID,
                 ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
-                "User-Agent": `opencode/${InstallationVersion}`,
+                "User-Agent": USER_AGENT, // kilocode_change
                 ...(input.model.providerID !== "anthropic" ? DEFAULT_HEADERS : undefined), // kilocode_change
               }),
           // kilocode_change start - headers for kilo provider

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -399,7 +399,7 @@ describe("session.llm.stream", () => {
 
         const capture = await request
         const body = capture.body
-        const headers = capture.headers // kilocode_change
+        const headers = capture.headers
         const url = capture.url
 
         expect(url.pathname.startsWith("/v1/")).toBe(true)

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -17,6 +17,7 @@ import type { Agent } from "../../src/agent/agent"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { USER_AGENT } from "../../src/installation" // kilocode_change
 
 async function getModel(providerID: ProviderID, modelID: ModelID, ctx: InstanceContext) {
   const effect = Effect.gen(function* () {
@@ -1159,8 +1160,10 @@ describe("session.llm.stream", () => {
 
         const capture = await request
         const body = capture.body
+        const headers = capture.headers
 
         expect(capture.url.pathname.endsWith("/messages")).toBe(true)
+        expect(headers.get("User-Agent")?.split(" ")[0]).toBe(USER_AGENT) // kilocode_change
         expect(body.messages).toStrictEqual([
           {
             role: "user",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -399,7 +399,7 @@ describe("session.llm.stream", () => {
 
         const capture = await request
         const body = capture.body
-        const headers = capture.headers
+        const headers = capture.headers // kilocode_change
         const url = capture.url
 
         expect(url.pathname.startsWith("/v1/")).toBe(true)
@@ -1160,7 +1160,7 @@ describe("session.llm.stream", () => {
 
         const capture = await request
         const body = capture.body
-        const headers = capture.headers
+        const headers = capture.headers // kilocode_change
 
         expect(capture.url.pathname.endsWith("/messages")).toBe(true)
         expect(headers.get("User-Agent")?.split(" ")[0]).toBe(USER_AGENT) // kilocode_change


### PR DESCRIPTION
## What

Fix provider request `User-Agent` headers emitted by the CLI LLM streaming path so they identify Kilo instead of OpenCode.

The LLM request code now uses the existing Kilo installation `USER_AGENT` value instead of hardcoding `opencode/${InstallationVersion}`. This covers both the Kilo-provider branch and the general provider branch before the AI SDK appends its own suffixes.

## Why

We observed provider/request logging with a header like:

```txt
opencode/7.3.46 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14
```

The `ai-sdk/provider-utils/... runtime/bun/...` suffix is appended by the AI SDK via its `withUserAgentSuffix` helper. The incorrect `opencode/<version>` prefix came from our code in `packages/opencode/src/session/llm.ts`, where two branches passed:

```ts
"User-Agent": `opencode/${InstallationVersion}`
```

There is already a Kilo-specific installation helper in `packages/opencode/src/installation/index.ts` that returns the canonical Kilo user-agent value. The bug was that the LLM path bypassed that helper.

## Regression Analysis

This does not appear to be a new `7.3.46` regression. Git history shows the hardcoded LLM header was introduced by:

```txt
fc6d4b4010 core: Add User-Agent header to identify client version in HTTP requests
```

That commit dates to Apr 25, 2026, and is contained by many later tags. The later Kilo compatibility refactor:

```txt
6ecaaab48a refactor: kilo compat for v1.14.51
```

updated the installation helper to return Kilo branding, but did not update this `session/llm.ts` call site. So the bad prefix survived specifically on paths where `DEFAULT_HEADERS` does not overwrite it, such as Anthropic and Kilo-provider requests.

## Testing

- `bun test ./test/session/llm.test.ts` from `packages/opencode/`
- `bun run script/check-opencode-annotations.ts` from repo root
