### PR TITLE
fix(cli): preserve plan file permissions in root workspaces

### DIFF
--- a/.changeset/fix-plan-permission-files.md
+++ b/.changeset/fix-plan-permission-files.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reinforce permissions for plan and architect modes to save plan files when agent-specific permissions are configured.

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -293,7 +293,7 @@ export const layer = Layer.effect(
         }
 
         // kilocode_change start - rename build→code, add debug/orchestrator/ask, patch plan/explore
-        KiloAgent.patchAgents(agents, defaults, user, cfg, kilo, ctx.worktree, whitelistedDirs)
+        KiloAgent.patchAgents(agents, defaults, user, cfg, kilo, ctx, whitelistedDirs)
 
         const agentConfigs = KiloAgent.preprocessConfig(cfg.agent ?? {})
         for (const [key, value] of Object.entries(agentConfigs)) {
@@ -323,8 +323,9 @@ export const layer = Layer.effect(
           item.name = value.name ?? item.name
           item.steps = value.steps ?? item.steps
           item.options = mergeDeep(item.options, value.options ?? {})
-          item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
-          KiloAgent.processConfigItem(item) // kilocode_change - populate displayName from options
+          const rules = Permission.fromConfig(value.permission ?? {}) // kilocode_change
+          item.permission = Permission.merge(item.permission, rules)
+          KiloAgent.processConfigItem(key, item, ctx, rules) // kilocode_change - apply Kilo config hooks
         }
 
         function referencePrompt(reference: Reference.Resolved) {

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -246,6 +246,9 @@ function planCapabilities(root: Root) {
     suggest: "allow",
     skill: "allow",
     plan_exit: "allow",
+    external_directory: {
+      [path.join(Global.Path.data, "plans", "*")]: "allow",
+    },
     edit: planEditAllowRules(root),
   })
 }

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -162,51 +162,91 @@ function askEditGuard() {
   return Permission.fromConfig({ edit: "deny" })
 }
 
+type Root = { worktree: string; directory: string }
+const dirs = [
+  path.join(".kilo", "plans", "*.md"),
+  path.join("plans", "*.md"),
+  path.join(".plans", "*.md"),
+  path.join(".opencode", "plans", "*.md"),
+]
+
+function flavor(root: Root) {
+  return path.win32.isAbsolute(root.directory) ? path.win32 : path
+}
+
+function scoped(root: Root, pattern: string) {
+  const paths = flavor(root)
+  const full = paths.isAbsolute(pattern) ? pattern : paths.join(root.directory, pattern)
+  return paths.relative(root.worktree, full)
+}
+
+function scopedRules(root: Root, rules: Permission.Ruleset) {
+  if (root.worktree !== "/") return []
+  return rules
+    .filter((rule) => rule.permission === "edit" && (path.isAbsolute(rule.pattern) || !rule.pattern.startsWith("..")))
+    .map((rule) => ({ ...rule, pattern: scoped(root, rule.pattern) }))
+}
+
 // Upstream v1.14.33 builds Agent state outside the Instance ALS, so reading
-// Instance.worktree here would crash. Thread worktree through from patchAgents
-// instead.
-function planEditRules(worktree: string) {
+// Instance.worktree here would crash. Thread the instance roots through instead.
+function planEditRules(root: Root) {
   return {
     "*": "deny" as const,
-    [path.join(".kilo", "plans", "*.md")]: "allow" as const,
-    [path.join("plans", "*.md")]: "allow" as const,
-    [path.join(".plans", "*.md")]: "allow" as const,
-    [path.join(".opencode", "plans", "*.md")]: "allow" as const,
-    [path.relative(worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow" as const,
+    ...planEditAllowRules(root),
   }
 }
 
-function planEditGuard(worktree: string) {
-  return Permission.fromConfig({ edit: planEditRules(worktree) })
+function planEditAllowRules(root: Root) {
+  const paths = flavor(root)
+  const global = paths.join(Global.Path.data, "plans", "*.md")
+  const rules = Object.fromEntries(dirs.map((dir) => [dir, "allow" as const]))
+  if (root.worktree === "/") {
+    for (const dir of dirs) rules[scoped(root, dir)] = "allow"
+  }
+  rules[paths.relative(root.worktree, global)] = "allow"
+  rules[global] = "allow"
+  return rules
 }
 
-function planGuard(worktree: string, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
+function planEditGuard(root: Root) {
+  return Permission.fromConfig({ edit: planEditRules(root) })
+}
+
+function planGuard(root: Root, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
+  return Permission.merge(
+    Permission.fromConfig({
+      "*": "deny",
+      bash: readOnlyBash,
+      read: {
+        "*": "allow",
+        "*.env": "ask",
+        "*.env.*": "ask",
+        "*.env.example": "allow",
+      },
+      grep: "allow",
+      glob: "allow",
+      list: "allow",
+      webfetch: "allow",
+      websearch: "allow",
+      codebase_search: "allow",
+      semantic_search: "allow",
+      external_directory: {
+        [Truncate.GLOB]: "allow",
+        [path.join(Global.Path.data, "plans", "*")]: "allow",
+      },
+      ...mcp,
+    }),
+    planCapabilities(root),
+  )
+}
+
+function planCapabilities(root: Root) {
   return Permission.fromConfig({
-    "*": "deny",
     question: "allow",
     suggest: "allow",
     skill: "allow",
     plan_exit: "allow",
-    bash: readOnlyBash,
-    read: {
-      "*": "allow",
-      "*.env": "ask",
-      "*.env.*": "ask",
-      "*.env.example": "allow",
-    },
-    grep: "allow",
-    glob: "allow",
-    list: "allow",
-    webfetch: "allow",
-    websearch: "allow",
-    codebase_search: "allow",
-    semantic_search: "allow",
-    external_directory: {
-      [Truncate.GLOB]: "allow",
-      [path.join(Global.Path.data, "plans", "*")]: "allow",
-    },
-    edit: planEditRules(worktree),
-    ...mcp,
+    edit: planEditAllowRules(root),
   })
 }
 
@@ -256,15 +296,36 @@ export function preprocessConfig<T>(agentConfig: Record<string, T>): Record<stri
   return result
 }
 
-// Set displayName and deprecated from options after config item is processed.
-export function processConfigItem(item: {
-  options: Record<string, unknown>
-  displayName?: string
-  deprecated?: boolean
-}) {
+// Apply Kilo config hooks after a config item is processed.
+export function processConfigItem(
+  key: string,
+  item: {
+    name: string
+    permission: Permission.Ruleset
+    options: Record<string, unknown>
+    displayName?: string
+    deprecated?: boolean
+  },
+  root: Root,
+  rules: Permission.Ruleset,
+) {
   if (item.options?.displayName && typeof item.options.displayName === "string") {
     item.displayName = item.options.displayName
   }
+  if (!isPlanAgent(key, item)) return
+  item.permission = Permission.merge(item.permission, scopedRules(root, rules), planCapabilities(root))
+}
+
+function isPlanAgent(
+  key: string,
+  item: {
+    name: string
+    options?: Record<string, unknown>
+  },
+) {
+  const name = item.name.toLowerCase()
+  const id = typeof item.options?.id === "string" ? item.options.id.toLowerCase() : undefined
+  return key === "plan" || key === "architect" || name === "plan" || name === "architect" || id === "architect"
 }
 
 const locked = new Set(["compaction", "title", "summary"])
@@ -331,7 +392,7 @@ export function patchAgents(
   user: Permission.Ruleset,
   cfg: Config.Info,
   kilo: KiloData,
-  worktree: string,
+  root: Root,
   whitelistedDirs: string[],
 ) {
   // Rename "build" → "code" for backward compatibility
@@ -354,13 +415,7 @@ export function patchAgents(
     agents.plan = {
       ...agents.plan,
       description: "Plan mode. Can only edit plan files; all other filesystem mutations are denied.",
-      permission: Permission.merge(
-        defaults,
-        planGuard(worktree, kilo.mcpRules),
-        user,
-        planEditGuard(worktree),
-        denies(user),
-      ),
+      permission: Permission.merge(defaults, planGuard(root, kilo.mcpRules), user, planEditGuard(root), denies(user)),
     }
   }
 

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -171,6 +171,7 @@ test("root workspace plan-like agent allows configured local and global plan pat
       expect(Permission.evaluate("edit", local, agent!.permission).action).toBe("allow")
       expect(Permission.evaluate("edit", path.relative(ctx.worktree, global), agent!.permission).action).toBe("allow")
       expect(Permission.evaluate("edit", global, agent!.permission).action).toBe("allow")
+      expect(Permission.evaluate("external_directory", global, agent!.permission).action).toBe("allow")
       expect(
         Permission.evaluate(
           "edit",
@@ -194,17 +195,23 @@ test("root workspace scopes Windows drive paths", () => {
     },
   })
   const agent = { name: "architect", permission: rules, options: {} }
+  const request = (file: string) => (process.platform === "win32" ? path.win32.relative("/", file) : file)
 
   processConfigItem("architect", agent, { worktree: "/", directory: dir }, rules)
 
-  expect(Permission.evaluate("edit", path.win32.join(dir, "docs", "test-session.md"), agent.permission).action).toBe(
-    "allow",
-  )
   expect(
-    Permission.evaluate("edit", path.win32.join(dir, ".kilo", "plans", "test-session.md"), agent.permission).action,
+    Permission.evaluate("edit", request(path.win32.join(dir, "docs", "test-session.md")), agent.permission).action,
   ).toBe("allow")
-  expect(Permission.evaluate("edit", path.win32.join(global, "test-session.md"), agent.permission).action).toBe("allow")
-  expect(Permission.evaluate("edit", path.win32.join(dir, "src", "main.ts"), agent.permission).action).toBe("deny")
+  expect(
+    Permission.evaluate("edit", request(path.win32.join(dir, ".kilo", "plans", "test-session.md")), agent.permission)
+      .action,
+  ).toBe("allow")
+  expect(
+    Permission.evaluate("edit", request(path.win32.join(global, "test-session.md")), agent.permission).action,
+  ).toBe("allow")
+  expect(Permission.evaluate("edit", request(path.win32.join(dir, "src", "main.ts")), agent.permission).action).toBe(
+    "deny",
+  )
 })
 
 test("system utility agents ignore per-agent permission allows", async () => {

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, expect, test } from "bun:test"
 import { Effect } from "effect"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
 import { Agent } from "../../src/agent/agent"
+import { processConfigItem } from "../../src/kilocode/agent"
 import { Permission } from "../../src/permission"
 import { provideTestInstance } from "../fixture/fixture"
 import { disposeAllInstances, provideInstance, tmpdir } from "../fixture/fixture"
@@ -74,6 +77,134 @@ test("plan agent still hard-denies non-plan edits after user edit allow", async 
       expect(Permission.evaluate("edit", ".plans/fix.md", plan!.permission).action).toBe("allow")
     },
   })
+})
+
+test("plan agent preserves plan file edits after per-agent edit deny", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        plan: {
+          permission: {
+            "*": "deny",
+            edit: { "*": "deny" },
+          },
+        },
+      },
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      expect(plan).toBeDefined()
+      expect(Permission.evaluate("plan_exit", "*", plan!.permission).action).toBe("allow")
+      expect(Permission.disabled(["write"], plan!.permission).has("write")).toBe(false)
+      expect(Permission.evaluate("edit", "src/output.log", plan!.permission).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".kilo/plans/fix.md", plan!.permission).action).toBe("allow")
+      expect(Permission.evaluate("edit", "plans/fix.md", plan!.permission).action).toBe("allow")
+    },
+  })
+})
+
+test("architect agent receives plan file permissions", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        architect: {
+          mode: "primary",
+          permission: {
+            "*": "deny",
+            read: "allow",
+            edit: {
+              "*.md": "allow",
+              "*": "deny",
+            },
+          },
+        },
+      },
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await load(tmp.path, (svc) => svc.get("architect"))
+      expect(agent).toBeDefined()
+      expect(Permission.evaluate("plan_exit", "*", agent!.permission).action).toBe("allow")
+      expect(Permission.disabled(["write"], agent!.permission).has("write")).toBe(false)
+      expect(Permission.evaluate("edit", "src/output.log", agent!.permission).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".kilo/plans/fix.md", agent!.permission).action).toBe("allow")
+      expect(Permission.evaluate("edit", "plans/fix.md", agent!.permission).action).toBe("allow")
+    },
+  })
+})
+
+test("root workspace plan-like agent allows configured local and global plan paths", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        architect: {
+          mode: "primary",
+          permission: {
+            "*": "deny",
+            edit: {
+              "*": "deny",
+              "docs/*.md": "allow",
+            },
+          },
+        },
+      },
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const agent = await load(tmp.path, (svc) => svc.get("architect"))
+      const docs = path.relative(ctx.worktree, path.join(tmp.path, "docs", "test-session.md"))
+      const local = path.relative(ctx.worktree, path.join(tmp.path, ".kilo", "plans", "test-session.md"))
+      const global = path.join(Global.Path.data, "plans", "test-session.md")
+
+      expect(ctx.worktree).toBe("/")
+      expect(Permission.evaluate("edit", docs, agent!.permission).action).toBe("allow")
+      expect(Permission.evaluate("edit", local, agent!.permission).action).toBe("allow")
+      expect(Permission.evaluate("edit", path.relative(ctx.worktree, global), agent!.permission).action).toBe("allow")
+      expect(Permission.evaluate("edit", global, agent!.permission).action).toBe("allow")
+      expect(
+        Permission.evaluate(
+          "edit",
+          path.relative(ctx.worktree, path.join(tmp.path, "src", "main.ts")),
+          agent!.permission,
+        ).action,
+      ).toBe("deny")
+    },
+  })
+})
+
+test("root workspace scopes Windows drive paths", () => {
+  const dir = String.raw`C:\Users\developer\projects\EAM_SLA`
+  const global = String.raw`C:\Users\developer\.local\share\kilo\plans`
+  const rules = Permission.fromConfig({
+    "*": "deny",
+    edit: {
+      "*": "deny",
+      "docs/*.md": "allow",
+      [path.win32.join(global, "*.md")]: "allow",
+    },
+  })
+  const agent = { name: "architect", permission: rules, options: {} }
+
+  processConfigItem("architect", agent, { worktree: "/", directory: dir }, rules)
+
+  expect(Permission.evaluate("edit", path.win32.join(dir, "docs", "test-session.md"), agent.permission).action).toBe(
+    "allow",
+  )
+  expect(
+    Permission.evaluate("edit", path.win32.join(dir, ".kilo", "plans", "test-session.md"), agent.permission).action,
+  ).toBe("allow")
+  expect(Permission.evaluate("edit", path.win32.join(global, "test-session.md"), agent.permission).action).toBe("allow")
+  expect(Permission.evaluate("edit", path.win32.join(dir, "src", "main.ts"), agent.permission).action).toBe("deny")
 })
 
 test("system utility agents ignore per-agent permission allows", async () => {


### PR DESCRIPTION
## Context

In non-git workspaces, the worktree is `/`, so edit requests can be evaluated as root-relative or absolute paths while configured allow rules remain project-relative. The broad plan edit deny then wins. Agent-specific permissions can also be merged after the built-in plan rules and override required plan capabilities.
There were three different issues: non-git workspaces and path mismatches, permission deny precedence during merge of permissions, and the global fallback path on non-git.

From reddit:
```
The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules [{"permission":"*","action":"allow","pattern":"*"},{"permission":"*","action":"deny","pattern":"*"},{"permission":"edit","pattern":"*","action":"deny"},{"permission":"edit","pattern":".kilo\\plans\\*.md","action":"allow"},{"permission":"edit","pattern":".plans\\*.md","action":"allow"},
```

From discord:
<img width="1075" height="354" alt="Screenshot 2026-06-17 at 12 12 21" src="https://github.com/user-attachments/assets/4d356eb2-a52d-4872-8339-be16daf851b7" />
Ref: https://www.reddit.com/r/kilocode/comments/1u48ulo/problems_with_tool_permissions/?solution=1888dfb101849b561888dfb101849b56&js_challenge=1&token=7afd7253fec22262ff1c52b1703fe9ec77a18548b65d62f5286a4e151d48dec6&jsc_orig_r=

## Implementation

Scope plan edit rules to the active directory when the worktree is `/`, preserve absolute global plan paths, and reapply allow-only plan capabilities after agent-specific rules. Non-plan edits remain denied.

Added guards and unit test for windows behavior.

## Screenshots / Video

Plan working on mac
<img width="1024" height="608" alt="Screenshot 2026-06-17 at 12 05 12" src="https://github.com/user-attachments/assets/495c4483-6d7b-46fe-92ee-7da078735c60" />

Added unit test to simulate Windows behavior

## How to Test

### Manual/local verification

- Agent: `bun test test/kilocode/agent-permission-overrides.test.ts` — 9 passed.
- Agent: `bun run typecheck` from `packages/opencode` — passed.
- Agent: `bun run script/check-opencode-annotations.ts` — passed.
- Agent: focused Oxlint — 0 errors.

### Reviewer test steps

1. Use a non-git workspace with a plan-like agent that allows a project-local Markdown path.
2. Confirm writes to that path and the global plan directory are allowed.
3. Confirm writes to non-plan source files remain denied.

## Checklist

- [x] No linked issue; exception explained above
- [x] Tests/verification described
- [x] Screenshots/video marked N/A
- [x] Changeset included
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.