### PR TITLE
feat(ci): require engineering approval without review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Require an engineering owner for all repository changes.
-* @marius-kilocode @markijbema @kirillk @chrarnoldus @catrielmuller @imanolmzd-svg @johnnyeric @lambertjosh @iscekic @alex-alecu @jeanduplessis @RSO
+* @Kilo-Org/engineering
 
 # Documentation-only changes may be approved by the docs team.
 /packages/kilo-docs/ @LigiaZ @alexkgold @olearycrew

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# Require an engineering owner for all repository changes.
-* @Kilo-Org/engineering
-
-# Documentation-only changes may be approved by the docs team.
-/packages/kilo-docs/ @LigiaZ @alexkgold @olearycrew
+# kilocode_change - intentionally empty; approvals are enforced without automatic reviewer requests

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# web + desktop packages
-packages/app/      @adamdotdevin
-packages/tauri/    @adamdotdevin
-packages/desktop/src-tauri/  @brendonovich
-packages/desktop/  @adamdotdevin
+# Require an engineering owner for all repository changes.
+* @marius-kilocode @markijbema @kirillk @chrarnoldus @catrielmuller @imanolmzd-svg @johnnyeric @lambertjosh @iscekic @alex-alecu @jeanduplessis @RSO
+
+# Documentation-only changes may be approved by the docs team.
+/packages/kilo-docs/ @LigiaZ @alexkgold @olearycrew

--- a/.github/workflows/approval-gate-review-signal.yml
+++ b/.github/workflows/approval-gate-review-signal.yml
@@ -1,0 +1,29 @@
+# kilocode_change - new file
+name: Approval gate review signal
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+
+jobs:
+  signal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Record pull request number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          printf '%s\n' "$PR_NUMBER" > pr-number
+
+      - name: Upload pull request reference
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: approval-gate-pr
+          path: pr-number
+          retention-days: 1

--- a/.github/workflows/approval-gate-review-signal.yml
+++ b/.github/workflows/approval-gate-review-signal.yml
@@ -13,17 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Record pull request number
+      - name: Validate pull request event
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
-          printf '%s\n' "$PR_NUMBER" > pr-number
-
-      - name: Upload pull request reference
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: approval-gate-pr
-          path: pr-number
-          retention-days: 1
+        run: '[[ "$PR_NUMBER" =~ ^[0-9]+$ ]]'

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -1,0 +1,86 @@
+# kilocode_change - new file
+name: Approval gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+  workflow_run:
+    workflows: ["Approval gate review signal"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: number
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: approval-gate-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || inputs.pr_number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download review signal
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: approval-gate-pr
+          path: signal
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Resolve pull request number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            PR_NUMBER="$(cat signal/pr-number)"
+          else
+            PR_NUMBER="${EVENT_PR:-$INPUT_PR}"
+          fi
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      # Always run trusted policy code from the default branch, never from the PR.
+      - name: Checkout trusted policy
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Create team membership token
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.KILO_MAINTAINER_APP_ID }}
+          private-key: ${{ secrets.KILO_MAINTAINER_APP_SECRET }}
+          owner: Kilo-Org
+          repositories: kilocode
+          permission-members: read
+
+      - name: Evaluate current approvals
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          STATUS_TOKEN: ${{ github.token }}
+          TEAM_TOKEN: ${{ steps.app.outputs.token }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bun run script/kilocode/approval-gate.ts

--- a/.github/workflows/approval-gate.yml
+++ b/.github/workflows/approval-gate.yml
@@ -15,7 +15,6 @@ on:
         type: number
 
 permissions:
-  actions: read
   contents: read
   pull-requests: read
   statuses: write
@@ -30,25 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download review signal
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: approval-gate-pr
-          path: signal
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-
       - name: Resolve pull request number
         id: pr
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           INPUT_PR: ${{ inputs.pr_number }}
+          RUN_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            PR_NUMBER="$(cat signal/pr-number)"
+            PR_NUMBER="$RUN_PR"
           else
             PR_NUMBER="${EVENT_PR:-$INPUT_PR}"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,11 @@ jobs:
         working-directory: packages/opencode
         run: bun run test:httpapi
 
+      - name: Test approval policy
+        if: runner.os == 'Linux'
+        working-directory: script/kilocode
+        run: bun test approval-policy.test.ts
+
       - name: Publish unit reports
         if: always()
         uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,10 +85,12 @@ jobs:
         working-directory: packages/opencode
         run: bun run test:httpapi
 
+      # kilocode_change start
       - name: Test approval policy
         if: runner.os == 'Linux'
         working-directory: script/kilocode
         run: bun test approval-policy.test.ts
+      # kilocode_change end
 
       - name: Publish unit reports
         if: always()

--- a/script/check-workflows.ts
+++ b/script/check-workflows.ts
@@ -27,6 +27,8 @@ const DIR = path.join(ROOT, ".github", "workflows")
 
 // Workflows we have deliberately accepted into CI. Sort alphabetically.
 const active = new Set([
+  "approval-gate-review-signal.yml",
+  "approval-gate.yml",
   "auto-docs.yml",
   "beta.yml",
   "check-forbidden-strings.yml",

--- a/script/kilocode/approval-gate.ts
+++ b/script/kilocode/approval-gate.ts
@@ -22,6 +22,7 @@ type Pull = {
 type ApiReview = {
   state: string
   submitted_at: string | null
+  commit_id: string
   user: { login: string } | null
 }
 
@@ -76,7 +77,7 @@ try {
   const reviews: Review[] = raw
     .filter((review) => review.user)
     .sort((a, b) => (a.submitted_at ?? "").localeCompare(b.submitted_at ?? ""))
-    .map((review) => ({ user: review.user!.login, state: review.state }))
+    .map((review) => ({ user: review.user!.login, state: review.state, commit: review.commit_id }))
   const engineers = new Set(members.map((member) => member.login.toLowerCase()))
   const current = (await request<Pull>(`/repos/${repo}/pulls/${number}`, statusToken)).data
   if (current.head.sha !== pull.head.sha) throw new Error("PR head changed during approval evaluation")
@@ -86,7 +87,7 @@ try {
     process.exit(1)
   }
 
-  const result = evaluate(reviews, engineers, pull.user.login)
+  const result = evaluate(reviews, engineers, pull.user.login, pull.head.sha)
   await status(pull.head.sha, result.ok ? "success" : "failure", result.reason)
   if (!result.ok) process.exit(1)
   console.log(result.reason)

--- a/script/kilocode/approval-gate.ts
+++ b/script/kilocode/approval-gate.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+
+import { evaluate, type Review } from "./approval-policy"
+
+const api = process.env.GITHUB_API_URL ?? "https://api.github.com"
+const repo = process.env.GITHUB_REPOSITORY
+const number = process.env.PR_NUMBER
+const statusToken = process.env.STATUS_TOKEN
+const teamToken = process.env.TEAM_TOKEN
+const target = process.env.GITHUB_RUN_URL
+
+if (!repo || !number || !statusToken || !teamToken) throw new Error("Missing required approval gate environment")
+if (!/^\d+$/.test(number)) throw new Error("Invalid PR number")
+
+type Pull = {
+  state: string
+  draft: boolean
+  head: { sha: string }
+  user: { login: string }
+}
+
+type ApiReview = {
+  state: string
+  submitted_at: string | null
+  user: { login: string } | null
+}
+
+type Member = { login: string }
+
+async function request<T>(path: string, token: string, init?: RequestInit) {
+  const response = await fetch(`${api}${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...init?.headers,
+    },
+  })
+  if (!response.ok) throw new Error(`GitHub API ${response.status}: ${path}`)
+  return { data: (await response.json()) as T, link: response.headers.get("link") }
+}
+
+async function pages<T>(path: string, token: string) {
+  const items: T[] = []
+  for (let page = 1; ; page++) {
+    const separator = path.includes("?") ? "&" : "?"
+    const response = await request<T[]>(`${path}${separator}per_page=100&page=${page}`, token)
+    items.push(...response.data)
+    if (!response.link?.includes('rel="next"')) return items
+  }
+}
+
+async function status(sha: string, state: "pending" | "success" | "failure" | "error", description: string) {
+  await request(`/repos/${repo}/statuses/${sha}`, statusToken, {
+    method: "POST",
+    body: JSON.stringify({
+      context: "Engineering approval",
+      state,
+      description: description.slice(0, 140),
+      target_url: target,
+    }),
+  })
+}
+
+const pull = (await request<Pull>(`/repos/${repo}/pulls/${number}`, statusToken)).data
+if (pull.state !== "open") throw new Error(`PR #${number} is not open`)
+
+await status(pull.head.sha, "pending", "Checking current approvals")
+
+try {
+  const [raw, members] = await Promise.all([
+    pages<ApiReview>(`/repos/${repo}/pulls/${number}/reviews`, statusToken),
+    pages<Member>("/orgs/Kilo-Org/teams/engineering/members", teamToken),
+  ])
+  const reviews: Review[] = raw
+    .filter((review) => review.user)
+    .sort((a, b) => (a.submitted_at ?? "").localeCompare(b.submitted_at ?? ""))
+    .map((review) => ({ user: review.user!.login, state: review.state }))
+  const engineers = new Set(members.map((member) => member.login.toLowerCase()))
+  const current = (await request<Pull>(`/repos/${repo}/pulls/${number}`, statusToken)).data
+  if (current.head.sha !== pull.head.sha) throw new Error("PR head changed during approval evaluation")
+
+  if (pull.draft) {
+    await status(pull.head.sha, "failure", "Approval gate waits until the PR is ready")
+    process.exit(1)
+  }
+
+  const result = evaluate(reviews, engineers, pull.user.login)
+  await status(pull.head.sha, result.ok ? "success" : "failure", result.reason)
+  if (!result.ok) process.exit(1)
+  console.log(result.reason)
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err)
+  await status(pull.head.sha, "error", "Unable to verify engineering approval")
+  throw new Error(message)
+}

--- a/script/kilocode/approval-policy.test.ts
+++ b/script/kilocode/approval-policy.test.ts
@@ -1,47 +1,46 @@
 import { describe, expect, test } from "bun:test"
-import { approvers, evaluate } from "./approval-policy"
+import { approvers, evaluate, type Review } from "./approval-policy"
 
 const engineers = new Set(["engineer"])
+const head = "current"
+const review = (user: string, state: string, commit = head): Review => ({ user, state, commit })
 
 describe("approval policy", () => {
   test("requires engineering approval", () => {
-    expect(evaluate([], engineers, "author").ok).toBe(false)
-    expect(evaluate([{ user: "outsider", state: "APPROVED" }], engineers, "author").ok).toBe(false)
-    expect(evaluate([{ user: "Engineer", state: "APPROVED" }], engineers, "author")).toEqual({
+    expect(evaluate([], engineers, "author", head).ok).toBe(false)
+    expect(evaluate([review("outsider", "APPROVED")], engineers, "author", head).ok).toBe(false)
+    expect(evaluate([review("Engineer", "APPROVED")], engineers, "author", head)).toEqual({
       ok: true,
       reason: "Approved by engineering team member @engineer",
     })
   })
 
   test("does not count self approval", () => {
-    expect(evaluate([{ user: "engineer", state: "APPROVED" }], engineers, "ENGINEER").ok).toBe(false)
+    expect(evaluate([review("engineer", "APPROVED")], engineers, "ENGINEER", head).ok).toBe(false)
+  })
+
+  test("does not count approval for an older commit", () => {
+    expect(evaluate([review("engineer", "APPROVED", "old")], engineers, "author", head).ok).toBe(false)
   })
 
   test("uses the latest opinionated review", () => {
     expect(
-      approvers([
-        { user: "engineer", state: "APPROVED" },
-        { user: "engineer", state: "COMMENTED" },
-        { user: "engineer", state: "CHANGES_REQUESTED" },
-      ]).has("engineer"),
+      approvers(
+        [review("engineer", "APPROVED"), review("engineer", "COMMENTED"), review("engineer", "CHANGES_REQUESTED")],
+        head,
+      ).has("engineer"),
     ).toBe(false)
   })
 
   test("retains approval after a comment-only review", () => {
-    expect(
-      approvers([
-        { user: "engineer", state: "APPROVED" },
-        { user: "engineer", state: "COMMENTED" },
-      ]).has("engineer"),
-    ).toBe(true)
+    expect(approvers([review("engineer", "APPROVED"), review("engineer", "COMMENTED")], head).has("engineer")).toBe(
+      true,
+    )
   })
 
   test("does not count a dismissed approval", () => {
-    expect(
-      approvers([
-        { user: "engineer", state: "APPROVED" },
-        { user: "engineer", state: "DISMISSED" },
-      ]).has("engineer"),
-    ).toBe(false)
+    expect(approvers([review("engineer", "APPROVED"), review("engineer", "DISMISSED")], head).has("engineer")).toBe(
+      false,
+    )
   })
 })

--- a/script/kilocode/approval-policy.test.ts
+++ b/script/kilocode/approval-policy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { approvers, evaluate } from "./approval-policy"
+
+const engineers = new Set(["engineer"])
+
+describe("approval policy", () => {
+  test("requires engineering approval", () => {
+    expect(evaluate([], engineers, "author").ok).toBe(false)
+    expect(evaluate([{ user: "outsider", state: "APPROVED" }], engineers, "author").ok).toBe(false)
+    expect(evaluate([{ user: "Engineer", state: "APPROVED" }], engineers, "author")).toEqual({
+      ok: true,
+      reason: "Approved by engineering team member @engineer",
+    })
+  })
+
+  test("does not count self approval", () => {
+    expect(evaluate([{ user: "engineer", state: "APPROVED" }], engineers, "ENGINEER").ok).toBe(false)
+  })
+
+  test("uses the latest opinionated review", () => {
+    expect(
+      approvers([
+        { user: "engineer", state: "APPROVED" },
+        { user: "engineer", state: "COMMENTED" },
+        { user: "engineer", state: "CHANGES_REQUESTED" },
+      ]).has("engineer"),
+    ).toBe(false)
+  })
+
+  test("retains approval after a comment-only review", () => {
+    expect(
+      approvers([
+        { user: "engineer", state: "APPROVED" },
+        { user: "engineer", state: "COMMENTED" },
+      ]).has("engineer"),
+    ).toBe(true)
+  })
+
+  test("does not count a dismissed approval", () => {
+    expect(
+      approvers([
+        { user: "engineer", state: "APPROVED" },
+        { user: "engineer", state: "DISMISSED" },
+      ]).has("engineer"),
+    ).toBe(false)
+  })
+})

--- a/script/kilocode/approval-policy.ts
+++ b/script/kilocode/approval-policy.ts
@@ -1,6 +1,7 @@
 export type Review = {
   user: string
   state: string
+  commit: string
 }
 
 export type Result = {
@@ -8,9 +9,10 @@ export type Result = {
   reason: string
 }
 
-export function approvers(reviews: Review[]) {
+export function approvers(reviews: Review[], head: string) {
   const states = new Map<string, string>()
   for (const review of reviews) {
+    if (review.commit !== head) continue
     const user = review.user.toLowerCase()
     if (!user) continue
     if (review.state === "APPROVED" || review.state === "CHANGES_REQUESTED" || review.state === "DISMISSED") {
@@ -20,8 +22,8 @@ export function approvers(reviews: Review[]) {
   return new Set([...states].filter(([, state]) => state === "APPROVED").map(([user]) => user))
 }
 
-export function evaluate(reviews: Review[], engineers: Set<string>, author: string): Result {
-  const approved = approvers(reviews)
+export function evaluate(reviews: Review[], engineers: Set<string>, author: string, head: string): Result {
+  const approved = approvers(reviews, head)
   approved.delete(author.toLowerCase())
 
   const engineer = [...approved].find((user) => engineers.has(user))

--- a/script/kilocode/approval-policy.ts
+++ b/script/kilocode/approval-policy.ts
@@ -1,0 +1,30 @@
+export type Review = {
+  user: string
+  state: string
+}
+
+export type Result = {
+  ok: boolean
+  reason: string
+}
+
+export function approvers(reviews: Review[]) {
+  const states = new Map<string, string>()
+  for (const review of reviews) {
+    const user = review.user.toLowerCase()
+    if (!user) continue
+    if (review.state === "APPROVED" || review.state === "CHANGES_REQUESTED" || review.state === "DISMISSED") {
+      states.set(user, review.state)
+    }
+  }
+  return new Set([...states].filter(([, state]) => state === "APPROVED").map(([user]) => user))
+}
+
+export function evaluate(reviews: Review[], engineers: Set<string>, author: string): Result {
+  const approved = approvers(reviews)
+  approved.delete(author.toLowerCase())
+
+  const engineer = [...approved].find((user) => engineers.has(user))
+  if (engineer) return { ok: true, reason: `Approved by engineering team member @${engineer}` }
+  return { ok: false, reason: "Waiting for approval from Kilo-Org/engineering" }
+}


### PR DESCRIPTION
## Summary

Require one current approval from a member of `Kilo-Org/engineering` without using CODEOWNERS to automatically request or notify reviewers.

The gate re-evaluates after PR updates and review submissions, edits, or dismissals, and publishes an `Engineering approval` commit status against the current PR head. The privileged evaluator runs only trusted default-branch code and uses the existing Kilo Maintainer GitHub App to read team membership.

`CODEOWNERS` is intentionally left without ownership rules, with a `kilocode_change` marker replacing stale upstream maintainer entries.

## Rollout

After merge, add the `Engineering approval` status to the main branch ruleset's required status checks. The workflow must land on the default branch before it can safely evaluate PRs.