### PR TITLE
feat: add experimental voice-steered design mode

### DIFF
--- a/.changeset/design-mode-voice.md
+++ b/.changeset/design-mode-voice.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add an experimental `kilo design` command for voice-steered live design iteration. It runs one in-process Kilo session driven by a continuous voice loop: speak (or type, in fake-voice mode) and finalized turns dispatch to the agent while edits stream back into the browser. Press Escape to interrupt and keep listening. The command is hidden from release builds while it's in development.

--- a/packages/kilo-design-fixture/AGENTS.md
+++ b/packages/kilo-design-fixture/AGENTS.md
@@ -1,0 +1,18 @@
+# Design canvas fixture
+
+This is a throwaway static site used as the Browser Canvas for `kilo design`. It
+is intentionally tiny so design requests have something concrete to act on.
+
+When asked to make a visual change, edit these files only:
+
+- `public/index.html` — the page markup
+- `public/styles.css` — the styling (CSS custom properties live in `:root`)
+
+Guidelines:
+
+- Prefer editing the CSS variables in `:root` (e.g. `--brand`, `--bg`, `--fg`,
+  `--radius`, `--space`) when a request is about color, spacing, or shape.
+- Keep changes small and focused on what was asked — this is a live, hot-reloading
+  canvas, so each edit should be immediately visible.
+- Do not add a build step, framework, or dependencies. Plain HTML + CSS only.
+- Do not touch `serve.ts` or anything outside `public/` unless explicitly asked.

--- a/packages/kilo-design-fixture/package.json
+++ b/packages/kilo-design-fixture/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@kilocode/design-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Throwaway Browser Canvas fixture for `kilo design` (zero-install, Bun dev server with live reload)",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run serve.ts"
+  }
+}

--- a/packages/kilo-design-fixture/public/index.html
+++ b/packages/kilo-design-fixture/public/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nimbus — design canvas</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="nav">
+      <div class="brand">Nimbus</div>
+      <nav class="links">
+        <a href="#">Product</a>
+        <a href="#">Pricing</a>
+        <a href="#">Docs</a>
+        <a class="cta" href="#">Get started</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <h1 class="hero-title">Ship interfaces at the speed of thought.</h1>
+        <p class="hero-sub">Nimbus turns rough ideas into polished product UI — no pixel-pushing required.</p>
+        <div class="hero-actions">
+          <a class="btn primary" href="#">Start free</a>
+          <a class="btn ghost" href="#">Watch demo</a>
+        </div>
+      </section>
+
+      <section class="cards">
+        <article class="card">
+          <h3>Fast</h3>
+          <p>Edits land the instant you describe them.</p>
+        </article>
+        <article class="card">
+          <h3>Flexible</h3>
+          <p>Every token is yours to shape and re-shape.</p>
+        </article>
+        <article class="card">
+          <h3>Friendly</h3>
+          <p>Talk to it like a teammate, not a tool.</p>
+        </article>
+      </section>
+    </main>
+
+    <footer class="foot">Built with Nimbus · design canvas fixture</footer>
+  </body>
+</html>

--- a/packages/kilo-design-fixture/public/styles.css
+++ b/packages/kilo-design-fixture/public/styles.css
@@ -1,0 +1,132 @@
+:root {
+  --brand: #ec4899;
+  --brand-ink: #ffffff;
+  --bg: #000000;
+  --fg: #0f172a;
+  --muted: #64748b;
+  --card-bg: #f8fafc;
+  --border: #e2e8f0;
+  --radius: 12px;
+  --space: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space) 32px;
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 20px;
+  color: var(--brand);
+}
+
+.links {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.links a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.links .cta {
+  background: var(--brand);
+  color: var(--brand-ink);
+  padding: 8px 14px;
+  border-radius: var(--radius);
+}
+
+.hero {
+  max-width: 760px;
+  margin: 80px auto 48px;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.hero-title {
+   font-size: 72px;
+   line-height: 1.1;
+   margin: 0 0 16px;
+ }
+
+.hero-sub {
+  font-size: 18px;
+  color: var(--muted);
+  margin: 0 0 28px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.btn {
+  padding: 12px 20px;
+  border-radius: var(--radius);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.btn.primary {
+  background: var(--brand);
+  color: var(--brand-ink);
+}
+
+.btn.ghost {
+  border: 1px solid var(--border);
+  color: var(--fg);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space);
+  max-width: 900px;
+  margin: 0 auto 64px;
+  padding: 0 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+}
+
+.card h3 {
+  margin: 0 0 8px;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.foot {
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+  padding: 24px;
+  border-top: 1px solid var(--border);
+}

--- a/packages/kilo-design-fixture/serve.ts
+++ b/packages/kilo-design-fixture/serve.ts
@@ -1,0 +1,88 @@
+// Zero-dependency dev server for the Design Mode canvas fixture.
+//
+// Serves ./public with live reload: a tiny WebSocket pushes a "reload" whenever
+// a file under ./public changes, so edits the design agent makes show up in the
+// browser instantly — the visible half of the speak → edit → see loop.
+
+import { watch } from "fs"
+import path from "path"
+
+const root = path.join(import.meta.dir, "public")
+const port = Number(process.env.PORT ?? 4321)
+
+const LIVE_RELOAD = `
+<script>
+(() => {
+  const connect = () => {
+    const ws = new WebSocket(\`ws://\${location.host}/__lr\`)
+    ws.onmessage = (e) => { if (e.data === "reload") location.reload() }
+    ws.onclose = () => setTimeout(connect, 600)
+  }
+  connect()
+})()
+</script>
+`
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".json": "application/json",
+}
+
+const server = Bun.serve({
+  port,
+  async fetch(req, server) {
+    const url = new URL(req.url)
+    if (url.pathname === "/__lr") {
+      if (server.upgrade(req)) return undefined as unknown as Response
+      return new Response("expected websocket", { status: 426 })
+    }
+
+    const rel = url.pathname === "/" ? "/index.html" : url.pathname
+    const file = Bun.file(path.join(root, rel))
+    if (!(await file.exists())) return new Response("not found", { status: 404 })
+
+    const ext = path.extname(rel)
+    if (ext === ".html") {
+      const html = (await file.text()).replace("</body>", `${LIVE_RELOAD}</body>`)
+      return new Response(html, { headers: { "content-type": MIME[".html"] } })
+    }
+    return new Response(file, { headers: { "content-type": MIME[ext] ?? "application/octet-stream" } })
+  },
+  websocket: {
+    open(ws) {
+      ws.subscribe("lr")
+    },
+    message() {},
+    close(ws) {
+      ws.unsubscribe("lr")
+    },
+  },
+})
+
+let debounce: ReturnType<typeof setTimeout> | undefined
+watch(root, { recursive: true }, () => {
+  clearTimeout(debounce)
+  debounce = setTimeout(() => server.publish("lr", "reload"), 80)
+})
+
+const fixtureDir = import.meta.dir
+process.stdout.write(
+  [
+    ``,
+    `  Design canvas → http://localhost:${port}`,
+    ``,
+    `  In another terminal, from the repo root, run:`,
+    ``,
+    `    ./bin/kilodev design --voice local --url http://localhost:${port} --dir ${fixtureDir}`,
+    ``,
+    `  (use --voice fake to drive it by typing instead of talking)`,
+    ``,
+    `  Watching ${path.relative(process.cwd(), root) || root} for changes — edits hot-reload.`,
+    ``,
+  ].join("\n") + "\n",
+)

--- a/packages/kilo-voice-sidecar/.gitignore
+++ b/packages/kilo-voice-sidecar/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+*.xcodeproj
+DerivedData/

--- a/packages/kilo-voice-sidecar/Package.swift
+++ b/packages/kilo-voice-sidecar/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "kilo-voice-sidecar",
+    platforms: [
+        .macOS(.v13)
+    ],
+    targets: [
+        .executableTarget(
+            name: "kilo-voice-sidecar",
+            path: "Sources/kilo-voice-sidecar",
+            exclude: ["Info.plist"],
+            linkerSettings: [
+                // Embed an Info.plist into the binary so macOS sees the
+                // microphone / speech-recognition usage strings. Without this a
+                // SwiftPM CLI has no usage descriptions and the TCC permission
+                // request never resolves (the mic silently fails).
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/kilo-voice-sidecar/Info.plist",
+                ])
+            ]
+        )
+    ]
+)

--- a/packages/kilo-voice-sidecar/Sources/kilo-voice-sidecar/Info.plist
+++ b/packages/kilo-voice-sidecar/Sources/kilo-voice-sidecar/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>ai.kilo.voice-sidecar</string>
+  <key>CFBundleName</key>
+  <string>kilo-voice-sidecar</string>
+  <key>CFBundleDisplayName</key>
+  <string>Kilo Voice Sidecar</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Kilo Design Mode uses the microphone so you can steer design changes by voice.</string>
+  <key>NSSpeechRecognitionUsageDescription</key>
+  <string>Kilo Design Mode transcribes your speech to drive live design edits.</string>
+</dict>
+</plist>

--- a/packages/kilo-voice-sidecar/Sources/kilo-voice-sidecar/main.swift
+++ b/packages/kilo-voice-sidecar/Sources/kilo-voice-sidecar/main.swift
@@ -1,0 +1,369 @@
+// Kilo Design Mode — local voice sidecar (Apple Speech).
+//
+// Speaks the Voice Helper Protocol: newline-delimited JSON on stdout, commands
+// on stdin. Default mode is continuous always-on listening with automatic
+// end-of-utterance: the mic stays open, partial transcripts stream out, and a
+// finalized `turn` is emitted after a short silence window — no key toggling.
+//
+// Events out (stdout):  {"type":"state","value":"listening"}
+//                       {"type":"partial","text":"..."}
+//                       {"type":"turn","text":"...","latencyMs":N}
+//                       {"type":"level","peak":0.0..1.0}
+//                       {"type":"error","message":"..."}
+// Commands in (stdin):  {"type":"reset"} {"type":"stop"} {"type":"shutdown"}
+//                       {"type":"set-activation","value":"continuous"|"push-to-talk"}
+//
+// Test modes (no mic): --turn "text"  or  --script "a|b|c"
+
+import Foundation
+import AVFoundation
+import Speech
+
+// MARK: - JSONL IO
+
+let outQueue = DispatchQueue(label: "kilo.voice.out")
+
+func emit(_ object: [String: Any]) {
+    guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+    outQueue.sync {
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([0x0a]))
+    }
+}
+
+func emitState(_ value: String) { emit(["type": "state", "value": value]) }
+func emitError(_ message: String) { emit(["type": "error", "message": message]) }
+
+// Diagnostic logging to stderr (the parent logs this; it never pollutes the
+// JSONL on stdout).
+func logErr(_ message: String) {
+    FileHandle.standardError.write(Data(("[voice] " + message + "\n").utf8))
+}
+
+// MARK: - Argument parsing
+
+struct Args {
+    var activation = "continuous"
+    var silenceMs = 1100
+    var script: [String] = []
+    var single: String?
+}
+
+func parseArgs() -> Args {
+    var args = Args()
+    var it = CommandLine.arguments.dropFirst().makeIterator()
+    while let arg = it.next() {
+        switch arg {
+        case "--activation": if let v = it.next() { args.activation = v }
+        case "--silence-ms": if let v = it.next(), let n = Int(v) { args.silenceMs = n }
+        case "--script": if let v = it.next() { args.script = v.split(separator: "|").map { String($0).trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty } }
+        case "--turn": args.single = it.next()
+        default: break
+        }
+    }
+    return args
+}
+
+let args = parseArgs()
+
+// MARK: - Scripted / single-turn test modes (no microphone)
+
+func runScript(_ turns: [String]) {
+    emitState("listening")
+    for text in turns {
+        Thread.sleep(forTimeInterval: 0.4)
+        emitState("processing")
+        emit(["type": "turn", "text": text])
+        emitState("listening")
+    }
+    Thread.sleep(forTimeInterval: 0.1)
+    exit(0)
+}
+
+if let single = args.single {
+    runScript([single])
+}
+if !args.script.isEmpty {
+    runScript(args.script)
+}
+
+// MARK: - Live microphone recognition
+
+final class Sidecar {
+    // Domain phrases to prime the recognizer with (improves accuracy for the
+    // words you actually say when steering a design).
+    static let designVocabulary = [
+        "brand", "brand color", "accent", "accent color", "primary color",
+        "hero", "hero title", "headline", "subtitle", "tagline",
+        "background", "background color", "foreground", "text color",
+        "navbar", "nav", "header", "footer", "button", "buttons", "call to action",
+        "card", "cards", "grid", "columns", "two columns", "three columns",
+        "padding", "margin", "spacing", "gap", "border", "border radius", "rounded corners",
+        "font", "font size", "bold", "italic", "uppercase", "center", "centered", "align",
+        "gradient", "shadow", "drop shadow", "dark mode", "light mode", "contrast",
+        "bigger", "smaller", "wider", "narrower", "taller",
+    ]
+
+    private let engine = AVAudioEngine()
+    private let recognizer = SFSpeechRecognizer()
+    private let lock = DispatchQueue(label: "kilo.voice.state")
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private var current = ""
+    private var lastChange = Date()
+    private var utteranceStart = Date()
+    private var lastLevelEmit = Date(timeIntervalSince1970: 0)
+    private var listening = false
+    private var settled = false
+    private var activation: String
+    private let silence: TimeInterval
+    private var timer: DispatchSourceTimer?
+    private var permTimer: DispatchSourceTimer?
+
+    init(activation: String, silenceMs: Int) {
+        self.activation = activation
+        self.silence = Double(silenceMs) / 1000.0
+    }
+
+    private func fault(_ message: String) {
+        lock.async {
+            if self.settled { return }
+            self.settled = true
+        }
+        emitError(message)
+        emitState("standby")
+    }
+
+    func start() {
+        emitState("requesting-permission")
+        let pre = SFSpeechRecognizer.authorizationStatus()
+        logErr("pre-check speech auth status = \(pre.rawValue) (0=notDetermined 1=denied 2=restricted 3=authorized)")
+        logErr("requesting speech-recognition authorization")
+
+        // Watchdog: if the permission prompt can't appear (e.g. launched from a
+        // host with no GUI session, or odd TCC attribution), requestAuthorization
+        // never calls back. Surface that instead of hanging forever.
+        let watchdog = DispatchSource.makeTimerSource(queue: lock)
+        watchdog.schedule(deadline: .now() + 6)
+        watchdog.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            if self.settled || self.listening { return }
+            self.fault("timed out waiting for microphone/speech permission. Grant your terminal app Microphone AND Speech Recognition in System Settings › Privacy & Security, then retry. (Tip: run the sidecar binary directly once to trigger the prompts.)")
+        }
+        watchdog.resume()
+        self.permTimer = watchdog
+
+        SFSpeechRecognizer.requestAuthorization { status in
+            logErr("speech auth status = \(status.rawValue) (0=notDetermined 1=denied 2=restricted 3=authorized)")
+            guard status == .authorized else {
+                self.fault("speech recognition not authorized — enable it for your terminal in System Settings › Privacy & Security › Speech Recognition")
+                return
+            }
+            // Starting AVAudioEngine triggers the microphone TCC prompt/attribution
+            // on macOS; an explicit AVCaptureDevice request is unnecessary and can
+            // hang for a non-bundled CLI.
+            self.requestMic { granted in
+                logErr("microphone access granted = \(granted)")
+                guard granted else {
+                    self.fault("microphone access denied — grant your terminal Microphone permission in System Settings › Privacy & Security › Microphone")
+                    return
+                }
+                self.beginAudio()
+            }
+        }
+    }
+
+    private func requestMic(_ done: @escaping (Bool) -> Void) {
+        if #available(macOS 14.0, *) {
+            switch AVAudioApplication.shared.recordPermission {
+            case .granted: done(true)
+            case .denied: done(false)
+            default: AVAudioApplication.requestRecordPermission(completionHandler: done)
+            }
+            return
+        }
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized: done(true)
+        case .denied, .restricted: done(false)
+        default: AVCaptureDevice.requestAccess(for: .audio, completionHandler: done)
+        }
+    }
+
+    private func beginAudio() {
+        guard let recognizer = recognizer, recognizer.isAvailable else {
+            fault("speech recognizer unavailable for this locale")
+            return
+        }
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        logErr("input format: \(format.sampleRate)Hz, \(format.channelCount)ch")
+        if format.sampleRate == 0 || format.channelCount == 0 {
+            fault("no audio input device available (input format is empty)")
+            return
+        }
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            guard let self = self else { return }
+            self.lock.async { self.request?.append(buffer) }
+            self.reportLevel(buffer)
+        }
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            fault("failed to start audio engine: \(error.localizedDescription)")
+            return
+        }
+        logErr("recognizer locale=\(recognizer.locale.identifier) onDevice=\(recognizer.supportsOnDeviceRecognition)")
+        startSegment()
+        startTimer()
+        lock.async {
+            self.listening = true
+            self.settled = true
+        }
+        logErr("audio engine started; listening")
+        emitState("listening")
+    }
+
+    // Begin a fresh recognition request for the next utterance.
+    private func startSegment() {
+        lock.async {
+            self.task?.cancel()
+            let req = SFSpeechAudioBufferRecognitionRequest()
+            req.shouldReportPartialResults = true
+            // Bias recognition toward design vocabulary so words like "brand" and
+            // "hero" stop becoming "brown"/"heroic". taskHint=.dictation tunes the
+            // model for free-form spoken instructions.
+            req.taskHint = .dictation
+            req.contextualStrings = Sidecar.designVocabulary
+            self.request = req
+            self.current = ""
+            self.lastChange = Date()
+            self.utteranceStart = Date()
+            guard let recognizer = self.recognizer else { return }
+            self.task = recognizer.recognitionTask(with: req) { [weak self] result, error in
+                guard let self = self else { return }
+                if let result = result {
+                    let text = result.bestTranscription.formattedString
+                    logErr("recognition result: '\(text)' final=\(result.isFinal)")
+                    self.lock.async {
+                        if text != self.current {
+                            self.current = text
+                            self.lastChange = Date()
+                            emit(["type": "partial", "text": text])
+                        }
+                    }
+                }
+                if let error = error {
+                    logErr("recognition error: \(error.localizedDescription)")
+                }
+            }
+            logErr("recognition segment started")
+        }
+    }
+
+    // Poll for end-of-utterance: text present and unchanged for the silence window.
+    private func startTimer() {
+        let t = DispatchSource.makeTimerSource(queue: lock)
+        t.schedule(deadline: .now() + 0.2, repeating: 0.2)
+        t.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            guard self.listening else { return }
+            let text = self.current.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty && Date().timeIntervalSince(self.lastChange) >= self.silence {
+                self.finalize(text)
+            }
+        }
+        timer = t
+        t.resume()
+    }
+
+    private func finalize(_ text: String) {
+        let latency = Int(Date().timeIntervalSince(utteranceStart) * 1000)
+        emitState("processing")
+        emit(["type": "turn", "text": text, "latencyMs": latency])
+        emitState("listening")
+        // Roll into a new segment without stopping the mic.
+        request?.endAudio()
+        startSegment()
+    }
+
+    private func reportLevel(_ buffer: AVAudioPCMBuffer) {
+        guard let channel = buffer.floatChannelData?[0] else { return }
+        let frames = Int(buffer.frameLength)
+        if frames == 0 { return }
+        var sum: Float = 0
+        for i in 0..<frames { sum += channel[i] * channel[i] }
+        let rms = (sum / Float(frames)).squareRoot()
+        let peak = min(1.0, Double(rms) * 6.0)
+        let now = Date()
+        if now.timeIntervalSince(lastLevelEmit) > 0.1 {
+            lastLevelEmit = now
+            emit(["type": "level", "peak": peak])
+        }
+    }
+
+    func reset() {
+        lock.async {
+            self.current = ""
+            self.lastChange = Date()
+        }
+        startSegment()
+        emit(["type": "partial", "text": ""])
+        emitState("listening")
+    }
+
+    func stop() {
+        lock.async { self.listening = false }
+        emitState("standby")
+    }
+
+    func setActivation(_ value: String) {
+        lock.async { self.activation = value }
+    }
+
+    func shutdown() {
+        timer?.cancel()
+        task?.cancel()
+        if engine.isRunning {
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+        }
+        exit(0)
+    }
+}
+
+let sidecar = Sidecar(activation: args.activation, silenceMs: args.silenceMs)
+
+// MARK: - stdin command loop
+
+func handleCommand(_ line: String) {
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let type = obj["type"] as? String else { return }
+    switch type {
+    case "reset": sidecar.reset()
+    case "stop": sidecar.stop()
+    case "shutdown": sidecar.shutdown()
+    case "set-activation": if let v = obj["value"] as? String { sidecar.setActivation(v) }
+    default: break
+    }
+}
+
+let stdinQueue = DispatchQueue(label: "kilo.voice.in")
+var stdinBuffer = Data()
+FileHandle.standardInput.readabilityHandler = { handle in
+    let chunk = handle.availableData
+    if chunk.isEmpty { return }
+    stdinQueue.async {
+        stdinBuffer.append(chunk)
+        while let nl = stdinBuffer.firstIndex(of: 0x0a) {
+            let lineData = stdinBuffer.subdata(in: stdinBuffer.startIndex..<nl)
+            stdinBuffer.removeSubrange(stdinBuffer.startIndex...nl)
+            if let line = String(data: lineData, encoding: .utf8) { handleCommand(line) }
+        }
+    }
+}
+
+sidecar.start()
+dispatchMain()

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -40,6 +40,7 @@ import { ProfileCommand } from "./kilocode/cli/cmd/profile" // kilocode_change
 import { DevSetupCommand, DevAliasCommand } from "./kilocode/cli/dev-setup" // kilocode_change
 import { DaemonCommand } from "./kilocode/cli/cmd/daemon" // kilocode_change
 import { KiloConsoleCommand } from "./kilocode/cli/cmd/console" // kilocode_change
+import { DesignCommand } from "./kilocode/design/cmd" // kilocode_change
 // kilocode_change start - Import telemetry, instance disposal, and legacy migration
 import { Telemetry } from "@kilocode/kilo-telemetry"
 import { InstanceRuntime } from "./project/instance-runtime" // kilocode_change
@@ -254,7 +255,7 @@ let cli = yargs(args) // kilocode_change
 
 // kilocode_change start - dev-only commands are hidden from release builds
 if (InstallationBuildKind !== "release") {
-  cli = cli.command(DevSetupCommand).command(DevAliasCommand)
+  cli = cli.command(DevSetupCommand).command(DevAliasCommand).command(DesignCommand)
 }
 // kilocode_change end
 

--- a/packages/opencode/src/kilocode/design/browser.ts
+++ b/packages/opencode/src/kilocode/design/browser.ts
@@ -1,0 +1,22 @@
+// Opens the Browser Canvas (the running app) next to the terminal. Best-effort
+// and cross-platform; failure to open is non-fatal (the user can open it).
+
+import { Process } from "@/util/process"
+import * as Log from "@opencode-ai/core/util/log"
+
+const log = Log.create({ service: "design.browser" })
+
+function openCommand(url: string): string[] {
+  if (process.platform === "darwin") return ["open", url]
+  if (process.platform === "win32") return ["cmd", "/c", "start", "", url]
+  return ["xdg-open", url]
+}
+
+export function openCanvas(url: string): void {
+  try {
+    const proc = Process.spawn(openCommand(url), { stdout: "ignore", stderr: "ignore" })
+    proc.exited.catch(() => {})
+  } catch (err) {
+    log.warn("failed to open browser canvas", { url, err })
+  }
+}

--- a/packages/opencode/src/kilocode/design/cmd.ts
+++ b/packages/opencode/src/kilocode/design/cmd.ts
@@ -1,0 +1,206 @@
+// `kilo design` — experimental, voice-steered live design iteration.
+//
+// Boots one in-process Kilo session and drives it from a continuous voice loop:
+// speak (or type, in fake mode) → automatic turn → dispatch → edits stream back
+// into the Browser Canvas. The command handler wires the real services to the
+// plain-TS orchestrator and blocks until the user quits (Ctrl+C).
+
+import type { Argv } from "yargs"
+import path from "path"
+import { Effect } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { effectCmd, fail } from "@/cli/effect-cmd"
+import { Bus } from "@/bus"
+import { Session } from "@/session/session"
+import { createActiveSession, type ModelRef } from "./session"
+import { createOrchestrator } from "./orchestrator"
+import { createTerminalSurface } from "./surface/terminal"
+import { createFakeVoice } from "./voice/fake"
+import { createSidecarVoice } from "./voice/sidecar"
+import { createLocalVoice, LocalVoiceUnavailable } from "./voice/local"
+import { openCanvas } from "./browser"
+import type { VoiceAdapter } from "./voice/adapter"
+import type { InputKind } from "./state"
+
+const log = Log.create({ service: "design" })
+
+function parseModel(value?: string): ModelRef | undefined {
+  if (!value) return undefined
+  const [providerID, ...rest] = value.split("/")
+  if (!providerID || rest.length === 0) return undefined
+  return { providerID, modelID: rest.join("/") }
+}
+
+type DesignArgs = {
+  url?: string
+  dir?: string
+  voice: string
+  "voice-helper-command"?: string
+  "voice-backend": string
+  "voice-activation": string
+  "silence-ms"?: number
+  "dev-command"?: string
+  browser: boolean
+  agent: string
+  model?: string
+}
+
+export const DesignCommand = effectCmd({
+  command: "design",
+  describe: "experimental: voice-steered live design iteration",
+  // Root the design session where the canvas lives so the agent edits that app,
+  // not whatever directory the launcher happened to start in.
+  directory: (args) => (args.dir ? path.resolve(process.cwd(), args.dir) : process.cwd()),
+  builder: (yargs: Argv) =>
+    yargs
+      .option("url", {
+        type: "string",
+        describe: "Browser Canvas URL (the running app to steer)",
+      })
+      .option("dir", {
+        type: "string",
+        describe: "directory the design session edits (defaults to current directory)",
+      })
+      .option("voice", {
+        type: "string",
+        choices: ["fake", "local"] as const,
+        default: "fake",
+        describe: "voice source: fake (typed) or local (sidecar)",
+      })
+      .option("voice-helper-command", {
+        type: "string",
+        describe: "command that speaks the Voice Helper Protocol (JSONL); used with --voice local",
+      })
+      .option("voice-backend", {
+        type: "string",
+        choices: ["apple-speech", "fluidaudio-eou"] as const,
+        default: "apple-speech",
+        describe: "local voice backend (fluidaudio-eou lands in a later milestone)",
+      })
+      .option("voice-activation", {
+        type: "string",
+        choices: ["continuous", "push-to-talk"] as const,
+        default: "continuous",
+        describe: "continuous always-on listening (default) or push-to-talk",
+      })
+      .option("silence-ms", {
+        type: "number",
+        describe: "end-of-utterance silence window for local voice (default 1100)",
+      })
+      .option("dev-command", {
+        type: "string",
+        describe: "command to start the dev server (reserved; resolver lands in M3)",
+      })
+      .option("browser", {
+        type: "boolean",
+        default: true,
+        describe: "auto-open the Browser Canvas (use --no-browser to skip)",
+      })
+      .option("agent", {
+        type: "string",
+        default: "build",
+        describe: "agent to use for the design session",
+      })
+      .option("model", {
+        type: "string",
+        describe: "model in provider/model form, e.g. kilo/anthropic/claude-haiku-4.5 (a fast model feels best)",
+      }) as Argv<DesignArgs>,
+  handler: Effect.fn("Cli.design")(function* (args) {
+    const input: InputKind = args.voice === "fake" ? "fake" : "voice"
+
+    const activation = args["voice-activation"] === "push-to-talk" ? "push-to-talk" : "continuous"
+
+    // Build the voice source.
+    const adapter: VoiceAdapter = yield* Effect.gen(function* () {
+      if (args.voice === "fake") return createFakeVoice()
+
+      // An explicit helper command always wins (protocol seam / scripted turns).
+      const helper = args["voice-helper-command"]
+      if (helper) return createSidecarVoice({ command: [helper], shell: true, activation })
+
+      if (args["voice-backend"] === "fluidaudio-eou") {
+        return yield* fail(
+          "the fluidaudio-eou backend lands in a later milestone. Use --voice-backend apple-speech (default) or --voice-helper-command.",
+        )
+      }
+
+      // Bundled Apple Speech sidecar (builds from source on first run).
+      try {
+        return createLocalVoice({ activation, silenceMs: args["silence-ms"] })
+      } catch (err) {
+        if (err instanceof LocalVoiceUnavailable) return yield* fail(err.message)
+        throw err
+      }
+    })
+
+    const bus = yield* Bus.Service
+    // Forward holder: the session is created before the orchestrator, but dispatch
+    // errors must reach the orchestrator's surface once it exists.
+    let reportError: (message: string) => void = () => {}
+    const session = yield* createActiveSession({
+      agent: args.agent,
+      input,
+      model: parseModel(args.model),
+      target: args.url,
+      onError: (message) => reportError(message),
+    })
+
+    log.info("design session started", { sessionID: session.sessionID, voice: args.voice })
+
+    let resolveDone: () => void = () => {}
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve
+    })
+    let quitting = false
+    const quit = () => {
+      if (quitting) return
+      quitting = true
+      resolveDone()
+    }
+
+    // Wire the orchestrator to the surface and the session. The surface and the
+    // orchestrator reference each other, so the surface's handlers close over
+    // `orchestrator` (assigned just below, before any input can fire).
+    const surface = createTerminalSurface({
+      input,
+      target: args.url,
+      onLine: (text) => orchestrator.submitLine(text),
+      onEscape: () => orchestrator.escape(),
+      onQuit: quit,
+    })
+
+    const orchestrator = createOrchestrator({
+      adapter,
+      input,
+      target: args.url,
+      dispatch: session.dispatch,
+      cancel: session.cancel,
+      render: (state) => surface.setState(state),
+    })
+    reportError = (message) => orchestrator.reportError(message)
+
+    // Agent busy/idle comes from the session bus, not from the dispatch promise.
+    const offOpen = yield* bus.subscribeCallback(Session.Event.TurnOpen, (event) => {
+      if (event.properties.sessionID === session.sessionID) orchestrator.agentOpen()
+    })
+    const offClose = yield* bus.subscribeCallback(Session.Event.TurnClose, (event) => {
+      if (event.properties.sessionID === session.sessionID) orchestrator.agentClose(event.properties.reason)
+    })
+
+    if (args.browser && args.url) openCanvas(args.url)
+
+    surface.start()
+    yield* Effect.promise(() => orchestrator.start())
+
+    yield* Effect.promise(() => done).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          offOpen()
+          offClose()
+          void orchestrator.stop()
+          surface.stop()
+        }),
+      ),
+    )
+  }),
+})

--- a/packages/opencode/src/kilocode/design/metadata.ts
+++ b/packages/opencode/src/kilocode/design/metadata.ts
@@ -1,0 +1,25 @@
+// Builds the metadata attached to the user text part for each dispatched turn,
+// so downstream (and any future analytics) can tell a Design Mode voice turn
+// apart from a normal chat message.
+
+import type { InputKind, Turn } from "./state"
+
+export type DesignMetadata = {
+  source: "design-mode"
+  input: InputKind
+  turnId: string
+  queued: boolean
+  latencyMs?: number
+  target?: string
+}
+
+export function designMetadata(turn: Turn, opts: { input: InputKind; target?: string }): DesignMetadata {
+  return {
+    source: "design-mode",
+    input: opts.input,
+    turnId: turn.id,
+    queued: turn.queued,
+    ...(turn.latencyMs !== undefined ? { latencyMs: turn.latencyMs } : {}),
+    ...(opts.target ? { target: opts.target } : {}),
+  }
+}

--- a/packages/opencode/src/kilocode/design/orchestrator.ts
+++ b/packages/opencode/src/kilocode/design/orchestrator.ts
@@ -1,0 +1,101 @@
+// The orchestrator owns the live loop. It holds the reducer state, feeds it
+// voice events and agent lifecycle signals, and runs the resulting effects
+// against injected sinks (dispatch / cancel). It is plain TypeScript so it can
+// be driven in tests by the real fake-voice adapter plus a stub dispatch sink —
+// no Effect runtime, no mocks.
+
+import type { VoiceAdapter } from "./voice/adapter"
+import type { VoiceEvent } from "./voice/protocol"
+import { initialState, reduce, type Action, type Effect, type InputKind, type State, type Turn } from "./state"
+
+export type OrchestratorOpts = {
+  adapter: VoiceAdapter
+  input: InputKind
+  target?: string
+  /** Dispatch a turn to the agent. Fire-and-forget; report progress via agentOpen/agentClose. */
+  dispatch: (turn: Turn) => void
+  /** Interrupt the active agent turn. */
+  cancel: () => void
+  /** Called after every state change so the surface can repaint. */
+  render: (state: State) => void
+}
+
+export type Orchestrator = {
+  start(): Promise<void>
+  /** Feed a typed line (fake voice) — becomes a finalized turn. */
+  submitLine(text: string): void
+  /** Escape: interrupt + clear queue, keep listening. */
+  escape(): void
+  /** Agent run started (from the session bus). */
+  agentOpen(): void
+  /** Agent run finished (from the session bus). */
+  agentClose(reason: "completed" | "error" | "interrupted"): void
+  /** Surface an error (e.g. a failed dispatch) on the console. */
+  reportError(message: string): void
+  stop(): Promise<void>
+  /** Current snapshot — exposed for tests and the surface. */
+  current(): State
+}
+
+export function createOrchestrator(opts: OrchestratorOpts): Orchestrator {
+  let state = initialState({ target: opts.target })
+  // When the active turn was dispatched, for real loop-latency (dispatch → close).
+  let dispatchAt = 0
+
+  function runEffect(effect: Effect) {
+    switch (effect.type) {
+      case "dispatch":
+        dispatchAt = Date.now()
+        opts.dispatch(effect.turn)
+        return
+      case "cancel":
+        opts.cancel()
+        return
+      case "reset-voice":
+        opts.adapter.reset()
+        return
+    }
+  }
+
+  function apply(action: Action) {
+    const result = reduce(state, action)
+    state = result.state
+    for (const effect of result.effects) runEffect(effect)
+    opts.render(state)
+  }
+
+  function onVoice(event: VoiceEvent) {
+    apply({ type: "voice", event })
+  }
+
+  return {
+    async start() {
+      await opts.adapter.start(onVoice)
+      opts.render(state)
+    },
+    submitLine(text) {
+      // In fake mode this injects a turn event; real sources segment audio
+      // themselves and don't implement inject, so typed lines are ignored.
+      opts.adapter.inject?.(text)
+    },
+    escape() {
+      apply({ type: "escape" })
+    },
+    agentOpen() {
+      apply({ type: "agent-open" })
+    },
+    agentClose(reason) {
+      const latencyMs = dispatchAt ? Date.now() - dispatchAt : undefined
+      apply({ type: "agent-close", reason, latencyMs })
+    },
+    reportError(message) {
+      apply({ type: "error", message })
+    },
+    async stop() {
+      await opts.adapter.shutdown()
+    },
+    current() {
+      return state
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/design/session.ts
+++ b/packages/opencode/src/kilocode/design/session.ts
@@ -1,0 +1,77 @@
+// ActiveDesignSession: one persistent Kilo session, driven in-process. Creates
+// the session, then returns plain `dispatch`/`cancel` callbacks the orchestrator
+// can fire from stdin/voice events. Each callback is wrapped with `Instance.bind`
+// so it restores the instance ALS when invoked outside the Effect fiber (the
+// callbacks fire from terminal input handlers), letting `AppRuntime.runPromise`
+// resolve the per-project services correctly.
+
+import { Effect } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { ModelID, ProviderID } from "@/provider/schema"
+import type { Permission } from "@/permission"
+import { Instance } from "@/project/instance"
+import { AppRuntime } from "@/effect/app-runtime"
+import { designMetadata } from "./metadata"
+import type { InputKind, Turn } from "./state"
+
+const log = Log.create({ service: "design.session" })
+
+export type ModelRef = { providerID: string; modelID: string }
+
+export type ActiveDesignSession = {
+  sessionID: string
+  /** Fire a turn at the agent (non-blocking). Progress arrives via the session bus. */
+  dispatch: (turn: Turn) => void
+  /** Interrupt the active agent turn. */
+  cancel: () => void
+}
+
+export const createActiveSession = Effect.fn("Design.createActiveSession")(function* (opts: {
+  agent: string
+  input: InputKind
+  model?: ModelRef
+  target?: string
+  /** Reports a dispatch failure (e.g. invalid model) so the surface can show it. */
+  onError?: (message: string) => void
+}) {
+  const sessions = yield* Session.Service
+  const prompt = yield* SessionPrompt.Service
+  // Design Mode is a fast, hands-free loop: auto-approve tool use so turns apply
+  // edits without blocking on permission prompts (the surface has none).
+  const permission: Permission.Ruleset = [{ permission: "*", pattern: "*", action: "allow" }]
+  const info = yield* sessions.create({ agent: opts.agent, permission })
+  const sessionID = info.id
+
+  const dispatch = Instance.bind((turn: Turn) => {
+    const effect = prompt.prompt({
+      sessionID,
+      agent: opts.agent,
+      ...(opts.model
+        ? { model: { providerID: ProviderID.make(opts.model.providerID), modelID: ModelID.make(opts.model.modelID) } }
+        : {}),
+      parts: [
+        {
+          type: "text",
+          text: turn.text,
+          metadata: designMetadata(turn, { input: opts.input, target: opts.target }),
+        },
+      ],
+    })
+    // Fire-and-forget: the orchestrator advances its queue from TurnClose on the
+    // bus, not from this promise. We only surface dispatch failures here.
+    AppRuntime.runPromise(effect).catch((err) => {
+      log.error("dispatch failed", { sessionID, turnId: turn.id, err })
+      opts.onError?.(err instanceof Error ? err.message : String(err))
+    })
+  })
+
+  const cancel = Instance.bind(() => {
+    AppRuntime.runPromise(prompt.cancel(sessionID)).catch((err) => {
+      log.error("cancel failed", { sessionID, err })
+    })
+  })
+
+  return { sessionID, dispatch, cancel } satisfies ActiveDesignSession
+})

--- a/packages/opencode/src/kilocode/design/state.ts
+++ b/packages/opencode/src/kilocode/design/state.ts
@@ -1,0 +1,177 @@
+// Pure reducer for Design Mode turn handling.
+//
+// Everything stateful about the loop lives here as `(state, action) -> {state,
+// effects}`. No timers, no IO, no randomness — so the whole turn lifecycle
+// (continuous capture, queue-while-busy, ordered drain, Escape barge-in) is
+// exhaustively unit-testable without mocks. The orchestrator runs the returned
+// effects against the real session/voice adapter.
+
+import type { VoiceEvent, VoiceState } from "./voice/protocol"
+
+export type AgentState = "idle" | "busy"
+export type InputKind = "voice" | "fake"
+
+export type Turn = {
+  id: string
+  text: string
+  /** True if it waited in the queue rather than dispatching immediately. */
+  queued: boolean
+  latencyMs?: number
+}
+
+export type State = {
+  voice: VoiceState
+  agent: AgentState
+  /** The turn currently dispatched and awaiting completion, if any. */
+  active?: Turn
+  /** Finalized turns waiting for the agent to free up. */
+  queue: Turn[]
+  /** Live partial transcript while the user is speaking. */
+  partial: string
+  /** Recent finalized turns, newest last — the rolling transcript. */
+  transcript: Turn[]
+  /** Count of finalized turns this session. */
+  turns: number
+  /** Mic level 0..1 for the meter. */
+  level: number
+  lastLatencyMs?: number
+  /** Monotonic counter used to mint turn ids deterministically. */
+  seq: number
+  target?: string
+  error?: string
+}
+
+export type Action =
+  | { type: "voice"; event: VoiceEvent }
+  | { type: "agent-open" }
+  | { type: "agent-close"; reason: "completed" | "error" | "interrupted"; latencyMs?: number }
+  | { type: "error"; message: string }
+  | { type: "escape" }
+
+export type Effect =
+  | { type: "dispatch"; turn: Turn }
+  | { type: "cancel" }
+  | { type: "reset-voice" }
+
+export type Reduced = { state: State; effects: Effect[] }
+
+const TRANSCRIPT_LIMIT = 50
+
+export function initialState(input?: { target?: string; voice?: VoiceState }): State {
+  return {
+    voice: input?.voice ?? "standby",
+    agent: "idle",
+    queue: [],
+    partial: "",
+    transcript: [],
+    turns: 0,
+    level: 0,
+    seq: 0,
+    target: input?.target,
+  }
+}
+
+function pushTranscript(transcript: Turn[], turn: Turn): Turn[] {
+  const next = [...transcript, turn]
+  return next.length > TRANSCRIPT_LIMIT ? next.slice(next.length - TRANSCRIPT_LIMIT) : next
+}
+
+/** Build a finalized turn from a voice `turn` event, minting an id if needed. */
+function makeTurn(state: State, event: Extract<VoiceEvent, { type: "turn" }>, queued: boolean): Turn {
+  const seq = state.seq + 1
+  return {
+    id: event.turnId ?? `turn_${String(seq).padStart(3, "0")}`,
+    text: event.text,
+    queued,
+    ...(event.latencyMs !== undefined ? { latencyMs: event.latencyMs } : {}),
+  }
+}
+
+function onTurn(state: State, event: Extract<VoiceEvent, { type: "turn" }>): Reduced {
+  // Nothing in flight: dispatch immediately.
+  if (!state.active) {
+    const turn = makeTurn(state, event, false)
+    return {
+      state: {
+        ...state,
+        active: turn,
+        partial: "",
+        transcript: pushTranscript(state.transcript, turn),
+        turns: state.turns + 1,
+        seq: state.seq + 1,
+      },
+      effects: [{ type: "dispatch", turn }],
+    }
+  }
+  // Agent busy: queue as a follow-up — "kept active while the agent edits".
+  const turn = makeTurn(state, event, true)
+  return {
+    state: {
+      ...state,
+      queue: [...state.queue, turn],
+      partial: "",
+      transcript: pushTranscript(state.transcript, turn),
+      turns: state.turns + 1,
+      seq: state.seq + 1,
+    },
+    effects: [],
+  }
+}
+
+function onVoice(state: State, event: VoiceEvent): Reduced {
+  switch (event.type) {
+    case "state":
+      return { state: { ...state, voice: event.value }, effects: [] }
+    case "partial":
+      return { state: { ...state, partial: event.text }, effects: [] }
+    case "level":
+      return { state: { ...state, level: event.peak }, effects: [] }
+    case "error":
+      return { state: { ...state, error: event.message }, effects: [] }
+    case "turn":
+      return onTurn(state, event)
+  }
+}
+
+function onAgentClose(state: State, latencyMs?: number): Reduced {
+  const last = latencyMs ?? state.lastLatencyMs
+  const [next, ...rest] = state.queue
+  if (!next) {
+    return { state: { ...state, agent: "idle", active: undefined, lastLatencyMs: last }, effects: [] }
+  }
+  // Drain the next queued turn in order.
+  return {
+    state: { ...state, agent: "busy", active: next, queue: rest, lastLatencyMs: last },
+    effects: [{ type: "dispatch", turn: next }],
+  }
+}
+
+/** Escape = hard interrupt: cancel active work, clear the queue, keep listening. */
+function onEscape(state: State): Reduced {
+  return {
+    state: {
+      ...state,
+      agent: "idle",
+      active: undefined,
+      queue: [],
+      partial: "",
+      error: undefined,
+    },
+    effects: [{ type: "cancel" }, { type: "reset-voice" }],
+  }
+}
+
+export function reduce(state: State, action: Action): Reduced {
+  switch (action.type) {
+    case "voice":
+      return onVoice(state, action.event)
+    case "agent-open":
+      return { state: { ...state, agent: "busy" }, effects: [] }
+    case "agent-close":
+      return onAgentClose(state, action.latencyMs)
+    case "error":
+      return { state: { ...state, error: action.message }, effects: [] }
+    case "escape":
+      return onEscape(state)
+  }
+}

--- a/packages/opencode/src/kilocode/design/surface/terminal.ts
+++ b/packages/opencode/src/kilocode/design/surface/terminal.ts
@@ -1,0 +1,118 @@
+// Terminal IO for the voice console: raw-mode keypress handling plus in-place
+// repaint of the pure `view` lines. Deliberately lightweight (ANSI redraw, not
+// a full reactive OpenTUI tree) so the exploratory MVP is robust and easy to
+// reason about; the view itself is pure and unit-tested in view.ts.
+
+import { resolveInteractiveStdin } from "@/cli/cmd/run/runtime.stdin"
+import type { InputKind, State } from "../state"
+import { initialState } from "../state"
+import { renderText } from "./view"
+
+export type TerminalSurface = {
+  start(): void
+  setState(state: State): void
+  stop(): void
+}
+
+export type SurfaceHandlers = {
+  input: InputKind
+  target?: string
+  /** A finalized typed line (fake voice). */
+  onLine(text: string): void
+  /** Escape pressed. */
+  onEscape(): void
+  /** Ctrl+C — quit. */
+  onQuit(): void
+}
+
+const ESC = "\x1b"
+const HIDE_CURSOR = `${ESC}[?25l`
+const SHOW_CURSOR = `${ESC}[?25h`
+
+export function createTerminalSurface(handlers: SurfaceHandlers): TerminalSurface {
+  const source = resolveInteractiveStdin()
+  const stdin = source.stdin
+  let state: State = initialState({ target: handlers.target })
+  let draft = ""
+  let lastLineCount = 0
+  let started = false
+
+  function frame(): string {
+    return renderText({ state, input: handlers.input, draft })
+  }
+
+  function paint() {
+    const text = frame()
+    const lines = text.split("\n")
+    const out: string[] = []
+    if (lastLineCount > 0) {
+      // Move to the top of the previous frame and clear downward.
+      out.push(`${ESC}[${lastLineCount - 1}A`)
+      out.push(`${ESC}[0G`)
+      out.push(`${ESC}[0J`)
+    }
+    out.push(lines.join("\r\n"))
+    lastLineCount = lines.length
+    process.stdout.write(out.join(""))
+  }
+
+  function onData(chunk: Buffer) {
+    // Lone Escape (not a CSI sequence like arrow keys).
+    if (chunk.length === 1 && chunk[0] === 0x1b) {
+      handlers.onEscape()
+      return
+    }
+    // Ignore multi-byte control sequences (arrows, function keys).
+    if (chunk[0] === 0x1b) return
+
+    for (const byte of chunk) {
+      if (byte === 0x03) {
+        handlers.onQuit()
+        return
+      }
+      if (byte === 0x0d || byte === 0x0a) {
+        const line = draft.trim()
+        draft = ""
+        paint()
+        if (line) handlers.onLine(line)
+        continue
+      }
+      if (byte === 0x7f || byte === 0x08) {
+        if (draft.length > 0) {
+          draft = draft.slice(0, -1)
+          paint()
+        }
+        continue
+      }
+      // Printable ASCII — only meaningful for typed (fake) input.
+      if (byte >= 0x20 && byte < 0x7f && handlers.input === "fake") {
+        draft += String.fromCharCode(byte)
+        paint()
+      }
+    }
+  }
+
+  return {
+    start() {
+      if (started) return
+      started = true
+      if (stdin.isTTY) stdin.setRawMode?.(true)
+      stdin.resume()
+      stdin.on("data", onData)
+      process.stdout.write(HIDE_CURSOR)
+      paint()
+    },
+    setState(next) {
+      state = next
+      if (started) paint()
+    },
+    stop() {
+      if (!started) return
+      started = false
+      stdin.off("data", onData)
+      if (stdin.isTTY) stdin.setRawMode?.(false)
+      process.stdout.write("\r\n" + SHOW_CURSOR)
+      source.cleanup?.()
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/design/surface/view.ts
+++ b/packages/opencode/src/kilocode/design/surface/view.ts
@@ -1,0 +1,84 @@
+// Pure rendering of the voice console. Takes a State (+ a little ambient input)
+// and returns the lines to paint. Kept free of ANSI/IO so it can be snapshot-
+// tested; the terminal layer adds cursor moves and colors around these strings.
+
+import type { State, InputKind } from "../state"
+
+export type ViewInput = {
+  state: State
+  input: InputKind
+  /** The line the user is currently typing (fake voice only). */
+  draft?: string
+  width?: number
+}
+
+const VOICE_GLYPH: Record<State["voice"], string> = {
+  standby: "○",
+  "requesting-permission": "◌",
+  listening: "●",
+  speaking: "◉",
+  processing: "◍",
+}
+
+/** A small bar meter for mic level, 0..1. */
+export function meter(level: number, slots = 12): string {
+  const filled = Math.round(Math.min(1, Math.max(0, level)) * slots)
+  return "[" + "#".repeat(filled) + ".".repeat(slots - filled) + "]"
+}
+
+function truncate(text: string, width: number): string {
+  if (text.length <= width) return text
+  if (width <= 1) return text.slice(0, width)
+  return text.slice(0, width - 1) + "…"
+}
+
+/**
+ * Build the console lines top-to-bottom:
+ *   voice-activity indicator, rolling transcript, status, hint.
+ */
+export function render(input: ViewInput): string[] {
+  const state = input.state
+  const width = input.width ?? 80
+  const lines: string[] = []
+
+  // Voice-activity indicator — the prominent "I'm listening" signal.
+  const glyph = VOICE_GLYPH[state.voice]
+  lines.push(`${glyph} voice: ${state.voice}   ${meter(state.level)}`)
+
+  // Rolling live transcript: recent finalized turns, then the in-progress line.
+  lines.push("")
+  const recent = state.transcript.slice(-5)
+  if (recent.length === 0 && !state.partial && !input.draft) {
+    lines.push("  (say something — I'm listening)")
+  } else {
+    for (const turn of recent) {
+      const mark = turn.queued ? "⋯" : "›"
+      lines.push("  " + truncate(`${mark} ${turn.text}`, width - 2))
+    }
+    const live = input.input === "fake" ? (input.draft ?? "") : state.partial
+    if (live) lines.push("  " + truncate(`… ${live}`, width - 2))
+  }
+
+  // Status line.
+  lines.push("")
+  const latency = state.lastLatencyMs !== undefined ? `${state.lastLatencyMs}ms` : "—"
+  const active = state.active ? "working" : "idle"
+  lines.push(
+    `agent: ${active}  ·  turns: ${state.turns}  ·  queued: ${state.queue.length}  ·  last: ${latency}` +
+      (state.target ? `  ·  ${truncate(state.target, 30)}` : ""),
+  )
+  if (state.error) lines.push(`error: ${truncate(state.error, width - 8)}`)
+
+  // Hint.
+  const hint =
+    input.input === "fake"
+      ? "type a change + Enter · Esc cancels & clears · Ctrl+C exits"
+      : "just keep talking · Esc cancels & clears · Ctrl+C exits"
+  lines.push(hint)
+
+  return lines
+}
+
+export function renderText(input: ViewInput): string {
+  return render(input).join("\n")
+}

--- a/packages/opencode/src/kilocode/design/surface/view.ts
+++ b/packages/opencode/src/kilocode/design/surface/view.ts
@@ -15,6 +15,7 @@ export type ViewInput = {
 const VOICE_GLYPH: Record<State["voice"], string> = {
   standby: "○",
   "requesting-permission": "◌",
+  loading: "◌",
   listening: "●",
   speaking: "◉",
   processing: "◍",

--- a/packages/opencode/src/kilocode/design/voice/adapter.ts
+++ b/packages/opencode/src/kilocode/design/voice/adapter.ts
@@ -1,0 +1,21 @@
+// The seam every voice source implements. The orchestrator only ever talks to
+// this interface, so fake voice, a scripted JSONL helper, and the Swift sidecar
+// are interchangeable.
+
+import type { VoiceCommand, VoiceEvent } from "./protocol"
+
+export type VoiceAdapter = {
+  /** Begin producing events. Resolves once the source is wired (not necessarily listening). */
+  start(onEvent: (event: VoiceEvent) => void): Promise<void> | void
+  /**
+   * Inject a finalized turn directly. Implemented by fake voice (typed lines);
+   * real sources that segment audio themselves leave this undefined.
+   */
+  inject?(text: string): void
+  /** Send a control command to the source (no-op for sources that don't take input). */
+  send?(cmd: VoiceCommand): void
+  /** Drop any in-progress capture and return to a clean listening state. */
+  reset(): void
+  /** Tear down the source and release the mic / child process. */
+  shutdown(): Promise<void> | void
+}

--- a/packages/opencode/src/kilocode/design/voice/fake.ts
+++ b/packages/opencode/src/kilocode/design/voice/fake.ts
@@ -1,0 +1,33 @@
+// Fake voice source: typed lines stand in for spoken utterances. This is a real
+// product component (used for `--voice fake`, tests, and dev), not a test mock —
+// it drives the exact same event path as the Swift sidecar.
+
+import type { VoiceAdapter } from "./adapter"
+import type { VoiceEvent } from "./protocol"
+
+export function createFakeVoice(): VoiceAdapter {
+  let emit: ((event: VoiceEvent) => void) | undefined
+  return {
+    start(onEvent) {
+      emit = onEvent
+      // Fake voice is "listening" the moment it starts — no permission prompt.
+      emit({ type: "state", value: "listening" })
+    },
+    inject(text) {
+      const trimmed = text.trim()
+      if (!trimmed || !emit) return
+      // Mirror the real source's shape: a brief processing blip, then a turn,
+      // then back to listening.
+      emit({ type: "state", value: "processing" })
+      emit({ type: "turn", text: trimmed })
+      emit({ type: "state", value: "listening" })
+    },
+    reset() {
+      emit?.({ type: "partial", text: "" })
+      emit?.({ type: "state", value: "listening" })
+    },
+    shutdown() {
+      emit = undefined
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/design/voice/local.ts
+++ b/packages/opencode/src/kilocode/design/voice/local.ts
@@ -1,0 +1,50 @@
+// Resolves and launches the bundled Swift voice sidecar for `--voice local`.
+// Builds from source on first run (dev/experimental gate); the sidecar speaks
+// the Voice Helper Protocol so it plugs into the same adapter as a scripted
+// helper.
+
+import path from "path"
+import { existsSync } from "fs"
+import { fileURLToPath } from "url"
+import { createSidecarVoice } from "./sidecar"
+import type { VoiceAdapter } from "./adapter"
+
+export type LocalVoiceOpts = {
+  activation: "continuous" | "push-to-talk"
+  silenceMs?: number
+}
+
+export class LocalVoiceUnavailable extends Error {}
+
+/** Locate `packages/kilo-voice-sidecar`. Honors KILO_VOICE_SIDECAR_DIR override. */
+export function resolveSidecarDir(): string {
+  const override = process.env["KILO_VOICE_SIDECAR_DIR"]
+  if (override) return override
+  const here = path.dirname(fileURLToPath(import.meta.url)) // .../src/kilocode/design/voice
+  return path.resolve(here, "../../../../../kilo-voice-sidecar")
+}
+
+export function createLocalVoice(opts: LocalVoiceOpts): VoiceAdapter {
+  if (process.platform !== "darwin") {
+    throw new LocalVoiceUnavailable(
+      "local voice (Apple Speech) is macOS-only. Use --voice fake, or --voice local --voice-helper-command \"<cmd>\".",
+    )
+  }
+  const dir = resolveSidecarDir()
+  if (!existsSync(path.join(dir, "Package.swift"))) {
+    throw new LocalVoiceUnavailable(
+      `voice sidecar package not found at ${dir}. Set KILO_VOICE_SIDECAR_DIR or use --voice-helper-command.`,
+    )
+  }
+  const flags = ["--activation", opts.activation, ...(opts.silenceMs ? ["--silence-ms", String(opts.silenceMs)] : [])]
+
+  // Prefer the prebuilt binary: fewer nested processes means cleaner microphone
+  // permission attribution, and no surprise rebuild mid-session. Fall back to
+  // `swift run` (which builds on demand) if it hasn't been built yet.
+  const binary = path.join(dir, ".build", "debug", "kilo-voice-sidecar")
+  const command = existsSync(binary)
+    ? [binary, ...flags]
+    : ["swift", "run", "--quiet", "kilo-voice-sidecar", ...flags]
+
+  return createSidecarVoice({ command, cwd: dir, shell: false, activation: opts.activation })
+}

--- a/packages/opencode/src/kilocode/design/voice/protocol.ts
+++ b/packages/opencode/src/kilocode/design/voice/protocol.ts
@@ -7,11 +7,12 @@
 // silently dropping malformed ones (a noisy sidecar must never crash the loop).
 
 /** Lifecycle states a voice source reports. Mirrors Yoke's status vocabulary. */
-export type VoiceState = "standby" | "requesting-permission" | "listening" | "speaking" | "processing"
+export type VoiceState = "standby" | "requesting-permission" | "loading" | "listening" | "speaking" | "processing"
 
 export const VOICE_STATES: readonly VoiceState[] = [
   "standby",
   "requesting-permission",
+  "loading",
   "listening",
   "speaking",
   "processing",

--- a/packages/opencode/src/kilocode/design/voice/protocol.ts
+++ b/packages/opencode/src/kilocode/design/voice/protocol.ts
@@ -1,0 +1,130 @@
+// Voice Helper Protocol — the contract between the orchestrator and any voice
+// source (the fake adapter, a scripted JSONL helper, or the Swift sidecar).
+//
+// A voice source emits newline-delimited JSON ("JSONL") on stdout. Each line is
+// one event. This module defines the event shape and a streaming parser that
+// turns raw stdout chunks into normalized events, tolerating partial lines and
+// silently dropping malformed ones (a noisy sidecar must never crash the loop).
+
+/** Lifecycle states a voice source reports. Mirrors Yoke's status vocabulary. */
+export type VoiceState = "standby" | "requesting-permission" | "listening" | "speaking" | "processing"
+
+export const VOICE_STATES: readonly VoiceState[] = [
+  "standby",
+  "requesting-permission",
+  "listening",
+  "speaking",
+  "processing",
+]
+
+/** A normalized event from a voice source. */
+export type VoiceEvent =
+  | { type: "state"; value: VoiceState }
+  /** Live, non-final transcript shown while the user is still speaking. */
+  | { type: "partial"; text: string }
+  /** A finalized utterance (automatic end-of-utterance, or a typed line in fake mode). */
+  | { type: "turn"; text: string; turnId?: string; latencyMs?: number }
+  /** Mic activity level 0..1, for the on-screen meter. */
+  | { type: "level"; peak: number }
+  | { type: "error"; message: string }
+
+/** Commands the orchestrator can send back to a voice source (over stdin). */
+export type VoiceCommand =
+  | { type: "stop" }
+  | { type: "reset" }
+  | { type: "shutdown" }
+  | { type: "set-activation"; value: "continuous" | "push-to-talk" }
+
+function isState(value: unknown): value is VoiceState {
+  return typeof value === "string" && (VOICE_STATES as readonly string[]).includes(value)
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0
+  return Math.min(1, Math.max(0, n))
+}
+
+/**
+ * Normalize one parsed JSON value into a VoiceEvent. Returns undefined for
+ * anything we don't recognize, so callers can drop junk without branching.
+ */
+export function normalize(raw: unknown): VoiceEvent | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  switch (obj.type) {
+    case "state":
+      return isState(obj.value) ? { type: "state", value: obj.value } : undefined
+    case "partial":
+      return typeof obj.text === "string" ? { type: "partial", text: obj.text } : undefined
+    case "turn": {
+      if (typeof obj.text !== "string") return undefined
+      const text = obj.text.trim()
+      if (!text) return undefined
+      return {
+        type: "turn",
+        text,
+        ...(typeof obj.turnId === "string" ? { turnId: obj.turnId } : {}),
+        ...(typeof obj.latencyMs === "number" && Number.isFinite(obj.latencyMs) ? { latencyMs: obj.latencyMs } : {}),
+      }
+    }
+    case "level":
+      return { type: "level", peak: clamp01(Number(obj.peak)) }
+    case "error":
+      return { type: "error", message: typeof obj.message === "string" ? obj.message : "voice error" }
+    default:
+      return undefined
+  }
+}
+
+/** Parse a single JSONL line into a VoiceEvent, or undefined if blank/malformed. */
+export function parseLine(line: string): VoiceEvent | undefined {
+  const trimmed = line.trim()
+  if (!trimmed) return undefined
+  try {
+    return normalize(JSON.parse(trimmed))
+  } catch {
+    // A malformed frame is expected occasionally (interleaved logging, partial
+    // flush). Dropping it is correct; the next valid frame recovers the stream.
+    return undefined
+  }
+}
+
+export type JsonlParser = {
+  /** Feed a raw chunk; returns any complete events it produced. */
+  write(chunk: string): VoiceEvent[]
+  /** Flush a trailing line with no newline (e.g. on stream end). */
+  flush(): VoiceEvent[]
+}
+
+/**
+ * Streaming JSONL parser. Buffers partial lines across chunks so a frame split
+ * over two reads still parses once its newline arrives.
+ */
+export function createJsonlParser(): JsonlParser {
+  let buffer = ""
+  return {
+    write(chunk) {
+      buffer += chunk
+      const events: VoiceEvent[] = []
+      let index = buffer.indexOf("\n")
+      while (index !== -1) {
+        const line = buffer.slice(0, index)
+        buffer = buffer.slice(index + 1)
+        const event = parseLine(line)
+        if (event) events.push(event)
+        index = buffer.indexOf("\n")
+      }
+      return events
+    },
+    flush() {
+      const rest = buffer
+      buffer = ""
+      const event = parseLine(rest)
+      return event ? [event] : []
+    },
+  }
+}
+
+export function encodeCommand(cmd: VoiceCommand): string {
+  return JSON.stringify(cmd) + "\n"
+}

--- a/packages/opencode/src/kilocode/design/voice/sidecar.ts
+++ b/packages/opencode/src/kilocode/design/voice/sidecar.ts
@@ -1,0 +1,86 @@
+// Child-process voice source. Spawns a helper command that speaks the Voice
+// Helper Protocol (JSONL on stdout, commands on stdin) and adapts it to the
+// VoiceAdapter seam. Used for `--voice local --voice-helper-command "<cmd>"`
+// and, later, for the bundled Swift sidecar. Keeping a generic JSONL helper as
+// a first-class path lets us exercise the exact same code with a scripted
+// helper before any native binary exists.
+
+import { Process, type Child } from "@/util/process"
+import * as Log from "@opencode-ai/core/util/log"
+import type { VoiceAdapter } from "./adapter"
+import { createJsonlParser, encodeCommand, type VoiceCommand, type VoiceEvent } from "./protocol"
+
+const log = Log.create({ service: "design.voice.sidecar" })
+
+export type SidecarOpts = {
+  /** Command argv to spawn (e.g. ["swift", "run", "kilo-voice-sidecar"]). */
+  command: string[]
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  /** Run the command through a shell (so a single quoted string works). */
+  shell?: boolean
+  activation?: "continuous" | "push-to-talk"
+}
+
+export function createSidecarVoice(opts: SidecarOpts): VoiceAdapter {
+  let child: Child | undefined
+  let emit: ((event: VoiceEvent) => void) | undefined
+
+  function command(cmd: VoiceCommand) {
+    if (child?.stdin && !child.stdin.destroyed) {
+      child.stdin.write(encodeCommand(cmd))
+    }
+  }
+
+  return {
+    start(onEvent) {
+      emit = onEvent
+      const proc = Process.spawn(opts.command, {
+        cwd: opts.cwd,
+        env: opts.env,
+        shell: opts.shell,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      child = proc
+
+      const parser = createJsonlParser()
+      proc.stdout?.setEncoding("utf8")
+      proc.stdout?.on("data", (chunk: string) => {
+        for (const event of parser.write(chunk)) emit?.(event)
+      })
+      proc.stderr?.setEncoding("utf8")
+      proc.stderr?.on("data", (chunk: string) => {
+        log.info("sidecar stderr", { chunk: chunk.trimEnd() })
+      })
+      proc.once("error", (err) => {
+        emit?.({ type: "error", message: `voice helper failed to start: ${err.message}` })
+      })
+      proc.exited.then(
+        (code) => {
+          for (const event of parser.flush()) emit?.(event)
+          if (code !== 0) emit?.({ type: "error", message: `voice helper exited (code ${code})` })
+        },
+        () => {},
+      )
+
+      if (opts.activation) command({ type: "set-activation", value: opts.activation })
+    },
+    send(cmd) {
+      command(cmd)
+    },
+    reset() {
+      command({ type: "reset" })
+    },
+    async shutdown() {
+      emit = undefined
+      if (!child) return
+      command({ type: "shutdown" })
+      const proc = child
+      child = undefined
+      await Promise.race([proc.exited.catch(() => 0), Bun.sleep(500)])
+      await Process.stop(proc)
+    },
+  }
+}

--- a/packages/opencode/test/kilocode/design/metadata.test.ts
+++ b/packages/opencode/test/kilocode/design/metadata.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { designMetadata } from "../../../src/kilocode/design/metadata"
+import type { Turn } from "../../../src/kilocode/design/state"
+
+describe("designMetadata", () => {
+  test("builds metadata for a voice turn", () => {
+    const turn: Turn = { id: "turn_001", text: "make it blue", queued: false, latencyMs: 120 }
+    expect(designMetadata(turn, { input: "voice", target: "http://localhost:3000" })).toEqual({
+      source: "design-mode",
+      input: "voice",
+      turnId: "turn_001",
+      queued: false,
+      latencyMs: 120,
+      target: "http://localhost:3000",
+    })
+  })
+
+  test("omits optional fields when absent", () => {
+    const turn: Turn = { id: "turn_002", text: "go", queued: true }
+    expect(designMetadata(turn, { input: "fake" })).toEqual({
+      source: "design-mode",
+      input: "fake",
+      turnId: "turn_002",
+      queued: true,
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/design/orchestrator.test.ts
+++ b/packages/opencode/test/kilocode/design/orchestrator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import { createOrchestrator } from "../../../src/kilocode/design/orchestrator"
+import { createFakeVoice } from "../../../src/kilocode/design/voice/fake"
+import type { State, Turn } from "../../../src/kilocode/design/state"
+
+// Drives the orchestrator with the real fake-voice adapter and a stub dispatch
+// sink that records turns and lets the test control agent busy/idle — exercising
+// the same path real voice + a real session would take. No mocks.
+function harness() {
+  const dispatched: Turn[] = []
+  let cancels = 0
+  const renders: State[] = []
+  const orchestrator = createOrchestrator({
+    adapter: createFakeVoice(),
+    input: "fake",
+    dispatch: (turn) => {
+      dispatched.push(turn)
+      // Mimic the session bus: a dispatch opens an agent turn.
+      orchestrator.agentOpen()
+    },
+    cancel: () => {
+      cancels++
+    },
+    render: (state) => {
+      renders.push(state)
+    },
+  })
+  return {
+    orchestrator,
+    dispatched,
+    renders,
+    cancels: () => cancels,
+    complete: () => orchestrator.agentClose("completed"),
+  }
+}
+
+describe("orchestrator with fake voice", () => {
+  test("a typed line dispatches one turn and goes listening", async () => {
+    const h = harness()
+    await h.orchestrator.start()
+    h.orchestrator.submitLine("make the brand color green")
+
+    expect(h.dispatched.map((t) => t.text)).toEqual(["make the brand color green"])
+    expect(h.orchestrator.current().voice).toBe("listening")
+    expect(h.orchestrator.current().agent).toBe("busy")
+  })
+
+  test("speech while busy queues, then drains in order on completion", async () => {
+    const h = harness()
+    await h.orchestrator.start()
+
+    h.orchestrator.submitLine("first")
+    h.orchestrator.submitLine("second")
+    h.orchestrator.submitLine("third")
+
+    // Only the first dispatched; the rest are queued behind the active turn.
+    expect(h.dispatched.map((t) => t.text)).toEqual(["first"])
+    expect(h.orchestrator.current().queue.map((t) => t.text)).toEqual(["second", "third"])
+
+    h.complete()
+    expect(h.dispatched.map((t) => t.text)).toEqual(["first", "second"])
+    h.complete()
+    expect(h.dispatched.map((t) => t.text)).toEqual(["first", "second", "third"])
+    h.complete()
+    expect(h.orchestrator.current().agent).toBe("idle")
+    expect(h.orchestrator.current().queue).toEqual([])
+  })
+
+  test("Escape cancels the active turn, clears the queue, and keeps listening", async () => {
+    const h = harness()
+    await h.orchestrator.start()
+
+    h.orchestrator.submitLine("first")
+    h.orchestrator.submitLine("second")
+    h.orchestrator.escape()
+
+    expect(h.cancels()).toBe(1)
+    expect(h.orchestrator.current().active).toBeUndefined()
+    expect(h.orchestrator.current().queue).toEqual([])
+    expect(h.orchestrator.current().voice).toBe("listening")
+
+    // Still usable afterwards.
+    h.orchestrator.submitLine("fresh start")
+    expect(h.dispatched.at(-1)?.text).toBe("fresh start")
+  })
+
+  test("blank typed lines are ignored", async () => {
+    const h = harness()
+    await h.orchestrator.start()
+    h.orchestrator.submitLine("   ")
+    expect(h.dispatched).toEqual([])
+  })
+
+  test("reportError surfaces a dispatch failure on the surface", async () => {
+    const h = harness()
+    await h.orchestrator.start()
+    h.orchestrator.reportError("Model not found: kilo/minimax/minimax-m2.1:free")
+    expect(h.orchestrator.current().error).toContain("Model not found")
+  })
+})

--- a/packages/opencode/test/kilocode/design/protocol.test.ts
+++ b/packages/opencode/test/kilocode/design/protocol.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+import { createJsonlParser, encodeCommand, normalize, parseLine } from "../../../src/kilocode/design/voice/protocol"
+
+describe("voice protocol normalize", () => {
+  test("accepts known states", () => {
+    expect(normalize({ type: "state", value: "listening" })).toEqual({ type: "state", value: "listening" })
+  })
+
+  test("rejects unknown state values", () => {
+    expect(normalize({ type: "state", value: "asleep" })).toBeUndefined()
+  })
+
+  test("trims and keeps turn text, dropping empty turns", () => {
+    expect(normalize({ type: "turn", text: "  make it blue  " })).toEqual({ type: "turn", text: "make it blue" })
+    expect(normalize({ type: "turn", text: "   " })).toBeUndefined()
+  })
+
+  test("carries turnId and latency when present", () => {
+    expect(normalize({ type: "turn", text: "go", turnId: "t1", latencyMs: 42 })).toEqual({
+      type: "turn",
+      text: "go",
+      turnId: "t1",
+      latencyMs: 42,
+    })
+  })
+
+  test("clamps level into 0..1", () => {
+    expect(normalize({ type: "level", peak: 2 })).toEqual({ type: "level", peak: 1 })
+    expect(normalize({ type: "level", peak: -5 })).toEqual({ type: "level", peak: 0 })
+  })
+
+  test("ignores junk", () => {
+    expect(normalize(null)).toBeUndefined()
+    expect(normalize({ type: "nope" })).toBeUndefined()
+    expect(normalize(42)).toBeUndefined()
+  })
+})
+
+describe("parseLine", () => {
+  test("returns undefined for blank or malformed lines", () => {
+    expect(parseLine("")).toBeUndefined()
+    expect(parseLine("   ")).toBeUndefined()
+    expect(parseLine("{not json")).toBeUndefined()
+  })
+
+  test("parses a valid frame", () => {
+    expect(parseLine('{"type":"partial","text":"make"}')).toEqual({ type: "partial", text: "make" })
+  })
+})
+
+describe("streaming JSONL parser", () => {
+  test("emits complete frames and buffers partial lines across chunks", () => {
+    const parser = createJsonlParser()
+    const first = parser.write('{"type":"state","value":"listening"}\n{"type":"par')
+    expect(first).toEqual([{ type: "state", value: "listening" }])
+
+    const second = parser.write('tial","text":"hello"}\n')
+    expect(second).toEqual([{ type: "partial", text: "hello" }])
+  })
+
+  test("drops malformed frames but recovers on the next valid one", () => {
+    const parser = createJsonlParser()
+    const events = parser.write('garbage line\n{"type":"turn","text":"go"}\n')
+    expect(events).toEqual([{ type: "turn", text: "go" }])
+  })
+
+  test("flush parses a trailing newline-less line", () => {
+    const parser = createJsonlParser()
+    expect(parser.write('{"type":"turn","text":"a"}')).toEqual([])
+    expect(parser.flush()).toEqual([{ type: "turn", text: "a" }])
+  })
+})
+
+describe("encodeCommand", () => {
+  test("produces newline-terminated JSON", () => {
+    expect(encodeCommand({ type: "reset" })).toBe('{"type":"reset"}\n')
+  })
+})

--- a/packages/opencode/test/kilocode/design/state.test.ts
+++ b/packages/opencode/test/kilocode/design/state.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import { initialState, reduce, type Action, type State } from "../../../src/kilocode/design/state"
+
+function run(state: State, actions: Action[]): State {
+  return actions.reduce((acc, action) => reduce(acc, action).state, state)
+}
+
+const turn = (text: string, turnId?: string): Action => ({
+  type: "voice",
+  event: { type: "turn", text, ...(turnId ? { turnId } : {}) },
+})
+
+describe("design reducer — turn handling", () => {
+  test("dispatches immediately when idle and nothing active", () => {
+    const result = reduce(initialState(), turn("make it blue"))
+    expect(result.effects).toEqual([{ type: "dispatch", turn: result.state.active! }])
+    expect(result.state.active?.text).toBe("make it blue")
+    expect(result.state.active?.queued).toBe(false)
+    expect(result.state.turns).toBe(1)
+  })
+
+  test("queues follow-ups while a turn is active", () => {
+    const after = run(initialState(), [turn("first"), turn("second"), turn("third")])
+    expect(after.active?.text).toBe("first")
+    expect(after.queue.map((t) => t.text)).toEqual(["second", "third"])
+    expect(after.queue.every((t) => t.queued)).toBe(true)
+    expect(after.turns).toBe(3)
+  })
+
+  test("drains the queue in order on agent-close", () => {
+    let state = run(initialState(), [turn("first"), turn("second"), turn("third")])
+    state = reduce(state, { type: "agent-open" }).state
+
+    const close = reduce(state, { type: "agent-close", reason: "completed" })
+    expect(close.state.active?.text).toBe("second")
+    expect(close.effects).toEqual([{ type: "dispatch", turn: close.state.active! }])
+    expect(close.state.queue.map((t) => t.text)).toEqual(["third"])
+
+    const close2 = reduce(close.state, { type: "agent-close", reason: "completed" })
+    expect(close2.state.active?.text).toBe("third")
+
+    const idle = reduce(close2.state, { type: "agent-close", reason: "completed" })
+    expect(idle.state.active).toBeUndefined()
+    expect(idle.state.agent).toBe("idle")
+    expect(idle.effects).toEqual([])
+  })
+
+  test("uses provided turnId, else mints a padded sequential id", () => {
+    const a = reduce(initialState(), turn("x")).state
+    expect(a.active?.id).toBe("turn_001")
+    const b = reduce(initialState(), turn("x", "custom")).state
+    expect(b.active?.id).toBe("custom")
+  })
+})
+
+describe("design reducer — Escape barge-in", () => {
+  test("cancels active, clears queue, resets voice, stays listening", () => {
+    let state = run(initialState({ voice: "listening" }), [turn("first"), turn("second"), turn("third")])
+    state = reduce(state, { type: "agent-open" }).state
+
+    const escaped = reduce(state, { type: "escape" })
+    expect(escaped.effects).toEqual([{ type: "cancel" }, { type: "reset-voice" }])
+    expect(escaped.state.active).toBeUndefined()
+    expect(escaped.state.queue).toEqual([])
+    expect(escaped.state.agent).toBe("idle")
+    expect(escaped.state.voice).toBe("listening")
+  })
+
+  test("after Escape the next turn dispatches immediately again", () => {
+    let state = run(initialState(), [turn("first"), turn("second")])
+    state = reduce(state, { type: "escape" }).state
+    const next = reduce(state, turn("fresh"))
+    expect(next.effects).toEqual([{ type: "dispatch", turn: next.state.active! }])
+    expect(next.state.active?.text).toBe("fresh")
+  })
+})
+
+describe("design reducer — errors and latency", () => {
+  test("error action surfaces a message without effects", () => {
+    const result = reduce(initialState(), { type: "error", message: "Model not found: x/y" })
+    expect(result.effects).toEqual([])
+    expect(result.state.error).toBe("Model not found: x/y")
+  })
+
+  test("agent-close records the real turn latency", () => {
+    let state = reduce(initialState(), turn("first")).state
+    state = reduce(state, { type: "agent-open" }).state
+    state = reduce(state, { type: "agent-close", reason: "completed", latencyMs: 1234 }).state
+    expect(state.lastLatencyMs).toBe(1234)
+  })
+})
+
+describe("design reducer — voice surface state", () => {
+  test("tracks partial, level, and voice state without effects", () => {
+    let state = initialState()
+    state = reduce(state, { type: "voice", event: { type: "state", value: "processing" } }).state
+    state = reduce(state, { type: "voice", event: { type: "partial", text: "make the" } }).state
+    state = reduce(state, { type: "voice", event: { type: "level", peak: 0.4 } }).state
+    expect(state.voice).toBe("processing")
+    expect(state.partial).toBe("make the")
+    expect(state.level).toBe(0.4)
+  })
+
+  test("clears partial when a turn finalizes", () => {
+    let state = reduce(initialState(), { type: "voice", event: { type: "partial", text: "make the cards" } }).state
+    state = reduce(state, turn("make the cards three columns")).state
+    expect(state.partial).toBe("")
+    expect(state.transcript.at(-1)?.text).toBe("make the cards three columns")
+  })
+})

--- a/packages/opencode/test/kilocode/design/view.test.ts
+++ b/packages/opencode/test/kilocode/design/view.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { meter, render } from "../../../src/kilocode/design/surface/view"
+import { initialState, reduce, type State } from "../../../src/kilocode/design/state"
+
+function withTurns(...texts: string[]): State {
+  return texts.reduce(
+    (acc: State, text) => reduce(acc, { type: "voice", event: { type: "turn", text } }).state,
+    initialState({ voice: "listening" }),
+  )
+}
+
+describe("meter", () => {
+  test("renders proportional fill", () => {
+    expect(meter(0, 4)).toBe("[....]")
+    expect(meter(1, 4)).toBe("[####]")
+    expect(meter(0.5, 4)).toBe("[##..]")
+  })
+})
+
+describe("view render", () => {
+  test("shows the listening prompt when there is nothing yet", () => {
+    const lines = render({ state: initialState({ voice: "listening" }), input: "voice" })
+    expect(lines[0]).toContain("voice: listening")
+    expect(lines.join("\n")).toContain("I'm listening")
+  })
+
+  test("foregrounds the rolling transcript of recent turns", () => {
+    const lines = render({ state: withTurns("make it blue", "bigger title"), input: "voice" })
+    const text = lines.join("\n")
+    expect(text).toContain("make it blue")
+    expect(text).toContain("bigger title")
+  })
+
+  test("shows the typed draft in fake mode", () => {
+    const lines = render({ state: initialState({ voice: "listening" }), input: "fake", draft: "make the cards" })
+    expect(lines.join("\n")).toContain("make the cards")
+  })
+
+  test("status line reflects queue depth and turn count", () => {
+    let state = withTurns("first", "second", "third")
+    state = reduce(state, { type: "agent-open" }).state
+    const text = render({ state, input: "voice" }).join("\n")
+    expect(text).toContain("turns: 3")
+    expect(text).toContain("queued: 2")
+    expect(text).toContain("agent: working")
+  })
+
+  test("hint differs between voice and fake input", () => {
+    expect(render({ state: initialState(), input: "voice" }).at(-1)).toContain("keep talking")
+    expect(render({ state: initialState(), input: "fake" }).at(-1)).toContain("Enter")
+  })
+})


### PR DESCRIPTION
Adds an experimental `kilo design` command for voice-steered browser editing.

- Adds the in-process design session orchestrator, terminal surface, voice protocol/adapters, and tests.
- Adds a Swift Apple Speech sidecar plus a small in-repo design fixture app.
- Keeps the command dev-only and isolated under `src/kilocode/design` with a changeset.
- Includes the `loading` voice lifecycle state used by the sidecar before listening begins.

This is an exploratory MVP for evaluating the continuous voice-to-edit loop rather than a production feature.