### PR TITLE
fix(cli): remap reasoning effort 'none' + persist MCP toggle to config

### DIFF
--- a/.changeset/mcp-toggle-persist.md
+++ b/.changeset/mcp-toggle-persist.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MCP server toggle not persisting to config file — connect/disconnect now update the `enabled` field in the project config so toggle state survives restarts.

--- a/.changeset/mimo-reasoning-none-fix.md
+++ b/.changeset/mimo-reasoning-none-fix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MiMo and other OpenAI-compatible models throwing error when thinking mode is set to "Instant" — remaps `reasoning: { effort: "none" }` to `reasoning: { enabled: false }` for `@ai-sdk/openai-compatible` providers that don't support the `"none"` reasoning effort tier.

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -674,14 +674,20 @@ export const layer = Layer.effect(
     const connect = Effect.fn("MCP.connect")(function* (name: string) {
       const mcp = yield* requireMcpConfig(name)
       yield* createAndStore(name, { ...mcp, enabled: true })
+      yield* cfgSvc.update({
+        mcp: { [name]: { ...mcp, enabled: true } },
+      })
     })
 
     const disconnect = Effect.fn("MCP.disconnect")(function* (name: string) {
-      yield* requireMcpConfig(name)
+      const mcp = yield* requireMcpConfig(name)
       const s = yield* InstanceState.get(state)
       yield* closeClient(s, name)
       delete s.clients[name]
       s.status[name] = { status: "disabled" }
+      yield* cfgSvc.update({
+        mcp: { [name]: { ...mcp, enabled: false } },
+      })
     })
 
     const tools = Effect.fn("MCP.tools")(function* () {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage, ToolResultPart } from "ai"
-import { mergeDeep, unique } from "remeda"
+import { mergeDeep, mapValues, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models-dev"
@@ -635,6 +635,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     model.variants &&
     Object.keys(model.variants).length > 0
   ) {
+    if (model.api.npm === "@ai-sdk/openai-compatible") {
+      return mapValues(model.variants, (v) => {
+        if (v?.reasoning?.effort === "none") {
+          return { reasoning: { enabled: false } }
+        }
+        return v
+      })
+    }
     return model.variants
   }
   // kilocode_change end

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -638,7 +638,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     if (model.api.npm === "@ai-sdk/openai-compatible") {
       return mapValues(model.variants, (v) => {
         if (v?.reasoning?.effort === "none") {
-          return { reasoning: { enabled: false } }
+          return { ...v, reasoning: { enabled: false } }
         }
         return v
       })

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -128,4 +128,44 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     })
     expect(upstream?.reasoning_effort).toBeUndefined()
   })
+
+  test("variants() for @ai-sdk/openai-compatible remaps reasoning effort 'none' to enabled false", () => {
+    // Regression: MiMo and other OpenAI-compatible providers reject
+    // reasoning_effort: "none". User-provided variants that carry
+    // { reasoning: { effort: "none" } } must be rewritten to
+    // { reasoning: { enabled: false } } so the SDK never sends "none".
+    const mimoModel = {
+      id: ModelID.make("opencode-go/mimo-v2.5-pro"),
+      providerID: ProviderID.make("opencode-go"),
+      name: "MiMo V2.5 Pro",
+      api: {
+        id: "mimo-v2.5-pro",
+        url: "https://opencode.ai/zen/go/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: {
+        reasoning: true,
+        temperature: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      limit: { context: 1_000_000, output: 128_000 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-04-22",
+      variants: {
+        instant: { reasoning: { effort: "none" } },
+        thinking: { reasoning: { effort: "high" } },
+      },
+    } satisfies Provider.Model
+
+    const result = ProviderTransform.variants(mimoModel)
+    expect(result.instant).toEqual({ reasoning: { enabled: false } })
+    expect(result.thinking).toEqual({ reasoning: { effort: "high" } })
+  })
 })

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -134,6 +134,7 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     // reasoning_effort: "none". User-provided variants that carry
     // { reasoning: { effort: "none" } } must be rewritten to
     // { reasoning: { enabled: false } } so the SDK never sends "none".
+    // Sibling options in the variant object must be preserved.
     const mimoModel = {
       id: ModelID.make("opencode-go/mimo-v2.5-pro"),
       providerID: ProviderID.make("opencode-go"),
@@ -167,5 +168,35 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     const result = ProviderTransform.variants(mimoModel)
     expect(result.instant).toEqual({ reasoning: { enabled: false } })
     expect(result.thinking).toEqual({ reasoning: { effort: "high" } })
+  })
+
+  test("variants() preserves sibling options when remapping reasoning effort 'none'", () => {
+    const model = {
+      id: ModelID.make("opencode-go/custom"),
+      providerID: ProviderID.make("opencode-go"),
+      name: "Custom",
+      api: { id: "custom", url: "https://example.com/v1", npm: "@ai-sdk/openai-compatible" },
+      capabilities: {
+        reasoning: true,
+        temperature: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 100_000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-01-01",
+      variants: {
+        instant: { reasoning: { effort: "none" }, temperature: 0.5 },
+      },
+    } satisfies Provider.Model
+
+    const result = ProviderTransform.variants(model)
+    expect(result.instant).toEqual({ reasoning: { enabled: false }, temperature: 0.5 })
   })
 })


### PR DESCRIPTION
## Summary

Two CLI bug fixes:

1. **MiMo reasoning_effort: 'none' error** (#11501): For `@ai-sdk/openai-compatible` providers, user-provided variants with `{ reasoning: { effort: 'none' } }` are now remapped to `{ reasoning: { enabled: false } }` so the SDK never sends an unsupported effort value.

2. **MCP server toggle not persisting** (#6157): The `connect()` and `disconnect()` functions only modified in-memory state. Now both persist the `enabled` field to the project config file via `cfgSvc.update()`.

## Changes

### Fix 1: Reasoning effort remapping
- **`packages/opencode/src/provider/transform.ts`**: For `@ai-sdk/openai-compatible` models with user-provided variants, remap `reasoning: { effort: 'none' }` → `reasoning: { enabled: false }` (preserving sibling options via spread).
- **`packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts`**: Two test cases covering basic remapping and sibling option preservation.

### Fix 2: MCP toggle persistence
- **`packages/opencode/src/mcp/index.ts`**: `connect()` and `disconnect()` now call `cfgSvc.update()` to persist the `enabled` field.
- **`.changeset/mimo-reasoning-none-fix.md`** and **`.changeset/mcp-toggle-persist.md`**: Patch changesets.

## Verification

- All 366 provider tests pass
- All 248 transform tests pass
- All 26 session LLM tests pass
- All 21 MCP lifecycle tests pass
- All 44 MCP unit tests pass

Fixes #11501, fixes #6157