### PR TITLE
fix(cli): restore Kilo Console release build

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,6 +21,9 @@ jobs:
       # kilocode_change start
       - name: Run TypeScript typecheck
         run: bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'
+
+      - name: Build Kilo Console
+        run: bun run --cwd packages/kilo-console build
       # kilocode_change end
 
   # kilocode_change start

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -23,7 +23,7 @@ jobs:
         run: bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'
 
       - name: Build Kilo Console
-        run: bun run --cwd packages/kilo-console build
+        run: bun turbo build --filter=@kilocode/kilo-console
       # kilocode_change end
 
   # kilocode_change start

--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,7 @@
         "@kilocode/kilo-web-ui": "workspace:*",
         "@kilocode/sdk": "workspace:*",
         "@lottiefiles/dotlottie-web": "0.74.0",
+        "@pierre/diffs": "catalog:",
         "@solidjs/router": "catalog:",
         "ghostty-web": "0.4.0",
         "solid-js": "catalog:",

--- a/packages/kilo-console/package.json
+++ b/packages/kilo-console/package.json
@@ -14,6 +14,7 @@
     "@kilocode/kilo-web-ui": "workspace:*",
     "@kilocode/sdk": "workspace:*",
     "@lottiefiles/dotlottie-web": "0.74.0",
+    "@pierre/diffs": "catalog:",
     "@solidjs/router": "catalog:",
     "ghostty-web": "0.4.0",
     "solid-js": "catalog:",


### PR DESCRIPTION
## What changed

Declare `@pierre/diffs` directly in Kilo Console and exercise the Console production bundle in the regular typecheck workflow.

## Why

The CLI release build configures Vite to deduplicate `@pierre/diffs` from the Console project root. Under Bun isolated installs, the package was available only through `kilo-web-ui`, so Vite could not resolve it and the [`v7.3.47` release build](https://github.com/Kilo-Org/kilocode/actions/runs/27695099983/job/81916965524) failed.

Declaring the dependency at the build root preserves the intended singleton resolution. Running the production Console build on pull requests prevents this class of release-only dependency regression, matching the lesson from #10753.

No changeset is included because this repairs the release pipeline for an existing unreleased change rather than adding separate user-facing behavior.