### PR TITLE
fix(console): add context to settings fields

### DIFF
--- a/packages/kilo-console/src/routes/config/AgentsRoute.tsx
+++ b/packages/kilo-console/src/routes/config/AgentsRoute.tsx
@@ -265,7 +265,10 @@ export function AgentBuilderRoute() {
                       onInput={(event) => state.setDesc(event.currentTarget.value)}
                     />
                   </FieldCard>
-                  <FieldCard label="Mode">
+                  <FieldCard
+                    label="Mode"
+                    description="Primary agents can run sessions directly; subagents are delegated to by other agents."
+                  >
                     <CustomSelect
                       label="Agent mode"
                       value={state.mode()}
@@ -323,6 +326,7 @@ export function AgentBuilderRoute() {
                 <div class="ui-form agent-builder-form">
                   <FieldCard
                     label="Model"
+                    description="Leave unset to inherit the default model, or choose one to pin this agent to a specific model."
                     actions={
                       <>
                         <Show when={!state.locked() && state.model()}>

--- a/packages/kilo-console/src/routes/config/ModelsRoute.tsx
+++ b/packages/kilo-console/src/routes/config/ModelsRoute.tsx
@@ -40,6 +40,7 @@ function chips(model: Model) {
   const list: string[] = []
   if (model.capabilities.toolcall) list.push("toolcall")
   if (model.capabilities.attachment) list.push("attachment")
+  if (model.capabilities.temperature) list.push("temperature")
   if (model.capabilities.input.image) list.push("vision")
   if (model.capabilities.input.audio || model.capabilities.output.audio) list.push("audio")
   return list
@@ -87,6 +88,7 @@ function Stat(props: { label: string; value: string; sub?: string; mono?: boolea
 const caps = [
   { key: "toolcall", label: "toolcall" },
   { key: "attachment", label: "attachment" },
+  { key: "temperature", label: "temperature" },
   { key: "input:image", label: "vision" },
   { key: "input:audio", label: "audio" },
 ] satisfies { key: Capability; label: string }[]
@@ -476,6 +478,7 @@ export function ModelsAvailableRoute() {
                     <Stat label="Input" value={money(item.model.cost.input)} sub="/ 1M tok" mono />
                     <Stat label="Output" value={money(item.model.cost.output)} sub="/ 1M tok" mono />
                     <Stat label="Reasoning" value={item.model.capabilities.reasoning ? "Yes" : "No"} />
+                    <Stat label="Temperature" value={item.model.capabilities.temperature ? "Yes" : "No"} />
                   </div>
                   <Show when={chips(item.model).length}>
                     <div class="tags model-capabilities">

--- a/packages/kilo-console/src/styles/models.css
+++ b/packages/kilo-console/src/styles/models.css
@@ -272,6 +272,10 @@
   flex-wrap: wrap;
 }
 
+.kilo-console .models-capabilities-list button {
+  text-transform: capitalize;
+}
+
 .kilo-console .explore-models {
   grid-template-columns: repeat(auto-fill, minmax(22.5rem, 1fr));
   gap: 0.625rem;


### PR DESCRIPTION
## Summary
- add contextual help for agent mode and agent model settings
- expose the existing temperature capability in model filters, cards, and tags

Fixes #7668

## Testing
- git diff --check
- bun run lint packages/kilo-console/src/routes/config/AgentsRoute.tsx packages/kilo-console/src/routes/config/ModelsRoute.tsx (passes with one existing no-unused-vars warning for Row in AgentsRoute.tsx)
- bun run --cwd packages/kilo-console typecheck

Note: bun install --frozen-lockfile could not complete locally because tree-sitter-powershell requires Visual Studio C++ build tools on Windows, but enough dependencies were present to run the targeted lint and package typecheck.