### PR TITLE
ci: reduce test workflow setup time

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -33,6 +33,8 @@ runs:
       shell: bash
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
+    # Restoring and extracting the ~1 GB cache took 2m23s on Windows, while a # kilocode_change
+    # fresh install took 1m27s. Keep Windows off this cache until that reverses. # kilocode_change
     - name: Restore Bun dependencies
       if: runner.os != 'Windows' # kilocode_change
       id: bun-cache
@@ -51,7 +53,7 @@ runs:
       run: |
         # Workaround for patched peer variants
         # e.g. ./patches/ for standard-openapi
-        # https://github.com/oven-sh/bun/issues/28147
+        # https://github.com/oven-sh/bun/issues/28147 # kilocode_change
         if [ "$RUNNER_OS" = "Windows" ]; then
           bun install --frozen-lockfile --linker hoisted ${{ inputs.install-flags }} # kilocode_change
         else
@@ -59,6 +61,7 @@ runs:
         fi
       shell: bash
 
+    # Do not upload a Windows cache that Windows jobs intentionally never restore. # kilocode_change
     - name: Save Bun dependencies
       if: runner.os != 'Windows' && steps.bun-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' # kilocode_change
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,7 +34,6 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Bun dependencies
-      if: runner.os != 'Windows'
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,7 +34,7 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Bun dependencies
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' # kilocode_change
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -53,14 +53,14 @@ runs:
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147
         if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --frozen-lockfile --linker hoisted ${{ inputs.install-flags }}
+          bun install --frozen-lockfile --linker hoisted ${{ inputs.install-flags }} # kilocode_change
         else
-          bun install --frozen-lockfile ${{ inputs.install-flags }}
+          bun install --frozen-lockfile ${{ inputs.install-flags }} # kilocode_change
         fi
       shell: bash
 
     - name: Save Bun dependencies
-      if: steps.bun-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+      if: runner.os != 'Windows' && steps.bun-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' # kilocode_change
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,6 +34,7 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Bun dependencies
+      if: runner.os != 'Windows'
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -34,6 +34,7 @@ runs:
       run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
 
     - name: Restore Bun dependencies
+      if: runner.os != 'Windows'
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -52,9 +53,9 @@ runs:
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147
         if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --linker hoisted ${{ inputs.install-flags }}
+          bun install --frozen-lockfile --linker hoisted ${{ inputs.install-flags }}
         else
-          bun install ${{ inputs.install-flags }}
+          bun install --frozen-lockfile ${{ inputs.install-flags }}
         fi
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache Turbo
         uses: actions/cache@v5 # kilocode_change
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache Turbo
         uses: actions/cache@v5 # kilocode_change
         with:
-          path: .turbo/cache
+          path: .turbo/cache # kilocode_change
           key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-


### PR DESCRIPTION
## Summary

Reduce test workflow wall time by making Turbo caching functional, skipping a counterproductive Windows Bun package-cache restore/save, and requiring immutable dependency installs.

The previous Turbo cache path did not exist after test execution, so no task results were persisted. Caching Turbo's current default `.turbo/cache` path allows unchanged unit-test and prerequisite-build tasks to be reused across commits on the same OS. Tasks whose source, tests, dependencies, configuration, or declared hashed environment change still execute normally.

## Benchmark results

- Windows `Setup Bun` without the Bun package cache: **1m27s**
- Windows `Setup Bun` with the roughly 1 GB Bun package cache: **2m23s**
- Final no-cache setup validation: **1m31s**
- Unchanged Windows Turbo graph: all 10 tasks restored in **163ms**, replaying a prior successful run of 486 files / 5,233 tests

The A/B result favors skipping both restore and save of the Bun package cache on Windows while retaining it on Linux. `--frozen-lockfile` prevents CI installs from silently changing the lockfile.

This matches upstream OpenCode's intended Turbo policy: unit tests are cacheable and the workflow restores prior OS-specific task results across commits. Upstream currently fails to persist those results because it still points the cache action at the obsolete `node_modules/.cache/turbo` directory.