### PR TITLE
test(ci): run unit suite on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
       - name: Run HttpApi exerciser gates
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' # kilocode_change
         working-directory: packages/opencode
         run: bun run test:httpapi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         settings:
           - name: linux
             host: blacksmith-4vcpu-ubuntu-2404 # kilocode_change
+          - name: macos
+            host: macos-15 # kilocode_change
           - name: windows
             host: blacksmith-4vcpu-windows-2025 # kilocode_change
     runs-on: ${{ matrix.settings.host }}
@@ -81,7 +83,7 @@ jobs:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
       - name: Run HttpApi exerciser gates
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
         working-directory: packages/opencode
         run: bun run test:httpapi
 

--- a/packages/opencode/test/cli/acp/acp-test-client.ts
+++ b/packages/opencode/test/cli/acp/acp-test-client.ts
@@ -44,7 +44,7 @@ export function createAcpClient(acp: AcpHandle): AcpClient {
       yield* acp.send(message)
 
       while (true) {
-        const received = yield* acp.receive.pipe(Effect.timeout(Duration.seconds(15)))
+        const received = yield* acp.receive.pipe(Effect.timeout(Duration.seconds(30))) // kilocode_change
         if (isJsonRpcResponse<T>(received) && received.id === id) return received
       }
     })

--- a/packages/opencode/test/cli/acp/lifecycle.test.ts
+++ b/packages/opencode/test/cli/acp/lifecycle.test.ts
@@ -18,7 +18,7 @@ describe("opencode acp lifecycle subprocess", () => {
         const acp = yield* opencode.acp()
         acp.close()
 
-        const code = yield* Effect.promise(() => acp.exited).pipe(Effect.timeout(Duration.seconds(5)))
+        const code = yield* Effect.promise(() => acp.exited).pipe(Effect.timeout(Duration.seconds(15))) // kilocode_change
         expect(code).toBe(0)
       }),
     60_000,

--- a/packages/opencode/test/server/httpapi-experimental.test.ts
+++ b/packages/opencode/test/server/httpapi-experimental.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect } from "bun:test"
+import { realpath } from "node:fs/promises" // kilocode_change
 import { Deferred, Effect, Fiber, Layer } from "effect"
 import { eq } from "drizzle-orm"
 import { GlobalBus, type GlobalEvent } from "@/bus/global"
@@ -271,7 +272,8 @@ describe("experimental HttpApi", () => {
           Effect.gen(function* () {
             const listed = yield* request(ExperimentalPaths.worktree, tmp.directory)
             expect(listed.status).toBe(200)
-            expect(yield* json(listed)).toContainEqual({ directory: info.directory, managed: true }) // kilocode_change
+            const directory = yield* Effect.promise(() => realpath(info.directory)) // kilocode_change
+            expect(yield* json(listed)).toContainEqual({ directory, managed: true }) // kilocode_change
 
             const reset = yield* request(ExperimentalPaths.worktreeReset, tmp.directory, {
               method: "POST",


### PR DESCRIPTION
The main unit test workflow currently exercises Linux and Windows, leaving macOS-specific filesystem, process, PTY, and worktree behavior uncovered until release validation.

Add a GitHub-hosted macOS 15 ARM runner to the existing unit matrix and run the HttpApi exerciser on both Unix platforms. Canonicalize the worktree path expected by the experimental API test so macOS path alias resolution is asserted consistently with the production listing behavior. Extend ACP subprocess response and shutdown deadlines to accommodate slower GitHub-hosted macOS cold starts without weakening the protocol assertions.