### PR TITLE
ci: complete the JetBrains test container

### DIFF
--- a/packages/containers/README.md
+++ b/packages/containers/README.md
@@ -8,7 +8,7 @@ Images
 
 - `base`: Ubuntu 24.04 with common build tools and utilities
 - `bun-node`: `base` plus Bun and Node.js 24
-- `jetbrains`: `bun-node` plus Java 21 and the pre-cached Gradle distribution
+- `jetbrains`: `bun-node` plus Java 21, JBR font libraries, and pre-cached Gradle and Bun packages <!-- kilocode_change -->
 - `rust`: `bun-node` plus Rust (stable, minimal profile)
 - `tauri-linux`: `rust` plus Tauri Linux build dependencies
 - `publish`: `bun-node` plus Docker CLI and AUR tooling

--- a/packages/containers/jetbrains/Dockerfile
+++ b/packages/containers/jetbrains/Dockerfile
@@ -1,6 +1,17 @@
 # kilocode_change start
 ARG REGISTRY=ghcr.io/kilo-org
+FROM ${REGISTRY}/build/bun-node:24.04 AS bun-cache
+
+WORKDIR /src
+COPY package.json bun.lock bunfig.toml ./
+COPY packages ./packages
+COPY patches ./patches
+RUN bun install --frozen-lockfile --ignore-scripts --cache-dir=/bun-cache
+
 FROM ${REGISTRY}/build/bun-node:24.04
+
+COPY --from=bun-cache /bun-cache/ /opt/bun/install/cache/
+ENV BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GRADLE_VERSION=9.4.1

--- a/packages/containers/jetbrains/Dockerfile
+++ b/packages/containers/jetbrains/Dockerfile
@@ -5,9 +5,13 @@ FROM ${REGISTRY}/build/bun-node:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GRADLE_VERSION=9.4.1
 
-# Install Java 21 (apt handles multi-arch automatically)
+# Install Java 21 and the font stack required by JBR headless tests
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openjdk-21-jdk-headless \
+  && apt-get install -y --no-install-recommends \
+    fonts-dejavu-core \
+    libfontconfig1 \
+    libfreetype6 \
+    openjdk-21-jdk-headless \
   && rm -rf /var/lib/apt/lists/*
 
 # Create a stable /usr/lib/jvm/java-21 symlink that works on amd64 and arm64
@@ -23,7 +27,7 @@ ENV GRADLE_USER_HOME=/gradle-home
 
 RUN set -euo pipefail; \
     url="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"; \
-    hash=$(echo -n "${url}" | md5sum | cut -d' ' -f1); \
+    hash=$(node -e 'const crypto = require("node:crypto"); const hex = crypto.createHash("md5").update(process.argv[1]).digest("hex"); console.log(BigInt(`0x${hex}`).toString(36))' "${url}"); \
     dir="/gradle-home/wrapper/dists/gradle-${GRADLE_VERSION}-bin/${hash}"; \
     mkdir -p "${dir}"; \
     curl -fsSL "${url}" -o "${dir}/gradle-${GRADLE_VERSION}-bin.zip"; \

--- a/packages/containers/jetbrains/Dockerfile
+++ b/packages/containers/jetbrains/Dockerfile
@@ -1,17 +1,6 @@
 # kilocode_change start
 ARG REGISTRY=ghcr.io/kilo-org
-FROM ${REGISTRY}/build/bun-node:24.04 AS bun-cache
-
-WORKDIR /src
-COPY package.json bun.lock bunfig.toml ./
-COPY packages ./packages
-COPY patches ./patches
-RUN bun install --frozen-lockfile --ignore-scripts --cache-dir=/bun-cache
-
-FROM ${REGISTRY}/build/bun-node:24.04
-
-COPY --from=bun-cache /bun-cache/ /opt/bun/install/cache/
-ENV BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache
+FROM ${REGISTRY}/build/bun-node:24.04 AS runtime
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GRADLE_VERSION=9.4.1
@@ -47,4 +36,17 @@ RUN set -euo pipefail; \
     rm "${dir}/gradle-${GRADLE_VERSION}-bin.zip"; \
     java -version; \
     "${dir}/gradle-${GRADLE_VERSION}/bin/gradle" --version
+
+FROM ${REGISTRY}/build/bun-node:24.04 AS bun-cache
+
+WORKDIR /src
+COPY package.json bun.lock bunfig.toml ./
+COPY packages ./packages
+COPY patches ./patches
+RUN bun install --frozen-lockfile --ignore-scripts --cache-dir=/bun-cache
+
+FROM runtime
+
+ENV BUN_INSTALL_CACHE_DIR=/opt/bun/install/cache
+COPY --from=bun-cache /bun-cache/ /opt/bun/install/cache/
 # kilocode_change end


### PR DESCRIPTION
## What

- Bake FreeType, Fontconfig, and DejaVu fonts into the JetBrains CI image so JBR-based Swing tests can run without installing OS packages in each job.
- Encode the Gradle wrapper distribution URL hash in base 36, matching Gradle's cache directory algorithm, instead of using the hexadecimal MD5 digest.
- Prewarm Bun's global package cache in an intermediate build stage, then copy only that cache into the final image.

## Why

The current image contains Bun and Java but is missing the font stack required by JetBrains Runtime's `libfontmanager.so`. The test workflow currently works around that with `apt-get update` and package installation on every run.

The image also places the pre-downloaded Gradle distribution under the wrong cache directory because Gradle uses `BigInteger(md5).toString(36)`. Correcting the hash lets the wrapper consume the distribution already baked into the image.

Prewarming `BUN_INSTALL_CACHE_DIR` avoids downloading unchanged packages during CI. The workflow still runs `bun install`, so each PR validates its current lockfile and materializes an exact `node_modules`; only missing or newer packages need downloading. Source files and `node_modules` from the image build stay in the intermediate stage and are not copied into the runtime image.

After this merges and `containers.yml` publishes `ghcr.io/kilo-org/build/jetbrains:24.04`, #11342 can remove its temporary APT step while retaining `bun install`.

Built for [Mark IJbema](https://kilo-code.slack.com/archives/C0A4SA041DE/p1781613361325899?thread_ts=1781607732.829409&cid=C0A4SA041DE) by [Kilo for Slack](https://kilo.ai/slack)