### PR TITLE
feat(vscode): add reasoning effort shortcut

### DIFF
--- a/.changeset/cycle-reasoning-effort.md
+++ b/.changeset/cycle-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Cycle reasoning effort from Kilo chat surfaces with a configurable `Alt+.` shortcut.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -792,7 +792,10 @@
         "command": "kilo-code.new.cycleReasoningEffort",
         "key": "alt+.",
         "mac": "alt+.",
-        "when": "kilo-code.new.sidebarFocus || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
+        "when": "kilo-code.new.sidebarFocus || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'",
+        "args": {
+          "nativeInput": "mac-option-period"
+        }
       },
       {
         "command": "kilo-code.new.autocomplete.cancelSuggestions",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -409,6 +409,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.cycleReasoningEffort",
+        "title": "Cycle Reasoning Effort",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.toggleAutoApprove",
         "title": "Toggle Auto-Approve",
         "category": "Kilo Code"
@@ -782,6 +787,12 @@
         "key": "ctrl+shift+.",
         "mac": "cmd+shift+.",
         "when": "sideBarFocus && kilo-code.new.sidebarVisible || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
+      },
+      {
+        "command": "kilo-code.new.cycleReasoningEffort",
+        "key": "alt+.",
+        "mac": "alt+.",
+        "when": "kilo-code.new.sidebarFocus || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
       },
       {
         "command": "kilo-code.new.autocomplete.cancelSuggestions",

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -262,6 +262,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private readonly instanceId = crypto.randomUUID()
 
   private webview: vscode.Webview | null = null
+  private sidebar = false
   private currentSession: Session | null = null
   /** Remembers the last selected session so /new can stay in the same worktree after clearSession. */
   private contextSessionID: string | undefined
@@ -580,6 +581,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     _context: vscode.WebviewViewResolveContext,
     _token: vscode.CancellationToken,
   ) {
+    this.sidebar = true
     this.isWebviewReady = false
     this.webview = webviewView.webview
 
@@ -607,6 +609,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private setSidebarVisible(visible: boolean): void {
     this.setStreamVisibility(visible)
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)
+    if (!visible) vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarFocus", false)
   }
 
   /** Resolve a WebviewPanel for displaying Kilo in an editor tab. */
@@ -802,6 +805,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }
       this.visibleTaskStreams.handle(message)
       switch (message.type) {
+        case "webviewFocusChanged":
+          if (this.sidebar) {
+            await vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarFocus", message.focused)
+          }
+          break
         case "webviewReady":
           console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
           this.isWebviewReady = true
@@ -3561,6 +3569,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Does NOT kill the server — that's the connection service's job.
    */
   dispose(): void {
+    if (this.sidebar) vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarFocus", false)
     this.unsubscribeRemote?.()
     this.focusSession()
     this.statsPoller?.stop()

--- a/packages/kilo-vscode/src/agent-manager/format-keybinding.ts
+++ b/packages/kilo-vscode/src/agent-manager/format-keybinding.ts
@@ -41,6 +41,7 @@ const GLOBAL_KEYBINDINGS: Record<string, string> = {
   "kilo-code.new.agentManagerOpen": "agentManagerOpen",
   "kilo-code.new.cycleAgentMode": "cycleAgentMode",
   "kilo-code.new.cyclePreviousAgentMode": "cyclePreviousAgentMode",
+  "kilo-code.new.cycleReasoningEffort": "cycleReasoningEffort",
 }
 
 /**

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -291,6 +291,7 @@ interface PRStatusOutMessage {
 interface ActionOutMessage {
   type: "action"
   action: string
+  nativeInput?: "mac-option-period"
 }
 
 interface RunStatusMessage extends RunStatus {

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -322,10 +322,11 @@ export function activate(context: vscode.ExtensionContext) {
     void vscode.commands.executeCommand(command)
   }
 
-  const postChatAction = (action: string) => {
-    provider.postMessage({ type: "action", action })
-    activeTabProvider()?.postMessage({ type: "action", action })
-    agentManagerProvider.postMessage({ type: "action", action })
+  const postChatAction = (action: string, nativeInput?: "mac-option-period") => {
+    const message = { type: "action", action, nativeInput }
+    provider.postMessage(message)
+    activeTabProvider()?.postMessage(message)
+    agentManagerProvider.postMessage(message)
   }
 
   // Register toolbar button command handlers
@@ -382,8 +383,9 @@ export function activate(context: vscode.ExtensionContext) {
       else provider.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
       agentManagerProvider.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
     }),
-    vscode.commands.registerCommand("kilo-code.new.cycleReasoningEffort", () => {
-      postChatAction("cycleReasoningEffort")
+    vscode.commands.registerCommand("kilo-code.new.cycleReasoningEffort", (opts?: { nativeInput?: unknown }) => {
+      const nativeInput = opts?.nativeInput === "mac-option-period" ? "mac-option-period" : undefined
+      postChatAction("cycleReasoningEffort", nativeInput)
     }),
     vscode.commands.registerCommand("kilo-code.new.profileButtonClicked", () => {
       settingsEditorProvider.openPanel("profile")

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -322,6 +322,12 @@ export function activate(context: vscode.ExtensionContext) {
     void vscode.commands.executeCommand(command)
   }
 
+  const postChatAction = (action: string) => {
+    provider.postMessage({ type: "action", action })
+    activeTabProvider()?.postMessage({ type: "action", action })
+    agentManagerProvider.postMessage({ type: "action", action })
+  }
+
   // Register toolbar button command handlers
   context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.sidebarTitle.plusButtonClicked", () => {
@@ -375,6 +381,9 @@ export function activate(context: vscode.ExtensionContext) {
       if (tab) tab.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
       else provider.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
       agentManagerProvider.postMessage({ type: "action", action: "cyclePreviousAgentMode" })
+    }),
+    vscode.commands.registerCommand("kilo-code.new.cycleReasoningEffort", () => {
+      postChatAction("cycleReasoningEffort")
     }),
     vscode.commands.registerCommand("kilo-code.new.profileButtonClicked", () => {
       settingsEditorProvider.openPanel("profile")

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -761,6 +761,26 @@ describe("Agent Manager — VS Code import boundary", () => {
   })
 })
 
+describe("Agent Manager reasoning effort routing", () => {
+  const app = fs.readFileSync(TSX_FILE, "utf-8")
+
+  it("clears a local pending tab when selecting a worktree", () => {
+    const start = app.indexOf("const selectWorktree")
+    const end = app.indexOf("const addSessionToCurrentWorktree", start)
+    const block = app.slice(start, end)
+    expect(block).toContain("setActivePendingId(undefined)")
+  })
+
+  it("targets the visible chat tab instead of stale pending state", () => {
+    const start = app.indexOf('msg.action === "cycleReasoningEffort"')
+    const end = app.indexOf("} else {", start)
+    const block = app.slice(start, end)
+    expect(block).toContain("visibleTabId()")
+    expect(block).toContain("session.cycleVariant(id)")
+    expect(block).not.toContain("activePendingId()")
+  })
+})
+
 // ---------------------------------------------------------------------------
 // Provider chain parity — sidebar App.tsx vs AgentManagerApp.tsx
 //

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -126,6 +126,31 @@ describe("Extension — package.json command sync", () => {
       when: "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'",
     })
   })
+
+  it("contributes an overridable reasoning effort shortcut for every chat surface", () => {
+    const command = pkg.contributes?.commands?.find(
+      (item: { command: string }) => item.command === "kilo-code.new.cycleReasoningEffort",
+    )
+    const binding = pkg.contributes?.keybindings?.find(
+      (item: { command: string }) => item.command === "kilo-code.new.cycleReasoningEffort",
+    )
+    expect(command).toMatchObject({ title: "Cycle Reasoning Effort", category: "Kilo Code" })
+    expect(binding).toMatchObject({
+      key: "alt+.",
+      mac: "alt+.",
+      when: "kilo-code.new.sidebarFocus || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'",
+    })
+  })
+
+  it("broadcasts reasoning effort changes to the focused chat surface", () => {
+    const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
+    const command = sliceBlock(ext, ext.indexOf('registerCommand("kilo-code.new.cycleReasoningEffort"'))
+    const helper = sliceBlock(ext, ext.indexOf("const postChatAction"))
+    expect(command).toContain('postChatAction("cycleReasoningEffort")')
+    expect(helper).toContain("provider.postMessage")
+    expect(helper).toContain("activeTabProvider()?.postMessage")
+    expect(helper).toContain("agentManagerProvider.postMessage")
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -139,14 +139,15 @@ describe("Extension — package.json command sync", () => {
       key: "alt+.",
       mac: "alt+.",
       when: "kilo-code.new.sidebarFocus || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'",
+      args: { nativeInput: "mac-option-period" },
     })
   })
 
   it("broadcasts reasoning effort changes to the focused chat surface", () => {
     const ext = fs.readFileSync(EXTENSION_FILE, "utf-8")
-    const command = sliceBlock(ext, ext.indexOf('registerCommand("kilo-code.new.cycleReasoningEffort"'))
     const helper = sliceBlock(ext, ext.indexOf("const postChatAction"))
-    expect(command).toContain('postChatAction("cycleReasoningEffort")')
+    expect(ext).toContain('opts?.nativeInput === "mac-option-period"')
+    expect(ext).toContain('postChatAction("cycleReasoningEffort", nativeInput)')
     expect(helper).toContain("provider.postMessage")
     expect(helper).toContain("activeTabProvider()?.postMessage")
     expect(helper).toContain("agentManagerProvider.postMessage")

--- a/packages/kilo-vscode/tests/unit/format-keybinding.test.ts
+++ b/packages/kilo-vscode/tests/unit/format-keybinding.test.ts
@@ -77,4 +77,10 @@ describe("buildKeybindingMap", () => {
     expect(buildKeybindingMap(bindings, true).search).toBe("⌘F")
     expect(buildKeybindingMap(bindings, false).search).toBe("Ctrl+F")
   })
+
+  it("maps the configurable reasoning effort shortcut", () => {
+    const bindings = [{ command: "kilo-code.new.cycleReasoningEffort", key: "alt+.", mac: "alt+." }]
+    expect(buildKeybindingMap(bindings, true).cycleReasoningEffort).toBe("⌥.")
+    expect(buildKeybindingMap(bindings, false).cycleReasoningEffort).toBe("Alt+.")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
@@ -11,7 +11,7 @@ import {
   isQuestioning,
   isPathMention,
   optionPeriodEdit,
-  matchesOptionPeriodInput,
+  optionPeriodInput,
   canRestoreOptionPeriodEdit,
 } from "../../webview-ui/src/components/chat/prompt-input-utils"
 
@@ -165,24 +165,11 @@ describe("Option+Period input", () => {
     isComposing: false,
   }
 
-  it("records the exact native edit at the caret", () => {
-    expect(optionPeriodEdit(key, "hello", 2, 2, "none")).toEqual({
-      before: "hello",
-      after: "he≥llo",
-      start: 2,
-      end: 2,
-      pos: 3,
-      direction: "none",
-    })
-  })
-
-  it("records replacement of selected text", () => {
+  it("records the value and selection before native input", () => {
     expect(optionPeriodEdit(key, "hello", 1, 4, "backward")).toEqual({
       before: "hello",
-      after: "h≥o",
       start: 1,
       end: 4,
-      pos: 2,
       direction: "backward",
     })
   })
@@ -195,18 +182,59 @@ describe("Option+Period input", () => {
     expect(optionPeriodEdit({ ...key, isComposing: true }, "", 0, 0, "none")).toBeUndefined()
   })
 
-  it("matches only the corresponding native insertion", () => {
-    const edit = optionPeriodEdit(key, "a≥b", 3, 3, "none")!
-    expect(matchesOptionPeriodInput(edit, { inputType: "insertText", data: "≥" }, "a≥b≥", 4, 4)).toBe(true)
-    expect(matchesOptionPeriodInput(edit, { inputType: "insertFromPaste", data: "≥" }, "a≥b≥", 4, 4)).toBe(false)
-    expect(matchesOptionPeriodInput(edit, { inputType: "insertText", data: "." }, "a≥b.", 4, 4)).toBe(false)
+  it.each([
+    ["≥", "he≥llo", 3],
+    ["…", "he…llo", 3],
+    ["🙂", "he🙂llo", 4],
+  ])("derives the native insertion from the input event for %s", (data, value, pos) => {
+    const edit = optionPeriodEdit(key, "hello", 2, 2, "none")!
+    expect(optionPeriodInput(edit, { inputType: "insertText", data, isComposing: false }, value, pos, pos)).toEqual({
+      ...edit,
+      after: value,
+      pos,
+    })
   })
 
-  it("restores only while the value and caret still match", () => {
+  it("records replacement of selected text", () => {
+    const edit = optionPeriodEdit(key, "hello", 1, 4, "backward")!
+    expect(optionPeriodInput(edit, { inputType: "insertText", data: "…", isComposing: false }, "h…o", 2, 2)).toEqual({
+      ...edit,
+      after: "h…o",
+      pos: 2,
+    })
+  })
+
+  it("rejects input that does not exactly match the native edit", () => {
     const edit = optionPeriodEdit(key, "a≥b", 3, 3, "none")!
-    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥", 4, 4)).toBe(true)
-    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥x", 5, 5)).toBe(false)
-    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥", 3, 3)).toBe(false)
+    expect(
+      optionPeriodInput(edit, { inputType: "insertFromPaste", data: "≥", isComposing: false }, "a≥b≥", 4, 4),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertCompositionText", data: "≥", isComposing: false }, "a≥b≥", 4, 4),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertText", data: "≥", isComposing: true }, "a≥b≥", 4, 4),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertText", data: null, isComposing: false }, "a≥b", 3, 3),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertText", data: "", isComposing: false }, "a≥b", 3, 3),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertText", data: "≥", isComposing: false }, "a≥b≥x", 5, 5),
+    ).toBeUndefined()
+    expect(
+      optionPeriodInput(edit, { inputType: "insertText", data: "≥", isComposing: false }, "a≥b≥", 3, 4),
+    ).toBeUndefined()
+  })
+
+  it("restores only while the observed value and caret still match", () => {
+    const edit = optionPeriodEdit(key, "a≥b", 3, 3, "none")!
+    const input = optionPeriodInput(edit, { inputType: "insertText", data: "🙂", isComposing: false }, "a≥b🙂", 5, 5)!
+    expect(canRestoreOptionPeriodEdit(input, "a≥b🙂", 5, 5)).toBe(true)
+    expect(canRestoreOptionPeriodEdit(input, "a≥b🙂x", 6, 6)).toBe(false)
+    expect(canRestoreOptionPeriodEdit(input, "a≥b🙂", 4, 4)).toBe(false)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
@@ -10,6 +10,9 @@ import {
   isSuggesting,
   isQuestioning,
   isPathMention,
+  optionPeriodEdit,
+  matchesOptionPeriodInput,
+  canRestoreOptionPeriodEdit,
 } from "../../webview-ui/src/components/chat/prompt-input-utils"
 
 describe("fileName", () => {
@@ -149,6 +152,61 @@ describe("atEnd", () => {
 
   it("returns false when caret is at start of non-empty input", () => {
     expect(atEnd(0, 0, 10)).toBe(false)
+  })
+})
+
+describe("Option+Period input", () => {
+  const key = {
+    code: "Period",
+    altKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    isComposing: false,
+  }
+
+  it("records the exact native edit at the caret", () => {
+    expect(optionPeriodEdit(key, "hello", 2, 2, "none")).toEqual({
+      before: "hello",
+      after: "he≥llo",
+      start: 2,
+      end: 2,
+      pos: 3,
+      direction: "none",
+    })
+  })
+
+  it("records replacement of selected text", () => {
+    expect(optionPeriodEdit(key, "hello", 1, 4, "backward")).toEqual({
+      before: "hello",
+      after: "h≥o",
+      start: 1,
+      end: 4,
+      pos: 2,
+      direction: "backward",
+    })
+  })
+
+  it("rejects modified, composing, and non-period keys", () => {
+    expect(optionPeriodEdit({ ...key, code: "Comma" }, "", 0, 0, "none")).toBeUndefined()
+    expect(optionPeriodEdit({ ...key, ctrlKey: true }, "", 0, 0, "none")).toBeUndefined()
+    expect(optionPeriodEdit({ ...key, metaKey: true }, "", 0, 0, "none")).toBeUndefined()
+    expect(optionPeriodEdit({ ...key, shiftKey: true }, "", 0, 0, "none")).toBeUndefined()
+    expect(optionPeriodEdit({ ...key, isComposing: true }, "", 0, 0, "none")).toBeUndefined()
+  })
+
+  it("matches only the corresponding native insertion", () => {
+    const edit = optionPeriodEdit(key, "a≥b", 3, 3, "none")!
+    expect(matchesOptionPeriodInput(edit, { inputType: "insertText", data: "≥" }, "a≥b≥", 4, 4)).toBe(true)
+    expect(matchesOptionPeriodInput(edit, { inputType: "insertFromPaste", data: "≥" }, "a≥b≥", 4, 4)).toBe(false)
+    expect(matchesOptionPeriodInput(edit, { inputType: "insertText", data: "." }, "a≥b.", 4, 4)).toBe(false)
+  })
+
+  it("restores only while the value and caret still match", () => {
+    const edit = optionPeriodEdit(key, "a≥b", 3, 3, "none")!
+    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥", 4, 4)).toBe(true)
+    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥x", 5, 5)).toBe(false)
+    expect(canRestoreOptionPeriodEdit(edit, "a≥b≥", 3, 3)).toBe(false)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import {
   getVariant,
+  nextVariant,
   sessionVariantKeys,
   sessionVariants,
   transferVariants,
@@ -10,6 +11,26 @@ import type { ModelSelection } from "../../webview-ui/src/types/messages"
 
 const model: ModelSelection = { providerID: "anthropic", modelID: "claude-sonnet-4" }
 const variants = ["low", "medium", "high"]
+
+describe("variant cycling", () => {
+  it("selects the next variant", () => {
+    expect(nextVariant("low", variants)).toBe("medium")
+  })
+
+  it("wraps the last variant to the first", () => {
+    expect(nextVariant("high", variants)).toBe("low")
+  })
+
+  it("starts from the first variant when the current value is missing or stale", () => {
+    expect(nextVariant(undefined, variants)).toBe("low")
+    expect(nextVariant("unsupported", variants)).toBe("low")
+  })
+
+  it("returns no variant for an empty list and preserves a single choice", () => {
+    expect(nextVariant("high", [])).toBeUndefined()
+    expect(nextVariant("high", ["high"])).toBe("high")
+  })
+})
 
 describe("per-session variant selection", () => {
   it("keeps reasoning effort independent for each Agent Manager session", () => {

--- a/packages/kilo-vscode/tests/unit/sidebar-search.test.ts
+++ b/packages/kilo-vscode/tests/unit/sidebar-search.test.ts
@@ -159,4 +159,13 @@ describe("Agent Manager shortcut map", () => {
       binding: "⌘⇧R",
     })
   })
+
+  it("includes reasoning effort in the global section", () => {
+    const categories = buildShortcutCategories({ cycleReasoningEffort: "⌥." }, (key) => key)
+    const global = categories.find((category) => category.title === "agentManager.shortcuts.category.global")
+    expect(global?.shortcuts).toContainEqual({
+      label: "command.model.variant.cycle",
+      binding: "⌥.",
+    })
+  })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -190,6 +190,7 @@ const defaultBindings: Record<string, string> = {
   agentManagerOpen: isMac ? "⌘⇧M" : "Ctrl+Shift+M",
   cycleAgentMode: isMac ? "⌘." : "Ctrl+.",
   cyclePreviousAgentMode: isMac ? "⌘⇧." : "Ctrl+Shift+.",
+  cycleReasoningEffort: isMac ? "⌥." : "Alt+.",
   ...Object.fromEntries(
     Array.from({ length: MAX_JUMP_INDEX }, (_, i) => [`jumpTo${i + 1}`, isMac ? `⌘${i + 1}` : `Ctrl+${i + 1}`]),
   ),
@@ -1066,6 +1067,8 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "newTerminal") termHandlers.requestNew()
       else if (msg.action === "cycleAgentMode" && document.hasFocus()) cycleAgent(1)
       else if (msg.action === "cyclePreviousAgentMode" && document.hasFocus()) cycleAgent(-1)
+      else if (msg.action === "cycleReasoningEffort" && document.hasFocus() && !terms.activeId())
+        session.cycleVariant(activePendingId())
       else {
         // Handle jumpTo1 through jumpTo9
         const match = /^jumpTo([1-9])$/.exec(msg.action ?? "")

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -941,6 +941,7 @@ const AgentManagerContent: Component = () => {
 
   const selectWorktree = (worktreeId: string) => {
     saveTabMemory()
+    setActivePendingId(undefined)
     setSelection(worktreeId)
     const remembered = tabMemory()[worktreeId]
     if (terms.hasRemembered(worktreeId, remembered)) return termHandlers.activate(remembered!)
@@ -1067,9 +1068,10 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "newTerminal") termHandlers.requestNew()
       else if (msg.action === "cycleAgentMode" && document.hasFocus()) cycleAgent(1)
       else if (msg.action === "cyclePreviousAgentMode" && document.hasFocus()) cycleAgent(-1)
-      else if (msg.action === "cycleReasoningEffort" && document.hasFocus() && !terms.activeId())
-        session.cycleVariant(activePendingId())
-      else {
+      else if (msg.action === "cycleReasoningEffort" && document.hasFocus()) {
+        const id = visibleTabId()
+        if (id && id !== REVIEW_TAB_ID && !isTerminalTabId(id)) session.cycleVariant(id)
+      } else {
         // Handle jumpTo1 through jumpTo9
         const match = /^jumpTo([1-9])$/.exec(msg.action ?? "")
         if (match) jumpToItem(parseInt(match[1]!) - 1)

--- a/packages/kilo-vscode/webview-ui/agent-manager/shortcuts.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/shortcuts.ts
@@ -8,6 +8,10 @@ export interface ShortcutCategory {
   shortcuts: ShortcutEntry[]
 }
 
+function binding(bindings: Record<string, string>, name: string) {
+  return bindings[name] ?? ""
+}
+
 export function buildShortcutCategories(
   bindings: Record<string, string>,
   t: (key: string, params?: Record<string, string | number>) => string,
@@ -62,6 +66,7 @@ export function buildShortcutCategories(
         { label: t("agentManager.shortcuts.openAgentManager"), binding: bindings.agentManagerOpen ?? "" },
         { label: t("agentManager.shortcuts.cycleAgentMode"), binding: bindings.cycleAgentMode ?? "" },
         { label: t("agentManager.shortcuts.cyclePreviousAgentMode"), binding: bindings.cyclePreviousAgentMode ?? "" },
+        { label: t("command.model.variant.cycle"), binding: binding(bindings, "cycleReasoningEffort") },
         { label: t("agentManager.shortcuts.showShortcuts"), binding: bindings.showShortcuts ?? "" },
       ].filter((s) => s.binding),
     },

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -227,6 +227,9 @@ const AppContent: Component = () => {
       case "cyclePreviousAgentMode":
         if (document.hasFocus()) cycleAgent(-1)
         break
+      case "cycleReasoningEffort":
+        if (document.hasFocus()) session.cycleVariant()
+        break
     }
   }
 
@@ -283,8 +286,18 @@ const AppContent: Component = () => {
         setMigrationNeeded(message.needed)
       }
     }
+    const focus = () => vscode.postMessage({ type: "webviewFocusChanged", focused: true })
+    const blur = () => vscode.postMessage({ type: "webviewFocusChanged", focused: false })
     window.addEventListener("message", handler)
-    onCleanup(() => window.removeEventListener("message", handler))
+    window.addEventListener("focus", focus)
+    window.addEventListener("blur", blur)
+    if (document.hasFocus()) focus()
+    onCleanup(() => {
+      window.removeEventListener("message", handler)
+      window.removeEventListener("focus", focus)
+      window.removeEventListener("blur", blur)
+      blur()
+    })
   })
 
   const handleSelectSession = (id: string) => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -42,6 +42,10 @@ import {
   insertSpacedText,
   isPromptBusy,
   isPathMention,
+  optionPeriodEdit,
+  matchesOptionPeriodInput,
+  canRestoreOptionPeriodEdit,
+  type NativeEdit,
 } from "./prompt-input-utils"
 import type { ReviewComment, SendMessageFailedMessage, TextPart } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
@@ -167,6 +171,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   let highlightRef: HTMLDivElement | undefined
   let dropdownRef: HTMLDivElement | undefined
   let slashDropdownRef: HTMLDivElement | undefined
+  let native: (NativeEdit & { inserted: boolean; command: boolean; enhanced: string | null }) | undefined
   // Save/restore input text when switching sessions.
   // Uses `on()` to track only draftKey — avoids re-running on every keystroke.
   createEffect(
@@ -435,6 +440,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       textareaRef?.focus()
     }
 
+    if (
+      message.type === "action" &&
+      message.action === "cycleReasoningEffort" &&
+      message.nativeInput === "mac-option-period" &&
+      native
+    ) {
+      native.command = true
+      restoreNativeInput()
+    }
+
     if (message.type === "enhancePromptResult") {
       const result = message as import("../../types/messages").EnhancePromptResultMessage
       if (result.requestId === `enhance-${draftKey()}-${enhanceCounter}`) {
@@ -461,6 +476,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   onCleanup(() => {
     // Persist current draft before unmounting
     saveDraft(draftKey(), text(), reviewComments(), imageAttach.images())
+    native = undefined
     unsubAutoApprove()
     unsubscribe()
   })
@@ -508,6 +524,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handlePaste = (e: ClipboardEvent) => {
+    native = undefined
     imageAttach.handlePaste(e)
     // After pasting text, the textarea content changes but the layout may not
     // have reflowed yet, causing the caret position to be visually out of sync.
@@ -518,22 +535,57 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     })
   }
 
-  const handleInput = (e: InputEvent) => {
-    const target = e.target as HTMLTextAreaElement
-    const val = target.value
+  const syncInput = (val: string, pos: number) => {
     setText(val)
-    preEnhanceText = null
     adjustHeight()
     syncHighlightScroll()
     history.reset()
-
-    slash.onInput(val, target.selectionStart ?? val.length)
-    mention.onInput(val, target.selectionStart ?? val.length)
+    slash.onInput(val, pos)
+    mention.onInput(val, pos)
     ghost.setMentionOpen(slash.show() || mention.showMention())
     ghost.scheduleRequest(val, textareaRef)
   }
 
+  function restoreNativeInput() {
+    const edit = native
+    const ref = textareaRef
+    if (!edit?.inserted || !edit.command || !ref || !document.hasFocus() || document.activeElement !== ref) return
+    if (!canRestoreOptionPeriodEdit(edit, ref.value, ref.selectionStart, ref.selectionEnd)) {
+      native = undefined
+      return
+    }
+    native = undefined
+    preEnhanceText = edit.enhanced
+    ref.value = edit.before
+    ref.setSelectionRange(edit.start, edit.end, edit.direction)
+    syncInput(edit.before, edit.end)
+  }
+
+  const handleInput = (e: InputEvent) => {
+    const target = e.target as HTMLTextAreaElement
+    const val = target.value
+    const edit = native
+    const matches =
+      edit &&
+      matchesOptionPeriodInput(edit, e, val, target.selectionStart ?? val.length, target.selectionEnd ?? val.length)
+    if (!matches) native = undefined
+    if (matches) {
+      edit.inserted = true
+      if (edit.command) {
+        restoreNativeInput()
+        return
+      }
+    }
+    preEnhanceText = null
+    syncInput(val, target.selectionStart ?? val.length)
+  }
+
   const handleKeyDown = (e: KeyboardEvent) => {
+    const ref = textareaRef
+    const edit = ref
+      ? optionPeriodEdit(e, ref.value, ref.selectionStart, ref.selectionEnd, ref.selectionDirection)
+      : undefined
+    native = edit ? { ...edit, inserted: false, command: false, enhanced: preEnhanceText } : undefined
     // Undo enhanced prompt with Ctrl+Z / ⌘Z
     if (e.key === "z" && (e.metaKey || e.ctrlKey) && !e.shiftKey && preEnhanceText !== null) {
       e.preventDefault()
@@ -981,9 +1033,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onKeyDown={handleKeyDown}
             onKeyUp={syncGhost}
             onPaste={handlePaste}
+            onCompositionStart={() => {
+              native = undefined
+            }}
             onClick={syncGhost}
             onFocus={syncGhost}
-            onBlur={syncGhost}
+            onBlur={() => {
+              native = undefined
+              syncGhost()
+            }}
             onSelect={() => {
               syncGhost()
               if (textareaRef) mention.snapSelection(textareaRef)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -43,9 +43,10 @@ import {
   isPromptBusy,
   isPathMention,
   optionPeriodEdit,
-  matchesOptionPeriodInput,
+  optionPeriodInput,
   canRestoreOptionPeriodEdit,
   type NativeEdit,
+  type NativeInput,
 } from "./prompt-input-utils"
 import type { ReviewComment, SendMessageFailedMessage, TextPart } from "../../types/messages"
 import { formatReviewCommentsMarkdown } from "../../utils/review-comment-markdown"
@@ -171,7 +172,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   let highlightRef: HTMLDivElement | undefined
   let dropdownRef: HTMLDivElement | undefined
   let slashDropdownRef: HTMLDivElement | undefined
-  let native: (NativeEdit & { inserted: boolean; command: boolean; enhanced: string | null }) | undefined
+  let native: { edit: NativeEdit; input?: NativeInput; command: boolean; enhanced: string | null } | undefined
   // Save/restore input text when switching sessions.
   // Uses `on()` to track only draftKey — avoids re-running on every keystroke.
   createEffect(
@@ -547,31 +548,32 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   function restoreNativeInput() {
-    const edit = native
+    const state = native
+    const edit = state?.input
     const ref = textareaRef
-    if (!edit?.inserted || !edit.command || !ref || !document.hasFocus() || document.activeElement !== ref) return
+    if (!edit || !state.command || !ref || !document.hasFocus() || document.activeElement !== ref) return
     if (!canRestoreOptionPeriodEdit(edit, ref.value, ref.selectionStart, ref.selectionEnd)) {
       native = undefined
       return
     }
     native = undefined
-    preEnhanceText = edit.enhanced
+    preEnhanceText = state.enhanced
     ref.value = edit.before
     ref.setSelectionRange(edit.start, edit.end, edit.direction)
-    syncInput(edit.before, edit.end)
+    syncInput(edit.before, ref.selectionStart ?? edit.start)
   }
 
   const handleInput = (e: InputEvent) => {
     const target = e.target as HTMLTextAreaElement
     const val = target.value
-    const edit = native
-    const matches =
-      edit &&
-      matchesOptionPeriodInput(edit, e, val, target.selectionStart ?? val.length, target.selectionEnd ?? val.length)
-    if (!matches) native = undefined
-    if (matches) {
-      edit.inserted = true
-      if (edit.command) {
+    const state = native
+    const input = state
+      ? optionPeriodInput(state.edit, e, val, target.selectionStart ?? val.length, target.selectionEnd ?? val.length)
+      : undefined
+    if (!input) native = undefined
+    if (state && input) {
+      state.input = input
+      if (state.command) {
         restoreNativeInput()
         return
       }
@@ -585,7 +587,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const edit = ref
       ? optionPeriodEdit(e, ref.value, ref.selectionStart, ref.selectionEnd, ref.selectionDirection)
       : undefined
-    native = edit ? { ...edit, inserted: false, command: false, enhanced: preEnhanceText } : undefined
+    native = edit ? { edit, command: false, enhanced: preEnhanceText } : undefined
     // Undo enhanced prompt with Ctrl+Z / ⌘Z
     if (e.key === "z" && (e.metaKey || e.ctrlKey) && !e.shiftKey && preEnhanceText !== null) {
       e.preventDefault()
@@ -672,6 +674,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       e.preventDefault()
       handleSend()
     }
+  }
+
+  const handleKeyUp = (e: KeyboardEvent) => {
+    if (native && !native.input && e.code === "Period" && e.altKey) native = undefined
+    syncGhost()
   }
 
   const canEnhance = () => !isBusy() && !isDisabled() && !enhancing()
@@ -1031,7 +1038,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             value={text()}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
-            onKeyUp={syncGhost}
+            onKeyUp={handleKeyUp}
             onPaste={handlePaste}
             onCompositionStart={() => {
               native = undefined

--- a/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
@@ -52,11 +52,14 @@ export function atEnd(start: number, end: number, len: number): boolean {
 
 export interface NativeEdit {
   before: string
-  after: string
   start: number
   end: number
-  pos: number
   direction: "forward" | "backward" | "none"
+}
+
+export interface NativeInput extends NativeEdit {
+  after: string
+  pos: number
 }
 
 export function optionPeriodEdit(
@@ -68,33 +71,25 @@ export function optionPeriodEdit(
 ): NativeEdit | undefined {
   if (event.code !== "Period" || !event.altKey || event.ctrlKey || event.metaKey || event.shiftKey || event.isComposing)
     return undefined
-  return {
-    before: value,
-    after: `${value.slice(0, start)}≥${value.slice(end)}`,
-    start,
-    end,
-    pos: start + 1,
-    direction,
-  }
+  return { before: value, start, end, direction }
 }
 
-export function matchesOptionPeriodInput(
+export function optionPeriodInput(
   edit: NativeEdit,
-  event: Pick<InputEvent, "data" | "inputType">,
+  event: Pick<InputEvent, "data" | "inputType" | "isComposing">,
   value: string,
   start: number,
   end: number,
-) {
-  return (
-    event.inputType === "insertText" &&
-    event.data === "≥" &&
-    value === edit.after &&
-    start === edit.pos &&
-    end === edit.pos
-  )
+): NativeInput | undefined {
+  const data = event.data
+  if (event.inputType !== "insertText" || event.isComposing || !data) return undefined
+  const after = `${edit.before.slice(0, edit.start)}${data}${edit.before.slice(edit.end)}`
+  const pos = edit.start + data.length
+  if (value !== after || start !== pos || end !== pos) return undefined
+  return { ...edit, after, pos }
 }
 
-export function canRestoreOptionPeriodEdit(edit: NativeEdit, value: string, start: number, end: number) {
+export function canRestoreOptionPeriodEdit(edit: NativeInput, value: string, start: number, end: number) {
   return value === edit.after && start === edit.pos && end === edit.pos
 }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
@@ -50,6 +50,54 @@ export function atEnd(start: number, end: number, len: number): boolean {
   return start === end && end === len
 }
 
+export interface NativeEdit {
+  before: string
+  after: string
+  start: number
+  end: number
+  pos: number
+  direction: "forward" | "backward" | "none"
+}
+
+export function optionPeriodEdit(
+  event: Pick<KeyboardEvent, "code" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "isComposing">,
+  value: string,
+  start: number,
+  end: number,
+  direction: "forward" | "backward" | "none",
+): NativeEdit | undefined {
+  if (event.code !== "Period" || !event.altKey || event.ctrlKey || event.metaKey || event.shiftKey || event.isComposing)
+    return undefined
+  return {
+    before: value,
+    after: `${value.slice(0, start)}≥${value.slice(end)}`,
+    start,
+    end,
+    pos: start + 1,
+    direction,
+  }
+}
+
+export function matchesOptionPeriodInput(
+  edit: NativeEdit,
+  event: Pick<InputEvent, "data" | "inputType">,
+  value: string,
+  start: number,
+  end: number,
+) {
+  return (
+    event.inputType === "insertText" &&
+    event.data === "≥" &&
+    value === edit.after &&
+    start === edit.pos &&
+    end === edit.pos
+  )
+}
+
+export function canRestoreOptionPeriodEdit(edit: NativeEdit, value: string, start: number, end: number) {
+  return value === edit.after && start === edit.pos && end === edit.pos
+}
+
 export function insertSpacedText(
   text: string,
   value: string,

--- a/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
@@ -24,6 +24,12 @@ export function getVariant(
   return stored && variants.includes(stored) ? stored : variants[0]
 }
 
+export function nextVariant(current: string | undefined, variants: string[]) {
+  if (variants.length === 0) return undefined
+  const idx = current ? variants.indexOf(current) : -1
+  return variants[(idx + 1) % variants.length]
+}
+
 export function transferVariants(store: Record<string, string>, from: string, to: string) {
   const prefix = `session/${from}/`
   return Object.fromEntries(

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -69,7 +69,7 @@ import { errorIDs } from "./session-errors"
 import { PartStash } from "./part-stash"
 import { mergeParts, sameParts } from "./session-parts"
 import { state as todoState } from "./todo-revert"
-import { getVariant, sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
+import { getVariant, nextVariant, sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
 import { KILO_AUTO, KILO_PROVIDER_ID, parseModelString } from "../../../src/shared/provider-model"
 import { reviewMetadata, type ReviewMessageData } from "../../../src/shared/review-comments"
 import { visibleMessages as filterVisibleMessages } from "./session-queue"
@@ -225,6 +225,7 @@ interface SessionContextValue {
   variantList: (sessionID?: string) => string[]
   currentVariant: (sessionID?: string) => string | undefined
   selectVariant: (value: string, sessionID?: string) => void
+  cycleVariant: (sessionID?: string) => void
 
   // Model favorites
   favoriteModels: Accessor<ModelSelection[]>
@@ -842,6 +843,16 @@ export const SessionProvider: ParentComponent = (props) => {
     const key = variantKey(sel, agentForScope(sid), sid)
     setStore("variantSelections", key, value)
     if (!sid) vscode.postMessage({ type: "persistVariant", key, value })
+  }
+
+  const cycleVariant = (sessionID?: string) => {
+    const sid = sessionID ?? currentSessionID() ?? draftSessionID() ?? undefined
+    const variants = variantList(sid)
+    if (variants.length < 2) return
+    const current = currentVariant(sid)
+    const next = nextVariant(current, variants)
+    if (!next || next === current) return
+    selectVariant(next, sid)
   }
 
   // Load persisted variants from extension globalState
@@ -2786,6 +2797,7 @@ export const SessionProvider: ParentComponent = (props) => {
     variantList,
     currentVariant,
     selectVariant,
+    cycleVariant,
     revert,
     revertedCount,
     summary,

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -248,6 +248,7 @@ export interface SelectKiloModelMessage {
 export interface ActionMessage {
   type: "action"
   action: string
+  nativeInput?: "mac-option-period"
 }
 
 export interface SetChatBoxMessage {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -155,6 +155,11 @@ export interface WebviewReadyRequest {
   type: "webviewReady"
 }
 
+export interface WebviewFocusRequest {
+  type: "webviewFocusChanged"
+  focused: boolean
+}
+
 export interface SelectSourceRequest {
   type: "selectSource"
   id: string
@@ -1122,6 +1127,7 @@ export type WebviewMessage =
   | CancelLoginRequest
   | SetOrganizationRequest
   | WebviewReadyRequest
+  | WebviewFocusRequest
   | SelectSourceRequest
   | RequestProvidersMessage
   | CompactRequest


### PR DESCRIPTION
A prompt can already be fully drafted when the user realizes that the task needs a different reasoning effort. The existing `/variant` action cannot solve that flow because slash commands are recognized only when they start the composer input. Once text exists, changing the variant requires leaving the keyboard flow and using the selector, even though the draft, attachments, review comments, and active Agent Manager session are otherwise ready to send.

This adds a draft-safe `Kilo Code: Cycle Reasoning Effort` command. Its default binding is `Alt+.`, it applies to the focused Kilo sidebar, Kilo editor tab, or Agent Manager chat, and it cycles only the active session's available variants. The command leaves the prompt and its associated state unchanged, preserves normal `Tab` and `Shift+Tab` focus navigation, and can be changed or removed through VS Code Keyboard Shortcuts.

On macOS, `Option+.` normally inserts `≥`. VS Code webviews can both execute the contributed shortcut and receive that native text input. The default keybinding is therefore tagged so the composer restores only that exact native insertion transaction when the shortcut fires. Existing, pasted, or intentionally entered `≥` characters are not removed, and remapping the command does not leave `Option+.` hardwired in the composer.

## Existing agent conventions

| Agent | Control | Draft behavior | Relevant takeaway |
|---|---|---|---|
| Kilo CLI | `Ctrl+T` cycles model variants; `Ctrl+P` opens the command list and `/variants` opens the picker | Variant changes do not alter the prompt buffer | Dedicated draft-safe variant control is already the Kilo CLI convention |
| [Pi](https://pi.dev/docs/latest/keybindings#models-and-thinking) | `Shift+Tab` cycles thinking level; `Ctrl+L` opens models; all bindings are configurable | Thinking changes are independent of the editor buffer | A terminal TUI can dedicate `Shift+Tab` because it owns focus navigation |
| [Claude Code](https://code.claude.com/docs/en/interactive-mode#general-controls) | `Option+T` / `Alt+T` toggles extended thinking; `Option+P` / `Alt+P` switches models | Both controls explicitly preserve the current prompt | A dedicated modified key is preferable to encoding the action in prompt text |
| [Codex CLI](https://developers.openai.com/codex/cli) | `/model` switches models and adjusts reasoning levels | Uses a picker-oriented command rather than a documented reasoning hotkey | Reasoning is a first-class setting, but slash-only access does not address Kilo's already-written-draft case |
| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | `Shift+Tab` cycles operating modes; `/model` switches models | Mode selection stays outside normal prompt content | `Shift+Tab` is common in terminal agents, but has different accessibility implications in a VS Code webview |
| Kilo VS Code after this change | `Alt+.` cycles reasoning effort; the VS Code command is rebindable | Prompt text, caret, attachments, review comments, and session scope remain intact | Matches the CLI's draft-safe behavior without taking over focus-navigation keys |

## Choices considered

| Choice | Advantage | Why it was not selected |
|---|---|---|
| Recognize a trailing `/variant` after arbitrary prompt text | Directly mirrors the reported input | Creates a second slash-command grammar, raises consistency questions for every other command, and risks suggestions or parsing inside prose, code, and paths |
| Use `Shift+Tab` | Familiar from Pi and Copilot CLI | Overrides standard reverse focus navigation in browsers and VS Code, which is an accessibility regression for keyboard users |
| Reuse Kilo CLI's `Ctrl+T` | Maximum cross-product consistency | Conflicts with Agent Manager and VS Code tab creation conventions, especially `Cmd+T` on macOS and `Ctrl+T` on Windows/Linux |
| Add a multi-key chord | Avoids printable-character and navigation conflicts | Adds more friction to a frequent adjustment and has weaker precedent among coding agents |
| Use `Alt+.` as a contributed VS Code command | Compact, draft-safe, scoped, and user-overridable | Selected, with exact native-input restoration on macOS so the shortcut does not also type `≥` |

The chosen behavior treats reasoning effort as session state rather than prompt syntax. That keeps the interaction available at the moment it is needed, after drafting but before sending, and gives users a standard VS Code override path when the default does not fit their keyboard layout or workflow.
