### PR TITLE
fix(cli): preserve custom subagent permissions

### DIFF
--- a/.changeset/keep-subagent-permissions.md
+++ b/.changeset/keep-subagent-permissions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve custom subagent tool permissions when tasks inherit restrictions from their parent agent.

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -42,12 +42,18 @@ export namespace KiloTask {
   }
 
   /**
-   * Build inherited permission rules from the calling agent.
+   * Build inherited permission ceilings from the calling agent.
    * Merges the static agent definition with the session's accumulated permissions
-   * so restrictions survive multi-hop chains (plan → general → explore).
+   * so denials survive multi-hop chains (plan → general → explore) without
+   * overriding the selected subagent's own allowlist with parent ask/allow rules.
+   *
+   * OpenCode removed parent-agent inheritance entirely in anomalyco/opencode#31696.
+   * Kilo intentionally differs: parent denials remain hard ceilings for Plan Mode
+   * and MCP restrictions, while parent ask/allow rules must not replace the
+   * selected subagent's policy. Preserve this distinction during upstream merges.
    *
    * The caller must resolve `caller` (Agent.Info) and `session` (Session.Info)
-   * before calling — this function is pure/synchronous.
+   * before calling. This function is pure/synchronous.
    */
   export function inherited(input: {
     caller: Agent.Info
@@ -58,7 +64,8 @@ export namespace KiloTask {
     const prefixes = Object.keys(input.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
     const isMcp = (p: string) => prefixes.some((prefix) => p.startsWith(prefix))
     return rules.filter(
-      (r: Permission.Rule) => r.permission === "edit" || r.permission === "bash" || isMcp(r.permission),
+      (r: Permission.Rule) =>
+        r.action === "deny" && (r.permission === "edit" || r.permission === "bash" || isMcp(r.permission)),
     )
   }
 

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -14,6 +14,7 @@ import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Provider } from "../../src/provider/provider"
+import { Permission } from "../../src/permission"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
 import { Truncate } from "../../src/tool/truncate"
@@ -231,6 +232,79 @@ describe("Kilo task nesting", () => {
       { permission: "edit", pattern: "*", action: "allow" },
     ])
   })
+
+  it.live("preserves a custom subagent bash policy while inheriting parent denials", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const agents = yield* Agent.Service
+          const { chat, assistant } = yield* seed()
+          const tool = yield* TaskTool
+          const def = yield* tool.init()
+
+          const result = yield* def.execute(
+            {
+              description: "validate ansible",
+              prompt: "run ansible-lint --version",
+              subagent_type: "validator",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps: stubOps() },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          const child = yield* sessions.get(result.metadata.sessionId)
+          const validator = yield* agents.get("validator")
+          expect(validator).toBeDefined()
+          if (!validator) return
+
+          expect(Permission.evaluate("bash", "ansible-lint --version", validator.permission).action).toBe("allow")
+          expect(Permission.evaluate("bash", "rm -rf build", validator.permission).action).toBe("deny")
+
+          const effective = Permission.merge(
+            validator.permission,
+            KiloSessionPrompt.guardPermissions({ agent: validator, session: child }),
+          )
+          expect(child.permission).not.toContainEqual({ permission: "bash", pattern: "*", action: "ask" })
+          expect(child.permission).toContainEqual({ permission: "bash", pattern: "rm -rf *", action: "deny" })
+          expect({
+            allowed: Permission.evaluate("bash", "ansible-lint --version", effective).action,
+            denied: Permission.evaluate("bash", "rm -rf build", effective).action,
+          }).toEqual({ allowed: "allow", denied: "deny" })
+        }),
+      {
+        config: {
+          permission: {
+            bash: {
+              "*": "ask",
+              "git -c *": "allow",
+              "echo *": "allow",
+              "rm -rf *": "deny",
+            },
+          },
+          agent: {
+            validator: {
+              mode: "subagent",
+              permission: {
+                bash: {
+                  "*": "deny",
+                  "*ansible-lint*": "allow",
+                },
+              },
+            },
+          },
+        },
+      },
+    ),
+  )
 
   it.live("refreshes inherited restrictions when resuming a task child", () =>
     provideTmpdirInstance(() =>


### PR DESCRIPTION
Custom Task subagents currently receive the complete caller-agent Bash, edit, and MCP rules after their own policy. Because permission evaluation is last-match-wins, a parent `bash "*": "ask"` fallback can override both a child allowlist and its deny fallback. Validators then stop for approval on explicitly allowed commands, while unlisted commands ask instead of being denied.

This narrows the Kilo-specific inherited Task rules to denials only. Custom subagent allow and deny rules remain authoritative unless a parent denial establishes a hard ceiling. Parent denials still propagate across multi-hop delegation, including Plan Mode and MCP restrictions. The regression coverage exercises the real Task child-session path for both an allowed validator command and an inherited destructive-command denial.

Upstream permission inheritance evolved through:

- [anomalyco/opencode#26597](https://github.com/anomalyco/opencode/pull/26597), which introduced parent-agent denial inheritance to close a Plan Mode bypass.
- [anomalyco/opencode#27201](https://github.com/anomalyco/opencode/pull/27201), which narrowed the overly broad inheritance after it erased subagent permissions.
- [anomalyco/opencode#31696](https://github.com/anomalyco/opencode/pull/31696), which removed parent-agent inheritance and let subagents use their own permissions.

The final upstream change first shipped in OpenCode v1.17.2 and has not reached Kilo. It cannot be cherry-picked unchanged because Kilo intentionally retains parent denials as hard ceilings. The comment beside `KiloTask.inherited()` records this distinction so a future upstream merge preserves the Kilo policy while adopting the upstream subagent-owned permission behavior.

Fixes #11046.