### PR TITLE
fix(vscode): stop moved active sessions

### DIFF
--- a/.changeset/stop-moved-agent-sessions.md
+++ b/.changeset/stop-moved-agent-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the Stop button working when an active session moves between the workspace and an Agent Manager worktree.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -72,12 +72,7 @@ import { fetchMessagePage, MESSAGE_PAGE_LIMIT } from "./kilo-provider/message-pa
 import { childID } from "./kilo-provider/task-session"
 import { VisibleTaskStreams } from "./kilo-provider/visible-task-streams"
 import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
-import {
-  abortSession,
-  resolveAbortDirectories,
-  updateActiveSessionDirectory,
-  type ActiveSessionDirectories,
-} from "./kilo-provider/abort"
+import { SessionAbort } from "./kilo-provider/abort"
 import {
   buildAutocompleteSettingsMessage,
   validAutocompleteSetting,
@@ -315,7 +310,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private syncedChildSessions: Set<string> = new Set()
   private sessionStatusMap = new Map<string, SessionStatus["type"]>() // Latest status used for destructive config warnings.
   private sessionDirectories = new Map<string, string>() // Per-session directory overrides, such as Agent Manager worktrees.
-  private activeSessionDirectories: ActiveSessionDirectories = new Map()
+  private readonly aborts = new SessionAbort()
   private projectID: string | undefined // Current workspace project ID used to filter sessions.
   private loadMessagesAbort: AbortController | null = null // Current load request cancellation.
   private lastReconciledAt = new Map<string, number>() // Per-session focus-mode reconcile timestamp.
@@ -663,24 +658,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * When set, all operations for this session use this directory instead of the workspace root.
    */
   public setSessionDirectory(sessionId: string, directory: string): void {
-    this.preserveDirectory(sessionId)
+    this.aborts.preserve(sessionId, this.sessionStatusMap.get(sessionId), this.getWorkspaceDirectory(sessionId))
     this.sessionDirectories.set(sessionId, directory)
   }
 
   public clearSessionDirectory(sessionId: string): void {
-    this.preserveDirectory(sessionId)
+    this.aborts.preserve(sessionId, this.sessionStatusMap.get(sessionId), this.getWorkspaceDirectory(sessionId))
     this.sessionDirectories.delete(sessionId)
-  }
-
-  private preserveDirectory(sessionID: string): void {
-    const status = this.sessionStatusMap.get(sessionID)
-    if (!status || status === "idle" || this.activeSessionDirectories.has(sessionID)) return
-    updateActiveSessionDirectory({
-      active: this.activeSessionDirectories,
-      sessionID,
-      status,
-      dir: this.getWorkspaceDirectory(sessionID),
-    })
   }
 
   /** Exposes the session→directory map so callers outside the webview can resolve worktree paths. */
@@ -1774,7 +1758,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.visibleTaskStreams.delete(sessionID)
       this.syncedChildSessions.delete(sessionID)
       this.sessionDirectories.delete(sessionID)
-      this.activeSessionDirectories.delete(sessionID)
+      this.aborts.delete(sessionID)
       this.lastReconciledAt.delete(sessionID)
       this.connectionService.pruneSession(sessionID)
       if (this.currentSession?.id === sessionID) {
@@ -2774,35 +2758,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private async handleAbort(sessionID?: string): Promise<void> {
-    const client = this.client
-    if (!client) return
-
-    const target = sessionID || this.currentSession?.id
-    if (!target) return
-
-    const known = this.activeSessionDirectories.has(target)
-    const dirs = resolveAbortDirectories(this.activeSessionDirectories, target, this.getWorkspaceDirectory(target))
-    const results = await Promise.allSettled(
-      dirs.map((dir) =>
-        abortSession({
-          client,
-          sessionID: target,
-          dir,
-        }),
-      ),
-    )
-    const failures = results.flatMap((result, index) =>
-      result.status === "rejected" ? [{ dir: dirs[index], error: result.reason }] : [],
-    )
-    if (known && failures.length === 0) {
-      this.activeSessionDirectories.delete(target)
-      this.sessionStatusMap.set(target, "idle")
-      this.streams.flush(target)
-      this.postMessage({ type: "sessionStatus", sessionID: target, status: "idle" })
-    }
-    if (failures.length > 0) {
-      console.error("[Kilo New] KiloProvider: Failed to abort session in one or more directories:", failures)
-    }
+    const sid = sessionID || this.currentSession?.id
+    if (!this.client || !sid || !(await this.aborts.stop(this.client, sid, this.getWorkspaceDirectory(sid)))) return
+    this.sessionStatusMap.set(sid, "idle")
+    this.streams.flush(sid)
+    this.postMessage({ type: "sessionStatus", sessionID: sid, status: "idle" })
   }
 
   private async handleRevertSession(sessionID: string, messageID: string, partID?: string): Promise<void> {
@@ -3187,12 +3147,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (event.type === "session.status") {
       const sid = event.properties.sessionID
       this.sessionStatusMap.set(sid, event.properties.status.type)
-      updateActiveSessionDirectory({
-        active: this.activeSessionDirectories,
-        sessionID: sid,
-        status: event.properties.status.type,
-        dir: directory,
-      })
+      this.aborts.observe(sid, event.properties.status.type, directory)
       const msg = mapSSEEventToWebviewMessage(event, sid)
       if (msg) {
         this.streams.flush(sid)
@@ -3225,17 +3180,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (event.type === "server.instance.disposed") {
       const props = event.properties as Record<string, unknown> | null
       const dir = typeof props?.directory === "string" ? props.directory : undefined
-      if (dir) {
-        for (const sessionID of [...this.activeSessionDirectories.keys()]) {
-          updateActiveSessionDirectory({
-            active: this.activeSessionDirectories,
-            sessionID,
-            status: "idle",
-            dir,
-          })
-          if (!this.activeSessionDirectories.has(sessionID)) this.sessionStatusMap.set(sessionID, "idle")
-        }
-      }
+      if (dir) for (const sid of this.aborts.dispose(dir)) this.sessionStatusMap.set(sid, "idle")
       if (dir && !sameDirectory(dir, this.getWorkspaceDirectory())) return
       void this.reloadAfterAuthChange()
       return
@@ -3648,7 +3593,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
-    this.activeSessionDirectories.clear()
+    this.aborts.clear()
     this.sessionStatusMap.clear()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -72,7 +72,13 @@ import { fetchMessagePage, MESSAGE_PAGE_LIMIT } from "./kilo-provider/message-pa
 import { childID } from "./kilo-provider/task-session"
 import { VisibleTaskStreams } from "./kilo-provider/visible-task-streams"
 import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
-import { abortSession } from "./kilo-provider/abort"
+import {
+  abortSession,
+  resolveAbortDirectories,
+  resolveActiveSessionStatus,
+  updateActiveSessionDirectory,
+  type ActiveSessionDirectories,
+} from "./kilo-provider/abort"
 import {
   buildAutocompleteSettingsMessage,
   validAutocompleteSetting,
@@ -310,6 +316,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private syncedChildSessions: Set<string> = new Set()
   private sessionStatusMap = new Map<string, SessionStatus["type"]>() // Latest status used for destructive config warnings.
   private sessionDirectories = new Map<string, string>() // Per-session directory overrides, such as Agent Manager worktrees.
+  private activeSessionDirectories: ActiveSessionDirectories = new Map()
+  private sessionStatusRevision = 0
+  private sessionStatusRevisions = new Map<string, Map<string, number>>()
   private projectID: string | undefined // Current workspace project ID used to filter sessions.
   private loadMessagesAbort: AbortController | null = null // Current load request cancellation.
   private lastReconciledAt = new Map<string, number>() // Per-session focus-mode reconcile timestamp.
@@ -657,10 +666,28 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * When set, all operations for this session use this directory instead of the workspace root.
    */
   public setSessionDirectory(sessionId: string, directory: string): void {
+    const status = this.sessionStatusMap.get(sessionId)
+    if (status && status !== "idle" && !this.activeSessionDirectories.has(sessionId)) {
+      updateActiveSessionDirectory({
+        active: this.activeSessionDirectories,
+        sessionID: sessionId,
+        status: { type: "busy" },
+        dir: this.getWorkspaceDirectory(sessionId),
+      })
+    }
     this.sessionDirectories.set(sessionId, directory)
   }
 
   public clearSessionDirectory(sessionId: string): void {
+    const status = this.sessionStatusMap.get(sessionId)
+    if (status && status !== "idle" && !this.activeSessionDirectories.has(sessionId)) {
+      updateActiveSessionDirectory({
+        active: this.activeSessionDirectories,
+        sessionID: sessionId,
+        status: { type: "busy" },
+        dir: this.getWorkspaceDirectory(sessionId),
+      })
+    }
     this.sessionDirectories.delete(sessionId)
   }
 
@@ -1513,17 +1540,28 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       })
       .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", e))
     this.postMessage({ type: "workspaceDirectoryChanged", directory: this.getWorkspaceDirectory(sessionID) })
+    const revision = this.sessionStatusRevision
     this.client.session
       .status({ directory: dir })
       .then((r) => {
         if (!r.data || signal?.aborted) return
         for (const [sid, info] of Object.entries(r.data) as [string, SessionStatus][]) {
-          if (!this.trackedSessionIds.has(sid)) continue
+          if (!this.trackedSessionIds.has(sid) || this.statusChanged(sid, dir, revision)) continue
+          this.markStatus(sid, dir)
+          updateActiveSessionDirectory({
+            active: this.activeSessionDirectories,
+            sessionID: sid,
+            status: info,
+            dir,
+          })
+          const status = resolveActiveSessionStatus(this.activeSessionDirectories, sid) ?? info
+          this.sessionStatusMap.set(sid, status.type)
           this.postMessage({
             type: "sessionStatus",
             sessionID: sid,
-            status: info.type,
-            ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+            status: status.type,
+            ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
+            ...(status.type === "offline" ? { message: status.message } : {}),
           })
         }
       })
@@ -1755,6 +1793,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.visibleTaskStreams.delete(sessionID)
       this.syncedChildSessions.delete(sessionID)
       this.sessionDirectories.delete(sessionID)
+      this.activeSessionDirectories.delete(sessionID)
+      this.sessionStatusRevisions.delete(sessionID)
       this.lastReconciledAt.delete(sessionID)
       this.connectionService.pruneSession(sessionID)
       if (this.currentSession?.id === sessionID) {
@@ -2192,6 +2232,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.postMessage(message)
   }
 
+  private markStatus(sessionID: string, dir?: string): void {
+    this.sessionStatusRevision += 1
+    const revisions = this.sessionStatusRevisions.get(sessionID) ?? new Map<string, number>()
+    const key = dir ? ([...revisions.keys()].find((entry) => entry && sameDirectory(entry, dir)) ?? dir) : ""
+    revisions.set(key, this.sessionStatusRevision)
+    this.sessionStatusRevisions.set(sessionID, revisions)
+  }
+
+  private statusChanged(sessionID: string, dir: string, revision: number): boolean {
+    const revisions = this.sessionStatusRevisions.get(sessionID)
+    if (!revisions) return false
+    return [...revisions].some(([entry, current]) => current > revision && (!entry || sameDirectory(entry, dir)))
+  }
+
   /**
    * Seed sessionStatusMap with current session statuses on connect.
    * Without this, the Settings panel (which has no tracked sessions) would see
@@ -2204,7 +2258,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async seedSessionStatusMap(reconcile = true): Promise<void> {
     if (!this.client || this.connectionState !== "connected") return
     const dir = this.getWorkspaceDirectory()
-    await seedSessionStatuses(this.client, dir, this.sessionStatusMap, (msg) => this.postMessage(msg), reconcile)
+    const revision = this.sessionStatusRevision
+    await seedSessionStatuses(
+      this.client,
+      dir,
+      this.sessionStatusMap,
+      (msg) => this.postMessage(msg),
+      reconcile,
+      (sessionID, status) => {
+        if (this.statusChanged(sessionID, dir, revision)) return
+        updateActiveSessionDirectory({
+          active: this.activeSessionDirectories,
+          sessionID,
+          status,
+          dir,
+        })
+        return resolveActiveSessionStatus(this.activeSessionDirectories, sessionID) ?? status
+      },
+    )
   }
 
   /**
@@ -2754,23 +2825,55 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private async handleAbort(sessionID?: string): Promise<void> {
-    if (!this.client) {
-      return
-    }
+    const client = this.client
+    if (!client) return
 
     const targetSessionID = sessionID || this.currentSession?.id
-    if (!targetSessionID) {
-      return
-    }
+    if (!targetSessionID) return
 
-    try {
-      await abortSession({
-        client: this.client,
+    const dirs = resolveAbortDirectories(
+      this.activeSessionDirectories,
+      targetSessionID,
+      this.getWorkspaceDirectory(targetSessionID),
+    )
+    const results = await Promise.allSettled(
+      dirs.map((dir) =>
+        abortSession({
+          client,
+          sessionID: targetSessionID,
+          dir,
+        }),
+      ),
+    )
+    const failures = results.flatMap((result, index) =>
+      result.status === "rejected" ? [{ dir: dirs[index], error: result.reason }] : [],
+    )
+    for (const [index, result] of results.entries()) {
+      if (result.status !== "fulfilled") continue
+      const dir = dirs[index]
+      if (!dir) continue
+      this.markStatus(targetSessionID, dir)
+      updateActiveSessionDirectory({
+        active: this.activeSessionDirectories,
         sessionID: targetSessionID,
-        dir: this.getWorkspaceDirectory(targetSessionID),
+        status: { type: "idle" },
+        dir,
       })
-    } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to abort session:", error)
+    }
+    const status = resolveActiveSessionStatus(this.activeSessionDirectories, targetSessionID) ?? {
+      type: "idle" as const,
+    }
+    this.sessionStatusMap.set(targetSessionID, status.type)
+    this.streams.flush(targetSessionID)
+    this.postMessage({
+      type: "sessionStatus",
+      sessionID: targetSessionID,
+      status: status.type,
+      ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
+      ...(status.type === "offline" ? { message: status.message } : {}),
+    })
+    if (failures.length > 0) {
+      console.error("[Kilo New] KiloProvider: Failed to abort session in one or more directories:", failures)
     }
   }
 
@@ -3155,8 +3258,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // busy-session warning on Save.
     if (event.type === "session.status") {
       const sid = event.properties.sessionID
-      this.sessionStatusMap.set(sid, event.properties.status.type)
-      const msg = mapSSEEventToWebviewMessage(event, sid)
+      this.markStatus(sid, directory)
+      updateActiveSessionDirectory({
+        active: this.activeSessionDirectories,
+        sessionID: sid,
+        status: event.properties.status,
+        dir: directory,
+      })
+      const status = resolveActiveSessionStatus(this.activeSessionDirectories, sid) ?? event.properties.status
+      this.sessionStatusMap.set(sid, status.type)
+      const msg = mapSSEEventToWebviewMessage({ ...event, properties: { ...event.properties, status } }, sid)
       if (msg) {
         this.streams.flush(sid)
         this.postMessage(msg)
@@ -3188,6 +3299,31 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (event.type === "server.instance.disposed") {
       const props = event.properties as Record<string, unknown> | null
       const dir = typeof props?.directory === "string" ? props.directory : undefined
+      if (dir) {
+        for (const sessionID of [...this.activeSessionDirectories.keys()]) {
+          const entries = this.activeSessionDirectories.get(sessionID)
+          if (![...(entries?.keys() ?? [])].some((entry) => sameDirectory(entry, dir))) continue
+          this.markStatus(sessionID, dir)
+          updateActiveSessionDirectory({
+            active: this.activeSessionDirectories,
+            sessionID,
+            status: { type: "idle" },
+            dir,
+          })
+          const status = resolveActiveSessionStatus(this.activeSessionDirectories, sessionID) ?? {
+            type: "idle" as const,
+          }
+          this.sessionStatusMap.set(sessionID, status.type)
+          this.streams.flush(sessionID)
+          this.postMessage({
+            type: "sessionStatus",
+            sessionID,
+            status: status.type,
+            ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
+            ...(status.type === "offline" ? { message: status.message } : {}),
+          })
+        }
+      }
       if (dir && !sameDirectory(dir, this.getWorkspaceDirectory())) return
       void this.reloadAfterAuthChange()
       return
@@ -3600,6 +3736,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.trackedSessionIds.clear()
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
+    this.activeSessionDirectories.clear()
+    this.sessionStatusRevisions.clear()
     this.sessionStatusMap.clear()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -75,7 +75,6 @@ import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
 import {
   abortSession,
   resolveAbortDirectories,
-  resolveActiveSessionStatus,
   updateActiveSessionDirectory,
   type ActiveSessionDirectories,
 } from "./kilo-provider/abort"
@@ -317,8 +316,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private sessionStatusMap = new Map<string, SessionStatus["type"]>() // Latest status used for destructive config warnings.
   private sessionDirectories = new Map<string, string>() // Per-session directory overrides, such as Agent Manager worktrees.
   private activeSessionDirectories: ActiveSessionDirectories = new Map()
-  private sessionStatusRevision = 0
-  private sessionStatusRevisions = new Map<string, Map<string, number>>()
   private projectID: string | undefined // Current workspace project ID used to filter sessions.
   private loadMessagesAbort: AbortController | null = null // Current load request cancellation.
   private lastReconciledAt = new Map<string, number>() // Per-session focus-mode reconcile timestamp.
@@ -666,29 +663,24 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * When set, all operations for this session use this directory instead of the workspace root.
    */
   public setSessionDirectory(sessionId: string, directory: string): void {
-    const status = this.sessionStatusMap.get(sessionId)
-    if (status && status !== "idle" && !this.activeSessionDirectories.has(sessionId)) {
-      updateActiveSessionDirectory({
-        active: this.activeSessionDirectories,
-        sessionID: sessionId,
-        status: { type: "busy" },
-        dir: this.getWorkspaceDirectory(sessionId),
-      })
-    }
+    this.preserveDirectory(sessionId)
     this.sessionDirectories.set(sessionId, directory)
   }
 
   public clearSessionDirectory(sessionId: string): void {
-    const status = this.sessionStatusMap.get(sessionId)
-    if (status && status !== "idle" && !this.activeSessionDirectories.has(sessionId)) {
-      updateActiveSessionDirectory({
-        active: this.activeSessionDirectories,
-        sessionID: sessionId,
-        status: { type: "busy" },
-        dir: this.getWorkspaceDirectory(sessionId),
-      })
-    }
+    this.preserveDirectory(sessionId)
     this.sessionDirectories.delete(sessionId)
+  }
+
+  private preserveDirectory(sessionID: string): void {
+    const status = this.sessionStatusMap.get(sessionID)
+    if (!status || status === "idle" || this.activeSessionDirectories.has(sessionID)) return
+    updateActiveSessionDirectory({
+      active: this.activeSessionDirectories,
+      sessionID,
+      status,
+      dir: this.getWorkspaceDirectory(sessionID),
+    })
   }
 
   /** Exposes the session→directory map so callers outside the webview can resolve worktree paths. */
@@ -1540,28 +1532,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       })
       .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", e))
     this.postMessage({ type: "workspaceDirectoryChanged", directory: this.getWorkspaceDirectory(sessionID) })
-    const revision = this.sessionStatusRevision
     this.client.session
       .status({ directory: dir })
       .then((r) => {
         if (!r.data || signal?.aborted) return
         for (const [sid, info] of Object.entries(r.data) as [string, SessionStatus][]) {
-          if (!this.trackedSessionIds.has(sid) || this.statusChanged(sid, dir, revision)) continue
-          this.markStatus(sid, dir)
-          updateActiveSessionDirectory({
-            active: this.activeSessionDirectories,
-            sessionID: sid,
-            status: info,
-            dir,
-          })
-          const status = resolveActiveSessionStatus(this.activeSessionDirectories, sid) ?? info
-          this.sessionStatusMap.set(sid, status.type)
+          if (!this.trackedSessionIds.has(sid)) continue
           this.postMessage({
             type: "sessionStatus",
             sessionID: sid,
-            status: status.type,
-            ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
-            ...(status.type === "offline" ? { message: status.message } : {}),
+            status: info.type,
+            ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
           })
         }
       })
@@ -1794,7 +1775,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.syncedChildSessions.delete(sessionID)
       this.sessionDirectories.delete(sessionID)
       this.activeSessionDirectories.delete(sessionID)
-      this.sessionStatusRevisions.delete(sessionID)
       this.lastReconciledAt.delete(sessionID)
       this.connectionService.pruneSession(sessionID)
       if (this.currentSession?.id === sessionID) {
@@ -2232,20 +2212,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.postMessage(message)
   }
 
-  private markStatus(sessionID: string, dir?: string): void {
-    this.sessionStatusRevision += 1
-    const revisions = this.sessionStatusRevisions.get(sessionID) ?? new Map<string, number>()
-    const key = dir ? ([...revisions.keys()].find((entry) => entry && sameDirectory(entry, dir)) ?? dir) : ""
-    revisions.set(key, this.sessionStatusRevision)
-    this.sessionStatusRevisions.set(sessionID, revisions)
-  }
-
-  private statusChanged(sessionID: string, dir: string, revision: number): boolean {
-    const revisions = this.sessionStatusRevisions.get(sessionID)
-    if (!revisions) return false
-    return [...revisions].some(([entry, current]) => current > revision && (!entry || sameDirectory(entry, dir)))
-  }
-
   /**
    * Seed sessionStatusMap with current session statuses on connect.
    * Without this, the Settings panel (which has no tracked sessions) would see
@@ -2258,24 +2224,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async seedSessionStatusMap(reconcile = true): Promise<void> {
     if (!this.client || this.connectionState !== "connected") return
     const dir = this.getWorkspaceDirectory()
-    const revision = this.sessionStatusRevision
-    await seedSessionStatuses(
-      this.client,
-      dir,
-      this.sessionStatusMap,
-      (msg) => this.postMessage(msg),
-      reconcile,
-      (sessionID, status) => {
-        if (this.statusChanged(sessionID, dir, revision)) return
-        updateActiveSessionDirectory({
-          active: this.activeSessionDirectories,
-          sessionID,
-          status,
-          dir,
-        })
-        return resolveActiveSessionStatus(this.activeSessionDirectories, sessionID) ?? status
-      },
-    )
+    await seedSessionStatuses(this.client, dir, this.sessionStatusMap, (msg) => this.postMessage(msg), reconcile)
   }
 
   /**
@@ -2828,19 +2777,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const client = this.client
     if (!client) return
 
-    const targetSessionID = sessionID || this.currentSession?.id
-    if (!targetSessionID) return
+    const target = sessionID || this.currentSession?.id
+    if (!target) return
 
-    const dirs = resolveAbortDirectories(
-      this.activeSessionDirectories,
-      targetSessionID,
-      this.getWorkspaceDirectory(targetSessionID),
-    )
+    const known = this.activeSessionDirectories.has(target)
+    const dirs = resolveAbortDirectories(this.activeSessionDirectories, target, this.getWorkspaceDirectory(target))
     const results = await Promise.allSettled(
       dirs.map((dir) =>
         abortSession({
           client,
-          sessionID: targetSessionID,
+          sessionID: target,
           dir,
         }),
       ),
@@ -2848,30 +2794,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const failures = results.flatMap((result, index) =>
       result.status === "rejected" ? [{ dir: dirs[index], error: result.reason }] : [],
     )
-    for (const [index, result] of results.entries()) {
-      if (result.status !== "fulfilled") continue
-      const dir = dirs[index]
-      if (!dir) continue
-      this.markStatus(targetSessionID, dir)
-      updateActiveSessionDirectory({
-        active: this.activeSessionDirectories,
-        sessionID: targetSessionID,
-        status: { type: "idle" },
-        dir,
-      })
+    if (known && failures.length === 0) {
+      this.activeSessionDirectories.delete(target)
+      this.sessionStatusMap.set(target, "idle")
+      this.streams.flush(target)
+      this.postMessage({ type: "sessionStatus", sessionID: target, status: "idle" })
     }
-    const status = resolveActiveSessionStatus(this.activeSessionDirectories, targetSessionID) ?? {
-      type: "idle" as const,
-    }
-    this.sessionStatusMap.set(targetSessionID, status.type)
-    this.streams.flush(targetSessionID)
-    this.postMessage({
-      type: "sessionStatus",
-      sessionID: targetSessionID,
-      status: status.type,
-      ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
-      ...(status.type === "offline" ? { message: status.message } : {}),
-    })
     if (failures.length > 0) {
       console.error("[Kilo New] KiloProvider: Failed to abort session in one or more directories:", failures)
     }
@@ -3258,16 +3186,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // busy-session warning on Save.
     if (event.type === "session.status") {
       const sid = event.properties.sessionID
-      this.markStatus(sid, directory)
+      this.sessionStatusMap.set(sid, event.properties.status.type)
       updateActiveSessionDirectory({
         active: this.activeSessionDirectories,
         sessionID: sid,
-        status: event.properties.status,
+        status: event.properties.status.type,
         dir: directory,
       })
-      const status = resolveActiveSessionStatus(this.activeSessionDirectories, sid) ?? event.properties.status
-      this.sessionStatusMap.set(sid, status.type)
-      const msg = mapSSEEventToWebviewMessage({ ...event, properties: { ...event.properties, status } }, sid)
+      const msg = mapSSEEventToWebviewMessage(event, sid)
       if (msg) {
         this.streams.flush(sid)
         this.postMessage(msg)
@@ -3301,27 +3227,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const dir = typeof props?.directory === "string" ? props.directory : undefined
       if (dir) {
         for (const sessionID of [...this.activeSessionDirectories.keys()]) {
-          const entries = this.activeSessionDirectories.get(sessionID)
-          if (![...(entries?.keys() ?? [])].some((entry) => sameDirectory(entry, dir))) continue
-          this.markStatus(sessionID, dir)
           updateActiveSessionDirectory({
             active: this.activeSessionDirectories,
             sessionID,
-            status: { type: "idle" },
+            status: "idle",
             dir,
           })
-          const status = resolveActiveSessionStatus(this.activeSessionDirectories, sessionID) ?? {
-            type: "idle" as const,
-          }
-          this.sessionStatusMap.set(sessionID, status.type)
-          this.streams.flush(sessionID)
-          this.postMessage({
-            type: "sessionStatus",
-            sessionID,
-            status: status.type,
-            ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
-            ...(status.type === "offline" ? { message: status.message } : {}),
-          })
+          if (!this.activeSessionDirectories.has(sessionID)) this.sessionStatusMap.set(sessionID, "idle")
         }
       }
       if (dir && !sameDirectory(dir, this.getWorkspaceDirectory())) return
@@ -3737,7 +3649,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.syncedChildSessions.clear()
     this.sessionDirectories.clear()
     this.activeSessionDirectories.clear()
-    this.sessionStatusRevisions.clear()
     this.sessionStatusMap.clear()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()

--- a/packages/kilo-vscode/src/kilo-provider/abort.ts
+++ b/packages/kilo-vscode/src/kilo-provider/abort.ts
@@ -1,36 +1,68 @@
 import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
 import { sameDirectory } from "../kilo-provider-utils"
 
-export type ActiveSessionDirectories = Map<string, Set<string>>
+export class SessionAbort {
+  private active = new Map<string, Set<string>>()
 
-export function updateActiveSessionDirectory(input: {
-  active: ActiveSessionDirectories
-  sessionID: string
-  status: SessionStatus["type"]
-  dir?: string
-}) {
-  const target = input.dir
-  if (!target) return
-  const dirs = input.active.get(input.sessionID)
-  if (input.status === "idle") {
-    if (!dirs) return
-    for (const dir of dirs) {
-      if (sameDirectory(dir, target)) dirs.delete(dir)
+  observe(sessionID: string, status: SessionStatus["type"], dir?: string) {
+    if (!dir) return
+    const dirs = this.active.get(sessionID)
+    if (status === "idle") {
+      if (!dirs) return
+      for (const entry of dirs) {
+        if (sameDirectory(entry, dir)) dirs.delete(entry)
+      }
+      if (dirs.size === 0) this.active.delete(sessionID)
+      return
     }
-    if (dirs.size === 0) input.active.delete(input.sessionID)
-    return
+    if (!dirs) {
+      this.active.set(sessionID, new Set([dir]))
+      return
+    }
+    if (![...dirs].some((entry) => sameDirectory(entry, dir))) dirs.add(dir)
   }
-  if (!dirs) {
-    input.active.set(input.sessionID, new Set([target]))
-    return
-  }
-  if (![...dirs].some((dir) => sameDirectory(dir, target))) dirs.add(target)
-}
 
-export function resolveAbortDirectories(active: ActiveSessionDirectories, sessionID: string, fallback: string) {
-  const dirs = [...(active.get(sessionID) ?? [])]
-  if (!dirs.some((dir) => sameDirectory(dir, fallback))) dirs.push(fallback)
-  return dirs
+  preserve(sessionID: string, status: SessionStatus["type"] | undefined, dir: string) {
+    if (!status || status === "idle" || this.active.has(sessionID)) return
+    this.observe(sessionID, status, dir)
+  }
+
+  async stop(client: KiloClient, sessionID: string, fallback: string) {
+    const known = this.active.has(sessionID)
+    const dirs = [...(this.active.get(sessionID) ?? [])]
+    if (!dirs.some((dir) => sameDirectory(dir, fallback))) dirs.push(fallback)
+    const results = await Promise.allSettled(dirs.map((dir) => abortSession({ client, sessionID, dir })))
+    const failures = results.flatMap((result, index) =>
+      result.status === "rejected" ? [{ dir: dirs[index], error: result.reason }] : [],
+    )
+    if (failures.length > 0) {
+      console.error("[Kilo New] KiloProvider: Failed to abort session in one or more directories:", failures)
+      return false
+    }
+    if (known) this.active.delete(sessionID)
+    return known
+  }
+
+  dispose(dir: string) {
+    const idle: string[] = []
+    for (const [sessionID, dirs] of this.active) {
+      for (const entry of dirs) {
+        if (sameDirectory(entry, dir)) dirs.delete(entry)
+      }
+      if (dirs.size > 0) continue
+      this.active.delete(sessionID)
+      idle.push(sessionID)
+    }
+    return idle
+  }
+
+  delete(sessionID: string) {
+    this.active.delete(sessionID)
+  }
+
+  clear() {
+    this.active.clear()
+  }
 }
 
 export async function abortSession(input: { client: KiloClient; sessionID: string; dir: string }) {

--- a/packages/kilo-vscode/src/kilo-provider/abort.ts
+++ b/packages/kilo-vscode/src/kilo-provider/abort.ts
@@ -1,4 +1,45 @@
-import type { KiloClient } from "@kilocode/sdk/v2/client"
+import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
+import { sameDirectory } from "../kilo-provider-utils"
+
+export type ActiveSessionDirectories = Map<string, Map<string, SessionStatus>>
+
+export function updateActiveSessionDirectory(input: {
+  active: ActiveSessionDirectories
+  sessionID: string
+  status: SessionStatus
+  dir?: string
+}) {
+  const target = input.dir
+  if (!target) return
+  const entries = input.active.get(input.sessionID)
+  if (input.status.type === "idle") {
+    if (!entries) return
+    for (const dir of entries.keys()) {
+      if (sameDirectory(dir, target)) entries.delete(dir)
+    }
+    if (entries.size === 0) input.active.delete(input.sessionID)
+    return
+  }
+  if (!entries) {
+    input.active.set(input.sessionID, new Map([[target, input.status]]))
+    return
+  }
+  for (const dir of entries.keys()) {
+    if (sameDirectory(dir, target)) entries.delete(dir)
+  }
+  entries.set(target, input.status)
+}
+
+export function resolveActiveSessionStatus(active: ActiveSessionDirectories, sessionID: string) {
+  const statuses = [...(active.get(sessionID)?.values() ?? [])]
+  return statuses[statuses.length - 1]
+}
+
+export function resolveAbortDirectories(active: ActiveSessionDirectories, sessionID: string, fallback: string) {
+  const dirs = [...(active.get(sessionID)?.keys() ?? [])]
+  if (!dirs.some((dir) => sameDirectory(dir, fallback))) dirs.push(fallback)
+  return dirs
+}
 
 export async function abortSession(input: { client: KiloClient; sessionID: string; dir: string }) {
   await input.client.session.abort({ sessionID: input.sessionID, directory: input.dir }, { throwOnError: true })

--- a/packages/kilo-vscode/src/kilo-provider/abort.ts
+++ b/packages/kilo-vscode/src/kilo-provider/abort.ts
@@ -1,42 +1,34 @@
 import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
 import { sameDirectory } from "../kilo-provider-utils"
 
-export type ActiveSessionDirectories = Map<string, Map<string, SessionStatus>>
+export type ActiveSessionDirectories = Map<string, Set<string>>
 
 export function updateActiveSessionDirectory(input: {
   active: ActiveSessionDirectories
   sessionID: string
-  status: SessionStatus
+  status: SessionStatus["type"]
   dir?: string
 }) {
   const target = input.dir
   if (!target) return
-  const entries = input.active.get(input.sessionID)
-  if (input.status.type === "idle") {
-    if (!entries) return
-    for (const dir of entries.keys()) {
-      if (sameDirectory(dir, target)) entries.delete(dir)
+  const dirs = input.active.get(input.sessionID)
+  if (input.status === "idle") {
+    if (!dirs) return
+    for (const dir of dirs) {
+      if (sameDirectory(dir, target)) dirs.delete(dir)
     }
-    if (entries.size === 0) input.active.delete(input.sessionID)
+    if (dirs.size === 0) input.active.delete(input.sessionID)
     return
   }
-  if (!entries) {
-    input.active.set(input.sessionID, new Map([[target, input.status]]))
+  if (!dirs) {
+    input.active.set(input.sessionID, new Set([target]))
     return
   }
-  for (const dir of entries.keys()) {
-    if (sameDirectory(dir, target)) entries.delete(dir)
-  }
-  entries.set(target, input.status)
-}
-
-export function resolveActiveSessionStatus(active: ActiveSessionDirectories, sessionID: string) {
-  const statuses = [...(active.get(sessionID)?.values() ?? [])]
-  return statuses[statuses.length - 1]
+  if (![...dirs].some((dir) => sameDirectory(dir, target))) dirs.add(target)
 }
 
 export function resolveAbortDirectories(active: ActiveSessionDirectories, sessionID: string, fallback: string) {
-  const dirs = [...(active.get(sessionID)?.keys() ?? [])]
+  const dirs = [...(active.get(sessionID) ?? [])]
   if (!dirs.some((dir) => sameDirectory(dir, fallback))) dirs.push(fallback)
   return dirs
 }

--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -16,7 +16,6 @@ export async function seedSessionStatuses(
   map: Map<string, SessionStatus["type"]>,
   post: (msg: unknown) => void,
   reconcile = true,
-  update?: (sessionID: string, status: SessionStatus, source: "snapshot" | "reconcile") => SessionStatus | undefined,
 ): Promise<void> {
   try {
     const result = await client.session.status({ directory: dir })
@@ -25,14 +24,12 @@ export async function seedSessionStatuses(
 
     // Seed/update entries the server knows about
     for (const [sid, info] of Object.entries(active) as [string, SessionStatus][]) {
-      const status = update ? update(sid, info, "snapshot") : info
-      if (!status) continue
-      map.set(sid, status.type)
+      map.set(sid, info.type)
       post({
         type: "sessionStatus",
         sessionID: sid,
-        status: status.type,
-        ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
+        status: info.type,
+        ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
       })
     }
 
@@ -43,15 +40,8 @@ export async function seedSessionStatuses(
     if (reconcile) {
       for (const [sid, status] of map) {
         if (status !== "idle" && !active[sid]) {
-          const next = update ? update(sid, { type: "idle" }, "reconcile") : { type: "idle" as const }
-          if (!next) continue
-          map.set(sid, next.type)
-          post({
-            type: "sessionStatus",
-            sessionID: sid,
-            status: next.type,
-            ...(next.type === "retry" ? { attempt: next.attempt, message: next.message, next: next.next } : {}),
-          })
+          map.set(sid, "idle")
+          post({ type: "sessionStatus", sessionID: sid, status: "idle" })
         }
       }
     }

--- a/packages/kilo-vscode/src/session-status.ts
+++ b/packages/kilo-vscode/src/session-status.ts
@@ -16,6 +16,7 @@ export async function seedSessionStatuses(
   map: Map<string, SessionStatus["type"]>,
   post: (msg: unknown) => void,
   reconcile = true,
+  update?: (sessionID: string, status: SessionStatus, source: "snapshot" | "reconcile") => SessionStatus | undefined,
 ): Promise<void> {
   try {
     const result = await client.session.status({ directory: dir })
@@ -24,12 +25,14 @@ export async function seedSessionStatuses(
 
     // Seed/update entries the server knows about
     for (const [sid, info] of Object.entries(active) as [string, SessionStatus][]) {
-      map.set(sid, info.type)
+      const status = update ? update(sid, info, "snapshot") : info
+      if (!status) continue
+      map.set(sid, status.type)
       post({
         type: "sessionStatus",
         sessionID: sid,
-        status: info.type,
-        ...(info.type === "retry" ? { attempt: info.attempt, message: info.message, next: info.next } : {}),
+        status: status.type,
+        ...(status.type === "retry" ? { attempt: status.attempt, message: status.message, next: status.next } : {}),
       })
     }
 
@@ -40,8 +43,15 @@ export async function seedSessionStatuses(
     if (reconcile) {
       for (const [sid, status] of map) {
         if (status !== "idle" && !active[sid]) {
-          map.set(sid, "idle")
-          post({ type: "sessionStatus", sessionID: sid, status: "idle" })
+          const next = update ? update(sid, { type: "idle" }, "reconcile") : { type: "idle" as const }
+          if (!next) continue
+          map.set(sid, next.type)
+          post({
+            type: "sessionStatus",
+            sessionID: sid,
+            status: next.type,
+            ...(next.type === "retry" ? { attempt: next.attempt, message: next.message, next: next.next } : {}),
+          })
         }
       }
     }

--- a/packages/kilo-vscode/tests/unit/abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/abort.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
-import {
-  abortSession,
-  resolveAbortDirectories,
-  updateActiveSessionDirectory,
-  type ActiveSessionDirectories,
-} from "../../src/kilo-provider/abort"
+import { abortSession, SessionAbort } from "../../src/kilo-provider/abort"
 
 function client(calls: unknown[], fail = false) {
   return {
@@ -19,31 +14,50 @@ function client(calls: unknown[], fail = false) {
   } as unknown as KiloClient
 }
 
-describe("active session directories", () => {
-  function update(active: ActiveSessionDirectories, status: "busy" | "idle", dir: string) {
-    updateActiveSessionDirectory({ active, sessionID: "session_1", status, dir })
-  }
+describe("SessionAbort", () => {
+  it("stops the active owner and current mapped directory", async () => {
+    const calls: unknown[] = []
+    const aborts = new SessionAbort()
+    aborts.observe("session_1", "busy", "/repo")
 
-  it("includes the active owner and current mapped directory", () => {
-    const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo")
-
-    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo", "/repo/worktree"])
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toBe(true)
+    expect(calls).toEqual([
+      {
+        type: "abort",
+        params: { sessionID: "session_1", directory: "/repo" },
+        opts: { throwOnError: true },
+      },
+      {
+        type: "abort",
+        params: { sessionID: "session_1", directory: "/repo/worktree" },
+        opts: { throwOnError: true },
+      },
+    ])
   })
 
-  it("removes an owner when its instance becomes idle", () => {
-    const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo")
-    update(active, "idle", "/repo")
+  it("forgets an owner when its instance becomes idle", async () => {
+    const calls: unknown[] = []
+    const aborts = new SessionAbort()
+    aborts.observe("session_1", "busy", "/repo")
+    aborts.observe("session_1", "idle", "/repo")
 
-    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/worktree"])
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toBe(false)
+    expect(calls).toEqual([
+      {
+        type: "abort",
+        params: { sessionID: "session_1", directory: "/repo/worktree" },
+        opts: { throwOnError: true },
+      },
+    ])
   })
 
-  it("deduplicates equivalent directory paths", () => {
-    const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo/worktree")
+  it("deduplicates equivalent directory paths", async () => {
+    const calls: unknown[] = []
+    const aborts = new SessionAbort()
+    aborts.observe("session_1", "busy", "/repo/worktree")
 
-    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree/.")).toEqual(["/repo/worktree"])
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree/.")).toBe(true)
+    expect(calls).toHaveLength(1)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/abort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
+import type { KiloClient } from "@kilocode/sdk/v2/client"
 import {
   abortSession,
   resolveAbortDirectories,
@@ -20,56 +20,26 @@ function client(calls: unknown[], fail = false) {
 }
 
 describe("active session directories", () => {
-  function update(active: ActiveSessionDirectories, type: SessionStatus["type"], dir?: string) {
-    const status: SessionStatus =
-      type === "retry"
-        ? { type, attempt: 1, message: "retrying", next: 1 }
-        : type === "offline"
-          ? { type, requestID: "request_1", message: "offline" }
-          : { type }
+  function update(active: ActiveSessionDirectories, status: "busy" | "idle", dir: string) {
     updateActiveSessionDirectory({ active, sessionID: "session_1", status, dir })
   }
 
-  it("includes the active owner and current session directory", () => {
+  it("includes the active owner and current mapped directory", () => {
     const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo/source")
+    update(active, "busy", "/repo")
 
-    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/source", "/repo/worktree"])
+    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo", "/repo/worktree"])
   })
 
-  it("falls back to the current directory after the active turn becomes idle", () => {
+  it("removes an owner when its instance becomes idle", () => {
     const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo/source")
-    update(active, "idle", "/repo/source")
+    update(active, "busy", "/repo")
+    update(active, "idle", "/repo")
 
     expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/worktree"])
   })
 
-  it("retains active directories when an unrelated instance reports idle", () => {
-    const active: ActiveSessionDirectories = new Map()
-    update(active, "retry", "/repo/source")
-    update(active, "idle", "/repo/worktree")
-    update(active, "idle")
-
-    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/source", "/repo/worktree"])
-  })
-
-  it("tracks concurrent instances and ignores delayed idle events from the old one", () => {
-    const active: ActiveSessionDirectories = new Map()
-    update(active, "busy", "/repo/source")
-    update(active, "offline", "/repo/worktree")
-
-    expect(resolveAbortDirectories(active, "session_1", "/repo/fallback")).toEqual([
-      "/repo/source",
-      "/repo/worktree",
-      "/repo/fallback",
-    ])
-
-    update(active, "idle", "/repo/source")
-    expect(resolveAbortDirectories(active, "session_1", "/repo/fallback")).toEqual(["/repo/worktree", "/repo/fallback"])
-  })
-
-  it("deduplicates the current directory when it is already active", () => {
+  it("deduplicates equivalent directory paths", () => {
     const active: ActiveSessionDirectories = new Map()
     update(active, "busy", "/repo/worktree")
 

--- a/packages/kilo-vscode/tests/unit/abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/abort.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
-import type { KiloClient } from "@kilocode/sdk/v2/client"
-import { abortSession } from "../../src/kilo-provider/abort"
+import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
+import {
+  abortSession,
+  resolveAbortDirectories,
+  updateActiveSessionDirectory,
+  type ActiveSessionDirectories,
+} from "../../src/kilo-provider/abort"
 
 function client(calls: unknown[], fail = false) {
   return {
@@ -13,6 +18,64 @@ function client(calls: unknown[], fail = false) {
     },
   } as unknown as KiloClient
 }
+
+describe("active session directories", () => {
+  function update(active: ActiveSessionDirectories, type: SessionStatus["type"], dir?: string) {
+    const status: SessionStatus =
+      type === "retry"
+        ? { type, attempt: 1, message: "retrying", next: 1 }
+        : type === "offline"
+          ? { type, requestID: "request_1", message: "offline" }
+          : { type }
+    updateActiveSessionDirectory({ active, sessionID: "session_1", status, dir })
+  }
+
+  it("includes the active owner and current session directory", () => {
+    const active: ActiveSessionDirectories = new Map()
+    update(active, "busy", "/repo/source")
+
+    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/source", "/repo/worktree"])
+  })
+
+  it("falls back to the current directory after the active turn becomes idle", () => {
+    const active: ActiveSessionDirectories = new Map()
+    update(active, "busy", "/repo/source")
+    update(active, "idle", "/repo/source")
+
+    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/worktree"])
+  })
+
+  it("retains active directories when an unrelated instance reports idle", () => {
+    const active: ActiveSessionDirectories = new Map()
+    update(active, "retry", "/repo/source")
+    update(active, "idle", "/repo/worktree")
+    update(active, "idle")
+
+    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree")).toEqual(["/repo/source", "/repo/worktree"])
+  })
+
+  it("tracks concurrent instances and ignores delayed idle events from the old one", () => {
+    const active: ActiveSessionDirectories = new Map()
+    update(active, "busy", "/repo/source")
+    update(active, "offline", "/repo/worktree")
+
+    expect(resolveAbortDirectories(active, "session_1", "/repo/fallback")).toEqual([
+      "/repo/source",
+      "/repo/worktree",
+      "/repo/fallback",
+    ])
+
+    update(active, "idle", "/repo/source")
+    expect(resolveAbortDirectories(active, "session_1", "/repo/fallback")).toEqual(["/repo/worktree", "/repo/fallback"])
+  })
+
+  it("deduplicates the current directory when it is already active", () => {
+    const active: ActiveSessionDirectories = new Map()
+    update(active, "busy", "/repo/worktree")
+
+    expect(resolveAbortDirectories(active, "session_1", "/repo/worktree/.")).toEqual(["/repo/worktree"])
+  })
+})
 
 describe("abortSession", () => {
   it("calls session.abort with the session id and directory", async () => {

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, spyOn } from "bun:test"
-import type { SessionStatus } from "@kilocode/sdk/v2/client"
 import type { PartUpdate } from "../../src/shared/stream-messages"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
@@ -45,8 +44,6 @@ function createClient(options?: {
   deleteDeferred?: Deferred<unknown>
   sessionData?: unknown
   sessionGet?: (params: { sessionID: string; directory?: string }) => Promise<{ data: unknown }>
-  statusData?: Record<string, SessionStatus>
-  statusDeferred?: Deferred<{ data: Record<string, SessionStatus> }>
   abortFailures?: string[]
 }) {
   const calls: { before?: string; limit?: number }[] = []
@@ -62,7 +59,7 @@ function createClient(options?: {
         if (options?.sessionGet) return options.sessionGet(params)
         return { data: options?.sessionData ?? null }
       },
-      status: async () => options?.statusDeferred?.promise ?? { data: options?.statusData ?? {} },
+      status: async () => ({ data: {} }),
       abort: async (params: { sessionID: string; directory?: string }) => {
         aborted.push(params)
         if (params.directory && options?.abortFailures?.includes(params.directory)) throw new Error("abort failed")
@@ -126,14 +123,11 @@ type ProviderInternals = {
   currentSession: { id: string; directory?: string } | null
   contextSessionID: string | undefined
   sessionDirectories: Map<string, string>
-  activeSessionDirectories: Map<string, Map<string, SessionStatus>>
   trackedSessionIds: Set<string>
   streams: { push: (msg: PartUpdate) => void }
   stopCurrentSessionProcesses: (next?: string) => void
   handleEvent: (event: unknown, directory?: string) => void
   handleAbort: (sid?: string) => Promise<void>
-  seedSessionStatusMap: (reconcile?: boolean) => Promise<void>
-  refreshSessionDetails: (sid: string, dir: string, signal?: AbortSignal) => void
   handleLoadMessages: (sid: string, opts?: { mode?: string; before?: string; limit?: number }) => Promise<void>
   handleDeleteSession: (sid: string) => Promise<void>
 }
@@ -153,9 +147,30 @@ function makeProvider(client: ReturnType<typeof createClient>) {
 }
 
 describe("KiloProvider.handleAbort", () => {
-  it("keeps the active owner when a running session moves to a worktree", async () => {
+  it("aborts the original owner after a running session moves to a worktree", async () => {
     const client = createClient()
     const { provider, internal, sent } = makeProvider(client)
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "busy" } },
+      },
+      "/repo",
+    )
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+    expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "idle" })
+  })
+
+  it("preserves the original owner when the status event lacks a directory", async () => {
+    const client = createClient()
+    const { provider, internal } = makeProvider(client)
     internal.handleEvent({
       type: "session.status",
       properties: { sessionID: "s1", status: { type: "busy" } },
@@ -168,30 +183,9 @@ describe("KiloProvider.handleAbort", () => {
       { sessionID: "s1", directory: "/repo" },
       { sessionID: "s1", directory: "/repo/worktree" },
     ])
-    expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "idle" })
   })
 
-  it("preserves a directory-qualified owner instead of inferring the current directory", async () => {
-    const client = createClient()
-    const { provider, internal } = makeProvider(client)
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "busy" } },
-      },
-      "/repo/source",
-    )
-    provider.setSessionDirectory("s1", "/repo/worktree")
-
-    await internal.handleAbort("s1")
-
-    expect(client.aborted).toEqual([
-      { sessionID: "s1", directory: "/repo/source" },
-      { sessionID: "s1", directory: "/repo/worktree" },
-    ])
-  })
-
-  it("attempts every owner when one abort request fails", async () => {
+  it("attempts every owner and stays busy when one abort fails", async () => {
     const error = spyOn(console, "error").mockImplementation(() => {})
     const client = createClient({ abortFailures: ["/repo"] })
     const { provider, internal, sent } = makeProvider(client)
@@ -213,174 +207,6 @@ describe("KiloProvider.handleAbort", () => {
     expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "busy" })
     expect(error).toHaveBeenCalledTimes(1)
     error.mockRestore()
-  })
-
-  it("restores the remaining owner status when another owner reports idle", () => {
-    const client = createClient()
-    const { internal, sent } = makeProvider(client)
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "offline", requestID: "request_1", message: "offline" } },
-      },
-      "/repo/source",
-    )
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "retry", attempt: 1, message: "retry", next: 1 } },
-      },
-      "/repo/worktree",
-    )
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "idle" } },
-      },
-      "/repo/worktree",
-    )
-
-    const statuses = sent.flatMap((msg) =>
-      typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
-        ? [(msg as { status: string }).status]
-        : [],
-    )
-    expect(statuses).toEqual(["offline", "retry", "offline"])
-
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "idle" } },
-      },
-      "/repo/source",
-    )
-    expect(
-      sent.flatMap((msg) =>
-        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
-          ? [(msg as { status: string }).status]
-          : [],
-      ),
-    ).toEqual(["offline", "retry", "offline", "idle"])
-  })
-
-  it("restores the remaining owner when an active instance is disposed", () => {
-    const client = createClient()
-    const { internal, sent } = makeProvider(client)
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "offline", requestID: "request_1", message: "offline" } },
-      },
-      "/repo/source",
-    )
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "retry", attempt: 1, message: "retry", next: 1 } },
-      },
-      "/repo/worktree",
-    )
-
-    internal.handleEvent({
-      type: "server.instance.disposed",
-      properties: { directory: "/repo/worktree" },
-    })
-
-    expect(
-      sent.flatMap((msg) =>
-        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
-          ? [(msg as { status: string }).status]
-          : [],
-      ),
-    ).toEqual(["offline", "retry", "offline"])
-  })
-
-  it("records an active owner discovered during status seeding", async () => {
-    const client = createClient({ statusData: { s1: { type: "busy" } } })
-    const { provider, internal } = makeProvider(client)
-    provider.setSessionDirectory("s1", "/repo/worktree")
-
-    await internal.seedSessionStatusMap()
-    await internal.handleAbort("s1")
-
-    expect(client.aborted).toEqual([
-      { sessionID: "s1", directory: "/repo" },
-      { sessionID: "s1", directory: "/repo/worktree" },
-    ])
-  })
-
-  it("records a worktree owner discovered while refreshing session details", async () => {
-    const status = defer<{ data: Record<string, SessionStatus> }>()
-    const client = createClient({ statusDeferred: status })
-    const { provider, internal } = makeProvider(client)
-    provider.setSessionDirectory("s1", "/repo/worktree")
-    internal.trackedSessionIds.add("s1")
-
-    internal.refreshSessionDetails("s1", "/repo/worktree")
-    status.resolve({ data: { s1: { type: "busy" } } })
-    await Bun.sleep(0)
-    provider.clearSessionDirectory("s1")
-    await internal.handleAbort("s1")
-
-    expect(client.aborted).toEqual([
-      { sessionID: "s1", directory: "/repo/worktree" },
-      { sessionID: "s1", directory: "/repo" },
-    ])
-  })
-
-  it("does not overwrite a newer busy event with a stale status seed", async () => {
-    const status = defer<{ data: Record<string, SessionStatus> }>()
-    const client = createClient({ statusDeferred: status })
-    const { provider, internal, sent } = makeProvider(client)
-    provider.setSessionDirectory("s1", "/repo/worktree")
-
-    const seed = internal.seedSessionStatusMap()
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "busy" } },
-      },
-      "/repo",
-    )
-    status.resolve({ data: {} })
-    await seed
-    await internal.handleAbort("s1")
-
-    expect(client.aborted).toEqual([
-      { sessionID: "s1", directory: "/repo" },
-      { sessionID: "s1", directory: "/repo/worktree" },
-    ])
-    expect(
-      sent.flatMap((msg) =>
-        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
-          ? [(msg as { status: string }).status]
-          : [],
-      ),
-    ).toEqual(["busy", "idle"])
-  })
-
-  it("keeps a seeded owner when another directory reports a newer status", async () => {
-    const status = defer<{ data: Record<string, SessionStatus> }>()
-    const client = createClient({ statusDeferred: status })
-    const { provider, internal } = makeProvider(client)
-    provider.setSessionDirectory("s1", "/repo/worktree")
-
-    const seed = internal.seedSessionStatusMap()
-    internal.handleEvent(
-      {
-        type: "session.status",
-        properties: { sessionID: "s1", status: { type: "busy" } },
-      },
-      "/repo/worktree",
-    )
-    status.resolve({ data: { s1: { type: "busy" } } })
-    await seed
-    await internal.handleAbort("s1")
-
-    expect(client.aborted).toEqual([
-      { sessionID: "s1", directory: "/repo/worktree" },
-      { sessionID: "s1", directory: "/repo" },
-    ])
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn } from "bun:test"
+import type { SessionStatus } from "@kilocode/sdk/v2/client"
 import type { PartUpdate } from "../../src/shared/stream-messages"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
@@ -44,19 +45,29 @@ function createClient(options?: {
   deleteDeferred?: Deferred<unknown>
   sessionData?: unknown
   sessionGet?: (params: { sessionID: string; directory?: string }) => Promise<{ data: unknown }>
+  statusData?: Record<string, SessionStatus>
+  statusDeferred?: Deferred<{ data: Record<string, SessionStatus> }>
+  abortFailures?: string[]
 }) {
   const calls: { before?: string; limit?: number }[] = []
   const stopped: { sessionID: string; directory?: string }[] = []
+  const aborted: { sessionID: string; directory?: string }[] = []
   return {
     calls,
     stopped,
+    aborted,
     session: {
       list: async () => ({ data: [] }),
       get: async (params: { sessionID: string; directory?: string }) => {
         if (options?.sessionGet) return options.sessionGet(params)
         return { data: options?.sessionData ?? null }
       },
-      status: async () => ({ data: {} }),
+      status: async () => options?.statusDeferred?.promise ?? { data: options?.statusData ?? {} },
+      abort: async (params: { sessionID: string; directory?: string }) => {
+        aborted.push(params)
+        if (params.directory && options?.abortFailures?.includes(params.directory)) throw new Error("abort failed")
+        return { data: true }
+      },
       messages: async (params: { before?: string; limit?: number }) => {
         calls.push({ before: params.before, limit: params.limit })
         if (options?.messagesDeferred) return options.messagesDeferred.promise
@@ -115,10 +126,14 @@ type ProviderInternals = {
   currentSession: { id: string; directory?: string } | null
   contextSessionID: string | undefined
   sessionDirectories: Map<string, string>
+  activeSessionDirectories: Map<string, Map<string, SessionStatus>>
   trackedSessionIds: Set<string>
   streams: { push: (msg: PartUpdate) => void }
   stopCurrentSessionProcesses: (next?: string) => void
-  handleEvent: (event: unknown) => void
+  handleEvent: (event: unknown, directory?: string) => void
+  handleAbort: (sid?: string) => Promise<void>
+  seedSessionStatusMap: (reconcile?: boolean) => Promise<void>
+  refreshSessionDetails: (sid: string, dir: string, signal?: AbortSignal) => void
   handleLoadMessages: (sid: string, opts?: { mode?: string; before?: string; limit?: number }) => Promise<void>
   handleDeleteSession: (sid: string) => Promise<void>
 }
@@ -136,6 +151,238 @@ function makeProvider(client: ReturnType<typeof createClient>) {
   }
   return { provider, internal, sent }
 }
+
+describe("KiloProvider.handleAbort", () => {
+  it("keeps the active owner when a running session moves to a worktree", async () => {
+    const client = createClient()
+    const { provider, internal, sent } = makeProvider(client)
+    internal.handleEvent({
+      type: "session.status",
+      properties: { sessionID: "s1", status: { type: "busy" } },
+    })
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+    expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "idle" })
+  })
+
+  it("preserves a directory-qualified owner instead of inferring the current directory", async () => {
+    const client = createClient()
+    const { provider, internal } = makeProvider(client)
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "busy" } },
+      },
+      "/repo/source",
+    )
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo/source" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+  })
+
+  it("attempts every owner when one abort request fails", async () => {
+    const error = spyOn(console, "error").mockImplementation(() => {})
+    const client = createClient({ abortFailures: ["/repo"] })
+    const { provider, internal, sent } = makeProvider(client)
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "busy" } },
+      },
+      "/repo",
+    )
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+    expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "busy" })
+    expect(error).toHaveBeenCalledTimes(1)
+    error.mockRestore()
+  })
+
+  it("restores the remaining owner status when another owner reports idle", () => {
+    const client = createClient()
+    const { internal, sent } = makeProvider(client)
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "offline", requestID: "request_1", message: "offline" } },
+      },
+      "/repo/source",
+    )
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "retry", attempt: 1, message: "retry", next: 1 } },
+      },
+      "/repo/worktree",
+    )
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "idle" } },
+      },
+      "/repo/worktree",
+    )
+
+    const statuses = sent.flatMap((msg) =>
+      typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
+        ? [(msg as { status: string }).status]
+        : [],
+    )
+    expect(statuses).toEqual(["offline", "retry", "offline"])
+
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "idle" } },
+      },
+      "/repo/source",
+    )
+    expect(
+      sent.flatMap((msg) =>
+        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
+          ? [(msg as { status: string }).status]
+          : [],
+      ),
+    ).toEqual(["offline", "retry", "offline", "idle"])
+  })
+
+  it("restores the remaining owner when an active instance is disposed", () => {
+    const client = createClient()
+    const { internal, sent } = makeProvider(client)
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "offline", requestID: "request_1", message: "offline" } },
+      },
+      "/repo/source",
+    )
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "retry", attempt: 1, message: "retry", next: 1 } },
+      },
+      "/repo/worktree",
+    )
+
+    internal.handleEvent({
+      type: "server.instance.disposed",
+      properties: { directory: "/repo/worktree" },
+    })
+
+    expect(
+      sent.flatMap((msg) =>
+        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
+          ? [(msg as { status: string }).status]
+          : [],
+      ),
+    ).toEqual(["offline", "retry", "offline"])
+  })
+
+  it("records an active owner discovered during status seeding", async () => {
+    const client = createClient({ statusData: { s1: { type: "busy" } } })
+    const { provider, internal } = makeProvider(client)
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    await internal.seedSessionStatusMap()
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+  })
+
+  it("records a worktree owner discovered while refreshing session details", async () => {
+    const status = defer<{ data: Record<string, SessionStatus> }>()
+    const client = createClient({ statusDeferred: status })
+    const { provider, internal } = makeProvider(client)
+    provider.setSessionDirectory("s1", "/repo/worktree")
+    internal.trackedSessionIds.add("s1")
+
+    internal.refreshSessionDetails("s1", "/repo/worktree")
+    status.resolve({ data: { s1: { type: "busy" } } })
+    await Bun.sleep(0)
+    provider.clearSessionDirectory("s1")
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo/worktree" },
+      { sessionID: "s1", directory: "/repo" },
+    ])
+  })
+
+  it("does not overwrite a newer busy event with a stale status seed", async () => {
+    const status = defer<{ data: Record<string, SessionStatus> }>()
+    const client = createClient({ statusDeferred: status })
+    const { provider, internal, sent } = makeProvider(client)
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    const seed = internal.seedSessionStatusMap()
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "busy" } },
+      },
+      "/repo",
+    )
+    status.resolve({ data: {} })
+    await seed
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo" },
+      { sessionID: "s1", directory: "/repo/worktree" },
+    ])
+    expect(
+      sent.flatMap((msg) =>
+        typeof msg === "object" && msg && (msg as { type?: unknown }).type === "sessionStatus"
+          ? [(msg as { status: string }).status]
+          : [],
+      ),
+    ).toEqual(["busy", "idle"])
+  })
+
+  it("keeps a seeded owner when another directory reports a newer status", async () => {
+    const status = defer<{ data: Record<string, SessionStatus> }>()
+    const client = createClient({ statusDeferred: status })
+    const { provider, internal } = makeProvider(client)
+    provider.setSessionDirectory("s1", "/repo/worktree")
+
+    const seed = internal.seedSessionStatusMap()
+    internal.handleEvent(
+      {
+        type: "session.status",
+        properties: { sessionID: "s1", status: { type: "busy" } },
+      },
+      "/repo/worktree",
+    )
+    status.resolve({ data: { s1: { type: "busy" } } })
+    await seed
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([
+      { sessionID: "s1", directory: "/repo/worktree" },
+      { sessionID: "s1", directory: "/repo" },
+    ])
+  })
+})
 
 describe("KiloProvider.handleLoadMessages / focus mode freshness", () => {
   it("stops background processes for the previous session when switching sessions", async () => {


### PR DESCRIPTION
Agent Manager can change the directory associated with a session while that session is already running. The backend does not move the active runner when this happens: runners are isolated by directory, so a turn started under `/repo` remains owned by the `/repo` instance even after Agent Manager maps the same session ID to `/repo/.kilo/worktrees/foo`.

Stop was sending `session.abort` only to the session's current mapped directory. In the example above, it asked the worktree instance to abort a runner that still belonged to the repository instance. The abort endpoint treats an absent runner as a successful no-op, so the request appeared successful while the original response continued and the UI remained in its Stop state. Remote mode can make the timing more visible, but it is not the cause.

**Regression history**

PR #11152 contains two overlapping cancellation fixes:

- Commit `a09dafe61b` first added directory-aware ownership tracking, aborted both the active owner and current mapped directory, and added moved-session regression coverage.
- Commit `b23d3dfd75` then added the separate ability to abort prompts during session startup. While replacing the same `handleAbort` and status-management path, it unintentionally restored single-directory cancellation and removed the moved-session coverage.

The final version of #11152 therefore retained its intended startup-cancellation behavior but lost the protection for already-running sessions that are reassigned between the local workspace and a worktree.

**Durable behavior**

This change combines both requirements rather than reverting #11152. An instance-scoped abort helper records directories that report a non-idle session and preserves the current owner before Agent Manager changes the session mapping. Stop asks every known owner plus the current mapped directory to abort, attempts all requests even if one fails, and returns the webview to Send only after all known-owner aborts succeed. Session deletion, provider disposal, idle events, and backend-instance disposal clear the corresponding ownership state.

The ownership and multi-directory orchestration live outside `KiloProvider`; the provider only forwards lifecycle signals and reconciles the successful Stop state.