### PR TITLE
feat(kilocode): implement skill management and marketplace

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -512,6 +512,7 @@
         "web-tree-sitter": "0.25.10",
         "which": "6.0.1",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+        "yaml": "2.8.3",
         "yargs": "18.0.0",
         "zod": "catalog:",
       },

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -107,6 +107,7 @@
     "@kilocode/plugin-atomic-chat": "workspace:*",
     "@kilocode/sdk": "workspace:*",
     "@lydell/node-pty": "catalog:",
+    "yaml": "2.8.3",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@morphllm/morphsdk": "0.2.166",
     "@npmcli/arborist": "9.4.0",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
@@ -1,7 +1,9 @@
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
-import { createResource, createMemo } from "solid-js"
+import { createResource, createMemo, createSignal } from "solid-js"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "@tui/context/sdk"
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
+import { DialogSkillMarketplace } from "@/kilocode/cli/cmd/tui/component/dialog-skill-marketplace" // kilocode_change
 
 export type DialogSkillProps = {
   onSelect: (skill: string) => void
@@ -10,12 +12,14 @@ export type DialogSkillProps = {
 export function DialogSkill(props: DialogSkillProps) {
   const dialog = useDialog()
   const sdk = useSDK()
-  dialog.setSize("large")
-
-  const [skills] = createResource(async () => {
+  // kilocode_change start - skill management (install/uninstall/browse marketplace)
+  const [skills, { refetch }] = createResource(async () => {
     const result = await sdk.client.app.skills()
     return result.data ?? []
   })
+  const [busy, setBusy] = createSignal<string | null>(null)
+  // kilocode_change end
+  dialog.setSize("large")
 
   const options = createMemo<DialogSelectOption<string>[]>(() => {
     const list = skills() ?? []
@@ -32,5 +36,96 @@ export function DialogSkill(props: DialogSkillProps) {
     }))
   })
 
-  return <DialogSelect title="Skills" placeholder="Search skills..." options={options()} />
+  // kilocode_change start - management actions (browse/install/uninstall)
+  const actions = createMemo(() => {
+    const installed = new Set((skills() ?? []).map((s) => s.name))
+    return [
+      {
+        command: "skill.marketplace.browse",
+        title: "browse",
+        requiresSelection: false as const,
+        onTrigger: () => {
+          dialog.replace(() => <DialogSkillMarketplace installed={installed} onInstalled={() => void refetch()} />)
+        },
+      },
+      {
+        command: "skill.install.url",
+        title: "install url",
+        requiresSelection: false as const,
+        onTrigger: async () => {
+          const url = await DialogPrompt.show(dialog, "Install skill from tarball URL", {
+            placeholder: "https://example.com/skill.tar.gz",
+          })
+          if (!url) return
+          const id = await DialogPrompt.show(dialog, "Skill id (directory name)", {
+            placeholder: "my-skill",
+          })
+          if (!id) return
+          setBusy(id)
+          try {
+            const result = await sdk.client.kilocode.installSkill({ id, url, scope: "global" })
+            if (!result.data?.success) {
+              console.error("Failed to install skill:", result.data?.error ?? "unknown error")
+            }
+            await refetch()
+          } catch (err) {
+            console.error("Failed to install skill:", err)
+          } finally {
+            setBusy(null)
+          }
+        },
+      },
+      {
+        command: "skill.install.folder",
+        title: "install folder",
+        requiresSelection: false as const,
+        onTrigger: async () => {
+          const folder = await DialogPrompt.show(
+            dialog,
+            "Install skill from local folder (adds to kilo.json skills.paths)",
+            {
+              placeholder: "/path/to/skills/my-skill or ~/my-skills",
+            },
+          )
+          if (!folder) return
+          setBusy(folder)
+          try {
+            const result = await sdk.client.kilocode.installSkillFolder({ path: folder, scope: "global" })
+            if (!result.data?.success) {
+              console.error("Failed to add skill path to config:", result.data?.error ?? "unknown error")
+            }
+            await refetch()
+          } catch (err) {
+            console.error("Failed to add skill path to config:", err)
+          } finally {
+            setBusy(null)
+          }
+        },
+      },
+      {
+        command: "skill.uninstall",
+        title: "uninstall",
+        requiresSelection: true as const,
+        onTrigger: async (option: DialogSelectOption<string>) => {
+          if (busy() !== null) return
+          const id = option.value
+          setBusy(id)
+          try {
+            const result = await sdk.client.kilocode.removeInstalledSkill({ id, scope: "global" })
+            if (!result.data?.success) {
+              console.error("Failed to uninstall skill:", result.data?.error ?? "unknown error")
+            }
+            await refetch()
+          } catch (err) {
+            console.error("Failed to uninstall skill:", err)
+          } finally {
+            setBusy(null)
+          }
+        },
+      },
+    ]
+  })
+  // kilocode_change end
+
+  return <DialogSelect title="Skills" placeholder="Search skills..." options={options()} actions={actions()} /> // kilocode_change - actions
 }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
@@ -1,9 +1,12 @@
 import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
-import { createResource, createMemo, createSignal } from "solid-js"
+import { createResource, createMemo } from "solid-js"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "@tui/context/sdk"
-import { DialogPrompt } from "@tui/ui/dialog-prompt"
 import { DialogSkillMarketplace } from "@/kilocode/cli/cmd/tui/component/dialog-skill-marketplace" // kilocode_change
+// kilocode_change start - Kilo skill management: busy signal + URL/folder prompts
+import { createSignal } from "solid-js"
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
+// kilocode_change end
 
 export type DialogSkillProps = {
   onSelect: (skill: string) => void
@@ -12,6 +15,7 @@ export type DialogSkillProps = {
 export function DialogSkill(props: DialogSkillProps) {
   const dialog = useDialog()
   const sdk = useSDK()
+  dialog.setSize("large")
   // kilocode_change start - skill management (install/uninstall/browse marketplace)
   const [skills, { refetch }] = createResource(async () => {
     const result = await sdk.client.app.skills()
@@ -19,7 +23,6 @@ export function DialogSkill(props: DialogSkillProps) {
   })
   const [busy, setBusy] = createSignal<string | null>(null)
   // kilocode_change end
-  dialog.setSize("large")
 
   const options = createMemo<DialogSelectOption<string>[]>(() => {
     const list = skills() ?? []

--- a/packages/opencode/src/cli/cmd/tui/config/keybind.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/keybind.ts
@@ -152,11 +152,11 @@ export const Definitions = {
   prompt_submit: keybind("none", "Submit prompt"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_skills: keybind("none", "Open skill selector"),
-  // kilocode_change start - skill management actions
-  skill_marketplace_browse: keybind("none", "Browse skill marketplace"),
-  skill_install_url: keybind("none", "Install skill from URL"),
-  skill_install_folder: keybind("none", "Install skill from local folder"),
-  skill_uninstall: keybind("none", "Uninstall selected skill"),
+  // kilocode_change start - skill management actions (function keys to avoid collisions with existing ctrl+/alt+ binds)
+  skill_marketplace_browse: keybind("f1", "Browse skill marketplace"),
+  skill_install_url: keybind("f2", "Install skill from URL"),
+  skill_install_folder: keybind("f3", "Install skill from local folder"),
+  skill_uninstall: keybind("f4", "Uninstall selected skill"),
   // kilocode_change end
   prompt_stash: keybind("none", "Stash prompt"),
   prompt_stash_pop: keybind("none", "Pop stashed prompt"),

--- a/packages/opencode/src/cli/cmd/tui/config/keybind.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/keybind.ts
@@ -152,6 +152,12 @@ export const Definitions = {
   prompt_submit: keybind("none", "Submit prompt"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_skills: keybind("none", "Open skill selector"),
+  // kilocode_change start - skill management actions
+  skill_marketplace_browse: keybind("none", "Browse skill marketplace"),
+  skill_install_url: keybind("none", "Install skill from URL"),
+  skill_install_folder: keybind("none", "Install skill from local folder"),
+  skill_uninstall: keybind("none", "Uninstall selected skill"),
+  // kilocode_change end
   prompt_stash: keybind("none", "Stash prompt"),
   prompt_stash_pop: keybind("none", "Pop stashed prompt"),
   prompt_stash_list: keybind("none", "List stashed prompts"),
@@ -351,6 +357,12 @@ export const CommandMap = {
   prompt_submit: "prompt.submit",
   prompt_editor_context_clear: "prompt.editor_context.clear",
   prompt_skills: "prompt.skills",
+  // kilocode_change start - skill management action command ids
+  skill_marketplace_browse: "skill.marketplace.browse",
+  skill_install_url: "skill.install.url",
+  skill_install_folder: "skill.install.folder",
+  skill_uninstall: "skill.uninstall",
+  // kilocode_change end
   prompt_stash: "prompt.stash",
   prompt_stash_pop: "prompt.stash.pop",
   prompt_stash_list: "prompt.stash.list",

--- a/packages/opencode/src/cli/cmd/tui/config/keybind.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/keybind.ts
@@ -152,11 +152,11 @@ export const Definitions = {
   prompt_submit: keybind("none", "Submit prompt"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_skills: keybind("none", "Open skill selector"),
-  // kilocode_change start - skill management actions (function keys to avoid collisions with existing ctrl+/alt+ binds)
-  skill_marketplace_browse: keybind("f1", "Browse skill marketplace"),
-  skill_install_url: keybind("f2", "Install skill from URL"),
-  skill_install_folder: keybind("f3", "Install skill from local folder"),
-  skill_uninstall: keybind("f4", "Uninstall selected skill"),
+  // kilocode_change start - skill management actions (leader-letter combos match existing convention; universally work in any terminal)
+  skill_marketplace_browse: keybind("<leader>k", "Browse skill marketplace"),
+  skill_install_url: keybind("<leader>i", "Install skill from URL"),
+  skill_install_folder: keybind("<leader>f", "Install skill from local folder"),
+  skill_uninstall: keybind("<leader>d", "Uninstall selected skill"),
   // kilocode_change end
   prompt_stash: keybind("none", "Stash prompt"),
   prompt_stash_pop: keybind("none", "Pop stashed prompt"),

--- a/packages/opencode/src/cli/cmd/tui/config/keybind.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/keybind.ts
@@ -152,11 +152,11 @@ export const Definitions = {
   prompt_submit: keybind("none", "Submit prompt"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_skills: keybind("none", "Open skill selector"),
-  // kilocode_change start - skill management actions (leader-letter combos match existing convention; universally work in any terminal)
-  skill_marketplace_browse: keybind("<leader>k", "Browse skill marketplace"),
-  skill_install_url: keybind("<leader>i", "Install skill from URL"),
-  skill_install_folder: keybind("<leader>f", "Install skill from local folder"),
-  skill_uninstall: keybind("<leader>d", "Uninstall selected skill"),
+  // kilocode_change start - skill management actions (ctrl+shift+letter combos that are free in TUI and not captured by VS Code in the integrated terminal)
+  skill_marketplace_browse: keybind("ctrl+shift+b", "Browse skill marketplace"),
+  skill_install_url: keybind("ctrl+shift+i", "Install skill from URL"),
+  skill_install_folder: keybind("ctrl+shift+f", "Install skill from local folder"),
+  skill_uninstall: keybind("ctrl+shift+u", "Uninstall selected skill"),
   // kilocode_change end
   prompt_stash: keybind("none", "Stash prompt"),
   prompt_stash_pop: keybind("none", "Pop stashed prompt"),

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -506,7 +506,21 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           <box flexDirection="row" gap={2}>
             <For each={left()}>
               {(item) => (
-                <text>
+                <text
+                  // kilocode_change start - make action footer clickable
+                  onMouseUp={() => {
+                    const action = actions().find((a) => a.title === item.title)
+                    if (!action) return
+                    if (action.requiresSelection === false) {
+                      action.onTrigger()
+                      return
+                    }
+                    const option = selected()
+                    if (!option) return
+                    action.onTrigger(option)
+                  }}
+                  // kilocode_change end
+                >
                   <span style={{ fg: theme.text }}>
                     <b>{item.title}</b>{" "}
                   </span>
@@ -518,7 +532,21 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           <box flexDirection="row" gap={2}>
             <For each={right()}>
               {(item) => (
-                <text>
+                <text
+                  // kilocode_change start - make action footer clickable
+                  onMouseUp={() => {
+                    const action = actions().find((a) => a.title === item.title)
+                    if (!action) return
+                    if (action.requiresSelection === false) {
+                      action.onTrigger()
+                      return
+                    }
+                    const option = selected()
+                    if (!option) return
+                    action.onTrigger(option)
+                  }}
+                  // kilocode_change end
+                >
                   <span style={{ fg: theme.text }}>
                     <b>{item.title}</b>{" "}
                   </span>

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-skill-marketplace.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-skill-marketplace.tsx
@@ -18,8 +18,14 @@ export function DialogSkillMarketplace(props: { installed: Set<string>; onInstal
   const [busy, setBusy] = createSignal<string | null>(null)
   const [error, setError] = createSignal<string | undefined>()
 
-  const [data] = createResource(async () => {
+  const [data, { refetch }] = createResource(async () => {
     const result = await sdk.client.kilocode.marketplaceSkills()
+    // Surface server-side errors (e.g. upstream marketplace outage) as a
+    // top-level error so the dialog can show it instead of a silent empty list.
+    if (result.error) {
+      const err = result.error as { message?: string }
+      throw new Error(err.message ?? "Failed to fetch marketplace skills")
+    }
     return result.data
   })
 
@@ -28,11 +34,15 @@ export function DialogSkillMarketplace(props: { installed: Set<string>; onInstal
     return items.map((item) => {
       const isInstalled = props.installed.has(item.id)
       const isBusy = busy() === item.id
+      // Title-case the id and category on the client (the API returns them
+      // in their raw kebab/snake form).
+      const displayName = kebabToTitleCase(item.id)
+      const displayCategory = kebabToTitleCase(item.category)
       return {
-        title: item.displayName,
+        title: displayName,
         description: item.description?.replace(/\s+/g, " ").trim(),
         value: item.id,
-        category: item.displayCategory || "Skills",
+        category: displayCategory || "Skills",
         gutter: isInstalled ? () => <InstalledMark /> : undefined,
         footer: isBusy ? <BusyMark /> : isInstalled ? <InstalledBadge /> : undefined,
         disabled: isBusy,
@@ -66,17 +76,48 @@ export function DialogSkillMarketplace(props: { installed: Set<string>; onInstal
     })
   })
 
+  // Loading state — shown while the resource is pending or during retry.
+  // Error state — replaces the list when the fetch failed; user can retry.
+  // Empty state — explicit "no skills" message (the marketplace API always
+  // returns 40, so an empty list is a server-side bug worth showing).
+  const loading = data.loading
+  const fetchError = data.error
+  const items = data()?.items ?? []
+
   return (
     <DialogSelect
       title="Marketplace Skills"
-      placeholder="Search marketplace..."
+      placeholder={
+        loading
+          ? "Loading marketplace..."
+          : fetchError
+            ? "Failed to load marketplace (press ctrl+r to retry)"
+            : "Search marketplace..."
+      }
       options={options()}
       onSelect={(_option) => {
         // Don't close on select; install action handles its own close.
       }}
-      footerHints={error() ? [{ title: "error", label: error()!, side: "right" }] : undefined}
+      footerHints={
+        fetchError
+          ? [{ title: "error", label: String((fetchError as Error).message ?? fetchError), side: "right" }]
+          : error()
+            ? [{ title: "error", label: error()!, side: "right" }]
+            : loading
+              ? [{ title: "loading", label: "fetching skills...", side: "right" }]
+              : items.length === 0
+                ? [{ title: "empty", label: "marketplace returned 0 skills", side: "right" }]
+                : undefined
+      }
     />
   )
+}
+
+function kebabToTitleCase(str: string): string {
+  return str
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
 }
 
 function InstalledMark() {

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-skill-marketplace.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-skill-marketplace.tsx
@@ -1,0 +1,106 @@
+// kilocode_change - new file
+// TUI dialog for browsing the Kilo Marketplace. Opened from the skills
+// dialog's "browse" action. Lists marketplace skills grouped by category,
+// marks already-installed skills with a checkmark, and installs a selected
+// skill into the user's global skills directory.
+
+import { createMemo, createResource, createSignal, For, Show } from "solid-js"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { useDialog } from "@tui/ui/dialog"
+import { useSDK } from "@tui/context/sdk"
+import { useTheme } from "@tui/context/theme"
+import { TextAttributes } from "@opentui/core"
+
+export function DialogSkillMarketplace(props: { installed: Set<string>; onInstalled: () => void }) {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const { theme } = useTheme()
+  const [busy, setBusy] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string | undefined>()
+
+  const [data] = createResource(async () => {
+    const result = await sdk.client.kilocode.marketplaceSkills()
+    return result.data
+  })
+
+  const options = createMemo<DialogSelectOption<string>[]>(() => {
+    const items = data()?.items ?? []
+    return items.map((item) => {
+      const isInstalled = props.installed.has(item.id)
+      const isBusy = busy() === item.id
+      return {
+        title: item.displayName,
+        description: item.description?.replace(/\s+/g, " ").trim(),
+        value: item.id,
+        category: item.displayCategory || "Skills",
+        gutter: isInstalled ? () => <InstalledMark /> : undefined,
+        footer: isBusy ? <BusyMark /> : isInstalled ? <InstalledBadge /> : undefined,
+        disabled: isBusy,
+        onSelect: async () => {
+          if (isInstalled) {
+            // Already installed — just close the marketplace view.
+            dialog.clear()
+            return
+          }
+          setBusy(item.id)
+          setError(undefined)
+          try {
+            const result = await sdk.client.kilocode.installSkill({
+              id: item.id,
+              url: item.content,
+              scope: "global",
+            })
+            if (!result.data?.success) {
+              setError(result.data?.error ?? "Install failed")
+              return
+            }
+            props.onInstalled()
+            dialog.clear()
+          } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+          } finally {
+            setBusy(null)
+          }
+        },
+      }
+    })
+  })
+
+  return (
+    <DialogSelect
+      title="Marketplace Skills"
+      placeholder="Search marketplace..."
+      options={options()}
+      onSelect={(_option) => {
+        // Don't close on select; install action handles its own close.
+      }}
+      footerHints={error() ? [{ title: "error", label: error()!, side: "right" }] : undefined}
+    />
+  )
+}
+
+function InstalledMark() {
+  return (
+    <text fg="#7dba65" attributes={TextAttributes.BOLD}>
+      ✓
+    </text>
+  )
+}
+
+function InstalledBadge() {
+  const { theme } = useTheme()
+  return (
+    <text fg={theme.textMuted} attributes={TextAttributes.DIM}>
+      installed
+    </text>
+  )
+}
+
+function BusyMark() {
+  const { theme } = useTheme()
+  return (
+    <text fg={theme.textMuted} attributes={TextAttributes.DIM}>
+      installing…
+    </text>
+  )
+}

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -45,12 +45,10 @@ export const SkillInstallResult = Schema.Struct({
 
 export const MarketplaceSkillItem = Schema.Struct({
   id: Schema.String,
-  name: Schema.String,
-  displayName: Schema.String,
   description: Schema.String,
   category: Schema.String,
-  displayCategory: Schema.String,
   githubUrl: Schema.String,
+  rawUrl: Schema.String,
   content: Schema.String,
 })
 

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -18,10 +18,55 @@ export const RemoveAgentPayload = Schema.Struct({
   name: Schema.String,
 })
 
+const Scope = Schema.Literals(["global", "project"])
+
+export const InstallSkillPayload = Schema.Struct({
+  id: Schema.String,
+  url: Schema.String,
+  scope: Scope,
+})
+
+export const RemoveInstalledSkillPayload = Schema.Struct({
+  id: Schema.String,
+  scope: Scope,
+})
+
+export const InstallSkillFolderPayload = Schema.Struct({
+  path: Schema.String,
+  scope: Scope,
+})
+
+export const SkillInstallResult = Schema.Struct({
+  success: Schema.Boolean,
+  slug: Schema.String,
+  error: Schema.optional(Schema.String),
+  filePath: Schema.optional(Schema.String),
+})
+
+export const MarketplaceSkillItem = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  displayName: Schema.String,
+  description: Schema.String,
+  category: Schema.String,
+  displayCategory: Schema.String,
+  githubUrl: Schema.String,
+  content: Schema.String,
+})
+
+export const MarketplaceSkillsResponse = Schema.Struct({
+  items: Schema.Array(MarketplaceSkillItem),
+  error: Schema.optional(Schema.String),
+})
+
 export const KilocodePaths = {
   heapSnapshot: `${root}/heap/snapshot`,
   removeSkill: `${root}/skill/remove`,
   removeAgent: `${root}/agent/remove`,
+  installSkill: `${root}/skill/install`,
+  removeInstalledSkill: `${root}/skill/installed/remove`,
+  marketplaceSkills: `${root}/marketplace/skills`,
+  installSkillFolder: `${root}/skill/install/folder`,
 } as const
 
 export const KilocodeApi = HttpApi.make("kilocode")
@@ -62,6 +107,56 @@ export const KilocodeApi = HttpApi.make("kilocode")
             summary: "Remove a custom agent",
             description:
               "Remove a custom (non-native) agent by deleting its markdown file from disk and refreshing state.",
+          }),
+        ),
+        HttpApiEndpoint.post("installSkill", KilocodePaths.installSkill, {
+          query: WorkspaceRoutingQuery,
+          payload: InstallSkillPayload,
+          success: described(SkillInstallResult, "Skill install result"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.installSkill",
+            summary: "Install a skill from a tarball URL",
+            description:
+              "Download a skill tarball, extract it into ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project), and dispose the instance so skill state reloads.",
+          }),
+        ),
+        HttpApiEndpoint.post("removeInstalledSkill", KilocodePaths.removeInstalledSkill, {
+          query: WorkspaceRoutingQuery,
+          payload: RemoveInstalledSkillPayload,
+          success: described(SkillInstallResult, "Skill removal result"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.removeInstalledSkill",
+            summary: "Remove an installed skill directory",
+            description:
+              "Recursively delete a skill folder under ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project) and dispose the instance so skill state reloads.",
+          }),
+        ),
+        HttpApiEndpoint.post("installSkillFolder", KilocodePaths.installSkillFolder, {
+          query: WorkspaceRoutingQuery,
+          payload: InstallSkillFolderPayload,
+          success: described(SkillInstallResult, "Skill folder install result"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.installSkillFolder",
+            summary: "Register a local folder as a skill source",
+            description:
+              "Add a folder path to kilo.json skills.paths (or remove it if already present) so skills inside are discovered on next session start.",
+          }),
+        ),
+        HttpApiEndpoint.get("marketplaceSkills", KilocodePaths.marketplaceSkills, {
+          query: WorkspaceRoutingQuery,
+          success: described(MarketplaceSkillsResponse, "Marketplace skills list"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.marketplaceSkills",
+            summary: "List marketplace skills",
+            description: "Fetch the current list of skills available in the Kilo Marketplace.",
           }),
         ),
       )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -2,6 +2,8 @@ import { Effect } from "effect"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import * as KiloAgent from "@/kilocode/agent"
 import * as KiloSkill from "@/kilocode/skill-remove"
+import * as KiloSkillInstall from "@/kilocode/skills/install"
+import * as KiloMarketplace from "@/kilocode/skills/marketplace"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { EffectBridge } from "@/effect/bridge"
@@ -10,7 +12,13 @@ import { HeapSnapshot } from "@/kilocode/cli/heap-snapshot"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Skill } from "@/skill"
-import { RemoveAgentPayload, RemoveSkillPayload } from "../groups/kilocode"
+import {
+  InstallSkillFolderPayload,
+  InstallSkillPayload,
+  RemoveAgentPayload,
+  RemoveInstalledSkillPayload,
+  RemoveSkillPayload,
+} from "../groups/kilocode"
 
 export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode", (handlers) =>
   Effect.gen(function* () {
@@ -49,9 +57,69 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       return true
     })
 
+    const marketplaceSkills = Effect.fn("KilocodeHttpApi.marketplaceSkills")(function* () {
+      return yield* Effect.tryPromise({
+        try: () => KiloMarketplace.client.skills(),
+        catch: () => new HttpApiError.BadRequest({}),
+      })
+    })
+
+    const installSkill = Effect.fn("KilocodeHttpApi.installSkill")(function* (ctx: {
+      payload: typeof InstallSkillPayload.Type
+    }) {
+      const instance = yield* InstanceState.context
+      const result = yield* EffectBridge.fromPromise(() =>
+        KiloSkillInstall.install({
+          id: ctx.payload.id,
+          url: ctx.payload.url,
+          scope: ctx.payload.scope,
+          workspace: ctx.payload.scope === "project" ? instance.directory : undefined,
+        }),
+      )
+      if (result.success) yield* store.dispose(instance)
+      return result
+    })
+
+    const removeInstalledSkill = Effect.fn("KilocodeHttpApi.removeInstalledSkill")(function* (ctx: {
+      payload: typeof RemoveInstalledSkillPayload.Type
+    }) {
+      const instance = yield* InstanceState.context
+      const result = yield* EffectBridge.fromPromise(() =>
+        KiloSkillInstall.remove({
+          id: ctx.payload.id,
+          scope: ctx.payload.scope,
+          workspace: ctx.payload.scope === "project" ? instance.directory : undefined,
+        }),
+      )
+      if (result.success) yield* store.dispose(instance)
+      return result
+    })
+
+    // kilocode_change start - register a local folder as a skill source
+    const installSkillFolder = Effect.fn("KilocodeHttpApi.installSkillFolder")(function* (ctx: {
+      payload: typeof InstallSkillFolderPayload.Type
+    }) {
+      const instance = yield* InstanceState.context
+      const cfg = yield* config.get()
+      const skills = cfg.skills ?? {}
+      const paths = skills.paths ?? []
+      // Toggle: if path already present, remove it; otherwise append.
+      const next = paths.includes(ctx.payload.path)
+        ? paths.filter((p) => p !== ctx.payload.path)
+        : [...paths, ctx.payload.path]
+      yield* config.update({ ...cfg, skills: { ...skills, paths: next } })
+      yield* store.dispose(instance)
+      return { success: true, slug: ctx.payload.path }
+    })
+    // kilocode_change end
+
     return handlers
       .handle("heapSnapshot", heapSnapshot)
       .handle("removeSkill", removeSkill)
       .handle("removeAgent", removeAgent)
+      .handle("marketplaceSkills", marketplaceSkills)
+      .handle("installSkill", installSkill)
+      .handle("removeInstalledSkill", removeInstalledSkill)
+      .handle("installSkillFolder", installSkillFolder)
   }),
 )

--- a/packages/opencode/src/kilocode/skills/install-target.ts
+++ b/packages/opencode/src/kilocode/skills/install-target.ts
@@ -1,0 +1,83 @@
+// kilocode_change - new file
+// Pure path/id resolvers for skill install/remove. Kept separate so they
+// can be unit-tested without an Effect runtime, mirroring skill-remove.ts.
+
+import * as path from "path"
+import os from "os"
+import { Global } from "@opencode-ai/core/global"
+
+export type Scope = "global" | "project"
+
+/**
+ * Skill install directory for a given scope.
+ * - global: ~/.kilo/skills (matches KilocodePaths.globalDirs and the
+ *   VS Code MarketplacePaths.skillsDir default)
+ * - project: <workspace>/.kilo/skills
+ */
+export function skillsDir(scope: Scope, workspace?: string): string {
+  if (scope === "project") {
+    if (!workspace) throw new Error("workspace directory is required for project-scope install")
+    return path.join(workspace, ".kilo", "skills")
+  }
+  return path.join(Global.Path.home, ".kilo", "skills")
+}
+
+/**
+ * Validate a skill id is safe to use as a directory name. Rejects path
+ * traversal, Windows reserved names, and characters outside the allowed set.
+ * Mirrors MarketplaceInstaller.isSafeId in the VS Code extension.
+ */
+export function isSafeId(id: string): boolean {
+  if (!id || id === "." || id.includes("..") || id.includes("/") || id.includes("\\") || id.endsWith(".")) return false
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.|$)/i.test(id)) return false
+  return /^[\w\-@.]+$/.test(id)
+}
+
+/** Resolve the final skill directory and confirm it stays inside base. */
+export function resolveTarget(base: string, id: string): string {
+  if (!isSafeId(id)) throw new Error(`invalid skill id: ${id}`)
+  const dir = path.join(base, id)
+  if (!contains(base, dir)) throw new Error(`invalid skill id: ${id}`)
+  return dir
+}
+
+/** True if `filepath` is inside `dir` (prevents path escape from the base). */
+export function contains(dir: string, filepath: string): boolean {
+  return path.resolve(filepath).startsWith(path.resolve(dir) + path.sep)
+}
+
+/** The cache directory used for URL-pulled skills (protected from remove). */
+export function cacheDir(): string {
+  return path.join(Global.Path.cache, "skills")
+}
+
+/** Walk a directory tree and return any paths that escape `root` (incl. symlinks). */
+export async function findEscapedPaths(root: string): Promise<string[]> {
+  const fs = await import("fs/promises")
+  const resolved = path.resolve(root)
+  const escaped: string[] = []
+
+  async function walk(current: string) {
+    const entries = await fs.readdir(current, { withFileTypes: true })
+    for (const entry of entries) {
+      const full = path.resolve(current, entry.name)
+      if (!full.startsWith(resolved + path.sep) && full !== resolved) {
+        escaped.push(full)
+        continue
+      }
+      if (entry.isSymbolicLink()) {
+        const target = await fs.realpath(full)
+        if (!target.startsWith(resolved + path.sep) && target !== resolved) {
+          escaped.push(full)
+          continue
+        }
+      }
+      if (entry.isDirectory()) await walk(full)
+    }
+  }
+
+  await walk(root)
+  return escaped
+}
+
+export { os }

--- a/packages/opencode/src/kilocode/skills/install.ts
+++ b/packages/opencode/src/kilocode/skills/install.ts
@@ -1,0 +1,150 @@
+// kilocode_change - new file
+// Install and remove marketplace skills on disk. Ports the VS Code
+// MarketplaceInstaller.installSkill/removeSkill flow into the CLI/TUI.
+// Skills are extracted into ~/.kilo/skills/<id>/ (global) or
+// <workspace>/.kilo/skills/<id>/ (project) and discovered by glob on the
+// next session start. The caller (server handler) disposes the instance
+// so skill state reloads.
+
+import * as fs from "fs/promises"
+import * as path from "path"
+import { randomUUID } from "crypto"
+import { Process } from "@/util/process"
+import { Global } from "@opencode-ai/core/global"
+import { findEscapedPaths, resolveTarget, skillsDir, type Scope } from "./install-target"
+
+export interface InstallInput {
+  id: string
+  url: string // tarball content URL
+  scope: Scope
+  workspace?: string
+}
+
+export interface RemoveInput {
+  id: string
+  scope: Scope
+  workspace?: string
+}
+
+export interface Result {
+  success: boolean
+  slug: string
+  error?: string
+  filePath?: string
+}
+
+async function exists(filepath: string): Promise<boolean> {
+  try {
+    await fs.access(filepath)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw err
+  }
+}
+
+/**
+ * Download a skill tarball from `url`, extract it with `--strip-components=1`,
+ * validate the archive is safe and contains a SKILL.md, then atomically
+ * rename the staging directory into place.
+ */
+export async function install(input: InstallInput): Promise<Result> {
+  const { id, url, scope, workspace } = input
+
+  if (scope === "project" && !workspace) {
+    return { success: false, slug: id, error: "No workspace directory for project-scope install" }
+  }
+  if (!url) return { success: false, slug: id, error: "Skill has no tarball URL" }
+
+  const base = skillsDir(scope, workspace)
+  let dir: string
+  try {
+    dir = resolveTarget(base, id)
+  } catch (err) {
+    return { success: false, slug: id, error: err instanceof Error ? err.message : "Invalid skill id" }
+  }
+
+  if (await exists(dir)) {
+    return { success: false, slug: id, error: "Skill already installed. Uninstall it before installing again." }
+  }
+
+  // Stage under base so fs.rename never crosses filesystems (EXDEV).
+  await fs.mkdir(base, { recursive: true })
+  const staging = await fs.mkdtemp(path.join(base, `.staging-${id}-`))
+  const tarball = path.join(Global.Path.tmp, `kilo-skill-${id}-${randomUUID()}.tar.gz`)
+
+  try {
+    const response = await fetch(url)
+    if (!response.ok) return { success: false, slug: id, error: `Download failed: ${response.status}` }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    await fs.writeFile(tarball, buffer)
+
+    await Process.run(["tar", "-xzf", tarball, "--strip-components=1", "-C", staging])
+
+    const escaped = await findEscapedPaths(staging)
+    if (escaped.length > 0) {
+      console.warn(`Skill archive ${id} contains escaped paths:`, escaped)
+      return { success: false, slug: id, error: "Skill archive contains unsafe paths" }
+    }
+
+    try {
+      await fs.access(path.join(staging, "SKILL.md"))
+    } catch {
+      return { success: false, slug: id, error: "Extracted archive missing SKILL.md" }
+    }
+
+    await fs.rename(staging, dir)
+    return { success: true, slug: id, filePath: path.join(dir, "SKILL.md") }
+  } catch (err) {
+    if (await exists(dir)) {
+      return { success: false, slug: id, error: "Skill already installed. Uninstall it before installing again." }
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`Failed to install skill ${id}:`, err)
+    return { success: false, slug: id, error: message }
+  } finally {
+    await Promise.all([
+      fs.rm(staging, { recursive: true, force: true }).catch((err) => {
+        console.warn(`Failed to clean up staging directory ${staging}:`, err)
+      }),
+      fs.rm(tarball, { force: true }).catch((err) => {
+        console.warn(`Failed to clean up temp file ${tarball}:`, err)
+      }),
+    ])
+  }
+}
+
+/**
+ * Remove an installed skill directory. Complements the manifest-only
+ * KiloSkill.remove (which only deletes SKILL.md) — this removes the whole
+ * skill folder, which is what the marketplace installer created.
+ */
+export async function remove(input: RemoveInput): Promise<Result> {
+  const { id, scope, workspace } = input
+
+  if (scope === "project" && !workspace) {
+    return { success: false, slug: id, error: "No workspace directory for project-scope removal" }
+  }
+
+  const base = skillsDir(scope, workspace)
+  let dir: string
+  try {
+    dir = resolveTarget(base, id)
+  } catch (err) {
+    return { success: false, slug: id, error: err instanceof Error ? err.message : "Invalid skill id" }
+  }
+
+  try {
+    await fs.access(dir)
+    await fs.rm(dir, { recursive: true })
+    return { success: true, slug: id }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { success: true, slug: id }
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`Failed to remove skill ${id}:`, err)
+    return { success: false, slug: id, error: message }
+  }
+}
+
+export * as Install from "./install"

--- a/packages/opencode/src/kilocode/skills/marketplace.ts
+++ b/packages/opencode/src/kilocode/skills/marketplace.ts
@@ -2,8 +2,10 @@
 // Kilo Marketplace API client for browsing installable skills.
 // Ported from packages/kilo-vscode/src/services/marketplace/api.ts so the
 // CLI/TUI can browse skills without depending on the VS Code extension.
-// JSON-only parsing to avoid adding a `yaml` runtime dependency to the
-// shared opencode package; the marketplace API returns JSON.
+// The marketplace API returns YAML; we import `yaml` (already a Kilo
+// dependency in kilo-vscode and kilo-console) to parse it.
+
+import { parse as parseYaml } from "yaml"
 
 export const BASE_URL = "https://api.kilo.ai/api/marketplace"
 const CACHE_TTL = 300_000
@@ -20,17 +22,16 @@ export interface RawSkill {
   description: string
   category: string
   githubUrl: string
+  rawUrl: string
   content: string
 }
 
 export interface SkillItem {
   id: string
-  name: string
-  displayName: string
   description: string
   category: string
-  displayCategory: string
   githubUrl: string
+  rawUrl: string
   content: string
 }
 
@@ -42,24 +43,27 @@ export function kebabToTitleCase(str: string): string {
 }
 
 export function transformSkill(raw: RawSkill): SkillItem {
-  const display = kebabToTitleCase(raw.id)
   return {
     id: raw.id,
-    name: display,
-    displayName: display,
     description: raw.description,
     category: raw.category,
-    displayCategory: kebabToTitleCase(raw.category),
     githubUrl: raw.githubUrl,
+    rawUrl: raw.rawUrl,
     content: raw.content,
   }
 }
 
 function parseResponse(text: string): unknown {
+  // Marketplace API returns YAML. Try YAML first; fall back to JSON for
+  // any future endpoint that may switch to JSON.
   try {
-    return JSON.parse(text)
+    return parseYaml(text)
   } catch {
-    return { items: [] }
+    try {
+      return JSON.parse(text)
+    } catch {
+      return { items: [] }
+    }
   }
 }
 

--- a/packages/opencode/src/kilocode/skills/marketplace.ts
+++ b/packages/opencode/src/kilocode/skills/marketplace.ts
@@ -1,0 +1,125 @@
+// kilocode_change - new file
+// Kilo Marketplace API client for browsing installable skills.
+// Ported from packages/kilo-vscode/src/services/marketplace/api.ts so the
+// CLI/TUI can browse skills without depending on the VS Code extension.
+// JSON-only parsing to avoid adding a `yaml` runtime dependency to the
+// shared opencode package; the marketplace API returns JSON.
+
+export const BASE_URL = "https://api.kilo.ai/api/marketplace"
+const CACHE_TTL = 300_000
+const MAX_RETRIES = 3
+const TIMEOUT = 10_000
+
+interface CacheEntry {
+  data: SkillItem[]
+  timestamp: number
+}
+
+export interface RawSkill {
+  id: string
+  description: string
+  category: string
+  githubUrl: string
+  content: string
+}
+
+export interface SkillItem {
+  id: string
+  name: string
+  displayName: string
+  description: string
+  category: string
+  displayCategory: string
+  githubUrl: string
+  content: string
+}
+
+export function kebabToTitleCase(str: string): string {
+  return str
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+export function transformSkill(raw: RawSkill): SkillItem {
+  const display = kebabToTitleCase(raw.id)
+  return {
+    id: raw.id,
+    name: display,
+    displayName: display,
+    description: raw.description,
+    category: raw.category,
+    displayCategory: kebabToTitleCase(raw.category),
+    githubUrl: raw.githubUrl,
+    content: raw.content,
+  }
+}
+
+function parseResponse(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return { items: [] }
+  }
+}
+
+async function fetchWithRetry(url: string, attempt = 0): Promise<string> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), TIMEOUT)
+
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    clearTimeout(timer)
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+    return await response.text()
+  } catch (err) {
+    clearTimeout(timer)
+    if (attempt >= MAX_RETRIES - 1) throw err
+    const delay = 1000 * Math.pow(2, attempt)
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    return fetchWithRetry(url, attempt + 1)
+  }
+}
+
+export class Client {
+  private cache = new Map<string, CacheEntry>()
+
+  private getCached(key: string): SkillItem[] | undefined {
+    const entry = this.cache.get(key)
+    if (!entry) return undefined
+    if (Date.now() - entry.timestamp > CACHE_TTL) {
+      this.cache.delete(key)
+      return undefined
+    }
+    return entry.data
+  }
+
+  private setCache(key: string, data: SkillItem[]): void {
+    this.cache.set(key, { data, timestamp: Date.now() })
+  }
+
+  async skills(): Promise<{ items: SkillItem[]; error?: string }> {
+    const cached = this.getCached("skills")
+    if (cached) return { items: cached }
+
+    try {
+      const text = await fetchWithRetry(`${BASE_URL}/skills`)
+      const parsed = parseResponse(text) as { items?: RawSkill[] }
+      const raw = parsed.items ?? []
+      const items = raw.map(transformSkill)
+      this.setCache("skills", items)
+      return { items }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { items: [], error: `Failed to fetch skills: ${message}` }
+    }
+  }
+
+  dispose(): void {
+    this.cache.clear()
+  }
+}
+
+export const client = new Client()
+
+export * as Marketplace from "./marketplace"

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -142,8 +142,16 @@ import type {
   KiloCloudSessionsResponses,
   KilocodeHeapSnapshotErrors,
   KilocodeHeapSnapshotResponses,
+  KilocodeInstallSkillErrors,
+  KilocodeInstallSkillFolderErrors,
+  KilocodeInstallSkillFolderResponses,
+  KilocodeInstallSkillResponses,
+  KilocodeMarketplaceSkillsErrors,
+  KilocodeMarketplaceSkillsResponses,
   KilocodeRemoveAgentErrors,
   KilocodeRemoveAgentResponses,
+  KilocodeRemoveInstalledSkillErrors,
+  KilocodeRemoveInstalledSkillResponses,
   KilocodeRemoveSkillErrors,
   KilocodeRemoveSkillResponses,
   KilocodeSessionImportMessageErrors,
@@ -7407,6 +7415,171 @@ export class Kilocode extends HeyApiClient {
         },
       },
     )
+  }
+
+  /**
+   * Install a skill from a tarball URL
+   *
+   * Download a skill tarball, extract it into ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project), and dispose the instance so skill state reloads.
+   */
+  public installSkill<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      id?: string
+      url?: string
+      scope?: "global" | "project"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "id" },
+            { in: "body", key: "url" },
+            { in: "body", key: "scope" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeInstallSkillResponses,
+      KilocodeInstallSkillErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/skill/install",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Remove an installed skill directory
+   *
+   * Recursively delete a skill folder under ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project) and dispose the instance so skill state reloads.
+   */
+  public removeInstalledSkill<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      id?: string
+      scope?: "global" | "project"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "id" },
+            { in: "body", key: "scope" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeRemoveInstalledSkillResponses,
+      KilocodeRemoveInstalledSkillErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/skill/installed/remove",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Register a local folder as a skill source
+   *
+   * Add a folder path to kilo.json skills.paths (or remove it if already present) so skills inside are discovered on next session start.
+   */
+  public installSkillFolder<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      path?: string
+      scope?: "global" | "project"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "path" },
+            { in: "body", key: "scope" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeInstallSkillFolderResponses,
+      KilocodeInstallSkillFolderErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/skill/install/folder",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * List marketplace skills
+   *
+   * Fetch the current list of skills available in the Kilo Marketplace.
+   */
+  public marketplaceSkills<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      KilocodeMarketplaceSkillsResponses,
+      KilocodeMarketplaceSkillsErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/marketplace/skills",
+      ...options,
+      ...params,
+    })
   }
 
   private _heap?: Heap

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -10618,12 +10618,10 @@ export type KilocodeMarketplaceSkillsResponses = {
   200: {
     items: Array<{
       id: string
-      name: string
-      displayName: string
       description: string
       category: string
-      displayCategory: string
       githubUrl: string
+      rawUrl: string
       content: string
     }>
     error?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5,17 +5,10 @@ export type ClientOptions = {
 }
 
 export type Event =
+  | EventServerInstanceDisposed
   | EventServerConnected
   | EventGlobalDisposed
   | EventGlobalConfigUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow1
-  | EventTuiSessionSelect
-  | EventKilocodeAgentManagerStart
-  | EventIndexingStatus
-  | EventIndexingWarning
-  | EventServerInstanceDisposed
   | EventFileEdited
   | EventFileWatcherUpdated
   | EventQuestionAsked
@@ -23,6 +16,10 @@ export type Event =
   | EventQuestionRejected
   | EventLspClientDiagnostics
   | EventLspUpdated
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow1
+  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventSessionNetworkAsked
@@ -49,6 +46,7 @@ export type Event =
   | EventCommandExecuted
   | EventProjectUpdated
   | EventSessionCompacted
+  | EventKilocodeAgentManagerStart
   | EventVcsBranchUpdated
   | EventKiloSessionsRemoteStatusChanged
   | EventWorkspaceReady
@@ -93,11 +91,13 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
-  | EventCatalogModelUpdated
+  | EventIndexingStatus
+  | EventIndexingWarning
   | EventModelsDevRefreshed
   | EventAccountAdded
   | EventAccountRemoved
   | EventAccountSwitched
+  | EventCatalogModelUpdated
 
 export type OAuth = {
   type: "oauth"
@@ -133,76 +133,6 @@ export type InvalidRequestError = {
   message: string
   kind?: string
   field?: string
-}
-
-export type EventTuiPromptAppend = {
-  id: string
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  id: string
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  id: string
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  id: string
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
-}
-
-export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
-
-export type IndexingStatus = {
-  state: IndexingStatusState
-  message: string
-  processedFiles: number
-  totalFiles: number
-  percent: number
-}
-
-export type IndexingWarning = {
-  code: "qdrant.version-incompatible" | "qdrant.version-unavailable"
-  message: string
 }
 
 export type QuestionOption = {
@@ -265,6 +195,61 @@ export type QuestionReplied = {
 export type QuestionRejected = {
   sessionID: string
   requestID: string
+}
+
+export type EventTuiPromptAppend = {
+  id: string
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  id: string
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  id: string
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  id: string
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
 }
 
 export type SessionNetworkWait = {
@@ -910,22 +895,30 @@ export type Prompt = {
   references?: Array<PromptReferenceAttachment>
 }
 
+export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
+
+export type IndexingStatus = {
+  state: IndexingStatusState
+  message: string
+  processedFiles: number
+  totalFiles: number
+  percent: number
+}
+
+export type IndexingWarning = {
+  code: "qdrant.version-incompatible" | "qdrant.version-unavailable"
+  message: string
+}
+
 export type GlobalEvent = {
   directory: string
   project?: string
   workspace?: string
   payload:
+    | EventServerInstanceDisposed
     | EventServerConnected
     | EventGlobalDisposed
     | EventGlobalConfigUpdated
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
-    | EventKilocodeAgentManagerStart
-    | EventIndexingStatus
-    | EventIndexingWarning
-    | EventServerInstanceDisposed
     | EventFileEdited
     | EventFileWatcherUpdated
     | EventQuestionAsked
@@ -933,6 +926,10 @@ export type GlobalEvent = {
     | EventQuestionRejected
     | EventLspClientDiagnostics
     | EventLspUpdated
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventSessionNetworkAsked
@@ -959,6 +956,7 @@ export type GlobalEvent = {
     | EventCommandExecuted
     | EventProjectUpdated
     | EventSessionCompacted
+    | EventKilocodeAgentManagerStart
     | EventVcsBranchUpdated
     | EventKiloSessionsRemoteStatusChanged
     | EventWorkspaceReady
@@ -1003,11 +1001,13 @@ export type GlobalEvent = {
     | EventSessionNextCompactionStarted
     | EventSessionNextCompactionDelta
     | EventSessionNextCompactionEnded
-    | EventCatalogModelUpdated
+    | EventIndexingStatus
+    | EventIndexingWarning
     | EventModelsDevRefreshed
     | EventAccountAdded
     | EventAccountRemoved
     | EventAccountSwitched
+    | EventCatalogModelUpdated
     | SyncEventMessageUpdated
     | SyncEventMessageRemoved
     | SyncEventMessagePartUpdated
@@ -2936,6 +2936,14 @@ export type SyncEventSessionNextCompactionEnded = {
   }
 }
 
+export type EventServerInstanceDisposed = {
+  id: string
+  type: "server.instance.disposed"
+  properties: {
+    directory: string
+  }
+}
+
 export type EventServerConnected = {
   id: string
   type: "server.connected"
@@ -2957,44 +2965,6 @@ export type EventGlobalConfigUpdated = {
   type: "global.config.updated"
   properties: {
     [key: string]: unknown
-  }
-}
-
-export type EventKilocodeAgentManagerStart = {
-  id: string
-  type: "kilocode.agent_manager.start"
-  properties: {
-    requestID: string
-    sessionID: string
-    mode: "worktree" | "local"
-    versions?: boolean
-    tasks: Array<{
-      prompt?: string
-      name?: string
-      branchName?: string
-    }>
-  }
-}
-
-export type EventIndexingStatus = {
-  id: string
-  type: "indexing.status"
-  properties: {
-    status: IndexingStatus
-  }
-}
-
-export type EventIndexingWarning = {
-  id: string
-  type: "indexing.warning"
-  properties: IndexingWarning
-}
-
-export type EventServerInstanceDisposed = {
-  id: string
-  type: "server.instance.disposed"
-  properties: {
-    directory: string
   }
 }
 
@@ -3289,6 +3259,22 @@ export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
     sessionID: string
+  }
+}
+
+export type EventKilocodeAgentManagerStart = {
+  id: string
+  type: "kilocode.agent_manager.start"
+  properties: {
+    requestID: string
+    sessionID: string
+    mode: "worktree" | "local"
+    versions?: boolean
+    tasks: Array<{
+      prompt?: string
+      name?: string
+      branchName?: string
+    }>
   }
 }
 
@@ -3830,6 +3816,79 @@ export type EventSessionNextCompactionEnded = {
   }
 }
 
+export type EventIndexingStatus = {
+  id: string
+  type: "indexing.status"
+  properties: {
+    status: IndexingStatus
+  }
+}
+
+export type EventIndexingWarning = {
+  id: string
+  type: "indexing.warning"
+  properties: IndexingWarning
+}
+
+export type EventModelsDevRefreshed = {
+  id: string
+  type: "models-dev.refreshed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
+export type AccountV2oAuthCredential = {
+  type: "oauth"
+  refresh: string
+  access: string
+  expires: number
+  accountId?: string
+}
+
+export type AccountV2ApiKeyCredential = {
+  type: "api"
+  key: string
+  metadata?: {
+    [key: string]: string
+  }
+}
+
+export type AccountV2Credential = AccountV2oAuthCredential | AccountV2ApiKeyCredential
+
+export type AccountV2Info = {
+  id: string
+  serviceID: string
+  description: string
+  credential: AccountV2Credential
+}
+
+export type EventAccountAdded = {
+  id: string
+  type: "account.added"
+  properties: {
+    account: AccountV2Info
+  }
+}
+
+export type EventAccountRemoved = {
+  id: string
+  type: "account.removed"
+  properties: {
+    account: AccountV2Info
+  }
+}
+
+export type EventAccountSwitched = {
+  id: string
+  type: "account.switched"
+  properties: {
+    serviceID: string
+    from?: string
+    to?: string
+  }
+}
+
 export type ModelV2Info = {
   id: string
   apiID: string
@@ -3933,65 +3992,6 @@ export type EventCatalogModelUpdated = {
   type: "catalog.model.updated"
   properties: {
     model: ModelV2Info
-  }
-}
-
-export type EventModelsDevRefreshed = {
-  id: string
-  type: "models-dev.refreshed"
-  properties: {
-    [key: string]: unknown
-  }
-}
-
-export type AccountV2oAuthCredential = {
-  type: "oauth"
-  refresh: string
-  access: string
-  expires: number
-  accountId?: string
-}
-
-export type AccountV2ApiKeyCredential = {
-  type: "api"
-  key: string
-  metadata?: {
-    [key: string]: string
-  }
-}
-
-export type AccountV2Credential = AccountV2oAuthCredential | AccountV2ApiKeyCredential
-
-export type AccountV2Info = {
-  id: string
-  serviceID: string
-  description: string
-  credential: AccountV2Credential
-}
-
-export type EventAccountAdded = {
-  id: string
-  type: "account.added"
-  properties: {
-    account: AccountV2Info
-  }
-}
-
-export type EventAccountRemoved = {
-  id: string
-  type: "account.removed"
-  properties: {
-    account: AccountV2Info
-  }
-}
-
-export type EventAccountSwitched = {
-  id: string
-  type: "account.switched"
-  properties: {
-    serviceID: string
-    from?: string
-    to?: string
   }
 }
 
@@ -10479,6 +10479,159 @@ export type KilocodeRemoveAgentResponses = {
 }
 
 export type KilocodeRemoveAgentResponse = KilocodeRemoveAgentResponses[keyof KilocodeRemoveAgentResponses]
+
+export type KilocodeInstallSkillData = {
+  body?: {
+    id: string
+    url: string
+    scope: "global" | "project"
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/skill/install"
+}
+
+export type KilocodeInstallSkillErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type KilocodeInstallSkillError = KilocodeInstallSkillErrors[keyof KilocodeInstallSkillErrors]
+
+export type KilocodeInstallSkillResponses = {
+  /**
+   * Skill install result
+   */
+  200: {
+    success: boolean
+    slug: string
+    error?: string
+    filePath?: string
+  }
+}
+
+export type KilocodeInstallSkillResponse = KilocodeInstallSkillResponses[keyof KilocodeInstallSkillResponses]
+
+export type KilocodeRemoveInstalledSkillData = {
+  body?: {
+    id: string
+    scope: "global" | "project"
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/skill/installed/remove"
+}
+
+export type KilocodeRemoveInstalledSkillErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type KilocodeRemoveInstalledSkillError =
+  KilocodeRemoveInstalledSkillErrors[keyof KilocodeRemoveInstalledSkillErrors]
+
+export type KilocodeRemoveInstalledSkillResponses = {
+  /**
+   * Skill removal result
+   */
+  200: {
+    success: boolean
+    slug: string
+    error?: string
+    filePath?: string
+  }
+}
+
+export type KilocodeRemoveInstalledSkillResponse =
+  KilocodeRemoveInstalledSkillResponses[keyof KilocodeRemoveInstalledSkillResponses]
+
+export type KilocodeInstallSkillFolderData = {
+  body?: {
+    path: string
+    scope: "global" | "project"
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/skill/install/folder"
+}
+
+export type KilocodeInstallSkillFolderErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type KilocodeInstallSkillFolderError = KilocodeInstallSkillFolderErrors[keyof KilocodeInstallSkillFolderErrors]
+
+export type KilocodeInstallSkillFolderResponses = {
+  /**
+   * Skill folder install result
+   */
+  200: {
+    success: boolean
+    slug: string
+    error?: string
+    filePath?: string
+  }
+}
+
+export type KilocodeInstallSkillFolderResponse =
+  KilocodeInstallSkillFolderResponses[keyof KilocodeInstallSkillFolderResponses]
+
+export type KilocodeMarketplaceSkillsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/marketplace/skills"
+}
+
+export type KilocodeMarketplaceSkillsErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type KilocodeMarketplaceSkillsError = KilocodeMarketplaceSkillsErrors[keyof KilocodeMarketplaceSkillsErrors]
+
+export type KilocodeMarketplaceSkillsResponses = {
+  /**
+   * Marketplace skills list
+   */
+  200: {
+    items: Array<{
+      id: string
+      name: string
+      displayName: string
+      description: string
+      category: string
+      displayCategory: string
+      githubUrl: string
+      content: string
+    }>
+    error?: string
+  }
+}
+
+export type KilocodeMarketplaceSkillsResponse =
+  KilocodeMarketplaceSkillsResponses[keyof KilocodeMarketplaceSkillsResponses]
 
 export type NetworkListData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15099,38 +15099,23 @@
                           "id": {
                             "type": "string"
                           },
-                          "name": {
-                            "type": "string"
-                          },
-                          "displayName": {
-                            "type": "string"
-                          },
                           "description": {
                             "type": "string"
                           },
                           "category": {
                             "type": "string"
                           },
-                          "displayCategory": {
+                          "githubUrl": {
                             "type": "string"
                           },
-                          "githubUrl": {
+                          "rawUrl": {
                             "type": "string"
                           },
                           "content": {
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "id",
-                          "name",
-                          "displayName",
-                          "description",
-                          "category",
-                          "displayCategory",
-                          "githubUrl",
-                          "content"
-                        ],
+                        "required": ["id", "description", "category", "githubUrl", "rawUrl", "content"],
                         "additionalProperties": false
                       }
                     },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14764,6 +14764,415 @@
         ]
       }
     },
+    "/kilocode/skill/install": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.installSkill",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill install result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "filePath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["success", "slug"],
+                  "additionalProperties": false,
+                  "description": "Skill install result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Download a skill tarball, extract it into ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project), and dispose the instance so skill state reloads.",
+        "summary": "Install a skill from a tarball URL",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": ["global", "project"]
+                  }
+                },
+                "required": ["id", "url", "scope"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.installSkill({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/skill/installed/remove": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.removeInstalledSkill",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill removal result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "filePath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["success", "slug"],
+                  "additionalProperties": false,
+                  "description": "Skill removal result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Recursively delete a skill folder under ~/.kilo/skills/<id>/ (global) or <workspace>/.kilo/skills/<id>/ (project) and dispose the instance so skill state reloads.",
+        "summary": "Remove an installed skill directory",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": ["global", "project"]
+                  }
+                },
+                "required": ["id", "scope"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.removeInstalledSkill({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/skill/install/folder": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.installSkillFolder",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill folder install result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "slug": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "filePath": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["success", "slug"],
+                  "additionalProperties": false,
+                  "description": "Skill folder install result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Add a folder path to kilo.json skills.paths (or remove it if already present) so skills inside are discovered on next session start.",
+        "summary": "Register a local folder as a skill source",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "scope": {
+                    "type": "string",
+                    "enum": ["global", "project"]
+                  }
+                },
+                "required": ["path", "scope"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.installSkillFolder({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/marketplace/skills": {
+      "get": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.marketplaceSkills",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Marketplace skills list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "category": {
+                            "type": "string"
+                          },
+                          "displayCategory": {
+                            "type": "string"
+                          },
+                          "githubUrl": {
+                            "type": "string"
+                          },
+                          "content": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "displayName",
+                          "description",
+                          "category",
+                          "displayCategory",
+                          "githubUrl",
+                          "content"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["items"],
+                  "additionalProperties": false,
+                  "description": "Marketplace skills list"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetch the current list of skills available in the Kilo Marketplace.",
+        "summary": "List marketplace skills",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilocode.marketplaceSkills({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/network": {
       "get": {
         "tags": ["network"],
@@ -16468,6 +16877,9 @@
       "Event": {
         "anyOf": [
           {
+            "$ref": "#/components/schemas/EventServerInstanceDisposed"
+          },
+          {
             "$ref": "#/components/schemas/EventServerConnected"
           },
           {
@@ -16475,30 +16887,6 @@
           },
           {
             "$ref": "#/components/schemas/EventGlobalConfigUpdated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.prompt.append"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.command.execute"
-          },
-          {
-            "$ref": "#/components/schemas/EventTuiToastShow1"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.session.select"
-          },
-          {
-            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
-          },
-          {
-            "$ref": "#/components/schemas/EventIndexingStatus"
-          },
-          {
-            "$ref": "#/components/schemas/EventIndexingWarning"
-          },
-          {
-            "$ref": "#/components/schemas/EventServerInstanceDisposed"
           },
           {
             "$ref": "#/components/schemas/EventFileEdited"
@@ -16520,6 +16908,18 @@
           },
           {
             "$ref": "#/components/schemas/EventLspUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.prompt.append"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.command.execute"
+          },
+          {
+            "$ref": "#/components/schemas/EventTuiToastShow1"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.session.select"
           },
           {
             "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -16598,6 +16998,9 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionCompacted"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
           },
           {
             "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -16732,6 +17135,24 @@
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
           },
           {
+            "$ref": "#/components/schemas/EventIndexingStatus"
+          },
+          {
+            "$ref": "#/components/schemas/EventIndexingWarning"
+          },
+          {
+            "$ref": "#/components/schemas/EventModels-devRefreshed"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountAdded"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountRemoved"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountSwitched"
+          },
+          {
             "$ref": "#/components/schemas/EventCatalogModelUpdated"
           },
           {
@@ -16811,18 +17232,6 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-          },
-          {
-            "$ref": "#/components/schemas/EventModels-devRefreshed"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountAdded"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountRemoved"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountSwitched"
           }
         ]
       },
@@ -16932,184 +17341,6 @@
           }
         },
         "required": ["_tag", "message"],
-        "additionalProperties": false
-      },
-      "Event.tui.prompt.append": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.prompt.append"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "text": {
-                "type": "string"
-              }
-            },
-            "required": ["text"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.command.execute": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.command.execute"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "command": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "enum": [
-                      "session.list",
-                      "session.new",
-                      "session.share",
-                      "session.interrupt",
-                      "session.compact",
-                      "session.page.up",
-                      "session.page.down",
-                      "session.line.up",
-                      "session.line.down",
-                      "session.half.page.up",
-                      "session.half.page.down",
-                      "session.first",
-                      "session.last",
-                      "prompt.clear",
-                      "prompt.submit",
-                      "agent.cycle"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.toast.show": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.toast.show"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              },
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"]
-              },
-              "duration": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "required": ["message", "variant"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.session.select": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.session.select"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses",
-                "description": "Session ID to navigate to"
-              }
-            },
-            "required": ["sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "IndexingStatusState": {
-        "type": "string",
-        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
-      },
-      "IndexingStatus": {
-        "type": "object",
-        "properties": {
-          "state": {
-            "$ref": "#/components/schemas/IndexingStatusState"
-          },
-          "message": {
-            "type": "string"
-          },
-          "processedFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "totalFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "percent": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
-          }
-        },
-        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
-        "additionalProperties": false
-      },
-      "IndexingWarning": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "enum": ["qdrant.version-incompatible", "qdrant.version-unavailable"]
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": ["code", "message"],
         "additionalProperties": false
       },
       "QuestionOption": {
@@ -17252,6 +17483,140 @@
           }
         },
         "required": ["sessionID", "requestID"],
+        "additionalProperties": false
+      },
+      "Event.tui.prompt.append": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.prompt.append"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.command.execute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.command.execute"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "command": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "session.list",
+                      "session.new",
+                      "session.share",
+                      "session.interrupt",
+                      "session.compact",
+                      "session.page.up",
+                      "session.page.down",
+                      "session.line.up",
+                      "session.line.down",
+                      "session.half.page.up",
+                      "session.half.page.down",
+                      "session.first",
+                      "session.last",
+                      "prompt.clear",
+                      "prompt.submit",
+                      "agent.cycle"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.toast.show": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.toast.show"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string",
+                "enum": ["info", "success", "warning", "error"]
+              },
+              "duration": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["message", "variant"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.session.select": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.select"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "Session ID to navigate to"
+              }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
       "SessionNetworkWait": {
@@ -19223,6 +19588,50 @@
         "required": ["text"],
         "additionalProperties": false
       },
+      "IndexingStatusState": {
+        "type": "string",
+        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
+      },
+      "IndexingStatus": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/IndexingStatusState"
+          },
+          "message": {
+            "type": "string"
+          },
+          "processedFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "percent": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        },
+        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
+        "additionalProperties": false
+      },
+      "IndexingWarning": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": ["qdrant.version-incompatible", "qdrant.version-unavailable"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      },
       "GlobalEvent": {
         "type": "object",
         "properties": {
@@ -19238,6 +19647,9 @@
           "payload": {
             "anyOf": [
               {
+                "$ref": "#/components/schemas/EventServerInstanceDisposed"
+              },
+              {
                 "$ref": "#/components/schemas/EventServerConnected"
               },
               {
@@ -19245,30 +19657,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventGlobalConfigUpdated"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.prompt.append"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.command.execute"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.toast.show"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.session.select"
-              },
-              {
-                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
-              },
-              {
-                "$ref": "#/components/schemas/EventIndexingStatus"
-              },
-              {
-                "$ref": "#/components/schemas/EventIndexingWarning"
-              },
-              {
-                "$ref": "#/components/schemas/EventServerInstanceDisposed"
               },
               {
                 "$ref": "#/components/schemas/EventFileEdited"
@@ -19290,6 +19678,18 @@
               },
               {
                 "$ref": "#/components/schemas/EventLspUpdated"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.prompt.append"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.command.execute"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.toast.show"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.session.select"
               },
               {
                 "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -19368,6 +19768,9 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionCompacted"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
               },
               {
                 "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -19502,6 +19905,24 @@
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
               },
               {
+                "$ref": "#/components/schemas/EventIndexingStatus"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexingWarning"
+              },
+              {
+                "$ref": "#/components/schemas/EventModels-devRefreshed"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountAdded"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountRemoved"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountSwitched"
+              },
+              {
                 "$ref": "#/components/schemas/EventCatalogModelUpdated"
               },
               {
@@ -19581,18 +20002,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-              },
-              {
-                "$ref": "#/components/schemas/EventModels-devRefreshed"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountAdded"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountRemoved"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountSwitched"
               },
               {
                 "$ref": "#/components/schemas/SyncEventMessageUpdated"
@@ -25526,6 +25935,30 @@
         "required": ["type", "name", "id", "seq", "aggregateID", "data"],
         "additionalProperties": false
       },
+      "EventServerInstanceDisposed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["server.instance.disposed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string"
+              }
+            },
+            "required": ["directory"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "EventServerConnected": {
         "type": "object",
         "properties": {
@@ -25575,126 +26008,6 @@
           "properties": {
             "type": "object",
             "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventKilocodeAgent_managerStart": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["kilocode.agent_manager.start"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "requestID": {
-                "type": "string"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "mode": {
-                "type": "string",
-                "enum": ["worktree", "local"]
-              },
-              "versions": {
-                "type": "boolean"
-              },
-              "tasks": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "prompt": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "branchName": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "minItems": 1,
-                "maxItems": 20
-              }
-            },
-            "required": ["requestID", "sessionID", "mode", "tasks"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventIndexingStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["indexing.status"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "status": {
-                "$ref": "#/components/schemas/IndexingStatus"
-              }
-            },
-            "required": ["status"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventIndexingWarning": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["indexing.warning"]
-          },
-          "properties": {
-            "$ref": "#/components/schemas/IndexingWarning"
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventServerInstanceDisposed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["server.instance.disposed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "directory": {
-                "type": "string"
-              }
-            },
-            "required": ["directory"],
-            "additionalProperties": false
           }
         },
         "required": ["id", "type", "properties"],
@@ -26585,6 +26898,61 @@
               }
             },
             "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeAgent_managerStart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.agent_manager.start"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["worktree", "local"]
+              },
+              "versions": {
+                "type": "boolean"
+              },
+              "tasks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prompt": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "branchName": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 20
+              }
+            },
+            "required": ["requestID", "sessionID", "mode", "tasks"],
             "additionalProperties": false
           }
         },
@@ -28220,6 +28588,216 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventIndexingStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.status"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/IndexingStatus"
+              }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventIndexingWarning": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.warning"]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/IndexingWarning"
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventModels-devRefreshed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["models-dev.refreshed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "AccountV2OAuthCredential": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["oauth"]
+          },
+          "refresh": {
+            "type": "string"
+          },
+          "access": {
+            "type": "string"
+          },
+          "expires": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "accountId": {
+            "type": "string"
+          }
+        },
+        "required": ["type", "refresh", "access", "expires"],
+        "additionalProperties": false
+      },
+      "AccountV2ApiKeyCredential": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["api"]
+          },
+          "key": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["type", "key"],
+        "additionalProperties": false
+      },
+      "AccountV2Credential": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AccountV2OAuthCredential"
+          },
+          {
+            "$ref": "#/components/schemas/AccountV2ApiKeyCredential"
+          }
+        ]
+      },
+      "AccountV2Info": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "serviceID": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "credential": {
+            "$ref": "#/components/schemas/AccountV2Credential"
+          }
+        },
+        "required": ["id", "serviceID", "description", "credential"],
+        "additionalProperties": false
+      },
+      "EventAccountAdded": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.added"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/AccountV2Info"
+              }
+            },
+            "required": ["account"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventAccountRemoved": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.removed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "account": {
+                "$ref": "#/components/schemas/AccountV2Info"
+              }
+            },
+            "required": ["account"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventAccountSwitched": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["account.switched"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "serviceID": {
+                "type": "string"
+              },
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              }
+            },
+            "required": ["serviceID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "ModelV2Info": {
         "type": "object",
         "properties": {
@@ -28562,175 +29140,6 @@
               }
             },
             "required": ["model"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventModels-devRefreshed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["models-dev.refreshed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "AccountV2OAuthCredential": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["oauth"]
-          },
-          "refresh": {
-            "type": "string"
-          },
-          "access": {
-            "type": "string"
-          },
-          "expires": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "accountId": {
-            "type": "string"
-          }
-        },
-        "required": ["type", "refresh", "access", "expires"],
-        "additionalProperties": false
-      },
-      "AccountV2ApiKeyCredential": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["api"]
-          },
-          "key": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        },
-        "required": ["type", "key"],
-        "additionalProperties": false
-      },
-      "AccountV2Credential": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/AccountV2OAuthCredential"
-          },
-          {
-            "$ref": "#/components/schemas/AccountV2ApiKeyCredential"
-          }
-        ]
-      },
-      "AccountV2Info": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "serviceID": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "credential": {
-            "$ref": "#/components/schemas/AccountV2Credential"
-          }
-        },
-        "required": ["id", "serviceID", "description", "credential"],
-        "additionalProperties": false
-      },
-      "EventAccountAdded": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.added"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "account": {
-                "$ref": "#/components/schemas/AccountV2Info"
-              }
-            },
-            "required": ["account"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventAccountRemoved": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.removed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "account": {
-                "$ref": "#/components/schemas/AccountV2Info"
-              }
-            },
-            "required": ["account"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventAccountSwitched": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["account.switched"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "serviceID": {
-                "type": "string"
-              },
-              "from": {
-                "type": "string"
-              },
-              "to": {
-                "type": "string"
-              }
-            },
-            "required": ["serviceID"],
             "additionalProperties": false
           }
         },


### PR DESCRIPTION
Add functionality to browse, install, and uninstall skills via the CLI. This includes support for installing skills from tarball URLs, registering local skill folders, and managing a skill marketplace.

- Implement `installSkill`, `removeInstalledSkill`, and `installSkillFolder` API endpoints in the kilocode server.
- Add TUI components for skill selection and marketplace browsing.
- Update the SDK with new kilocode service methods and types.
- Add new keybindings for skill management actions in the CLI.

## Issue

<!-- Reference an existing issue with `Fixes #123`, `Closes #123`, or equivalent linked issue wording. -->

Fixes #

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to? Keep this focused on context reviewers cannot infer from the diff; skip file-by-file summaries, placeholders, and other filler.

-->

## Screenshots / Video

<!-- Required for visual changes. Include the relevant before/after or resulting state. -->

| before | after |
|---|---|
|  |  |

## How to Test

### Manual/local verification

<!--
Describe local CLI, extension, or docs verification. Example:
- Opened the updated settings page and confirmed the new copy appears
-->

-

### Reviewer test steps

<!--
Provide steps reviewers can retrace. Example:
1. Sign in with a user with tracks
2. Activate `show_awesome_cat_gifs` feature by adding `?feature.show_awesome_cat_gifs=1` to your URL
3. Confirm you see a GIF with cats dancing
-->

-

### Blocked checks and substitute verification

<!--
If a relevant command could not be completed, name the command, explain the blocker or failure, and describe the substitute verification performed. Example:
- `bun run test:integration` could not complete because the required API key is unavailable; substitute verification was testing the affected flow manually in the development extension
-->

-

<!--
Every PR marked ready for review must include testing evidence. A bare "Not tested" or "N/A" answer is not sufficient. For each piece of evidence make clear if the test was executed by the agent or by a human

Docs-only, config-only, and similar changes still need concrete evidence. For examples, see [Testing Evidence for Pull Requests](https://kilo.ai/docs/contributing/development-environment#testing-evidence-for-pull-requests). Draft PRs may be incomplete until marked ready for review.
-->

## Checklist

- [ ] Issue linked above, or exception explained
- [ ] Tests/verification described
- [ ] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Kilo Code Discord](https://kilo.ai/discord), please share your handle here. -->
