### PR TITLE
test(ci): keep HttpApi exerciser Linux-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
       - name: Run HttpApi exerciser gates
-        if: runner.os != 'Windows' # kilocode_change
+        if: runner.os == 'Linux' # kilocode_change
         working-directory: packages/opencode
         run: bun run test:httpapi
 


### PR DESCRIPTION
The macOS unit lane currently reruns the serial HttpApi exerciser after the same full unit suite has already completed. That gate covers route completeness and authorization behavior rather than a macOS-specific boundary, and it adds several minutes to the slowest matrix leg.

Keep the complete macOS unit suite intact, but run the aggregate HttpApi exerciser only on Linux. This makes the macOS exclusion a single suite-level condition rather than a file allowlist that must be maintained as tests are added or moved.