### PR TITLE
fix(cli): recover stalled response streams

### DIFF
--- a/.changeset/recover-stalled-streams.md
+++ b/.changeset/recover-stalled-streams.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Recover stalled model response streams instead of leaving subagents running indefinitely.

--- a/.changeset/recover-stalled-streams.md
+++ b/.changeset/recover-stalled-streams.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Recover stalled model response streams instead of leaving subagents running indefinitely.
+Prevent subagents from hanging on stalled model response streams or interactive suggestions.

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -17,6 +17,15 @@ import { mapValues, omit, pickBy } from "remeda"
 /** Default timeout (ms) for provider HTTP requests (connection phase). */
 export const REQUEST_TIMEOUT_MS = 300_000 // 5 minutes
 
+/** Default maximum idle time between streamed response chunks. */
+export const STREAM_IDLE_TIMEOUT_MS = 120_000 // 2 minutes
+
+export function streamTimeout(input: { options: Record<string, unknown>; defaultMs?: number }): number | undefined {
+  const value = typeof input.options["chunkTimeout"] === "number" ? input.options["chunkTimeout"] : input.defaultMs
+  if (value === undefined || value <= 0) return
+  return value
+}
+
 // ---------------------------------------------------------------------------
 // Bundled providers
 // ---------------------------------------------------------------------------

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -3,6 +3,7 @@ import * as Stream from "effect/Stream"
 import type { LLMEvent } from "@opencode-ai/llm"
 import type { Logger } from "@opencode-ai/core/util/log"
 import type { Provider } from "@/provider/provider"
+import { streamTimeout } from "@/kilocode/provider/provider"
 import { KiloSessionOverflow } from "./overflow"
 
 const SAFETY = 2048
@@ -17,17 +18,10 @@ export namespace KiloLLM {
     )
   }
 
-  export function timeout(input: {
-    options: Record<string, unknown>
-    fallback?: Record<string, unknown>
-    log?: Pick<Logger, "debug">
-  }): { timeout?: { chunkMs: number } } {
-    const value =
-      typeof input.options["chunkTimeout"] === "number"
-        ? input.options["chunkTimeout"]
-        : typeof input.fallback?.["chunkTimeout"] === "number"
-          ? input.fallback["chunkTimeout"]
-          : undefined
+  export function timeout(input: { options: Record<string, unknown>; log?: Pick<Logger, "debug"> }): {
+    timeout?: { chunkMs: number }
+  } {
+    const value = streamTimeout(input)
     if (!value) return {}
     input.log?.debug("chunk idle timeout configured", { chunkTimeout: value })
     return { timeout: { chunkMs: value } }

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -97,21 +97,18 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         maxConnectionAge,
         init?.signal,
       )
-      // kilocode_change start
-      type First = { started: true } | { started: false; error: ProviderError.ResponseStreamError }
-      let resolveFirstEvent: (value: First) => void = () => {}
+      let resolveFirstEvent: (started: boolean) => void = () => {}
       let rejectFirstEvent: (error: Error) => void = () => {}
-      const firstEvent = new Promise<First>((resolve, reject) => {
+      const firstEvent = new Promise<boolean>((resolve, reject) => {
         resolveFirstEvent = resolve
         rejectFirstEvent = reject
       })
-      // kilocode_change end
       const response = OpenAIWebSocket.streamResponsesWebSocket({
         socket: entry.socket,
         body,
-        idleTimeout, // kilocode_change
-        signal: init?.signal ?? undefined, // kilocode_change
-        onFirstEvent: () => resolveFirstEvent({ started: true }), // kilocode_change
+        idleTimeout,
+        signal: init?.signal ?? undefined,
+        onFirstEvent: () => resolveFirstEvent(true),
         onTerminal: (event) => {
           entry.busy = false
           entry.lastUsedAt = Date.now()
@@ -124,10 +121,10 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         onConnectionInvalid: (error) => {
           log.warn("websocket invalidated", { key, error: error.message })
           entry.busy = false
-          if (!entry.fallback) recordStreamFailure(entry) // kilocode_change
-          invalidate(entry) // kilocode_change
-          resolveFirstEvent({ started: false, error }) // kilocode_change
-          return true // kilocode_change - the pool replaces the hidden pre-event response
+          entry.lastUsedAt = Date.now() // kilocode_change - port upstream #30586
+          if (!entry.fallback) recordStreamFailure(entry)
+          invalidate(entry)
+          resolveFirstEvent(false)
         },
         onAbort: (error) => {
           log.debug("websocket aborted", { key })
@@ -142,11 +139,10 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           if (!error) return undefined
           log.warn("websocket connection limit reached", { key })
           throw error
-        }, // kilocode_change
-      }) // kilocode_change
-      const first = await firstEvent // kilocode_change
-      if (first.started) return response // kilocode_change
-      if (!entry.fallback) return failedResponse(first.error) // kilocode_change
+        },
+      })
+      if (await firstEvent) return response
+      if (!entry.fallback) return response
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
       return httpFetch(input, httpInit)
     } catch (error) {
@@ -184,6 +180,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     const now = Date.now()
     for (const [key, entry] of pool) {
       if (entry.busy) continue
+      if (entry.fallback) continue // kilocode_change - port upstream #30586
       if (now - entry.lastUsedAt < idleTimeout) continue
       log.debug("websocket idle prune", { key })
       invalidate(entry)
@@ -206,14 +203,19 @@ function connectionLimitError(event: Record<string, unknown>) {
   return new Error(typeof event.error.message === "string" ? event.error.message : CONNECTION_LIMIT_REACHED_CODE)
 }
 
-// kilocode_change start - expose pre-event transport failures as retryable HTTP errors
 function failedResponse(error: ProviderError.ResponseStreamError) {
-  return Response.json(
-    { error: { message: error.message, type: "response_stream_error" } },
-    { status: 503, headers: { "retry-after": "0" } },
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(error)
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
   )
 }
-// kilocode_change end
 
 async function socket(
   entry: PoolEntry,

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -97,6 +97,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         maxConnectionAge,
         init?.signal,
       )
+      // kilocode_change start
       type First = { started: true } | { started: false; error: ProviderError.ResponseStreamError }
       let resolveFirstEvent: (value: First) => void = () => {}
       let rejectFirstEvent: (error: Error) => void = () => {}
@@ -104,12 +105,13 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         resolveFirstEvent = resolve
         rejectFirstEvent = reject
       })
+      // kilocode_change end
       const response = OpenAIWebSocket.streamResponsesWebSocket({
         socket: entry.socket,
         body,
-        idleTimeout,
-        signal: init?.signal ?? undefined,
-        onFirstEvent: () => resolveFirstEvent({ started: true }),
+        idleTimeout, // kilocode_change
+        signal: init?.signal ?? undefined, // kilocode_change
+        onFirstEvent: () => resolveFirstEvent({ started: true }), // kilocode_change
         onTerminal: (event) => {
           entry.busy = false
           entry.lastUsedAt = Date.now()
@@ -122,9 +124,9 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         onConnectionInvalid: (error) => {
           log.warn("websocket invalidated", { key, error: error.message })
           entry.busy = false
-          if (!entry.fallback) recordStreamFailure(entry)
-          invalidate(entry)
-          resolveFirstEvent({ started: false, error })
+          if (!entry.fallback) recordStreamFailure(entry) // kilocode_change
+          invalidate(entry) // kilocode_change
+          resolveFirstEvent({ started: false, error }) // kilocode_change
           return true // kilocode_change - the pool replaces the hidden pre-event response
         },
         onAbort: (error) => {
@@ -140,11 +142,11 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           if (!error) return undefined
           log.warn("websocket connection limit reached", { key })
           throw error
-        },
-      })
-      const first = await firstEvent
-      if (first.started) return response
-      if (!entry.fallback) return failedResponse(first.error)
+        }, // kilocode_change
+      }) // kilocode_change
+      const first = await firstEvent // kilocode_change
+      if (first.started) return response // kilocode_change
+      if (!entry.fallback) return failedResponse(first.error) // kilocode_change
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
       return httpFetch(input, httpInit)
     } catch (error) {
@@ -204,14 +206,14 @@ function connectionLimitError(event: Record<string, unknown>) {
   return new Error(typeof event.error.message === "string" ? event.error.message : CONNECTION_LIMIT_REACHED_CODE)
 }
 
+// kilocode_change start - expose pre-event transport failures as retryable HTTP errors
 function failedResponse(error: ProviderError.ResponseStreamError) {
-  // kilocode_change start - expose pre-event transport failures as retryable HTTP errors
   return Response.json(
     { error: { message: error.message, type: "response_stream_error" } },
     { status: 503, headers: { "retry-after": "0" } },
   )
-  // kilocode_change end
 }
+// kilocode_change end
 
 async function socket(
   entry: PoolEntry,

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -97,9 +97,10 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         maxConnectionAge,
         init?.signal,
       )
-      let resolveFirstEvent: (started: boolean) => void = () => {}
+      type First = { started: true } | { started: false; error: ProviderError.ResponseStreamError }
+      let resolveFirstEvent: (value: First) => void = () => {}
       let rejectFirstEvent: (error: Error) => void = () => {}
-      const firstEvent = new Promise<boolean>((resolve, reject) => {
+      const firstEvent = new Promise<First>((resolve, reject) => {
         resolveFirstEvent = resolve
         rejectFirstEvent = reject
       })
@@ -108,7 +109,7 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
         body,
         idleTimeout,
         signal: init?.signal ?? undefined,
-        onFirstEvent: () => resolveFirstEvent(true),
+        onFirstEvent: () => resolveFirstEvent({ started: true }),
         onTerminal: (event) => {
           entry.busy = false
           entry.lastUsedAt = Date.now()
@@ -123,7 +124,8 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           entry.busy = false
           if (!entry.fallback) recordStreamFailure(entry)
           invalidate(entry)
-          resolveFirstEvent(false)
+          resolveFirstEvent({ started: false, error })
+          return true // kilocode_change - the pool replaces the hidden pre-event response
         },
         onAbort: (error) => {
           log.debug("websocket aborted", { key })
@@ -140,8 +142,9 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
           throw error
         },
       })
-      if (await firstEvent) return response
-      if (!entry.fallback) return response
+      const first = await firstEvent
+      if (first.started) return response
+      if (!entry.fallback) return failedResponse(first.error)
       log.debug("http fallback", { key, reason: "websocket_retries_exhausted" })
       return httpFetch(input, httpInit)
     } catch (error) {
@@ -202,17 +205,12 @@ function connectionLimitError(event: Record<string, unknown>) {
 }
 
 function failedResponse(error: ProviderError.ResponseStreamError) {
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        controller.error(error)
-      },
-    }),
-    {
-      status: 200,
-      headers: { "content-type": "text/event-stream" },
-    },
+  // kilocode_change start - expose pre-event transport failures as retryable HTTP errors
+  return Response.json(
+    { error: { message: error.message, type: "response_stream_error" } },
+    { status: 503, headers: { "retry-after": "0" } },
   )
+  // kilocode_change end
 }
 
 async function socket(

--- a/packages/opencode/src/plugin/openai/ws.ts
+++ b/packages/opencode/src/plugin/openai/ws.ts
@@ -24,7 +24,7 @@ export interface StreamResponsesWebSocketOptions {
   onComplete?: (event: Record<string, unknown>) => void
   onTerminal?: (event: Record<string, unknown>) => void
   onRetryableTerminal?: (event: Record<string, unknown>) => Promise<WebSocket | undefined>
-  onConnectionInvalid?: (error: ProviderError.ResponseStreamError) => unknown // kilocode_change - acknowledge owned pre-event failures with true
+  onConnectionInvalid?: (error: ProviderError.ResponseStreamError) => void
   onAbort?: (error: Error) => void
 }
 
@@ -158,14 +158,8 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
     if (completed) return
     completed = true
     cleanup()
-    // kilocode_change start - settle pre-event responses according to whether the pool exposes or replaces them
-    const handled = !emitted && options.onConnectionInvalid?.(error) === true
-    if (handled) {
-      controller?.close()
-      return
-    }
-    queueMicrotask(() => queueMicrotask(() => controller?.error(error)))
-    // kilocode_change end
+    options.onConnectionInvalid?.(error)
+    controller?.error(error)
   }
 
   function resetIdleTimeout(message: string) {

--- a/packages/opencode/src/plugin/openai/ws.ts
+++ b/packages/opencode/src/plugin/openai/ws.ts
@@ -24,7 +24,7 @@ export interface StreamResponsesWebSocketOptions {
   onComplete?: (event: Record<string, unknown>) => void
   onTerminal?: (event: Record<string, unknown>) => void
   onRetryableTerminal?: (event: Record<string, unknown>) => Promise<WebSocket | undefined>
-  onConnectionInvalid?: (error: ProviderError.ResponseStreamError) => void
+  onConnectionInvalid?: (error: ProviderError.ResponseStreamError) => unknown // kilocode_change - acknowledge owned pre-event failures with true
   onAbort?: (error: Error) => void
 }
 
@@ -158,8 +158,14 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
     if (completed) return
     completed = true
     cleanup()
-    options.onConnectionInvalid?.(error)
-    controller?.error(error)
+    // kilocode_change start - settle pre-event responses according to whether the pool exposes or replaces them
+    const handled = !emitted && options.onConnectionInvalid?.(error) === true
+    if (handled) {
+      controller?.close()
+      return
+    }
+    queueMicrotask(() => queueMicrotask(() => controller?.error(error)))
+    // kilocode_change end
   }
 
   function resetIdleTimeout(message: string) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1679,10 +1679,12 @@ export const layer = Layer.effect(
         if (existing) return existing
 
         const customFetch = options["fetch"]
+        // kilocode_change start - prevent indefinitely stalled response streams
         const chunkTimeout = streamTimeout({
           options,
           defaultMs: STREAM_IDLE_TIMEOUT_MS,
-        }) // kilocode_change - prevent indefinitely stalled response streams
+        })
+        // kilocode_change end
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -39,6 +39,8 @@ import {
   patchKiloProviderPrivacy,
   kiloSmallModelPriority,
   buildTimeoutSignal,
+  STREAM_IDLE_TIMEOUT_MS,
+  streamTimeout,
 } from "@/kilocode/provider/provider"
 import * as ModelsRefresh from "@/kilocode/provider/models-refresh"
 // kilocode_change end
@@ -1677,7 +1679,10 @@ export const layer = Layer.effect(
         if (existing) return existing
 
         const customFetch = options["fetch"]
-        const chunkTimeout = options["chunkTimeout"]
+        const chunkTimeout = streamTimeout({
+          options,
+          defaultMs: STREAM_IDLE_TIMEOUT_MS,
+        }) // kilocode_change - prevent indefinitely stalled response streams
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
@@ -1725,7 +1730,7 @@ export const layer = Layer.effect(
               timeout: false,
             }).finally(() => headerTimeoutCtl?.clear())
             timeout.clear()
-            if (!chunkAbortCtl) return res
+            if (chunkTimeout === undefined || !chunkAbortCtl) return res
             return wrapSSE(res, chunkTimeout, chunkAbortCtl)
           } catch (err) {
             timeout.clear()

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -373,7 +373,7 @@ const live: Layer.Layer<
         toolChoice: input.toolChoice,
         maxOutputTokens: prepared.params.maxOutputTokens,
         abortSignal: input.abort,
-        ...KiloLLM.timeout({ options: prepared.params.options, fallback: item.options, log: l }), // kilocode_change
+        ...KiloLLM.timeout({ options: prepared.params.options, log: l }), // kilocode_change
         headers: prepared.headers,
         maxRetries: input.retries ?? 0,
         messages: prepared.messages,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -248,7 +248,10 @@ export const TaskTool = Tool.define(
           variant, // kilocode_change
           agent: next.name,
           tools: {
-            question: false, // kilocode_change - subagents cannot prompt the user directly
+            // kilocode_change start - subagents cannot prompt the user directly
+            question: false,
+            suggest: false,
+            // kilocode_change end
             ...(canTodo ? {} : { todowrite: false }),
             ...(canTask ? {} : { task: false }),
             ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -28,10 +28,12 @@ import { RepositoryCache } from "../../src/reference/repository-cache"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Instruction } from "../../src/session/instruction"
 import { LLM } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
+import { SessionID } from "../../src/session/schema"
 import { Session } from "../../src/session/session"
 import { SessionStatus } from "../../src/session/status"
 import { SystemPrompt } from "../../src/session/system"
@@ -45,7 +47,7 @@ import { Ripgrep } from "../../src/file/ripgrep"
 import { ToolRegistry } from "../../src/tool/registry"
 import { Truncate } from "../../src/tool/truncate"
 import { provideTmpdirServer } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 
 void Log.init({ print: false })
@@ -226,7 +228,7 @@ const cfg = {
   },
 }
 
-function providerCfg(url: string) {
+function providerCfg(url: string, options: Record<string, unknown> = {}) {
   return {
     ...cfg,
     provider: {
@@ -235,6 +237,7 @@ function providerCfg(url: string) {
         ...cfg.provider.test,
         options: {
           ...cfg.provider.test.options,
+          ...options,
           baseURL: url,
         },
       },
@@ -289,4 +292,94 @@ it.live("active tool calls use permissions changed after model streaming starts"
       }),
     },
   ),
+)
+
+it.live(
+  "recovers a foreground task when the child stream stalls after bash completes",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "Pinned",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* llm.tool("task", {
+          description: "run child bash",
+          prompt: "Run one shell command and report its output.",
+          subagent_type: "general",
+        })
+        yield* llm.tool("bash", {
+          command: "printf child-bash-done",
+          description: "Print child completion marker",
+        })
+        yield* llm.push(reply().reason("Reviewing the completed command output.").hang())
+        yield* llm.text("child recovered")
+        yield* llm.text("parent completed")
+
+        yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "delegate the child bash command" }],
+        })
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkScoped)
+        yield* awaitWithTimeout(llm.wait(3), "child did not open its post-bash model request", "10 seconds")
+
+        const task = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+            const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool" && part.tool === "task")
+            if (part?.type !== "tool" || part.state.status !== "running") return
+            const child = part.state.metadata?.sessionId
+            if (typeof child !== "string") return
+            return { part, child: SessionID.make(child) }
+          }),
+          "parent task never entered the running state",
+        )
+
+        const output = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            const msgs = yield* MessageV2.filterCompactedEffect(task.child)
+            const part = msgs.flatMap((msg) => msg.parts).find((part) => part.type === "tool" && part.tool === "bash")
+            if (part?.type !== "tool" || part.state.status !== "completed") return
+            return part.state.output
+          }),
+          "child bash tool never completed",
+        )
+
+        expect(output).toContain("child-bash-done")
+
+        const exit = yield* awaitWithTimeout(
+          Fiber.await(fiber),
+          "parent prompt remained stuck after the child stream stalled",
+          "5 seconds",
+        )
+        expect(Exit.isSuccess(exit)).toBe(true)
+        expect(yield* llm.calls).toBe(5)
+
+        const status = yield* SessionStatus.Service
+        expect((yield* status.get(chat.id)).type).toBe("idle")
+        expect((yield* status.get(task.child)).type).toBe("idle")
+
+        const parent = (yield* MessageV2.filterCompactedEffect(chat.id))
+          .flatMap((msg) => msg.parts)
+          .find((part) => part.type === "tool" && part.tool === "task")
+        expect(parent?.type === "tool" ? parent.state.status : undefined).toBe("completed")
+        expect(parent?.type === "tool" && parent.state.status === "completed" ? parent.state.output : "").toContain(
+          "child recovered",
+        )
+      }),
+      {
+        git: true,
+        config: (url) => ({
+          ...providerCfg(url, { chunkTimeout: 500 }),
+          permission: { task: "allow", bash: "allow" },
+        }),
+      },
+    ),
+  10_000,
 )

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -327,7 +327,7 @@ it.live(
         })
 
         const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkScoped)
-        yield* awaitWithTimeout(llm.wait(3), "child did not open its post-bash model request", "10 seconds")
+        yield* awaitWithTimeout(llm.wait(3), "child did not open its post-bash model request", "20 seconds")
 
         const task = yield* pollWithTimeout(
           Effect.gen(function* () {
@@ -356,7 +356,7 @@ it.live(
         const exit = yield* awaitWithTimeout(
           Fiber.await(fiber),
           "parent prompt remained stuck after the child stream stalled",
-          "5 seconds",
+          "10 seconds",
         )
         expect(Exit.isSuccess(exit)).toBe(true)
         expect(yield* llm.calls).toBe(5)
@@ -381,5 +381,5 @@ it.live(
         }),
       },
     ),
-  10_000,
+  30_000,
 )

--- a/packages/opencode/test/kilocode/session/llm.test.ts
+++ b/packages/opencode/test/kilocode/session/llm.test.ts
@@ -1,38 +1,46 @@
 import { describe, expect, test } from "bun:test"
 import { Effect, Stream } from "effect"
 import { LLMEvent } from "@opencode-ai/llm"
+import { STREAM_IDLE_TIMEOUT_MS, streamTimeout } from "@/kilocode/provider/provider"
 import { KiloLLM } from "@/kilocode/session/llm"
 
 describe("kilocode.session.llm.timeout", () => {
-  test("uses prepared options before the provider fallback", () => {
+  test("uses the prepared request timeout", () => {
     const result = KiloLLM.timeout({
       options: { chunkTimeout: 15_000 },
-      fallback: { chunkTimeout: 30_000 },
     })
 
     expect(result).toEqual({ timeout: { chunkMs: 15_000 } })
   })
 
-  test("uses the provider fallback when prepared options omit the timeout", () => {
-    const result = KiloLLM.timeout({
-      options: {},
-      fallback: { chunkTimeout: 30_000 },
-    })
-
-    expect(result).toEqual({ timeout: { chunkMs: 30_000 } })
-  })
-
-  test("uses the provider fallback when the prepared value is not a number", () => {
+  test("ignores invalid prepared values", () => {
     const result = KiloLLM.timeout({
       options: { chunkTimeout: "15_000" },
-      fallback: { chunkTimeout: 30_000 },
     })
 
-    expect(result).toEqual({ timeout: { chunkMs: 30_000 } })
+    expect(result).toEqual({})
   })
 
-  test("omits the timeout when it is not configured", () => {
+  test("omits the AI SDK timeout when it is not configured", () => {
     expect(KiloLLM.timeout({ options: {} })).toEqual({})
+  })
+
+  test("allows the AI SDK timeout to be disabled explicitly", () => {
+    expect(KiloLLM.timeout({ options: { chunkTimeout: 0 } })).toEqual({})
+  })
+})
+
+describe("kilocode.provider.streamTimeout", () => {
+  test("uses the default stream inactivity timeout", () => {
+    expect(streamTimeout({ options: {}, defaultMs: STREAM_IDLE_TIMEOUT_MS })).toBe(120_000)
+  })
+
+  test("prefers an explicit timeout over the default", () => {
+    expect(streamTimeout({ options: { chunkTimeout: 30_000 }, defaultMs: STREAM_IDLE_TIMEOUT_MS })).toBe(30_000)
+  })
+
+  test("allows the default timeout to be disabled", () => {
+    expect(streamTimeout({ options: { chunkTimeout: 0 }, defaultMs: STREAM_IDLE_TIMEOUT_MS })).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -62,7 +62,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readError(response)).message).toContain("idle timeout sending websocket request")
+    expect((await readError(response)).message).toContain("idle timeout sending websocket request") // kilocode_change
     expect(invalid).toEqual(["idle timeout sending websocket request"])
   })
 
@@ -111,6 +111,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error),
     })
 
+    // kilocode_change
     expect((await readError(response)).message).toContain(
       "WebSocket closed before response.completed (code 1009: message too big: payload too large)",
     )
@@ -135,7 +136,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readError(response)).message).toContain("Unexpected binary WebSocket frame")
+    expect((await readError(response)).message).toContain("Unexpected binary WebSocket frame") // kilocode_change
     expect(invalid).toEqual(["Unexpected binary WebSocket frame"])
   })
 })
@@ -196,8 +197,8 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
-    expect(await readError(first)).toBeInstanceOf(ProviderError.ResponseStreamError)
+    const first = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" })) // kilocode_change
+    expect(await readError(first)).toBeInstanceOf(ProviderError.ResponseStreamError) // kilocode_change
     const second = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
     const third = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
 
@@ -281,8 +282,8 @@ describe("plugin.openai.ws-pool", () => {
       url: server.url,
     })
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("Responses websocket connection limit reached")
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("Responses websocket connection limit reached") // kilocode_change
     const second = await fetch(server.url, streamRequest())
     const text = await second.text()
 
@@ -318,10 +319,10 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 2,
     })
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("Responses websocket connection limit reached")
-    const second = await fetch(server.url, streamRequest())
-    expect((await readError(second)).message).toContain("Responses websocket connection limit reached")
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("Responses websocket connection limit reached") // kilocode_change
+    const second = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(second)).message).toContain("Responses websocket connection limit reached") // kilocode_change
     const third = await fetch(server.url, streamRequest())
     const fourth = await fetch(server.url, streamRequest())
 
@@ -358,8 +359,8 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
     const second = await fetch(server.url, streamRequest())
 
     expect(await second.text()).toBe("http")
@@ -375,13 +376,13 @@ describe("plugin.openai.ws-pool", () => {
       socket.once("message", () => {})
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      idleTimeout: 1_000,
+      url: server.url, // kilocode_change
+      idleTimeout: 1_000, // kilocode_change
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("idle timeout waiting for websocket")
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("idle timeout waiting for websocket") // kilocode_change
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -393,22 +394,25 @@ describe("plugin.openai.ws-pool", () => {
   })
 
   test("falls back to HTTP after a failed websocket stream", async () => {
+    // kilocode_change
     await using server = await createWebSocketServer((socket) => {
       socket.once("message", () => {
         socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
       })
     })
+    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
       idleTimeout: 1_000,
       streamRetries: 0,
     })
+    // kilocode_change end
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("idle timeout waiting for websocket")
-    const second = await fetch(server.url, streamRequest())
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("idle timeout waiting for websocket") // kilocode_change
+    const second = await fetch(server.url, streamRequest()) // kilocode_change
 
-    expect(await second.text()).toBe("http")
+    expect(await second.text()).toBe("http") // kilocode_change
     expect(server.httpRequests).toHaveLength(1)
     fetch.close()
   })
@@ -429,16 +433,16 @@ describe("plugin.openai.ws-pool", () => {
       })
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url,
-      streamRetries: 1,
+      url: server.url, // kilocode_change
+      streamRetries: 1, // kilocode_change
     })
 
-    const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
+    const first = await fetch(server.url, streamRequest()) // kilocode_change
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
     const second = await fetch(server.url, streamRequest())
-    expect(await second.text()).toContain("data: [DONE]")
+    expect(await second.text()).toContain("data: [DONE]") // kilocode_change
     const third = await fetch(server.url, streamRequest())
-    expect((await readError(third)).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(third)).message).toContain("WebSocket closed before response.completed") // kilocode_change
     const fourth = await fetch(server.url, streamRequest())
 
     expect(await fourth.text()).toContain("data: [DONE]")
@@ -476,20 +480,22 @@ describe("plugin.openai.ws-pool", () => {
       })
     })
     const abort = new AbortController()
+    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
     })
+    // kilocode_change end
 
     const first = await fetch(server.url, streamRequest({}, abort.signal))
-    const firstError = readError(first)
+    const firstError = readError(first) // kilocode_change
     await waitFor(() => connections === 1, "websocket did not connect")
-    const second = await fetch(server.url, streamRequest())
+    const second = await fetch(server.url, streamRequest()) // kilocode_change
 
-    expect(await second.text()).toBe("http")
+    expect(await second.text()).toBe("http") // kilocode_change
     expect(server.httpRequests).toHaveLength(1)
-    expect(connections).toBe(1)
+    expect(connections).toBe(1) // kilocode_change
     abort.abort(new Error("stop"))
-    expect((await firstError).message).toContain("stop")
+    expect((await firstError).message).toContain("stop") // kilocode_change
     fetch.close()
   })
 
@@ -521,13 +527,15 @@ describe("plugin.openai.ws-pool", () => {
         socket.close(1001, "server shutdown")
       })
     })
+    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
       streamRetries: 1,
     })
+    // kilocode_change end
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -548,18 +556,20 @@ describe("plugin.openai.ws-pool", () => {
           return
         }
         socket.send(JSON.stringify({ type: "response.completed", response: { id: "resp_456" } }))
-      })
+      }) // kilocode_change
     })
+    // kilocode_change start
     const abort = new AbortController()
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
     })
+    // kilocode_change end
 
-    const first = await fetch(server.url, streamRequest({}, abort.signal))
-    const firstError = readError(first)
-    await waitFor(() => connections === 1, "first websocket did not connect")
+    const first = await fetch(server.url, streamRequest({}, abort.signal)) // kilocode_change
+    const firstError = readError(first) // kilocode_change
+    await waitFor(() => connections === 1, "first websocket did not connect") // kilocode_change
     abort.abort(new Error("stop"))
-    expect((await firstError).message).toContain("stop")
+    expect((await firstError).message).toContain("stop") // kilocode_change
 
     const second = await fetch(server.url, streamRequest())
 
@@ -601,15 +611,17 @@ describe("plugin.openai.ws-pool", () => {
 function streamRequest(headers?: Record<string, string>, signal?: AbortSignal): RequestInit {
   return {
     method: "POST",
+    // kilocode_change start
     headers: {
       "session-id": "session-1",
       authorization: "Bearer test",
       ...headers,
     },
-    body: JSON.stringify({ stream: true, input: "hi" }),
-    signal,
-  }
-}
+    // kilocode_change end
+    body: JSON.stringify({ stream: true, input: "hi" }), // kilocode_change
+    signal, // kilocode_change
+  } // kilocode_change
+} // kilocode_change
 
 // kilocode_change start - consume errored streams through an attached reader to avoid Bun Response.text races
 async function readError(response: Response) {

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -62,7 +62,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readError(response)).message).toContain("idle timeout sending websocket request") // kilocode_change
+    expect((await readTextError(response.text())).message).toContain("idle timeout sending websocket request")
     expect(invalid).toEqual(["idle timeout sending websocket request"])
   })
 
@@ -111,8 +111,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error),
     })
 
-    // kilocode_change
-    expect((await readError(response)).message).toContain(
+    expect((await readTextError(response.text())).message).toContain(
       "WebSocket closed before response.completed (code 1009: message too big: payload too large)",
     )
     expect(invalid[0]).toBeInstanceOf(ProviderError.ResponseStreamError)
@@ -136,7 +135,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readError(response)).message).toContain("Unexpected binary WebSocket frame") // kilocode_change
+    expect((await readTextError(response.text())).message).toContain("Unexpected binary WebSocket frame")
     expect(invalid).toEqual(["Unexpected binary WebSocket frame"])
   })
 })
@@ -197,8 +196,8 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" })) // kilocode_change
-    expect(await readError(first)).toBeInstanceOf(ProviderError.ResponseStreamError) // kilocode_change
+    const first = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
+    expect(await readTextError(first.text())).toBeInstanceOf(ProviderError.ResponseStreamError)
     const second = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
     const third = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
 
@@ -211,7 +210,7 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
-  test("prunes HTTP fallback after its idle timeout", async () => {
+  test("keeps HTTP fallback active after its idle timeout", async () => { // kilocode_change - port upstream #30586
     let websocketAttempts = 0
     await using server = await createRejectingWebSocketServer(() => websocketAttempts++)
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
@@ -227,7 +226,7 @@ describe("plugin.openai.ws-pool", () => {
     const second = await fetch(server.url, streamRequest())
 
     expect(await second.text()).toBe("http")
-    expect(websocketAttempts).toBe(2)
+    expect(websocketAttempts).toBe(1) // kilocode_change - port upstream #30586
     expect(server.httpRequests).toHaveLength(2)
     fetch.close()
   })
@@ -282,8 +281,8 @@ describe("plugin.openai.ws-pool", () => {
       url: server.url,
     })
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("Responses websocket connection limit reached") // kilocode_change
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("Responses websocket connection limit reached")
     const second = await fetch(server.url, streamRequest())
     const text = await second.text()
 
@@ -319,10 +318,10 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 2,
     })
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("Responses websocket connection limit reached") // kilocode_change
-    const second = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(second)).message).toContain("Responses websocket connection limit reached") // kilocode_change
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("Responses websocket connection limit reached")
+    const second = await fetch(server.url, streamRequest())
+    expect((await readTextError(second.text())).message).toContain("Responses websocket connection limit reached")
     const third = await fetch(server.url, streamRequest())
     const fourth = await fetch(server.url, streamRequest())
 
@@ -359,8 +358,8 @@ describe("plugin.openai.ws-pool", () => {
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
 
     expect(await second.text()).toBe("http")
@@ -376,13 +375,13 @@ describe("plugin.openai.ws-pool", () => {
       socket.once("message", () => {})
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url, // kilocode_change
-      idleTimeout: 1_000, // kilocode_change
+      url: server.url,
+      idleTimeout: 20,
       streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("idle timeout waiting for websocket") // kilocode_change
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -393,29 +392,37 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
-  test("falls back to HTTP after a failed websocket stream", async () => {
-    // kilocode_change
+  // kilocode_change start - port upstream #33387
+  test("retries failed websocket streams before using HTTP fallback", async () => {
+    const attempts: Array<(socket: WebSocket) => void> = []
     await using server = await createWebSocketServer((socket) => {
       socket.once("message", () => {
         socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
+        attempts.shift()?.(socket)
       })
     })
-    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 1_000,
-      streamRetries: 0,
+      streamRetries: 1,
     })
-    // kilocode_change end
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("idle timeout waiting for websocket") // kilocode_change
-    const second = await fetch(server.url, streamRequest()) // kilocode_change
+    const firstAttempt = new Promise<WebSocket>((resolve) => attempts.push(resolve))
+    const first = await fetch(server.url, streamRequest())
+    const firstSocket = await firstAttempt
+    firstSocket.terminate()
+    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
+    const secondAttempt = new Promise<WebSocket>((resolve) => attempts.push(resolve))
+    const second = await fetch(server.url, streamRequest())
+    const secondSocket = await secondAttempt
+    secondSocket.terminate()
+    expect((await readTextError(second.text())).message).toContain("WebSocket closed before response.completed")
+    const third = await fetch(server.url, streamRequest())
 
-    expect(await second.text()).toBe("http") // kilocode_change
+    expect(await third.text()).toBe("http")
     expect(server.httpRequests).toHaveLength(1)
     fetch.close()
   })
+  // kilocode_change end
 
   test("resets websocket stream failures after a completed response", async () => {
     let connections = 0
@@ -433,16 +440,16 @@ describe("plugin.openai.ws-pool", () => {
       })
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
-      url: server.url, // kilocode_change
-      streamRetries: 1, // kilocode_change
+      url: server.url,
+      streamRetries: 1,
     })
 
-    const first = await fetch(server.url, streamRequest()) // kilocode_change
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
-    expect(await second.text()).toContain("data: [DONE]") // kilocode_change
+    expect(await second.text()).toContain("data: [DONE]")
     const third = await fetch(server.url, streamRequest())
-    expect((await readError(third)).message).toContain("WebSocket closed before response.completed") // kilocode_change
+    expect((await readTextError(third.text())).message).toContain("WebSocket closed before response.completed")
     const fourth = await fetch(server.url, streamRequest())
 
     expect(await fourth.text()).toContain("data: [DONE]")
@@ -480,22 +487,20 @@ describe("plugin.openai.ws-pool", () => {
       })
     })
     const abort = new AbortController()
-    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
     })
-    // kilocode_change end
 
     const first = await fetch(server.url, streamRequest({}, abort.signal))
-    const firstError = readError(first) // kilocode_change
+    const firstText = first.text()
     await waitFor(() => connections === 1, "websocket did not connect")
-    const second = await fetch(server.url, streamRequest()) // kilocode_change
+    const second = await fetch(server.url, streamRequest())
 
-    expect(await second.text()).toBe("http") // kilocode_change
+    expect(await second.text()).toBe("http")
     expect(server.httpRequests).toHaveLength(1)
-    expect(connections).toBe(1) // kilocode_change
+    expect(connections).toBe(1)
     abort.abort(new Error("stop"))
-    expect((await firstError).message).toContain("stop") // kilocode_change
+    expect((await readTextError(firstText)).message).toContain("stop")
     fetch.close()
   })
 
@@ -527,15 +532,13 @@ describe("plugin.openai.ws-pool", () => {
         socket.close(1001, "server shutdown")
       })
     })
-    // kilocode_change start
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
       streamRetries: 1,
     })
-    // kilocode_change end
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readError(first)).message).toContain("WebSocket closed before response.completed") // kilocode_change
+    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -556,20 +559,18 @@ describe("plugin.openai.ws-pool", () => {
           return
         }
         socket.send(JSON.stringify({ type: "response.completed", response: { id: "resp_456" } }))
-      }) // kilocode_change
+      })
     })
-    // kilocode_change start
     const abort = new AbortController()
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
     })
-    // kilocode_change end
 
-    const first = await fetch(server.url, streamRequest({}, abort.signal)) // kilocode_change
-    const firstError = readError(first) // kilocode_change
-    await waitFor(() => connections === 1, "first websocket did not connect") // kilocode_change
+    const first = await fetch(server.url, streamRequest({}, abort.signal))
+    const firstText = first.text()
+    await waitFor(() => connections === 1, "first websocket did not connect")
     abort.abort(new Error("stop"))
-    expect((await firstError).message).toContain("stop") // kilocode_change
+    expect((await readTextError(firstText)).message).toContain("stop")
 
     const second = await fetch(server.url, streamRequest())
 
@@ -611,38 +612,28 @@ describe("plugin.openai.ws-pool", () => {
 function streamRequest(headers?: Record<string, string>, signal?: AbortSignal): RequestInit {
   return {
     method: "POST",
-    // kilocode_change start
     headers: {
       "session-id": "session-1",
       authorization: "Bearer test",
       ...headers,
     },
-    // kilocode_change end
-    body: JSON.stringify({ stream: true, input: "hi" }), // kilocode_change
-    signal, // kilocode_change
-  } // kilocode_change
-} // kilocode_change
-
-// kilocode_change start - consume errored streams through an attached reader to avoid Bun Response.text races
-async function readError(response: Response) {
-  if (!response.ok) {
-    const body = (await response.json()) as { error?: { message?: string } }
-    return new ProviderError.ResponseStreamError(body.error?.message ?? `HTTP ${response.status}`)
+    body: JSON.stringify({ stream: true, input: "hi" }),
+    signal,
   }
-  const reader = response.body?.getReader()
-  if (!reader) throw new Error("Expected response body")
-  try {
-    for (;;) {
-      const chunk = await reader.read()
-      if (chunk.done) break
-    }
-  } catch (error) {
-    expect(error).toBeInstanceOf(Error)
-    return error as Error
-  }
-  throw new Error("Expected response body to reject")
 }
-// kilocode_change end
+
+async function readTextError(promise: Promise<string>) {
+  // Bun 1.3.14 hangs on expect(response.text()).rejects for streams errored from ws callbacks.
+  return promise.then(
+    () => {
+      throw new Error("Expected response text to reject")
+    },
+    (error) => {
+      expect(error).toBeInstanceOf(Error)
+      return error as Error
+    },
+  )
+}
 
 async function createWebSocketServer(onConnection: (socket: WebSocket, request: IncomingMessage) => void) {
   const http = await createHttpServer()

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -62,7 +62,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readTextError(response.text())).message).toContain("idle timeout sending websocket request")
+    expect((await readError(response)).message).toContain("idle timeout sending websocket request")
     expect(invalid).toEqual(["idle timeout sending websocket request"])
   })
 
@@ -111,7 +111,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error),
     })
 
-    expect((await readTextError(response.text())).message).toContain(
+    expect((await readError(response)).message).toContain(
       "WebSocket closed before response.completed (code 1009: message too big: payload too large)",
     )
     expect(invalid[0]).toBeInstanceOf(ProviderError.ResponseStreamError)
@@ -135,7 +135,7 @@ describe("plugin.openai.ws", () => {
       onConnectionInvalid: (error) => invalid.push(error.message),
     })
 
-    expect((await readTextError(response.text())).message).toContain("Unexpected binary WebSocket frame")
+    expect((await readError(response)).message).toContain("Unexpected binary WebSocket frame")
     expect(invalid).toEqual(["Unexpected binary WebSocket frame"])
   })
 })
@@ -197,7 +197,7 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
-    expect(await readTextError(first.text())).toBeInstanceOf(ProviderError.ResponseStreamError)
+    expect(await readError(first)).toBeInstanceOf(ProviderError.ResponseStreamError)
     const second = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
     const third = await fetch(server.url, streamRequest({ [TITLE_HEADER]: "false" }))
 
@@ -282,7 +282,7 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("Responses websocket connection limit reached")
+    expect((await readError(first)).message).toContain("Responses websocket connection limit reached")
     const second = await fetch(server.url, streamRequest())
     const text = await second.text()
 
@@ -319,9 +319,9 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("Responses websocket connection limit reached")
+    expect((await readError(first)).message).toContain("Responses websocket connection limit reached")
     const second = await fetch(server.url, streamRequest())
-    expect((await readTextError(second.text())).message).toContain("Responses websocket connection limit reached")
+    expect((await readError(second)).message).toContain("Responses websocket connection limit reached")
     const third = await fetch(server.url, streamRequest())
     const fourth = await fetch(server.url, streamRequest())
 
@@ -359,7 +359,7 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
 
     expect(await second.text()).toBe("http")
@@ -376,12 +376,12 @@ describe("plugin.openai.ws-pool", () => {
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 20,
+      idleTimeout: 1_000,
       streamRetries: 1,
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
+    expect((await readError(first)).message).toContain("idle timeout waiting for websocket")
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -392,7 +392,7 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
-  test("retries failed websocket streams before using HTTP fallback", async () => {
+  test("falls back to HTTP after a failed websocket stream", async () => {
     await using server = await createWebSocketServer((socket) => {
       socket.once("message", () => {
         socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
@@ -400,17 +400,15 @@ describe("plugin.openai.ws-pool", () => {
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 20,
-      streamRetries: 1,
+      idleTimeout: 1_000,
+      streamRetries: 0,
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
+    expect((await readError(first)).message).toContain("idle timeout waiting for websocket")
     const second = await fetch(server.url, streamRequest())
-    expect((await readTextError(second.text())).message).toContain("idle timeout waiting for websocket")
-    const third = await fetch(server.url, streamRequest())
 
-    expect(await third.text()).toBe("http")
+    expect(await second.text()).toBe("http")
     expect(server.httpRequests).toHaveLength(1)
     fetch.close()
   })
@@ -436,11 +434,11 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
     expect(await second.text()).toContain("data: [DONE]")
     const third = await fetch(server.url, streamRequest())
-    expect((await readTextError(third.text())).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(third)).message).toContain("WebSocket closed before response.completed")
     const fourth = await fetch(server.url, streamRequest())
 
     expect(await fourth.text()).toContain("data: [DONE]")
@@ -483,7 +481,7 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest({}, abort.signal))
-    const firstText = first.text()
+    const firstError = readError(first)
     await waitFor(() => connections === 1, "websocket did not connect")
     const second = await fetch(server.url, streamRequest())
 
@@ -491,7 +489,7 @@ describe("plugin.openai.ws-pool", () => {
     expect(server.httpRequests).toHaveLength(1)
     expect(connections).toBe(1)
     abort.abort(new Error("stop"))
-    expect((await readTextError(firstText)).message).toContain("stop")
+    expect((await firstError).message).toContain("stop")
     fetch.close()
   })
 
@@ -529,7 +527,7 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
+    expect((await readError(first)).message).toContain("WebSocket closed before response.completed")
     const second = await fetch(server.url, streamRequest())
     const third = await fetch(server.url, streamRequest())
 
@@ -558,10 +556,10 @@ describe("plugin.openai.ws-pool", () => {
     })
 
     const first = await fetch(server.url, streamRequest({}, abort.signal))
-    const firstText = first.text()
+    const firstError = readError(first)
     await waitFor(() => connections === 1, "first websocket did not connect")
     abort.abort(new Error("stop"))
-    expect((await readTextError(firstText)).message).toContain("stop")
+    expect((await firstError).message).toContain("stop")
 
     const second = await fetch(server.url, streamRequest())
 
@@ -613,18 +611,26 @@ function streamRequest(headers?: Record<string, string>, signal?: AbortSignal): 
   }
 }
 
-async function readTextError(promise: Promise<string>) {
-  // Bun 1.3.14 hangs on expect(response.text()).rejects for streams errored from ws callbacks.
-  return promise.then(
-    () => {
-      throw new Error("Expected response text to reject")
-    },
-    (error) => {
-      expect(error).toBeInstanceOf(Error)
-      return error as Error
-    },
-  )
+// kilocode_change start - consume errored streams through an attached reader to avoid Bun Response.text races
+async function readError(response: Response) {
+  if (!response.ok) {
+    const body = (await response.json()) as { error?: { message?: string } }
+    return new ProviderError.ResponseStreamError(body.error?.message ?? `HTTP ${response.status}`)
+  }
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error("Expected response body")
+  try {
+    for (;;) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+    }
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error)
+    return error as Error
+  }
+  throw new Error("Expected response body to reject")
 }
+// kilocode_change end
 
 async function createWebSocketServer(onConnection: (socket: WebSocket, request: IncomingMessage) => void) {
   const http = await createHttpServer()

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -482,7 +482,10 @@ describe("tool.task", () => {
         )
         // kilocode_change end
         expect(seen?.tools).toEqual({
-          question: false, // kilocode_change - subagents cannot prompt the user directly
+          // kilocode_change start - subagents cannot prompt the user directly
+          question: false,
+          suggest: false,
+          // kilocode_change end
           todowrite: false,
           task: false, // kilocode_change - Kilo disallows nested subagents
           bash: false,


### PR DESCRIPTION
Foreground subagents could remain running indefinitely through two independent client-side wait paths.

A child could finish a command, begin the next model response, emit reasoning, and then receive no further stream data while the HTTP response remained open. Without a default chunk timeout, the stream neither completed nor failed, so session retry never ran and the parent Task continued awaiting the busy child.

Subagents also inherited the interactive `suggest` tool. Calling it waits for a human to accept or dismiss an action, but a Task child has no reliable direct interaction surface. The child could therefore wait inside the tool while the parent only reported the Task as in progress.

The response transport now applies a two-minute default idle timeout between SSE reads. Inactivity becomes the existing retryable `ProviderResponseStreamError`, allowing normal session retry to resume the child. Explicit `chunkTimeout` values still override the default, and `0` continues to disable it. Provider-level timeout handling remains in the fetch wrapper so it preserves the typed failure required by the retry path.

Task child prompts now disable `suggest`, matching the existing restriction on `question`, so subagents cannot enter a human-interaction wait.

The WebSocket retry tests and fallback lifecycle also include the corresponding later OpenCode fixes. Exhausted HTTP fallback state is retained instead of being pruned by the stream idle interval, and retry-failure tests terminate sockets through explicit readiness signals rather than depending on short wall-clock timeouts.