### PR TITLE
feat(sandbox): prototype Zig Windows confinement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,16 @@ jobs:
 
       - name: Setup Zig
         if: runner.os == 'Windows'
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.16.0
+        shell: pwsh
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP "zig-0.16.0.zip"
+          $target = Join-Path $env:RUNNER_TEMP "zig-0.16.0"
+          Invoke-WebRequest "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip" -OutFile $archive
+          $actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          $expected = "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e"
+          if ($actual -ne $expected) { throw "Unexpected Zig archive checksum: $actual" }
+          Expand-Archive $archive -DestinationPath $target
+          Add-Content $env:GITHUB_PATH (Join-Path $target "zig-x86_64-windows-0.16.0")
 
       - name: Build Windows sandbox helpers
         if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,23 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
 
+      - name: Setup Zig
+        if: runner.os == 'Windows'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Build Windows sandbox helpers
+        if: runner.os == 'Windows'
+        working-directory: packages/kilo-sandbox/windows
+        run: |
+          zig build test
+          zig build -Dtarget=x86_64-windows-gnu -Doptimize=Debug --prefix dist/windows-x64
+          zig build -Dtarget=aarch64-windows-gnu -Doptimize=Debug --prefix dist/windows-arm64
+          echo "KILO_WINDOWS_SANDBOX_HELPER=$(cygpath -w "$PWD/dist/windows-x64/bin/kilo-sandbox-windows.exe")" >> "$GITHUB_ENV"
+          echo "KILO_WINDOWS_SANDBOX_PROTOTYPE=1" >> "$GITHUB_ENV"
+          echo "NODE_ENV=test" >> "$GITHUB_ENV"
+
       - name: Configure git identity
         run: |
           git config --global user.email "kilo-maintainer[bot]@users.noreply.github.com"
@@ -107,6 +124,16 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: packages/*/.artifacts/unit/junit.xml
+
+      - name: Upload Windows sandbox comparison helpers
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: zig-windows-sandbox-${{ github.sha }}-${{ github.run_attempt }}
+          retention-days: 7
+          path: |
+            packages/kilo-sandbox/windows/dist/windows-x64/bin/kilo-sandbox-windows.exe
+            packages/kilo-sandbox/windows/dist/windows-arm64/bin/kilo-sandbox-windows.exe
   # kilocode_change end
 
   # kilocode_change start

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
           zig build -Dtarget=x86_64-windows-gnu -Doptimize=Debug --prefix dist/windows-x64
           zig build -Dtarget=aarch64-windows-gnu -Doptimize=Debug --prefix dist/windows-arm64
           echo "KILO_WINDOWS_SANDBOX_HELPER=$(cygpath -w "$PWD/dist/windows-x64/bin/kilo-sandbox-windows.exe")" >> "$GITHUB_ENV"
+          echo "KILO_WINDOWS_SANDBOX_PROBE=$(cygpath -w "$PWD/dist/windows-x64/bin/kilo-sandbox-windows-probe.exe")" >> "$GITHUB_ENV"
           echo "KILO_WINDOWS_SANDBOX_PROTOTYPE=1" >> "$GITHUB_ENV"
           echo "NODE_ENV=test" >> "$GITHUB_ENV"
 
@@ -144,8 +145,8 @@ jobs:
           name: zig-windows-sandbox-${{ github.sha }}-${{ github.run_attempt }}
           retention-days: 7
           path: |
-            packages/kilo-sandbox/windows/dist/windows-x64/bin/kilo-sandbox-windows.exe
-            packages/kilo-sandbox/windows/dist/windows-arm64/bin/kilo-sandbox-windows.exe
+            packages/kilo-sandbox/windows/dist/windows-x64/bin/kilo-sandbox-windows*.exe
+            packages/kilo-sandbox/windows/dist/windows-arm64/bin/kilo-sandbox-windows*.exe
   # kilocode_change end
 
   # kilocode_change start

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,11 @@ jobs:
           echo "KILO_WINDOWS_SANDBOX_PROTOTYPE=1" >> "$GITHUB_ENV"
           echo "NODE_ENV=test" >> "$GITHUB_ENV"
 
+      - name: Run Windows sandbox kernel test
+        if: runner.os == 'Windows'
+        working-directory: packages/kilo-sandbox
+        run: bun test test/windows.integration.test.ts --timeout 30000
+
       - name: Configure git identity
         run: |
           git config --global user.email "kilo-maintainer[bot]@users.noreply.github.com"
@@ -133,7 +138,7 @@ jobs:
           path: packages/*/.artifacts/unit/junit.xml
 
       - name: Upload Windows sandbox comparison helpers
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && always()
         uses: actions/upload-artifact@v7
         with:
           name: zig-windows-sandbox-${{ github.sha }}-${{ github.run_attempt }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
 
+      # kilocode_change start
       - name: Setup Zig
         if: runner.os == 'Windows'
         shell: pwsh
@@ -92,6 +93,7 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: packages/kilo-sandbox
         run: bun test test/windows.integration.test.ts --timeout 30000
+      # kilocode_change end
 
       - name: Configure git identity
         run: |
@@ -137,16 +139,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: packages/*/.artifacts/unit/junit.xml
-
-      - name: Upload Windows sandbox comparison helpers
-        if: runner.os == 'Windows' && always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: zig-windows-sandbox-${{ github.sha }}-${{ github.run_attempt }}
-          retention-days: 7
-          path: |
-            packages/kilo-sandbox/windows/dist/windows-x64/bin/kilo-sandbox-windows*.exe
-            packages/kilo-sandbox/windows/dist/windows-arm64/bin/kilo-sandbox-windows*.exe
   # kilocode_change end
 
   # kilocode_change start

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ tsconfig.tsbuildinfo
 # Test Artifacts
 packages/app/.artifacts/
 packages/opencode/.artifacts/
+packages/kilo-sandbox/.artifacts/

--- a/packages/kilo-sandbox/package.json
+++ b/packages/kilo-sandbox/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "typecheck": "tsgo --noEmit",
-    "test": "bun test --timeout 30000"
+    "test": "bun test --timeout 30000",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
   },
   "dependencies": {
     "effect": "catalog:"

--- a/packages/kilo-sandbox/src/backend.ts
+++ b/packages/kilo-sandbox/src/backend.ts
@@ -3,6 +3,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { current } from "./context"
 import type { Profile } from "./profile"
 import { seatbelt } from "./seatbelt"
+import { windows } from "./windows"
 
 export interface Launch {
   readonly command: string
@@ -19,7 +20,7 @@ export interface Support {
 
 export interface Backend {
   readonly support: Support
-  readonly prepare: (profile: Profile, launch: Launch) => Effect.Effect<Launch, never, Scope.Scope>
+  readonly prepare: (profile: Profile, launch: Launch) => Effect.Effect<Launch, PlatformError.PlatformError, Scope.Scope>
 }
 
 function unavailable(reason: string): Backend {
@@ -36,7 +37,7 @@ function select(): Backend {
     case "linux":
       return unavailable("The Linux sandbox backend is not available")
     case "win32":
-      return unavailable("The Windows sandbox backend is not available")
+      return windows
     default:
       return unavailable("No sandbox backend is available for this operating system")
   }

--- a/packages/kilo-sandbox/src/windows.ts
+++ b/packages/kilo-sandbox/src/windows.ts
@@ -1,0 +1,195 @@
+import { closeSync, existsSync, mkdtempSync, openSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { Effect, PlatformError } from "effect"
+import type { Backend, Launch, Support } from "./backend"
+import type { PathRule, Profile } from "./profile"
+
+export const protocol = 1
+const executable = "kilo-sandbox-windows.exe"
+const prototype = process.env.KILO_WINDOWS_SANDBOX_PROTOTYPE === "1"
+const limit = {
+  args: 4096,
+  rules: 4096,
+  names: 1024,
+  text: 32 * 1024,
+  request: 1024 * 1024,
+} as const
+
+export interface WindowsRequest {
+  readonly version: number
+  readonly command: string
+  readonly args: ReadonlyArray<string>
+  readonly cwd: string
+  readonly allowWrite: ReadonlyArray<PathRule>
+  readonly denyWrite: ReadonlyArray<PathRule>
+  readonly denyNames: ReadonlyArray<string>
+  readonly temporaryDirectory?: string | undefined
+}
+
+function value(env: Readonly<Record<string, string | undefined>>, key: string) {
+  const found = Object.keys(env).find((item) => item.toLowerCase() === key.toLowerCase())
+  return found === undefined ? undefined : env[found]
+}
+
+function extensions(env: Readonly<Record<string, string | undefined>>) {
+  const source = value(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD"
+  return source
+    .split(";")
+    .map((item) => item.trim())
+    .filter((item) => item.startsWith(".") && !item.includes("/") && !item.includes("\\"))
+}
+
+function candidates(command: string, env: Readonly<Record<string, string | undefined>>) {
+  if (path.win32.extname(command)) return [command]
+  return extensions(env).map((ext) => `${command}${ext}`)
+}
+
+function file(target: string) {
+  try {
+    return statSync(target).isFile()
+  } catch (err) {
+    if (typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT") return false
+    throw err
+  }
+}
+
+export function resolveExecutable(
+  command: string,
+  cwd: string,
+  env: Readonly<Record<string, string | undefined>>,
+  exists: (target: string) => boolean = file,
+) {
+  const direct = path.win32.isAbsolute(command) || command.includes("/") || command.includes("\\")
+  const roots = direct
+    ? [path.win32.isAbsolute(command) ? "" : cwd]
+    : (value(env, "PATH") ?? "")
+        .split(";")
+        .filter((item) => item.length > 0)
+  for (const root of roots) {
+    for (const candidate of candidates(command, env)) {
+      const target = path.win32.resolve(root, candidate)
+      if (exists(target)) return target
+    }
+  }
+  return undefined
+}
+
+function text(value: string) {
+  return value.length <= limit.text && !value.includes("\0")
+}
+
+function bounded(values: ReadonlyArray<string>, max: number) {
+  return values.length <= max && values.every(text)
+}
+
+export function request(profile: Profile, launch: Launch, command: string): WindowsRequest | undefined {
+  const rules = [...profile.filesystem.allowWrite, ...profile.filesystem.denyWrite]
+  if (!text(command) || launch.cwd === undefined || !text(launch.cwd)) return undefined
+  if (!bounded(launch.args, limit.args) || !bounded(profile.filesystem.denyNames, limit.names)) return undefined
+  if (rules.length > limit.rules || rules.some((rule) => !text(rule.path))) return undefined
+  if (profile.filesystem.temporaryDirectory !== undefined && !text(profile.filesystem.temporaryDirectory)) return undefined
+  const result: WindowsRequest = {
+    version: protocol,
+    command,
+    args: launch.args,
+    cwd: launch.cwd,
+    allowWrite: profile.filesystem.allowWrite,
+    denyWrite: profile.filesystem.denyWrite,
+    denyNames: profile.filesystem.denyNames,
+    ...(profile.filesystem.temporaryDirectory === undefined
+      ? {}
+      : { temporaryDirectory: profile.filesystem.temporaryDirectory }),
+  }
+  return Buffer.byteLength(JSON.stringify(result), "utf8") <= limit.request ? result : undefined
+}
+
+function failure(command: string, description: string, cause?: unknown) {
+  return PlatformError.systemError({
+    _tag: "PermissionDenied",
+    module: "Sandbox",
+    method: "prepareWindowsCommand",
+    pathOrDescriptor: command,
+    description,
+    cause,
+  })
+}
+
+function helper() {
+  const override = process.env.KILO_WINDOWS_SANDBOX_HELPER
+  const dev = process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test" || process.env.BUN_ENV === "test"
+  if (dev && override && path.win32.isAbsolute(override)) return override
+  return path.join(path.dirname(process.execPath), executable)
+}
+
+function sanitize(env: Readonly<Record<string, string | undefined>>) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => {
+      const name = key.toUpperCase()
+      return name !== "KILO_WINDOWS_SANDBOX_HELPER" && name !== "KILO_WINDOWS_SANDBOX_PROTOTYPE"
+    }),
+  )
+}
+
+export function generate(
+  profile: Profile,
+  launch: Launch,
+  bin = helper(),
+  exists: (target: string) => boolean = file,
+  ready: (target: string) => boolean = existsSync,
+) {
+  return Effect.gen(function* () {
+    if (!path.win32.isAbsolute(bin) || !ready(bin)) {
+      return yield* Effect.fail(failure(launch.command, "Windows sandbox helper is not available"))
+    }
+    if (profile.filesystem.allowWrite.some((rule) => rule.kind !== "subtree")) {
+      return yield* Effect.fail(failure(launch.command, "Windows sandbox only supports subtree allow rules"))
+    }
+    const cwd = path.win32.resolve(launch.cwd ?? process.cwd())
+    const env = launch.environment ?? {}
+    const shell = typeof launch.shell === "string" ? launch.shell : value(env, "COMSPEC") ?? "cmd.exe"
+    const source = launch.shell ? shell : launch.command
+    const command = resolveExecutable(source, cwd, env, exists)
+    if (!command) {
+      return yield* Effect.fail(failure(source, "Could not securely resolve the sandboxed executable"))
+    }
+    const name = path.win32.basename(command).toLowerCase()
+    const args = launch.shell
+      ? name === "cmd.exe" || name === "cmd"
+        ? ["/d", "/s", "/c", launch.command]
+        : ["-c", launch.command]
+      : launch.args
+    const body = request(profile, { ...launch, args, cwd, shell: false }, command)
+    if (!body) return yield* Effect.fail(failure(launch.command, "Windows sandbox request exceeds protocol limits"))
+    const file = yield* Effect.acquireRelease(
+      Effect.try({
+        try: () => {
+          const dir = mkdtempSync(path.join(tmpdir(), "kilo-sandbox-"))
+          const target = path.join(dir, "request.json")
+          const fd = openSync(target, "wx", 0o600)
+          try {
+            writeFileSync(fd, JSON.stringify(body), "utf8")
+          } finally {
+            closeSync(fd)
+          }
+          return { dir, target }
+        },
+        catch: (cause) => failure(launch.command, "Could not create the Windows sandbox request", cause),
+      }),
+      (item) => Effect.sync(() => rmSync(item.dir, { recursive: true, force: true })),
+    )
+    return { ...launch, command: bin, args: ["--request", file.target], environment: sanitize(env), shell: false }
+  })
+}
+
+const target = helper()
+const support: Support = !prototype
+  ? { available: false, reason: "The Windows sandbox backend is prototype-only" }
+  : existsSync(target)
+    ? { available: true }
+    : { available: false, reason: `${target} is not available` }
+
+export const windows: Backend = {
+  support,
+  prepare: generate,
+}

--- a/packages/kilo-sandbox/src/windows.ts
+++ b/packages/kilo-sandbox/src/windows.ts
@@ -126,7 +126,11 @@ function sanitize(env: Readonly<Record<string, string | undefined>>) {
   return Object.fromEntries(
     Object.entries(env).filter(([key]) => {
       const name = key.toUpperCase()
-      return name !== "KILO_WINDOWS_SANDBOX_HELPER" && name !== "KILO_WINDOWS_SANDBOX_PROTOTYPE"
+      return (
+        name !== "KILO_WINDOWS_SANDBOX_HELPER" &&
+        name !== "KILO_WINDOWS_SANDBOX_PROBE" &&
+        name !== "KILO_WINDOWS_SANDBOX_PROTOTYPE"
+      )
     }),
   )
 }

--- a/packages/kilo-sandbox/test/backend.test.ts
+++ b/packages/kilo-sandbox/test/backend.test.ts
@@ -63,7 +63,8 @@ describe("sandbox launch preparation", () => {
   })
 
   test("merges profile environment values and applies exact deny names", async () => {
-    const result = await Effect.runPromise(Effect.scoped(run(makeProfile(), prepare(launch))))
+    const target = { ...launch, command: process.execPath, cwd: process.cwd() }
+    const result = await Effect.runPromise(Effect.scoped(run(makeProfile(), prepare(target))))
     expect(result.environment?.KEEP).toBe("profile")
     expect(result.environment?.DROP).toBeUndefined()
     expect(result.environment?.RESET).toBeUndefined()

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -86,7 +86,9 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
             stdout: "pipe",
             stderr: "pipe",
           })
-          expect(child.exitCode).toBe(0)
+          if (child.exitCode !== 0) {
+            throw new Error(`Windows sandbox helper exited ${child.exitCode}: ${child.stderr.toString()}`)
+          }
           return child.stdout.toString()
         }),
       ),

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -10,15 +10,6 @@ import { generate, resolveExecutable } from "../src/windows"
 const helper = process.env.KILO_WINDOWS_SANDBOX_HELPER
 const enabled = process.platform === "win32" && helper !== undefined && path.win32.isAbsolute(helper)
 
-function write(target: string) {
-  try {
-    writeFileSync(target, "ok")
-    return true
-  } catch {
-    return false
-  }
-}
-
 test.skipIf(!enabled)("Windows helper enforces writes through the generated backend launch", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "kilo-sandbox-windows-"))
   const project = path.join(root, "project")
@@ -28,7 +19,33 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
   mkdirSync(git, { recursive: true })
   mkdirSync(temp)
   mkdirSync(external)
+
+  const paths = {
+    project: path.join(project, "project.txt"),
+    external: path.join(external, "external.txt"),
+    git: path.join(git, "config"),
+    temp: path.join(temp, "temp.txt"),
+    child: path.join(external, "child.txt"),
+  }
+  const child = path.join(project, "child.cmd")
+  const script = path.join(project, "probe.cmd")
+  const blocked = path.join(project, "blocked.cmd")
   const marker = path.join(external, "target-started")
+  writeFileSync(child, `@echo off\r\necho bad>"${paths.child}"\r\nexit /b 0\r\n`)
+  writeFileSync(blocked, `@echo off\r\necho bad>"${marker}"\r\nexit /b 0\r\n`)
+  writeFileSync(
+    script,
+    [
+      "@echo off",
+      `echo ok>"${paths.project}"`,
+      `echo bad>"${paths.external}"`,
+      `echo bad>"${paths.git}"`,
+      `echo ok>"${paths.temp}"`,
+      `"%ComSpec%" /d /s /c ""${child}""`,
+      "exit /b 0",
+      "",
+    ].join("\r\n"),
+  )
 
   const profile: Profile = {
     filesystem: {
@@ -43,31 +60,11 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     network: { mode: "deny", allowedHosts: [] },
     environment: { deny: [], set: {} },
   }
-  const code = `
-    const fs = require("node:fs");
-    const cp = require("node:child_process");
-    const paths = JSON.parse(process.argv[1]);
-    function write(file) { try { fs.writeFileSync(file, "ok"); return true } catch { return false } }
-    const child = cp.spawnSync(process.execPath, ["-e", "require('node:fs').writeFileSync(process.argv[1], 'bad')", paths.child]);
-    process.stdout.write(JSON.stringify({
-      project: write(paths.project),
-      external: write(paths.external),
-      git: write(paths.git),
-      temp: write(paths.temp),
-      child: child.status === 0,
-    }));
-  `
-  const paths = {
-    project: path.join(project, "project.txt"),
-    external: path.join(external, "external.txt"),
-    git: path.join(git, "config"),
-    temp: path.join(temp, "temp.txt"),
-    child: path.join(external, "child.txt"),
-  }
-  const runtime = resolveExecutable("node", project, process.env) ?? process.execPath
+  const command = resolveExecutable(process.env.COMSPEC ?? "cmd.exe", project, process.env)
+  if (!command) throw new Error("Could not resolve cmd.exe for the Windows sandbox test")
   const launch: Launch = {
-    command: runtime,
-    args: ["-e", code, JSON.stringify(paths)],
+    command,
+    args: ["/d", "/s", "/c", script],
     cwd: project,
     environment: {
       ...process.env,
@@ -78,29 +75,33 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
       TMPDIR: temp,
     },
   }
+  const blockedLaunch = { ...launch, args: ["/d", "/s", "/c", blocked] }
 
   try {
-    const output = await Effect.runPromise(
+    await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
           const next = yield* generate(profile, launch, helper)
-          const child = Bun.spawnSync([next.command, ...next.args], {
+          const proc = Bun.spawnSync([next.command, ...next.args], {
             cwd: next.cwd,
             env: next.environment,
             stdout: "pipe",
             stderr: "pipe",
           })
-          if (child.exitCode !== 0) {
-            throw new Error(`Windows sandbox helper exited ${child.exitCode}: ${child.stderr.toString()}`)
+          if (proc.exitCode !== 0) {
+            throw new Error(`Windows sandbox helper exited ${proc.exitCode}: ${proc.stderr.toString()}`)
           }
-          return child.stdout.toString()
         }),
       ),
     )
-    expect(JSON.parse(output)).toEqual({ project: true, external: false, git: false, temp: true, child: false })
+    expect(existsSync(paths.project)).toBe(true)
+    expect(existsSync(paths.external)).toBe(false)
+    expect(existsSync(paths.git)).toBe(false)
+    expect(existsSync(paths.temp)).toBe(true)
+    expect(existsSync(paths.child)).toBe(false)
 
     await expect(
-      Effect.runPromise(Effect.scoped(generate(profile, { ...launch, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "bad")`] }, path.join(root, "missing.exe")))),
+      Effect.runPromise(Effect.scoped(generate(profile, blockedLaunch, path.join(root, "missing.exe")))),
     ).rejects.toThrow("helper is not available")
     expect(existsSync(marker)).toBe(false)
 
@@ -111,9 +112,14 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const next = yield* generate(invalid, { ...launch, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "bad")`] }, helper)
-          const failed = Bun.spawnSync([next.command, ...next.args], { cwd: next.cwd, env: next.environment })
-          expect(failed.exitCode).not.toBe(0)
+          const next = yield* generate(invalid, blockedLaunch, helper)
+          const proc = Bun.spawnSync([next.command, ...next.args], {
+            cwd: next.cwd,
+            env: next.environment,
+            stdout: "pipe",
+            stderr: "pipe",
+          })
+          expect(proc.exitCode).not.toBe(0)
         }),
       ),
     )

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { Effect } from "effect"
+import type { Launch } from "../src/backend"
+import type { Profile } from "../src/profile"
+import { generate } from "../src/windows"
+
+const helper = process.env.KILO_WINDOWS_SANDBOX_HELPER
+const enabled = process.platform === "win32" && helper !== undefined && path.win32.isAbsolute(helper)
+
+function write(target: string) {
+  try {
+    writeFileSync(target, "ok")
+    return true
+  } catch {
+    return false
+  }
+}
+
+test.skipIf(!enabled)("Windows helper enforces writes through the generated backend launch", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "kilo-sandbox-windows-"))
+  const project = path.join(root, "project")
+  const temp = path.join(root, "temp")
+  const external = path.join(root, "external")
+  const git = path.join(project, ".git")
+  mkdirSync(git, { recursive: true })
+  mkdirSync(temp)
+  mkdirSync(external)
+  const marker = path.join(external, "target-started")
+
+  const profile: Profile = {
+    filesystem: {
+      allowWrite: [
+        { path: project, kind: "subtree" },
+        { path: temp, kind: "subtree" },
+      ],
+      denyWrite: [{ path: git, kind: "subtree" }],
+      denyNames: [".git"],
+      temporaryDirectory: temp,
+    },
+    network: { mode: "deny", allowedHosts: [] },
+    environment: { deny: [], set: {} },
+  }
+  const code = `
+    const fs = require("node:fs");
+    const cp = require("node:child_process");
+    const paths = JSON.parse(process.argv[1]);
+    function write(file) { try { fs.writeFileSync(file, "ok"); return true } catch { return false } }
+    const child = cp.spawnSync(process.execPath, ["-e", "require('node:fs').writeFileSync(process.argv[1], 'bad')", paths.child]);
+    process.stdout.write(JSON.stringify({
+      project: write(paths.project),
+      external: write(paths.external),
+      git: write(paths.git),
+      temp: write(paths.temp),
+      child: child.status === 0,
+    }));
+  `
+  const paths = {
+    project: path.join(project, "project.txt"),
+    external: path.join(external, "external.txt"),
+    git: path.join(git, "config"),
+    temp: path.join(temp, "temp.txt"),
+    child: path.join(external, "child.txt"),
+  }
+  const launch: Launch = {
+    command: process.execPath,
+    args: ["-e", code, JSON.stringify(paths)],
+    cwd: project,
+      environment: {
+        ...process.env,
+        KILO_WINDOWS_SANDBOX_HELPER: undefined,
+        KILO_WINDOWS_SANDBOX_PROTOTYPE: undefined,
+      },
+  }
+
+  try {
+    const output = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const next = yield* generate(profile, launch, helper)
+          const child = Bun.spawnSync([next.command, ...next.args], {
+            cwd: next.cwd,
+            env: next.environment,
+            stdout: "pipe",
+            stderr: "pipe",
+          })
+          expect(child.exitCode).toBe(0)
+          return child.stdout.toString()
+        }),
+      ),
+    )
+    expect(JSON.parse(output)).toEqual({ project: true, external: false, git: false, temp: true, child: false })
+
+    await expect(
+      Effect.runPromise(Effect.scoped(generate(profile, { ...launch, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "bad")`] }, path.join(root, "missing.exe")))),
+    ).rejects.toThrow("helper is not available")
+    expect(existsSync(marker)).toBe(false)
+
+    const invalid: Profile = {
+      ...profile,
+      filesystem: { ...profile.filesystem, allowWrite: [{ path: path.join(root, "missing"), kind: "subtree" }] },
+    }
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const next = yield* generate(invalid, { ...launch, args: ["-e", `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "bad")`] }, helper)
+          const failed = Bun.spawnSync([next.command, ...next.args], { cwd: next.cwd, env: next.environment })
+          expect(failed.exitCode).not.toBe(0)
+        }),
+      ),
+    )
+    expect(existsSync(marker)).toBe(false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -1,14 +1,20 @@
 import { expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { Effect } from "effect"
 import type { Launch } from "../src/backend"
 import type { Profile } from "../src/profile"
-import { generate, resolveExecutable } from "../src/windows"
+import { generate } from "../src/windows"
 
 const helper = process.env.KILO_WINDOWS_SANDBOX_HELPER
-const enabled = process.platform === "win32" && helper !== undefined && path.win32.isAbsolute(helper)
+const probe = process.env.KILO_WINDOWS_SANDBOX_PROBE
+const enabled =
+  process.platform === "win32" &&
+  helper !== undefined &&
+  path.win32.isAbsolute(helper) &&
+  probe !== undefined &&
+  path.win32.isAbsolute(probe)
 
 test.skipIf(!enabled)("Windows helper enforces writes through the generated backend launch", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "kilo-sandbox-windows-"))
@@ -25,28 +31,7 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     external: path.join(external, "external.txt"),
     git: path.join(git, "config"),
     temp: path.join(temp, "temp.txt"),
-    child: path.join(external, "child.txt"),
   }
-  const child = path.join(project, "child.cmd")
-  const script = path.join(project, "probe.cmd")
-  const blocked = path.join(project, "blocked.cmd")
-  const marker = path.join(external, "target-started")
-  writeFileSync(child, `@echo off\r\necho bad>"${paths.child}"\r\nexit /b 0\r\n`)
-  writeFileSync(blocked, `@echo off\r\necho bad>"${marker}"\r\nexit /b 0\r\n`)
-  writeFileSync(
-    script,
-    [
-      "@echo off",
-      `echo ok>"${paths.project}"`,
-      `echo bad>"${paths.external}"`,
-      `echo bad>"${paths.git}"`,
-      `echo ok>"${paths.temp}"`,
-      `"%ComSpec%" /d /s /c ""${child}""`,
-      "exit /b 0",
-      "",
-    ].join("\r\n"),
-  )
-
   const profile: Profile = {
     filesystem: {
       allowWrite: [
@@ -60,22 +45,29 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     network: { mode: "deny", allowedHosts: [] },
     environment: { deny: [], set: {} },
   }
-  const command = resolveExecutable(process.env.COMSPEC ?? "cmd.exe", project, process.env)
-  if (!command) throw new Error("Could not resolve cmd.exe for the Windows sandbox test")
   const launch: Launch = {
-    command,
-    args: ["/d", "/s", "/c", script],
+    command: probe!,
+    args: [],
     cwd: project,
     environment: {
       ...process.env,
       KILO_WINDOWS_SANDBOX_HELPER: undefined,
       KILO_WINDOWS_SANDBOX_PROTOTYPE: undefined,
+      KILO_WINDOWS_SANDBOX_PROBE: undefined,
+      KILO_PROBE_PROJECT: paths.project,
+      KILO_PROBE_EXTERNAL: paths.external,
+      KILO_PROBE_GIT: paths.git,
+      KILO_PROBE_TEMP: paths.temp,
       TEMP: temp,
       TMP: temp,
       TMPDIR: temp,
     },
   }
-  const blockedLaunch = { ...launch, args: ["/d", "/s", "/c", blocked] }
+  const marker = path.join(external, "target-started")
+  const blocked = {
+    ...launch,
+    environment: { ...launch.environment, KILO_PROBE_PROJECT: marker },
+  }
 
   try {
     await Effect.runPromise(
@@ -98,10 +90,9 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     expect(existsSync(paths.external)).toBe(false)
     expect(existsSync(paths.git)).toBe(false)
     expect(existsSync(paths.temp)).toBe(true)
-    expect(existsSync(paths.child)).toBe(false)
 
     await expect(
-      Effect.runPromise(Effect.scoped(generate(profile, blockedLaunch, path.join(root, "missing.exe")))),
+      Effect.runPromise(Effect.scoped(generate(profile, blocked, path.join(root, "missing.exe")))),
     ).rejects.toThrow("helper is not available")
     expect(existsSync(marker)).toBe(false)
 
@@ -112,7 +103,7 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const next = yield* generate(invalid, blockedLaunch, helper)
+          const next = yield* generate(invalid, blocked, helper)
           const proc = Bun.spawnSync([next.command, ...next.args], {
             cwd: next.cwd,
             env: next.environment,

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -72,6 +72,9 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
         ...process.env,
         KILO_WINDOWS_SANDBOX_HELPER: undefined,
         KILO_WINDOWS_SANDBOX_PROTOTYPE: undefined,
+        TEMP: temp,
+        TMP: temp,
+        TMPDIR: temp,
       },
   }
 

--- a/packages/kilo-sandbox/test/windows.integration.test.ts
+++ b/packages/kilo-sandbox/test/windows.integration.test.ts
@@ -5,7 +5,7 @@ import path from "node:path"
 import { Effect } from "effect"
 import type { Launch } from "../src/backend"
 import type { Profile } from "../src/profile"
-import { generate } from "../src/windows"
+import { generate, resolveExecutable } from "../src/windows"
 
 const helper = process.env.KILO_WINDOWS_SANDBOX_HELPER
 const enabled = process.platform === "win32" && helper !== undefined && path.win32.isAbsolute(helper)
@@ -64,18 +64,19 @@ test.skipIf(!enabled)("Windows helper enforces writes through the generated back
     temp: path.join(temp, "temp.txt"),
     child: path.join(external, "child.txt"),
   }
+  const runtime = resolveExecutable("node", project, process.env) ?? process.execPath
   const launch: Launch = {
-    command: process.execPath,
+    command: runtime,
     args: ["-e", code, JSON.stringify(paths)],
     cwd: project,
-      environment: {
-        ...process.env,
-        KILO_WINDOWS_SANDBOX_HELPER: undefined,
-        KILO_WINDOWS_SANDBOX_PROTOTYPE: undefined,
-        TEMP: temp,
-        TMP: temp,
-        TMPDIR: temp,
-      },
+    environment: {
+      ...process.env,
+      KILO_WINDOWS_SANDBOX_HELPER: undefined,
+      KILO_WINDOWS_SANDBOX_PROTOTYPE: undefined,
+      TEMP: temp,
+      TMP: temp,
+      TMPDIR: temp,
+    },
   }
 
   try {

--- a/packages/kilo-sandbox/test/windows.test.ts
+++ b/packages/kilo-sandbox/test/windows.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { Effect } from "effect"
+import type { Launch } from "../src/backend"
+import type { Profile } from "../src/profile"
+import { generate, protocol, request, resolveExecutable } from "../src/windows"
+
+const profile: Profile = {
+  filesystem: {
+    allowWrite: [{ path: "C:\\workspace", kind: "subtree" }],
+    denyWrite: [{ path: "C:\\workspace\\.git", kind: "subtree" }],
+    denyNames: [".git"],
+    temporaryDirectory: "C:\\workspace\\tmp",
+  },
+  network: { mode: "deny", allowedHosts: [] },
+  environment: { deny: [], set: {} },
+}
+
+const launch: Launch = {
+  command: "tool",
+  args: ["hello", "world"],
+  cwd: "C:\\workspace",
+  environment: { Path: "C:\\safe;C:\\other", PATHEXT: ".EXE;.CMD", SAFE: "yes" },
+}
+
+describe("Windows sandbox backend", () => {
+  test("resolves commands only through the supplied PATH and PATHEXT", () => {
+    const seen: Array<string> = []
+    const result = resolveExecutable("tool", "C:\\workspace", launch.environment ?? {}, (target) => {
+      seen.push(target)
+      return target.toLowerCase() === "c:\\other\\tool.cmd"
+    })
+    expect(result).toBe("C:\\other\\tool.CMD")
+    expect(seen).toEqual([
+      "C:\\safe\\tool.EXE",
+      "C:\\safe\\tool.CMD",
+      "C:\\other\\tool.EXE",
+      "C:\\other\\tool.CMD",
+    ])
+  })
+
+  test("does not fall back to PATH for a relative command containing separators", () => {
+    const seen: Array<string> = []
+    const result = resolveExecutable("bin\\tool.exe", "C:\\workspace", launch.environment ?? {}, (target) => {
+      seen.push(target)
+      return false
+    })
+    expect(result).toBeUndefined()
+    expect(seen).toEqual(["C:\\workspace\\bin\\tool.exe"])
+  })
+
+  test("generates the bounded versioned helper request without environment", () => {
+    const result = request(profile, launch, "C:\\safe\\tool.exe")
+    expect(result).toEqual({
+      version: protocol,
+      command: "C:\\safe\\tool.exe",
+      args: ["hello", "world"],
+      cwd: "C:\\workspace",
+      allowWrite: profile.filesystem.allowWrite,
+      denyWrite: profile.filesystem.denyWrite,
+      denyNames: [".git"],
+      temporaryDirectory: "C:\\workspace\\tmp",
+    })
+    expect(result).not.toHaveProperty("environment")
+  })
+
+  test("writes a scoped request and preserves the helper environment", async () => {
+    let target = ""
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const next = yield* generate(
+            profile,
+            launch,
+            "C:\\kilo\\kilo-sandbox-win.exe",
+            (item) => item.toLowerCase() === "c:\\safe\\tool.exe",
+            () => true,
+          )
+          target = next.args[1]
+          expect(path.isAbsolute(target)).toBe(true)
+          expect(JSON.parse(readFileSync(target, "utf8"))).toEqual(
+            request(profile, launch, "C:\\safe\\tool.EXE"),
+          )
+          return next
+        }),
+      ),
+    )
+    expect(result.command).toBe("C:\\kilo\\kilo-sandbox-win.exe")
+    expect(result.args).toEqual(["--request", target])
+    expect(result.environment).toEqual(launch.environment ?? {})
+    expect(result.environment).not.toBe(launch.environment)
+    expect(existsSync(target)).toBe(false)
+  })
+
+  test("rejects literal allow rules before writing a request", async () => {
+    await expect(
+      Effect.runPromise(
+        Effect.scoped(
+          generate(
+            { ...profile, filesystem: { ...profile.filesystem, allowWrite: [{ path: "C:\\workspace", kind: "literal" }] } },
+            launch,
+            "C:\\helper.exe",
+            () => true,
+            () => true,
+          ),
+        ),
+      ),
+    ).rejects.toThrow("only supports subtree")
+  })
+
+  test("fails closed for unresolved commands", async () => {
+    await expect(
+      Effect.runPromise(
+        Effect.scoped(generate(profile, { ...launch, command: "missing" }, "C:\\helper.exe", () => false, () => true)),
+      ),
+    ).rejects.toThrow("Could not securely resolve")
+  })
+
+  test("resolves requested shell inside the backend", async () => {
+    const body = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const result = yield* generate(
+            profile,
+            { ...launch, command: "echo hello", args: [], shell: true, environment: { COMSPEC: "C:\\Windows\\cmd.exe" } },
+            "C:\\helper.exe",
+            (target) => target.toLowerCase() === "c:\\windows\\cmd.exe",
+            () => true,
+          )
+          return JSON.parse(readFileSync(result.args[1], "utf8"))
+        }),
+      ),
+    )
+    expect(body.command).toBe("C:\\Windows\\cmd.exe")
+    expect(body.args).toEqual(["/d", "/s", "/c", "echo hello"])
+  })
+})

--- a/packages/kilo-sandbox/windows/.gitignore
+++ b/packages/kilo-sandbox/windows/.gitignore
@@ -1,0 +1,3 @@
+.zig-cache/
+zig-out/
+dist/

--- a/packages/kilo-sandbox/windows/build.zig
+++ b/packages/kilo-sandbox/windows/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn build(b: *std.Build) void {
+    if (builtin.zig_version.major != 0 or builtin.zig_version.minor != 16 or builtin.zig_version.patch != 0)
+        @panic("kilo-sandbox-windows requires Zig 0.16.0 exactly");
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    if (optimize != .Debug) @panic("kilo-sandbox-windows currently supports Debug builds only due Zig 0.16 MinGW header translation errors");
+
+    const exe = b.addExecutable(.{
+        .name = "kilo-sandbox-windows",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.linkSystemLibrary("c", .{});
+    exe.root_module.linkSystemLibrary("advapi32", .{});
+    exe.root_module.linkSystemLibrary("kernel32", .{});
+    exe.root_module.linkSystemLibrary("userenv", .{});
+    b.installArtifact(exe);
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/protocol.zig"),
+            .target = b.graph.host,
+            .optimize = optimize,
+        }),
+    });
+    tests.root_module.linkSystemLibrary("c", .{});
+    const run = b.addRunArtifact(tests);
+    const step = b.step("test", "Run unit tests");
+    step.dependOn(&run.step);
+}

--- a/packages/kilo-sandbox/windows/build.zig
+++ b/packages/kilo-sandbox/windows/build.zig
@@ -22,6 +22,17 @@ pub fn build(b: *std.Build) void {
     exe.root_module.linkSystemLibrary("userenv", .{});
     b.installArtifact(exe);
 
+    const probe = b.addExecutable(.{
+        .name = "kilo-sandbox-windows-probe",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/probe.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    probe.root_module.linkSystemLibrary("kernel32", .{});
+    b.installArtifact(probe);
+
     const tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/protocol.zig"),

--- a/packages/kilo-sandbox/windows/build.zig.zon
+++ b/packages/kilo-sandbox/windows/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = .kilo_sandbox_windows,
+    .version = "0.0.0",
+    .minimum_zig_version = "0.16.0",
+    .fingerprint = 0xe79a78838134eed6,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -243,6 +243,37 @@ fn verify(token: Handle, expected: win.DWORD) !void {
     if (groups.GroupCount == 0 or groups.GroupCount != expected) return error.MissingRestrictedSids;
 }
 
+fn defaults(alloc: Allocator, token: Handle, roots: []const Root) !void {
+    var size: win.DWORD = 0;
+    _ = win.GetTokenInformation(token, win.TokenUser, null, 0, &size);
+    if (size == 0) return error.MissingTokenUser;
+    const buf = try alloc.alignedAlloc(u8, .of(usize), size);
+    defer alloc.free(buf);
+    if (win.GetTokenInformation(token, win.TokenUser, buf.ptr, size, &size) == 0) return error.TokenUserInfo;
+    const user: *win.TOKEN_USER = @ptrCast(@alignCast(buf.ptr));
+
+    const entries = try alloc.alloc(win.EXPLICIT_ACCESS_W, roots.len + 1);
+    defer alloc.free(entries);
+    for (entries, 0..) |*entry, i| {
+        entry.* = std.mem.zeroes(win.EXPLICIT_ACCESS_W);
+        entry.grfAccessPermissions = win.GENERIC_ALL;
+        entry.grfAccessMode = win.GRANT_ACCESS;
+        entry.grfInheritance = win.NO_INHERITANCE;
+        entry.Trustee.TrusteeForm = win.TRUSTEE_IS_SID;
+        entry.Trustee.TrusteeType = win.TRUSTEE_IS_UNKNOWN;
+        const value = if (i == 0) user.User.Sid else roots[i - 1].sid;
+        entry.Trustee.ptstrName = @ptrCast(@alignCast(value));
+    }
+    var acl: win.PACL = null;
+    if (win.SetEntriesInAclW(@intCast(entries.len), entries.ptr, null, &acl) != win.ERROR_SUCCESS) return error.MakeDefaultAcl;
+    defer if (acl != null) {
+        _ = win.LocalFree(acl);
+    };
+    var info = std.mem.zeroes(win.TOKEN_DEFAULT_DACL);
+    info.DefaultDacl = acl;
+    if (win.SetTokenInformation(token, win.TokenDefaultDacl, &info, @sizeOf(win.TOKEN_DEFAULT_DACL)) == 0) return error.SetDefaultAcl;
+}
+
 fn run(alloc: Allocator, req: protocol.Request) !u32 {
     if (!protocol.absolute(req.command) or !protocol.absolute(req.cwd)) return error.NotAbsolute;
     const exe = try open(alloc, req.command, false, 0);
@@ -284,7 +315,8 @@ fn run(alloc: Allocator, req: protocol.Request) !u32 {
     };
 
     var source: Handle = null;
-    check(win.OpenProcessToken(win.GetCurrentProcess(), win.TOKEN_ALL_ACCESS, &source), "OpenProcessToken");
+    const access = win.TOKEN_DUPLICATE | win.TOKEN_QUERY | win.TOKEN_ASSIGN_PRIMARY | win.TOKEN_ADJUST_DEFAULT | win.TOKEN_ADJUST_SESSIONID | win.TOKEN_ADJUST_PRIVILEGES;
+    check(win.OpenProcessToken(win.GetCurrentProcess(), access, &source), "OpenProcessToken");
     defer close(source);
     const groups = try alloc.alloc(win.SID_AND_ATTRIBUTES, roots.len);
     defer alloc.free(groups);
@@ -293,6 +325,9 @@ fn run(alloc: Allocator, req: protocol.Request) !u32 {
     check(win.CreateRestrictedToken(source, win.DISABLE_MAX_PRIVILEGE | win.LUA_TOKEN | win.WRITE_RESTRICTED, 0, null, 0, null, @intCast(groups.len), groups.ptr, &restricted), "CreateRestrictedToken");
     defer close(restricted);
     try verify(restricted, @intCast(groups.len));
+    // The default descriptor must satisfy both the normal user-SID check and the
+    // WRITE_RESTRICTED capability-SID check for process-private kernel objects.
+    try defaults(alloc, restricted, roots);
 
     var handles = [_]Handle{ win.GetStdHandle(win.STD_INPUT_HANDLE), win.GetStdHandle(win.STD_OUTPUT_HANDLE), win.GetStdHandle(win.STD_ERROR_HANDLE) };
     for (handles) |handle| {

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -368,7 +368,10 @@ pub fn main(init: std.process.Init) !void {
     // additive ACEs persist without an ownership journal/recovery mechanism, and restoring
     // stale whole DACLs is forbidden; denyNames only protects entries present during this
     // scan; process containment still needs an independent parent-death lease.
-    const code = try run(alloc, parsed.value);
+    const code = run(alloc, parsed.value) catch |err| {
+        std.debug.print("kilo-sandbox-windows: setup failed: {s}\n", .{@errorName(err)});
+        std.process.exit(125);
+    };
     std.process.exit(@truncate(code));
 }
 

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -348,7 +348,7 @@ fn run(alloc: Allocator, req: protocol.Request) !u32 {
     return code;
 }
 
-pub fn main(init: std.process.Init) !void {
+fn execute(init: std.process.Init) !u32 {
     const alloc = init.gpa;
     var args = try init.minimal.args.iterateAllocator(alloc);
     defer args.deinit();
@@ -368,7 +368,11 @@ pub fn main(init: std.process.Init) !void {
     // additive ACEs persist without an ownership journal/recovery mechanism, and restoring
     // stale whole DACLs is forbidden; denyNames only protects entries present during this
     // scan; process containment still needs an independent parent-death lease.
-    const code = run(alloc, parsed.value) catch |err| {
+    return run(alloc, parsed.value);
+}
+
+pub fn main(init: std.process.Init) void {
+    const code = execute(init) catch |err| {
         std.debug.print("kilo-sandbox-windows: setup failed: {s}\n", .{@errorName(err)});
         std.process.exit(125);
     };

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -67,7 +67,6 @@ fn open(alloc: Allocator, raw: []const u8, directory: ?bool, access: win.DWORD) 
     var info: win.BY_HANDLE_FILE_INFORMATION = undefined;
     if (win.GetFileInformationByHandle(handle, &info) == 0) return error.PathInfo;
     if ((info.dwFileAttributes & win.FILE_ATTRIBUTE_REPARSE_POINT) != 0) return error.ReparsePoint;
-    if (info.nNumberOfLinks != 1) return error.Hardlink;
     const is_dir = (info.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0;
     if (directory) |expected| if (is_dir != expected) return error.PathType;
     return .{ .handle = handle, .path = try canonical(alloc, handle), .info = info };
@@ -166,6 +165,7 @@ fn scan(alloc: Allocator, path: []const u8, root_sid: win.PSID, req: protocol.Re
         alloc.free(node.path);
     }
     const directory = (node.info.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0;
+    if (!directory and node.info.nNumberOfLinks != 1) return error.Hardlink;
     const inherit: win.DWORD = if (directory) win.SUB_CONTAINERS_AND_OBJECTS_INHERIT else win.NO_INHERITANCE;
     try ace(node.handle, root_sid, win.GRANT_ACCESS, allow_mask, inherit);
     if (protocol.denied(node.path, leaf(node.path), req.denyWrite, req.denyNames))

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -1,0 +1,378 @@
+const std = @import("std");
+const protocol = @import("protocol.zig");
+
+const win = @cImport({
+    @cDefine("UNICODE", "1");
+    @cDefine("_UNICODE", "1");
+    @cInclude("windows.h");
+    @cInclude("aclapi.h");
+    @cInclude("sddl.h");
+    @cInclude("userenv.h");
+});
+
+const Allocator = std.mem.Allocator;
+const W = win.WCHAR;
+const Handle = win.HANDLE;
+const invalid = @as(Handle, @ptrFromInt(@as(usize, @bitCast(@as(isize, -1)))));
+const allow_mask = win.FILE_GENERIC_READ | win.FILE_GENERIC_WRITE | win.FILE_GENERIC_EXECUTE | win.DELETE;
+const deny_mask = win.FILE_GENERIC_WRITE | win.DELETE | win.FILE_DELETE_CHILD | win.WRITE_DAC | win.WRITE_OWNER;
+
+const Node = struct {
+    handle: Handle,
+    path: []u8,
+    info: win.BY_HANDLE_FILE_INFORMATION,
+};
+
+const Root = struct {
+    node: Node,
+    sid: win.PSID,
+};
+
+fn fail(name: []const u8) noreturn {
+    std.debug.print("kilo-sandbox-windows: {s} failed ({d})\n", .{ name, win.GetLastError() });
+    std.process.exit(125);
+}
+
+fn check(ok: win.BOOL, name: []const u8) void {
+    if (ok == 0) fail(name);
+}
+
+fn wide(alloc: Allocator, text: []const u8) ![:0]W {
+    return std.unicode.utf8ToUtf16LeAllocZ(alloc, text);
+}
+
+fn utf8(alloc: Allocator, text: []const W) ![]u8 {
+    return std.unicode.utf16LeToUtf8Alloc(alloc, text);
+}
+
+fn close(handle: Handle) void {
+    if (handle != null and handle != invalid) _ = win.CloseHandle(handle);
+}
+
+fn canonical(alloc: Allocator, handle: Handle) ![]u8 {
+    var buf: [32768]W = undefined;
+    const count = win.GetFinalPathNameByHandleW(handle, &buf, buf.len, win.FILE_NAME_NORMALIZED | win.VOLUME_NAME_DOS);
+    if (count == 0 or count >= buf.len) return error.FinalPath;
+    const start: usize = if (count >= 4 and std.mem.eql(W, buf[0..4], &[_]W{ '\\', '\\', '?', '\\' })) 4 else 0;
+    return utf8(alloc, buf[start..count]);
+}
+
+fn open(alloc: Allocator, raw: []const u8, directory: ?bool, access: win.DWORD) !Node {
+    if (!protocol.absolute(raw)) return error.NotAbsolute;
+    const path = try wide(alloc, raw);
+    defer alloc.free(path);
+    const handle = win.CreateFileW(path.ptr, access, win.FILE_SHARE_READ | win.FILE_SHARE_WRITE | win.FILE_SHARE_DELETE, null, win.OPEN_EXISTING, win.FILE_FLAG_BACKUP_SEMANTICS | win.FILE_FLAG_OPEN_REPARSE_POINT, null);
+    if (handle == invalid) return error.OpenPath;
+    errdefer close(handle);
+    var info: win.BY_HANDLE_FILE_INFORMATION = undefined;
+    if (win.GetFileInformationByHandle(handle, &info) == 0) return error.PathInfo;
+    if ((info.dwFileAttributes & win.FILE_ATTRIBUTE_REPARSE_POINT) != 0) return error.ReparsePoint;
+    if (info.nNumberOfLinks != 1) return error.Hardlink;
+    const is_dir = (info.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0;
+    if (directory) |expected| if (is_dir != expected) return error.PathType;
+    return .{ .handle = handle, .path = try canonical(alloc, handle), .info = info };
+}
+
+fn local(alloc: Allocator, raw: []const u8) !Node {
+    const node = try open(alloc, raw, true, win.READ_CONTROL | win.WRITE_DAC);
+    errdefer {
+        close(node.handle);
+        alloc.free(node.path);
+    }
+    const path = try wide(alloc, node.path);
+    defer alloc.free(path);
+    var volume: [win.MAX_PATH + 1]W = undefined;
+    if (win.GetVolumePathNameW(path.ptr, &volume, volume.len) == 0) return error.VolumePath;
+    const vlen = std.mem.indexOfScalar(W, &volume, 0) orelse return error.VolumePath;
+    const root = try utf8(alloc, volume[0..vlen]);
+    defer alloc.free(root);
+    if (std.ascii.eqlIgnoreCase(node.path, root)) return error.VolumeRoot;
+    if (win.GetDriveTypeW(&volume) != win.DRIVE_FIXED) return error.NotFixed;
+    var fs: [32]W = undefined;
+    if (win.GetVolumeInformationW(&volume, null, 0, null, null, null, &fs, fs.len) == 0) return error.VolumeInfo;
+    const flen = std.mem.indexOfScalar(W, &fs, 0) orelse return error.VolumeInfo;
+    const name = try utf8(alloc, fs[0..flen]);
+    defer alloc.free(name);
+    if (!std.ascii.eqlIgnoreCase(name, "NTFS")) return error.NotNtfs;
+    return node;
+}
+
+fn profile(alloc: Allocator) ![]u8 {
+    var token: Handle = null;
+    check(win.OpenProcessToken(win.GetCurrentProcess(), win.TOKEN_QUERY, &token), "OpenProcessToken");
+    defer close(token);
+    var size: win.DWORD = 0;
+    _ = win.GetUserProfileDirectoryW(token, null, &size);
+    if (size == 0) return error.ProfilePath;
+    const buf = try alloc.alloc(W, size);
+    defer alloc.free(buf);
+    if (win.GetUserProfileDirectoryW(token, buf.ptr, &size) == 0) return error.ProfilePath;
+    const len = std.mem.indexOfScalar(W, buf, 0) orelse return error.ProfilePath;
+    const raw = try utf8(alloc, buf[0..len]);
+    defer alloc.free(raw);
+    const node = try open(alloc, raw, true, 0);
+    defer {
+        close(node.handle);
+        alloc.free(node.path);
+    }
+    return alloc.dupe(u8, node.path);
+}
+
+fn sid(alloc: Allocator, node: Node) !win.PSID {
+    var buf: [96]u8 = undefined;
+    const id = (@as(u64, node.info.nFileIndexHigh) << 32) | node.info.nFileIndexLow;
+    const text = try protocol.sidText(&buf, node.path, node.info.dwVolumeSerialNumber, id);
+    const value = try wide(alloc, text);
+    defer alloc.free(value);
+    var out: win.PSID = null;
+    if (win.ConvertStringSidToSidW(value.ptr, &out) == 0) return error.InvalidSid;
+    return out;
+}
+
+fn ace(handle: Handle, root_sid: win.PSID, mode: win.ACCESS_MODE, mask: win.DWORD, inherit: win.DWORD) !void {
+    var old: win.PACL = null;
+    var desc: win.PSECURITY_DESCRIPTOR = null;
+    const got = win.GetSecurityInfo(handle, win.SE_FILE_OBJECT, win.DACL_SECURITY_INFORMATION, null, null, &old, null, &desc);
+    if (got != win.ERROR_SUCCESS) return error.ReadAcl;
+    defer if (desc != null) {
+        _ = win.LocalFree(desc);
+    };
+    var entry = std.mem.zeroes(win.EXPLICIT_ACCESS_W);
+    entry.grfAccessPermissions = mask;
+    entry.grfAccessMode = mode;
+    entry.grfInheritance = inherit;
+    entry.Trustee.TrusteeForm = win.TRUSTEE_IS_SID;
+    entry.Trustee.TrusteeType = win.TRUSTEE_IS_UNKNOWN;
+    entry.Trustee.ptstrName = @ptrCast(@alignCast(root_sid));
+    var next: win.PACL = null;
+    const made = win.SetEntriesInAclW(1, &entry, old, &next);
+    if (made != win.ERROR_SUCCESS) return error.MakeAcl;
+    defer if (next != null) {
+        _ = win.LocalFree(next);
+    };
+    const set = win.SetSecurityInfo(handle, win.SE_FILE_OBJECT, win.DACL_SECURITY_INFORMATION, null, null, next, null);
+    if (set != win.ERROR_SUCCESS) return error.WriteAcl;
+}
+
+fn leaf(path: []const u8) []const u8 {
+    const at = std.mem.lastIndexOfAny(u8, path, "\\/") orelse return path;
+    return path[at + 1 ..];
+}
+
+fn scan(alloc: Allocator, path: []const u8, root_sid: win.PSID, req: protocol.Request) !void {
+    const node = try open(alloc, path, null, win.READ_CONTROL | win.WRITE_DAC);
+    defer {
+        close(node.handle);
+        alloc.free(node.path);
+    }
+    const directory = (node.info.dwFileAttributes & win.FILE_ATTRIBUTE_DIRECTORY) != 0;
+    const inherit: win.DWORD = if (directory) win.SUB_CONTAINERS_AND_OBJECTS_INHERIT else win.NO_INHERITANCE;
+    try ace(node.handle, root_sid, win.GRANT_ACCESS, allow_mask, inherit);
+    if (protocol.denied(node.path, leaf(node.path), req.denyWrite, req.denyNames))
+        try ace(node.handle, root_sid, win.DENY_ACCESS, deny_mask, inherit);
+    if (!directory) return;
+    const pattern = try std.fmt.allocPrint(alloc, "{s}\\*", .{node.path});
+    defer alloc.free(pattern);
+    const wpattern = try wide(alloc, pattern);
+    defer alloc.free(wpattern);
+    var data: win.WIN32_FIND_DATAW = undefined;
+    const find = win.FindFirstFileW(wpattern.ptr, &data);
+    if (find == invalid) {
+        if (win.GetLastError() == win.ERROR_FILE_NOT_FOUND) return;
+        return error.ScanTree;
+    }
+    defer _ = win.FindClose(find);
+    while (true) {
+        const len = std.mem.indexOfScalar(W, &data.cFileName, 0) orelse return error.ScanTree;
+        const name = try utf8(alloc, data.cFileName[0..len]);
+        defer alloc.free(name);
+        if (!std.mem.eql(u8, name, ".") and !std.mem.eql(u8, name, "..")) {
+            const child = try std.fmt.allocPrint(alloc, "{s}\\{s}", .{ node.path, name });
+            defer alloc.free(child);
+            try scan(alloc, child, root_sid, req);
+        }
+        if (win.FindNextFileW(find, &data) == 0) {
+            if (win.GetLastError() != win.ERROR_NO_MORE_FILES) return error.ScanTree;
+            break;
+        }
+    }
+}
+
+fn quote(list: *std.ArrayList(u8), alloc: Allocator, arg: []const u8) !void {
+    try list.append(alloc, '"');
+    var slashes: usize = 0;
+    for (arg) |char| {
+        if (char == '\\') {
+            slashes += 1;
+            continue;
+        }
+        if (char == '"') {
+            try list.appendNTimes(alloc, '\\', slashes * 2 + 1);
+            try list.append(alloc, '"');
+            slashes = 0;
+            continue;
+        }
+        try list.appendNTimes(alloc, '\\', slashes);
+        slashes = 0;
+        try list.append(alloc, char);
+    }
+    try list.appendNTimes(alloc, '\\', slashes * 2);
+    try list.append(alloc, '"');
+}
+
+fn command(alloc: Allocator, req: protocol.Request) ![:0]W {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(alloc);
+    try quote(&out, alloc, req.command);
+    for (req.args) |arg| {
+        try out.append(alloc, ' ');
+        try quote(&out, alloc, arg);
+    }
+    return wide(alloc, out.items);
+}
+
+fn verify(token: Handle, expected: win.DWORD) !void {
+    if (win.IsTokenRestricted(token) == 0) return error.UnrestrictedToken;
+    var size: win.DWORD = 0;
+    _ = win.GetTokenInformation(token, win.TokenRestrictedSids, null, 0, &size);
+    if (size == 0) return error.MissingRestrictedSids;
+    const buf = try std.heap.page_allocator.alloc(u8, size);
+    defer std.heap.page_allocator.free(buf);
+    if (win.GetTokenInformation(token, win.TokenRestrictedSids, buf.ptr, size, &size) == 0) return error.RestrictedSidInfo;
+    const groups: *win.TOKEN_GROUPS = @ptrCast(@alignCast(buf.ptr));
+    if (groups.GroupCount == 0 or groups.GroupCount != expected) return error.MissingRestrictedSids;
+}
+
+fn run(alloc: Allocator, req: protocol.Request) !u32 {
+    if (!protocol.absolute(req.command) or !protocol.absolute(req.cwd)) return error.NotAbsolute;
+    const exe = try open(alloc, req.command, false, 0);
+    defer {
+        close(exe.handle);
+        alloc.free(exe.path);
+    }
+    const cwd = try open(alloc, req.cwd, true, 0);
+    defer {
+        close(cwd.handle);
+        alloc.free(cwd.path);
+    }
+    const home = try profile(alloc);
+    defer alloc.free(home);
+    var roots = try alloc.alloc(Root, req.allowWrite.len);
+    defer alloc.free(roots);
+    var count: usize = 0;
+    errdefer for (roots[0..count]) |root| {
+        close(root.node.handle);
+        alloc.free(root.node.path);
+        if (root.sid != null) _ = win.LocalFree(root.sid);
+    };
+    for (req.allowWrite, 0..) |rule, i| {
+        const node = try local(alloc, rule.path);
+        errdefer {
+            close(node.handle);
+            alloc.free(node.path);
+        }
+        if (std.ascii.eqlIgnoreCase(node.path, home)) return error.UserProfileRoot;
+        const root_sid = try sid(alloc, node);
+        roots[i] = .{ .node = node, .sid = root_sid };
+        count += 1;
+        try scan(alloc, node.path, root_sid, req);
+    }
+    defer for (roots) |root| {
+        close(root.node.handle);
+        alloc.free(root.node.path);
+        if (root.sid != null) _ = win.LocalFree(root.sid);
+    };
+
+    var source: Handle = null;
+    check(win.OpenProcessToken(win.GetCurrentProcess(), win.TOKEN_ALL_ACCESS, &source), "OpenProcessToken");
+    defer close(source);
+    const groups = try alloc.alloc(win.SID_AND_ATTRIBUTES, roots.len);
+    defer alloc.free(groups);
+    for (roots, 0..) |root, i| groups[i] = .{ .Sid = root.sid, .Attributes = 0 };
+    var restricted: Handle = null;
+    check(win.CreateRestrictedToken(source, win.DISABLE_MAX_PRIVILEGE | win.LUA_TOKEN | win.WRITE_RESTRICTED, 0, null, 0, null, @intCast(groups.len), groups.ptr, &restricted), "CreateRestrictedToken");
+    defer close(restricted);
+    try verify(restricted, @intCast(groups.len));
+
+    var handles = [_]Handle{ win.GetStdHandle(win.STD_INPUT_HANDLE), win.GetStdHandle(win.STD_OUTPUT_HANDLE), win.GetStdHandle(win.STD_ERROR_HANDLE) };
+    for (handles) |handle| {
+        if (handle == null or handle == invalid) return error.InvalidStdHandle;
+        check(win.SetHandleInformation(handle, win.HANDLE_FLAG_INHERIT, win.HANDLE_FLAG_INHERIT), "SetHandleInformation");
+    }
+    var size: win.SIZE_T = 0;
+    _ = win.InitializeProcThreadAttributeList(null, 1, 0, &size);
+    const attrs = try alloc.alignedAlloc(u8, .of(usize), size);
+    defer alloc.free(attrs);
+    const list: win.LPPROC_THREAD_ATTRIBUTE_LIST = @ptrCast(attrs.ptr);
+    check(win.InitializeProcThreadAttributeList(list, 1, 0, &size), "InitializeProcThreadAttributeList");
+    defer win.DeleteProcThreadAttributeList(list);
+    check(win.UpdateProcThreadAttribute(list, 0, win.PROC_THREAD_ATTRIBUTE_HANDLE_LIST, &handles, @sizeOf(@TypeOf(handles)), null, null), "UpdateProcThreadAttribute");
+
+    var start = std.mem.zeroes(win.STARTUPINFOEXW);
+    start.StartupInfo.cb = @sizeOf(win.STARTUPINFOEXW);
+    start.StartupInfo.dwFlags = win.STARTF_USESTDHANDLES;
+    start.StartupInfo.hStdInput = handles[0];
+    start.StartupInfo.hStdOutput = handles[1];
+    start.StartupInfo.hStdError = handles[2];
+    start.lpAttributeList = list;
+    var proc: win.PROCESS_INFORMATION = undefined;
+    const line = try command(alloc, req);
+    defer alloc.free(line);
+    const wexe = try wide(alloc, exe.path);
+    defer alloc.free(wexe);
+    const wcwd = try wide(alloc, cwd.path);
+    defer alloc.free(wcwd);
+    check(win.CreateProcessAsUserW(restricted, wexe.ptr, line.ptr, null, null, 1, win.CREATE_SUSPENDED | win.CREATE_UNICODE_ENVIRONMENT | win.CREATE_NO_WINDOW | win.EXTENDED_STARTUPINFO_PRESENT, null, wcwd.ptr, &start.StartupInfo, &proc), "CreateProcessAsUserW");
+    defer close(proc.hThread);
+    defer close(proc.hProcess);
+    defer _ = win.TerminateProcess(proc.hProcess, 125);
+    const job = win.CreateJobObjectW(null, null);
+    if (job == null) fail("CreateJobObjectW");
+    defer close(job);
+    var limits = std.mem.zeroes(win.JOBOBJECT_EXTENDED_LIMIT_INFORMATION);
+    limits.BasicLimitInformation.LimitFlags = win.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    check(win.SetInformationJobObject(job, win.JobObjectExtendedLimitInformation, &limits, @sizeOf(@TypeOf(limits))), "SetInformationJobObject");
+    check(win.AssignProcessToJobObject(job, proc.hProcess), "AssignProcessToJobObject");
+    const current = try alloc.alloc(win.BY_HANDLE_FILE_INFORMATION, roots.len);
+    defer alloc.free(current);
+    for (roots, 0..) |root, i| {
+        if (win.GetFileInformationByHandle(root.node.handle, &current[i]) == 0) return error.PathInfo;
+        if (current[i].dwVolumeSerialNumber != root.node.info.dwVolumeSerialNumber or
+            current[i].nFileIndexHigh != root.node.info.nFileIndexHigh or
+            current[i].nFileIndexLow != root.node.info.nFileIndexLow) return error.RootChanged;
+    }
+    if (win.ResumeThread(proc.hThread) == @as(win.DWORD, 0xffffffff)) fail("ResumeThread");
+    if (win.WaitForSingleObject(proc.hProcess, win.INFINITE) != win.WAIT_OBJECT_0) fail("WaitForSingleObject");
+    var code: win.DWORD = 0;
+    check(win.GetExitCodeProcess(proc.hProcess, &code), "GetExitCodeProcess");
+    return code;
+}
+
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.gpa;
+    var args = try init.minimal.args.iterateAllocator(alloc);
+    defer args.deinit();
+    _ = args.next() orelse return error.RequestArgumentRequired;
+    const flag = args.next() orelse return error.RequestArgumentRequired;
+    if (!std.mem.eql(u8, flag, "--request")) return error.RequestArgumentRequired;
+    const path = args.next() orelse return error.RequestArgumentRequired;
+    if (args.next() != null) return error.RequestArgumentRequired;
+    const file = try std.Io.Dir.openFile(.cwd(), init.io, path, .{});
+    defer file.close(init.io);
+    const data = try alloc.alloc(u8, protocol.max_request + 1);
+    const len = try file.readPositionalAll(init.io, data, 0);
+    const parsed = try protocol.parse(alloc, data[0..len]);
+    defer parsed.deinit();
+
+    // RELEASE BLOCKERS: provisioning is not race-proof against concurrent tree mutation;
+    // additive ACEs persist without an ownership journal/recovery mechanism, and restoring
+    // stale whole DACLs is forbidden; denyNames only protects entries present during this
+    // scan; process containment still needs an independent parent-death lease.
+    const code = try run(alloc, parsed.value);
+    std.process.exit(@truncate(code));
+}
+
+comptime {
+    if (@import("builtin").os.tag != .windows and !@import("builtin").is_test)
+        @compileError("kilo-sandbox-windows only targets Windows");
+}

--- a/packages/kilo-sandbox/windows/src/main.zig
+++ b/packages/kilo-sandbox/windows/src/main.zig
@@ -345,6 +345,7 @@ fn run(alloc: Allocator, req: protocol.Request) !u32 {
     if (win.WaitForSingleObject(proc.hProcess, win.INFINITE) != win.WAIT_OBJECT_0) fail("WaitForSingleObject");
     var code: win.DWORD = 0;
     check(win.GetExitCodeProcess(proc.hProcess, &code), "GetExitCodeProcess");
+    if (code != 0) std.debug.print("kilo-sandbox-windows: target exited {d}\n", .{code});
     return code;
 }
 

--- a/packages/kilo-sandbox/windows/src/probe.zig
+++ b/packages/kilo-sandbox/windows/src/probe.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+fn write(init: std.process.Init, key: []const u8) bool {
+    const path = init.environ_map.get(key) orelse return false;
+    const file = std.Io.Dir.createFileAbsolute(init.io, path, .{}) catch return false;
+    defer file.close(init.io);
+    file.writeStreamingAll(init.io, "probe") catch return false;
+    return true;
+}
+
+pub fn main(init: std.process.Init) u8 {
+    const project = write(init, "KILO_PROBE_PROJECT");
+    const external = write(init, "KILO_PROBE_EXTERNAL");
+    const git = write(init, "KILO_PROBE_GIT");
+    const temp = write(init, "KILO_PROBE_TEMP");
+    return if (project and !external and !git and temp) 0 else 2;
+}

--- a/packages/kilo-sandbox/windows/src/protocol.zig
+++ b/packages/kilo-sandbox/windows/src/protocol.zig
@@ -1,0 +1,130 @@
+const std = @import("std");
+
+pub const version = 1;
+pub const max_request = 1024 * 1024;
+pub const max_args = 4096;
+pub const max_rules = 4096;
+pub const max_names = 1024;
+pub const max_text = 32 * 1024;
+
+pub const Kind = enum { literal, subtree };
+
+pub const Rule = struct {
+    path: []const u8,
+    kind: Kind,
+};
+
+pub const Request = struct {
+    version: u32,
+    command: []const u8,
+    args: []const []const u8,
+    cwd: []const u8,
+    allowWrite: []const Rule,
+    denyWrite: []const Rule,
+    denyNames: []const []const u8,
+    temporaryDirectory: ?[]const u8 = null,
+};
+
+pub fn parse(alloc: std.mem.Allocator, data: []const u8) !std.json.Parsed(Request) {
+    if (data.len == 0 or data.len > max_request) return error.InvalidRequestSize;
+    const parsed = try std.json.parseFromSlice(Request, alloc, data, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = false,
+        .max_value_len = max_request,
+    });
+    errdefer parsed.deinit();
+    const req = parsed.value;
+    if (req.version != version) return error.UnsupportedVersion;
+    if (!text(req.command) or !text(req.cwd)) return error.MissingPath;
+    if (req.args.len > max_args or req.allowWrite.len == 0) return error.InvalidCount;
+    if (req.allowWrite.len + req.denyWrite.len > max_rules or req.denyNames.len > max_names) return error.InvalidCount;
+    for (req.args) |arg| if (!text(arg)) return error.InvalidText;
+    for (req.allowWrite) |rule| {
+        if (!text(rule.path)) return error.InvalidText;
+        if (rule.kind != .subtree) return error.UnsupportedAllowLiteral;
+    }
+    for (req.denyWrite) |rule| if (!text(rule.path)) return error.InvalidText;
+    for (req.denyNames) |name| {
+        if (!text(name) or name.len == 0 or std.mem.indexOfAny(u8, name, "\\/") != null) return error.InvalidName;
+    }
+    if (req.temporaryDirectory) |path| if (!text(path)) return error.InvalidText;
+    return parsed;
+}
+
+fn text(value: []const u8) bool {
+    return value.len <= max_text and std.mem.indexOfScalar(u8, value, 0) == null;
+}
+
+pub fn absolute(path: []const u8) bool {
+    if (path.len < 3) return false;
+    if (!std.ascii.isAlphabetic(path[0]) or path[1] != ':' or (path[2] != '\\' and path[2] != '/')) return false;
+    return std.mem.indexOfScalar(u8, path, 0) == null;
+}
+
+pub fn sidText(buf: []u8, path: []const u8, serial: u32, id: u64) ![]const u8 {
+    var hash: [32]u8 = undefined;
+    var state = std.crypto.hash.sha2.Sha256.init(.{});
+    state.update(path);
+    state.update(std.mem.asBytes(&serial));
+    state.update(std.mem.asBytes(&id));
+    state.final(&hash);
+    const a = std.mem.readInt(u32, hash[0..4], .little);
+    const b = std.mem.readInt(u32, hash[4..8], .little);
+    const c = std.mem.readInt(u32, hash[8..12], .little);
+    const d = std.mem.readInt(u32, hash[12..16], .little);
+    return std.fmt.bufPrint(buf, "S-1-5-21-{d}-{d}-{d}-{d}", .{ a, b, c, d });
+}
+
+fn prefix(path: []const u8, root: []const u8) bool {
+    if (path.len < root.len or !std.ascii.eqlIgnoreCase(path[0..root.len], root)) return false;
+    if (path.len == root.len) return true;
+    return path[root.len] == '\\' or path[root.len] == '/';
+}
+
+pub fn denied(path: []const u8, name: []const u8, writes: []const Rule, names: []const []const u8) bool {
+    for (writes) |rule| switch (rule.kind) {
+        .literal => if (std.ascii.eqlIgnoreCase(path, rule.path)) return true,
+        .subtree => if (prefix(path, rule.path)) return true,
+    };
+    for (names) |rule| if (std.ascii.eqlIgnoreCase(name, rule)) return true;
+    return false;
+}
+
+test "strict versioned request rejects empty roots and literal allows" {
+    const alloc = std.testing.allocator;
+    try std.testing.expectError(error.InvalidRequestSize, parse(alloc, ""));
+    try std.testing.expectError(error.InvalidCount, parse(alloc,
+        \\{"version":1,"command":"C:\\\\tool.exe","args":[],"cwd":"C:\\\\work","allowWrite":[],"denyWrite":[],"denyNames":[]}
+    ));
+    try std.testing.expectError(error.UnsupportedAllowLiteral, parse(alloc,
+        \\{"version":1,"command":"C:\\\\tool.exe","args":[],"cwd":"C:\\\\work","allowWrite":[{"path":"C:\\\\work","kind":"literal"}],"denyWrite":[],"denyNames":[]}
+    ));
+}
+
+test "fully qualified drive paths only" {
+    try std.testing.expect(absolute("C:\\work\\tool.exe"));
+    try std.testing.expect(!absolute("tool.exe"));
+    try std.testing.expect(!absolute("\\\\server\\share\\tool.exe"));
+    try std.testing.expect(!absolute("C:tool.exe"));
+}
+
+test "synthetic root SID includes canonical identity" {
+    var one: [96]u8 = undefined;
+    var two: [96]u8 = undefined;
+    var three: [96]u8 = undefined;
+    const a = try sidText(&one, "c:\\work", 7, 9);
+    const b = try sidText(&two, "c:\\work", 7, 9);
+    const c = try sidText(&three, "c:\\work", 7, 10);
+    try std.testing.expectEqualStrings(a, b);
+    try std.testing.expect(!std.mem.eql(u8, a, c));
+}
+
+test "literal and subtree deny rules differ" {
+    const writes = [_]Rule{
+        .{ .path = "C:\\work\\one", .kind = .literal },
+        .{ .path = "C:\\work\\tree", .kind = .subtree },
+    };
+    try std.testing.expect(denied("c:\\WORK\\ONE", "one", &writes, &.{}));
+    try std.testing.expect(!denied("C:\\work\\one\\child", "child", &writes, &.{}));
+    try std.testing.expect(denied("C:\\work\\tree\\child", "child", &writes, &.{}));
+}


### PR DESCRIPTION
Windows currently has no process-write backend for the generic sandbox profile, so enabling sandboxing must reject model-originated processes rather than run them with ordinary user authority. This draft adds an independent Zig implementation that can be compared with the Rust prototype before choosing a production direction.

The standalone helper derives root-specific restricting SIDs, provisions narrow NTFS capability and deny ACEs, creates a `WRITE_RESTRICTED` token, and starts the target suspended with an explicit handle list before assigning it to a kill-on-close Job. The TypeScript backend only translates the normalized profile, resolves the helper beside the Kilo executable or through an explicit development override, and preserves fail-closed behavior.

The backend remains behind `KILO_WINDOWS_SANDBOX_PROTOTYPE=1`. ACL journaling and recovery, race-proof recursive provisioning, future-name `.git` protection, and a dedicated parent-death lease remain release blockers, so the helper is emitted only as a short-lived comparison artifact and is not included in CLI or VSIX packages.

Part of #11542.