### PR TITLE
fix(agent-manager): speed up worktree hover cards

### DIFF
--- a/.changeset/swift-pr-hover-cards.md
+++ b/.changeset/swift-pr-hover-cards.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Speed up Agent Manager worktree hover cards so pull request details appear and dismiss more quickly.

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -151,8 +151,9 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
       </Show>
       <ContextMenu>
         <HoverCard
-          openDelay={100}
-          closeDelay={100}
+          class="am-worktree-hover-card"
+          openDelay={50}
+          closeDelay={50}
           placement="right-start"
           gutter={8}
           open={hovered() && !overClose() && !props.pendingDelete}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -3126,6 +3126,14 @@ body.am-wt-dragging-active * {
 
 /* HoverCard popover for worktree items */
 
+.am-worktree-hover-card[data-expanded] {
+  animation-duration: 80ms;
+}
+
+.am-worktree-hover-card[data-closed] {
+  animation-duration: 60ms;
+}
+
 .am-hover-card {
   padding: 10px 12px;
   min-width: 160px;


### PR DESCRIPTION
Agent Manager worktree hover cards currently take too long to appear and linger after the pointer leaves, making pull request details feel unresponsive.

This reduces the open and close delays and shortens both animation phases. The faster animation is scoped to worktree hover cards so other hover-card interactions retain their existing timing.