### PR TITLE
fix(vscode): type provider list callbacks

### DIFF
--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -2,7 +2,7 @@
  * Provider action handlers extracted from KiloProvider to stay under max-lines.
  * These are pure async functions that operate on the SDK client — no vscode dependency.
  */
-import type { Config, KiloClient } from "@kilocode/sdk/v2"
+import type { Config, KiloClient, Provider } from "@kilocode/sdk/v2"
 import { validateProviderID as validateProviderIDShared } from "./shared/custom-provider"
 import {
   resolveCustomProviderAuth,
@@ -71,7 +71,8 @@ export async function fetchProviderData(client: KiloClient, dir: string) {
   ])
   const authStates: Record<string, AuthState> = {}
   const storedKeys: Record<string, StoredProviderKey> = {}
-  const all = response.all.map((item) => {
+  const providers: Provider[] = response.all
+  const all = providers.map((item) => {
     const raw = item as Record<string, unknown>
     if (typeof raw.id === "string" && typeof raw.key === "string" && raw.key) {
       authStates[raw.id] = "api"
@@ -86,7 +87,7 @@ export async function fetchProviderData(client: KiloClient, dir: string) {
     if (!("key" in raw)) return item
     const next = { ...raw }
     delete next.key
-    return next as (typeof response.all)[number]
+    return next as Provider
   })
   delete authStates[KILO_PROVIDER_ID]
   if (kiloAuth) authStates[KILO_PROVIDER_ID] = kiloAuth
@@ -386,7 +387,8 @@ export async function disconnectProvider(
     const configured = !!cfg || !!effective
     const custom = customProvider(cfg) || customProvider(effective)
     const { response } = await fetchProviderData(ctx.client, ctx.workspaceDir)
-    const active = response.all.find((item) => item.id === id)
+    const providers: Provider[] = response.all
+    const active = providers.find((item) => item.id === id)
     const oauth = active?.source === "custom" && configured && !custom
 
     // Config-sourced providers may not have auth store entries because


### PR DESCRIPTION
## What
Fix strict TypeScript errors in provider action callbacks by preserving the generated `Provider` item type before mapping/finding provider list entries.

## Why
`response.all` was losing its element type in extension compilation, so callback params were inferred as implicit `any` under strict mode.

## Checks
- `bun run --cwd packages/kilo-vscode check-types:extension`
- `bun run --cwd packages/kilo-vscode lint`
