### PR TITLE
fix(vscode): announce compact Settings tabs

### DIFF
--- a/.changeset/name-compact-settings-tabs.md
+++ b/.changeset/name-compact-settings-tabs.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Announce every Settings tab by name to screen readers in compact sidebars.

--- a/packages/kilo-vscode/tests/settings-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/settings-accessibility.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+const NAMES = [
+  "Models",
+  "Providers",
+  "Agent Behaviour",
+  "Auto-Approve",
+  "Browser",
+  "Checkpoints",
+  "Display",
+  "Autocomplete",
+  "Notifications",
+  "Context",
+  "Commit Message",
+  "Experimental",
+  "Language",
+  "About Kilo Code",
+]
+
+function story(page: Page) {
+  return page.goto(`/iframe.html?id=settings--settings-panel&viewMode=story&globals=${GLOBALS}`, {
+    waitUntil: "load",
+  })
+}
+
+test.describe("settings tab accessibility", () => {
+  test("exposes named tabs and selected state in the compact sidebar", async ({ page }) => {
+    await page.setViewportSize({ width: 420, height: 720 })
+    await story(page)
+
+    const tabs = page.getByRole("tab")
+    await expect(tabs).toHaveCount(NAMES.length)
+    for (const name of NAMES) {
+      await expect(page.getByRole("tab", { name, exact: true })).toBeVisible()
+    }
+
+    const models = page.getByRole("tab", { name: "Models" })
+    const providers = page.getByRole("tab", { name: "Providers" })
+    await expect(models).toHaveAttribute("aria-selected", "true")
+    await expect(providers).toHaveAttribute("aria-selected", "false")
+    await expect(page.getByRole("tabpanel", { name: "Models" })).toBeVisible()
+
+    await models.focus()
+    await page.keyboard.press("ArrowDown")
+    await expect(providers).toBeFocused()
+    await expect(providers).toHaveAttribute("aria-selected", "true")
+    await expect(page.getByRole("tabpanel", { name: "Providers" })).toBeVisible()
+
+    await page.keyboard.press("ArrowUp")
+    await expect(models).toBeFocused()
+    await expect(models).toHaveAttribute("aria-selected", "true")
+    await expect(page.getByRole("tabpanel", { name: "Models" })).toBeVisible()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -145,66 +145,66 @@ const Settings: Component<SettingsProps> = (props) => {
         style={{ flex: 1, overflow: "hidden" }}
       >
         <Tabs.List>
-          <Tabs.Trigger value="models">
+          <Tabs.Trigger value="models" aria-label={language.t("settings.models.title")}>
             <Icon name="models" />
             <span class="label">{language.t("settings.models.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="providers">
+          <Tabs.Trigger value="providers" aria-label={language.t("settings.providers.title")}>
             <Icon name="providers" />
             <span class="label">{language.t("settings.providers.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="agentBehaviour">
+          <Tabs.Trigger value="agentBehaviour" aria-label={language.t("settings.agentBehaviour.title")}>
             <Icon name="brain" />
             <span class="label">{language.t("settings.agentBehaviour.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="autoApprove">
+          <Tabs.Trigger value="autoApprove" aria-label={language.t("settings.autoApprove.title")}>
             <Icon name="checklist" />
             <span class="label">{language.t("settings.autoApprove.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="browser">
+          <Tabs.Trigger value="browser" aria-label={language.t("settings.browser.title")}>
             <Icon name="window-cursor" />
             <span class="label">{language.t("settings.browser.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="checkpoints">
+          <Tabs.Trigger value="checkpoints" aria-label={language.t("settings.checkpoints.title")}>
             <Icon name="branch" />
             <span class="label">{language.t("settings.checkpoints.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="display">
+          <Tabs.Trigger value="display" aria-label={language.t("settings.display.title")}>
             <Icon name="eye" />
             <span class="label">{language.t("settings.display.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="autocomplete">
+          <Tabs.Trigger value="autocomplete" aria-label={language.t("settings.autocomplete.title")}>
             <Icon name="code-lines" />
             <span class="label">{language.t("settings.autocomplete.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="notifications">
+          <Tabs.Trigger value="notifications" aria-label={language.t("settings.notifications.title")}>
             <Icon name="circle-check" />
             <span class="label">{language.t("settings.notifications.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="context">
+          <Tabs.Trigger value="context" aria-label={language.t("settings.context.title")}>
             <Icon name="server" />
             <span class="label">{language.t("settings.context.title")}</span>
           </Tabs.Trigger>
 
-          <Tabs.Trigger value="commitMessage">
+          <Tabs.Trigger value="commitMessage" aria-label={language.t("settings.commitMessage.title")}>
             <Icon name="edit" />
             <span class="label">{language.t("settings.commitMessage.title")}</span>
           </Tabs.Trigger>
           <Show when={features().indexing}>
-            <Tabs.Trigger value="indexing">
+            <Tabs.Trigger value="indexing" aria-label={language.t("settings.indexing.title")}>
               <Icon name="server" />
               <span class="label">{language.t("settings.indexing.title")}</span>
             </Tabs.Trigger>
           </Show>
-          <Tabs.Trigger value="experimental">
+          <Tabs.Trigger value="experimental" aria-label={language.t("settings.experimental.title")}>
             <Icon name="settings-gear" />
             <span class="label">{language.t("settings.experimental.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="language">
+          <Tabs.Trigger value="language" aria-label={language.t("settings.language.title")}>
             <Icon name="speech-bubble" />
             <span class="label">{language.t("settings.language.title")}</span>
           </Tabs.Trigger>
-          <Tabs.Trigger value="aboutKiloCode">
+          <Tabs.Trigger value="aboutKiloCode" aria-label={language.t("settings.aboutKiloCode.title")}>
             <Icon name="help" />
             <span class="label">{language.t("settings.aboutKiloCode.title")}</span>
           </Tabs.Trigger>


### PR DESCRIPTION
Accessibility feedback from a user revealed that the sidebar Settings tabs were announced only as "tab" at compact widths. The compact layout removes the visible label from the accessibility tree while the decorative icons are intentionally hidden from assistive technology, leaving Models, Providers, and the other tabs unnamed.

Give every Settings trigger an explicit localized accessible name so the compact and wide layouts expose the same labels. Kobalte continues to own tab roles, selection, keyboard navigation, and tabpanel relationships, and the change remains scoped to the main Settings surface.