### PR TITLE
fix: sync remote sessions across extension surfaces

### DIFF
--- a/.changeset/remote-agent-manager-sessions.md
+++ b/.changeset/remote-agent-manager-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Enable remote control from Agent Manager without disrupting concurrent sidebar sessions, and include all open Agent Manager sessions.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -598,7 +598,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.statsPoller.setEnabled(webviewView.visible)
         this.statsPoller.setVisible(webviewView.visible)
       }
-      this.focusSession(webviewView.visible ? this.currentSession?.id : undefined)
+      this.focusSession(webviewView.visible ? this.contextSessionID : undefined)
     })
     this.initializeConnection()
   }
@@ -1481,6 +1481,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.stopCurrentSessionProcesses(session.id)
       this.setCurrentSession(session)
       this.contextSessionID = session.id
+      this.focusSession(session.id)
       this.trackDirectory(session.id, workspaceDir)
       this.trackedSessionIds.add(session.id)
 
@@ -2501,6 +2502,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.stopCurrentSessionProcesses(session.id)
       this.setCurrentSession(session)
       this.contextSessionID = session.id
+      this.focusSession(session.id)
       this.trackDirectory(session.id, dir)
       this.trackedSessionIds.add(session.id)
       this.postMessage({

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -249,6 +249,9 @@ export class AgentManagerProvider implements Disposable {
         this.statsPoller.stop()
         this.prBridge.poller.stop()
         this.diffs.stop()
+        this.activeSessionId = undefined
+        this.connectionService.unregisterFocused("agent-manager")
+        this.connectionService.registerOpen("agent-manager", [])
         this.panel = undefined
         this.onVisibilityChange?.(false)
       }

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -15,6 +15,7 @@ import { buildWebviewHtml } from "../utils"
 import { openFileInEditor, getWorkspaceRoot } from "../review-utils"
 import { TelemetryProxy, type TelemetryEventName } from "../services/telemetry"
 import type { AutoApproveController } from "../commands/toggle-auto-approve"
+import type { RemoteStatusService } from "../services/RemoteStatusService"
 
 export class VscodeHost implements Host {
   private diffVirtual: DiffVirtualProvider | undefined
@@ -24,6 +25,7 @@ export class VscodeHost implements Host {
     private readonly extensionUri: vscode.Uri,
     private readonly connectionService: KiloConnectionService,
     private readonly context: vscode.ExtensionContext,
+    private readonly remoteService: RemoteStatusService,
   ) {}
 
   setDiffVirtualProvider(provider: DiffVirtualProvider): void {
@@ -98,6 +100,7 @@ export class VscodeHost implements Host {
     if (this.diffVirtual) {
       provider.setDiffVirtualProvider(this.diffVirtual)
     }
+    provider.setRemoteService(this.remoteService)
     provider.attachToWebview(panel.webview, {
       onBeforeMessage: opts.onBeforeMessage,
     })

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -147,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(kiloClawProvider)
 
   // Create Agent Manager provider for editor panel
-  const agentManagerHost = new VscodeHost(context.extensionUri, connectionService, context)
+  const agentManagerHost = new VscodeHost(context.extensionUri, connectionService, context, remoteService)
   const agentManagerProvider = new AgentManagerProvider(agentManagerHost, connectionService)
   agentManagerProvider.onPanelVisibilityChange((visible) => remember({ agentManager: visible }))
   agentManager = agentManagerProvider

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
@@ -1,6 +1,50 @@
 import { describe, expect, test } from "bun:test"
 import { KiloConnectionService } from "./connection-service"
 
+describe("KiloConnectionService viewed sessions", () => {
+  test("keeps Agent Manager sessions when sidebar focus changes during a flush", async () => {
+    const service = new KiloConnectionService({} as any)
+    const calls: Array<{ focused: string[]; open?: string[] }> = []
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let active = 0
+    let max = 0
+
+    ;(service as any).remoteService = { getState: () => ({ enabled: true }) }
+    ;(service as any).client = {
+      session: {
+        viewed: async (input: { focused: string[]; open?: string[] }) => {
+          calls.push(input)
+          active += 1
+          max = Math.max(max, active)
+          if (calls.length === 1) await gate
+          active -= 1
+        },
+      },
+    }
+
+    service.registerFocused("agent-manager", "am-1")
+    service.registerOpen("agent-manager", ["am-1", "am-2"])
+    await Bun.sleep(175)
+    expect(calls).toEqual([{ focused: ["am-1"], open: ["am-2"] }])
+
+    service.registerFocused("sidebar", "side-1")
+    await Bun.sleep(175)
+    expect(calls).toHaveLength(1)
+
+    release()
+    await Bun.sleep(10)
+    expect(max).toBe(1)
+    expect(calls[1]).toEqual({ focused: ["am-1", "side-1"], open: ["am-2"] })
+
+    service.unregisterFocused("sidebar")
+    await Bun.sleep(175)
+    expect(calls[2]).toEqual({ focused: ["am-1"], open: ["am-2"] })
+  })
+})
+
 describe("KiloConnectionService drainPendingPrompts", () => {
   test("ignores stale NotFoundError replies while draining permissions", async () => {
     const service = new KiloConnectionService({} as any)

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -85,6 +85,8 @@ export class KiloConnectionService {
   /** Provider key → all open (background) session IDs. */
   private readonly opened: Map<string, string[]> = new Map()
   private debounceTimer: ReturnType<typeof setTimeout> | null = null
+  private viewedSending = false
+  private viewedDirty = false
   private unsubRemote: (() => void) | null = null
 
   constructor(context: vscode.ExtensionContext) {
@@ -520,17 +522,38 @@ export class KiloConnectionService {
     if (this.debounceTimer) clearTimeout(this.debounceTimer)
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null
-      const focus = new Set(this.focused.values())
-      const open = new Set<string>()
-      for (const ids of this.opened.values()) {
-        for (const id of ids) {
-          if (!focus.has(id)) open.add(id)
-        }
-      }
-      this.client?.session
-        .viewed({ focused: [...focus], open: [...open] })
-        .catch((err) => console.warn("[Kilo New] ConnectionService: viewed flush failed:", err))
+      this.sendViewed()
     }, 150)
+  }
+
+  private sendViewed(): void {
+    if (!this.isRemoteEnabled()) {
+      this.viewedDirty = false
+      return
+    }
+    if (this.viewedSending) {
+      this.viewedDirty = true
+      return
+    }
+    if (!this.client) return
+
+    const focus = new Set(this.focused.values())
+    const open = new Set<string>()
+    for (const ids of this.opened.values()) {
+      for (const id of ids) {
+        if (!focus.has(id)) open.add(id)
+      }
+    }
+
+    this.viewedSending = true
+    this.viewedDirty = false
+    void this.client.session
+      .viewed({ focused: [...focus], open: [...open] })
+      .catch((err) => console.warn("[Kilo New] ConnectionService: viewed flush failed:", err))
+      .finally(() => {
+        this.viewedSending = false
+        if (this.viewedDirty) this.sendViewed()
+      })
   }
 
   /**
@@ -558,6 +581,7 @@ export class KiloConnectionService {
       clearTimeout(this.debounceTimer)
       this.debounceTimer = null
     }
+    this.viewedDirty = false
     this.unsubRemote?.()
     this.unsubRemote = null
     this.client = null

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -210,6 +210,18 @@ describe("Agent Manager Provider Messages", () => {
     expect(body).toContain("await this.terminalRouter.dispose()")
     expect(body).not.toContain("void this.terminalRouter.dispose()")
   })
+
+  it("clears remote session registrations when the panel closes", () => {
+    const body = getMethodBody("attachPanel")
+    expect(body).toContain('this.connectionService.unregisterFocused("agent-manager")')
+    expect(body).toContain('this.connectionService.registerOpen("agent-manager", [])')
+    expect(body).toContain("this.activeSessionId = undefined")
+  })
+
+  it("reports all open Agent Manager sessions for remote control", () => {
+    const body = fs.readFileSync(TSX_FILE, "utf-8")
+    expect(body).toContain("reportRemoteSessions(vscode, localSessionIDs, managedSessions, isPending)")
+  })
 })
 
 describe("Agent Manager Model Picker", () => {

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -16,6 +16,7 @@ const PKG_JSON_FILE = path.join(ROOT, "package.json")
 const SRC_DIR = path.join(ROOT, "src")
 const EXTENSION_FILE = path.join(ROOT, "src/extension.ts")
 const KILO_PROVIDER_FILE = path.join(ROOT, "src/KiloProvider.ts")
+const VSCODE_HOST_FILE = path.join(ROOT, "src/agent-manager/vscode-host.ts")
 
 function sliceBlock(source: string, start: number): string {
   const open = source.indexOf("{", start)
@@ -186,6 +187,35 @@ describe("Extension — KiloProvider handler wiring", () => {
 // must send an error back to the webview so the spinner resets. Previously
 // it silently no-op'd, leaving the UI stuck.
 // ---------------------------------------------------------------------------
+
+describe("Extension — Agent Manager remote wiring", () => {
+  const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
+  const host = fs.readFileSync(VSCODE_HOST_FILE, "utf-8")
+
+  it("passes the shared remote service to Agent Manager", () => {
+    expect(ext).toContain("new VscodeHost(context.extensionUri, connectionService, context, remoteService)")
+  })
+
+  it("wires the remote service before attaching the Agent Manager webview", () => {
+    const remote = host.indexOf("provider.setRemoteService(this.remoteService)")
+    const attach = host.indexOf("provider.attachToWebview")
+    expect(remote).toBeGreaterThan(-1)
+    expect(attach).toBeGreaterThan(-1)
+    expect(remote).toBeLessThan(attach)
+  })
+})
+
+describe("KiloProvider — remote focus lifecycle", () => {
+  const provider = fs.readFileSync(KILO_PROVIDER_FILE, "utf-8")
+
+  it("registers newly created sessions and uses the synchronous session ID", () => {
+    const create = sliceBlock(provider, provider.indexOf("private async handleCreateSession"))
+    const resolve = sliceBlock(provider, provider.indexOf("private async resolveSession"))
+    expect(create).toContain("this.focusSession(session.id)")
+    expect(resolve).toContain("this.focusSession(session.id)")
+    expect(provider).toContain("this.focusSession(webviewView.visible ? this.contextSessionID : undefined)")
+  })
+})
 
 describe("KiloProvider — continueInWorktree error fallback", () => {
   const helper = fs.readFileSync(path.join(ROOT, "src/kilo-provider/continue-worktree.ts"), "utf-8")

--- a/packages/kilo-vscode/tests/unit/navigate.test.ts
+++ b/packages/kilo-vscode/tests/unit/navigate.test.ts
@@ -6,6 +6,7 @@ import {
   restoreLocalSessions,
   reconcileLocalSessions,
   filterUnassignedSessions,
+  remoteSessions,
   LOCAL,
 } from "../../webview-ui/agent-manager/navigate"
 
@@ -393,6 +394,30 @@ describe("restoreLocalSessions", () => {
   it("returns undefined when no disk sessions and no tab order", () => {
     const result = restoreLocalSessions([], [], undefined, isPending, identity)
     expect(result).toBeUndefined()
+  })
+})
+
+describe("remoteSessions", () => {
+  const pending = (id: string) => id.startsWith("pending:")
+
+  it("returns every real tab without collapsing sessions in the same worktree", () => {
+    const result = remoteSessions(
+      ["local-1", "pending:1", "shared"],
+      [
+        { id: "shared", worktreeId: "wt-1" },
+        { id: "worktree-1", worktreeId: "wt-1" },
+        { id: "worktree-2", worktreeId: "wt-1" },
+        { id: "worktree-3", worktreeId: "wt-2" },
+        { id: "closed-local", worktreeId: null },
+      ],
+      pending,
+    )
+
+    expect(result).toEqual(["local-1", "shared", "worktree-1", "worktree-2", "worktree-3"])
+  })
+
+  it("returns an empty list without open sessions", () => {
+    expect(remoteSessions([], [], pending)).toEqual([])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -99,6 +99,7 @@ import {
 } from "./navigate"
 import { reorderTabs, applyTabOrder, firstOrderedTitle } from "./tab-order"
 import { createTabOrderSync } from "./tab-order-sync"
+import { reportRemoteSessions } from "./remote-sessions"
 import { ConstrainDragYAxis } from "./sortable-tab"
 import { isTerminalTabId, createTerminalState, createTerminalHandlers, createTerminalMessageHandler } from "./terminal"
 import { renderTab, renderTerminalLayer, renderNewTabButton } from "./tab-rendering"
@@ -544,6 +545,7 @@ const AgentManagerContent: Component = () => {
   )
 
   const isPending = (id: string) => id.startsWith(PENDING_PREFIX)
+  reportRemoteSessions(vscode, localSessionIDs, managedSessions, isPending)
 
   // Drag-and-drop state for tab reordering
   const [draggingTab, setDraggingTab] = createSignal<string | undefined>()

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -143,6 +143,19 @@ export function restoreLocalSessions(
   return changed ? merged : undefined
 }
 
+export function remoteSessions(
+  local: string[],
+  managed: { id: string; worktreeId: string | null }[],
+  pending: (id: string) => boolean,
+): string[] {
+  return [
+    ...new Set([
+      ...local.filter((id) => !pending(id)),
+      ...managed.filter((session) => session.worktreeId).map((session) => session.id),
+    ]),
+  ]
+}
+
 export function reconcileLocalSessions(
   current: string[],
   loaded: string[],

--- a/packages/kilo-vscode/webview-ui/agent-manager/remote-sessions.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/remote-sessions.ts
@@ -1,0 +1,22 @@
+import { createEffect, type Accessor } from "solid-js"
+import { remoteSessions } from "./navigate"
+
+type Bridge = {
+  postMessage(message: { type: "agentManager.openSessions"; sessionIDs: string[] }): void
+}
+
+type Managed = { id: string; worktreeId: string | null }
+
+export function reportRemoteSessions(
+  vscode: Bridge,
+  local: Accessor<string[]>,
+  managed: Accessor<Managed[]>,
+  pending: (id: string) => boolean,
+): void {
+  createEffect(() => {
+    vscode.postMessage({
+      type: "agentManager.openSessions",
+      sessionIDs: remoteSessions(local(), managed(), pending),
+    })
+  })
+}

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -200,7 +200,7 @@ export namespace KiloSessions {
   })
 
   const remoteEnabled = process.env["KILO_REMOTE"] === "1"
-  let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender; heartbeat: () => Promise<void> } | undefined
+  let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender } | undefined
   let enabling: Promise<void> | undefined
   let remoteSeq = 0
   const focused = new Set<string>()
@@ -452,17 +452,13 @@ export namespace KiloSessions {
         log,
       })
 
-      const heartbeat = async () => {
-        conn.send({ type: "heartbeat", ...(await getSessions()) })
-      }
-
       if (seq !== remoteSeq) {
         sender.dispose()
         conn.close()
         return
       }
 
-      remote = { conn, sender, heartbeat }
+      remote = { conn, sender }
       log.info("remote connection enabled", { connected: conn.connected })
       Telemetry.trackRemoteConnectionOpened()
       void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: true, connected: conn.connected })
@@ -509,7 +505,7 @@ export namespace KiloSessions {
     for (const id of input.open ?? []) {
       opened.add(id)
     }
-    if (remote) void remote.heartbeat().catch((err) => log.warn("heartbeat failed", { error: String(err) }))
+    if (remote) void remote.conn.heartbeat().catch((err) => log.warn("heartbeat failed", { error: String(err) }))
   }
 
   export async function create(sessionId: string) {

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -27,6 +27,7 @@ export namespace RemoteWS {
   export type Connection = {
     readonly connectionId: string
     send(msg: RemoteProtocol.Outbound): void
+    heartbeat(): Promise<void>
     close(): void
     readonly connected: boolean
   }
@@ -43,13 +44,37 @@ export namespace RemoteWS {
     let beat: Timer | undefined
     let closed = false
     const buffer: string[] = []
+    let beating: Promise<void> | undefined
+    let queued = false
+
+    function heartbeat(): Promise<void> {
+      queued = true
+      if (beating) return beating
+
+      const current = Promise.resolve(
+        withContext(async () => {
+          while (queued && !closed) {
+            queued = false
+            const sessions = await options.getSessions()
+            if (closed) return
+            send({ type: "heartbeat", ...sessions })
+          }
+        }),
+      ).finally(() => {
+        beating = undefined
+        if (!queued || closed) return
+        void heartbeat().catch((err) => {
+          options.log.error("remote-ws heartbeat failed", { error: String(err) })
+        })
+      })
+      beating = current
+      return current
+    }
 
     function startHeartbeat() {
       stopHeartbeat()
       beat = setInterval(() => {
-        void withContext(async () => {
-          send({ type: "heartbeat", ...(await options.getSessions()) })
-        }).catch((err) => {
+        void heartbeat().catch((err) => {
           options.log.error("remote-ws heartbeat failed", { error: String(err) })
         })
       }, interval)
@@ -168,6 +193,7 @@ export namespace RemoteWS {
 
     function close() {
       closed = true
+      queued = false
       stopHeartbeat()
       stopWatchdog()
       if (timer) clearTimeout(timer)
@@ -179,6 +205,7 @@ export namespace RemoteWS {
     return {
       connectionId,
       send,
+      heartbeat,
       close,
       get connected() {
         return ws?.readyState === WebSocket.OPEN

--- a/packages/opencode/test/kilocode/sessions/remote-ws.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-ws.test.ts
@@ -109,6 +109,48 @@ describe("RemoteWS", () => {
     expect(parsed.sessions).toEqual([{ id: "s1", status: "active", title: "Test" }])
   })
 
+  test("serializes concurrent heartbeat snapshots", async () => {
+    server = createServer()
+    const connecting = server.waitForConnect()
+    const firstMessage = server.waitForMessage()
+    const secondMessage = server.waitForMessage()
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let calls = 0
+    let active = 0
+    let max = 0
+
+    conn = RemoteWS.connect({
+      url: server.url,
+      getToken: async () => "tok",
+      getSessions: async () => {
+        const call = ++calls
+        active += 1
+        max = Math.max(max, active)
+        if (call === 1) await gate
+        active -= 1
+        return { sessions: [{ id: `s${call}`, status: "active" as const, title: `Session ${call}` }] }
+      },
+      log: nolog(),
+      heartbeat: 60_000,
+    })
+
+    await connecting
+    await settled()
+    const first = conn.heartbeat()
+    const second = conn.heartbeat()
+    await Bun.sleep(10)
+    expect(calls).toBe(1)
+
+    release()
+    await Promise.all([first, second])
+    expect(max).toBe(1)
+    expect(JSON.parse(await firstMessage).sessions[0].id).toBe("s1")
+    expect(JSON.parse(await secondMessage).sessions[0].id).toBe("s2")
+  })
+
   test("buffers when disconnected, flushes on reconnect", async () => {
     server = createServer()
     const connecting = server.waitForConnect()


### PR DESCRIPTION
Remote control was only fully wired into the sidebar. Running `/remote` from Agent Manager silently did nothing because its embedded provider did not receive the shared remote status service, and Agent Manager only reported its selected session while omitting other open tabs. Opening a sidebar session at the same time could also leave that session unregistered or let overlapping heartbeat snapshots arrive out of order, causing one surface's session set to replace the other remotely.

This injects the extension-scoped remote service into Agent Manager and reports every real Agent Manager tab by session ID, excluding pending drafts and preserving multiple sessions in the same worktree. New sidebar sessions register as focused immediately, while closing Agent Manager clears its registrations.

Viewed-session updates and WebSocket heartbeats are serialized and coalesced so sidebar, editor, and Agent Manager state is combined into one ordered remote snapshot. The result is one shared remote connection that keeps all concurrently open extension sessions available without one surface dropping another.