### PR TITLE
fix(vscode): show full external permission paths

### DIFF
--- a/.changeset/show-external-permission-paths.md
+++ b/.changeset/show-external-permission-paths.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show full external directory paths in permission auto-approve rules.

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -119,14 +119,14 @@ describe("ProjectV2.resolve", () => {
         Effect.promise(() => tmpdir()),
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
       )
-      yield* Effect.promise(() => initRepo(ssh.path, { commit: true, remote: "git@github.com:owner/repo.git" }))
-      yield* Effect.promise(() => initRepo(https.path, { commit: true, remote: "https://github.com/owner/repo.git" }))
+      yield* Effect.promise(() => initRepo(ssh.path, { commit: true, remote: "git@example.com:owner/repo.git" }))
+      yield* Effect.promise(() => initRepo(https.path, { commit: true, remote: "https://example.com/owner/repo.git" }))
       const project = yield* Project.Service
 
       const a = yield* project.resolve(abs(ssh.path))
       const b = yield* project.resolve(abs(https.path))
 
-      expect(a.id).toBe(remoteID("github.com/owner/repo"))
+      expect(a.id).toBe(remoteID("example.com/owner/repo"))
       expect(b.id).toBe(a.id)
     }),
   )

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/permission-dock-dropdown/external-dir-expanded-pending-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/permission-dock-dropdown/external-dir-expanded-pending-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af33f5d026513422db6efc37848eec76d9da511432e5933606ae0be73da684f8
-size 16675
+oid sha256:6ee59e48c176043eee3b22441ce1c50e8d17dbafe58e969cfc8e97f404f2608d
+size 17429

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c4f1492f44da109debc1fc09195eac2a02a20cb211ee45b6651f81478d66b1a
-size 71547
+oid sha256:6f05d9512bbe3309c6d073fd8aca8e0800c7e2827bdefe6115e636e8a6e94070
+size 16239

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b1d0bc725e3b33a40d1d777d71b70afcec1b6cdcfae15e2023667bc4574f23
-size 17201
+oid sha256:5c4f1492f44da109debc1fc09195eac2a02a20cb211ee45b6651f81478d66b1a
+size 71547

--- a/packages/kilo-vscode/tests/permission-dock-dropdown.spec.ts
+++ b/packages/kilo-vscode/tests/permission-dock-dropdown.spec.ts
@@ -211,6 +211,21 @@ test.describe("Permission Dock Dropdown — external directory", () => {
     await page.waitForSelector("#storybook-root *", { state: "attached" })
     await openDropdown(page)
 
+    const text = "Read External Directory /Users/developer/projects/kilo-bench/dashboard/app/routes/*"
+    const hint = page.locator('[data-slot="permission-hint"]')
+    await expect(hint).toHaveText(text)
+    await expect(hint).toHaveAttribute("title", text)
+    expect(
+      await hint.evaluate((node) => node.scrollWidth > node.clientWidth || node.scrollHeight > node.clientHeight),
+    ).toBe(false)
+
+    const rule = page.locator('[data-slot="permission-rule"]')
+    await expect(rule).toHaveText(text)
+    await expect(rule).toHaveAttribute("title", text)
+    expect(
+      await rule.evaluate((node) => node.scrollWidth > node.clientWidth || node.scrollHeight > node.clientHeight),
+    ).toBe(false)
+
     const root = page.locator("#storybook-root")
     await expect(root).toHaveScreenshot(["permission-dock-dropdown", "external-dir-expanded-pending.png"])
   })

--- a/packages/kilo-vscode/tests/unit/permission-description.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-description.test.ts
@@ -181,6 +181,7 @@ describe("describeRule", () => {
 
   test("preserves existing permission rule labels", () => {
     expect(describeRule("read", "*", t)).toBe("Read")
+    expect(describeRule("external_directory", "*", t)).toBe("Read External Directory")
     expect(describeRule("read", "src/app.ts", t)).toBe("Read src/app.ts")
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -251,7 +251,7 @@ export const PermissionDock: Component<{
                             </Tooltip>
                           </div>
                           <code data-slot="permission-rule" data-wrap={external() ? "" : undefined} title={text(rule)}>
-                            <Show when={external()} fallback={text(rule)}>
+                            <Show when={external() && rule !== "*"} fallback={text(rule)}>
                               <span data-slot="permission-rule-label">
                                 {language.t("ui.permission.toolLabel.externalDirectory")}{" "}
                               </span>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -48,6 +48,8 @@ export const PermissionDock: Component<{
     // Normalize IDN/Unicode hostnames to punycode ASCII to prevent homograph attacks.
     return normalizeUrls(cmd)
   }
+  const text = (rule: string) => (command() ? label(rule) : describeRule(props.request.toolName, rule, language.t))
+  const external = () => props.request.toolName === "external_directory"
   const cmdDescription = () => {
     const val = props.request.args?.description
     return typeof val === "string" && val.length > 0 ? val : undefined
@@ -248,8 +250,13 @@ export const PermissionDock: Component<{
                               </button>
                             </Tooltip>
                           </div>
-                          <code data-slot="permission-rule">
-                            {command() ? label(rule) : describeRule(props.request.toolName, rule, language.t)}
+                          <code data-slot="permission-rule" data-wrap={external() ? "" : undefined} title={text(rule)}>
+                            <Show when={external()} fallback={text(rule)}>
+                              <span data-slot="permission-rule-label">
+                                {language.t("ui.permission.toolLabel.externalDirectory")}{" "}
+                              </span>
+                              <span data-slot="permission-rule-path">{rule}</span>
+                            </Show>
                           </code>
                         </div>
                       )}
@@ -268,7 +275,16 @@ export const PermissionDock: Component<{
           const desc = description()
           if (!desc)
             return !command() && toolDescription() ? <div data-slot="permission-hint">{toolDescription()}</div> : null
-          if (desc.kind === "single") return <div data-slot="permission-hint">{desc.text}</div>
+          if (desc.kind === "single")
+            return (
+              <div
+                data-slot="permission-hint"
+                data-wrap={external() ? "" : undefined}
+                title={external() ? desc.text : undefined}
+              >
+                {desc.text}
+              </div>
+            )
           return (
             <div data-slot="permission-patterns">
               <span data-slot="permission-patterns-title">{desc.title}</span>

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -958,9 +958,9 @@ const externalDirPermission: PermissionRequest = {
   id: "perm-extdir-001",
   sessionID: SESSION_ID,
   toolName: "external_directory",
-  patterns: ["/home/user/other-project/*"],
-  always: ["/home/user/other-project/*"],
-  args: { filepath: "/home/user/other-project/config.json" },
+  patterns: ["/Users/developer/projects/kilo-bench/dashboard/app/routes/*"],
+  always: ["/Users/developer/projects/kilo-bench/dashboard/app/routes/*"],
+  args: { filepath: "/Users/developer/projects/kilo-bench/dashboard/app/routes/index.tsx" },
   tool: { messageID: ASST_MSG_ID, callID: "call-extdir-001" },
 }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -109,6 +109,11 @@
 
   [data-slot="permission-hint"] {
     font-size: var(--kilo-font-size-12);
+
+    &[data-wrap] {
+      overflow-wrap: anywhere;
+      word-break: normal;
+    }
   }
 
   [data-slot="permission-patterns"] {
@@ -316,6 +321,24 @@
     white-space: nowrap;
     min-width: 0;
     flex: 1;
+
+    &[data-wrap] {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      overflow: visible;
+      text-overflow: clip;
+      white-space: normal;
+      word-break: normal;
+    }
+  }
+
+  [data-slot="permission-rule-label"] {
+    color: var(--text-base, var(--vscode-foreground));
+  }
+
+  [data-slot="permission-rule-path"] {
+    overflow-wrap: anywhere;
   }
 
   [data-slot="permission-rule-actions"] {


### PR DESCRIPTION
## What changed

External-directory permission prompts now show the entire requested path instead of truncating the auto-approve rule. Long paths wrap naturally in both the permission description and expanded rule, while the full text remains available through the native title tooltip.

The visual fixture now uses a realistically long path, and the interaction test verifies that neither rendered path overflows its container. The core remote-normalization fixture uses the neutral `example.com` domain so runner-level GitHub URL rewrites cannot change its expected project ID.

## Screenshots

### Collapsed prompt

![Collapsed external-directory permission prompt](https://raw.githubusercontent.com/Kilo-Org/kilocode/radial-rock/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/permission-dock-external-dir-chromium-linux.png)

### Expanded auto-approve rule

![Expanded external-directory permission rule](https://raw.githubusercontent.com/Kilo-Org/kilocode/radial-rock/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/permission-dock-dropdown/external-dir-expanded-pending-chromium-linux.png)

## Example

<img width="213" height="195" alt="image" src="https://github.com/user-attachments/assets/dcbcd92a-3d70-46db-b7f4-ead33f1a1876" />
