### PR TITLE
fix(vscode): highlight exact changed characters in diffs

### DIFF
--- a/.changeset/highlight-changed-characters.md
+++ b/.changeset/highlight-changed-characters.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Highlight the exact changed characters within modified diff lines.

--- a/packages/kilo-ui/src/pierre/index.test.ts
+++ b/packages/kilo-ui/src/pierre/index.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+import { createDefaultOptions } from "./index"
+
+describe("Pierre diff options", () => {
+  test("highlights changed characters in unified and split diffs", () => {
+    expect(createDefaultOptions("unified").lineDiffType).toBe("char")
+    expect(createDefaultOptions("split").lineDiffType).toBe("char")
+  })
+})

--- a/packages/kilo-ui/src/pierre/index.ts
+++ b/packages/kilo-ui/src/pierre/index.ts
@@ -10,6 +10,8 @@ import { createDefaultOptions as defaults, styleVariables } from "@opencode-ai/u
 
 export { styleVariables }
 
+export const LINE_DIFF_TYPE = "char" as const
+
 // Pierre 1.1 treats its changed-line override properties as tint targets. Apply
 // Kilo semantic surfaces at the computed row level so host diff colors stay final.
 const css = `
@@ -35,6 +37,7 @@ export function createDefaultOptions<T>(style: FileDiffOptions<T>["diffStyle"]) 
   const opts = defaults<T>(style)
   return {
     ...opts,
+    lineDiffType: LINE_DIFF_TYPE,
     unsafeCSS: `${opts.unsafeCSS}\n${css}`,
   }
 }

--- a/packages/kilo-vscode/webview-ui/pierre-worker.ts
+++ b/packages/kilo-vscode/webview-ui/pierre-worker.ts
@@ -12,6 +12,7 @@
 // the page. Pierre can offload highlighted updates to the pool after its initial
 // plain render. The diff wrapper still needs to keep that initial render cheap,
 // which is why review surfaces pass hunk-bounded patches instead of full files.
+import { LINE_DIFF_TYPE } from "@kilocode/kilo-ui/pierre"
 import { WorkerPoolManager } from "@pierre/diffs/worker"
 import { ensureKiloDiffTheme, KILO_DIFF_THEME } from "@opencode-ai/ui/pierre/kilo-diff-theme"
 
@@ -41,10 +42,10 @@ export function workerFactory(): Worker {
   return new Worker(url)
 }
 
-function createPool(lineDiffType: "none" | "word-alt") {
+function createPool() {
   const pool = new WorkerPoolManager(
     { workerFactory, poolSize: 2 },
-    { theme: KILO_DIFF_THEME, lineDiffType, preferredHighlighter: ENGINE },
+    { theme: KILO_DIFF_THEME, lineDiffType: LINE_DIFF_TYPE, preferredHighlighter: ENGINE },
   )
   void pool.initialize().catch((err) => console.warn("[Kilo New] Failed to initialize Pierre worker pool", err))
   return pool
@@ -59,11 +60,11 @@ export function getWorkerPool(style: WorkerPoolStyle | undefined): WorkerPoolMan
   if (!uri()) return undefined
 
   if (style === "split") {
-    if (!split) split = createPool("word-alt")
+    if (!split) split = createPool()
     return split.isInitialized() ? split : undefined
   }
 
-  if (!unified) unified = createPool("none")
+  if (!unified) unified = createPool()
   return unified.isInitialized() ? unified : undefined
 }
 


### PR DESCRIPTION
Modified lines currently rely on whole-line tinting or coarse word groups, which makes small edits difficult to identify in dense text.

Configure Kilo diff rendering to use Pierre character-level line diffs in both unified and split views. The worker pools use the same shared option so asynchronous highlighting preserves the initial render behavior, while the existing long-line and large-file safeguards remain in place.

Before:
<img width="827" height="340" alt="file-87cca02d425a69238d011fb32d7c3818" src="https://github.com/user-attachments/assets/c1de2407-0622-4f91-a3b3-8ae8fff95dba" />

After:
<img width="799" height="385" alt="file-1646f8bbfc23aeb1b653e90cadc2c562" src="https://github.com/user-attachments/assets/3da4dcc8-8d26-44ae-b4b4-78979732d840" />


Closes #9966