### PR TITLE
fix(cli): show live session spend in TUI sidebar during active turn

### DIFF
--- a/.changeset/tui-live-spent-cost.md
+++ b/.changeset/tui-live-spent-cost.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show live session spend in the TUI sidebar while an assistant turn is still running.

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -14,7 +14,15 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
-  const cost = createMemo(() => session()?.cost ?? 0)
+  // kilocode_change start
+  const cost = createMemo(() => {
+    const total = msg().reduce((sum, item) => {
+      if (item.role !== "assistant") return sum
+      return sum + (item.cost ?? 0)
+    }, 0)
+    return Math.max(session()?.cost ?? 0, total)
+  })
+  // kilocode_change end
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)


### PR DESCRIPTION
## Issue

Fixes #11480

## Context

The TUI sidebar showed live spend as `$0.00` while an assistant turn was still running, even though token count and context percentage updated live. `session.cost` is only the persisted session aggregate, which is stale until the turn finalizes, so the sidebar read `0` mid-turn.

## Implementation

In `sidebar/context.tsx`, the `cost` memo now sums `cost` across the live assistant messages and takes `Math.max` of that against `session()?.cost`. During an active turn the per-message sum leads; once the aggregate is persisted it wins (or ties), so the displayed value never regresses. This mirrors how the adjacent `tokens` / context-percent memos already derive from the live message list rather than the session aggregate. Client-only change; no server or protocol changes.

## Screenshots

| before | after |
|---|---|
| sidebar "spent" reads `$0.00` during an active turn | sidebar "spent" reflects accumulating cost during the turn |

N/A for a static capture in this environment — the change is a derived-value calculation in the sidebar memo. See verification below.

## How to Test

### Manual/local verification

- Start a TUI session, send a prompt, and watch the sidebar "spent" line during the assistant turn: it now climbs with the running cost instead of staying at `$0.00`, and settles at the session total when the turn finalizes.

### Reviewer test steps

1. Open the TUI and start an assistant turn that incurs cost.
2. While the turn is still streaming, observe the sidebar "spent" value.
3. Confirm it shows a non-zero, increasing value mid-turn and matches the session total after completion.

### Blocked checks and substitute verification

- `bun test ./test/cli/tui/usage.test.ts` could not complete in this environment (missing `@opentui/solid/preload`, an environment/runtime dependency unrelated to the change). Substitute verification: reviewed that `cost` now derives from the same `msg()` live-message list the existing `tokens`/context memos use, and that `Math.max` preserves the persisted aggregate so the value is monotonic across turn finalization.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

AI was used for assistance.
