### PR TITLE
chore(ci): filter test workspace dependencies

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -45,8 +45,7 @@ runs:
       with:
         path: ${{ steps.cache.outputs.dir }}
         key: ${{ runner.os }}-${{ inputs.cache-namespace }}-${{ hashFiles('**/bun.lock') }} # kilocode_change
-        restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache-namespace }}- # kilocode_change
+        restore-keys: ${{ runner.os }}-${{ inputs.cache-namespace }}- # kilocode_change
 
     - name: Install setuptools for distutils compatibility
       run: python3 -m pip install setuptools || pip install setuptools || true

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -5,6 +5,12 @@ inputs:
     description: "Additional flags to pass to 'bun install'"
     required: false
     default: ""
+  # kilocode_change start
+  cache-namespace:
+    description: "Namespace used to isolate Bun dependency caches"
+    required: false
+    default: "bun"
+  # kilocode_change end
 runs:
   using: "composite"
   steps:
@@ -38,9 +44,9 @@ runs:
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ runner.os }}-${{ inputs.cache-namespace }}-${{ hashFiles('**/bun.lock') }} # kilocode_change
         restore-keys: |
-          ${{ runner.os }}-bun-
+          ${{ runner.os }}-${{ inputs.cache-namespace }}- # kilocode_change
 
     - name: Install setuptools for distutils compatibility
       run: python3 -m pip install setuptools || pip install setuptools || true
@@ -63,4 +69,4 @@ runs:
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ runner.os }}-${{ inputs.cache-namespace }}-${{ hashFiles('**/bun.lock') }} # kilocode_change

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version: "24"
       # kilocode_change end
-
+      # kilocode_change start
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
@@ -78,6 +78,7 @@ jobs:
             --filter='@opencode-ai/llm'
             --filter='@opencode-ai/script'
             --filter='@opencode-ai/ui'
+        # kilocode_change end
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,24 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
+        with:
+          cache-namespace: bun-test
+          # Keep this allowlist aligned with test:ci workspaces and their build dependencies.
+          install-flags: >-
+            --filter='./'
+            --filter='@kilocode/cli'
+            --filter='@kilocode/kilo-gateway'
+            --filter='@kilocode/kilo-indexing'
+            --filter='@kilocode/kilo-telemetry'
+            --filter='@kilocode/plugin'
+            --filter='@kilocode/plugin-atomic-chat'
+            --filter='@kilocode/sdk'
+            --filter='@opencode-ai/core'
+            --filter='@opencode-ai/effect-drizzle-sqlite'
+            --filter='@opencode-ai/http-recorder'
+            --filter='@opencode-ai/llm'
+            --filter='@opencode-ai/script'
+            --filter='@opencode-ai/ui'
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
-          cache-namespace: bun-test
+          cache-namespace: test-bun
           # Keep this allowlist aligned with test:ci workspaces and their build dependencies.
           install-flags: >-
             --filter='./'


### PR DESCRIPTION
## Summary

Limit the unit-test job's Bun install to the root, the six workspaces that define the selected `test:ci` tasks, and their transitive workspace/build dependencies. This avoids downloading unrelated VS Code, Storybook, docs, and web dependencies while retaining required optional native packages such as LanceDB.

Give filtered installs a dedicated cache namespace so they do not restore or race with full-workspace Bun caches. Existing setup-bun consumers keep the current cache keys through the default namespace.

Closes #11413