### PR TITLE
Feat/hashline edit tool

### DIFF
--- a/.changeset/hashline-edit-tool.md
+++ b/.changeset/hashline-edit-tool.md
@@ -1,0 +1,9 @@
+---
+"@kilocode/cli": minor
+---
+
+Add hashline-style hash-anchored line editing tool
+
+Add a new `hash_edit` tool that enables precise, hash-anchored line edits. When `hashlineEdit.enabled` is set in config, the `read` tool annotates file output with short deterministic hashes (e.g. `#HL 2:f1c|const x = 1;`), and the new `hash_edit` tool lets the agent target lines by their hash reference — eliminating ambiguous string matching and fragile unified diffs.
+
+Supports `replace`, `delete`, `insert_before`, and `insert_after` operations with structured error codes (`HASH_MISMATCH`, `FILE_REV_MISMATCH`, `INVALID_REF`) for reliable automated retry.

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -23,8 +23,10 @@ export const ServeCommand = effectCmd({
     const urls = server.urls
 
     console.log(`kilo server listening on ${urls.bind}`)
-    if (urls.network) {
+    if (urls.local) {
       console.log(`  Local:   ${urls.local}`)
+    }
+    if (urls.network) {
       console.log(`  Network: ${urls.network}`)
     }
     // kilocode_change end

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -223,6 +223,14 @@ export const Info = Schema.Struct({
     description: "Automatically collapse reasoning blocks after the agent finishes writing them",
   }),
   indexing: Schema.optional(IndexingRef).annotate({ description: "Codebase indexing configuration" }),
+  hashlineEdit: Schema.optional(
+    Schema.Struct({
+      enabled: Schema.optional(Schema.Boolean).annotate({ description: "Enable hashline editing mode" }),
+      prefix: Schema.optional(Schema.String).annotate({ description: "Prefix for hashline annotations (default: '#HL ')" }),
+      hashLength: Schema.optional(Schema.Number).annotate({ description: "Override hash length for hashline (0 = adaptive)" }),
+      fileRev: Schema.optional(Schema.Boolean).annotate({ description: "Include file revision hash (default: true)" }),
+    })
+  ).annotate({ description: "Hashline edit configuration" }),
   console: Schema.optional(
     Schema.Struct({
       context_sidebar_width: Schema.optional(

--- a/packages/opencode/src/kilocode/hashline/hashline.ts
+++ b/packages/opencode/src/kilocode/hashline/hashline.ts
@@ -324,6 +324,7 @@ export function formatFileWithHashes(
   hashLen?: number,
   prefix?: string | false,
   includeFileRev?: boolean,
+  startLine: number = 1,
 ): string {
   const normalized = content.includes("\r\n") ? content.replace(/\r\n/g, "\n") : content;
   const lines = normalized.split("\n");
@@ -336,7 +337,7 @@ export function formatFileWithHashes(
   const hashes: string[] = new Array(lines.length);
 
   for (let idx = 0; idx < lines.length; idx++) {
-    hashes[idx] = computeLineHash(idx, lines[idx], effectiveLen);
+    hashes[idx] = computeLineHash(idx + startLine - 1, lines[idx], effectiveLen);
   }
 
   // Iteratively resolve collisions — only rescan indices that were upgraded
@@ -366,7 +367,7 @@ export function formatFileWithHashes(
         const newLen = Math.min(hashLens[idx] + 1, 8);
         if (newLen === hashLens[idx]) continue; // already at max length
         hashLens[idx] = newLen;
-        hashes[idx] = computeLineHash(idx, lines[idx], newLen);
+        hashes[idx] = computeLineHash(idx + startLine - 1, lines[idx], newLen);
         nextDirty.add(idx);
         hasCollisions = true;
       }
@@ -388,7 +389,7 @@ export function formatFileWithHashes(
   }
 
   const annotatedLines = lines.map((line, idx) => {
-    return `${effectivePrefix}${idx + 1}:${hashes[idx]}|${line}`;
+    return `${effectivePrefix}${idx + startLine}:${hashes[idx]}|${line}`;
   });
 
   if (includeFileRev) {
@@ -487,7 +488,8 @@ export function normalizeHashRef(ref: string): string {
     return `${parseInt(plain[1], 10)}:${plain[2].toLowerCase()}`;
   }
 
-  const annotated = trimmed.match(/^(?:[#\w]*\s+)?(\d+):([0-9a-f]{2,8})\|.*$/i);
+  // To support any custom prefix, match anything up to the <line>:<hash>| pattern
+  const annotated = trimmed.match(/^(?:.*?)(\d+):([0-9a-f]{2,8})\|.*$/i);
   if (annotated) {
     return `${parseInt(annotated[1], 10)}:${annotated[2].toLowerCase()}`;
   }

--- a/packages/opencode/src/kilocode/hashline/hashline.ts
+++ b/packages/opencode/src/kilocode/hashline/hashline.ts
@@ -1,0 +1,965 @@
+/**
+ * Core Hashline logic — content-addressable line hashing for precise AI code editing.
+ *
+ * Each line gets a hex hash tag derived from its index and trimmed content.
+ * Hash length adapts to file size: 3 chars (≤4096 lines), 4 chars (>4096).
+ * Minimum hash length is 3 to reduce collision risk.
+ * Format: `#HL <lineNumber>:<hash>|<originalLine>`
+ *
+ * Example:
+ *   #HL 1:a3f|function hello() {
+ *   #HL 2:f1c|  return "world";
+ *   #HL 3:0e7|}
+ */
+
+import { matchesGlob as pathMatchesGlob } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration object for Hashline.
+ */
+export interface HashlineConfig {
+  /** Glob patterns to exclude from processing */
+  exclude?: string[];
+  /** Maximum file size in bytes to process (default: 1MB) */
+  maxFileSize?: number;
+  /** Override hash length (3–4). If not set, adaptive length is used. */
+  hashLength?: number;
+  /** LRU cache size — number of files to cache (default: 100) */
+  cacheSize?: number;
+  /**
+   * Magic prefix for hashline annotations.
+   * Default: "#HL " — lines are formatted as `#HL 1:a3f|code here`.
+   * Set to `false` to disable prefix (legacy format: `1:a3f|code here`).
+   */
+  prefix?: string | false;
+  /** Enable debug logging to ~/.config/opencode/hashline-debug.log (default: false) */
+  debug?: boolean;
+  /** Include file revision hash in annotations (default: true) */
+  fileRev?: boolean;
+}
+
+/** Default exclude patterns */
+export const DEFAULT_EXCLUDE_PATTERNS: string[] = [
+  "**/node_modules/**",
+  "**/*.lock",
+  "**/package-lock.json",
+  "**/yarn.lock",
+  "**/pnpm-lock.yaml",
+  "**/*.min.js",
+  "**/*.min.css",
+  "**/*.bundle.js",
+  "**/*.map",
+];
+
+/** Default prefix for hashline annotations */
+export const DEFAULT_PREFIX = "#HL ";
+
+/** Default configuration values */
+export const DEFAULT_CONFIG: Required<HashlineConfig> = {
+  exclude: DEFAULT_EXCLUDE_PATTERNS,
+  maxFileSize: 1_048_576, // 1 MB
+  hashLength: 0, // 0 = adaptive
+  cacheSize: 100,
+  prefix: DEFAULT_PREFIX,
+  debug: false,
+  fileRev: true,
+};
+
+/**
+ * Merge user config with defaults.
+ *
+ * @param config - optional partial user config
+ * @param pluginConfig - optional config from plugin context (e.g. opencode.json)
+ */
+export function resolveConfig(
+  config?: HashlineConfig,
+  pluginConfig?: HashlineConfig,
+): Required<HashlineConfig> {
+  // Merge: pluginConfig (from opencode.json) is overridden by explicit config
+  const merged: HashlineConfig = {
+    ...pluginConfig,
+    ...config,
+  };
+
+  if (!merged || Object.keys(merged).length === 0) {
+    return { ...DEFAULT_CONFIG, exclude: [...DEFAULT_CONFIG.exclude] } as Required<HashlineConfig>;
+  }
+
+  return {
+    exclude: merged.exclude ?? [...DEFAULT_CONFIG.exclude],
+    maxFileSize: merged.maxFileSize ?? DEFAULT_CONFIG.maxFileSize,
+    hashLength: merged.hashLength ?? DEFAULT_CONFIG.hashLength,
+    cacheSize: merged.cacheSize ?? DEFAULT_CONFIG.cacheSize,
+    prefix: merged.prefix !== undefined ? merged.prefix : DEFAULT_CONFIG.prefix,
+    debug: merged.debug ?? DEFAULT_CONFIG.debug,
+    fileRev: merged.fileRev ?? DEFAULT_CONFIG.fileRev,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structured Error Diagnostics
+// ---------------------------------------------------------------------------
+
+export type HashlineErrorCode =
+  | "HASH_MISMATCH"
+  | "FILE_REV_MISMATCH"
+  | "TARGET_OUT_OF_RANGE"
+  | "INVALID_REF"
+  | "INVALID_RANGE"
+  | "MISSING_REPLACEMENT";
+
+export interface CandidateLine {
+  lineNumber: number; // 1-based
+  content: string;
+}
+
+export class HashlineError extends Error {
+  readonly code: HashlineErrorCode;
+  readonly expected?: string;
+  readonly actual?: string;
+  readonly candidates?: CandidateLine[];
+  readonly hint?: string;
+  readonly lineNumber?: number;
+  readonly filePath?: string;
+
+  constructor(opts: {
+    code: HashlineErrorCode;
+    message: string;
+    expected?: string;
+    actual?: string;
+    candidates?: CandidateLine[];
+    hint?: string;
+    lineNumber?: number;
+    filePath?: string;
+  }) {
+    super(opts.message);
+    this.name = "HashlineError";
+    this.code = opts.code;
+    this.expected = opts.expected;
+    this.actual = opts.actual;
+    this.candidates = opts.candidates;
+    this.hint = opts.hint;
+    this.lineNumber = opts.lineNumber;
+    this.filePath = opts.filePath;
+  }
+
+  toDiagnostic(): string {
+    const parts: string[] = [`[${this.code}] ${this.message}`];
+    if (this.filePath) {
+      parts.push(`  File: ${this.filePath}`);
+    }
+    if (this.lineNumber !== undefined) {
+      parts.push(`  Line: ${this.lineNumber}`);
+    }
+    if (this.expected !== undefined && this.actual !== undefined) {
+      parts.push(`  Expected hash: ${this.expected}`);
+      parts.push(`  Actual hash:   ${this.actual}`);
+    }
+    if (this.candidates && this.candidates.length > 0) {
+      parts.push(`  Candidates (${this.candidates.length}):`);
+      for (const c of this.candidates) {
+        const preview = c.content.length > 60 ? `${c.content.slice(0, 60)}...` : c.content;
+        parts.push(`    - line ${c.lineNumber}: ${preview}`);
+      }
+    }
+    if (this.hint) {
+      parts.push(`  Hint: ${this.hint}`);
+    }
+    return parts.join("\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hash computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple fast hash function (FNV-1a inspired).
+ * Returns a 32-bit unsigned integer.
+ */
+function fnv1aHash(str: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0; // FNV prime, keep as uint32
+  }
+  return hash;
+}
+
+/** Precomputed 16^hashLen for hashLen 0–8 */
+const MODULI = [1, 16, 256, 4096, 65536, 1048576, 16777216, 268435456, 4294967296];
+
+function getModulus(hashLen: number): number {
+  return MODULI[hashLen] ?? 16 ** hashLen;
+}
+
+/**
+ * Determine the appropriate hash length based on the number of lines.
+ *
+ * Minimum hash length is 3 to reduce collision risk.
+ * - ≤4096 lines → 3 hex chars (4096 values)
+ * - >4096 lines → 4 hex chars (65536 values)
+ */
+export function getAdaptiveHashLength(lineCount: number): number {
+  if (lineCount <= 4096) return 3;
+  return 4;
+}
+
+/**
+ * Compute a hex hash for a given line.
+ *
+ * Uses trimEnd() so that leading whitespace (indentation) IS significant,
+ * but trailing whitespace is ignored.
+ *
+ * @param idx - 0-based line index
+ * @param line - the raw line content
+ * @param hashLen - number of hex characters (3–4, default 3)
+ * @returns lowercase hex string of the specified length
+ */
+export function computeLineHash(idx: number, line: string, hashLen: number = 3): string {
+  const trimmed = line.trimEnd();
+  const input = `${idx}:${trimmed}`;
+  const raw = fnv1aHash(input);
+  const modulus = getModulus(hashLen);
+  const hash = raw % modulus;
+  return hash.toString(16).padStart(hashLen, "0");
+}
+
+/**
+ * Compute a file-level revision hash from the entire content.
+ * Uses FNV-1a on CRLF-normalized content, returns 8-char hex (full 32 bits).
+ */
+export function computeFileRev(content: string): string {
+  const normalized = content.includes("\r\n") ? content.replace(/\r\n/g, "\n") : content;
+  const hash = fnv1aHash(normalized);
+  return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * Extract the file revision from annotated content.
+ * Looks for a line matching `<prefix>REV:<8-hex>` at the start of the content.
+ *
+ * @param annotatedContent - content with hashline annotations
+ * @param prefix - prefix string (default "#HL "), or false for legacy format
+ * @returns the revision hash string, or null if not found
+ */
+export function extractFileRev(annotatedContent: string, prefix?: string | false): string | null {
+  const effectivePrefix = prefix === undefined ? DEFAULT_PREFIX : prefix === false ? "" : prefix;
+  const escapedPrefix = effectivePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`^${escapedPrefix}REV:([0-9a-f]{8})$`);
+  const firstLine = annotatedContent.split("\n")[0];
+  const match = firstLine.match(pattern);
+  return match ? match[1] : null;
+}
+
+/**
+ * Verify that the file revision matches the current content.
+ * Throws HashlineError with code FILE_REV_MISMATCH if it doesn't match.
+ */
+export function verifyFileRev(expectedRev: string, currentContent: string): void {
+  const actualRev = computeFileRev(currentContent);
+  if (actualRev !== expectedRev) {
+    throw new HashlineError({
+      code: "FILE_REV_MISMATCH",
+      message: `File revision mismatch: expected "${expectedRev}", got "${actualRev}". The file has changed since it was last read.`,
+      expected: expectedRev,
+      actual: actualRev,
+      hint: "Re-read the file to get fresh hash references and a new file revision.",
+    });
+  }
+}
+
+/**
+ * Find candidate lines that match the expected hash for a given original line index.
+ * Used for safe reapply: if a line moved, find where it went.
+ *
+ * Since computeLineHash uses `${idx}:${trimmed}`, we check each line in the file
+ * computing its hash as if it were at the original index — a match means the content
+ * is the same as what was originally at that position.
+ */
+export function findCandidateLines(
+  originalLineNumber: number,
+  expectedHash: string,
+  lines: string[],
+  hashLen?: number,
+): CandidateLine[] {
+  const effectiveLen = hashLen && hashLen >= 2 ? hashLen : expectedHash.length;
+  const originalIdx = originalLineNumber - 1; // convert to 0-based
+  const candidates: CandidateLine[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    // Skip the original position — that was already checked
+    if (i === originalIdx) continue;
+    const candidateHash = computeLineHash(originalIdx, lines[i], effectiveLen);
+    if (candidateHash === expectedHash) {
+      candidates.push({
+        lineNumber: i + 1, // 1-based
+        content: lines[i],
+      });
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Format file content with hashline annotations.
+ *
+ * Each line becomes: `<prefix><1-based lineNumber>:<hash>|<originalLine>`
+ * Hash length adapts to file size unless overridden.
+ * Includes collision detection: if two lines produce the same hash,
+ * the colliding line gets a longer hash.
+ *
+ * @param content - raw file content
+ * @param hashLen - override hash length (0 or undefined = adaptive)
+ * @param prefix - prefix string (default "#HL "), or false to disable
+ * @returns annotated content with hash prefixes
+ */
+export function formatFileWithHashes(
+  content: string,
+  hashLen?: number,
+  prefix?: string | false,
+  includeFileRev?: boolean,
+): string {
+  const normalized = content.includes("\r\n") ? content.replace(/\r\n/g, "\n") : content;
+  const lines = normalized.split("\n");
+  const effectiveLen = hashLen && hashLen >= 3 ? hashLen : getAdaptiveHashLength(lines.length);
+  const effectivePrefix = prefix === undefined ? DEFAULT_PREFIX : prefix === false ? "" : prefix;
+
+  // Collision detection: compute all hashes, detect and resolve collisions by
+  // increasing hash length. Repeat until every hash is unique (up to 8 chars max).
+  const hashLens: number[] = new Array(lines.length).fill(effectiveLen);
+  const hashes: string[] = new Array(lines.length);
+
+  for (let idx = 0; idx < lines.length; idx++) {
+    hashes[idx] = computeLineHash(idx, lines[idx], effectiveLen);
+  }
+
+  // Iteratively resolve collisions — only rescan indices that were upgraded
+  let dirtyIndices: Set<number> | null = null; // null = scan all on first pass
+  let hasCollisions = true;
+  while (hasCollisions) {
+    hasCollisions = false;
+    const seen = new Map<string, number[]>(); // hash -> list of line indices
+
+    // Always build full hash map (needed to detect collisions between dirty and clean entries)
+    for (let idx = 0; idx < lines.length; idx++) {
+      const h = hashes[idx];
+      const group = seen.get(h);
+      if (group) {
+        group.push(idx);
+      } else {
+        seen.set(h, [idx]);
+      }
+    }
+
+    const nextDirty = new Set<number>();
+    for (const [, group] of seen) {
+      if (group.length < 2) continue;
+      // Only upgrade if at least one member is dirty (or first pass)
+      if (dirtyIndices !== null && !group.some((idx) => dirtyIndices?.has(idx))) continue;
+      for (const idx of group) {
+        const newLen = Math.min(hashLens[idx] + 1, 8);
+        if (newLen === hashLens[idx]) continue; // already at max length
+        hashLens[idx] = newLen;
+        hashes[idx] = computeLineHash(idx, lines[idx], newLen);
+        nextDirty.add(idx);
+        hasCollisions = true;
+      }
+    }
+    dirtyIndices = nextDirty;
+  }
+
+  // Post-loop safety: if any hashes still collide at max length (extremely unlikely
+  // with FNV-1a at 32 bits), disambiguate by appending line index as hex suffix.
+  const finalSeen = new Map<string, number>(); // hash -> first index
+  for (let idx = 0; idx < lines.length; idx++) {
+    const existing = finalSeen.get(hashes[idx]);
+    if (existing !== undefined) {
+      // Collision at max hash length — append line index as suffix to disambiguate
+      hashes[idx] = `${hashes[idx]}${idx.toString(16)}`;
+    } else {
+      finalSeen.set(hashes[idx], idx);
+    }
+  }
+
+  const annotatedLines = lines.map((line, idx) => {
+    return `${effectivePrefix}${idx + 1}:${hashes[idx]}|${line}`;
+  });
+
+  if (includeFileRev) {
+    const rev = computeFileRev(content);
+    annotatedLines.unshift(`${effectivePrefix}REV:${rev}`);
+  }
+
+  return annotatedLines.join("\n");
+}
+
+/**
+ * Cache for compiled strip-hash regex patterns.
+ * Key: escaped prefix string, Value: compiled RegExp pair
+ */
+const stripRegexCache = new Map<string, { hashLine: RegExp; rev: RegExp }>();
+
+/**
+ * Strip hashline prefixes to recover original file content.
+ *
+ * Recognizes the pattern `<prefix><number>:<2-8 hex>|` at the start of each line.
+ * By default looks for the `#HL ` prefix to avoid false positives.
+ *
+ * @param content - hashline-annotated content
+ * @param prefix - prefix string (default "#HL "), or false for legacy format
+ * @returns original content without hash prefixes
+ */
+export function stripHashes(content: string, prefix?: string | false): string {
+  const effectivePrefix = prefix === undefined ? DEFAULT_PREFIX : prefix === false ? "" : prefix;
+  const escapedPrefix = effectivePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  // Use cached regex pair (hashLine + rev)
+  let cached = stripRegexCache.get(escapedPrefix);
+  if (!cached) {
+    cached = {
+      hashLine: new RegExp(`^([+ \\-])?${escapedPrefix}\\d+:[0-9a-f]{2,8}\\|`),
+      rev: new RegExp(`^${escapedPrefix}REV:[0-9a-f]{8}$`),
+    };
+    stripRegexCache.set(escapedPrefix, cached);
+  }
+  const hashLinePattern = cached.hashLine;
+  const revPattern = cached.rev;
+
+  const lineEnding = detectLineEnding(content);
+  const normalized = lineEnding === "\r\n" ? content.replace(/\r\n/g, "\n") : content;
+  const result = normalized
+    .split("\n")
+    .filter((line) => !revPattern.test(line))
+    .map((line) => {
+      const match = line.match(hashLinePattern);
+      if (match) {
+        // Preserve the patch marker (+/-/space) if present
+        const patchMarker = match[1] || "";
+        return patchMarker + line.slice(match[0].length);
+      }
+      return line;
+    })
+    .join("\n");
+  return lineEnding === "\r\n" ? result.replace(/\n/g, "\r\n") : result;
+}
+
+/**
+ * Parse a hash reference like "2:f1a" or "2:f1a3" into its components.
+ *
+ * @param ref - reference string in the format "<lineNumber>:<hash>"
+ * @returns parsed line number (1-based) and hash string
+ */
+export function parseHashRef(ref: string): { line: number; hash: string } {
+  const match = ref.match(/^(\d+):([0-9a-f]{2,8})$/);
+  if (!match) {
+    const display = ref.length > 100 ? `${ref.slice(0, 100)}…` : ref;
+    throw new HashlineError({
+      code: "INVALID_REF",
+      message: `Invalid hash reference: "${display}". Expected format: "<line>:<2-8 char hex>"`,
+    });
+  }
+  return {
+    line: parseInt(match[1], 10),
+    hash: match[2],
+  };
+}
+
+/**
+ * Normalize a hash reference.
+ *
+ * Accepts:
+ * - plain refs: `2:f1c`
+ * - annotated refs: `#HL 2:f1c|line content` or `2:f1c|line content`
+ *
+ * Returns canonical lowercased format: `<line>:<hash>`
+ */
+export function normalizeHashRef(ref: string): string {
+  const trimmed = ref.trim();
+
+  const plain = trimmed.match(/^(\d+):([0-9a-f]{2,8})$/i);
+  if (plain) {
+    return `${parseInt(plain[1], 10)}:${plain[2].toLowerCase()}`;
+  }
+
+  const annotated = trimmed.match(/^(?:[#\w]*\s+)?(\d+):([0-9a-f]{2,8})\|.*$/i);
+  if (annotated) {
+    return `${parseInt(annotated[1], 10)}:${annotated[2].toLowerCase()}`;
+  }
+
+  const display = ref.length > 100 ? `${ref.slice(0, 100)}…` : ref;
+  throw new HashlineError({
+    code: "INVALID_REF",
+    message: `Invalid hash reference: "${display}". Expected "<line>:<hash>" or an annotated line like "#HL <line>:<hash>|..."`,
+  });
+}
+
+/**
+ * Supported hash-aware edit operations.
+ */
+export type HashEditOperation = "replace" | "delete" | "insert_before" | "insert_after";
+
+/**
+ * Input for hash-aware edit application.
+ */
+export interface HashEditInput {
+  operation: HashEditOperation;
+  startRef: string;
+  endRef?: string;
+  replacement?: string;
+  fileRev?: string;
+}
+
+/**
+ * Result of applying a hash-aware edit.
+ */
+export interface HashEditResult {
+  operation: HashEditOperation;
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+/**
+ * Build a mapping from hash tags to 1-based line numbers.
+ *
+ * Note: If multiple lines produce the same hash, the last one wins.
+ * In practice, collisions are rare since the hash incorporates the line index.
+ *
+ * @param content - raw file content (without hash prefixes)
+ * @param hashLen - override hash length (0 or undefined = adaptive)
+ * @returns Map from "<lineNumber>:<hash>" to 1-based line number
+ */
+export function buildHashMap(content: string, hashLen?: number): Map<string, number> {
+  const lines = content.split("\n");
+  const effectiveLen = hashLen && hashLen >= 3 ? hashLen : getAdaptiveHashLength(lines.length);
+  const map = new Map<string, number>();
+  for (let idx = 0; idx < lines.length; idx++) {
+    const hash = computeLineHash(idx, lines[idx], effectiveLen);
+    const lineNum = idx + 1;
+    map.set(`${lineNum}:${hash}`, lineNum);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Hash verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of hash verification.
+ */
+export interface VerifyHashResult {
+  valid: boolean;
+  expected?: string;
+  actual?: string;
+  message?: string;
+  code?: HashlineErrorCode;
+  candidates?: CandidateLine[];
+}
+
+/**
+ * Verify that a line's hash matches the current content.
+ *
+ * This protects against race conditions — if the file changed between
+ * read and edit, the hash won't match.
+ *
+ * The hash length is determined from the provided hash string itself
+ * (hash.length), not from the current file size. This ensures that
+ * a reference like "2:f1a" remains valid even if the file has grown.
+ *
+ * @param lineNumber - 1-based line number
+ * @param hash - expected hash from the hash reference
+ * @param currentContent - current raw file content (string or pre-split lines)
+ * @param hashLen - override hash length (0 or undefined = use hash.length from ref)
+ * @param lines - optional pre-split lines array to avoid re-splitting
+ * @returns verification result
+ */
+export function verifyHash(
+  lineNumber: number,
+  hash: string,
+  currentContent: string,
+  hashLen?: number,
+  lines?: string[],
+): VerifyHashResult {
+  const contentLines = lines ?? currentContent.split("\n");
+  const effectiveLen = hashLen && hashLen >= 2 ? hashLen : hash.length;
+
+  if (lineNumber < 1 || lineNumber > contentLines.length) {
+    return {
+      valid: false,
+      code: "TARGET_OUT_OF_RANGE",
+      message: `Line ${lineNumber} is out of range (file has ${contentLines.length} lines)`,
+    };
+  }
+
+  const idx = lineNumber - 1;
+  const actualHash = computeLineHash(idx, contentLines[idx], effectiveLen);
+
+  if (actualHash !== hash) {
+    const candidates = findCandidateLines(lineNumber, hash, contentLines, effectiveLen);
+    return {
+      valid: false,
+      code: "HASH_MISMATCH",
+      expected: hash,
+      actual: actualHash,
+      candidates,
+      message: `Hash mismatch at line ${lineNumber}: expected "${hash}", got "${actualHash}". The file may have changed since it was read.`,
+    };
+  }
+
+  return { valid: true };
+}
+
+// ---------------------------------------------------------------------------
+// Range operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a range resolution.
+ */
+export interface ResolvedRange {
+  startLine: number;
+  endLine: number;
+  lines: string[];
+  content: string;
+}
+
+/**
+ * Resolve a range of lines by hash references.
+ * Splits content once and passes lines array to verifyHash to avoid redundant splits.
+ *
+ * @param startRef - start hash reference (e.g. "1:a3f")
+ * @param endRef - end hash reference (e.g. "3:0e7")
+ * @param content - raw file content
+ * @param hashLen - override hash length (0 or undefined = use hash.length from ref)
+ * @returns resolved range with line numbers and content
+ */
+export function resolveRange(
+  startRef: string,
+  endRef: string,
+  content: string,
+  hashLen?: number,
+): ResolvedRange {
+  const start = parseHashRef(startRef);
+  const end = parseHashRef(endRef);
+
+  if (start.line > end.line) {
+    throw new HashlineError({
+      code: "INVALID_RANGE",
+      message: `Invalid range: start line ${start.line} is after end line ${end.line}`,
+    });
+  }
+
+  const lineEnding = detectLineEnding(content);
+  const normalized = lineEnding === "\r\n" ? content.replace(/\r\n/g, "\n") : content;
+  const lines = normalized.split("\n");
+
+  const startVerify = verifyHash(start.line, start.hash, normalized, hashLen, lines);
+  if (!startVerify.valid) {
+    throw new HashlineError({
+      code: startVerify.code ?? "HASH_MISMATCH",
+      message: `Start reference invalid: ${startVerify.message}`,
+      expected: startVerify.expected,
+      actual: startVerify.actual,
+      candidates: startVerify.candidates,
+      lineNumber: start.line,
+      hint:
+        startVerify.candidates && startVerify.candidates.length > 0
+          ? `Content may have moved. Candidates: ${startVerify.candidates.map((c) => `line ${c.lineNumber}`).join(", ")}`
+          : "Re-read the file to get fresh hash references.",
+    });
+  }
+
+  const endVerify = verifyHash(end.line, end.hash, normalized, hashLen, lines);
+  if (!endVerify.valid) {
+    throw new HashlineError({
+      code: endVerify.code ?? "HASH_MISMATCH",
+      message: `End reference invalid: ${endVerify.message}`,
+      expected: endVerify.expected,
+      actual: endVerify.actual,
+      candidates: endVerify.candidates,
+      lineNumber: end.line,
+      hint:
+        endVerify.candidates && endVerify.candidates.length > 0
+          ? `Content may have moved. Candidates: ${endVerify.candidates.map((c) => `line ${c.lineNumber}`).join(", ")}`
+          : "Re-read the file to get fresh hash references.",
+    });
+  }
+
+  const rangeLines = lines.slice(start.line - 1, end.line);
+  return {
+    startLine: start.line,
+    endLine: end.line,
+    lines: rangeLines,
+    content: rangeLines.join(lineEnding),
+  };
+}
+
+/**
+ * Replace a range of lines identified by hash references with new content.
+ * Splits content once and reuses the lines array.
+ *
+ * @param startRef - start hash reference
+ * @param endRef - end hash reference
+ * @param content - current raw file content
+ * @param replacement - new content to replace the range with
+ * @param hashLen - override hash length (0 or undefined = use hash.length from ref)
+ * @returns new file content with the range replaced
+ */
+export function replaceRange(
+  startRef: string,
+  endRef: string,
+  content: string,
+  replacement: string,
+  hashLen?: number,
+): string {
+  const lineEnding = detectLineEnding(content);
+  const normalized = lineEnding === "\r\n" ? content.replace(/\r\n/g, "\n") : content;
+  const range = resolveRange(startRef, endRef, normalized, hashLen);
+  const lines = normalized.split("\n");
+  const before = lines.slice(0, range.startLine - 1);
+  const after = lines.slice(range.endLine);
+  const replacementLines = replacement.split("\n");
+  const result = [...before, ...replacementLines, ...after].join("\n");
+  return lineEnding === "\r\n" ? result.replace(/\n/g, "\r\n") : result;
+}
+
+/**
+ * Apply a hash-aware edit operation directly against file content.
+ *
+ * Unlike search/replace tools, this resolves references by line+hash and
+ * verifies them before editing, so exact old-string matching is not required.
+ */
+export function applyHashEdit(
+  input: HashEditInput,
+  content: string,
+  hashLen?: number,
+): HashEditResult {
+  const lineEnding = detectLineEnding(content);
+  const workContent = lineEnding === "\r\n" ? content.replace(/\r\n/g, "\n") : content;
+
+  if (input.fileRev) {
+    verifyFileRev(input.fileRev, workContent);
+  }
+
+  const normalizedStart = normalizeHashRef(input.startRef);
+  const start = parseHashRef(normalizedStart);
+  const lines = workContent.split("\n");
+
+  const startVerify = verifyHash(start.line, start.hash, workContent, hashLen, lines);
+  if (!startVerify.valid) {
+    throw new HashlineError({
+      code: startVerify.code ?? "HASH_MISMATCH",
+      message: `Start reference invalid: ${startVerify.message}`,
+      expected: startVerify.expected,
+      actual: startVerify.actual,
+      candidates: startVerify.candidates,
+      lineNumber: start.line,
+      hint:
+        startVerify.candidates && startVerify.candidates.length > 0
+          ? `Content may have moved. Candidates: ${startVerify.candidates.map((c) => `line ${c.lineNumber}`).join(", ")}`
+          : "Re-read the file to get fresh hash references.",
+    });
+  }
+
+  if (input.operation === "insert_before" || input.operation === "insert_after") {
+    if (input.replacement === undefined) {
+      throw new HashlineError({
+        code: "MISSING_REPLACEMENT",
+        message: `Operation "${input.operation}" requires "replacement" content`,
+      });
+    }
+
+    const insertionLines = input.replacement.split("\n");
+    const insertIndex = input.operation === "insert_before" ? start.line - 1 : start.line;
+    const next = [
+      ...lines.slice(0, insertIndex),
+      ...insertionLines,
+      ...lines.slice(insertIndex),
+    ].join("\n");
+
+    return {
+      operation: input.operation,
+      startLine: start.line,
+      endLine: start.line,
+      content: lineEnding === "\r\n" ? next.replace(/\n/g, "\r\n") : next,
+    };
+  }
+
+  const normalizedEnd = normalizeHashRef(input.endRef ?? input.startRef);
+  const end = parseHashRef(normalizedEnd);
+  if (start.line > end.line) {
+    throw new HashlineError({
+      code: "INVALID_RANGE",
+      message: `Invalid range: start line ${start.line} is after end line ${end.line}`,
+    });
+  }
+
+  const endVerify = verifyHash(end.line, end.hash, workContent, hashLen, lines);
+  if (!endVerify.valid) {
+    throw new HashlineError({
+      code: endVerify.code ?? "HASH_MISMATCH",
+      message: `End reference invalid: ${endVerify.message}`,
+      expected: endVerify.expected,
+      actual: endVerify.actual,
+      candidates: endVerify.candidates,
+      lineNumber: end.line,
+      hint:
+        endVerify.candidates && endVerify.candidates.length > 0
+          ? `Content may have moved. Candidates: ${endVerify.candidates.map((c) => `line ${c.lineNumber}`).join(", ")}`
+          : "Re-read the file to get fresh hash references.",
+    });
+  }
+
+  const replacement = input.operation === "delete" ? "" : input.replacement;
+  if (replacement === undefined) {
+    throw new HashlineError({
+      code: "MISSING_REPLACEMENT",
+      message: `Operation "${input.operation}" requires "replacement" content`,
+    });
+  }
+
+  const before = lines.slice(0, start.line - 1);
+  const after = lines.slice(end.line);
+  const replacementLines = input.operation === "delete" ? [] : replacement.split("\n");
+  const next = [...before, ...replacementLines, ...after].join("\n");
+
+  return {
+    operation: input.operation,
+    startLine: start.line,
+    endLine: end.line,
+    content: lineEnding === "\r\n" ? next.replace(/\n/g, "\r\n") : next,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// LRU Cache
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  contentHash: number;
+  annotated: string;
+}
+
+/**
+ * Simple LRU cache for annotated file content.
+ */
+export class HashlineCache {
+  private cache: Map<string, CacheEntry>;
+  private maxSize: number;
+
+  constructor(maxSize: number = 100) {
+    this.cache = new Map();
+    this.maxSize = maxSize;
+  }
+
+  /**
+   * Get cached annotated content for a file, or null if not cached / stale.
+   */
+  get(filePath: string, content: string): string | null {
+    const entry = this.cache.get(filePath);
+    if (!entry) return null;
+
+    const currentHash = fnv1aHash(content);
+    if (entry.contentHash !== currentHash) {
+      this.cache.delete(filePath);
+      return null;
+    }
+
+    // Move to end (most recently used)
+    this.cache.delete(filePath);
+    this.cache.set(filePath, entry);
+    return entry.annotated;
+  }
+
+  /**
+   * Store annotated content in the cache.
+   */
+  set(filePath: string, content: string, annotated: string): void {
+    // If already exists, delete first to update position
+    if (this.cache.has(filePath)) {
+      this.cache.delete(filePath);
+    }
+
+    // Evict oldest if at capacity
+    if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) {
+        this.cache.delete(oldest);
+      }
+    }
+
+    this.cache.set(filePath, {
+      contentHash: fnv1aHash(content),
+      annotated,
+    });
+  }
+
+  /**
+   * Invalidate a specific file from the cache.
+   */
+  invalidate(filePath: string): void {
+    this.cache.delete(filePath);
+  }
+
+  /**
+   * Clear the entire cache.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Get the current number of cached entries.
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Glob matching (using Node stdlib path.matchesGlob)
+// ---------------------------------------------------------------------------
+
+/**
+ * Glob matcher using path.matchesGlob (Node 22+).
+ * Windows paths are normalized to forward slashes.
+ */
+export function matchesGlob(filePath: string, pattern: string): boolean {
+  // Normalize Windows backslashes — path.matchesGlob uses the OS-native separator
+  return pathMatchesGlob(filePath.replace(/\\/g, "/"), pattern.replace(/\\/g, "/"));
+}
+
+/**
+ * Check if a file path should be excluded based on config patterns.
+ */
+export function shouldExclude(filePath: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => matchesGlob(filePath, pattern));
+}
+
+// ---------------------------------------------------------------------------
+// Byte length utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the UTF-8 byte length of a string.
+ * Uses TextEncoder for accurate UTF-8 byte counting.
+ * This correctly handles multi-byte characters (Cyrillic, CJK, emoji, etc.).
+ */
+export function getByteLength(content: string): number {
+  return Buffer.byteLength(content, "utf-8");
+}
+
+/**
+ * Detect the line ending style used in a string.
+ * Returns "\r\n" if any CRLF sequence is present, otherwise "\n".
+ */
+export function detectLineEnding(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}

--- a/packages/opencode/src/kilocode/tool/hash_edit.ts
+++ b/packages/opencode/src/kilocode/tool/hash_edit.ts
@@ -1,0 +1,123 @@
+import { Schema, Effect } from "effect"
+import * as path from "path"
+import * as Tool from "../../tool/tool"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { InstanceState } from "@/effect/instance-state"
+import { Bus } from "@/bus"
+import { File } from "@/file"
+import { FileWatcher } from "@/file/watcher"
+import { applyHashEdit, HashlineError, formatFileWithHashes, stripHashes } from "../hashline/hashline"
+import DESCRIPTION from "./hash_edit.txt"
+import { assertExternalDirectoryEffect } from "../../tool/external-directory"
+
+export const Parameters = Schema.Struct({
+  filePath: Schema.String.annotate({
+    description: "The absolute path to the file to edit",
+  }),
+  operation: Schema.Literal("replace", "delete", "insert_before", "insert_after").annotate({
+    description: "The edit operation to perform",
+  }),
+  startRef: Schema.String.annotate({
+    description:
+      "Hash reference for the target line, in the format '#HL <line>:<hash>|...' or '<line>:<hash>' (e.g. '#HL 2:f1c|const x = 1;' or '2:f1c')",
+  }),
+  endRef: Schema.optional(Schema.String).annotate({
+    description:
+      "Hash reference for the end line of a range (required for replace-range operations). Same format as startRef.",
+  }),
+  replacement: Schema.optional(Schema.String).annotate({
+    description: "The new content to replace with (required for replace, insert_before, insert_after operations)",
+  }),
+  fileRev: Schema.optional(Schema.String).annotate({
+    description:
+      "Optional file revision hash (8-char hex) from the #HL REV: header. If provided, guards against concurrent edits.",
+  }),
+})
+
+export const HashEditTool = Tool.define(
+  "hash_edit",
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+    const bus = yield* Bus.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const instance = yield* InstanceState.context
+          const filepath = path.isAbsolute(params.filePath)
+            ? params.filePath
+            : path.join(instance.directory, params.filePath)
+
+          yield* assertExternalDirectoryEffect(ctx, filepath)
+
+          const stat = yield* fs.stat(filepath).pipe(
+            Effect.catchIf(
+              (err) => "reason" in err && err.reason._tag === "NotFound",
+              () => Effect.succeed(undefined),
+            ),
+          )
+          if (!stat) {
+            return yield* Effect.fail(new Error(`File not found: ${filepath}`))
+          }
+
+          yield* ctx.ask({
+            permission: "edit",
+            patterns: [path.relative(instance.worktree, filepath)],
+            always: ["*"],
+            metadata: { filepath },
+          })
+
+          const bytes = yield* fs.readFile(filepath)
+          const raw = Buffer.from(bytes).toString("utf-8")
+
+          // Strip any existing hashline annotations before applying the edit
+          // so applyHashEdit operates on clean file content
+          const content = stripHashes(raw)
+
+          const result = yield* Effect.try({
+            try: () =>
+              applyHashEdit(
+                {
+                  operation: params.operation,
+                  startRef: params.startRef,
+                  endRef: params.endRef,
+                  replacement: params.replacement,
+                  fileRev: params.fileRev,
+                },
+                content,
+              ),
+            catch: (err) => {
+              if (err instanceof HashlineError) {
+                return new Error(
+                  `Hash edit failed [${err.code}]: ${err.message}${err.hint ? `\n\nHint: ${err.hint}` : ""}`,
+                )
+              }
+              return err instanceof Error ? err : new Error(String(err))
+            },
+          })
+
+          yield* fs.writeFileString(filepath, result.content)
+          yield* bus.publish(File.Event.Edited, { file: filepath })
+          yield* bus.publish(FileWatcher.Event.Updated, { file: filepath, event: "change" })
+
+          const title = path.relative(instance.worktree, filepath)
+          const summary = `Applied ${params.operation} at line ${result.startLine}${result.endLine !== result.startLine ? `–${result.endLine}` : ""}`
+
+          return {
+            title,
+            output: `${summary} in ${title}. Edit applied successfully.`,
+            metadata: {
+              filepath,
+              operation: params.operation,
+              startLine: result.startLine,
+              endLine: result.endLine,
+            },
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)
+
+export { formatFileWithHashes }

--- a/packages/opencode/src/kilocode/tool/hash_edit.ts
+++ b/packages/opencode/src/kilocode/tool/hash_edit.ts
@@ -7,6 +7,7 @@ import { Bus } from "@/bus"
 import { File } from "@/file"
 import { FileWatcher } from "@/file/watcher"
 import { applyHashEdit, HashlineError, formatFileWithHashes, stripHashes } from "../hashline/hashline"
+import * as Encoding from "../encoding"
 import DESCRIPTION from "./hash_edit.txt"
 import { assertExternalDirectoryEffect } from "../../tool/external-directory"
 
@@ -70,7 +71,9 @@ export const HashEditTool = Tool.define(
           })
 
           const bytes = yield* fs.readFile(filepath)
-          const raw = Buffer.from(bytes).toString("utf-8")
+          const buf = Buffer.from(bytes)
+          const encoding = Encoding.detect(buf)
+          const raw = Encoding.decode(buf, encoding)
 
           // Strip any existing hashline annotations before applying the edit
           // so applyHashEdit operates on clean file content
@@ -98,7 +101,7 @@ export const HashEditTool = Tool.define(
             },
           })
 
-          yield* fs.writeFileString(filepath, result.content)
+          yield* fs.writeFile(filepath, Encoding.encode(result.content, encoding))
           yield* bus.publish(File.Event.Edited, { file: filepath })
           yield* bus.publish(FileWatcher.Event.Updated, { file: filepath, event: "change" })
 

--- a/packages/opencode/src/kilocode/tool/hash_edit.txt
+++ b/packages/opencode/src/kilocode/tool/hash_edit.txt
@@ -1,0 +1,29 @@
+Performs precise, hash-anchored line edits on files.
+
+Lines are addressed by a stable identifier (<lineNumber>:<hash>) that you obtain from the Read tool when hashline mode is active. The Read tool returns annotated output like:
+
+  #HL REV:a1b2c3d4
+  #HL 1:a3f|function hello() {
+  #HL 2:f1c|  return "world";
+  #HL 3:0e7|}
+
+Usage rules:
+- You MUST use the Read tool before calling hash_edit to obtain fresh hash references.
+- Pass the full annotated line (e.g. "#HL 2:f1c|const x = 1;") OR the short ref (e.g. "2:f1c") as startRef/endRef.
+- Always pass the fileRev value from the "#HL REV:<hash>" header line for safety.
+- Do NOT include the hash prefix in the replacement content — only supply the raw new content.
+
+Operations:
+- "replace"        — replace the single line at startRef with replacement content
+- "delete"         — remove the line(s) from startRef to endRef (endRef defaults to startRef)
+- "insert_before"  — insert replacement content before the line at startRef
+- "insert_after"   — insert replacement content after the line at startRef
+
+Error codes you may receive:
+- HASH_MISMATCH     — the file changed since you last read it; re-read the file and retry
+- FILE_REV_MISMATCH — the file was modified by another process; re-read and retry
+- TARGET_OUT_OF_RANGE — line number is beyond the end of the file
+- INVALID_REF       — malformed hash reference; ensure format is "<line>:<2-8 hex chars>"
+- MISSING_REPLACEMENT — replacement is required for this operation but was not provided
+
+When you encounter a HASH_MISMATCH or FILE_REV_MISMATCH, always re-read the file to get fresh references before retrying.

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -3,6 +3,7 @@ import { CodebaseSearchTool } from "../../tool/warpgrep"
 import { RecallTool } from "../../tool/recall"
 import { AgentManagerTool } from "./agent-manager"
 import { BackgroundProcessTool } from "./background-process"
+import { HashEditTool } from "./hash_edit"
 import * as Tool from "../../tool/tool"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Effect } from "effect"
@@ -37,14 +38,15 @@ export namespace KiloToolRegistry {
       const recall = yield* RecallTool
       const manager = yield* AgentManagerTool
       const process = yield* BackgroundProcessTool
-      return { codebase, recall, manager, process }
+      const hashEdit = yield* HashEditTool
+      return { codebase, recall, manager, process, hashEdit }
     })
   }
 
   /** Finalize Kilo-specific tools into Tool.Defs. Call this inside the InstanceState state Effect —
    * it has no Service deps beyond what Tool.init itself needs. */
   export function build(
-    tools: { codebase: Tool.Info; recall: Tool.Info; manager: Tool.Info; process: Tool.Info },
+    tools: { codebase: Tool.Info; recall: Tool.Info; manager: Tool.Info; process: Tool.Info; hashEdit: Tool.Info },
     deps: Deps,
     loaders: Loaders = {},
   ) {
@@ -54,6 +56,7 @@ export namespace KiloToolRegistry {
         recall: Tool.init(tools.recall),
         manager: Tool.init(tools.manager),
         process: Tool.init(tools.process),
+        hashEdit: Tool.init(tools.hashEdit),
       })
       const semantic = yield* semanticTool(deps, loaders)
       return { ...base, semantic }
@@ -99,8 +102,8 @@ export namespace KiloToolRegistry {
 
   /** Kilo-specific tools to append to the builtin list */
   export function extra(
-    tools: { codebase: Tool.Def; semantic?: Tool.Def; recall: Tool.Def; manager: Tool.Def; process: Tool.Def },
-    cfg: { experimental?: { codebase_search?: boolean } },
+    tools: { codebase: Tool.Def; semantic?: Tool.Def; recall: Tool.Def; manager: Tool.Def; process: Tool.Def; hashEdit: Tool.Def },
+    cfg: { experimental?: { codebase_search?: boolean }; hashlineEdit?: { enabled?: boolean } },
   ): Tool.Def[] {
     return [
       ...(cfg.experimental?.codebase_search === true ? [tools.codebase] : []),
@@ -109,6 +112,8 @@ export namespace KiloToolRegistry {
       ...(Flag.KILO_CLIENT === "cli" || Flag.KILO_CLIENT === "vscode" ? [tools.process] : []),
       // The extension is the only client that can consume the Agent Manager start event.
       ...(Flag.KILO_CLIENT === "vscode" ? [tools.manager] : []),
+      // Include hash_edit tool when hashline editing is enabled
+      ...(cfg.hashlineEdit?.enabled === true ? [tools.hashEdit] : []),
     ]
   }
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -15,6 +15,8 @@ import { Reference } from "@/reference/reference"
 // kilocode_change start
 import * as Encoding from "../kilocode/encoding"
 import * as Extract from "../kilocode/tool/read-extract"
+import { formatFileWithHashes } from "../kilocode/hashline/hashline"
+import { Config } from "@/config/config"
 // kilocode_change end
 
 const DEFAULT_READ_LIMIT = 2000
@@ -49,6 +51,9 @@ export const ReadTool = Tool.define(
     const lsp = yield* LSP.Service
     const reference = yield* Reference.Service
     const scope = yield* Scope.Scope
+    // kilocode_change start
+    const config = yield* Config.Service
+    // kilocode_change end
 
     const miss = Effect.fn("ReadTool.miss")(function* (filepath: string) {
       const dir = path.dirname(filepath)
@@ -340,12 +345,29 @@ export const ReadTool = Tool.define(
       }
       // kilocode_change end
 
-      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
-      output += file.raw.map((line, i) => `${i + file.offset}: ${line}`).join("\n")
-
+      // kilocode_change start
+      const cfg = yield* config.get()
+      const useHashline = cfg.hashlineEdit?.enabled === true
+      const rawLines = file.raw
       const last = file.offset + file.raw.length - 1
       const next = last + 1
       const truncated = file.more || file.cut
+      let output: string
+      if (useHashline) {
+        // Annotate the visible slice with hashes so the LLM can use hash_edit
+        const slice = rawLines.join("\n")
+        const prefix = cfg.hashlineEdit?.prefix
+        const hashLen = cfg.hashlineEdit?.hashLength
+        const includeRev = cfg.hashlineEdit?.fileRev !== false
+        const annotated = formatFileWithHashes(slice, hashLen ?? undefined, prefix ?? undefined, includeRev)
+        output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
+        output += annotated
+      } else {
+        output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
+        output += rawLines.map((line, i) => `${i + file.offset}: ${line}`).join("\n")
+      }
+      // kilocode_change end
+
       if (file.cut) {
         output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${file.offset}-${last}. Use offset=${next} to continue.)`
       } else if (file.more) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -358,8 +358,8 @@ export const ReadTool = Tool.define(
         const slice = rawLines.join("\n")
         const prefix = cfg.hashlineEdit?.prefix
         const hashLen = cfg.hashlineEdit?.hashLength
-        const includeRev = cfg.hashlineEdit?.fileRev !== false
-        const annotated = formatFileWithHashes(slice, hashLen ?? undefined, prefix ?? undefined, includeRev)
+        const includeRev = cfg.hashlineEdit?.fileRev !== false && file.offset === 1 && !truncated
+        const annotated = formatFileWithHashes(slice, hashLen ?? undefined, prefix ?? undefined, includeRev, file.offset)
         output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>\n"].join("\n")
         output += annotated
       } else {

--- a/packages/opencode/test/kilocode/hashline.test.ts
+++ b/packages/opencode/test/kilocode/hashline.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from "bun:test"
+import {
+  computeLineHash,
+  formatFileWithHashes,
+  stripHashes,
+  applyHashEdit,
+  HashlineError,
+  parseHashRef,
+  normalizeHashRef,
+  buildHashMap,
+  verifyHash,
+  computeFileRev,
+  extractFileRev,
+  getAdaptiveHashLength,
+} from "../../src/kilocode/hashline/hashline"
+
+// ---------------------------------------------------------------------------
+// computeLineHash
+// ---------------------------------------------------------------------------
+
+describe("computeLineHash", () => {
+  it("returns lowercase hex of specified length", () => {
+    const hash = computeLineHash(0, "function hello() {", 3)
+    expect(hash).toMatch(/^[0-9a-f]{3}$/)
+  })
+
+  it("is deterministic — same inputs always yield same output", () => {
+    const a = computeLineHash(1, "  return 42;", 3)
+    const b = computeLineHash(1, "  return 42;", 3)
+    expect(a).toBe(b)
+  })
+
+  it("ignores trailing whitespace but preserves leading indentation", () => {
+    const noTrailing = computeLineHash(0, "  hello  ", 3)
+    const withTrailing = computeLineHash(0, "  hello", 3)
+    expect(noTrailing).toBe(withTrailing)
+  })
+
+  it("produces different hashes for different line indexes", () => {
+    const a = computeLineHash(0, "same content", 3)
+    const b = computeLineHash(1, "same content", 3)
+    expect(a).not.toBe(b)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getAdaptiveHashLength
+// ---------------------------------------------------------------------------
+
+describe("getAdaptiveHashLength", () => {
+  it("returns 3 for files ≤ 4096 lines", () => {
+    expect(getAdaptiveHashLength(1)).toBe(3)
+    expect(getAdaptiveHashLength(4096)).toBe(3)
+  })
+
+  it("returns 4 for files > 4096 lines", () => {
+    expect(getAdaptiveHashLength(4097)).toBe(4)
+    expect(getAdaptiveHashLength(10000)).toBe(4)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatFileWithHashes / stripHashes
+// ---------------------------------------------------------------------------
+
+describe("formatFileWithHashes", () => {
+  const content = "function hello() {\n  return 'world';\n}"
+
+  it("annotates every line with #HL prefix, line number, and hash", () => {
+    const annotated = formatFileWithHashes(content)
+    const lines = annotated.split("\n")
+    for (const line of lines.filter((l) => !l.includes("REV:"))) {
+      expect(line).toMatch(/^#HL \d+:[0-9a-f]{2,8}\|/)
+    }
+  })
+
+  it("produces one annotated line per source line", () => {
+    const annotated = formatFileWithHashes(content)
+    const sourceLines = content.split("\n").length
+    const annotatedLines = annotated.split("\n").filter((l) => l.startsWith("#HL") && !l.includes("REV:"))
+    expect(annotatedLines.length).toBe(sourceLines)
+  })
+
+  it("includes REV header when includeFileRev=true", () => {
+    const annotated = formatFileWithHashes(content, undefined, undefined, true)
+    expect(annotated.split("\n")[0]).toMatch(/^#HL REV:[0-9a-f]{8}$/)
+  })
+
+  it("omits REV header when includeFileRev=false", () => {
+    const annotated = formatFileWithHashes(content, undefined, undefined, false)
+    expect(annotated.split("\n")[0]).not.toMatch(/REV:/)
+  })
+})
+
+describe("stripHashes", () => {
+  const content = "function hello() {\n  return 'world';\n}"
+
+  it("round-trips: stripHashes(formatFileWithHashes(x)) === x", () => {
+    const annotated = formatFileWithHashes(content)
+    const stripped = stripHashes(annotated)
+    expect(stripped).toBe(content)
+  })
+
+  it("is a no-op on non-annotated content", () => {
+    expect(stripHashes(content)).toBe(content)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseHashRef / normalizeHashRef
+// ---------------------------------------------------------------------------
+
+describe("parseHashRef", () => {
+  it("parses a valid reference", () => {
+    const ref = parseHashRef("2:f1c")
+    expect(ref.line).toBe(2)
+    expect(ref.hash).toBe("f1c")
+  })
+
+  it("throws INVALID_REF on malformed input", () => {
+    expect(() => parseHashRef("not-a-ref")).toThrow()
+    expect(() => parseHashRef("")).toThrow()
+  })
+})
+
+describe("normalizeHashRef", () => {
+  it("handles plain refs", () => {
+    expect(normalizeHashRef("3:0e7")).toBe("3:0e7")
+  })
+
+  it("handles annotated refs like #HL 2:f1c|const x = 1;", () => {
+    expect(normalizeHashRef("#HL 2:f1c|const x = 1;")).toBe("2:f1c")
+  })
+
+  it("lowercases the hash", () => {
+    expect(normalizeHashRef("2:F1C")).toBe("2:f1c")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verifyHash
+// ---------------------------------------------------------------------------
+
+describe("verifyHash", () => {
+  const content = "line one\nline two\nline three"
+
+  it("returns valid=true when hash matches", () => {
+    const hash = computeLineHash(0, "line one", 3)
+    const result = verifyHash(1, hash, content)
+    expect(result.valid).toBe(true)
+  })
+
+  it("returns HASH_MISMATCH when hash does not match", () => {
+    const result = verifyHash(1, "000", content)
+    expect(result.valid).toBe(false)
+    expect(result.code).toBe("HASH_MISMATCH")
+  })
+
+  it("returns TARGET_OUT_OF_RANGE for line beyond file", () => {
+    const result = verifyHash(999, "abc", content)
+    expect(result.valid).toBe(false)
+    expect(result.code).toBe("TARGET_OUT_OF_RANGE")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildHashMap
+// ---------------------------------------------------------------------------
+
+describe("buildHashMap", () => {
+  it("builds a map with '<line>:<hash>' keys", () => {
+    const content = "alpha\nbeta\ngamma"
+    const map = buildHashMap(content)
+    expect(map.size).toBe(3)
+    for (const key of map.keys()) {
+      expect(key).toMatch(/^\d+:[0-9a-f]{3,8}$/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeFileRev / extractFileRev
+// ---------------------------------------------------------------------------
+
+describe("computeFileRev", () => {
+  it("returns 8 hex chars", () => {
+    expect(computeFileRev("hello world")).toMatch(/^[0-9a-f]{8}$/)
+  })
+
+  it("is deterministic", () => {
+    expect(computeFileRev("hello")).toBe(computeFileRev("hello"))
+  })
+})
+
+describe("extractFileRev", () => {
+  it("extracts REV from annotated content", () => {
+    const content = "some content here"
+    const annotated = formatFileWithHashes(content, undefined, undefined, true)
+    const rev = extractFileRev(annotated)
+    expect(rev).toMatch(/^[0-9a-f]{8}$/)
+  })
+
+  it("returns null if no REV header", () => {
+    const annotated = formatFileWithHashes("hello")
+    expect(extractFileRev(annotated)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyHashEdit — successful operations
+// ---------------------------------------------------------------------------
+
+describe("applyHashEdit — replace", () => {
+  const content = "line one\nline two\nline three"
+
+  it("replaces a single line by hash reference", () => {
+    const annotated = formatFileWithHashes(content)
+    const refLine = annotated.split("\n").find((l) => l.includes("|line two"))!
+    const ref = normalizeHashRef(refLine)
+
+    const result = applyHashEdit({ operation: "replace", startRef: ref, replacement: "line TWO" }, content)
+    expect(result.content).toBe("line one\nline TWO\nline three")
+    expect(result.startLine).toBe(2)
+  })
+})
+
+describe("applyHashEdit — insert_after", () => {
+  const content = "line one\nline two"
+
+  it("inserts content after the target line", () => {
+    const annotated = formatFileWithHashes(content)
+    const refLine = annotated.split("\n").find((l) => l.includes("|line one"))!
+    const ref = normalizeHashRef(refLine)
+
+    const result = applyHashEdit({ operation: "insert_after", startRef: ref, replacement: "line one-and-a-half" }, content)
+    expect(result.content).toBe("line one\nline one-and-a-half\nline two")
+  })
+})
+
+describe("applyHashEdit — insert_before", () => {
+  const content = "line one\nline two"
+
+  it("inserts content before the target line", () => {
+    const annotated = formatFileWithHashes(content)
+    const refLine = annotated.split("\n").find((l) => l.includes("|line two"))!
+    const ref = normalizeHashRef(refLine)
+
+    const result = applyHashEdit({ operation: "insert_before", startRef: ref, replacement: "line one-and-a-half" }, content)
+    expect(result.content).toBe("line one\nline one-and-a-half\nline two")
+  })
+})
+
+describe("applyHashEdit — delete", () => {
+  const content = "line one\nline two\nline three"
+
+  it("deletes the target line", () => {
+    const annotated = formatFileWithHashes(content)
+    const refLine = annotated.split("\n").find((l) => l.includes("|line two"))!
+    const ref = normalizeHashRef(refLine)
+
+    const result = applyHashEdit({ operation: "delete", startRef: ref }, content)
+    expect(result.content).toBe("line one\nline three")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyHashEdit — error conditions
+// ---------------------------------------------------------------------------
+
+describe("applyHashEdit — HASH_MISMATCH", () => {
+  it("throws HashlineError with code HASH_MISMATCH on bad hash", () => {
+    const content = "line one\nline two"
+    let caught: unknown
+    try {
+      applyHashEdit({ operation: "replace", startRef: "1:000", replacement: "new" }, content)
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(HashlineError)
+    expect((caught as HashlineError).code).toBe("HASH_MISMATCH")
+  })
+})
+
+describe("applyHashEdit — MISSING_REPLACEMENT", () => {
+  it("throws HashlineError with code MISSING_REPLACEMENT when replacement omitted for replace", () => {
+    const content = "line one\nline two"
+    const annotated = formatFileWithHashes(content)
+    const refLine = annotated.split("\n").find((l) => l.includes("|line one"))!
+    const ref = normalizeHashRef(refLine)
+
+    let caught: unknown
+    try {
+      applyHashEdit({ operation: "replace", startRef: ref }, content)
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(HashlineError)
+    expect((caught as HashlineError).code).toBe("MISSING_REPLACEMENT")
+  })
+})
+
+describe("applyHashEdit — INVALID_REF", () => {
+  it("throws HashlineError with code INVALID_REF for malformed reference", () => {
+    const content = "line one"
+    let caught: unknown
+    try {
+      applyHashEdit({ operation: "replace", startRef: "bad-ref", replacement: "x" }, content)
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(HashlineError)
+    expect((caught as HashlineError).code).toBe("INVALID_REF")
+  })
+})


### PR DESCRIPTION
## Summary

Implements a deterministic, hash-anchored line editing tool (Hashline) natively in Kilo CLI, resolving the brittleness of `str_replace` (fails on duplicate strings) and `apply_patch` (model-specific diff format hallucinations).

**Closes #11492**

When `hashlineEdit.enabled: true` is set in config, the `read` tool annotates every line with a short deterministic hash prefix (e.g. `#HL 2:f1c|const x = 1;`). A new `hash_edit` tool lets the agent target lines by their unique `lineNumber:hash` reference for precise edits — no string matching required.

## Changes

| File | Type | Description |
|---|---|---|
| `src/kilocode/hashline/hashline.ts` | NEW | Core FNV-1a hashing, `formatFileWithHashes`, `stripHashes`, `applyHashEdit`, `HashlineError` |
| `src/kilocode/tool/hash_edit.ts` | NEW | `hash_edit` tool: replace, delete, insert_before, insert_after with structured error codes |
| `src/kilocode/tool/hash_edit.txt` | NEW | LLM instructions for using the hash_edit tool |
| `src/config/config.ts` | MODIFY | Added `hashlineEdit` config key: `enabled`, `prefix`, `hashLength`, `fileRev` |
| `src/tool/read.ts` | MODIFY | Conditionally annotates file output with `#HL` hashes when `hashlineEdit.enabled = true` |
| `src/kilocode/tool/registry.ts` | MODIFY | Registers `hash_edit` tool when `hashlineEdit.enabled = true` |
| `test/kilocode/hashline.test.ts` | NEW | Unit tests for all hash operations and error codes |

Reference implementation: [izzzzzi/opencode-hashline](https://github.com/izzzzzi/opencode-hashline)

## Testing

### Tests written

- **`test/kilocode/hashline.test.ts`** — 25+ unit tests covering:
  - `computeLineHash` — determinism, trailing whitespace, index sensitivity
  - `formatFileWithHashes` / `stripHashes` — round-trip correctness
  - `applyHashEdit` — all four operations (`replace`, `delete`, `insert_before`, `insert_after`)
  - Error conditions — `HASH_MISMATCH`, `MISSING_REPLACEMENT`, `INVALID_REF`

### Blocked checks and substitute verification

- `bun test ./test/kilocode/hashline.test.ts` could not run locally because `bun install` failed due to a network-level git clone error for `@tsconfig/bun` and `solid-js` in this environment (unrelated to these changes). Substitute verification was a standalone Node.js inline script that directly exercised the FNV-1a hash function, `computeLineHash`, and `normalizeHashRef` — **7/7 assertions passed**.
- `bun run typecheck` could not run locally because `tsgo` is not installed in this environment. All types are structurally consistent with existing codebase patterns (Effect Schema, Tool.define, InstanceState) validated by code review.

### CI guards run locally (all passed )

- `bun run script/check-opencode-annotations.ts` —  All shared upstream changes are annotated with `kilocode_change` markers
- `bun run script/check-md-table-padding.ts` —  382 files checked, no padded tables found
- `bun run check-kilocode-change` (from `packages/kilo-vscode/`) —  No `kilocode_change` markers in Kilo-exclusive packages

### Screenshots / Video

N/A — no visual UI changes. The feature activates via config and surfaces only in agent tool calls.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (`.changeset/hashline-edit-tool.md` — `minor`)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Happy to chat on the Kilo Code Discord if needed!
