### PR TITLE
fix(vscode): improve autocomplete error messages to cover BYOK and credits scenarios

### DIFF
--- a/.changeset/fix-autocomplete-error-messages.md
+++ b/.changeset/fix-autocomplete-error-messages.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+---
+
+Improve autocomplete error messages to clarify BYOK and credits issues
+
+When autocomplete is paused due to a payment or auth error, the messages now explain all possible causes: no Kilo credits, API key (BYOK) quota exhausted, not signed in, or invalid/missing API key.

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
@@ -42,8 +42,8 @@ export const dict = {
   "kilocode:autocomplete.incompatibilityExtensionPopup.disableCopilot": "Disable Copilot",
   "kilocode:autocomplete.incompatibilityExtensionPopup.disableInlineAssist": "Disable Autocomplete",
   "kilocode:autocomplete.creditsExhausted.message":
-    "Kilo Code Autocomplete has been paused because your account has no remaining credits. Add credits to resume autocomplete.",
+    "Kilo Code Autocomplete has been paused. Possible causes: your Kilo account has no remaining credits, or your configured API key (BYOK) has reached its quota limit. Add Kilo credits or check your API key configuration to resume autocomplete.",
   "kilocode:autocomplete.creditsExhausted.addCredits": "Add Credits",
   "kilocode:autocomplete.authError.message":
-    "Kilo Code Autocomplete has been paused due to an authentication error. Please sign in again.",
+    "Kilo Code Autocomplete has been paused due to an authentication issue. Possible causes: you are not signed in to Kilo, or your API key (BYOK) is invalid or missing. Please sign in again or check your provider API key settings.",
 }


### PR DESCRIPTION
## Summary

- Improves the autocomplete paused notification messages to clearly explain all possible causes for authentication and payment errors
- **402 (payment required)**: Now mentions both exhausted Kilo credits *and* BYOK API key quota limits, so users with their own keys understand the error applies to them too
- **401/403 (auth error)**: Now mentions both not being signed in to Kilo *and* an invalid/missing API key (BYOK), so users with BYOK configurations know to check their API key settings

## Context

When autocomplete fails with a 402, 401, or 403 error, a VS Code warning popup is shown. Previously:

- The 402 message only mentioned Kilo account credits, but 402s also occur when a BYOK provider's API key has reached its quota
- The 401/403 message said "Please sign in again" but gave no hint that an invalid BYOK API key is a common cause

The gateway (`kilo-gateway.ts`) returns 401 for both missing Kilo auth *and* BYOK key resolution failures. It passes through 402 from upstream providers when quota is exhausted — whether that's Kilo's gateway or a BYOK provider. The VS Code client (`AutocompleteServiceManager.ts`) maps these to user-visible messages without knowing which underlying cause triggered them, so both causes must be described.

## Changes

Only `packages/kilo-vscode/src/services/autocomplete/i18n/en.ts` is changed — this is the sole source of autocomplete error strings (the autocomplete i18n system only has an English file; no other language files exist for these keys).

Built for [Mark IJbema](https://kilo-code.slack.com/archives/C08T316B7J9/p1782239203220199?thread_ts=1782238921.501869&cid=C08T316B7J9) by [Kilo for Slack](https://kilo.ai/slack)