### PR TITLE
test(ci): focus macOS PR tests on Darwin coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
         run: bun turbo test:ci --filter='!@kilocode/kilo-jetbrains'
         env:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
+          KILO_TEST_PROFILE: ${{ runner.os == 'macOS' && github.event_name == 'pull_request' && 'darwin' || '' }} # kilocode_change
 
       - name: Run HttpApi exerciser gates
         if: runner.os == 'Linux' # kilocode_change

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
       - name: Run HttpApi exerciser gates
-        if: runner.os != 'Windows' # kilocode_change
+        if: runner.os == 'Linux' # kilocode_change
         working-directory: packages/opencode
         run: bun run test:httpapi
 

--- a/packages/opencode/script/kilocode/test-profile.ts
+++ b/packages/opencode/script/kilocode/test-profile.ts
@@ -44,6 +44,7 @@ export namespace TestProfile {
   export const names = Object.keys(profiles)
 
   export function resolve(name: string, all: readonly string[]) {
+    const files = all.map((file) => file.replaceAll("\\", "/"))
     const profile = profiles[name as keyof typeof profiles]
     if (!profile) {
       return {
@@ -74,7 +75,7 @@ export namespace TestProfile {
       )
       .map(([group]) => group)
     const globs = patterns.map((pattern) => ({ pattern, glob: new Bun.Glob(pattern) }))
-    const unmatched = globs.filter((item) => !all.some((file) => item.glob.match(file))).map((item) => item.pattern)
+    const unmatched = globs.filter((item) => !files.some((file) => item.glob.match(file))).map((item) => item.pattern)
     const errors = [
       malformed.length > 0 ? `Malformed patterns: ${malformed.join(", ")}` : "",
       duplicates.length > 0 ? `Duplicate patterns: ${duplicates.join(", ")}` : "",
@@ -93,7 +94,7 @@ export namespace TestProfile {
     return {
       ok: true as const,
       description: profile.description,
-      files: all.filter((file) => globs.some((item) => item.glob.match(file))),
+      files: files.filter((file) => globs.some((item) => item.glob.match(file))),
     }
   }
 }

--- a/packages/opencode/script/kilocode/test-profile.ts
+++ b/packages/opencode/script/kilocode/test-profile.ts
@@ -1,0 +1,99 @@
+export namespace TestProfile {
+  // Broad globs keep platform coverage maintainable as tests are added or renamed.
+  // Full macOS runs on main remain the backstop for tests outside these areas.
+  const profiles = {
+    darwin: {
+      description: "Darwin-native process, terminal, filesystem, worktree, and runtime coverage",
+      groups: {
+        cli: [
+          "cli/acp/*.test.ts",
+          "cli/install-artifact.test.ts",
+          "cli/run/{footer.view,run-process,scrollback.surface}.test.{ts,tsx}",
+          "cli/serve/*.test.ts",
+          "cli/smokes/*.test.ts",
+          "cli/tui/{app-lifecycle,dialog-prompt,diff-viewer-file-tree,diff-viewer,inline-tool-wrap-snapshot,keymap,plugin-loader-entrypoint,slot-replace,thread,use-event}.test.{ts,tsx}",
+        ],
+        filesystem: [
+          "file/{index,path-traversal,ripgrep}.test.ts",
+          "git/*.test.ts",
+          "image/*.test.ts",
+          "plugin/{install-concurrency,loader-shared}.test.ts",
+          "reference/*.test.ts",
+          "snapshot/*.test.ts",
+          "tool/{external-directory,glob,grep,read,repo_clone,repo_overview,shell}.test.ts",
+          "util/{filesystem,module,process,which}.test.ts",
+        ],
+        kilo: [
+          "kilocode/{background-process,bin-tree-sitter-env,daemon,external-directory-boundary,indexing-worker,indexing-worktree,mcp-oauth-callback,primary-worktree,snapshot-freeze-repro,snapshot-revert-move,snapshot-seed}.test.ts",
+          "kilocode/server/{listener-runtime,worktree-list}.test.ts",
+          "kilocode/session-export/{e2e,sequence,worker,workspace-provider}.test.ts",
+          "kilocode/session-export/worker/{storage,zstd}.test.ts",
+          "kilocode/sessions/*.test.ts",
+          "kilocode/worktree*.test.ts",
+        ],
+        process: ["provider/header-timeout.test.ts", "session/{prompt,retry}.test.ts", "shell/*.test.ts"],
+        project: ["project/*.test.ts"],
+        pty: ["pty/pty-*.test.ts", "server/httpapi-pty*.test.ts"],
+        server: [
+          "server/{httpapi-compression,httpapi-experimental,httpapi-file,httpapi-listen,httpapi-workspace-routing,project-init-git,workspace-proxy,worktree-endpoint-repro}.test.ts",
+        ],
+      },
+    },
+  } as const
+
+  export const names = Object.keys(profiles)
+
+  export function resolve(name: string, all: readonly string[]) {
+    const profile = profiles[name as keyof typeof profiles]
+    if (!profile) {
+      return {
+        ok: false as const,
+        error: `Unknown test profile "${name}". Available profiles: ${names.join(", ")}`,
+      }
+    }
+
+    const groups = Object.entries(profile.groups)
+    const patterns = groups.flatMap(([, patterns]) => patterns)
+    const malformed = patterns.filter(
+      (pattern) =>
+        pattern.startsWith("/") ||
+        pattern.startsWith("test/") ||
+        pattern.includes("\\") ||
+        pattern.split("/").includes("..") ||
+        !/\.test\.(ts|tsx|\{ts,tsx\})$/.test(pattern),
+    )
+    const seen = new Set<string>()
+    const duplicates = patterns.filter((pattern) => {
+      if (seen.has(pattern)) return true
+      seen.add(pattern)
+      return false
+    })
+    const unsorted = groups
+      .filter(([, patterns]) =>
+        patterns.some((pattern, index) => index > 0 && patterns[index - 1].localeCompare(pattern) > 0),
+      )
+      .map(([group]) => group)
+    const globs = patterns.map((pattern) => ({ pattern, glob: new Bun.Glob(pattern) }))
+    const unmatched = globs.filter((item) => !all.some((file) => item.glob.match(file))).map((item) => item.pattern)
+    const errors = [
+      malformed.length > 0 ? `Malformed patterns: ${malformed.join(", ")}` : "",
+      duplicates.length > 0 ? `Duplicate patterns: ${duplicates.join(", ")}` : "",
+      unmatched.length > 0 ? `Unmatched patterns: ${unmatched.join(", ")}` : "",
+      unsorted.length > 0 ? `Unsorted groups: ${unsorted.join(", ")}` : "",
+      patterns.length === 0 ? "Profile contains no patterns" : "",
+    ].filter(Boolean)
+
+    if (errors.length > 0) {
+      return {
+        ok: false as const,
+        error: `Invalid test profile "${name}":\n${errors.map((error) => `- ${error}`).join("\n")}`,
+      }
+    }
+
+    return {
+      ok: true as const,
+      description: profile.description,
+      files: all.filter((file) => globs.some((item) => item.glob.match(file))),
+    }
+  }
+}

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -102,7 +102,9 @@ const bold = (s: string) => (tty ? `\x1b[1m${s}\x1b[0m` : s)
 // ---------------------------------------------------------------------------
 
 const glob = new Bun.Glob("**/*.test.{ts,tsx}")
-const all = (await Array.fromAsync(glob.scan({ cwd: path.join(root, "test") }))).sort()
+const all = (await Array.fromAsync(glob.scan({ cwd: path.join(root, "test") })))
+  .map((file) => file.replaceAll("\\", "/"))
+  .sort()
 
 export const skipped = new Set([
   // Upstream browser OAuth integration tests bind the fixed callback port and

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -7,6 +7,7 @@
 import os from "os"
 import path from "path"
 import fs from "fs/promises"
+import { TestProfile } from "./kilocode/test-profile"
 
 const root = path.resolve(import.meta.dir, "..")
 const argv = process.argv.slice(2)
@@ -29,6 +30,7 @@ if (argv.includes("--help") || argv.includes("-h")) {
       "  --timeout <ms>       Per-test timeout passed to bun test (default: 60000)",
       "  --file-timeout <ms>  Per-file process timeout (default: 300000)",
       "  --retries <N>        Extra attempts for failing files (default: 1)",
+      "  --profile <name>     Run a curated test profile (env: KILO_TEST_PROFILE)",
       "  --bail               Stop on first failure",
       "  --verbose            Show full output for every file",
       "  -h, --help           Show this help",
@@ -50,6 +52,15 @@ function opt(name: string, fallback: number) {
   return i >= 0 && i + 1 < argv.length ? Number(argv[i + 1]) || fallback : fallback
 }
 
+function text(name: string) {
+  const i = argv.indexOf(`--${name}`)
+  if (i < 0) return
+  const value = argv[i + 1]
+  if (value && !value.startsWith("-")) return value
+  console.error(`Missing value for --${name}`)
+  process.exit(2)
+}
+
 const ci = argv.includes("--ci")
 const bail = argv.includes("--bail")
 const verbose = argv.includes("--verbose")
@@ -60,8 +71,15 @@ const concurrency = opt("concurrency", Math.min(4, os.cpus().length))
 const timeout = opt("timeout", 60000)
 const deadline = opt("file-timeout", 300000)
 const retries = opt("retries", 1)
+const flag = text("profile")
+const env = process.env.KILO_TEST_PROFILE?.trim() || undefined
+if (flag && env && flag !== env) {
+  console.error(`Conflicting test profiles: --profile=${flag}, KILO_TEST_PROFILE=${env}`)
+  process.exit(2)
+}
+const profile = flag ?? env
 
-const valued = new Set(["--concurrency", "--timeout", "--file-timeout", "--retries"])
+const valued = new Set(["--concurrency", "--timeout", "--file-timeout", "--retries", "--profile"])
 const patterns = argv.filter((arg, i) => {
   if (arg.startsWith("-")) return false
   if (i > 0 && valued.has(argv[i - 1])) return false
@@ -92,9 +110,28 @@ export const skipped = new Set([
   "mcp/oauth-browser.test.ts",
 ])
 
+const selected = (() => {
+  if (!profile) return all
+  const result = TestProfile.resolve(profile, all)
+  if (!result.ok) {
+    console.error(result.error)
+    process.exit(2)
+  }
+  const blocked = result.files.filter((file) => skipped.has(file))
+  if (blocked.length > 0) {
+    console.error(`Test profile "${profile}" contains skipped files:\n${blocked.map((file) => `- ${file}`).join("\n")}`)
+    process.exit(2)
+  }
+  console.log(`Using test profile "${profile}": ${result.description} (${result.files.length} files)`)
+  return result.files
+})()
 const matched =
-  patterns.length > 0 ? all.filter((f) => patterns.some((p) => f.includes(p) || path.join("test", f).includes(p))) : all
-const files = patterns.length > 0 ? matched : matched.filter((f) => !skipped.has(f)) // kilocode_change
+  patterns.length > 0
+    ? selected.filter((file) =>
+        patterns.some((pattern) => file.includes(pattern) || path.join("test", file).includes(pattern)),
+      )
+    : selected
+const files = patterns.length > 0 && !profile ? matched : matched.filter((file) => !skipped.has(file)) // kilocode_change
 
 if (files.length === 0) {
   console.log("No test files found")

--- a/packages/opencode/test/kilocode/test-profile.test.ts
+++ b/packages/opencode/test/kilocode/test-profile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { TestProfile } from "../../script/kilocode/test-profile"
+
+const root = path.resolve(import.meta.dir, "..")
+const glob = new Bun.Glob("**/*.test.{ts,tsx}")
+const all = (await Array.fromAsync(glob.scan({ cwd: root }))).sort()
+
+describe("test profiles", () => {
+  test("darwin profile contains valid test files", () => {
+    const result = TestProfile.resolve("darwin", all)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.files.length).toBeGreaterThan(50)
+    expect(result.files).toContain("pty/pty-session.test.ts")
+    expect(result.files).toContain("kilocode/sessions/remote-ws.test.ts")
+    expect(result.files).toContain("kilocode/sessions/remote-sender.test.ts")
+  })
+
+  test("unknown profiles fail with available names", () => {
+    const result = TestProfile.resolve("unknown", all)
+    expect(result).toEqual({
+      ok: false,
+      error: 'Unknown test profile "unknown". Available profiles: darwin',
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/test-profile.test.ts
+++ b/packages/opencode/test/kilocode/test-profile.test.ts
@@ -17,6 +17,17 @@ describe("test profiles", () => {
     expect(result.files).toContain("kilocode/sessions/remote-sender.test.ts")
   })
 
+  test("normalizes Windows test paths", () => {
+    const result = TestProfile.resolve(
+      "darwin",
+      all.map((file) => file.replaceAll("/", "\\")),
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.files).toContain("pty/pty-session.test.ts")
+    expect(result.files.some((file) => file.includes("\\"))).toBe(false)
+  })
+
   test("unknown profiles fail with available names", () => {
     const result = TestProfile.resolve("unknown", all)
     expect(result).toEqual({

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,7 @@
     },
     "@kilocode/cli#test:ci": {
       "dependsOn": ["^build"],
+      "env": ["KILO_TEST_PROFILE"],
       "outputs": [".artifacts/unit/junit.xml"],
       "passThroughEnv": ["*"]
     },


### PR DESCRIPTION
The full macOS unit lane repeats thousands of platform-neutral assertions already covered by Linux, while the useful additional signal comes from Darwin native modules and operating-system boundaries. The duplicate HttpApi exerciser also adds several minutes after equivalent focused server tests have run.

Use a curated Darwin profile for the CLI tests in macOS pull-request jobs. The other workspace package suites continue to run unchanged. Pushes to `main` and manual workflow runs continue to execute the complete macOS suite as a backstop for profile drift.

The macOS CLI profile covers these domains:

- Native terminal rendering through the Darwin OpenTUI package, including its threaded renderer.
- Real PTY allocation, shell I/O, resize, exit handling, and PTY WebSocket routes through `bun-pty`.
- CLI and ACP subprocess startup, stdin/stdout protocol handling, EOF shutdown, signals, daemon lifecycle, and process cleanup.
- Darwin background-process port discovery through `ps` and `lsof`.
- Filesystem behavior including real paths, symlinks, permissions, executable lookup, ripgrep, and native Photon image loading.
- Git repositories, projects, worktrees, snapshots, submodules, and macOS temporary-path canonicalization.
- Loopback listeners, proxies, WebSockets, connection resets, compression, and server shutdown behavior.
- Kilo runtime boundaries including workers, indexing worktrees, disk-backed SQLite/WAL sequencing, zstd, session export, and remote session transport.

Broad capability globs keep the profile maintainable as tests are added or renamed. The profile rejects malformed or fully unmatched patterns, and the full macOS run on `main` remains the backstop for tests outside these areas.

| Runner | CLI files | Unit test cases | Extra HttpApi scenarios | Duration |
|---|---:|---:|---:|---:|
| macOS PR | 95 | 1,507 | 0 | 9m00s |
| Linux PR | 529 | 5,692 | 211 | 9m36s |

The counts are from the current PR suite and will change as tests evolve. macOS now runs about 26.5% of the Linux unit-test count while retaining the host-dependent coverage.

Keep the aggregate HttpApi exerciser in its Linux lane, and include the selected profile in the CLI Turbo cache key so partial and complete reports cannot be mixed.