### PR TITLE
fix(vscode): preserve code index across updates

### DIFF
--- a/.changeset/persist-index-updates.md
+++ b/.changeset/persist-index-updates.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve unchanged codebase indexes when extension or VS Code updates interrupt an incremental scan.

--- a/packages/kilo-indexing/src/indexing/orchestrator.ts
+++ b/packages/kilo-indexing/src/indexing/orchestrator.ts
@@ -277,6 +277,8 @@ export class CodeIndexOrchestrator {
 
   private async _runScan(mode: IndexingTelemetryMode, trigger: IndexingTelemetryTrigger): Promise<void> {
     if (this._cancelRequested) {
+      if (mode === "incremental") await this.vectorStore.markIndexingComplete()
+      this.stateManager.setSystemState("Standby", "Indexing cancelled.")
       log.info("scan skipped: cancellation was requested", { workspacePath: this.workspacePath, mode })
       return
     }
@@ -319,6 +321,10 @@ export class CodeIndexOrchestrator {
     })
 
     if (this._cancelRequested || this.scanner.isCancelled) {
+      if (mode === "incremental" && result.stats.processed === 0 && batchErrors.length === 0) {
+        await this.vectorStore.markIndexingComplete()
+        log.info("preserved unchanged index after cancelled scan", { workspacePath: this.workspacePath })
+      }
       this._isProcessing = false
       if (this.stateManager.state !== "Error") {
         this.stateManager.setSystemState("Standby", "Indexing cancelled.")

--- a/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
@@ -18,7 +18,9 @@ import { Emitter } from "../../../src/indexing/runtime"
 class Store {
   public clearCount = 0
   public closeCount = 0
+  public completeCount = 0
   public deleteCount = 0
+  public incompleteCount = 0
 
   constructor(
     private readonly existing: boolean,
@@ -57,8 +59,12 @@ class Store {
   async hasIndexedData(): Promise<boolean> {
     return this.existing
   }
-  async markIndexingComplete(): Promise<void> {}
-  async markIndexingIncomplete(): Promise<void> {}
+  async markIndexingComplete(): Promise<void> {
+    this.completeCount += 1
+  }
+  async markIndexingIncomplete(): Promise<void> {
+    this.incompleteCount += 1
+  }
 }
 
 class Scanner {
@@ -270,6 +276,31 @@ describe("CodeIndexOrchestrator telemetry", () => {
 
     expect(scanner.finished).toBe(true)
     expect(store.closeCount).toBe(1)
+    expect(store.incompleteCount).toBe(1)
+    expect(store.completeCount).toBe(0)
+  })
+
+  test("preserves an unchanged index when an incremental scan is interrupted", async () => {
+    const scanner = new BlockingScanner()
+    const store = new Store(true)
+    const orchestrator = new CodeIndexOrchestrator(
+      createConfig(),
+      new CodeIndexStateManager(),
+      "/tmp/ws",
+      { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+      store as unknown as IVectorStore,
+      scanner as unknown as DirectoryScanner,
+      new Watcher() as unknown as IFileWatcher,
+    )
+
+    const active = orchestrator.startIndexing("background")
+    await scanner.started.promise
+    await orchestrator.shutdown()
+    await active
+
+    expect(store.incompleteCount).toBe(1)
+    expect(store.completeCount).toBe(1)
+    expect(store.clearCount).toBe(0)
   })
 
   test("clears stale vectors and hashes before rebuilding an incomplete store", async () => {


### PR DESCRIPTION
When VS Code shuts down during an unchanged incremental scan, the index can remain marked incomplete. The next extension startup treats that otherwise valid index as stale and rebuilds it from scratch, making extension updates appear to discard codebase indexing progress.

Preserve the complete marker when cancellation occurs before an incremental scan processes any changes. Interrupted full scans and incremental scans that already mutated data remain incomplete so recovery still rebuilds potentially inconsistent indexes.

Closes #11581