### PR TITLE
WIP: Enterprise eval documentation

### DIFF
--- a/packages/kilo-docs/lib/nav/collaborate.ts
+++ b/packages/kilo-docs/lib/nav/collaborate.ts
@@ -52,6 +52,33 @@ export const CollaborateNav: NavSection[] = [
     ],
   },
   {
+    title: "Evaluation",
+    links: [
+      {
+        href: "/collaborate/evaluation",
+        children: "Run a Kilo Evaluation",
+        subLinks: [
+          {
+            href: "/collaborate/evaluation/plan",
+            children: "Plan your evaluation",
+          },
+          {
+            href: "/collaborate/evaluation/setup",
+            children: "Set up your evaluation",
+          },
+          {
+            href: "/collaborate/evaluation/measure",
+            children: "Measure adoption, quality, and cost",
+          },
+          {
+            href: "/collaborate/evaluation/decide",
+            children: "Make a rollout decision",
+          },
+        ],
+      },
+    ],
+  },
+  {
     title: "Enterprise",
     links: [
       { href: "/collaborate/enterprise/sso", children: "SSO" },

--- a/packages/kilo-docs/pages/collaborate/evaluation/decide.md
+++ b/packages/kilo-docs/pages/collaborate/evaluation/decide.md
@@ -1,0 +1,107 @@
+---
+title: "Make a rollout decision"
+description: "Use observed evidence to choose GO, EXTEND, or NO-GO / STOP for your Kilo rollout."
+---
+
+# Make a rollout decision
+
+At the end of the measured period, choose one decision: GO, EXTEND, or NO-GO / STOP. Keep the decision tied to observed evidence, unresolved risks, and the original evaluation scope.
+
+## Separate facts from assumptions
+
+Before deciding, separate what you observed from what you believe might happen later.
+
+| Type | Examples |
+|---|---|
+| Observed facts | Activated participants, weekly active participants, logged task outcomes, workflow coverage, spend, blockers, incidents |
+| Assumptions | Expected full-team adoption, future cost at scale, productivity improvement, rollout support needs |
+| Unknowns | Untested workflows, missing analytics paths, unresolved policy questions, thin task volume |
+
+Do not use assumptions to override a failed required workflow, unresolved critical issue, unacceptable quality, or materially above-tolerance spend.
+
+## GO criteria
+
+Choose GO when the evaluation shows enough evidence to expand under defined rollout conditions.
+
+GO usually requires:
+
+- Target participants activated at an acceptable rate
+- Meaningful repeat usage occurred during the measured period
+- Work happened in approved workflow categories that matter for rollout
+- Logged outcomes were mostly accepted or useful after normal review
+- Spend was acceptable for the measured scope and expected next rollout step
+- No unresolved critical security, privacy, legal, or policy issue exists
+- Blockers are understood and manageable during rollout
+
+A GO decision can still include rollout conditions, such as a smaller first rollout group, approved model/provider guidance, budget thresholds, extra onboarding, or excluded workflows.
+
+## EXTEND criteria
+
+Choose EXTEND when the evidence is promising but too thin to support GO or NO-GO, and a short unchanged-scope extension can answer a specific question.
+
+EXTEND is appropriate when:
+
+- Setup or onboarding issues reduced participation
+- There were too few logged tasks to judge the required workflows
+- Usage is promising but repeat evidence is thin
+- A required workflow needs a small amount of additional observed use
+- A short extension can keep the same scope, success criteria, data boundaries, and budget expectations
+
+Define one extension question, a short end date, and an automatic stop condition. Avoid repeated extensions that only defer the decision.
+
+## NO-GO / STOP criteria
+
+Choose NO-GO or STOP when the evaluation does not support rollout or should not continue.
+
+NO-GO / STOP is appropriate when:
+
+- Adoption remains weak after setup issues are resolved
+- Required workflows are unsupported or cannot be evaluated reliably
+- Quality is unacceptable after normal review and validation
+- Spend is materially above tolerance or cannot be understood
+- A critical security, privacy, legal, or policy issue occurs
+- The evaluation cannot produce reliable evidence because the scope, data, or measurement path is too incomplete
+
+For NO-GO / STOP, record what must change before trying again. Avoid turning unresolved product, policy, or workflow gaps into implied future commitments.
+
+## Decision summary template
+
+Copy this summary into your team workspace.
+
+| Field | Summary |
+|---|---|
+| Decision | `GO / EXTEND / NO-GO / STOP` |
+| Decision owner | `[Name / role]` |
+| Evaluation dates | `[Start / end]` |
+| Cohort | `[Invited, activated, weekly active, repeat active]` |
+| Approved workflow coverage | `[Categories tested and not tested]` |
+| Task outcomes | `[Accepted, useful after rework, rejected, blocked, still in progress]` |
+| Quality summary | `[What normal review and checks showed]` |
+| Spend summary | `[Spend to date, model/provider concentration if available, budget result]` |
+| Blockers | `[Top blockers and status]` |
+| Security/privacy/policy issues | `[None / resolved / unresolved]` |
+| Observed facts supporting decision | `[Bullets or short paragraph]` |
+| Assumptions not proven | `[ROI, productivity, future scale, untested workflows, or other assumptions]` |
+| Unresolved risks | `[Risk, owner, next step]` |
+| Rollout or closeout conditions | `[If GO: conditions. If EXTEND: question and end date. If NO-GO: re-entry condition.]` |
+
+## Rollout conditions for GO
+
+If the decision is GO, define the next step instead of opening access without guardrails.
+
+Useful rollout conditions include:
+
+- Which teams, repositories, or workflow categories are included next
+- Which workflows remain excluded until tested
+- Which models/providers participants should use
+- Who monitors spend and usage
+- What budget or spend threshold triggers review
+- What onboarding participants receive
+- What support channel and escalation path stay active
+- When the rollout decision should be rechecked
+
+## Closeout for EXTEND or NO-GO
+
+For EXTEND, keep the scope unchanged unless you intentionally start a new evaluation. Changing the cohort, workflows, data boundaries, or model/provider policy makes the evidence harder to interpret.
+
+For NO-GO / STOP, close out access and spend according to your organization process, document unresolved blockers, and state the re-entry condition clearly.

--- a/packages/kilo-docs/pages/collaborate/evaluation/index.md
+++ b/packages/kilo-docs/pages/collaborate/evaluation/index.md
@@ -1,0 +1,76 @@
+---
+title: "Run a Kilo Evaluation"
+description: "Run a lightweight, bounded Kilo evaluation with a small cohort and a clear rollout decision."
+---
+
+# Run a Kilo Evaluation
+
+Use this guide to evaluate Kilo with a small, representative group before a wider team or enterprise rollout. The goal is to answer one practical question:
+
+> Did enough of the right people use Kilo, on approved work, safely, at acceptable quality and cost?
+
+## Who this guide is for
+
+This guide is for team leads, engineering managers, platform owners, and organization admins who need a bounded evaluation before expanding Kilo usage.
+
+It works best when you already have:
+
+- A sponsor or champion who owns the decision
+- A small group of engineers who can try Kilo on real work
+- Approved workflow categories, models, providers, and data boundaries
+- Normal code review, testing, and security controls in place
+- Access to organization usage, billing, or analytics views where applicable
+
+## What a Kilo evaluation is
+
+A Kilo evaluation is a short, scoped period of measured usage. Participants use approved Kilo surfaces such as the IDE, CLI, Cloud Agent, or Code Reviews where those surfaces are supported and approved for your organization.
+
+Recommended defaults:
+
+| Item | Recommendation |
+|---|---|
+| Duration | Roughly 2 measured weeks after setup and onboarding |
+| Cohort | A small, representative team or enterprise cohort |
+| Scope | A few approved workflow categories, models, providers, and repositories or repository classes |
+| Outcome | GO, EXTEND, or NO-GO / STOP |
+
+## What it can answer
+
+A focused evaluation can help you decide whether:
+
+- Participants can get access and start using Kilo in the right organization context
+- Kilo fits approved development workflows such as implementation, tests, debugging, refactoring, review, or documentation
+- Participants return after initial setup and use Kilo more than once
+- Outputs are useful after normal engineering review and validation
+- Spend is understandable and within your expected range
+- Blockers, unsupported workflows, or policy concerns need to be resolved before rollout
+
+## What it cannot prove
+
+A short evaluation cannot prove broad ROI, productivity improvement, or headcount reduction by itself. Those claims require a proper baseline, comparable work, agreed measurement methods, and enough data to support the conclusion.
+
+Treat these limits explicitly:
+
+| Signal | What it shows | What it does not prove |
+|---|---|---|
+| Usage | People tried Kilo | ROI, quality, or productivity |
+| Satisfaction | Participants liked or disliked the experience | Code quality or business impact |
+| Self-reported time saved | Perceived efficiency | Verified labor savings |
+| Accepted work | Output survived normal review | Future performance on untested workflows |
+
+## Evaluation flow
+
+1. [Plan your evaluation](/docs/collaborate/evaluation/plan)
+2. [Set up your evaluation](/docs/collaborate/evaluation/setup)
+3. Onboard participants with approved workflows, model/provider guidance, and safe-use rules
+4. [Measure adoption, quality, and cost](/docs/collaborate/evaluation/measure)
+5. [Make a rollout decision](/docs/collaborate/evaluation/decide)
+
+## Guide pages
+
+| Page | Use it to |
+|---|---|
+| [Plan your evaluation](/docs/collaborate/evaluation/plan) | Define scope, participants, success criteria, spend expectations, and boundaries before inviting users |
+| [Set up your evaluation](/docs/collaborate/evaluation/setup) | Configure the organization, access, models, spend visibility, integrations, and onboarding path |
+| [Measure adoption, quality, and cost](/docs/collaborate/evaluation/measure) | Track lightweight usage, task outcomes, blockers, spend, and participant sentiment |
+| [Make a rollout decision](/docs/collaborate/evaluation/decide) | Choose GO, EXTEND, or NO-GO / STOP using observed evidence and unresolved risks |

--- a/packages/kilo-docs/pages/collaborate/evaluation/measure.md
+++ b/packages/kilo-docs/pages/collaborate/evaluation/measure.md
@@ -1,0 +1,105 @@
+---
+title: "Measure adoption, quality, and cost"
+description: "Track lightweight adoption, task outcomes, workflow coverage, spend, blockers, and participant sentiment."
+---
+
+# Measure adoption, quality, and cost
+
+Measure only what you need to make the rollout decision. Keep the dataset privacy-minimal and avoid collecting prompts, generated code, secrets, or customer data in evaluation records.
+
+## Recommended metrics
+
+| Metric | What it does | What it does not prove |
+|---|---|---|
+| Invited participants | Shows who was asked to join | Eligibility, activation, or usage |
+| Activated participants | Shows who completed setup and used Kilo at least once | Sustained adoption or value |
+| Weekly active participants | Shows who used Kilo during each measured week | Depth, quality, or ROI |
+| Repeat active participants | Shows whether people returned after first use | Productivity or broad rollout success |
+| Tasks attempted or logged | Shows evaluation task volume | That all work was valuable or complete |
+| Task outcome split | Shows accepted, useful with rework, rejected, and blocked work | Independent quality unless reviewed |
+| Workflow coverage | Shows which approved categories were represented | That untested workflows are ready |
+| Spend to date | Shows current cost for tracked usage | Future rollout cost by itself |
+| Spend by model/provider | Shows cost concentration where available | Complete cost if usage bypasses the measured path |
+| Blockers | Shows setup, workflow, policy, or support issues | Whether Kilo is unsuitable without context |
+| Participant sentiment | Shows perceived usefulness and friction | Objective quality or verified savings |
+
+Usage is not ROI. Satisfaction is not quality. Self-reported time saved is not verified labor savings.
+
+## Use product analytics where they apply
+
+Use existing Kilo usage and billing views where they match your evaluation scope:
+
+- [Analytics](/docs/collaborate/teams/analytics)
+- [AI Adoption Dashboard](/docs/collaborate/adoption-dashboard/overview)
+- [Dashboard](/docs/collaborate/teams/dashboard)
+- [Gateway Usage & Billing](/docs/gateway/usage-and-billing)
+
+Confirm the measurement boundary before launch. For example, team analytics describe Kilo Gateway usage and do not cover every possible direct-provider path. If measured work uses paths outside the available analytics, keep those results separate or lower confidence in the spend and usage conclusions.
+
+## Privacy-minimal measurement
+
+Do not collect these items in task logs, surveys, or evaluation notes:
+
+- Prompts
+- Model responses
+- Generated code
+- Secrets, credentials, tokens, or API keys
+- Customer data
+- Sensitive personal information
+- Repository, branch, file, ticket, or commit details in free text
+
+If your organization needs identity, repository, or artifact mappings, keep them in customer-controlled systems with appropriate access controls. The evaluation summary can use aggregates and content-free references.
+
+## Task log template
+
+Ask participants to log meaningful tasks quickly. One row per task is enough.
+
+| Field | Example |
+|---|---|
+| Date | `2026-07-15` |
+| Participant ID | `P03` |
+| Workflow category | `Tests` |
+| Kilo surface | `IDE` |
+| Model/provider category | `Approved default` |
+| Complexity | `Low / Medium / High` |
+| Outcome | `Accepted / Useful after rework / Rejected / Blocked / Still in progress` |
+| Normal checks completed | `Yes / No / Not applicable` |
+| Human review completed | `Yes / No / Not applicable` |
+| Blocker category | `Access / Quality / Latency / Cost / Policy / Unsupported workflow / None` |
+| Content-free note | `Optional. Do not include prompts, code, secrets, customer data, or repository details.` |
+
+Recommended outcome meanings:
+
+| Outcome | Meaning |
+|---|---|
+| Accepted | The result was used after normal review and required checks |
+| Useful after rework | Kilo helped, but material human edits or retries were needed |
+| Rejected | The output was not useful enough to use |
+| Blocked | The participant could not complete the task because of access, workflow, policy, or technical blockers |
+| Still in progress | The task is not ready to judge yet |
+
+## Weekly pulse template
+
+Send a short pulse at the end of each measured week. Keep it under two minutes.
+
+| Question | Response type |
+|---|---|
+| Did you use Kilo for approved work this week? | `Yes / No` |
+| Which approved workflow was most useful? | Single select from your workflow categories |
+| What was your biggest blocker? | `Access / Setup / Quality / Latency / Cost / Policy / Unsupported workflow / No suitable task / None / Other` |
+| How satisfied were you with Kilo this week? | `1 very dissatisfied` to `5 very satisfied` |
+| Would you keep using Kilo for this type of work? | `Yes / Maybe / No` |
+| Did you encounter a safety, security, privacy, or policy concern? | `Yes / No`, with reporting instructions outside the survey if yes |
+| Optional content-free note | Free text with a reminder not to include prompts, code, secrets, customer data, or repository details |
+
+## Read the signals together
+
+Avoid making the decision from one metric. For example:
+
+| Pattern | Likely interpretation |
+|---|---|
+| High activation, low repeat usage | Setup worked, but ongoing value or task fit may be weak |
+| Low activation, strong satisfaction among active users | Onboarding or access may have limited the evidence |
+| High task volume, many rejected outcomes | Adoption exists, but quality or workflow fit may be poor |
+| Good outcomes, spend above tolerance | Rollout may need model/provider guidance or budget controls |
+| Promising usage, few logged tasks | Evidence is thin; a short extension may be better than GO |

--- a/packages/kilo-docs/pages/collaborate/evaluation/plan.md
+++ b/packages/kilo-docs/pages/collaborate/evaluation/plan.md
@@ -1,0 +1,134 @@
+---
+title: "Plan your evaluation"
+description: "Define scope, participants, workflows, models, success criteria, spend expectations, and safe-use boundaries."
+---
+
+# Plan your evaluation
+
+Plan the evaluation before inviting participants. Keep the plan short enough to use, but explicit enough that everyone knows what is in scope.
+
+## Choose an owner
+
+Pick one sponsor or champion who can:
+
+- State the decision the evaluation must support
+- Select or confirm the participant cohort
+- Coordinate admins, team leads, and support contacts
+- Keep scope changes visible
+- Prepare the final GO, EXTEND, or NO-GO recommendation
+
+## Choose participants
+
+Select a small cohort that represents the rollout you are considering. Avoid a group made only of AI enthusiasts or only one unusually advanced team unless that is the actual rollout target.
+
+Good cohorts usually include:
+
+- Engineers from the teams or workflows you expect to expand to next
+- A mix of experience levels with the codebase and AI coding tools
+- People with enough normal work during the evaluation window to try Kilo on real tasks
+- Team leads who will keep normal review and validation expectations in place
+
+## Choose approved workflow categories
+
+Define the types of work participants may use Kilo for. Examples:
+
+| Workflow category | Example use |
+|---|---|
+| Implementation | Build a small feature or code path |
+| Tests | Add or update unit, integration, or regression tests |
+| Debugging | Investigate a failing test, bug, or runtime issue |
+| Refactoring | Improve structure without changing behavior |
+| Review | Review local changes or pull requests |
+| Documentation | Explain code or update developer-facing docs |
+
+Keep the list small. If a workflow is required for rollout, make sure it is represented during the evaluation.
+
+## Choose approved models and providers
+
+Decide which models and providers participants should use for measured work. Where applicable, configure controls using existing organization or Gateway settings instead of relying only on instructions.
+
+Useful setup references:
+
+- [Model Access Controls](/docs/collaborate/enterprise/model-access-controls)
+- [Gateway Usage & Billing](/docs/gateway/usage-and-billing)
+- [Bring Your Own Key (BYOK)](/docs/getting-started/byok)
+- [AI Providers](/docs/ai-providers)
+
+## Choose approved Kilo surfaces
+
+Choose only the Kilo surfaces that are supported, configured, and approved for your evaluation.
+
+| Surface | Setup reference |
+|---|---|
+| IDE | [Installation](/docs/getting-started/installing) |
+| CLI | [CLI](/docs/code-with-ai/platforms/cli) |
+| Cloud Agent | [Cloud Agent](/docs/code-with-ai/platforms/cloud-agent) |
+| Code Reviews | [Code Reviews](/docs/automate/code-reviews/overview) |
+
+If a surface depends on a repository integration, confirm the integration and repository scope before including it. See [Integrations](/docs/automate/integrations).
+
+## Define success criteria
+
+Define success criteria before usage begins. Use observable signals, not broad claims.
+
+Example criteria:
+
+- Most target participants activate and use Kilo during the evaluation
+- Meaningful repeat usage occurs across the measured period
+- Logged tasks cover the approved workflow categories that matter for rollout
+- Most determinate task outcomes are accepted or useful after normal review
+- Spend is acceptable for the measured cohort and expected rollout size
+- No unresolved critical security, privacy, legal, or policy issue exists
+
+## Define spend expectations
+
+Set an expected spend range or budget threshold before launch. Decide who watches spend and what happens if spend approaches the threshold.
+
+Use the relevant billing and usage docs for setup details:
+
+- [Team Billing](/docs/collaborate/teams/billing)
+- [Team Analytics](/docs/collaborate/teams/analytics)
+- [Gateway Usage & Billing](/docs/gateway/usage-and-billing)
+
+## Confirm security, legal, and data boundaries
+
+Before participants start, confirm:
+
+- Which data classes are allowed
+- Which repositories or repository classes are allowed
+- Which models, providers, and traffic paths are approved
+- Whether SSO or organization-managed access is required
+- Who can pause the evaluation for security, privacy, legal, or policy reasons
+- Where participants should report blockers or policy concerns
+
+Participants should not enter:
+
+- Secrets, API keys, access tokens, or credentials
+- Production customer data unless explicitly approved by your organization
+- Sensitive personal information
+- Contract, legal, or sensitive business text not approved for AI use
+- Prompts, generated code, or repository details into survey or task-log free text
+
+Continue using normal code review, testing, branch protection, security scanning, and deployment controls. An evaluation should not bypass the controls you use for ordinary engineering work.
+
+## Planning checklist
+
+Copy this checklist into your team workspace and fill in the right column.
+
+| Item | Decision |
+|---|---|
+| Sponsor or champion | `[Name / role]` |
+| Evaluation dates | `[Setup date, start date, end date]` |
+| Target cohort | `[Teams / roles / participant count]` |
+| Approved workflow categories | `[Implementation, tests, debugging, refactor, review, documentation, other]` |
+| Required workflow categories | `[Categories that must be represented to decide GO]` |
+| Approved Kilo surfaces | `[IDE, CLI, Cloud Agent, Code Reviews]` |
+| Approved organization context | `[Organization name or team]` |
+| Approved models/providers | `[List or policy reference]` |
+| Approved repositories or repository classes | `[Scope or customer-controlled reference]` |
+| Data participants must not enter | `[Data classes or examples]` |
+| Success criteria | `[Activation, repeat usage, task outcomes, spend, blockers]` |
+| Spend expectation or threshold | `[$ amount or policy]` |
+| Analytics and billing reviewer | `[Name / role]` |
+| Support and escalation path | `[Channel / owner]` |
+| Stop conditions | `[Security, privacy, policy, quality, spend, or adoption triggers]` |

--- a/packages/kilo-docs/pages/collaborate/evaluation/setup.md
+++ b/packages/kilo-docs/pages/collaborate/evaluation/setup.md
@@ -1,0 +1,101 @@
+---
+title: "Set up your evaluation"
+description: "Configure organization access, model controls, spend visibility, integrations, and participant onboarding."
+---
+
+# Set up your evaluation
+
+Use this page as a setup checklist. Follow the linked setup docs for product-specific steps instead of duplicating them in your evaluation plan.
+
+## Setup checklist
+
+| Step | Action | Reference |
+|---|---|---|
+| 1 | Create or use the right organization or team | [Getting Started with Teams](/docs/collaborate/teams/getting-started) |
+| 2 | Confirm owner/admin access for the people running setup | [Team Management](/docs/collaborate/teams/team-management) |
+| 3 | Invite only the approved participants | [Team Management](/docs/collaborate/teams/team-management) |
+| 4 | Confirm participants use the right organization context | [Team Billing](/docs/collaborate/teams/billing) |
+| 5 | Configure SSO if required | [SSO](/docs/collaborate/enterprise/sso) |
+| 6 | Configure model/provider controls if applicable | [Model Access Controls](/docs/collaborate/enterprise/model-access-controls) |
+| 7 | Configure Gateway spend controls if applicable | [Gateway Usage & Billing](/docs/gateway/usage-and-billing) |
+| 8 | Confirm analytics and billing visibility | [Analytics](/docs/collaborate/teams/analytics) and [Dashboard](/docs/collaborate/teams/dashboard) |
+| 9 | Configure repository integrations only where relevant | [Integrations](/docs/automate/integrations) |
+| 10 | Set up approved Kilo surfaces | [Installation](/docs/getting-started/installing), [CLI](/docs/code-with-ai/platforms/cli), [Cloud Agent](/docs/code-with-ai/platforms/cloud-agent), [Code Reviews](/docs/automate/code-reviews/overview) |
+| 11 | Confirm the support and escalation path | Your internal support channel |
+| 12 | Send participant onboarding instructions | [Participant onboarding checklist](#participant-onboarding-checklist) |
+
+## Organization and access
+
+Use the organization or team that matches the evaluation scope. If you are evaluating an enterprise rollout, make sure participants are invited to the intended organization and understand how to select that organization context in Kilo.
+
+Do not mix personal and organization usage in measured results unless you have a specific reconciliation plan. If organization analytics are part of the evaluation, confirm what usage they include before the measured period starts. See [Analytics](/docs/collaborate/teams/analytics).
+
+## Identity and SSO
+
+If your organization requires SSO, configure it before the measured period starts. The SSO setup process may require coordination with Kilo and your identity provider, so plan lead time. See [SSO](/docs/collaborate/enterprise/sso).
+
+## Models, providers, and spend
+
+Set model/provider expectations before participants begin measured work.
+
+Use the controls that match your chosen traffic path:
+
+| Need | Reference |
+|---|---|
+| Limit models or providers in Enterprise organization settings | [Model Access Controls](/docs/collaborate/enterprise/model-access-controls) |
+| Use Gateway organization balances, allow lists, and per-user daily limits | [Gateway Usage & Billing](/docs/gateway/usage-and-billing) |
+| Use your own provider keys through Gateway | [Bring Your Own Key (BYOK)](/docs/getting-started/byok) |
+| Understand available AI providers | [AI Providers](/docs/ai-providers) |
+
+## Repository integrations
+
+Configure repository integrations only if your evaluation includes hosted repository workflows such as Cloud Agent or hosted Code Reviews.
+
+Relevant docs:
+
+- [Integrations](/docs/automate/integrations)
+- [Cloud Agent](/docs/code-with-ai/platforms/cloud-agent)
+- [Code Reviews](/docs/automate/code-reviews/overview)
+
+Confirm the repository scope matches what your organization approved. Use normal repository permissions and review controls.
+
+## Support path
+
+Before launch, tell participants where to report:
+
+- Access or setup problems
+- Unsupported workflow or repository issues
+- Model/provider or cost questions
+- Quality concerns
+- Security, privacy, or policy concerns
+
+Define who can pause the evaluation if a critical issue occurs.
+
+## Participant onboarding checklist
+
+Copy this into the onboarding message for participants.
+
+| Item | Participant instruction |
+|---|---|
+| Evaluation dates | `Use Kilo for approved work between [start] and [end].` |
+| Organization context | `Use [organization/team name], not your personal context, for measured work.` |
+| Approved surfaces | `Use only [IDE / CLI / Cloud Agent / Code Reviews] for this evaluation.` |
+| Approved workflows | `Use Kilo for [workflow categories]. Do not use it for excluded workflows.` |
+| Approved models/providers | `Use [approved model/provider guidance].` |
+| Data boundaries | `Do not enter secrets, credentials, sensitive personal information, or unapproved customer data.` |
+| Normal controls | `Keep using normal review, tests, scans, branch protection, and deployment rules.` |
+| Task logging | `Log each meaningful task with outcome and blocker status. Do not include prompts, code, customer data, secrets, or repository details in free text.` |
+| Weekly pulse | `Complete the weekly pulse survey. Keep free-text answers content-free.` |
+| Help path | `Report blockers or policy concerns in [channel/contact].` |
+
+## Pre-launch check
+
+Before the measured period starts, verify:
+
+- Participants can sign in and access the right organization
+- The selected Kilo surfaces work in the approved environments
+- Model/provider expectations are visible to participants
+- Spend and usage views are accessible to the right admins
+- Repository integrations work only for the approved scope
+- The support path is staffed
+- Participants received onboarding instructions

--- a/packages/kilo-docs/pages/collaborate/index.md
+++ b/packages/kilo-docs/pages/collaborate/index.md
@@ -39,6 +39,7 @@ Kilo Code's paid plans provide powerful team management features:
 
 Enterprise features for large organizations:
 
+- [**Run a Kilo Evaluation**](/docs/collaborate/evaluation) — Evaluate Kilo with a small cohort, approved workflows, lightweight measurement, and a clear GO / EXTEND / NO-GO decision
 - [**Audit Logs**](/docs/collaborate/enterprise/audit-logs) — Track and audit team activity
 - [**SSO**](/docs/collaborate/enterprise/sso) — Single sign-on with OIDC and SCIM
 - [**Model Access Controls**](/docs/collaborate/enterprise/model-access-controls) — Limit models and providers


### PR DESCRIPTION
## Summary

Adds a new customer-facing docs guide for running a lightweight Kilo evaluation before wider team or enterprise rollout.

## Changes

- Added a new “Run a Kilo Evaluation” guide under Collaborate.
- Added child pages for planning, setup, measurement, and rollout decisions.
- Included practical templates for planning, onboarding, task logging, weekly pulse checks, and final decision summaries.
- Linked to existing setup docs for teams, SSO, model access controls, Gateway billing, analytics, Cloud Agent, Code Reviews, CLI, and installation.
- Updated Collaborate navigation so the evaluation guide is discoverable.

## Notes

This keeps the evaluation content concise and docs-native, avoids internal pilot-program language, and frames the outcome as GO, EXTEND, or NO-GO / STOP.