### PR TITLE
fix(cli): default Gateway MiniMax M3 to adaptive thinking

### DIFF
--- a/.changeset/minimax-m3-gateway-thinking.md
+++ b/.changeset/minimax-m3-gateway-thinking.md
@@ -3,4 +3,4 @@
 "kilo-code": patch
 ---
 
-Default MiniMax M3 requests through Kilo Gateway to adaptive thinking while preserving the `none` option to disable it.
+Default MiniMax M3 requests through Kilo Gateway to adaptive thinking while preserving the `instant` option to disable it.

--- a/.changeset/minimax-m3-gateway-thinking.md
+++ b/.changeset/minimax-m3-gateway-thinking.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Default MiniMax M3 requests through Kilo Gateway to adaptive thinking while preserving the `none` option to disable it.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1209,6 +1209,11 @@ export function options(input: {
   if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
     result["thinking"] = { type: "adaptive" }
   }
+  // kilocode_change start - match MiniMax M3's adaptive default through Kilo Gateway
+  if (modelId.includes("minimax-m3") && input.model.api.npm === "@kilocode/kilo-gateway") {
+    result["reasoning"] = { enabled: true }
+  }
+  // kilocode_change end
 
   // Enable thinking by default for kimi models using anthropic SDK
   if (

--- a/packages/opencode/test/kilocode/provider/minimax-m3.test.ts
+++ b/packages/opencode/test/kilocode/provider/minimax-m3.test.ts
@@ -23,7 +23,7 @@ describe("Kilo Gateway MiniMax M3 thinking", () => {
     expect(kiloProviderOptions(options).anthropic.thinking).toEqual({ type: "adaptive" })
   })
 
-  test("allows the none variant to disable thinking", () => {
+  test("allows the instant variant to disable thinking", () => {
     const base = ProviderTransform.options({ model, sessionID: "test-session" })
     const options = mergeDeep(base, { reasoning: { enabled: false, effort: "none" } })
 

--- a/packages/opencode/test/kilocode/provider/minimax-m3.test.ts
+++ b/packages/opencode/test/kilocode/provider/minimax-m3.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { mergeDeep } from "remeda"
+import { kiloProviderOptions } from "@/kilocode/provider-options"
+import { ProviderTransform } from "@/provider/transform"
+
+const model = {
+  id: "kilo/minimax/minimax-m3",
+  providerID: "kilo",
+  api: {
+    id: "minimax/minimax-m3",
+    url: "https://api.kilo.ai/api/openrouter",
+    npm: "@kilocode/kilo-gateway",
+  },
+  capabilities: { reasoning: true },
+  limit: { output: 64_000 },
+} as any
+
+describe("Kilo Gateway MiniMax M3 thinking", () => {
+  test("defaults to adaptive thinking", () => {
+    const options = ProviderTransform.options({ model, sessionID: "test-session" })
+
+    expect(options.reasoning).toEqual({ enabled: true })
+    expect(kiloProviderOptions(options).anthropic.thinking).toEqual({ type: "adaptive" })
+  })
+
+  test("allows the none variant to disable thinking", () => {
+    const base = ProviderTransform.options({ model, sessionID: "test-session" })
+    const options = mergeDeep(base, { reasoning: { enabled: false, effort: "none" } })
+
+    expect(kiloProviderOptions(options).anthropic.thinking).toEqual({ type: "disabled" })
+  })
+})


### PR DESCRIPTION
## Summary

Default MiniMax M3 requests through Kilo Gateway to adaptive thinking, matching the direct Anthropic provider behavior merged from upstream. The cloud model catalog keeps the common Gateway labels `thinking` and `instant`; selecting `instant` overrides this default and sends disabled thinking.

This is the CLI companion to Kilo-Org/cloud#4188.