### PR TITLE
fix(vscode): prevent shell output from blanking webview

### DIFF
--- a/.changeset/steady-shell-expansion.md
+++ b/.changeset/steady-shell-expansion.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent large highlighted shell outputs from blanking the VS Code webview when expanded.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/diff-panel-with-diffs-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/diff-panel-with-diffs-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9d8327c530c9d071b5eb07ebbf48441ea8d64b8a4cd7201665a8fa037ca82ed
-size 50349
+oid sha256:e8318f427b6c0ff71d4cce5c8ac03ba4778f99fda5723d24d23c38471523b622
+size 52203

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2235,7 +2235,6 @@ ToolRegistry.register({
         defaultOpen={props.defaultOpen ?? true}
         onOpenChange={setOpen}
         allowPendingToggle
-        animated
         trigger={
           <div data-slot="basic-tool-tool-info-structured">
             <div data-slot="basic-tool-tool-info-main">

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -201,8 +201,9 @@ describe("Bash tool static terminal preview (source)", () => {
     expect(block).toContain("BashHighlightedOutput")
   })
 
-  it("animates expanded bash details", () => {
-    expect(block).toMatch(/allowPendingToggle\s+animated\s+trigger=/)
+  it("does not animate expanded bash details", () => {
+    expect(block).toMatch(/allowPendingToggle\s+trigger=/)
+    expect(block).not.toMatch(/allowPendingToggle\s+animated/)
   })
 
   it("BashHighlightedOutput syntax highlights the command next to the prompt", () => {


### PR DESCRIPTION
Agent Manager can turn into a blank gray editor after expanding a completed Shell tool call in a large session. The failure was reproduced by opening a long Agent Manager transcript, expanding a Shell output pane, and observing the webview stop painting while Agent Manager extension-host polling continued. Because the renderer fails below the application JavaScript, the webview console may show no exception.

The polished Shell preview from #11146 renders the command and output as Shiki-highlighted DOM. Its final restore-motion commit also enabled `BasicTool` content-height animation for Shell. `BasicTool` animates the details region from `0px` to `auto`. For a large highlighted output, Chromium repeatedly recalculates and lays out the full Shiki span tree and surrounding transcript during the animation. In an already large Agent Manager session, that layout pressure can make the webview renderer unresponsive, leaving only VS Code's gray webview background.

Disable the content-height animation for Shell only. The command and output remain highlighted, copy and open-in-editor controls remain available, and the chevron still animates. Other tool previews retain their existing motion.


<img width="632" height="696" alt="file-6eb68b00299706b3116f7b3bb5c79526" src="https://github.com/user-attachments/assets/2de30af4-f85c-49a7-b006-91849707f605" />

