### PR TITLE
fix(vscode): widen chat readable lane from 78ch to 88ch for more content space

### DIFF
--- a/.changeset/widen-chat-readable-lane.md
+++ b/.changeset/widen-chat-readable-lane.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Widen the sidebar chat readable lane from 78ch to 88ch so tools and content use a little more screen space.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a645eecb71442d1ffde6febbcaa67054d1e048ea7f24b7e6837b3a2bb635aea
-size 51100
+oid sha256:e6ecf78a0bcfaebdb945c3caacb8e32155fe2f6e4017f766e129dd0d17ad8fab
+size 51349

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -18,7 +18,7 @@
   min-height: 0;
   overflow: hidden;
   container: chat / inline-size;
-  --chat-readable-width: 78ch;
+  --chat-readable-width: 88ch;
   --chat-gutter: clamp(16px, 4cqi, 48px);
   --chat-scrollbar-width: 10px;
 }


### PR DESCRIPTION
The sidebar chat constrains messages, tool calls, diffs, and the composer to a centered `--chat-readable-width` lane. The current 78ch maximum feels narrow when tools and code blocks are displayed.

This bumps it to 88ch (~13% wider), which uses the available sidebar space more efficiently without pushing content to the edges.