### PR TITLE
fix(vscode): widen chat readable lane

### DIFF
--- a/.changeset/widen-chat-lane-further.md
+++ b/.changeset/widen-chat-lane-further.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Widen the chat readable lane from 88ch to 98ch so conversations, tools, and diffs can use more editor space.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/readable-chat-1280-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6ecf78a0bcfaebdb945c3caacb8e32155fe2f6e4017f766e129dd0d17ad8fab
-size 51349
+oid sha256:270d3ecab98c4462a0e6af3e8fe43b3313da03759c507914d0b1048045474f1e
+size 50886

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -18,7 +18,7 @@
   min-height: 0;
   overflow: hidden;
   container: chat / inline-size;
-  --chat-readable-width: 88ch;
+  --chat-readable-width: 98ch;
   --chat-gutter: clamp(16px, 4cqi, 48px);
   --chat-scrollbar-width: 10px;
 }


### PR DESCRIPTION
The centered chat lane still leaves useful editor width unused in Agent Manager, particularly for tool output and diffs. Increase the shared readable width from 88ch to 98ch so conversations and their aligned controls use more horizontal space while retaining the existing centered layout and responsive gutters.