### PR TITLE
fix(console): show external link icon on profile sidebar shortcuts

### DIFF
--- a/.changeset/console-profile-external-link-icons.md
+++ b/.changeset/console-profile-external-link-icons.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-web-ui": patch
+---
+
+Show trailing external-link icons for Kilo Console profile links that open in a new tab.

--- a/packages/kilo-console/src/routes/profile/ProfileRoute.tsx
+++ b/packages/kilo-console/src/routes/profile/ProfileRoute.tsx
@@ -1,6 +1,7 @@
 import { A, useLocation, useNavigate } from "@solidjs/router"
 import { Button } from "@kilocode/kilo-web-ui/button"
 import { Card } from "@kilocode/kilo-web-ui/card"
+import { Icon } from "@kilocode/kilo-web-ui/icon"
 import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js"
 import { LoadingScreen } from "../../components/LoadingScreen"
 import { loadKiloProfile, logoutKilo, setKiloOrganization, type KiloProfileData, type ProjectQuery } from "../../client"
@@ -137,11 +138,13 @@ export function ProfileRoute() {
             <A class="config-top-option active" href={overview()} aria-current="page">
               <span>Overview</span>
             </A>
-            <a class="config-top-option" href={usageUrl()} target="_blank" rel="noreferrer">
+            <a class="config-top-option config-top-option-external" href={usageUrl()} target="_blank" rel="noreferrer">
               <span>Usage</span>
+              <Icon name="square-arrow-top-right" size="small" />
             </a>
-            <a class="config-top-option" href={creditsUrl()} target="_blank" rel="noreferrer">
+            <a class="config-top-option config-top-option-external" href={creditsUrl()} target="_blank" rel="noreferrer">
               <span>Buy Credits</span>
+              <Icon name="square-arrow-top-right" size="small" />
             </a>
           </nav>
         </aside>
@@ -169,6 +172,7 @@ export function ProfileRoute() {
                   rel="noreferrer"
                 >
                   Open Dashboard
+                  <Icon name="square-arrow-top-right" size="small" />
                 </a>
               </div>
             </header>

--- a/packages/kilo-console/src/styles/profile.css
+++ b/packages/kilo-console/src/styles/profile.css
@@ -60,6 +60,10 @@
   text-decoration: none;
 }
 
+.kilo-console .profile-primary-link[data-component="button"][data-variant="primary"] [data-slot="icon-svg"] {
+  color: var(--primary-foreground);
+}
+
 .kilo-console .profile-connect-card {
   display: grid;
   min-height: 18rem;

--- a/packages/kilo-web-ui/src/styles/console-shell.css
+++ b/packages/kilo-web-ui/src/styles/console-shell.css
@@ -596,6 +596,18 @@
   display: none;
 }
 
+.kilo-console .config-top-option-external {
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.kilo-console .config-top-option-external [data-component="icon"] {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-weaker);
+  flex: none;
+}
+
 .kilo-console .config-group-items {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Issue

Closes #11558

## Context

The Usage and Buy Credits items in the Kilo Console profile sidebar as well as the Open Dashboard primary CTA in the profile header open in a new tab, but none of them show an external-link icon. Users had no visual cue that those actions navigate them out of the Kilo Console and into the Kilo cloud app.

This adds a small "open in new tab" icon to all three controls and fixes the icon color on the primary CTA so it stays readable.

## Implementation

- Render the existing `square-arrow-top-right` icon inside each of the three anchors in `packages/kilo-console/src/routes/profile/ProfileRoute.tsx`. Sidebar items get a new `config-top-option-external` modifier; the primary CTA reuses the button's existing inline-flex layout with its built-in `gap: 0.25rem`.
- In `packages/kilo-web-ui/src/styles/console-shell.css`, add a `.config-top-option-external` rule that overrides the shared `[data-component="icon"] { display: none }` rule used inside `.config-top-option`, and pushes the icon to the right of the label with `justify-content: space-between`. The icon picks up the weaker text color so it doesn't compete with the label.
- In `packages/kilo-console/src/styles/profile.css`, add a `.profile-primary-link[data-component="button"][data-variant="primary"] [data-slot="icon-svg"]` rule with specificity 0-5-0 so it beats the global UI button rule (0-3-0) that was forcing the icon's `color` to `var(--icon-invert-base)` (white) on primary buttons, and pins it to `var(--primary-foreground)` for proper contrast on the yellow background.
- Add a patch changeset for `@kilocode/kilo-console`.

## Screenshots / Video

| before | after |
|---|---|
|<img width="1920" height="911" alt="image" src="https://github.com/user-attachments/assets/597555c8-67d4-41df-952c-23382a2f73af" /> | <img width="1920" height="911" alt="chrome_1WAQzGUwca" src="https://github.com/user-attachments/assets/47b80cbf-ec99-42e2-a5e4-6880345863af" /> |

## How to Test

### Manual/local verification

- Open Kilo Console, sign in, and visit `/console/profile`.
- Confirm the **Usage** and **Buy Credits** sidebar items now show an external-link icon to the right of the label.
- Confirm the **Open Dashboard** primary CTA in the header also shows the icon, in a dark color that matches the button's text.

### Reviewer test steps

1. Open Kilo Console, sign in, and visit `/console/profile`.
2. Verify the external-link icon appears next to **Usage**, **Buy Credits**, and inside the **Open Dashboard** button, and that all three icons render in a readable color.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18