### PR TITLE
fix(cli): isolate sandboxed worktree writes

### DIFF
--- a/.changeset/secure-worktree-sandboxes.md
+++ b/.changeset/secure-worktree-sandboxes.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Confine sandboxed worktree sessions to their active worktree instead of allowing writes to sibling or primary checkouts.

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -1,3 +1,5 @@
+import { readFileSync, statSync } from "node:fs"
+import path from "node:path"
 import { Effect } from "effect"
 import { Global } from "@opencode-ai/core/global"
 import { run as runSandbox, type Profile } from "@kilocode/sandbox"
@@ -9,11 +11,44 @@ function root(path: string) {
   return { path, kind: "subtree" as const }
 }
 
+function marker(dir: string) {
+  try {
+    const file = path.join(dir, ".git")
+    const entry = statSync(file, { throwIfNoEntry: false })
+    if (!entry?.isFile()) return false
+    const match = readFileSync(file, "utf8")
+      .trim()
+      .match(/^gitdir:\s*(.+)$/i)
+    if (!match) return true
+    const git = path.resolve(dir, match[1])
+    if (!statSync(git, { throwIfNoEntry: false })?.isDirectory()) return true
+    return statSync(path.join(git, "commondir"), { throwIfNoEntry: false })?.isFile() ?? false
+  } catch {
+    return true
+  }
+}
+
+function linked(dir: string, stop: string): boolean {
+  if (marker(dir)) return true
+  if (dir === stop) return false
+  const parent = path.dirname(dir)
+  if (parent === dir) return false
+  return linked(parent, stop)
+}
+
+function isolated(ctx: InstanceContext) {
+  if (ctx.worktree === "/") return true
+  return linked(path.resolve(ctx.directory), path.resolve(ctx.worktree))
+}
+
 export function profile(ctx: InstanceContext): Profile {
+  const project = isolated(ctx)
+    ? [ctx.directory]
+    : ctx.directory === ctx.worktree
+      ? [ctx.directory]
+      : [ctx.worktree, ctx.directory]
   const writable = [
-    ...(ctx.worktree === "/" ? [] : [ctx.worktree]),
-    ctx.directory,
-    ...(ctx.project.sandboxes ?? []),
+    ...project,
     Global.Path.data,
     Global.Path.cache,
     Global.Path.config,

--- a/packages/opencode/test/kilocode/sandbox/policy.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/policy.test.ts
@@ -1,51 +1,212 @@
+import fs from "node:fs/promises"
+import path from "node:path"
 import { describe, expect, test } from "bun:test"
 import { Global } from "@opencode-ai/core/global"
+import { assertWrite, run as runSandbox } from "@kilocode/sandbox"
+import { Effect, Exit } from "effect"
 import { profile } from "@/kilocode/sandbox/policy"
 import type { InstanceContext } from "@/project/instance-context"
 import { ProjectID } from "@/project/schema"
+import { tmpdir } from "../../fixture/fixture"
 
-const ctx: InstanceContext = {
-  directory: "/workspace/project",
-  worktree: "/workspace",
-  project: {
-    id: ProjectID.make("sandbox-policy-test"),
-    worktree: "/workspace",
-    time: { created: 0, updated: 0 },
-    sandboxes: ["/workspace/sandbox"],
-  },
+const kilo = [
+  Global.Path.data,
+  Global.Path.cache,
+  Global.Path.config,
+  Global.Path.state,
+  Global.Path.tmp,
+  Global.Path.bin,
+  Global.Path.log,
+  Global.Path.repos,
+]
+
+type Dirs = {
+  main: string
+  local: string
+  separate: string
+  separateLocal: string
+  a: string
+  b: string
+  external: string
+  approved: string
 }
 
-function paths() {
+function fixture() {
+  return tmpdir<Dirs>({
+    init: async (root) => {
+      const main = path.join(root, "main")
+      const local = path.join(main, "packages", "app")
+      const separate = path.join(root, "separate")
+      const separateLocal = path.join(separate, "packages", "app")
+      const store = path.join(root, "separate-git")
+      const a = path.join(main, ".kilo", "worktrees", "a")
+      const b = path.join(main, ".kilo", "worktrees", "b")
+      const external = path.join(root, "imported")
+      const approved = path.join(root, "approved")
+      await Promise.all([
+        fs.mkdir(path.join(main, ".git"), { recursive: true }),
+        fs.mkdir(local, { recursive: true }),
+        fs.mkdir(separateLocal, { recursive: true }),
+        fs.mkdir(store, { recursive: true }),
+        fs.mkdir(a, { recursive: true }),
+        fs.mkdir(b, { recursive: true }),
+        fs.mkdir(external, { recursive: true }),
+        fs.mkdir(approved, { recursive: true }),
+      ])
+      await fs.writeFile(path.join(separate, ".git"), `gitdir: ${store}\n`)
+      await Promise.all(
+        [a, b, external].map(async (dir, index) => {
+          const git = path.join(root, "worktrees", String(index))
+          await fs.mkdir(git, { recursive: true })
+          await fs.writeFile(path.join(git, "commondir"), "../..\n")
+          await fs.writeFile(path.join(dir, ".git"), `gitdir: ${git}\n`)
+        }),
+      )
+      return { main, local, separate, separateLocal, a, b, external, approved }
+    },
+  })
+}
+
+function context(directory: string, worktree: string, dirs: Dirs): InstanceContext {
+  return {
+    directory,
+    worktree,
+    project: {
+      id: ProjectID.make("sandbox-policy-test"),
+      worktree: dirs.main,
+      vcs: "git",
+      time: { created: 0, updated: 0 },
+      sandboxes: [dirs.a, dirs.b, dirs.external],
+    },
+  }
+}
+
+function roots(ctx: InstanceContext) {
   return profile(ctx).filesystem.allowWrite.map((rule) => rule.path)
 }
 
+function expected(...directories: string[]) {
+  return new Set([...directories, ...kilo])
+}
+
+const posix = process.platform === "win32" ? test.skip : test
+
 describe("sandbox policy", () => {
-  test("allows project and Kilo state roots", () => {
-    const result = paths()
-    expect(result).toContain(ctx.worktree)
-    expect(result).toContain(ctx.directory)
-    expect(result).toContain(ctx.project.sandboxes?.[0])
-    expect(result).toContain(Global.Path.data)
-    expect(result).toContain(Global.Path.state)
-    expect(result).toContain(Global.Path.tmp)
+  test("keeps a normal checkout writable from an active subdirectory", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.local, dirs.main, dirs)
+    const result = roots(ctx)
+    const write = await Effect.runPromise(
+      runSandbox(profile(ctx), assertWrite(path.join(dirs.main, "outside-cwd.txt")).pipe(Effect.exit)),
+    )
+
+    expect(new Set(result)).toEqual(expected(dirs.main, dirs.local))
+    expect(result).not.toContain(dirs.a)
+    expect(result).not.toContain(dirs.b)
+    expect(Exit.isSuccess(write)).toBe(true)
   })
 
-  test("does not derive writable roots from tool permissions", () => {
-    expect(new Set(paths())).toEqual(
-      new Set([
-        ctx.worktree,
-        ctx.directory,
-        ...(ctx.project.sandboxes ?? []),
-        Global.Path.data,
-        Global.Path.cache,
-        Global.Path.config,
-        Global.Path.state,
-        Global.Path.tmp,
-        Global.Path.bin,
-        Global.Path.log,
-        Global.Path.repos,
+  test("keeps a separate git directory checkout writable from an active subdirectory", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.separateLocal, dirs.separate, dirs)
+    const result = roots(ctx)
+
+    expect(new Set(result)).toEqual(expected(dirs.separate, dirs.separateLocal))
+  })
+
+  test("confines a managed worktree to its active directory", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const actual = roots(context(dirs.a, dirs.a, dirs))
+    const shared = roots(context(dirs.a, dirs.main, dirs))
+
+    expect(new Set(actual)).toEqual(expected(dirs.a))
+    expect(new Set(shared)).toEqual(expected(dirs.a))
+    expect(actual).not.toContain(dirs.main)
+    expect(actual).not.toContain(dirs.b)
+  })
+
+  posix("fails closed when a worktree marker cannot be resolved", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    await fs.symlink(".git", path.join(dirs.local, ".git"))
+    const result = roots(context(dirs.local, dirs.main, dirs))
+
+    expect(new Set(result)).toEqual(expected(dirs.local))
+    expect(result).not.toContain(dirs.main)
+  })
+
+  test("confines an imported worktree to its active directory", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const result = roots(context(dirs.external, dirs.external, dirs))
+
+    expect(new Set(result)).toEqual(expected(dirs.external))
+    expect(result).not.toContain(dirs.main)
+    expect(result).not.toContain(dirs.a)
+    expect(result).not.toContain(dirs.b)
+  })
+
+  test("derives concurrent worktree profiles without cross-contamination", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const check = (own: InstanceContext, other: string) =>
+      runSandbox(
+        profile(own),
+        Effect.all({
+          own: assertWrite(path.join(own.directory, "allowed.txt")).pipe(Effect.exit),
+          other: assertWrite(path.join(other, "denied.txt")).pipe(Effect.exit),
+        }),
+      )
+    const [left, right] = await Effect.runPromise(
+      Effect.all([check(context(dirs.a, dirs.a, dirs), dirs.b), check(context(dirs.b, dirs.b, dirs), dirs.a)], {
+        concurrency: "unbounded",
+      }),
+    )
+
+    expect(Exit.isSuccess(left.own)).toBe(true)
+    expect(Exit.isFailure(left.other)).toBe(true)
+    expect(Exit.isSuccess(right.own)).toBe(true)
+    expect(Exit.isFailure(right.other)).toBe(true)
+  })
+
+  test("keeps Kilo state and temporary roots writable", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.a, dirs.a, dirs)
+
+    expect(new Set(roots(ctx))).toEqual(expected(dirs.a))
+    expect(profile(ctx).filesystem.temporaryDirectory).toBe(Global.Path.tmp)
+  })
+
+  test("keeps .git denied inside overlapping writable roots", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const linked = context(dirs.a, dirs.a, dirs)
+    const local = context(dirs.local, dirs.main, dirs)
+    const result = await Effect.runPromise(
+      Effect.all([
+        runSandbox(profile(linked), assertWrite(path.join(dirs.a, ".git")).pipe(Effect.exit)),
+        runSandbox(profile(linked), assertWrite(path.join(dirs.a, "nested", ".git", "config")).pipe(Effect.exit)),
+        runSandbox(profile(local), assertWrite(path.join(dirs.main, ".git", "config")).pipe(Effect.exit)),
       ]),
     )
-    expect(profile(ctx).filesystem.denyNames).toContain(".git")
+
+    expect(result.every(Exit.isFailure)).toBe(true)
+    expect(profile(linked).filesystem.denyNames).toContain(".git")
+  })
+
+  test("does not add externally approved paths to writable roots", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.a, dirs.a, dirs)
+    const result = await Effect.runPromise(
+      runSandbox(profile(ctx), assertWrite(path.join(dirs.approved, "denied.txt")).pipe(Effect.exit)),
+    )
+
+    expect(roots(ctx)).not.toContain(dirs.approved)
+    expect(Exit.isFailure(result)).toBe(true)
   })
 })

--- a/packages/opencode/test/kilocode/sandbox/session-tools.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/session-tools.test.ts
@@ -1,0 +1,351 @@
+import { existsSync } from "node:fs"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { expect } from "bun:test"
+import { Effect, Exit, Layer } from "effect"
+import type { Tool as AITool, ToolExecutionOptions } from "ai"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { Global } from "@opencode-ai/core/global"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Agent } from "@/agent/agent"
+import { Bus } from "@/bus"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Format } from "@/format"
+import { LSP } from "@/lsp/lsp"
+import { MCP } from "@/mcp"
+import { Permission } from "@/permission"
+import { ProjectID } from "@/project/schema"
+import type { InstanceContext } from "@/project/instance-context"
+import { Plugin } from "@/plugin"
+import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session/session"
+import { SessionTools } from "@/session/tools"
+import { MessageID, SessionID } from "@/session/schema"
+import { ShellTool } from "@/tool/shell"
+import * as Tool from "@/tool/tool"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { WriteTool } from "@/tool/write"
+import { TestConfig } from "../../fixture/config"
+import { tmpdirScoped } from "../../fixture/fixture"
+import { ProviderTest } from "../../fake/provider"
+import { testEffect } from "../../lib/effect"
+
+const projectID = ProjectID.make("sandbox-session-tools")
+const sessionID = SessionID.make("ses_sandbox-session-tools")
+const model = ProviderTest.model()
+const agent: Agent.Info = {
+  name: "build",
+  mode: "primary",
+  permission: Permission.fromConfig({ "*": "allow" }),
+  options: {},
+}
+const approvals: Permission.AskInput[] = []
+
+function session(directory: string): Session.Info {
+  return {
+    id: sessionID,
+    slug: "sandbox-session-tools",
+    projectID,
+    directory,
+    title: "Sandbox worktree isolation",
+    version: "test",
+    permission: Permission.fromConfig({ "*": "allow" }),
+    time: { created: 0, updated: 0 },
+  }
+}
+
+function message(ctx: InstanceContext): MessageV2.Assistant {
+  return {
+    id: MessageID.make("msg_sandbox-session-tools"),
+    role: "assistant",
+    parentID: MessageID.make("msg_sandbox-session-tools-parent"),
+    sessionID,
+    mode: "build",
+    agent: agent.name,
+    path: { cwd: ctx.directory, root: ctx.worktree },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: model.id,
+    providerID: model.providerID,
+    time: { created: 0 },
+  }
+}
+
+function context(directory: string, main: string, sandboxes: string[]): InstanceContext {
+  return {
+    directory,
+    worktree: main,
+    project: {
+      id: projectID,
+      worktree: main,
+      vcs: "git",
+      time: { created: 0, updated: 0 },
+      sandboxes,
+    },
+  }
+}
+
+const config = TestConfig.layer({
+  get: () => Effect.succeed({ experimental: { sandbox: true } }),
+})
+const agents = Layer.mock(Agent.Service)({
+  get: () => Effect.succeed(agent),
+})
+const sessions = Layer.mock(Session.Service)({
+  get: () => Effect.succeed(session("/workspace/project/.kilo/worktrees/a")),
+})
+const permission = Layer.mock(Permission.Service)({
+  ask: (input) =>
+    Effect.sync(() => {
+      approvals.push(input)
+    }),
+})
+const plugin = Layer.mock(Plugin.Service)({
+  trigger: (_name, _input, output) => Effect.succeed(output),
+})
+const mcp = Layer.mock(MCP.Service)({
+  tools: () => Effect.succeed({}),
+})
+const lsp = Layer.mock(LSP.Service)({
+  touchFile: () => Effect.void,
+  diagnostics: () => Effect.succeed({}),
+})
+const format = Layer.mock(Format.Service)({
+  file: () => Effect.succeed(false),
+})
+const truncate = Layer.mock(Truncate.Service)({
+  output: (text: string) => Effect.succeed({ content: text, truncated: false as const }),
+  limits: () => Effect.succeed({ maxLines: Truncate.MAX_LINES, maxBytes: Truncate.MAX_BYTES }),
+})
+const base = Layer.mergeAll(
+  config,
+  agents,
+  sessions,
+  permission,
+  plugin,
+  mcp,
+  lsp,
+  format,
+  truncate,
+  Bus.layer,
+  AppFileSystem.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+  RuntimeFlags.layer(),
+)
+const registry = Layer.effect(
+  ToolRegistry.Service,
+  Effect.gen(function* () {
+    const write = yield* WriteTool.pipe(Effect.flatMap(Tool.init))
+    const shell = yield* ShellTool.pipe(Effect.flatMap(Tool.init))
+    const list = [write, shell]
+    return ToolRegistry.Service.of({
+      ids: () => Effect.succeed(list.map((item) => item.id)),
+      all: () => Effect.succeed(list),
+      named: () => Effect.die(new Error("named tools are not used by this test")),
+      tools: () => Effect.succeed(list),
+    })
+  }),
+).pipe(Layer.provideMerge(base))
+const it = testEffect(registry)
+
+function resolve(ctx: InstanceContext) {
+  return SessionTools.resolve({
+    agent,
+    model,
+    session: session(ctx.directory),
+    processor: {
+      message: message(ctx),
+      metadata: () => Effect.void,
+      completeToolCall: () => Effect.void,
+    },
+    bypassAgentCheck: false,
+    messages: [],
+    promptOps: {
+      cancel: () => Effect.die(new Error("cancel is not used by this test")),
+      resolvePromptParts: () => Effect.die(new Error("resolvePromptParts is not used by this test")),
+      prompt: () => Effect.die(new Error("prompt is not used by this test")),
+    },
+  }).pipe(Effect.provideService(InstanceRef, ctx))
+}
+
+function call(tool: AITool, input: unknown, id: string) {
+  const options: ToolExecutionOptions = {
+    toolCallId: id,
+    messages: [],
+    abortSignal: new AbortController().signal,
+  }
+  if (!tool.execute) return Effect.die(new Error("tool has no execute callback"))
+  return Effect.tryPromise({
+    try: () => Promise.resolve(tool.execute?.(input, options)),
+    catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+  })
+}
+
+function exists(file: string) {
+  return Effect.promise(() =>
+    fs
+      .access(file)
+      .then(() => true)
+      .catch(() => false),
+  )
+}
+
+function fixture() {
+  return Effect.gen(function* () {
+    const root = yield* tmpdirScoped()
+    const main = path.join(root, "main")
+    const local = path.join(main, "packages", "app")
+    const a = path.join(main, ".kilo", "worktrees", "a")
+    const b = path.join(main, ".kilo", "worktrees", "b")
+    const approved = path.join(root, "approved")
+    yield* Effect.promise(() =>
+      Promise.all([path.join(main, ".git"), local, a, b, approved].map((dir) => fs.mkdir(dir, { recursive: true }))),
+    )
+    yield* Effect.promise(() =>
+      Promise.all(
+        [
+          [a, "a"],
+          [b, "b"],
+        ].map(async ([dir, name]) => {
+          const git = path.join(main, ".git", "worktrees", name)
+          await fs.mkdir(git, { recursive: true })
+          await fs.writeFile(path.join(git, "commondir"), "../..\n")
+          await fs.writeFile(path.join(dir, ".git"), `gitdir: ${git}\n`)
+        }),
+      ),
+    )
+    return { root, main, local, a, b, approved, ctx: context(a, main, [a, b]) }
+  })
+}
+
+it.live("confines model-originated file mutations to the active worktree", () =>
+  Effect.gen(function* () {
+    const dirs = yield* fixture()
+    const tools = yield* resolve(dirs.ctx)
+    const write = tools.write
+    if (!write) yield* Effect.die(new Error("write tool is missing"))
+
+    const active = path.join(dirs.a, "active.txt")
+    const sibling = path.join(dirs.b, "sibling.txt")
+    const primary = path.join(dirs.main, "primary.txt")
+    const outside = path.join(dirs.approved, "approved.txt")
+    const outsideGit = path.join(dirs.approved, ".git", "config")
+    const git = path.join(dirs.a, ".git")
+    const start = approvals.length
+    const stateDir = path.join(Global.Path.tmp, path.basename(dirs.root))
+    const state = path.join(stateDir, "state.txt")
+    yield* Effect.addFinalizer(() => Effect.promise(() => fs.rm(stateDir, { recursive: true, force: true })))
+
+    const allowed = yield* call(write, { filePath: active, content: "active" }, "call-active").pipe(Effect.exit)
+    const kilo = yield* call(write, { filePath: state, content: "state" }, "call-state").pipe(Effect.exit)
+    const siblingResult = yield* call(write, { filePath: sibling, content: "sibling" }, "call-sibling").pipe(
+      Effect.exit,
+    )
+    const primaryResult = yield* call(write, { filePath: primary, content: "primary" }, "call-primary").pipe(
+      Effect.exit,
+    )
+    const outsideResult = yield* call(write, { filePath: outside, content: "approved" }, "call-approved").pipe(
+      Effect.exit,
+    )
+    const outsideGitResult = yield* call(write, { filePath: outsideGit, content: "changed" }, "call-approved-git").pipe(
+      Effect.exit,
+    )
+    const gitResult = yield* call(write, { filePath: git, content: "changed" }, "call-git").pipe(Effect.exit)
+    const requested = approvals.slice(start)
+
+    expect(Exit.isSuccess(allowed)).toBe(true)
+    expect(Exit.isSuccess(kilo)).toBe(true)
+    expect(Exit.isFailure(siblingResult)).toBe(true)
+    expect(Exit.isFailure(primaryResult)).toBe(true)
+    expect(Exit.isFailure(outsideResult)).toBe(true)
+    expect(Exit.isFailure(outsideGitResult)).toBe(true)
+    expect(Exit.isFailure(gitResult)).toBe(true)
+    expect(
+      requested.some(
+        (request) =>
+          request.permission === "external_directory" &&
+          request.patterns.some((pattern) => pattern.includes(dirs.approved)),
+      ),
+    ).toBe(true)
+    expect(yield* exists(active)).toBe(true)
+    expect(yield* exists(state)).toBe(true)
+    expect(yield* exists(sibling)).toBe(false)
+    expect(yield* exists(primary)).toBe(false)
+    expect(yield* exists(outside)).toBe(false)
+    expect(yield* exists(outsideGit)).toBe(false)
+    expect(yield* Effect.promise(() => fs.readFile(git, "utf8"))).toContain("gitdir:")
+  }),
+)
+
+it.live("keeps model-originated file mutations writable in a local checkout", () =>
+  Effect.gen(function* () {
+    const dirs = yield* fixture()
+    const ctx = context(dirs.local, dirs.main, [dirs.a, dirs.b])
+    const tools = yield* resolve(ctx)
+    const write = tools.write
+    if (!write) yield* Effect.die(new Error("write tool is missing"))
+    const file = path.join(dirs.main, "outside-active-directory.txt")
+
+    const result = yield* call(write, { filePath: file, content: "local" }, "call-local").pipe(Effect.exit)
+
+    expect(Exit.isSuccess(result)).toBe(true)
+    expect(yield* exists(file)).toBe(true)
+  }),
+)
+
+it.live("keeps concurrent session profiles call-local", () =>
+  Effect.gen(function* () {
+    const dirs = yield* fixture()
+    const left = yield* resolve(context(dirs.a, dirs.main, [dirs.a, dirs.b]))
+    const right = yield* resolve(context(dirs.b, dirs.main, [dirs.a, dirs.b]))
+    if (!left.write || !right.write) yield* Effect.die(new Error("write tool is missing"))
+    const ownA = path.join(dirs.a, "session-a.txt")
+    const ownB = path.join(dirs.b, "session-b.txt")
+    const escapeA = path.join(dirs.b, "from-a.txt")
+    const escapeB = path.join(dirs.a, "from-b.txt")
+
+    const result = yield* Effect.all(
+      {
+        ownA: call(left.write, { filePath: ownA, content: "a" }, "call-a-own").pipe(Effect.exit),
+        ownB: call(right.write, { filePath: ownB, content: "b" }, "call-b-own").pipe(Effect.exit),
+        escapeA: call(left.write, { filePath: escapeA, content: "a" }, "call-a-escape").pipe(Effect.exit),
+        escapeB: call(right.write, { filePath: escapeB, content: "b" }, "call-b-escape").pipe(Effect.exit),
+      },
+      { concurrency: "unbounded" },
+    )
+
+    expect(Exit.isSuccess(result.ownA)).toBe(true)
+    expect(Exit.isSuccess(result.ownB)).toBe(true)
+    expect(Exit.isFailure(result.escapeA)).toBe(true)
+    expect(Exit.isFailure(result.escapeB)).toBe(true)
+    expect(yield* exists(ownA)).toBe(true)
+    expect(yield* exists(ownB)).toBe(true)
+    expect(yield* exists(escapeA)).toBe(false)
+    expect(yield* exists(escapeB)).toBe(false)
+  }),
+)
+
+const mac = process.platform === "darwin" && existsSync("/usr/bin/sandbox-exec") ? it.live : it.live.skip
+
+mac("confines a model-originated sandboxed process to the active worktree", () =>
+  Effect.gen(function* () {
+    const dirs = yield* fixture()
+    const tools = yield* resolve(dirs.ctx)
+    const shell = tools.bash
+    if (!shell) yield* Effect.die(new Error("bash tool is missing"))
+    const active = path.join(dirs.a, "shell-active.txt")
+    const sibling = path.join(dirs.b, "shell-sibling.txt")
+    const primary = path.join(dirs.main, "shell-primary.txt")
+    const command = (file: string) => `printf sandbox > ${JSON.stringify(file)}`
+
+    yield* call(shell, { command: command(active), workdir: dirs.a, description: "write active" }, "shell-active")
+    yield* call(shell, { command: command(sibling), workdir: dirs.a, description: "write sibling" }, "shell-sibling")
+    yield* call(shell, { command: command(primary), workdir: dirs.a, description: "write primary" }, "shell-primary")
+
+    expect(yield* exists(active)).toBe(true)
+    expect(yield* exists(sibling)).toBe(false)
+    expect(yield* exists(primary)).toBe(false)
+  }),
+)


### PR DESCRIPTION
Sandbox profiles currently treat the shared checkout root and every registered sandbox as writable. In worktree-backed sessions, that lets an agent mutate sibling worktrees or the primary checkout even though the session is scoped to one active directory.

Derive project write roots from the active directory and Git worktree topology instead. Linked worktrees are confined to their active directory, while ordinary checkout sessions retain project-wide writes when started from a subdirectory. Kilo-owned state remains writable, `.git` remains globally denied, and external-directory approval does not expand sandbox confinement. Profile derivation stays call-local so concurrent sessions cannot share writable roots.

Fixes #11544