### PR TITLE
feat(vscode): make chat width limit configurable

### DIFF
--- a/.changeset/flexible-chat-width.md
+++ b/.changeset/flexible-chat-width.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Allow the chat content width limit to be disabled from Display settings.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -946,6 +946,11 @@
           "maximum": 24,
           "description": "Font size in pixels for the Kilo Code webview UI."
         },
+        "kilo-code.new.limitChatContentWidth": {
+          "type": "boolean",
+          "default": true,
+          "description": "Limit chat content to a centered, readable-width column on wide panels. Disable this to use the full panel width."
+        },
         "kilo-code.new.browserAutomation.enabled": {
           "type": "boolean",
           "default": false,

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -15,7 +15,7 @@ import { previewSound } from "./services/attention"
 import type { EditorContext, IndexingStatus } from "./services/cli-backend/types"
 import { FileIgnoreController } from "./services/autocomplete/shims/FileIgnoreController"
 import { ChatTextAreaAutocomplete } from "./services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete"
-import { buildWebviewHtml, getWebviewFontSize } from "./utils"
+import { buildWebviewHtml, getChatContentWidthLimit, getWebviewFontSize } from "./utils"
 import { saveImage } from "./kilo-provider/save-image"
 import { handleEditorAction } from "./kilo-provider/editor-actions"
 import { exportTranscript } from "./kilo-provider/export-transcript"
@@ -63,6 +63,7 @@ import { parseMessageFiles, type MessageFile } from "./kilo-provider/message-fil
 import { renameSession } from "./kilo-provider/rename-session"
 import { handleFileSearch } from "./kilo-provider/file-search"
 import { watchFontSizeConfig } from "./kilo-provider/font-size"
+import { watchChatContentWidthConfig } from "./kilo-provider/chat-width"
 import { getTerminalContents } from "./services/terminal/context"
 import { disposeGitChangesTarget } from "./kilo-provider/git-changes-target"
 import { interceptMessage } from "./kilo-provider/git-changes-request"
@@ -519,6 +520,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // Always push connection state first so the UI can render appropriately.
     this.postConnectionState()
     pushTelemetryState((m) => this.postMessage(m))
+    this.postMessage({ type: "chatContentWidthLimitChanged", limited: getChatContentWidthLimit() })
 
     // Re-send ready so the webview can recover after refresh.
     if (serverInfo) {
@@ -1253,6 +1255,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
     })
     this.webviewMessageDisposable = watchFontSizeConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
+    this.webviewMessageDisposable = watchChatContentWidthConfig(
+      (msg) => this.postMessage(msg),
+      this.webviewMessageDisposable,
+    )
     this.webviewMessageDisposable = watchWorkStyleConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
   }
 

--- a/packages/kilo-vscode/src/kilo-provider/chat-width.ts
+++ b/packages/kilo-vscode/src/kilo-provider/chat-width.ts
@@ -1,0 +1,14 @@
+import * as vscode from "vscode"
+import { getChatContentWidthLimit } from "../utils"
+
+export function watchChatContentWidthConfig(
+  post: (msg: { type: "chatContentWidthLimitChanged"; limited: boolean }) => void,
+  next?: vscode.Disposable,
+) {
+  const width = vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration("kilo-code.new.limitChatContentWidth")) {
+      post({ type: "chatContentWidthLimitChanged", limited: getChatContentWidthLimit() })
+    }
+  })
+  return next ? vscode.Disposable.from(width, next) : width
+}

--- a/packages/kilo-vscode/src/utils.ts
+++ b/packages/kilo-vscode/src/utils.ts
@@ -18,12 +18,18 @@ export function getWebviewFontSize(): number {
   return clamp(raw)
 }
 
-function fontStyle(): string {
+export function getChatContentWidthLimit(): boolean {
+  return vscode.workspace.getConfiguration("kilo-code.new").get<boolean>("limitChatContentWidth", true)
+}
+
+function rootStyle(): string {
   const base = getWebviewFontSize()
   const vars = SIZES.map((size) => `--kilo-font-size-${size}: ${(base * size) / 13}px;`).join("\n      ")
+  const width = getChatContentWidthLimit() ? "initial" : "100%"
   return `:root {
       ${vars}
       --kilo-font-scale: ${base / 13};
+      --kilo-chat-content-width: ${width};
       --font-size-x-small: var(--kilo-font-size-10);
       --font-size-small: var(--kilo-font-size-11);
       --font-size-base: var(--kilo-font-size-13);
@@ -55,7 +61,7 @@ export function buildWebviewHtml(
   <link rel="stylesheet" href="${opts.styleUri}">
   <title>${opts.title}</title>
   <style>
-    ${fontStyle()}
+    ${rootStyle()}
     html {
       scrollbar-color: auto;
 

--- a/packages/kilo-vscode/tests/unit/chat-width-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/chat-width-arch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+
+function read(file: string) {
+  return fs.readFileSync(path.join(ROOT, file), "utf-8")
+}
+
+describe("chat content width setting", () => {
+  it("keeps the readable width limit enabled by default", async () => {
+    const manifest = (await Bun.file(path.join(ROOT, "package.json")).json()) as {
+      contributes: { configuration: { properties: Record<string, { default?: unknown }> } }
+    }
+
+    expect(manifest.contributes.configuration.properties["kilo-code.new.limitChatContentWidth"]?.default).toBe(true)
+  })
+
+  it("seeds and applies the width preference before the webview renders", () => {
+    const utils = read("src/utils.ts")
+    const layout = read("webview-ui/src/styles/chat-layout.css")
+    const display = read("webview-ui/src/context/display.tsx")
+
+    expect(utils).toContain("--kilo-chat-content-width")
+    expect(layout).toContain("var(--kilo-chat-content-width, 88ch)")
+    expect(display).toContain('limitChatContentWidth() ? "initial" : "100%"')
+  })
+
+  it("synchronizes changes across open chat webviews", () => {
+    const provider = read("src/KiloProvider.ts")
+    const watcher = read("src/kilo-provider/chat-width.ts")
+    const display = read("webview-ui/src/context/display.tsx")
+
+    expect(provider).toContain("watchChatContentWidthConfig")
+    expect(provider).toContain('type: "chatContentWidthLimitChanged"')
+    expect(watcher).toContain('affectsConfiguration("kilo-code.new.limitChatContentWidth")')
+    expect(display).toContain('key: "limitChatContentWidth"')
+  })
+})

--- a/packages/kilo-vscode/tests/unit/chat-width-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/chat-width-arch.test.ts
@@ -23,7 +23,7 @@ describe("chat content width setting", () => {
     const display = read("webview-ui/src/context/display.tsx")
 
     expect(utils).toContain("--kilo-chat-content-width")
-    expect(layout).toContain("var(--kilo-chat-content-width, 88ch)")
+    expect(layout).toContain("var(--kilo-chat-content-width, 98ch)")
     expect(display).toContain('limitChatContentWidth() ? "initial" : "100%"')
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -64,6 +64,21 @@ const DisplayTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.display.limitChatContentWidth.title")}
+          description={language.t("settings.display.limitChatContentWidth.description")}
+        >
+          <Switch
+            checked={display.limitChatContentWidth()}
+            onChange={(checked: boolean) => {
+              display.setLimitChatContentWidth(checked)
+            }}
+            hideLabel
+          >
+            {language.t("settings.display.limitChatContentWidth.title")}
+          </Switch>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.display.reasoningAutoCollapse.title")}
           description={language.t("settings.display.reasoningAutoCollapse.description")}
         >

--- a/packages/kilo-vscode/webview-ui/src/context/display.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/display.tsx
@@ -18,23 +18,39 @@ interface DisplayContextValue {
   setReasoningAutoCollapse: (collapse: boolean) => void
   fontSize: Accessor<number>
   setFontSize: (size: number) => void
+  limitChatContentWidth: Accessor<boolean>
+  setLimitChatContentWidth: (limited: boolean) => void
 }
 
 export const DisplayContext = createContext<DisplayContextValue>()
+
+function readChatContentWidthLimit() {
+  const width = getComputedStyle(document.documentElement).getPropertyValue("--kilo-chat-content-width").trim()
+  return width !== "100%"
+}
 
 export const DisplayProvider: ParentComponent = (props) => {
   const { config, updateConfig } = useConfig()
   const vscode = useVSCode()
   const reasoningAutoCollapse = createMemo(() => config().auto_collapse_reasoning ?? false)
   const [fontSize, setFontSizeSignal] = createSignal(readFontSize())
+  const [limitChatContentWidth, setLimitChatContentWidthSignal] = createSignal(readChatContentWidthLimit())
 
   const unsubscribe = vscode.onMessage((message: ExtensionMessage) => {
     if (message.type === "ready" && message.fontSize !== undefined) setFontSizeSignal(clampFontSize(message.fontSize))
     if (message.type === "fontSizeChanged") setFontSizeSignal(clampFontSize(message.fontSize))
+    if (message.type === "chatContentWidthLimitChanged") setLimitChatContentWidthSignal(message.limited)
   })
 
   createEffect(() => {
     applyFontSize(fontSize())
+  })
+
+  createEffect(() => {
+    document.documentElement.style.setProperty(
+      "--kilo-chat-content-width",
+      limitChatContentWidth() ? "initial" : "100%",
+    )
   })
 
   onCleanup(unsubscribe)
@@ -49,6 +65,11 @@ export const DisplayProvider: ParentComponent = (props) => {
           const next = clampFontSize(size)
           setFontSizeSignal(next)
           vscode.postMessage({ type: "updateSetting", key: "fontSize", value: next })
+        },
+        limitChatContentWidth,
+        setLimitChatContentWidth: (limited) => {
+          setLimitChatContentWidthSignal(limited)
+          vscode.postMessage({ type: "updateSetting", key: "limitChatContentWidth", value: limited })
         },
       }}
     >

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1483,6 +1483,9 @@ export const dict = {
   "settings.display.username.description": "اسم مستخدم مخصص في المحادثات",
   "settings.display.fontSize.title": "حجم الخط",
   "settings.display.fontSize.description": "اضبط حجم خط webview UI الخاص بـ Kilo بشكل مستقل عن VS Code.",
+  "settings.display.limitChatContentWidth.title": "تقييد عرض محتوى المحادثة",
+  "settings.display.limitChatContentWidth.description":
+    "أبقِ محتوى المحادثة والموجّه في عمود يتوسط اللوحة وبعرض مريح للقراءة. عطّل هذا الخيار لاستخدام عرض اللوحة بالكامل.",
   "settings.display.reasoningAutoCollapse.title": "طي الاستدلال تلقائيًا",
   "settings.display.reasoningAutoCollapse.description":
     "يطوي كتل الاستدلال بعد أن ينتهي الوكيل من كتابتها. اتركه معطلاً لإبقاء الاستدلال موسعًا ما لم تطوه يدويًا.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1528,6 +1528,9 @@ export const dict = {
   "settings.display.fontSize.title": "Tamanho da fonte",
   "settings.display.fontSize.description":
     "Ajuste o tamanho da fonte da webview UI do Kilo independentemente do VS Code.",
+  "settings.display.limitChatContentWidth.title": "Limitar largura do conteúdo do chat",
+  "settings.display.limitChatContentWidth.description":
+    "Mantenha o conteúdo do chat e o prompt em uma coluna centralizada, com largura confortável para leitura. Desative para usar toda a largura do painel.",
   "settings.display.reasoningAutoCollapse.title": "Recolher raciocínio automaticamente",
   "settings.display.reasoningAutoCollapse.description":
     "Recolhe os blocos de raciocínio depois que o agente termina de escrevê-los. Deixe desativado para manter o raciocínio expandido, a menos que você o recolha manualmente.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1522,6 +1522,9 @@ export const dict = {
   "settings.display.username.description": "Prilagođeno korisničko ime u razgovorima",
   "settings.display.fontSize.title": "Veličina fonta",
   "settings.display.fontSize.description": "Prilagodite veličinu fonta za Kilo webview UI nezavisno od VS Code-a.",
+  "settings.display.limitChatContentWidth.title": "Ograniči širinu sadržaja razgovora",
+  "settings.display.limitChatContentWidth.description":
+    "Zadržite sadržaj razgovora i prompt u centriranoj koloni širine prilagođene čitanju. Isključite za korištenje pune širine panela.",
   "settings.display.reasoningAutoCollapse.title": "Automatski sažmi razmišljanje",
   "settings.display.reasoningAutoCollapse.description":
     "Sažima blokove razmišljanja nakon što ih agent završi pisati. Ostavite isključeno da razmišljanje ostane prošireno, osim ako ga ručno sažmete.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1512,6 +1512,9 @@ export const dict = {
   "settings.display.username.description": "Brugerdefineret brugernavn i samtaler",
   "settings.display.fontSize.title": "Skriftstørrelse",
   "settings.display.fontSize.description": "Juster skriftstørrelsen for Kilo webview UI uafhængigt af VS Code.",
+  "settings.display.limitChatContentWidth.title": "Begræns chatindholdets bredde",
+  "settings.display.limitChatContentWidth.description":
+    "Hold chatindholdet og prompten i en centreret kolonne med en læsevenlig bredde. Slå fra for at bruge hele panelets bredde.",
   "settings.display.reasoningAutoCollapse.title": "Skjul ræsonnement automatisk",
   "settings.display.reasoningAutoCollapse.description":
     "Skjuler ræsonnementsblokke, når agenten er færdig med at skrive dem. Lad den være slået fra for at holde ræsonnement udvidet, medmindre du skjuler det manuelt.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1543,6 +1543,9 @@ export const dict = {
   "settings.display.username.description": "Benutzerdefinierter Benutzername in Gesprächen",
   "settings.display.fontSize.title": "Schriftgröße",
   "settings.display.fontSize.description": "Passen Sie die Schriftgröße der Kilo webview UI unabhängig von VS Code an.",
+  "settings.display.limitChatContentWidth.title": "Breite des Chat-Inhalts begrenzen",
+  "settings.display.limitChatContentWidth.description":
+    "Chat-Inhalte und den Prompt in einer zentrierten Spalte mit gut lesbarer Breite anzeigen. Deaktivieren Sie diese Option, um die gesamte Breite des Panels zu nutzen.",
   "settings.display.reasoningAutoCollapse.title": "Reasoning automatisch einklappen",
   "settings.display.reasoningAutoCollapse.description":
     "Klappt Reasoning-Blöcke ein, nachdem der Agent sie fertig geschrieben hat. Deaktiviert lassen, damit Reasoning erweitert bleibt, sofern du es nicht manuell einklappst.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1495,6 +1495,9 @@ export const dict = {
   "settings.display.username.description": "Custom username displayed in conversations",
   "settings.display.fontSize.title": "Font Size",
   "settings.display.fontSize.description": "Adjust the Kilo webview UI font size independently from VS Code.",
+  "settings.display.limitChatContentWidth.title": "Limit Chat Content Width",
+  "settings.display.limitChatContentWidth.description":
+    "Keep chat content and the prompt in a centered, readable-width column. Turn off to use the full panel width.",
   "settings.display.reasoningAutoCollapse.title": "Auto-Collapse Reasoning",
   "settings.display.reasoningAutoCollapse.description":
     "Collapse reasoning blocks after the agent finishes writing them. Leave off to keep reasoning expanded unless you collapse it manually.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1536,6 +1536,9 @@ export const dict = {
   "settings.display.fontSize.title": "Tamaño de fuente",
   "settings.display.fontSize.description":
     "Ajusta el tamaño de fuente de la webview UI de Kilo de forma independiente a VS Code.",
+  "settings.display.limitChatContentWidth.title": "Limitar el ancho del contenido del chat",
+  "settings.display.limitChatContentWidth.description":
+    "Mantén el contenido del chat y el prompt en una columna centrada con un ancho cómodo para la lectura. Desactiva esta opción para usar todo el ancho del panel.",
   "settings.display.reasoningAutoCollapse.title": "Contraer razonamiento automáticamente",
   "settings.display.reasoningAutoCollapse.description":
     "Contrae los bloques de razonamiento después de que el agente termine de escribirlos. Déjalo desactivado para mantener el razonamiento expandido, a menos que lo contraigas manualmente.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1556,6 +1556,9 @@ export const dict = {
   "settings.display.fontSize.title": "Taille de la police",
   "settings.display.fontSize.description":
     "Ajustez la taille de la police de la webview UI de Kilo indépendamment de VS Code.",
+  "settings.display.limitChatContentWidth.title": "Limiter la largeur du contenu du chat",
+  "settings.display.limitChatContentWidth.description":
+    "Conservez le contenu du chat et le prompt dans une colonne centrée d’une largeur confortable pour la lecture. Désactivez cette option pour utiliser toute la largeur du panneau.",
   "settings.display.reasoningAutoCollapse.title": "Réduire automatiquement le raisonnement",
   "settings.display.reasoningAutoCollapse.description":
     "Réduit les blocs de raisonnement une fois que l'agent a fini de les écrire. Laissez désactivé pour garder le raisonnement développé, sauf si vous le réduisez manuellement.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1344,6 +1344,9 @@ export const dict = {
   "settings.display.fontSize.title": "Dimensione font",
   "settings.display.fontSize.description":
     "Regola la dimensione del font della webview Kilo indipendentemente da VS Code.",
+  "settings.display.limitChatContentWidth.title": "Limita la larghezza del contenuto della chat",
+  "settings.display.limitChatContentWidth.description":
+    "Mantieni il contenuto della chat e il prompt in una colonna centrata di larghezza comoda per la lettura. Disattiva questa opzione per usare l'intera larghezza del pannello.",
   "settings.display.reasoningAutoCollapse.title": "Comprimi automaticamente ragionamento",
   "settings.display.reasoningAutoCollapse.description":
     "Comprimi i blocchi di ragionamento dopo che l'agente ha finito di scriverli. Lascia disattivato per tenerli espansi finché non li comprimi manualmente.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1507,6 +1507,9 @@ export const dict = {
   "settings.display.username.description": "会話に表示されるカスタムユーザー名",
   "settings.display.fontSize.title": "フォントサイズ",
   "settings.display.fontSize.description": "VS Code とは独立して Kilo webview UI のフォントサイズを調整します。",
+  "settings.display.limitChatContentWidth.title": "チャットコンテンツの幅を制限",
+  "settings.display.limitChatContentWidth.description":
+    "チャットコンテンツとプロンプトを、読みやすい幅で中央に表示します。パネルの幅全体を使用するにはオフにしてください。",
   "settings.display.reasoningAutoCollapse.title": "推論を自動で折りたたむ",
   "settings.display.reasoningAutoCollapse.description":
     "エージェントが推論の書き込みを終えた後に推論ブロックを自動で折りたたみます。手動で折りたたむまでは推論を展開したままにするには、オフのままにしてください。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1492,6 +1492,9 @@ export const dict = {
   "settings.display.username.description": "대화에 표시되는 사용자 정의 사용자 이름",
   "settings.display.fontSize.title": "글꼴 크기",
   "settings.display.fontSize.description": "VS Code와 독립적으로 Kilo webview UI 글꼴 크기를 조정합니다.",
+  "settings.display.limitChatContentWidth.title": "채팅 콘텐츠 너비 제한",
+  "settings.display.limitChatContentWidth.description":
+    "채팅 콘텐츠와 프롬프트를 읽기 편한 너비로 가운데에 표시합니다. 패널의 전체 너비를 사용하려면 끄세요.",
   "settings.display.reasoningAutoCollapse.title": "추론 자동 접기",
   "settings.display.reasoningAutoCollapse.description":
     "에이전트가 추론 작성을 마친 뒤 추론 블록을 자동으로 접습니다. 수동으로 접기 전까지 추론을 펼친 상태로 두려면 끄세요.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1487,6 +1487,9 @@ export const dict = {
   "settings.display.username.description": "Aangepaste gebruikersnaam weergegeven in gesprekken",
   "settings.display.fontSize.title": "Lettergrootte",
   "settings.display.fontSize.description": "Pas de lettergrootte van de Kilo webview UI onafhankelijk van VS Code aan.",
+  "settings.display.limitChatContentWidth.title": "Breedte van chatinhoud beperken",
+  "settings.display.limitChatContentWidth.description":
+    "Houd de chatinhoud en de prompt in een gecentreerde kolom met een goed leesbare breedte. Schakel deze optie uit om de volledige paneelbreedte te gebruiken.",
   "settings.display.reasoningAutoCollapse.title": "Redenering automatisch inklappen",
   "settings.display.reasoningAutoCollapse.description":
     "Klapt redeneerblokken in nadat de agent klaar is met schrijven. Laat uitgeschakeld om redenering uitgeklapt te houden, tenzij je die handmatig inklapt.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1510,6 +1510,9 @@ export const dict = {
   "settings.display.username.description": "Egendefinert brukernavn i samtaler",
   "settings.display.fontSize.title": "Skriftstørrelse",
   "settings.display.fontSize.description": "Juster skriftstørrelsen for Kilo webview UI uavhengig av VS Code.",
+  "settings.display.limitChatContentWidth.title": "Begrens bredden på chatinnholdet",
+  "settings.display.limitChatContentWidth.description":
+    "Hold chatinnholdet og prompten i en sentrert kolonne med leservennlig bredde. Slå av for å bruke hele panelbredden.",
   "settings.display.reasoningAutoCollapse.title": "Skjul resonnement automatisk",
   "settings.display.reasoningAutoCollapse.description":
     "Skjuler resonnementblokker etter at agenten er ferdig med å skrive dem. La være av for å holde resonnement utvidet med mindre du skjuler det manuelt.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1520,6 +1520,9 @@ export const dict = {
   "settings.display.username.description": "Niestandardowa nazwa użytkownika w rozmowach",
   "settings.display.fontSize.title": "Rozmiar czcionki",
   "settings.display.fontSize.description": "Dostosuj rozmiar czcionki webview UI Kilo niezależnie od VS Code.",
+  "settings.display.limitChatContentWidth.title": "Ogranicz szerokość zawartości czatu",
+  "settings.display.limitChatContentWidth.description":
+    "Umieść zawartość czatu i prompt w wyśrodkowanej kolumnie o czytelnej szerokości. Wyłącz, aby używać pełnej szerokości panelu.",
   "settings.display.reasoningAutoCollapse.title": "Automatycznie zwijaj rozumowanie",
   "settings.display.reasoningAutoCollapse.description":
     "Zwija bloki rozumowania po zakończeniu ich pisania przez agenta. Pozostaw wyłączone, aby rozumowanie pozostało rozwinięte, chyba że zwiniesz je ręcznie.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1520,6 +1520,9 @@ export const dict = {
   "settings.display.username.description": "Пользовательское имя в разговорах",
   "settings.display.fontSize.title": "Размер шрифта",
   "settings.display.fontSize.description": "Настройте размер шрифта webview UI для Kilo независимо от VS Code.",
+  "settings.display.limitChatContentWidth.title": "Ограничить ширину содержимого чата",
+  "settings.display.limitChatContentWidth.description":
+    "Размещайте содержимое чата и поле ввода запроса в центрированном столбце удобной для чтения ширины. Отключите, чтобы использовать всю ширину панели.",
   "settings.display.reasoningAutoCollapse.title": "Автоматически сворачивать рассуждение",
   "settings.display.reasoningAutoCollapse.description":
     "Сворачивает блоки рассуждения после того, как агент закончит их писать. Оставьте выключенным, чтобы рассуждение оставалось раскрытым, пока вы не свернете его вручную.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1490,6 +1490,9 @@ export const dict = {
   "settings.display.username.description": "ชื่อผู้ใช้กำหนดเองในบทสนทนา",
   "settings.display.fontSize.title": "ขนาดฟอนต์",
   "settings.display.fontSize.description": "ปรับขนาดฟอนต์ webview UI ของ Kilo แยกเป็นอิสระจาก VS Code.",
+  "settings.display.limitChatContentWidth.title": "จำกัดความกว้างของเนื้อหาแชต",
+  "settings.display.limitChatContentWidth.description":
+    "แสดงเนื้อหาแชตและพรอมต์ในคอลัมน์กึ่งกลางที่มีความกว้างพอเหมาะต่อการอ่าน ปิดเพื่อใช้ความกว้างเต็มแผง",
   "settings.display.reasoningAutoCollapse.title": "ยุบเหตุผลอัตโนมัติ",
   "settings.display.reasoningAutoCollapse.description":
     "ยุบ block เหตุผลหลังจากเอเจนต์เขียนเสร็จ ปิดไว้เพื่อให้เหตุผลยังคงขยายอยู่ เว้นแต่คุณจะยุบเอง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1476,6 +1476,9 @@ export const dict = {
   "settings.display.username.description": "Sohbetlerde görüntülenen özel kullanıcı adı",
   "settings.display.fontSize.title": "Yazı Tipi Boyutu",
   "settings.display.fontSize.description": "Kilo webview UI yazı tipi boyutunu VS Code'dan bağımsız olarak ayarlayın.",
+  "settings.display.limitChatContentWidth.title": "Sohbet İçeriği Genişliğini Sınırla",
+  "settings.display.limitChatContentWidth.description":
+    "Sohbet içeriğini ve komut alanını ortalanmış, rahat okunabilir genişlikte bir sütunda tutun. Panelin tam genişliğini kullanmak için kapatın.",
   "settings.display.reasoningAutoCollapse.title": "Akıl yürütmeyi otomatik daralt",
   "settings.display.reasoningAutoCollapse.description":
     "Ajan yazmayı bitirdikten sonra akıl yürütme bloklarını daraltır. Manuel olarak daraltmadığınız sürece akıl yürütmenin geniş kalması için kapalı bırakın.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1474,6 +1474,9 @@ export const dict = {
   "settings.display.username.description": "Власне ім'я користувача, що відображається в чатах",
   "settings.display.fontSize.title": "Розмір шрифту",
   "settings.display.fontSize.description": "Налаштуйте розмір шрифту webview UI для Kilo незалежно від VS Code.",
+  "settings.display.limitChatContentWidth.title": "Обмежити ширину вмісту чату",
+  "settings.display.limitChatContentWidth.description":
+    "Розміщуйте вміст чату та поле введення запиту в центрованому стовпці зручної для читання ширини. Вимкніть, щоб використовувати всю ширину панелі.",
   "settings.display.reasoningAutoCollapse.title": "Автоматично згортати міркування",
   "settings.display.reasoningAutoCollapse.description":
     "Згортає блоки міркувань після того, як агент закінчить їх писати. Залиште вимкненим, щоб міркування залишалися розгорнутими, доки ви не згорнете їх вручну.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1455,6 +1455,9 @@ export const dict = {
   "settings.display.username.description": "对话中显示的自定义用户名",
   "settings.display.fontSize.title": "字体大小",
   "settings.display.fontSize.description": "独立于 VS Code 调整 Kilo webview UI 的字体大小。",
+  "settings.display.limitChatContentWidth.title": "限制聊天内容宽度",
+  "settings.display.limitChatContentWidth.description":
+    "让聊天内容和提示词以适合阅读的宽度居中显示。关闭后将使用面板的完整宽度。",
   "settings.display.reasoningAutoCollapse.title": "自动折叠推理",
   "settings.display.reasoningAutoCollapse.description":
     "在智能体写完推理后折叠推理块。保持关闭可让推理保持展开，除非你手动折叠它。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1425,6 +1425,9 @@ export const dict = {
   "settings.display.username.description": "對話中顯示的自訂使用者名稱",
   "settings.display.fontSize.title": "字體大小",
   "settings.display.fontSize.description": "獨立於 VS Code 調整 Kilo webview UI 的字體大小。",
+  "settings.display.limitChatContentWidth.title": "限制聊天內容寬度",
+  "settings.display.limitChatContentWidth.description":
+    "讓聊天內容和提示詞以適合閱讀的寬度置中顯示。關閉後將使用完整的面板寬度。",
   "settings.display.reasoningAutoCollapse.title": "自動收合推理",
   "settings.display.reasoningAutoCollapse.description":
     "在代理寫完推理後收合推理區塊。保持關閉可讓推理保持展開，除非你手動收合它。",

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -18,7 +18,7 @@
   min-height: 0;
   overflow: hidden;
   container: chat / inline-size;
-  --chat-readable-width: 98ch;
+  --chat-readable-width: var(--kilo-chat-content-width, 98ch);
   --chat-gutter: clamp(16px, 4cqi, 48px);
   --chat-scrollbar-width: 10px;
 }

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -65,6 +65,11 @@ export interface FontSizeChangedMessage {
   fontSize: number
 }
 
+export interface ChatContentWidthLimitChangedMessage {
+  type: "chatContentWidthLimitChanged"
+  limited: boolean
+}
+
 export interface GitStatusMessage {
   type: "gitStatus"
   repo: boolean
@@ -962,6 +967,7 @@ export interface RemoteStatusMessage {
 export type ExtensionMessage =
   | ReadyMessage
   | FontSizeChangedMessage
+  | ChatContentWidthLimitChangedMessage
   | GitStatusMessage
   | ConnectionStateMessage
   | ErrorMessage


### PR DESCRIPTION
Wide VS Code editor and Agent Manager panels constrain chat content to a readable column. That remains the right default, but it prevents users who prefer denser layouts from using the full available panel width.

This adds a **Limit Chat Content Width** toggle under Display settings. The setting defaults to enabled, so existing behavior is preserved. Turning it off expands the transcript and prompt area to the available panel width while retaining responsive gutters.

The preference is stored in VS Code configuration, applied before each webview renders, and synchronized live across open sidebar, editor, and Agent Manager webviews. The new setting is localized across all supported extension languages.

<img width="731" height="90" alt="file-b87e05b9119f683bfe16c5ac28b7b7de" src="https://github.com/user-attachments/assets/b8dc7cca-076f-4727-b743-4670d37bdef5" />

