### PR TITLE
fix(jetbrains): disclose prompt-training models

### DIFF
--- a/.changeset/show-jetbrains-training-disclosures.md
+++ b/.changeset/show-jetbrains-training-disclosures.md
@@ -1,5 +1,0 @@
----
-"@kilocode/kilo-jetbrains": patch
----
-
-Show prompt-training disclosures for every affected model in the JetBrains model picker.

--- a/.changeset/show-jetbrains-training-disclosures.md
+++ b/.changeset/show-jetbrains-training-disclosures.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Show prompt-training disclosures for every affected model in the JetBrains model picker.

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
@@ -993,6 +993,7 @@ object KiloCliDataParser {
             recommendedIndex = model.recommendedIndex,
             variants = model.variants,
             limit = model.limit?.let { ModelLimitDto(it.context, it.input, it.output) },
+            mayTrainOnYourPrompts = model.mayTrainOnYourPrompts,
         )
     }
 
@@ -1018,6 +1019,7 @@ object KiloCliDataParser {
                     output = it.long("output") ?: 0,
                 )
             },
+            mayTrainOnYourPrompts = obj.bool("mayTrainOnYourPrompts"),
         )
     }
 

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceDtoMapper.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceDtoMapper.kt
@@ -79,6 +79,7 @@ internal object KiloWorkspaceDtoMapper {
         recommendedIndex = m.recommendedIndex,
         variants = m.variants,
         limit = m.limit?.let { ModelLimitDto(it.context, it.input, it.output) },
+        mayTrainOnYourPrompts = m.mayTrainOnYourPrompts,
     )
 
     private fun agent(a: AgentInfo) = AgentDto(

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/workspace/KiloWorkspaceState.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/workspace/KiloWorkspaceState.kt
@@ -59,6 +59,7 @@ data class ModelInfo(
     val recommendedIndex: Double?,
     val variants: List<String>,
     val limit: ModelLimitInfo?,
+    val mayTrainOnYourPrompts: Boolean = false,
 )
 
 data class ModelLimitInfo(

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
@@ -1256,6 +1256,7 @@ class KiloCliDataParserTest {
                             "status": "active",
                             "isFree": false,
                             "hasUserByokAvailable": true,
+                            "mayTrainOnYourPrompts": true,
                             "recommendedIndex": 2,
                             "variants": {"high": {}, "low": {}, "medium": {}},
                             "options": {}, "headers": {}
@@ -1277,6 +1278,7 @@ class KiloCliDataParserTest {
             assertEquals("active", model.status)
             assertFalse(model.free)
             assertTrue(model.byok)
+            assertTrue(model.mayTrainOnYourPrompts)
             assertEquals(2.0, model.recommendedIndex)
             assertEquals(200000L, model.limit?.context)
             assertEquals(100000L, model.limit?.input)
@@ -1326,7 +1328,13 @@ class KiloCliDataParserTest {
                         "extra": true
                     },
                     "unknown": "ok",
-                    "models": {}
+                    "models": {
+                        "gpt-5": {
+                            "name": "GPT-5",
+                            "capabilities": {},
+                            "mayTrainOnYourPrompts": true
+                        }
+                    }
                 }],
                 "default": {"code":"openai/gpt-5"},
                 "connected": ["openai"]
@@ -1339,6 +1347,7 @@ class KiloCliDataParserTest {
             assertEquals("Build with OpenAI models", provider.description)
             assertEquals("openai", provider.metadata?.icon)
             assertEquals(3, provider.metadata?.priority)
+            assertTrue(provider.models.getValue("gpt-5").mayTrainOnYourPrompts)
             assertEquals(listOf("openai"), result.second)
             assertEquals(mapOf("code" to "openai/gpt-5"), result.third)
         }
@@ -1372,6 +1381,7 @@ class KiloCliDataParserTest {
             assertEquals(false, model.reasoning)
             assertEquals(false, model.temperature)
             assertEquals(false, model.toolCall)
+            assertFalse(model.mayTrainOnYourPrompts)
             assertNull(model.limit)
         }
 

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceDtoMapperTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceDtoMapperTest.kt
@@ -1,0 +1,44 @@
+package ai.kilocode.backend.rpc
+
+import ai.kilocode.backend.workspace.ModelInfo
+import ai.kilocode.backend.workspace.ProviderData
+import ai.kilocode.backend.workspace.ProviderInfo
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class KiloWorkspaceDtoMapperTest {
+
+    @Test
+    fun `providers preserve prompt training disclosure`() {
+        val model = ModelInfo(
+            id = "paid",
+            name = "Paid",
+            attachment = false,
+            reasoning = false,
+            temperature = false,
+            toolCall = true,
+            free = false,
+            status = null,
+            recommendedIndex = null,
+            variants = emptyList(),
+            limit = null,
+            mayTrainOnYourPrompts = true,
+        )
+        val data = ProviderData(
+            providers = listOf(
+                ProviderInfo(
+                    id = "kilo",
+                    name = "Kilo",
+                    source = "api",
+                    models = mapOf(model.id to model),
+                ),
+            ),
+            connected = listOf("kilo"),
+            defaults = emptyMap(),
+        )
+
+        val result = KiloWorkspaceDtoMapper.providers(data)
+
+        assertTrue(result.providers.single().models.getValue("paid").mayTrainOnYourPrompts)
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionUi.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/SessionUi.kt
@@ -398,16 +398,17 @@ class SessionUi(
                     }, m.agent)
                     val items = m.models.map {
                         ModelPicker.Item(
-                            it.id,
-                            it.display,
-                            it.provider,
-                            it.providerName,
-                             it.recommendedIndex,
-                             it.free,
-                             it.byok,
-                             it.variants,
-                             it.attachment,
-                         )
+                            id = it.id,
+                            display = it.display,
+                            provider = it.provider,
+                            providerName = it.providerName,
+                            recommendedIndex = it.recommendedIndex,
+                            free = it.free,
+                            byok = it.byok,
+                            variants = it.variants,
+                            attachment = it.attachment,
+                            mayTrainOnYourPrompts = it.mayTrainOnYourPrompts,
+                        )
                     }
                     val selected =
                         m.model?.let { full -> items.firstOrNull { it.key == full }?.key }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/controller/SessionController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/controller/SessionController.kt
@@ -657,17 +657,18 @@ class SessionController(
                             .flatMap { provider ->
                                 provider.models.map { (id, info) ->
                                     ModelItem(
-                                        id,
-                                        info.name,
-                                        provider.id,
-                                        provider.name,
-                                         info.recommendedIndex,
-                                         info.free,
-                                         info.byok,
-                                         info.variants,
-                                         info.limit?.let { ModelLimitItem(it.context, it.input, it.output) },
-                                         info.attachment,
-                                     )
+                                        id = id,
+                                        display = info.name,
+                                        provider = provider.id,
+                                        providerName = provider.name,
+                                        recommendedIndex = info.recommendedIndex,
+                                        free = info.free,
+                                        byok = info.byok,
+                                        variants = info.variants,
+                                        limit = info.limit?.let { ModelLimitItem(it.context, it.input, it.output) },
+                                        attachment = info.attachment,
+                                        mayTrainOnYourPrompts = info.mayTrainOnYourPrompts,
+                                    )
                                 }
                             }
                     } ?: emptyList()

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/model/SessionModel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/model/SessionModel.kt
@@ -587,6 +587,7 @@ data class ModelItem(
     val variants: List<String>,
     val limit: ModelLimitItem?,
     val attachment: Boolean = false,
+    val mayTrainOnYourPrompts: Boolean = false,
 ) {
     val key: String get() = "$provider/$id"
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/model/ModelPicker.kt
@@ -59,6 +59,7 @@ class ModelPicker : PickerButton() {
         val byok: Boolean = false,
         val variants: List<String> = emptyList(),
         val attachment: Boolean = false,
+        val mayTrainOnYourPrompts: Boolean = false,
     ) {
         val key: String get() = "$provider/$id"
 
@@ -474,7 +475,7 @@ internal object ModelText {
 
     fun freeLabel(): String = KiloBundle.message("model.picker.free")
 
-    fun collectsData(item: ModelPicker.Item): Boolean = item.free && item.provider == "kilo"
+    fun collectsData(item: ModelPicker.Item): Boolean = item.mayTrainOnYourPrompts
 
     fun freeBg(): JBColor = JBColor.namedColor("Kilo.ModelPicker.freeBadgeBackground", JBColor(0x95D6AC, 0x7FCA99))
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/settings/models/ModelsSettingsUi.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/settings/models/ModelsSettingsUi.kt
@@ -183,6 +183,7 @@ internal class ModelsSettingsUi(
                         model.free,
                         model.byok,
                         model.variants,
+                        mayTrainOnYourPrompts = model.mayTrainOnYourPrompts,
                     )
                     if (!includeSmall && ModelText.small(item)) return@mapNotNull null
                     item

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/WorkspaceWatchingTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/WorkspaceWatchingTest.kt
@@ -1,6 +1,8 @@
 package ai.kilocode.client.session.controller
 
 import ai.kilocode.rpc.dto.AgentDto
+import ai.kilocode.rpc.dto.ModelDto
+import ai.kilocode.rpc.dto.ProviderDto
 
 class WorkspaceWatchingTest : SessionControllerTestBase() {
 
@@ -10,13 +12,28 @@ class WorkspaceWatchingTest : SessionControllerTestBase() {
         flush()
         events.clear()
 
-        projectRpc.state.value = workspaceReady()
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(
+                ProviderDto(
+                    id = "kilo",
+                    name = "Kilo",
+                    models = mapOf(
+                        "gpt-5" to ModelDto(
+                            id = "gpt-5",
+                            name = "GPT-5",
+                            mayTrainOnYourPrompts = true,
+                        ),
+                    ),
+                ),
+            ),
+        )
         flush()
 
         assertEquals(1, m.model.agents.size)
         assertEquals("code", m.model.agents[0].name)
         assertEquals(1, m.model.models.size)
         assertEquals("gpt-5", m.model.models[0].id)
+        assertTrue(m.model.models[0].mayTrainOnYourPrompts)
         assertFalse(m.model.isReady())
         assertControllerEvents("""
             AccountOverlayChanged show loggedIn=false

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/model/ModelPickerTest.kt
@@ -265,20 +265,20 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertEquals(listOf("low", "high"), item.variants)
     }
 
-    fun `test selected free model indicates data collection`() {
+    fun `test selected paid model with training flag indicates data collection`() {
         val picker = ModelPicker()
 
-        picker.setItems(listOf(item("auto", "Auto Free", "kilo", "Kilo", free = true)))
+        picker.setItems(listOf(item("paid", "Paid", "kilo", "Kilo", training = true)))
 
         assertFalse(picker.text.contains("Data may be used for training"))
         assertSame(ModelPickerRenderer.DATA_COLLECTED, picker.icon)
         assertEquals("<html><nobr>Select model</nobr><br><nobr>The current selected model may be used for training</nobr></html>", picker.toolTipText)
     }
 
-    fun `test selected non-kilo free model does not indicate data collection`() {
+    fun `test selected free model without training flag does not indicate data collection`() {
         val picker = ModelPicker()
 
-        picker.setItems(listOf(item("free", "OpenRouter Free", "openrouter", "OpenRouter", free = true)))
+        picker.setItems(listOf(item("free", "Free", "kilo", "Kilo", free = true)))
 
         assertNull(picker.icon)
         assertEquals("Select model", picker.toolTipText)
@@ -393,6 +393,18 @@ class ModelPickerTest : BasePlatformTestCase() {
 
         assertTrue(renderer.badgeVisible())
         assertEquals("Free", renderer.badgeText())
+        assertFalse(renderer.warningVisible())
+    }
+
+    fun `test renderer shows data collection warning for paid training model`() {
+        val row = ModelPickerRow(item("paid", "Paid", "kilo", "Kilo", training = true), "Kilo", false)
+        val model = CollectionListModel(listOf(row))
+        val renderer = ModelPickerRenderer(model, { null }, { emptySet() })
+        val list = JBList(model)
+
+        renderer.getListCellRendererComponent(list, row, 0, false, false)
+
+        assertFalse(renderer.badgeVisible())
         assertTrue(renderer.warningVisible())
         assertEquals("Data may be used for training", renderer.warningTooltip())
     }
@@ -413,7 +425,7 @@ class ModelPickerTest : BasePlatformTestCase() {
         assertFalse(renderer.badgeVisible())
     }
 
-    fun `test renderer hides data collection warning for non-kilo free model`() {
+    fun `test renderer hides data collection warning without training flag`() {
         val row = ModelPickerRow(ModelPicker.Item("free", "Free", "openrouter", "OpenRouter", free = true), "OpenRouter", false)
         val model = CollectionListModel(listOf(row))
         val renderer = ModelPickerRenderer(model, { null }, { emptySet() })
@@ -446,7 +458,8 @@ class ModelPickerTest : BasePlatformTestCase() {
         name: String,
         index: Double? = null,
         free: Boolean = false,
-    ) = ModelPicker.Item(id, display, provider, name, index, free = free)
+        training: Boolean = false,
+    ) = ModelPicker.Item(id, display, provider, name, index, free = free, mayTrainOnYourPrompts = training)
 
     private fun favoriteInset(list: JBList<*>): Int {
         if (!NewUI.isEnabled()) return 0

--- a/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/dto/ProviderDto.kt
+++ b/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/dto/ProviderDto.kt
@@ -16,6 +16,7 @@ data class ModelDto(
     val recommendedIndex: Double? = null,
     val variants: List<String> = emptyList(),
     val limit: ModelLimitDto? = null,
+    val mayTrainOnYourPrompts: Boolean = false,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary
- propagate the model API's prompt-training flag through the JetBrains split-mode RPC and frontend model flow
- drive picker disclosures from the explicit flag instead of assuming every free Kilo model trains on prompts
- cover paid training models, non-training free models, parser defaults, and RPC mapping

JetBrains previously inferred data collection from a model being free and served by Kilo. That left paid models marked `mayTrainOnYourPrompts` unlabeled and could incorrectly label free models without the flag.