### PR TITLE
fix(cli): show local IPv6 URL for wildcard binds

### DIFF
--- a/.changeset/show-ipv6-loopback-url.md
+++ b/.changeset/show-ipv6-loopback-url.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show the usable local IPv6 URL when the server binds to the IPv6 wildcard address.

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -23,10 +23,8 @@ export const ServeCommand = effectCmd({
     const urls = server.urls
 
     console.log(`kilo server listening on ${urls.bind}`)
-    if (urls.network) {
-      console.log(`  Local:   ${urls.local}`)
-      console.log(`  Network: ${urls.network}`)
-    }
+    if (urls.local !== urls.bind) console.log(`  Local:   ${urls.local}`)
+    if (urls.network) console.log(`  Network: ${urls.network}`)
     // kilocode_change end
 
     // kilocode_change start - graceful signal shutdown

--- a/packages/opencode/test/kilocode/cli/cmd/serve.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/serve.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import { tmpdir } from "../../../fixture/fixture"
+
+const root = path.resolve(import.meta.dir, "../../../..")
+const entry = path.join(root, "src/index.ts")
+
+test("prints the local IPv6 URL for wildcard binds", async () => {
+  await using tmp = await tmpdir()
+  const proc = Bun.spawn(
+    [process.execPath, "--conditions=browser", entry, "serve", "--hostname", "::", "--port", "0"],
+    {
+      cwd: tmp.path,
+      env: {
+        ...process.env,
+        HOME: tmp.path,
+        XDG_CONFIG_HOME: path.join(tmp.path, ".config"),
+        XDG_DATA_HOME: path.join(tmp.path, ".local/share"),
+        XDG_STATE_HOME: path.join(tmp.path, ".local/state"),
+        XDG_CACHE_HOME: path.join(tmp.path, ".cache"),
+        KILO_TEST_HOME: tmp.path,
+        KILO_CONFIG_CONTENT: "{}",
+        KILO_DISABLE_PROJECT_CONFIG: "1",
+        KILO_DISABLE_AUTOUPDATE: "1",
+        KILO_DISABLE_MODELS_FETCH: "1",
+        KILO_PURE: "1",
+        KILO_SERVER_PASSWORD: "test",
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+    },
+  )
+  const errors = new Response(proc.stderr).text()
+  const timeout = setTimeout(() => proc.kill(), 15_000)
+  const output = await (async () => {
+    const reader = proc.stdout.getReader()
+    const decoder = new TextDecoder()
+    let text = ""
+
+    while (!text.includes("  Local:")) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      text += decoder.decode(chunk.value, { stream: true })
+    }
+
+    reader.releaseLock()
+    return text + decoder.decode()
+  })().finally(async () => {
+    clearTimeout(timeout)
+    proc.kill()
+    await proc.exited
+  })
+  const stderr = await errors
+
+  expect(output, `stdout:\n${output}\nstderr:\n${stderr}`).toMatch(
+    /kilo server listening on http:\/\/\[::\]:(\d+)\r?\n  Local:   http:\/\/\[::1\]:\1(?:\r?\n|$)/,
+  )
+}, 30_000)


### PR DESCRIPTION
Fixes #11477

When `kilo serve` binds to `::`, the URL helper derives `http://[::1]:<port>` correctly, but the command hid it because both Local and Network output were gated on IPv4 network discovery.

Print the Local URL whenever it differs from the raw bind URL, while keeping Network output conditional on a discovered network address. Add subprocess regression coverage that verifies the IPv6 wildcard and loopback URLs use the same dynamically assigned port.