### PR TITLE
fix(vscode): order model variants

### DIFF
--- a/.changeset/order-thinking-efforts.md
+++ b/.changeset/order-thinking-efforts.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Order standard thinking variants from weakest to strongest in variant selectors.

--- a/packages/kilo-vscode/tests/unit/provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-utils.test.ts
@@ -41,6 +41,103 @@ describe("flattenModels", () => {
     const providers = { empty: makeProvider("empty", "Empty", []) }
     expect(flattenModels(providers)).toEqual([])
   })
+
+  it("orders standard reasoning variants from weakest to strongest", () => {
+    const provider = makeProvider("openai", "OpenAI", ["gpt-5"])
+    provider.models["gpt-5"]!.variants = {
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      none: { reasoningEffort: "none" },
+      max: { reasoning: { enabled: true, effort: "xhigh" }, verbosity: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
+      minimal: { reasoningEffort: "minimal" },
+      medium: { reasoningEffort: "medium" },
+    }
+
+    const model = flattenModels({ openai: provider })[0]!
+
+    expect(Object.keys(model.variants ?? {})).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+    expect(model.variants?.max).toEqual({ reasoning: { enabled: true, effort: "xhigh" }, verbosity: "max" })
+  })
+
+  it("orders reasoning subsets used by cloud model families", () => {
+    const cases = {
+      openai: {
+        input: ["low", "high", "none", "xhigh", "medium"],
+        output: ["none", "low", "medium", "high", "xhigh"],
+      },
+      codex: {
+        input: ["low", "high", "xhigh", "medium"],
+        output: ["low", "medium", "high", "xhigh"],
+      },
+      claude: {
+        input: ["low", "high", "none", "max", "medium"],
+        output: ["none", "low", "medium", "high", "max"],
+      },
+      opus: {
+        input: ["low", "high", "none", "xhigh", "max", "medium"],
+        output: ["none", "low", "medium", "high", "xhigh", "max"],
+      },
+      gemini25: {
+        input: ["max", "high"],
+        output: ["high", "max"],
+      },
+      deepseek: {
+        input: ["high", "none", "xhigh"],
+        output: ["none", "high", "xhigh"],
+      },
+    }
+    const result = Object.fromEntries(
+      Object.entries(cases).map(([id, sample]) => {
+        const provider = makeProvider(id, id, ["model"])
+        provider.models.model!.variants = Object.fromEntries(sample.input.map((name) => [name, { name }]))
+        const model = flattenModels({ [id]: provider })[0]!
+        return [id, Object.keys(model.variants ?? {})]
+      }),
+    )
+
+    expect(result).toEqual(Object.fromEntries(Object.entries(cases).map(([id, sample]) => [id, sample.output])))
+  })
+
+  it("orders cloud toggle and mixed reasoning variants", () => {
+    const cases = {
+      binary: {
+        input: ["thinking", "instant"],
+        output: ["instant", "thinking"],
+      },
+      thinkingOnly: {
+        input: ["thinking"],
+        output: ["thinking"],
+      },
+      mercury: {
+        input: ["low", "high", "instant", "medium"],
+        output: ["instant", "low", "medium", "high"],
+      },
+    }
+    const result = Object.fromEntries(
+      Object.entries(cases).map(([id, sample]) => {
+        const provider = makeProvider(id, id, ["model"])
+        provider.models.model!.variants = Object.fromEntries(sample.input.map((name) => [name, { name }]))
+        const model = flattenModels({ [id]: provider })[0]!
+        return [id, Object.keys(model.variants ?? {})]
+      }),
+    )
+
+    expect(result).toEqual(Object.fromEntries(Object.entries(cases).map(([id, sample]) => [id, sample.output])))
+  })
+
+  it("preserves provider order when variants include custom names", () => {
+    const provider = makeProvider("custom", "Custom", ["model"])
+    provider.models.model!.variants = {
+      high: { reasoningEffort: "high" },
+      turbo: { reasoningEffort: "high" },
+      low: { reasoningEffort: "low" },
+    }
+
+    const model = flattenModels({ custom: provider })[0]!
+
+    expect(Object.keys(model.variants ?? {})).toEqual(["high", "turbo", "low"])
+  })
 })
 
 describe("findModel", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/provider-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/provider-utils.ts
@@ -2,6 +2,20 @@ import type { Provider, ProviderModel, ModelSelection } from "../types/messages"
 
 export type EnrichedModel = ProviderModel & { providerID: string; providerName: string }
 
+const ORDERS = [
+  ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+  ["instant", "thinking"],
+  ["instant", "low", "medium", "high"],
+]
+
+function order(variants: NonNullable<ProviderModel["variants"]>) {
+  const entries = Object.entries(variants)
+  const names = entries.map(([name]) => name)
+  const ranks = ORDERS.find((rank) => names.every((name) => rank.includes(name)))
+  if (!ranks) return variants
+  return Object.fromEntries(entries.sort(([a], [b]) => ranks.indexOf(a) - ranks.indexOf(b)))
+}
+
 /**
  * Flatten a provider map into a list of models enriched with provider info.
  */
@@ -10,8 +24,10 @@ export function flattenModels(providers: Record<string, Provider>): EnrichedMode
   for (const providerID of Object.keys(providers)) {
     const provider = providers[providerID]!
     for (const modelID of Object.keys(provider.models)) {
+      const model = provider.models[modelID]!
       result.push({
-        ...provider.models[modelID]!,
+        ...model,
+        ...(model.variants ? { variants: order(model.variants) } : {}),
         id: modelID,
         providerID,
         providerName: provider.name,


### PR DESCRIPTION
Model variant selectors currently render backend object insertion order, which can place reasoning levels in a confusing sequence and make the order vary by provider.

Normalize known variant families as provider models enter the webview. Effort levels are ordered from weakest to strongest, binary modes place Instant before Thinking, and Mercury-style mixed modes place Instant before effort levels. Unknown or custom variant families retain their provider-defined order so the client does not invent semantics for arbitrary names.

The recognized families match the variant shapes emitted by the cloud model catalog and CLI provider transforms, including OpenAI, Codex, Claude and Opus, Gemini, DeepSeek and GLM, toggle-based models, and Mercury.

<img width="219" height="206" alt="dyn-57a05117c1f119d5247d6c5df13be220" src="https://github.com/user-attachments/assets/d6e15aa6-871c-47e1-9b38-16cce94fc098" />
<img width="234" height="232" alt="dyn-d1dabe94358dbe7eb720a8c398a7d431" src="https://github.com/user-attachments/assets/dfebbf4c-2282-4bae-849a-b17bd9b9505d" />
