### PR TITLE
fix(vscode): persist notification dismissals

### DIFF
--- a/.changeset/fuzzy-lions-rest.md
+++ b/.changeset/fuzzy-lions-rest.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep dismissed VS Code notifications hidden after closing them.

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -82,7 +82,7 @@
 - <https://github.com/Kilo-Org/kilocode>
   <!-- packages/kilo-vscode/webview-ui/src/components/settings/AboutKiloCodeTab.tsx -->
 - <https://github.com/Kilo-Org/kilocode/>
-  <!-- packages/kilo-vscode/webview-ui/src/context/notifications.tsx -->
+  <!-- packages/kilo-vscode/src/shared/notifications.ts -->
 - <https://github.com/Kilo-Org/kilocode/issues/6986>
   <!-- packages/kilo-vscode/src/agent-manager/constants.ts -->
 - <https://github.com/Kilo-Org/kilocode/issues/9618>

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -128,6 +128,7 @@ import {
 import { fetchAndSendPendingSuggestions } from "./kilo-provider/handlers/suggestion"
 import { nativeTitle } from "./kilo-provider/native-tab-title"
 import { parseReview, reviewMetadata, type ReviewMessageData } from "./shared/review-comments"
+import { pruneDismissals } from "./shared/notifications"
 
 import {
   buildActionContext,
@@ -2315,12 +2316,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const { data: all } = await retry(() => this.client!.kilo.notifications(undefined, { throwOnError: true }))
       const notifications = all.filter((n) => !n.showIn || n.showIn.includes("extension"))
       const existing = this.extensionContext?.globalState.get<string[]>("kilo.dismissedNotificationIds", []) ?? []
-      const active = new Set(notifications.map((n) => n.id))
-      // Only prune stale dismissed IDs when we have a non-empty notification
-      // list. An empty list may mean the API returned nothing due to being
-      // unauthenticated (e.g. right after logout), not that all notifications
-      // are gone — pruning in that case would wipe the persisted dismissals.
-      const dismissedIds = notifications.length > 0 ? existing.filter((id) => active.has(id)) : existing
+      // Keep built-in notification dismissals while pruning stale API IDs. An
+      // empty API list may mean the user is logged out, so preserve all IDs.
+      const dismissedIds = pruneDismissals(notifications, existing)
       if (dismissedIds.length !== existing.length) {
         await this.extensionContext?.globalState.update("kilo.dismissedNotificationIds", dismissedIds)
       }

--- a/packages/kilo-vscode/src/shared/notifications.ts
+++ b/packages/kilo-vscode/src/shared/notifications.ts
@@ -1,0 +1,23 @@
+import type { KilocodeNotification } from "@kilocode/kilo-gateway"
+
+export const BUILTIN_NOTIFICATIONS: KilocodeNotification[] = [
+  {
+    id: "star-giveaway-june-2026",
+    title: "GitHub Star Giveaway",
+    message: "We're giving away $500 of AI Credits when we reach 25,000 stars on GitHub. Support us:",
+    action: { actionText: "github.com/Kilo-Org/kilocode", actionURL: "https://github.com/Kilo-Org/kilocode/" },
+  },
+]
+
+export function pruneDismissals(
+  notifications: readonly KilocodeNotification[],
+  dismissed: readonly string[],
+): string[] {
+  if (notifications.length === 0) return [...dismissed]
+  const active = new Set([...BUILTIN_NOTIFICATIONS, ...notifications].map((notification) => notification.id))
+  return dismissed.filter((id) => active.has(id))
+}
+
+export function mergeDismissals(dismissed: readonly string[], local: ReadonlySet<string>): string[] {
+  return Array.from(new Set([...dismissed, ...local]))
+}

--- a/packages/kilo-vscode/tests/unit/notifications.test.ts
+++ b/packages/kilo-vscode/tests/unit/notifications.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { mergeDismissals, pruneDismissals } from "../../src/shared/notifications"
+
+const remote = {
+  id: "remote",
+  title: "Remote notification",
+  message: "Remote message",
+}
+
+describe("notification dismissals", () => {
+  it("preserves dismissed built-in notifications during API reconciliation", () => {
+    expect(pruneDismissals([remote], ["star-giveaway-june-2026"])).toEqual(["star-giveaway-june-2026"])
+  })
+
+  it("prunes stale API notification dismissals", () => {
+    expect(pruneDismissals([remote], ["remote", "stale"])).toEqual(["remote"])
+  })
+
+  it("preserves dismissals when the API returns no notifications", () => {
+    expect(pruneDismissals([], ["star-giveaway-june-2026", "remote"])).toEqual(["star-giveaway-june-2026", "remote"])
+  })
+
+  it("keeps local dismissals hidden when a stale response omits them", () => {
+    expect(mergeDismissals([], new Set(["star-giveaway-june-2026"]))).toEqual(["star-giveaway-june-2026"])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/notifications.tsx
@@ -10,16 +10,7 @@ import {
 } from "solid-js"
 import { useVSCode } from "./vscode"
 import type { KilocodeNotification, ExtensionMessage } from "../types/messages"
-
-// Static notifications always shown unconditionally (not fetched from API)
-const STATIC_NOTIFICATIONS: KilocodeNotification[] = [
-  {
-    id: "star-giveaway-june-2026",
-    title: "GitHub Star Giveaway",
-    message: "We're giving away $500 of AI Credits when we reach 25,000 stars on GitHub. Support us:",
-    action: { actionText: "github.com/Kilo-Org/kilocode", actionURL: "https://github.com/Kilo-Org/kilocode/" },
-  },
-]
+import { BUILTIN_NOTIFICATIONS, mergeDismissals } from "../../../src/shared/notifications"
 
 interface NotificationsContextValue {
   notifications: Accessor<KilocodeNotification[]>
@@ -33,11 +24,12 @@ export const NotificationsProvider: ParentComponent = (props) => {
   const vscode = useVSCode()
   const [notifications, setNotifications] = createSignal<KilocodeNotification[]>([])
   const [dismissedIds, setDismissedIds] = createSignal<string[]>([])
+  const local = new Set<string>()
 
   const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "notificationsLoaded") {
       setNotifications(message.notifications)
-      setDismissedIds(message.dismissedIds)
+      setDismissedIds(mergeDismissals(message.dismissedIds, local))
     }
   })
 
@@ -63,11 +55,12 @@ export const NotificationsProvider: ParentComponent = (props) => {
 
   const filteredNotifications = createMemo(() => {
     const dismissed = dismissedIds()
-    const all = [...STATIC_NOTIFICATIONS, ...notifications()]
+    const all = [...BUILTIN_NOTIFICATIONS, ...notifications()]
     return all.filter((n) => !dismissed.includes(n.id))
   })
 
   const dismiss = (id: string) => {
+    local.add(id)
     setDismissedIds((prev) => (prev.includes(id) ? prev : [...prev, id]))
     vscode.postMessage({ type: "dismissNotification", notificationId: id })
   }


### PR DESCRIPTION
## Summary
- Preserve dismissals for built-in notifications when extension-side API reconciliation prunes stale IDs.
- Keep optimistic dismissals hidden across stale or out-of-order notification snapshots.
- Centralize built-in notification metadata so the extension and webview use the same identities.

The built-in giveaway notification was rendered only in the webview, so the extension treated its persisted dismissal ID as stale during the immediate refetch and sent a snapshot that made the card reappear. This keeps built-in IDs authoritative on both sides while retaining stale API-ID cleanup.