### PR TITLE
fix(core): create the default `.kilo/plans` directory automatically when Plan mode starts

### DIFF
--- a/.changeset/create-plan-dir.md
+++ b/.changeset/create-plan-dir.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Create the default `.kilo/plans` directory automatically when Plan mode starts.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -289,7 +289,7 @@ export namespace KiloSessionPrompt {
     const target = saved ?? plan
     const time = input.session.time.created
     const dir = path.dirname(target)
-    if (saved && !(await Filesystem.exists(target))) await ensurePlanDir(dir)
+    if (!saved || !(await Filesystem.exists(target))) await ensurePlanDir(dir)
 
     const info = saved
       ? `The current saved plan file is ${target}. Read and edit this file when refining the plan.`

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -648,6 +648,43 @@ describe("plan_exit detection", () => {
       expect(text).not.toContain("No plan file exists yet")
     }))
 
+  test("native plan reminder creates the default plan directory", () =>
+    withInstance(async () => {
+      const session = await sessions.create({})
+      const dir = path.dirname(Session.plan(session, Instance.current))
+      await expect(fs.stat(dir).then(() => true, () => false)).resolves.toBe(false)
+
+      const id = MessageID.ascending()
+      const user: MessageV2.WithParts = {
+        info: {
+          id,
+          role: "user",
+          sessionID: session.id,
+          time: { created: Date.now() },
+          agent: "plan",
+          model,
+        },
+        parts: [
+          {
+            id: PartID.ascending(),
+            messageID: id,
+            sessionID: session.id,
+            type: "text",
+            text: "Create a plan.",
+          },
+        ],
+      }
+
+      await KiloSessionPrompt.insertPlanReminders({
+        agent: { name: "plan", options: {} },
+        session,
+        userMessage: user,
+        messages: [user],
+      })
+
+      await expect(fs.stat(dir).then((stat) => stat.isDirectory())).resolves.toBe(true)
+    }))
+
   test("native plan reminder prefers project plan path instructions over fallback", () =>
     withInstance(async () => {
       const session = await sessions.create({})


### PR DESCRIPTION
## Issue

Fixes #11502

## Context

Currently, Kilo does not automatically create the .kilo/plans directory if it does not exist. The Plan agent does not have permission to automatically create it, unless the user has created overrides that allow it to do so. To resolve this, we have the Kilo harness automatically create the directory if it does not exist when the user starts a session with the Plan agent.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Open Kilo in a directory where `.kilo/plans` does not exist
- Start a new plan session in Plan mode
- Kilo should automatically create `.kilo/plans`

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord