### PR TITLE
ci(jetbrains): install deps before publish build

### DIFF
--- a/.github/workflows/publish-jetbrains.yml
+++ b/.github/workflows/publish-jetbrains.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
 
+      - name: Install dependencies
+        run: bun install
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.kilo/skills/release-jetbrains/SKILL.md
+++ b/.kilo/skills/release-jetbrains/SKILL.md
@@ -50,7 +50,7 @@ Pass a generous Bash timeout, such as `1800000` ms, because the script blocks on
 bun .kilo/skills/release-jetbrains/script/dispatch-prepare.ts --kind rc --version 7.0.1-rc.7 --run-id <run-id>
 ```
 
-The script prints `prNumber`, `prUrl`, `runUrl`, and `branch` on success.
+The script prints `prNumber`, `prUrl`, `runUrl`, and `branch` on success. Immediately show the `prUrl` to the user so they can open the release PR without asking for it later.
 
 ## Changelog Draft
 
@@ -116,6 +116,8 @@ gh api "repos/Kilo-Org/kilocode/contents/packages/kilo-jetbrains/CHANGELOG.md?re
 ```
 
 Then either fix and retry the helper, or perform the equivalent contents API update using `ref` in the query string.
+
+After the changelog commit succeeds, show the release PR URL again and tell the user that the PR needs manual approval and merge before publishing can continue.
 
 ## Approve And Publish
 


### PR DESCRIPTION
## Summary
- install workspace dependencies in the JetBrains publish workflow after checking out the release tag
- ensure the CLI/Kilo Console build can resolve catalog dependencies such as @pierre/diffs

## Testing
- bun run script/check-workflows.ts