### PR TITLE
console: show actual server listening address when --hostname 0.0.0.0 is used

### DIFF
--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -53,5 +53,6 @@ export const KiloConsoleCommand = cmd({
       console.warn(`Could not open browser automatically: ${err instanceof Error ? err.message : String(err)}`)
     })
     console.log(`Kilo Console: ${url}`)
+    console.log(`kilo server listening on http://${state.options.hostname}:${state.options.port}`)
   },
 })


### PR DESCRIPTION
Fixes #11027.

When running `kilo console --hostname 0.0.0.0 --port <port>` (or `kilo serve …`), the printed address shows `http://127.0.0.1:<port>` instead of the requested `0.0.0.0`. The server actually binds on all interfaces, but users only see the loopback address, making LAN access difficult to discover.

This change adds a log line that prints the actual server listening address using the raw hostname from the daemon options, so users see:

```
kilo server listening on http://0.0.0.0:4097
```

 alongside the existing Kilo Console URL.

- One-line change, zero risk.
- Improves LAN‑discoverability.
- Mirrors the format the server itself logs for consistency.

Testing:
- Built the CLI locally and verified the output shows both the console URL and the correct listening address.
- Ran the existing console‑command test suite – all tests pass.

Closes #11027.
