### PR TITLE
test(vscode): stabilize visual regression snapshots

### DIFF
--- a/packages/kilo-vscode/tests/visual-regression.spec.ts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts
@@ -58,10 +58,14 @@ async function settle(page: Page) {
     await document.fonts.ready
   })
   await frames()
-  await page.waitForFunction(() => {
-    const root = document.querySelector("#storybook-root")
-    return root && !root.querySelector('pre > code[data-lang]:not([data-lang="mermaid"])')
-  })
+  await page.waitForFunction(
+    () => {
+      const root = document.querySelector("#storybook-root")
+      return root && !root.querySelector('pre > code[data-lang]:not([data-lang="mermaid"])')
+    },
+    undefined,
+    { timeout: 5_000 },
+  )
   await frames()
 }
 

--- a/packages/kilo-vscode/tests/visual-regression.spec.ts
+++ b/packages/kilo-vscode/tests/visual-regression.spec.ts
@@ -45,6 +45,26 @@ async function disableAnimations(page: Page) {
   })
 }
 
+async function settle(page: Page) {
+  const frames = () =>
+    page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+        }),
+    )
+
+  await page.evaluate(async () => {
+    await document.fonts.ready
+  })
+  await frames()
+  await page.waitForFunction(() => {
+    const root = document.querySelector("#storybook-root")
+    return root && !root.querySelector('pre > code[data-lang]:not([data-lang="mermaid"])')
+  })
+  await frames()
+}
+
 // Stories to skip from visual regression (add IDs here if needed)
 // Spinner animation captures at an indeterminate frame, causing flaky diffs.
 // Permission dock config-preloaded has non-deterministic toggle rendering.
@@ -97,6 +117,7 @@ for (const story of stories) {
     )
     await disableAnimations(page)
     await page.waitForSelector("#storybook-root *", { state: "attached" })
+    await settle(page)
 
     const [component, variant] = story.id.split("--")
     const root = page.locator("#storybook-root")


### PR DESCRIPTION
## Summary
- wait for Storybook fonts and deferred syntax highlighting before visual snapshots
- allow final animation frames to settle before screenshot comparison

The Tool Call Lab snapshot could be captured before its asynchronous Markdown highlighting completed, producing a transient four-pixel layout shift and an unnecessary baseline update.