### PR TITLE
ci(jetbrains): add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish-jetbrains.yml
+++ b/.github/workflows/publish-jetbrains.yml
@@ -7,9 +7,15 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Merged release PR number to republish"
+        required: true
+        type: string
 
 concurrency:
-  group: publish-jetbrains-pr-${{ github.event.pull_request.number }}
+  group: publish-jetbrains-pr-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: false
 
 permissions:
@@ -23,17 +29,33 @@ jobs:
   publish:
     if: >-
       github.repository == 'Kilo-Org/kilocode' &&
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'jetbrains/release/') &&
-      contains(github.event.pull_request.labels.*.name, 'jetbrains-release') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.pull_request.merged == true &&
+          startsWith(github.event.pull_request.head.ref, 'jetbrains/release/') &&
+          contains(github.event.pull_request.labels.*.name, 'jetbrains-release') &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      )
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
+      - name: Resolve release PR
+        id: pr
+        run: |
+          pr="${{ github.event.pull_request.number || inputs.pr_number }}"
+          merge_sha=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid')
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
       - name: Checkout merged release PR
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ steps.pr.outputs.merge_sha }}
 
       - name: Setup Bun for validation
         uses: ./.github/actions/setup-bun
@@ -44,7 +66,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
 
       - name: Save reviewed release metadata
         run: |

--- a/.kilo/skills/release-jetbrains/SKILL.md
+++ b/.kilo/skills/release-jetbrains/SKILL.md
@@ -50,7 +50,7 @@ Pass a generous Bash timeout, such as `1800000` ms, because the script blocks on
 bun .kilo/skills/release-jetbrains/script/dispatch-prepare.ts --kind rc --version 7.0.1-rc.7 --run-id <run-id>
 ```
 
-The script prints `prNumber`, `prUrl`, `runUrl`, and `branch` on success.
+The script prints `prNumber`, `prUrl`, `runUrl`, and `branch` on success. Immediately show the `prUrl` to the user so they can open the release PR without asking for it later.
 
 ## Changelog Draft
 
@@ -116,6 +116,8 @@ gh api "repos/Kilo-Org/kilocode/contents/packages/kilo-jetbrains/CHANGELOG.md?re
 ```
 
 Then either fix and retry the helper, or perform the equivalent contents API update using `ref` in the query string.
+
+After the changelog commit succeeds, show the release PR URL again and tell the user that the PR needs manual approval and merge before publishing can continue.
 
 ## Approve And Publish
 


### PR DESCRIPTION
Allows manually re-triggering the JetBrains publish workflow with a PR number when the automatic `pull_request: closed` run fails and cannot be rerun (e.g. due to a build fix merged after the original trigger).