### PR TITLE
fix(cli): support MiniMax M3 thinking controls

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -655,6 +655,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
+  if (
+    model.api.id.toLowerCase().includes("minimax-m3") &&
+    ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
+  ) {
+    return {
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    }
+  }
   const adaptiveOpus = anthropicOpus47OrLater(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
 
@@ -1173,8 +1182,13 @@ export function options(input: {
     }
   }
 
-  // Enable thinking by default for kimi models using anthropic SDK
   const modelId = input.model.api.id.toLowerCase()
+  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
+  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
+    result["thinking"] = { type: "adaptive" }
+  }
+
+  // Enable thinking by default for kimi models using anthropic SDK
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -172,6 +172,39 @@ describe("ProviderTransform.options - zai/zhipuai thinking", () => {
   }
 })
 
+describe("ProviderTransform.options - minimax m3 thinking", () => {
+  const createModel = (npm: string) =>
+    ({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com",
+        npm,
+      },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+    }) as any
+
+  test("explicitly enables adaptive thinking with the anthropic SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/anthropic"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toEqual({ type: "adaptive" })
+  })
+
+  test("uses the native default with the openai-compatible SDK", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("@ai-sdk/openai-compatible"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 
@@ -2411,13 +2444,46 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  // kilocode_change start: minimax
-  test("minimax direct anthropic provider returns instant/thinking toggle", () => {
+  test("minimax m3 using anthropic returns thinking toggles", () => {
     const model = createMockModel({
-      id: "minimax/MiniMax-M3",
+      id: "minimax/minimax-m3",
       providerID: "minimax",
       api: {
         id: "MiniMax-M3",
+        url: "https://api.minimax.com/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
+  })
+
+  test("minimax m3 using openai-compatible returns thinking toggles", () => {
+    const model = createMockModel({
+      id: "minimax/minimax-m3",
+      providerID: "minimax",
+      api: {
+        id: "minimax-m3",
+        url: "https://api.minimax.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
+  })
+
+  // kilocode_change start: minimax
+  test("minimax m2.7 direct anthropic provider returns instant/thinking toggle", () => {
+    const model = createMockModel({
+      id: "minimax/MiniMax-M2.7",
+      providerID: "minimax",
+      api: {
+        id: "MiniMax-M2.7",
         url: "https://api.minimax.io/anthropic/v1",
         npm: "@ai-sdk/anthropic",
       },


### PR DESCRIPTION
## What changed

Cherry-pick anomalyco/opencode#31426 so direct MiniMax M3 integrations explicitly use adaptive thinking on the Anthropic interface and expose native `none` / `thinking` variants on Anthropic and OpenAI-compatible interfaces. The conflict resolution retains Kilo's existing MiniMax M2.7 and Kilo Gateway variant coverage.

## Why

MiniMax M3 accepts `thinking.type` values of `adaptive` or `disabled`, while its Anthropic interface defaults thinking off. Explicitly selecting adaptive thinking avoids relying on interface-specific defaults and keeps direct provider behavior aligned with MiniMax's API contract.

## Reviewer notes

This is a direct upstream cherry-pick, so the shared source changes intentionally do not carry `kilocode_change` markers. The Kilo Gateway model still uses `@kilocode/kilo-gateway`, not `@ai-sdk/anthropic`; its default behavior and compatibility with persisted `instant` selections should be reviewed as Kilo-specific follow-up concerns.