### PR TITLE
fix(cli): skip bundled Atomic Chat in plugin loader

### DIFF
--- a/.changeset/prevent-atomic-chat-install.md
+++ b/.changeset/prevent-atomic-chat-install.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent the bundled Atomic Chat plugin from triggering an npm installation.

--- a/packages/opencode/src/plugin/loader.ts
+++ b/packages/opencode/src/plugin/loader.ts
@@ -11,6 +11,7 @@ import {
 import { ConfigPlugin } from "@/config/plugin"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { isIndexingPlugin } from "@kilocode/kilo-indexing/detect" // kilocode_change
+import { isAtomicChatPlugin } from "@/kilocode/atomic-chat-feature" // kilocode_change
 
 export namespace PluginLoader {
   // A normalized plugin declaration derived from config before any filesystem or npm work happens.
@@ -143,6 +144,7 @@ export namespace PluginLoader {
     // Deprecated plugin packages are silently ignored because they are now built in.
     if (plan.deprecated) return
     if (isIndexingPlugin(candidate.plan.spec)) return // kilocode_change
+    if (isAtomicChatPlugin(candidate.plan.spec)) return // kilocode_change
     report?.start?.(candidate, retry)
 
     const resolved = await resolve(plan, kind)

--- a/packages/opencode/test/kilocode/config/atomic-chat-default-plugin.test.ts
+++ b/packages/opencode/test/kilocode/config/atomic-chat-default-plugin.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
+import { Npm } from "@opencode-ai/core/npm"
 import type { ConfigPlugin } from "@/config/plugin"
 import { hasAtomicChatPlugin } from "@/kilocode/atomic-chat-feature"
 import { KilocodeDefaultPlugins } from "@/kilocode/config/default-plugins"
+import { PluginLoader } from "@/plugin/loader"
 
 const atomic = "@kilocode/plugin-atomic-chat"
 
@@ -95,5 +97,22 @@ describe("kilocode default atomic chat plugin", () => {
     expect(cfg.plugin).toContain(spec)
     expect(cfg.plugin).toContain(atomic)
     expect(cfg.plugin_origins).toEqual([origin])
+  })
+
+  test("external loader skips bundled atomic chat before npm installation", async () => {
+    const install = spyOn(Npm, "add").mockRejectedValue(new Error("unexpected install"))
+    const specs = [atomic, `${atomic}@7.3.46`, `npm:${atomic}`, `atomic@npm:${atomic}@7.3.46`]
+
+    try {
+      const loaded = await PluginLoader.loadExternal({
+        items: specs.map((spec) => ({ spec, source: "test", scope: "global" as const })),
+        kind: "server",
+      })
+
+      expect(loaded).toEqual([])
+      expect(install).not.toHaveBeenCalled()
+    } finally {
+      install.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
The Atomic Chat integration is bundled into the CLI, but the external plugin loader only had a final safeguard for the bundled indexing plugin. PR #11031 began propagating default plugins through `plugin_origins`, which exposed the Atomic Chat package marker to npm resolution and produced a 404 for the unpublished package. PR #11291 filtered the normal configuration path, but the loader itself could still attempt installation if the marker reached it.

Skip recognized Atomic Chat package specs before external resolution, using the same detection as the bundled configuration path. This covers bare, versioned, and npm-aliased markers and keeps the loader aligned with the internal plugin lifecycle.

Fixes #11325
Regression introduced in #11031.