### PR TITLE
fix(vscode): keep diff identifiers intact

### DIFF
--- a/.changeset/keep-diff-identifiers-intact.md
+++ b/.changeset/keep-diff-identifiers-intact.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep changed identifiers intact when highlighting edits within diff lines.

--- a/packages/kilo-ui/src/pierre/index.test.ts
+++ b/packages/kilo-ui/src/pierre/index.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { createDefaultOptions } from "./index"
 
 describe("Pierre diff options", () => {
-  test("highlights changed characters in unified and split diffs", () => {
-    expect(createDefaultOptions("unified").lineDiffType).toBe("char")
-    expect(createDefaultOptions("split").lineDiffType).toBe("char")
+  test("keeps changed identifiers intact in unified and split diffs", () => {
+    expect(createDefaultOptions("unified").lineDiffType).toBe("word-alt")
+    expect(createDefaultOptions("split").lineDiffType).toBe("word-alt")
   })
 })

--- a/packages/kilo-ui/src/pierre/index.ts
+++ b/packages/kilo-ui/src/pierre/index.ts
@@ -10,7 +10,9 @@ import { createDefaultOptions as defaults, styleVariables } from "@opencode-ai/u
 
 export { styleVariables }
 
-export const LINE_DIFF_TYPE = "char" as const
+// Character matching fragments inserted identifiers when they share letters with
+// existing symbols. Word-alt keeps those logical additions visually intact.
+export const LINE_DIFF_TYPE = "word-alt" as const
 
 // Pierre 1.1 treats its changed-line override properties as tint targets. Apply
 // Kilo semantic surfaces at the computed row level so host diff colors stay final.


### PR DESCRIPTION
Character-level matching can split newly inserted identifiers into misleading fragments whenever they share letters with an existing symbol. The resulting emphasis implies that parts of a new identifier were unchanged and makes diff reviews harder to scan.

Use Pierre's word-alt intraline strategy consistently for unified and split rendering. Inline edits remain highlighted, while identifiers and punctuation are preserved as coherent changes.
Before:
<img width="670" height="233" alt="file-4153e635ad83e0532a9b1c23fb4fa0e8" src="https://github.com/user-attachments/assets/68aa2e59-e1ad-41cb-9e5e-35ffff81a4f5" />
After:
<img width="725" height="280" alt="file-de793e1bf3da64f8e59564dbf1112641" src="https://github.com/user-attachments/assets/eed4c901-8a37-47fc-a6e3-52bbec6a0767" />


Follow-up to #11349.