### PR TITLE
fix(cli): prevent snapshot questions from hanging run

### DIFF
--- a/.changeset/settle-slow-snapshots.md
+++ b/.changeset/settle-slow-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent non-interactive `kilo run` commands from hanging when slow snapshot initialization asks a question.

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -718,8 +718,8 @@ export const RunCommand = effectCmd({
 
             if (event.type === "message.part.updated") {
               const part = event.properties.part
-              // kilocode_change start - track Task child sessions for --auto permission replies
-              if (args.auto) KiloRunAuto.track(auto, part)
+              // kilocode_change start - track Task child sessions for non-interactive replies
+              KiloRunAuto.track(auto, part)
               // kilocode_change end
               if (part.sessionID !== sessionID) continue
 
@@ -809,6 +809,15 @@ export const RunCommand = effectCmd({
             ) {
               break
             }
+
+            // kilocode_change start - non-interactive runs cannot answer blocking questions
+            if (event.type === "question.asked") {
+              const question = event.properties
+              if (!KiloRunAuto.allowed(auto, question.sessionID)) continue
+              await client.question.reject({ requestID: question.id })
+              continue
+            }
+            // kilocode_change end
 
             if (event.type === "permission.asked") {
               const permission = event.properties

--- a/packages/opencode/test/kilocode/run-question.test.ts
+++ b/packages/opencode/test/kilocode/run-question.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+
+type Event = {
+  type: string
+  properties: Record<string, unknown>
+}
+
+function feed<T>() {
+  const list: T[] = []
+  const wait: Array<() => void> = []
+  const state = { done: false }
+
+  return {
+    push(item: T) {
+      list.push(item)
+      while (wait.length) wait.shift()?.()
+    },
+    end() {
+      state.done = true
+      while (wait.length) wait.shift()?.()
+    },
+    async *stream() {
+      while (!state.done || list.length) {
+        if (list.length) {
+          yield list.shift() as T
+          continue
+        }
+        await new Promise<void>((resolve) => wait.push(resolve))
+      }
+    },
+  }
+}
+
+function question(id: string, sessionID: string): Event {
+  return {
+    type: "question.asked",
+    properties: {
+      id,
+      sessionID,
+      blocking: true,
+      questions: [
+        {
+          header: "Snapshot is slow",
+          question: "Disable snapshots?",
+          custom: false,
+          options: [],
+        },
+      ],
+    },
+  }
+}
+
+function task(child: string): Event {
+  return {
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: "prt_task",
+        type: "tool",
+        tool: "task",
+        sessionID: "ses_root",
+        state: {
+          status: "running",
+          input: {},
+          metadata: { sessionId: child },
+          time: { start: 0 },
+        },
+      },
+    },
+  }
+}
+
+function idle(): Event {
+  return {
+    type: "session.status",
+    properties: {
+      sessionID: "ses_root",
+      status: { type: "idle" },
+    },
+  }
+}
+
+function args() {
+  return {
+    _: [],
+    $0: "kilo",
+    message: ["hi"],
+    command: undefined,
+    continue: false,
+    session: "ses_root",
+    fork: false,
+    "cloud-fork": false,
+    cloudFork: false,
+    share: false,
+    model: undefined,
+    agent: undefined,
+    format: "json",
+    file: undefined,
+    title: undefined,
+    attach: "http://127.0.0.1:4096",
+    password: undefined,
+    dir: undefined,
+    port: undefined,
+    variant: undefined,
+    thinking: false,
+    interactive: false,
+    auto: false,
+    "dangerously-skip-permissions": false,
+    dangerouslySkipPermissions: false,
+    "--": [],
+  }
+}
+
+const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+
+afterEach(() => {
+  if (tty) {
+    Object.defineProperty(process.stdin, "isTTY", tty)
+    return
+  }
+  delete (process.stdin as { isTTY?: boolean }).isTTY
+})
+
+async function run(sdk: Record<string, unknown>) {
+  mock.module("@kilocode/sdk/v2", () => ({
+    createKiloClient: () => sdk,
+  }))
+
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: true,
+  })
+
+  const key = JSON.stringify({ time: Date.now(), rand: Math.random() })
+  const { RunCommand } = await import(`../../src/cli/cmd/run?${key}`)
+  return RunCommand.handler(args() as never)
+}
+
+async function bounded(promise: Promise<unknown>) {
+  return Promise.race([
+    promise,
+    Bun.sleep(1_000).then(() => {
+      throw new Error("kilo run hung on an unanswered question")
+    }),
+  ])
+}
+
+describe("cli run questions", () => {
+  test("rejects a blocking root question so the run can continue", async () => {
+    const q = feed<Event>()
+    const calls: string[] = []
+    const gate = Promise.withResolvers<void>()
+
+    const sdk = {
+      config: {
+        get: async () => ({ data: { share: "manual" } }),
+      },
+      event: {
+        subscribe: async () => ({ stream: q.stream() }),
+      },
+      question: {
+        reject: async (input: { requestID: string }) => {
+          calls.push(input.requestID)
+          gate.resolve()
+          return { data: true }
+        },
+      },
+      session: {
+        get: async (input: { sessionID: string }) => ({
+          data: { id: input.sessionID, directory: "/tmp/project" },
+        }),
+        prompt: async () => {
+          q.push(question("que_snapshot", "ses_root"))
+          await gate.promise
+          q.push(idle())
+          q.end()
+          return { data: undefined }
+        },
+      },
+    }
+
+    await bounded(run(sdk))
+
+    expect(calls).toEqual(["que_snapshot"])
+  })
+
+  test("rejects tracked Task child questions and ignores unrelated sessions", async () => {
+    const q = feed<Event>()
+    const calls: string[] = []
+    const gate = Promise.withResolvers<void>()
+
+    const sdk = {
+      config: {
+        get: async () => ({ data: { share: "manual" } }),
+      },
+      event: {
+        subscribe: async () => ({ stream: q.stream() }),
+      },
+      question: {
+        reject: async (input: { requestID: string }) => {
+          calls.push(input.requestID)
+          gate.resolve()
+          return { data: true }
+        },
+      },
+      session: {
+        get: async (input: { sessionID: string }) => ({
+          data: { id: input.sessionID, directory: "/tmp/project" },
+        }),
+        prompt: async () => {
+          q.push(task("ses_child"))
+          q.push(question("que_other", "ses_other"))
+          q.push(question("que_child", "ses_child"))
+          await gate.promise
+          q.push(idle())
+          q.end()
+          return { data: undefined }
+        },
+      },
+    }
+
+    await bounded(run(sdk))
+
+    expect(calls).toEqual(["que_child"])
+  })
+})


### PR DESCRIPTION
Slow snapshot initialization can ask a blocking internal question before the model stream starts. Interactive clients can answer it, but plain `kilo run` has no question UI, and denying the model-facing question tool does not prevent infrastructure from calling `Question.ask()`. The prompt request therefore remains pending indefinitely.

Non-interactive runs now dismiss questions belonging to the active root session or a discovered Task child while leaving unrelated sessions untouched. Dismissal cancels only the current snapshot attempt without permanently disabling snapshots, allowing the model turn to continue deterministically. Interactive `kilo run`, TUI, and VS Code question behavior remain unchanged.

Focused regression coverage reproduces the blocked root request and verifies Task child filtering. A patch changeset records the user-facing fix.