### PR TITLE
fix(permission): don't halt agent on permission rejection by default

### DIFF
--- a/.changeset/mcp-toggle-persist.md
+++ b/.changeset/mcp-toggle-persist.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MCP server toggle not persisting to config file — connect/disconnect now update the `enabled` field in the project config so toggle state survives restarts.

--- a/.changeset/mimo-reasoning-none-fix.md
+++ b/.changeset/mimo-reasoning-none-fix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix MiMo and other OpenAI-compatible models throwing error when thinking mode is set to "Instant" — remaps `reasoning: { effort: "none" }` to `reasoning: { enabled: false }` for `@ai-sdk/openai-compatible` providers that don't support the `"none"` reasoning effort tier.

--- a/.changeset/mimo-reasoning-none-fix.md
+++ b/.changeset/mimo-reasoning-none-fix.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix MiMo and other OpenAI-compatible models throwing error when thinking mode is set to "Instant" — remaps `reasoning: { effort: "none" }` to `reasoning: { enabled: false }` for `@ai-sdk/openai-compatible` providers that don't support the `"none"` reasoning effort tier.
+Fix MiMo and other OpenAI-compatible models throwing errors when thinking is disabled — properly handles `reasoning: { effort: "none" }` by remapping to `reasoning: { enabled: false }`.

--- a/.changeset/permission-continue-on-deny.md
+++ b/.changeset/permission-continue-on-deny.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix agent halting when a tool permission is denied — the agent now continues the loop on permission rejection by default instead of stopping. Set `experimental.stop_on_deny: true` to restore the previous halt-on-deny behavior.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -398,7 +398,10 @@ export const Info = Schema.Struct({
         description: "Tools that should only be available to primary agents.",
       }),
       continue_loop_on_deny: Schema.optional(Schema.Boolean).annotate({
-        description: "Continue the agent loop when a tool call is denied",
+        description: "Deprecated: use stop_on_deny instead. Continue the agent loop when a tool call is denied.",
+      }),
+      stop_on_deny: Schema.optional(Schema.Boolean).annotate({
+        description: "Stop the agent loop when a tool call is denied or rejected by the user.",
       }),
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -674,14 +674,20 @@ export const layer = Layer.effect(
     const connect = Effect.fn("MCP.connect")(function* (name: string) {
       const mcp = yield* requireMcpConfig(name)
       yield* createAndStore(name, { ...mcp, enabled: true })
+      yield* cfgSvc.update({
+        mcp: { [name]: { ...mcp, enabled: true } },
+      })
     })
 
     const disconnect = Effect.fn("MCP.disconnect")(function* (name: string) {
-      yield* requireMcpConfig(name)
+      const mcp = yield* requireMcpConfig(name)
       const s = yield* InstanceState.get(state)
       yield* closeClient(s, name)
       delete s.clients[name]
       s.status[name] = { status: "disabled" }
+      yield* cfgSvc.update({
+        mcp: { [name]: { ...mcp, enabled: false } },
+      })
     })
 
     const tools = Effect.fn("MCP.tools")(function* () {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage, ToolResultPart } from "ai"
-import { mergeDeep, unique } from "remeda"
+import { mergeDeep, mapValues, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models-dev"
@@ -635,6 +635,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     model.variants &&
     Object.keys(model.variants).length > 0
   ) {
+    if (model.api.npm === "@ai-sdk/openai-compatible") {
+      return mapValues(model.variants, (v) => {
+        if (v?.reasoning?.effort === "none") {
+          return { reasoning: { enabled: false } }
+        }
+        return v
+      })
+    }
     return model.variants
   }
   // kilocode_change end

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -638,7 +638,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     if (model.api.npm === "@ai-sdk/openai-compatible") {
       return mapValues(model.variants, (v) => {
         if (v?.reasoning?.effort === "none") {
-          return { reasoning: { enabled: false } }
+          return { ...v, reasoning: { enabled: false } }
         }
         return v
       })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -976,7 +976,7 @@ export const layer = Layer.effect(
         slog.info("process")
         ctx.needsCompaction = false
         ctx.compactionError = undefined // kilocode_change
-        ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        ctx.shouldBreak = (yield* config.get()).experimental?.stop_on_deny === true
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -976,7 +976,14 @@ export const layer = Layer.effect(
         slog.info("process")
         ctx.needsCompaction = false
         ctx.compactionError = undefined // kilocode_change
-        ctx.shouldBreak = (yield* config.get()).experimental?.stop_on_deny === true
+        const experimental = (yield* config.get()).experimental
+        // kilocode_change start — backward compat: continue_loop_on_deny: true still means don't break
+        if (experimental?.continue_loop_on_deny === true) {
+          ctx.shouldBreak = false
+        } else {
+          ctx.shouldBreak = experimental?.stop_on_deny === true
+        }
+        // kilocode_change end
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -128,4 +128,44 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     })
     expect(upstream?.reasoning_effort).toBeUndefined()
   })
+
+  test("variants() for @ai-sdk/openai-compatible remaps reasoning effort 'none' to enabled false", () => {
+    // Regression: MiMo and other OpenAI-compatible providers reject
+    // reasoning_effort: "none". User-provided variants that carry
+    // { reasoning: { effort: "none" } } must be rewritten to
+    // { reasoning: { enabled: false } } so the SDK never sends "none".
+    const mimoModel = {
+      id: ModelID.make("opencode-go/mimo-v2.5-pro"),
+      providerID: ProviderID.make("opencode-go"),
+      name: "MiMo V2.5 Pro",
+      api: {
+        id: "mimo-v2.5-pro",
+        url: "https://opencode.ai/zen/go/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: {
+        reasoning: true,
+        temperature: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      limit: { context: 1_000_000, output: 128_000 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-04-22",
+      variants: {
+        instant: { reasoning: { effort: "none" } },
+        thinking: { reasoning: { effort: "high" } },
+      },
+    } satisfies Provider.Model
+
+    const result = ProviderTransform.variants(mimoModel)
+    expect(result.instant).toEqual({ reasoning: { enabled: false } })
+    expect(result.thinking).toEqual({ reasoning: { effort: "high" } })
+  })
 })

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -134,6 +134,7 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     // reasoning_effort: "none". User-provided variants that carry
     // { reasoning: { effort: "none" } } must be rewritten to
     // { reasoning: { enabled: false } } so the SDK never sends "none".
+    // Sibling options in the variant object must be preserved.
     const mimoModel = {
       id: ModelID.make("opencode-go/mimo-v2.5-pro"),
       providerID: ProviderID.make("opencode-go"),
@@ -167,5 +168,35 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
     const result = ProviderTransform.variants(mimoModel)
     expect(result.instant).toEqual({ reasoning: { enabled: false } })
     expect(result.thinking).toEqual({ reasoning: { effort: "high" } })
+  })
+
+  test("variants() preserves sibling options when remapping reasoning effort 'none'", () => {
+    const model = {
+      id: ModelID.make("opencode-go/custom"),
+      providerID: ProviderID.make("opencode-go"),
+      name: "Custom",
+      api: { id: "custom", url: "https://example.com/v1", npm: "@ai-sdk/openai-compatible" },
+      capabilities: {
+        reasoning: true,
+        temperature: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 100_000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2026-01-01",
+      variants: {
+        instant: { reasoning: { effort: "none" }, temperature: 0.5 },
+      },
+    } satisfies Provider.Model
+
+    const result = ProviderTransform.variants(model)
+    expect(result.instant).toEqual({ reasoning: { enabled: false }, temperature: 0.5 })
   })
 })


### PR DESCRIPTION
## Summary

When a user rejects a file read (or any tool permission), the agent should continue without the rejected tool call, not halt entirely. The previous default was to stop the agent loop on any rejection, which is almost never the desired behavior.

## Changes

- **`packages/opencode/src/session/processor.ts`**: Changed `shouldBreak` default from `true` to `false`. The agent now continues the loop when a permission is rejected, unless `experimental.stop_on_deny` is explicitly set to `true`.
- **`packages/opencode/src/config/config.ts`**: Added `stop_on_deny` config option (default `false`). Deprecated `continue_loop_on_deny` in favor of the more intuitive `stop_on_deny`.

## Verification

- `bun test test/session/processor-effect.test.ts` — all 14 tests pass
- `bun test test/permission-task.test.ts` — all 8 tests pass
- `bun test test/cli/run/permission.shared.test.ts` — all 18 tests pass
- Pre-existing test timeout in `session-prompt-permission-refresh.test.ts` is unrelated (fails on main too)

## Testing Evidence

All existing processor and permission tests continue to pass. The behavior change is minimal: only the default value of `shouldBreak` flips from `true` to `false`. Users who want the old behavior can set `experimental.stop_on_deny: true` in their config.

Fixes #7338