### PR TITLE
docs: document REVIEW.md sub-agent guidance

### DIFF
--- a/packages/kilo-docs/pages/automate/code-reviews/github.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/github.md
@@ -40,7 +40,7 @@ The GitHub App requests the following permissions:
    - **Repository Selection** — All repositories or select specific ones
    - **Focus Areas** — Security, performance, bugs, style, testing, documentation
    - **Max Review Time** — 5 to 30 minutes
-   - **Custom Instructions** — Add team-specific review guidelines
+   - **Use REVIEW.md** — Load repository-specific review guidance, including sub-agent usage, from the base branch
 4. Click **Save Configuration**
 
 ### Step 3: Open a Pull Request

--- a/packages/kilo-docs/pages/automate/code-reviews/gitlab.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/gitlab.md
@@ -37,7 +37,7 @@ Once connected, return here to configure the Review Agent.
    - **Repository Selection** — All repositories or select specific ones
    - **Focus Areas** — Security, performance, bugs, style, testing, documentation
    - **Max Review Time** — 5 to 30 minutes
-   - **Custom Instructions** — Add team-specific review guidelines
+   - **Use REVIEW.md** — Load repository-specific review guidance, including sub-agent usage, from the base branch
 4. Click **Save Configuration**
 
 When you select repositories, Kilo **automatically creates webhooks** on each project.

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -61,7 +61,7 @@ To use it:
 
 1. Create `REVIEW.md` at the repository root.
 2. Commit it to the base branch used by pull requests or merge requests.
-3. Open Code Reviews settings and enable **Use REVIEW.md**.
+3. Open Code Reviews settings in the [Kilo web app](https://app.kilo.ai/code-reviews) and enable **Use REVIEW.md**.
 4. Save the configuration and run a review.
 
 Kilo reads `REVIEW.md` from the PR/MR base branch, not the feature branch. That prevents an unreviewed change from rewriting the review policy used to evaluate itself. If the file is disabled, missing, empty, or unreadable, Kilo falls back to built-in guidance. If it is longer than 10,000 characters, Kilo truncates it and notes that in the review summary footer.

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -78,7 +78,7 @@ By default, Code Reviews uses sub-agents only when they materially improve cover
 
 The reviewer does not spawn sub-agents for a single-file or straightforward typo/config change. Sub-agents are read-only and do not post comments themselves. They return findings with path, line, severity, and rationale. The main reviewer remains responsible for verifying findings, removing duplicates, checking that inline comments target valid diff lines, and posting the final comments and summary.
 
-### Changing Sub-Agent Behavior
+#### Changing Sub-Agent Behavior
 
 `REVIEW.md` can replace the default sub-agent guidance. Use it to change both how many sub-agents Kilo should use and what each one should inspect.
 

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -14,6 +14,7 @@ Kilo's **Code Reviews** feature automatically analyzes your pull or merge reques
 - Automatic detection of bugs, security risks, and anti-patterns
 - Deep reasoning over changed files, diffs, and repo context
 - Customizable review strictness and focus areas
+- Repository-owned review guidance through `REVIEW.md`, including sub-agent usage
 
 ## Supported Platforms
 
@@ -45,12 +46,72 @@ Before enabling Code Reviews:
 5. Choose which **repositories** should receive automatic reviews.
 6. Optionally select **Focus Areas** such as security, performance, bugs, style, testing, or documentation.
 7. Set a **maximum review time** (5–30 minutes).
-8. Add **custom instructions** to shape how the agent reviews your code.
+8. Optionally enable **Use REVIEW.md** and add a `REVIEW.md` file at the repository root to shape how the agent reviews your code.
 
 Once configured, the Review Agent runs automatically on PR/MR events. For platform-specific setup, see:
 
 - [GitHub Code Reviews](./github)
 - [GitLab Code Reviews](./gitlab)
+
+## Repository Guidance with REVIEW.md
+
+Use `REVIEW.md` when review policy should live with the repository instead of only in the Kilo dashboard. This is the best place to document domain-specific rules, severity calibration, files to skip, verification expectations, summary style, and how Kilo should use sub-agents.
+
+To use it:
+
+1. Create `REVIEW.md` at the repository root.
+2. Commit it to the base branch used by pull requests or merge requests.
+3. Open Code Reviews settings and enable **Use REVIEW.md**.
+4. Save the configuration and run a review.
+
+Kilo reads `REVIEW.md` from the PR/MR base branch, not the feature branch. That prevents an unreviewed change from rewriting the review policy used to evaluate itself. If the file is disabled, missing, empty, or unreadable, Kilo falls back to built-in guidance. If it is longer than 10,000 characters, Kilo truncates it and notes that in the review summary footer.
+
+### Default Sub-Agent Usage
+
+By default, Code Reviews uses sub-agents only when they materially improve coverage. After reading the diff, the reviewer estimates changed file count and changed lines, then chooses the largest tier triggered by either signal.
+
+| Diff size | Default behavior | Why |
+|---|---|---|
+| Tiny: up to 2 files and under 100 changed lines | Use 0 sub-agents and review directly | The coordination cost is higher than the coverage benefit for very small changes. |
+| Small: 3-5 files or 100-300 changed lines | Use at most 1 sub-agent for a distinct risky area | One focused second pass can help without creating duplicate or low-signal findings. |
+| Medium and larger: 6+ files or more than 300 changed lines | Use the full 6 sub-agents, sharded by independent areas | Larger diffs benefit from parallel coverage across files, domains, and risk categories. |
+
+The reviewer does not spawn sub-agents for a single-file or straightforward typo/config change. Sub-agents are read-only and do not post comments themselves. They return findings with path, line, severity, and rationale. The main reviewer remains responsible for verifying findings, removing duplicates, checking that inline comments target valid diff lines, and posting the final comments and summary.
+
+### Changing Sub-Agent Behavior
+
+`REVIEW.md` can replace the default sub-agent guidance. Use it to change both how many sub-agents Kilo should use and what each one should inspect.
+
+Good sub-agent guidance is explicit about:
+
+- When to use 0 sub-agents.
+- When to use 1-2 targeted sub-agents.
+- When to use the full 6 sub-agents.
+- Which areas each sub-agent should own.
+- What each sub-agent should return to the main reviewer.
+- Which hard constraints still matter, such as read-only review and no direct commenting by sub-agents.
+
+Example `REVIEW.md` section:
+
+```markdown
+## Sub-agent usage
+
+Use 0 sub-agents for docs-only, formatting-only, dependency-lockfile-only, or single-file typo changes.
+
+Use 1 sub-agent for focused changes under 300 changed lines when the diff touches one risky area, such as authentication, billing, database migrations, or security-sensitive parsing.
+
+Use 3 sub-agents when a PR spans API, data model, and UI changes:
+
+1. API/data reviewer: check request validation, authorization, persistence, and migration safety.
+2. UI reviewer: check user-visible behavior, accessibility, empty states, and error states.
+3. Test reviewer: check that tests cover the observable behavior and important edge cases.
+
+Use the full 6 sub-agents only for large cross-cutting changes, security-sensitive work, or changes above 800 changed lines. Split them by independent domains rather than asking every sub-agent to review the same files.
+
+Each sub-agent must stay read-only, must not post comments, and must return findings with path, line, severity, rationale, and confidence. The main reviewer must verify every finding before posting it.
+```
+
+`REVIEW.md` can change review policy and sub-agent usage, but it cannot override Kilo's hard safety constraints, read-only mode, non-interactive execution, platform API instructions, diff-line rules, duplicate-comment rules, or output formatting requirements.
 
 ## Local Code Reviews
 
@@ -173,6 +234,6 @@ The Review Agent is ideal for:
 
 - Reviews can run for **up to 30 minutes** depending on your setting.
 - The agent reviews **only the changed files**, not the entire repository.
-- Some highly dynamic or domain-specific code may require additional context in custom instructions.
+- Some highly dynamic or domain-specific code may require additional context in `REVIEW.md`.
 - The agent will only run on **selected repositories**.
 - During beta, review capacity may be throttled for extremely large PRs.


### PR DESCRIPTION
## Summary

Document how Code Reviews uses `REVIEW.md` for repository-owned review policy, including the default sub-agent tiers and how teams can override sub-agent counts and responsibilities.

Related: https://github.com/Kilo-Org/cloud/pull/4097

## Notes

This updates the public Code Reviews overview plus the GitHub and GitLab setup pages so the UI setting is described as `Use REVIEW.md` instead of legacy custom instructions.