### PR TITLE
docs: add translated readmes in translations directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  English | <a href="translations/README.zh.md">简体中文</a> | <a href="translations/README.zht.md">繁體中文</a> | <a href="translations/README.ko.md">한국어</a> | <a href="translations/README.de.md">Deutsch</a> | <a href="translations/README.es.md">Español</a> | <a href="translations/README.fr.md">Français</a> | <a href="translations/README.it.md">Italiano</a> | <a href="translations/README.da.md">Dansk</a> | <a href="translations/README.ja.md">日本語</a> | <a href="translations/README.pl.md">Polski</a> | <a href="translations/README.ru.md">Русский</a> | <a href="translations/README.bs.md">Bosanski</a> | <a href="translations/README.ar.md">العربية</a> | <a href="translations/README.no.md">Norsk</a> | <a href="translations/README.br.md">Português (Brasil)</a> | <a href="translations/README.th.md">ไทย</a> | <a href="translations/README.tr.md">Türkçe</a> | <a href="translations/README.uk.md">Українська</a> | <a href="translations/README.bn.md">বাংলা</a> | <a href="translations/README.gr.md">Ελληνικά</a> | <a href="translations/README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
   <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
 </p>
 

--- a/translations/README.ar.md
+++ b/translations/README.ar.md
@@ -1,0 +1,181 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | العربية | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<div dir="rtl">
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">وكيل برمجة مفتوح المصدر للبناء باستخدام الذكاء الاصطناعي في VS Code أو JetBrains أو CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code هو وكيل برمجة بالذكاء الاصطناعي يعمل معك أينما تعمل: [VS Code](https://kilo.ai/landing/vs-code) و[JetBrains](https://kilo.ai/features/jetbrains-native) و[CLI](https://kilo.ai/cli). إنه مفتوح المصدر وبتسعير مفتوح. يمكنك الاختيار من بين أكثر من 500 نموذج، والتبديل بينها أثناء المهمة، ودفع سعر مزود النموذج من دون أي هامش إضافي. لا تحتاج إلى مفاتيح API للبدء.
+
+### التثبيت
+
+اختر المكان الذي تريد تشغيل Kilo فيه.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+ثبّت [إضافة Kilo Code](vscode:extension/kilocode.kilo-code) مباشرة، أو احصل عليها من [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). أنشئ حسابًا وستحصل على إمكانية الوصول إلى أكثر من 500 نموذج، بما في ذلك GPT-5.5 وClaude Opus 4.7 وClaude Sonnet 4.6 وGemini 3.1 Pro Preview، كلها بسعر المزود.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+بعد ذلك شغّل `kilo` في أي مجلد مشروع للبدء.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+ثبّت [إضافة Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) من JetBrains Marketplace، أو ابحث عن "Kilo Code" في `Settings → Plugins` داخل أي JetBrains IDE.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+شغّل Kilo من الويب، من دون جهاز محلي، على [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>مراجعات الكود</strong></summary>
+
+<br>
+
+أعدّ مراجعات كود آلية بالذكاء الاصطناعي لطلبات السحب الخاصة بك على [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+شغّل وكيل الذكاء الاصطناعي الدائم لديك على [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>تثبيت CLI من GitHub Releases (ملفات ثنائية)</summary>
+
+نزّل أحدث ملف ثنائي من [صفحة Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| المنصة | الملف |
+|---|---|
+| Windows (معظم أجهزة PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+ملاحظات: `x64-baseline` هو بناء توافق للمعالجات القديمة التي لا تدعم AVX. `musl` هو البناء المرتبط ثابتًا لـ Alpine أو صور Docker البسيطة من دون glibc. `kilo-vscode-*.vsix` هو حزمة إضافة VS Code وليس CLI. أرشيفات `Source code` مخصصة للبناء من المصدر.
+
+</details>
+
+### Agents
+
+يأتي Kilo مع agents متخصصة يمكنك التبديل بينها حسب المهمة. يمكنك أيضًا إنشاء agents مخصصة خاصة بك.
+
+- **Code** - الافتراضي. ينفذ الكود ويعدّله من اللغة الطبيعية.
+- **Plan** - يصمم البنية ويكتب خطط التنفيذ قبل كتابة أي كود.
+- **Ask** - يجيب عن الأسئلة حول قاعدة الكود من دون تعديل الملفات.
+- **Debug** - يستكشف المشكلات ويتتبعها.
+- **Review** - يراجع تغييراتك ويكشف مشكلات الأداء والأمان والأسلوب وتغطية الاختبارات.
+
+تعرّف أكثر على [agents وagents المخصصة](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### ما الذي يفعله
+
+- **توليد الكود** من اللغة الطبيعية عبر ملفات متعددة.
+- **إكمال تلقائي داخل السطر** مع اقتراحات ghost-text والضغط على Tab للقبول.
+- **فحص ذاتي** لكي يراجع الوكيل عمله ويصححه.
+- **تحكم في الطرفية والمتصفح** لتشغيل الأوامر وأتمتة الويب.
+- **سوق MCP** للعثور على خوادم MCP وربطها لتوسيع قدرات الوكيل.
+- **أكثر من 500 نموذج** مع التبديل أثناء المهمة، لتطابق زمن الاستجابة والتكلفة والاستدلال مع العمل.
+
+### الوضع المستقل (CI/CD)
+
+شغّل `kilo run` مع `--auto` للعمل بشكل مستقل بالكامل ومن دون prompts، وهو مصمم لخطوط CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+يعطّل `--auto` كل مطالبات الأذونات ويسمح للوكيل بتنفيذ أي إجراء من دون تأكيد. استخدمه فقط في بيئات موثوقة.
+
+### التوثيق
+
+لإعدادات التكوين وكل ما عدا ذلك، راجع [التوثيق](https://kilo.ai/docs).
+
+### المساهمة
+
+نرحب بمساهمات المطورين والكتّاب والجميع. ابدأ بـ [Contributing Guide](/CONTRIBUTING.md) لإعداد البيئة ومعايير الكود وكيفية فتح pull request. راجع [RELEASING.md](../RELEASING.md) لعملية إصدار إضافة VS Code وCLI، و[packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) لإضافة JetBrains.
+
+يرجى قراءة [Code of Conduct](/CODE_OF_CONDUCT.md) قبل المشاركة.
+
+### الترخيص
+
+MIT. يمكنك استخدام هذا الكود وتعديله وتوزيعه، بما في ذلك تجاريًا، ما دمت تحتفظ بإشعارات النسبة والترخيص. راجع [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>من أين جاء Kilo CLI؟</summary>
+
+Kilo CLI هو fork من [OpenCode](https://github.com/anomalyco/opencode)، وتم تحسينه للعمل داخل منصة Kilo agentic engineering.
+
+</details>
+
+---
+
+**انضم إلى المجتمع** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)
+
+</div>

--- a/translations/README.bn.md
+++ b/translations/README.bn.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | বাংলা | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">VS Code, JetBrains বা CLI-তে AI দিয়ে তৈরি করার জন্য ওপেন সোর্স কোডিং এজেন্ট।</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code হলো একটি AI কোডিং এজেন্ট যা আপনি যেখানে কাজ করেন সেখানেই কাজ করে: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) এবং [CLI](https://kilo.ai/cli)। এটি ওপেন সোর্স এবং খোলা মূল্যনীতির। আপনি 500টির বেশি মডেল থেকে বেছে নিতে পারেন, কাজের মাঝখানে মডেল বদলাতে পারেন এবং কোনো অতিরিক্ত চার্জ ছাড়াই মডেল প্রদানকারীর রেট পরিশোধ করেন। শুরু করতে API key দরকার নেই।
+
+### ইনস্টলেশন
+
+আপনি কোথায় Kilo চালাতে চান তা বেছে নিন।
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+[Kilo Code extension](vscode:extension/kilocode.kilo-code) সরাসরি ইনস্টল করুন, অথবা [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) থেকে নিন। একটি অ্যাকাউন্ট তৈরি করলে GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 এবং Gemini 3.1 Pro Preview সহ 500টির বেশি মডেলে প্রদানকারীর দামে অ্যাক্সেস পাবেন।
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+তারপর শুরু করতে যেকোনো প্রজেক্ট ডিরেক্টরিতে `kilo` চালান।
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+JetBrains Marketplace থেকে [Kilo Code plugin](https://plugins.jetbrains.com/plugin/28350-kilo-code) ইনস্টল করুন, অথবা যেকোনো JetBrains IDE-তে `Settings → Plugins`-এ "Kilo Code" খুঁজুন।
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+লোকাল মেশিন ছাড়াই ওয়েব থেকে [app.kilo.ai/cloud](https://app.kilo.ai/cloud)-এ Kilo চালান।
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+[app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews)-এ আপনার pull request-এ স্বয়ংক্রিয় AI code review সেট আপ করুন।
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+[app.kilo.ai/claw](https://app.kilo.ai/claw)-এ আপনার always-on AI agent চালু করুন।
+
+</details>
+
+<details>
+<summary>GitHub Releases থেকে CLI ইনস্টল করুন (বাইনারি)</summary>
+
+[Releases page](https://github.com/Kilo-Org/kilocode/releases) থেকে সর্বশেষ বাইনারি ডাউনলোড করুন।
+
+| প্ল্যাটফর্ম | Asset |
+|---|---|
+| Windows (বেশিরভাগ PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+নোট: `x64-baseline` হলো AVX ছাড়া পুরোনো CPU-এর জন্য compatibility build। `musl` হলো Alpine বা glibc ছাড়া minimal Docker image-এর জন্য statically linked build। `kilo-vscode-*.vsix` হলো VS Code extension package, CLI নয়। `Source code` archive source থেকে build করার জন্য।
+
+</details>
+
+### Agents
+
+Kilo বিশেষায়িত agents সহ আসে, কাজ অনুযায়ী আপনি এগুলোর মধ্যে বদলাতে পারেন। আপনি নিজের custom agents-ও বানাতে পারেন।
+
+- **Code** - ডিফল্ট। প্রাকৃতিক ভাষা থেকে কোড implement এবং edit করে।
+- **Plan** - কোনো কোড লেখার আগে architecture design করে এবং implementation plan লেখে।
+- **Ask** - কোনো ফাইল না ছুঁয়ে আপনার codebase সম্পর্কে প্রশ্নের উত্তর দেয়।
+- **Debug** - সমস্যা troubleshoot এবং trace করে।
+- **Review** - আপনার পরিবর্তন review করে এবং performance, security, style ও test coverage-এর সমস্যা তুলে ধরে।
+
+[agents এবং custom agents](https://kilo.ai/docs/code-with-ai/agents/using-agents) সম্পর্কে আরও জানুন।
+
+### এটি কী করে
+
+- প্রাকৃতিক ভাষা থেকে একাধিক ফাইলে **code generation**।
+- ghost-text suggestion এবং Tab দিয়ে accept করার **inline autocomplete**।
+- agent যেন নিজের কাজ review ও correct করে তার জন্য **self-checking**।
+- command চালানো এবং web automate করার জন্য **terminal ও browser control**।
+- agent-এর ক্ষমতা বাড়ায় এমন MCP server খুঁজে ও যুক্ত করার জন্য **MCP marketplace**।
+- latency, cost এবং reasoning কাজের সাথে মেলাতে mid-task switching সহ **500টির বেশি model**।
+
+### Autonomous Mode (CI/CD)
+
+CI/CD pipeline-এর জন্য prompts ছাড়া পুরোপুরি autonomous operation পেতে `kilo run`-এর সাথে `--auto` ব্যবহার করুন:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` সব permission prompt বন্ধ করে এবং agent-কে confirmation ছাড়া যেকোনো action execute করতে দেয়। শুধু trusted environment-এ ব্যবহার করুন।
+
+### ডকুমেন্টেশন
+
+Configuration এবং বাকি সবকিছুর জন্য [docs](https://kilo.ai/docs) দেখুন।
+
+### Contributing
+
+Developer, writer এবং সবাইকে contribution-এর জন্য স্বাগতম। environment setup, coding standard এবং pull request খোলার পদ্ধতির জন্য [Contributing Guide](/CONTRIBUTING.md) দিয়ে শুরু করুন। VS Code extension এবং CLI release process-এর জন্য [RELEASING.md](../RELEASING.md), এবং JetBrains plugin-এর জন্য [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) দেখুন।
+
+অংশ নেওয়ার আগে আমাদের [Code of Conduct](/CODE_OF_CONDUCT.md) পড়ুন।
+
+### License
+
+MIT। attribution এবং license notice রেখে আপনি এই code ব্যবহার, পরিবর্তন এবং distribute করতে পারেন, commercial ব্যবহারসহ। [License](/LICENSE) দেখুন।
+
+### FAQ
+
+<details>
+<summary>Kilo CLI কোথা থেকে এসেছে?</summary>
+
+Kilo CLI হলো [OpenCode](https://github.com/anomalyco/opencode)-এর একটি fork, Kilo agentic engineering platform-এর মধ্যে কাজ করার জন্য উন্নত করা হয়েছে।
+
+</details>
+
+---
+
+**কমিউনিটিতে যোগ দিন** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.br.md
+++ b/translations/README.br.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | Português (Brasil) | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">O agente de programação open source para criar com IA no VS Code, JetBrains ou CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code é um agente de programação com IA que acompanha você em todos os lugares onde trabalha: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) e [CLI](https://kilo.ai/cli). É open source e tem preços abertos. Você escolhe entre mais de 500 modelos, alterna entre eles no meio da tarefa e paga a tarifa do provedor do modelo sem acréscimo. Não são necessárias chaves de API para começar.
+
+### Instalação
+
+Escolha onde você quer executar o Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Instale a [extensão Kilo Code](vscode:extension/kilocode.kilo-code) diretamente ou baixe pelo [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Crie uma conta e você terá acesso a mais de 500 modelos, incluindo GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 e Gemini 3.1 Pro Preview, todos com preço do provedor.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Depois execute `kilo` em qualquer diretório de projeto para começar.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Instale o [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) pelo JetBrains Marketplace ou procure por "Kilo Code" em `Settings → Plugins` dentro de qualquer IDE JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Execute o Kilo pela web, sem máquina local, em [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Revisões de código</strong></summary>
+
+<br>
+
+Configure revisões automáticas de código com IA nos seus pull requests em [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Inicie seu agente de IA sempre ativo em [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Instalar a CLI pelo GitHub Releases (binários)</summary>
+
+Baixe o binário mais recente na [página de Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Plataforma | Asset |
+|---|---|
+| Windows (a maioria dos PCs) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Notas: `x64-baseline` é uma build de compatibilidade para CPUs antigas sem AVX. `musl` é a build com link estático para Alpine ou imagens Docker mínimas sem glibc. `kilo-vscode-*.vsix` é o pacote da extensão VS Code, não a CLI. Arquivos `Source code` são para compilar a partir do código-fonte.
+
+</details>
+
+### Agents
+
+Kilo vem com agents especializados para você alternar dependendo da tarefa. Você também pode criar seus próprios agents personalizados.
+
+- **Code** - O padrão. Implementa e edita código a partir de linguagem natural.
+- **Plan** - Desenha a arquitetura e escreve planos de implementação antes de qualquer código ser escrito.
+- **Ask** - Responde perguntas sobre sua base de código sem tocar nos arquivos.
+- **Debug** - Soluciona e rastreia problemas.
+- **Review** - Revisa suas mudanças e aponta problemas de performance, segurança, estilo e cobertura de testes.
+
+Saiba mais sobre [agents e agents personalizados](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### O que ele faz
+
+- **Geração de código** a partir de linguagem natural, em vários arquivos.
+- **Autocomplete inline** com sugestões ghost-text e Tab para aceitar.
+- **Autoverificação** para que o agente revise e corrija o próprio trabalho.
+- **Controle de terminal e navegador** para executar comandos e automatizar a web.
+- **Marketplace MCP** para encontrar e conectar servidores MCP que ampliam o que o agente pode fazer.
+- **Mais de 500 modelos** com alternância no meio da tarefa, para combinar latência, custo e raciocínio com o trabalho.
+
+### Modo autônomo (CI/CD)
+
+Execute `kilo run` com `--auto` para operação totalmente autônoma e sem prompts, criada para pipelines CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` desativa todos os prompts de permissão e permite que o agente execute qualquer ação sem confirmação. Use apenas em ambientes confiáveis.
+
+### Documentação
+
+Para configuração e todo o resto, consulte a [documentação](https://kilo.ai/docs).
+
+### Contribuindo
+
+Contribuições são bem-vindas de desenvolvedores, escritores e qualquer pessoa. Comece pelo [Contributing Guide](/CONTRIBUTING.md) para configurar o ambiente, conhecer os padrões de código e abrir um pull request. Consulte [RELEASING.md](../RELEASING.md) para o processo de release da extensão VS Code e da CLI, e [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) para o plugin JetBrains.
+
+Leia nosso [Code of Conduct](/CODE_OF_CONDUCT.md) antes de participar.
+
+### Licença
+
+MIT. Você pode usar, modificar e distribuir este código, inclusive comercialmente, desde que mantenha os avisos de atribuição e licença. Consulte [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>De onde veio o Kilo CLI?</summary>
+
+Kilo CLI é um fork do [OpenCode](https://github.com/anomalyco/opencode), aprimorado para funcionar dentro da plataforma de engenharia agêntica da Kilo.
+
+</details>
+
+---
+
+**Participe da comunidade** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.bs.md
+++ b/translations/README.bs.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | Bosanski | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Open source agent za kodiranje s AI-jem u VS Codeu, JetBrainsu ili CLI-ju.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code je AI agent za kodiranje koji vas prati svugdje gdje radite: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) i [CLI](https://kilo.ai/cli). Open source je i ima otvorene cijene. Birate između više od 500 modela, mijenjate ih usred zadatka i plaćate cijenu pružaoca modela bez dodatne marže. API ključevi nisu potrebni za početak.
+
+### Instalacija
+
+Odaberite gdje želite pokrenuti Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Instalirajte [Kilo Code ekstenziju](vscode:extension/kilocode.kilo-code) direktno ili je preuzmite sa [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Kreirajte račun i imat ćete pristup za više od 500 modela, uključujući GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 i Gemini 3.1 Pro Preview, sve po cijenama pružaoca.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Zatim pokrenite `kilo` u bilo kojem direktoriju projekta.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Instalirajte [Kilo Code plugin](https://plugins.jetbrains.com/plugin/28350-kilo-code) sa JetBrains Marketplacea ili potražite "Kilo Code" u `Settings → Plugins` unutar bilo kojeg JetBrains IDE-a.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Pokrenite Kilo s weba, bez lokalne mašine, na [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Pregledi koda</strong></summary>
+
+<br>
+
+Postavite automatske AI preglede koda na svojim pull requestovima na [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Pokrenite svog uvijek aktivnog AI agenta na [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Instalirajte CLI iz GitHub Releases (binarne datoteke)</summary>
+
+Preuzmite najnoviju binarnu datoteku sa [Releases stranice](https://github.com/Kilo-Org/kilocode/releases).
+
+| Platforma | Asset |
+|---|---|
+| Windows (većina PC računara) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Napomene: `x64-baseline` je kompatibilna verzija za starije CPU-e bez AVX-a. `musl` je statički linkovana verzija za Alpine ili minimalne Docker slike bez glibc-a. `kilo-vscode-*.vsix` je paket VS Code ekstenzije, ne CLI. `Source code` arhive služe za build iz izvornog koda.
+
+</details>
+
+### Agents
+
+Kilo dolazi sa specijaliziranim agents koje mijenjate zavisno od zadatka. Možete napraviti i vlastite prilagođene agents.
+
+- **Code** - Zadani. Implementira i uređuje kod iz prirodnog jezika.
+- **Plan** - Dizajnira arhitekturu i piše implementacijske planove prije pisanja koda.
+- **Ask** - Odgovara na pitanja o codebaseu bez mijenjanja datoteka.
+- **Debug** - Rješava i prati probleme.
+- **Review** - Pregleda vaše promjene i pronalazi probleme u performansama, sigurnosti, stilu i pokrivenosti testovima.
+
+Saznajte više o [agents i prilagođenim agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Šta radi
+
+- **Generisanje koda** iz prirodnog jezika, kroz više datoteka.
+- **Inline autocomplete** sa ghost-text prijedlozima i Tab za prihvatanje.
+- **Samoprovjera** kako bi agent pregledao i ispravio vlastiti rad.
+- **Kontrola terminala i browsera** za pokretanje komandi i automatizaciju weba.
+- **MCP marketplace** za pronalaženje i povezivanje MCP servera koji proširuju mogućnosti agenta.
+- **Više od 500 modela** sa prebacivanjem usred zadatka, da uskladite latenciju, cijenu i rezonovanje s poslom.
+
+### Autonomni način rada (CI/CD)
+
+Pokrenite `kilo run` s `--auto` za potpuno autonoman rad bez promptova, napravljen za CI/CD pipelineove:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` isključuje sve upite za dozvole i dopušta agentu da izvrši bilo koju radnju bez potvrde. Koristite samo u pouzdanim okruženjima.
+
+### Dokumentacija
+
+Za konfiguraciju i sve ostalo posjetite [dokumentaciju](https://kilo.ai/docs).
+
+### Doprinos
+
+Doprinosi su dobrodošli od developera, pisaca i svih ostalih. Počnite sa [Contributing Guide](/CONTRIBUTING.md) za podešavanje okruženja, standarde kodiranja i otvaranje pull requesta. Pogledajte [RELEASING.md](../RELEASING.md) za proces izdavanja VS Code ekstenzije i CLI-ja, te [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) za JetBrains plugin.
+
+Prije uključivanja pročitajte naš [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+### Licenca
+
+MIT. Možete koristiti, mijenjati i distribuirati ovaj kod, uključujući komercijalno, dok god zadržite atribuciju i obavijesti o licenci. Pogledajte [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Odakle dolazi Kilo CLI?</summary>
+
+Kilo CLI je fork [OpenCode](https://github.com/anomalyco/opencode), poboljšan za rad unutar Kilo agentic engineering platforme.
+
+</details>
+
+---
+
+**Pridružite se zajednici** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.da.md
+++ b/translations/README.da.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | Dansk | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Den open source-kodeagent til at bygge med AI i VS Code, JetBrains eller CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code er en AI-kodeagent, der møder dig overalt, hvor du arbejder: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) og [CLI](https://kilo.ai/cli). Den er open source med åben prissætning. Du vælger mellem mere end 500 modeller, skifter mellem dem midt i en opgave og betaler modeludbyderens pris uden tillæg. Ingen API-nøgler kræves for at komme i gang.
+
+### Installation
+
+Vælg, hvor du vil køre Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Installer [Kilo Code-udvidelsen](vscode:extension/kilocode.kilo-code) direkte, eller hent den fra [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Opret en konto, og du får adgang til mere end 500 modeller, herunder GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 og Gemini 3.1 Pro Preview, alle til udbyderpris.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Kør derefter `kilo` i en vilkårlig projektmappe for at starte.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Installer [Kilo Code-pluginet](https://plugins.jetbrains.com/plugin/28350-kilo-code) fra JetBrains Marketplace, eller søg efter "Kilo Code" i `Settings → Plugins` i en JetBrains IDE.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Kør Kilo fra webben, uden lokal maskine, på [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Kodegennemgange</strong></summary>
+
+<br>
+
+Opsæt automatiske AI-kodegennemgange på dine pull requests på [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Start din altid aktive AI-agent på [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Installer CLI fra GitHub Releases (binære filer)</summary>
+
+Download den nyeste binære fil fra [Releases-siden](https://github.com/Kilo-Org/kilocode/releases).
+
+| Platform | Asset |
+|---|---|
+| Windows (de fleste pc'er) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Bemærk: `x64-baseline` er en kompatibilitetsbuild til ældre CPU'er uden AVX. `musl` er den statisk linkede build til Alpine eller minimale Docker-images uden glibc. `kilo-vscode-*.vsix` er VS Code-udvidelsespakken, ikke CLI'en. `Source code`-arkiver er til at bygge fra kildekode.
+
+</details>
+
+### Agents
+
+Kilo leveres med specialiserede agents, som du kan skifte mellem afhængigt af opgaven. Du kan også bygge dine egne brugerdefinerede agents.
+
+- **Code** - Standard. Implementerer og redigerer kode fra naturligt sprog.
+- **Plan** - Designer arkitektur og skriver implementeringsplaner, før der skrives kode.
+- **Ask** - Besvarer spørgsmål om din kodebase uden at ændre filer.
+- **Debug** - Fejlfinder og sporer problemer.
+- **Review** - Gennemgår dine ændringer og finder problemer med ydeevne, sikkerhed, stil og testdækning.
+
+Læs mere om [agents og brugerdefinerede agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Hvad den gør
+
+- **Kodegenerering** fra naturligt sprog på tværs af flere filer.
+- **Inline-autocomplete** med ghost-text-forslag og Tab for at acceptere.
+- **Selvkontrol**, så agenten gennemgår og retter sit eget arbejde.
+- **Terminal- og browserkontrol** til at køre kommandoer og automatisere webben.
+- **MCP-markedsplads** til at finde og tilslutte MCP-servere, der udvider agentens muligheder.
+- **Mere end 500 modeller** med skift midt i opgaven, så du kan matche latenstid, pris og ræsonnement til arbejdet.
+
+### Autonom tilstand (CI/CD)
+
+Kør `kilo run` med `--auto` for fuldt autonom drift uden prompts, bygget til CI/CD-pipelines:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` deaktiverer alle tilladelsesprompts og lader agenten udføre enhver handling uden bekræftelse. Brug det kun i betroede miljøer.
+
+### Dokumentation
+
+For konfiguration og alt andet, se [dokumentationen](https://kilo.ai/docs).
+
+### Bidrag
+
+Bidrag er velkomne fra udviklere, forfattere og alle andre. Start med [Contributing Guide](/CONTRIBUTING.md) for miljøopsætning, kodestandarder og hvordan du åbner en pull request. Se [RELEASING.md](../RELEASING.md) for releaseprocessen for VS Code-udvidelsen og CLI'en, og [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) for JetBrains-pluginet.
+
+Læs venligst vores [Code of Conduct](/CODE_OF_CONDUCT.md), før du deltager.
+
+### Licens
+
+MIT. Du kan bruge, ændre og distribuere denne kode, også kommercielt, så længe du beholder attribution og licensmeddelelser. Se [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Hvor kommer Kilo CLI fra?</summary>
+
+Kilo CLI er en fork af [OpenCode](https://github.com/anomalyco/opencode), forbedret til at fungere i Kilo agentic engineering-platformen.
+
+</details>
+
+---
+
+**Deltag i fællesskabet** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | Deutsch | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Der Open-Source-Coding-Agent zum Entwickeln mit KI in VS Code, JetBrains oder der CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code ist ein KI-Coding-Agent, der überall dort arbeitet, wo du arbeitest: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) und die [CLI](https://kilo.ai/cli). Es ist Open Source mit transparenter Preisgestaltung. Du wählst aus über 500 Modellen, wechselst sie mitten in einer Aufgabe und zahlst den Tarif des Modellanbieters ohne Aufschlag. Zum Start sind keine API-Schlüssel erforderlich.
+
+### Installation
+
+Wähle aus, wo du Kilo ausführen möchtest.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Installiere die [Kilo Code-Erweiterung](vscode:extension/kilocode.kilo-code) direkt oder lade sie aus dem [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Erstelle ein Konto und erhalte Zugriff auf über 500 Modelle, darunter GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 und Gemini 3.1 Pro Preview, alle zu Anbieterpreisen.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Führe anschließend `kilo` in einem beliebigen Projektverzeichnis aus.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Installiere das [Kilo Code-Plugin](https://plugins.jetbrains.com/plugin/28350-kilo-code) aus dem JetBrains Marketplace oder suche in einer JetBrains-IDE unter `Settings → Plugins` nach "Kilo Code".
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Führe Kilo im Web aus, ohne lokalen Rechner, unter [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+Richte automatisierte KI-Code-Reviews für deine Pull Requests unter [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) ein.
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Starte deinen ständig aktiven KI-Agenten unter [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>CLI aus GitHub Releases installieren (Binärdateien)</summary>
+
+Lade die neueste Binärdatei von der [Releases-Seite](https://github.com/Kilo-Org/kilocode/releases) herunter.
+
+| Plattform | Asset |
+|---|---|
+| Windows (die meisten PCs) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Hinweise: `x64-baseline` ist ein Kompatibilitäts-Build für ältere CPUs ohne AVX. `musl` ist der statisch gelinkte Build für Alpine oder minimale Docker-Images ohne glibc. `kilo-vscode-*.vsix` ist das VS Code-Erweiterungspaket, nicht die CLI. `Source code`-Archive dienen dem Bauen aus dem Quellcode.
+
+</details>
+
+### Agents
+
+Kilo wird mit spezialisierten Agents ausgeliefert, zwischen denen du je nach Aufgabe wechselst. Du kannst auch eigene Agents erstellen.
+
+- **Code** - Standard. Implementiert und bearbeitet Code aus natürlicher Sprache.
+- **Plan** - Entwirft Architektur und schreibt Implementierungspläne, bevor Code geschrieben wird.
+- **Ask** - Beantwortet Fragen zu deiner Codebasis, ohne Dateien zu ändern.
+- **Debug** - Untersucht und verfolgt Probleme.
+- **Review** - Prüft deine Änderungen und findet Probleme bei Performance, Sicherheit, Stil und Testabdeckung.
+
+Mehr erfahren über [Agents und benutzerdefinierte Agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Funktionen
+
+- **Codegenerierung** aus natürlicher Sprache über mehrere Dateien hinweg.
+- **Inline-Autocomplete** mit Ghost-Text-Vorschlägen und Tab zum Übernehmen.
+- **Selbstprüfung**, damit der Agent seine eigene Arbeit prüft und korrigiert.
+- **Terminal- und Browsersteuerung**, um Befehle auszuführen und das Web zu automatisieren.
+- **MCP-Marktplatz**, um MCP-Server zu finden und einzubinden, die den Agent erweitern.
+- **Über 500 Modelle** mit Wechsel während einer Aufgabe, damit du Latenz, Kosten und Reasoning passend zur Aufgabe wählst.
+
+### Autonomer Modus (CI/CD)
+
+Führe `kilo run` mit `--auto` für vollständig autonomen Betrieb ohne Prompts aus, geeignet für CI/CD-Pipelines:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` deaktiviert alle Berechtigungsabfragen und erlaubt dem Agent, jede Aktion ohne Bestätigung auszuführen. Verwende es nur in vertrauenswürdigen Umgebungen.
+
+### Dokumentation
+
+Für Konfiguration und alles Weitere lies die [Dokumentation](https://kilo.ai/docs).
+
+### Mitwirken
+
+Beiträge von Entwicklerinnen, Autoren und allen anderen sind willkommen. Beginne mit dem [Contributing Guide](/CONTRIBUTING.md) für Einrichtung, Coding-Standards und Pull Requests. Siehe [RELEASING.md](../RELEASING.md) für den Release-Prozess der VS Code-Erweiterung und CLI sowie [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) für das JetBrains-Plugin.
+
+Bitte lies unseren [Code of Conduct](/CODE_OF_CONDUCT.md), bevor du mitwirkst.
+
+### Lizenz
+
+MIT. Du darfst diesen Code verwenden, ändern und verbreiten, auch kommerziell, solange du die Attribution und Lizenzhinweise beibehältst. Siehe [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Woher stammt Kilo CLI?</summary>
+
+Kilo CLI ist ein Fork von [OpenCode](https://github.com/anomalyco/opencode), erweitert für die Kilo-Agentic-Engineering-Plattform.
+
+</details>
+
+---
+
+**Tritt der Community bei** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.es.md
+++ b/translations/README.es.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | Español | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">El agente de programación de código abierto para construir con IA en VS Code, JetBrains o la CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code es un agente de programación con IA que te acompaña en todos los lugares donde trabajas: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) y la [CLI](https://kilo.ai/cli). Es de código abierto y tiene precios abiertos. Puedes elegir entre más de 500 modelos, cambiar entre ellos a mitad de una tarea y pagar la tarifa del proveedor del modelo sin recargos. No necesitas claves de API para empezar.
+
+### Instalación
+
+Elige dónde quieres ejecutar Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Instala directamente la [extensión Kilo Code](vscode:extension/kilocode.kilo-code), o descárgala desde [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Crea una cuenta y tendrás acceso a más de 500 modelos, incluidos GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 y Gemini 3.1 Pro Preview, todos con precios del proveedor.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Luego ejecuta `kilo` en cualquier directorio de proyecto para empezar.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Instala el [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) desde JetBrains Marketplace, o busca "Kilo Code" en `Settings → Plugins` dentro de cualquier IDE de JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Ejecuta Kilo desde la web, sin necesitar una máquina local, en [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Revisiones de código</strong></summary>
+
+<br>
+
+Configura revisiones automáticas de código con IA en tus pull requests en [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Activa tu agente de IA siempre disponible en [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Instalar la CLI desde GitHub Releases (binarios)</summary>
+
+Descarga el binario más reciente desde la [página de Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Plataforma | Recurso |
+|---|---|
+| Windows (la mayoría de PCs) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Notas: `x64-baseline` es una compilación de compatibilidad para CPUs antiguas sin AVX. `musl` es la compilación enlazada estáticamente para Alpine o imágenes Docker mínimas sin glibc. `kilo-vscode-*.vsix` es el paquete de extensión de VS Code, no la CLI. Los archivos `Source code` son para compilar desde el código fuente.
+
+</details>
+
+### Agents
+
+Kilo incluye agents especializados entre los que puedes cambiar según la tarea. También puedes crear tus propios agents personalizados.
+
+- **Code** - El predeterminado. Implementa y edita código a partir de lenguaje natural.
+- **Plan** - Diseña la arquitectura y escribe planes de implementación antes de que se escriba código.
+- **Ask** - Responde preguntas sobre tu base de código sin tocar archivos.
+- **Debug** - Diagnostica y rastrea problemas.
+- **Review** - Revisa tus cambios y detecta problemas de rendimiento, seguridad, estilo y cobertura de pruebas.
+
+Más información sobre [agents y agents personalizados](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Qué hace
+
+- **Generación de código** desde lenguaje natural, en varios archivos.
+- **Autocompletado en línea** con sugerencias ghost-text y Tab para aceptar.
+- **Autoverificación** para que el agente revise y corrija su propio trabajo.
+- **Control de terminal y navegador** para ejecutar comandos y automatizar la web.
+- **Marketplace MCP** para encontrar y conectar servidores MCP que amplían lo que el agente puede hacer.
+- **Más de 500 modelos** con cambio a mitad de tarea, para ajustar latencia, costo y razonamiento al trabajo.
+
+### Modo autónomo (CI/CD)
+
+Ejecuta `kilo run` con `--auto` para operar de forma totalmente autónoma y sin prompts, pensado para pipelines CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` desactiva todos los prompts de permisos y permite que el agente ejecute cualquier acción sin confirmación. Úsalo solo en entornos de confianza.
+
+### Documentación
+
+Para configuración y todo lo demás, consulta la [documentación](https://kilo.ai/docs).
+
+### Contribuir
+
+Las contribuciones de desarrolladores, escritores y cualquier persona son bienvenidas. Empieza con la [Guía de contribución](/CONTRIBUTING.md) para la configuración del entorno, los estándares de código y cómo abrir un pull request. Consulta [RELEASING.md](../RELEASING.md) para el proceso de lanzamiento de la extensión de VS Code y la CLI, y [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) para el plugin de JetBrains.
+
+Lee nuestro [Código de conducta](/CODE_OF_CONDUCT.md) antes de participar.
+
+### Licencia
+
+MIT. Puedes usar, modificar y distribuir este código, incluso comercialmente, siempre que conserves los avisos de atribución y licencia. Consulta [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>¿De dónde viene Kilo CLI?</summary>
+
+Kilo CLI es un fork de [OpenCode](https://github.com/anomalyco/opencode), mejorado para funcionar dentro de la plataforma de ingeniería agéntica de Kilo.
+
+</details>
+
+---
+
+**Únete a la comunidad** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.fr.md
+++ b/translations/README.fr.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | Français | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">L'agent de codage open source pour construire avec l'IA dans VS Code, JetBrains ou la CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code est un agent de codage avec IA qui vous accompagne partout où vous travaillez : [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) et la [CLI](https://kilo.ai/cli). Il est open source avec une tarification ouverte. Vous choisissez parmi plus de 500 modèles, vous pouvez en changer en cours de tâche et vous payez le tarif du fournisseur du modèle sans majoration. Aucune clé API n'est nécessaire pour commencer.
+
+### Installation
+
+Choisissez où vous voulez exécuter Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Installez directement l'[extension Kilo Code](vscode:extension/kilocode.kilo-code), ou récupérez-la sur le [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Créez un compte et vous aurez accès à plus de 500 modèles, dont GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 et Gemini 3.1 Pro Preview, tous au prix fournisseur.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Exécutez ensuite `kilo` dans n'importe quel répertoire de projet pour commencer.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Installez le [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) depuis JetBrains Marketplace, ou recherchez "Kilo Code" dans `Settings → Plugins` dans n'importe quel IDE JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Exécutez Kilo depuis le web, sans machine locale, sur [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Revues de code</strong></summary>
+
+<br>
+
+Configurez des revues de code IA automatisées sur vos pull requests à l'adresse [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Lancez votre agent IA toujours actif sur [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Installer la CLI depuis GitHub Releases (binaires)</summary>
+
+Téléchargez le dernier binaire depuis la [page des releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Plateforme | Fichier |
+|---|---|
+| Windows (la plupart des PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Notes : `x64-baseline` est une build de compatibilité pour les anciens processeurs sans AVX. `musl` est la build liée statiquement pour Alpine ou les images Docker minimales sans glibc. `kilo-vscode-*.vsix` est le paquet de l'extension VS Code, pas la CLI. Les archives `Source code` servent à compiler depuis les sources.
+
+</details>
+
+### Agents
+
+Kilo inclut des agents spécialisés entre lesquels vous pouvez basculer selon la tâche. Vous pouvez aussi créer vos propres agents personnalisés.
+
+- **Code** - Par défaut. Implémente et modifie le code à partir du langage naturel.
+- **Plan** - Conçoit l'architecture et rédige des plans d'implémentation avant l'écriture du code.
+- **Ask** - Répond aux questions sur votre base de code sans modifier les fichiers.
+- **Debug** - Diagnostique et trace les problèmes.
+- **Review** - Examine vos changements et signale les problèmes de performance, sécurité, style et couverture de tests.
+
+En savoir plus sur les [agents et agents personnalisés](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Fonctionnalités
+
+- **Génération de code** en langage naturel, sur plusieurs fichiers.
+- **Autocomplétion en ligne** avec suggestions ghost-text et Tab pour accepter.
+- **Auto-vérification** pour que l'agent relise et corrige son propre travail.
+- **Contrôle du terminal et du navigateur** pour exécuter des commandes et automatiser le web.
+- **Marketplace MCP** pour trouver et connecter des serveurs MCP qui étendent les capacités de l'agent.
+- **Plus de 500 modèles** avec changement en cours de tâche, pour adapter latence, coût et raisonnement au travail.
+
+### Mode autonome (CI/CD)
+
+Exécutez `kilo run` avec `--auto` pour un fonctionnement entièrement autonome sans prompts, conçu pour les pipelines CI/CD :
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` désactive toutes les demandes d'autorisation et permet à l'agent d'exécuter n'importe quelle action sans confirmation. Utilisez-le uniquement dans des environnements de confiance.
+
+### Documentation
+
+Pour la configuration et tout le reste, consultez la [documentation](https://kilo.ai/docs).
+
+### Contribuer
+
+Les contributions des développeurs, rédacteurs et de toute personne intéressée sont les bienvenues. Commencez par le [guide de contribution](/CONTRIBUTING.md) pour la configuration de l'environnement, les standards de code et l'ouverture d'une pull request. Consultez [RELEASING.md](../RELEASING.md) pour le processus de release de l'extension VS Code et de la CLI, et [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) pour le plugin JetBrains.
+
+Veuillez lire notre [Code de conduite](/CODE_OF_CONDUCT.md) avant de participer.
+
+### Licence
+
+MIT. Vous pouvez utiliser, modifier et distribuer ce code, y compris commercialement, tant que vous conservez les mentions d'attribution et de licence. Voir [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>D'où vient Kilo CLI ?</summary>
+
+Kilo CLI est un fork d'[OpenCode](https://github.com/anomalyco/opencode), amélioré pour fonctionner au sein de la plateforme d'ingénierie agentique Kilo.
+
+</details>
+
+---
+
+**Rejoindre la communauté** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.gr.md
+++ b/translations/README.gr.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | Ελληνικά | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Ο open source agent προγραμματισμού για δημιουργία με AI σε VS Code, JetBrains ή CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Το Kilo Code είναι ένας AI agent προγραμματισμού που σας συναντά παντού όπου εργάζεστε: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) και [CLI](https://kilo.ai/cli). Είναι open source με ανοιχτή τιμολόγηση. Επιλέγετε από περισσότερα από 500 μοντέλα, αλλάζετε μεταξύ τους στη μέση μιας εργασίας και πληρώνετε την τιμή του παρόχου του μοντέλου χωρίς προσαύξηση. Δεν απαιτούνται API keys για να ξεκινήσετε.
+
+### Εγκατάσταση
+
+Επιλέξτε πού θέλετε να εκτελέσετε το Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Εγκαταστήστε απευθείας την [επέκταση Kilo Code](vscode:extension/kilocode.kilo-code) ή κατεβάστε τη από το [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Δημιουργήστε λογαριασμό και θα έχετε πρόσβαση σε περισσότερα από 500 μοντέλα, όπως GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 και Gemini 3.1 Pro Preview, όλα στην τιμή του παρόχου.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Στη συνέχεια εκτελέστε `kilo` σε οποιονδήποτε κατάλογο έργου για να ξεκινήσετε.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Εγκαταστήστε το [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) από το JetBrains Marketplace ή αναζητήστε "Kilo Code" στο `Settings → Plugins` σε οποιοδήποτε JetBrains IDE.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Εκτελέστε το Kilo από τον ιστό, χωρίς τοπικό μηχάνημα, στο [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+Ρυθμίστε αυτοματοποιημένα AI code reviews στα pull requests σας στο [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Εκκινήστε τον πάντα ενεργό AI agent σας στο [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Εγκατάσταση CLI από GitHub Releases (binaries)</summary>
+
+Κατεβάστε το πιο πρόσφατο binary από τη [σελίδα Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Πλατφόρμα | Asset |
+|---|---|
+| Windows (οι περισσότεροι υπολογιστές) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Σημειώσεις: Το `x64-baseline` είναι build συμβατότητας για παλαιότερους CPU χωρίς AVX. Το `musl` είναι το στατικά συνδεδεμένο build για Alpine ή ελάχιστες Docker images χωρίς glibc. Το `kilo-vscode-*.vsix` είναι το πακέτο επέκτασης VS Code, όχι το CLI. Τα αρχεία `Source code` είναι για build από τον πηγαίο κώδικα.
+
+</details>
+
+### Agents
+
+Το Kilo περιλαμβάνει εξειδικευμένους agents ανάμεσα στους οποίους αλλάζετε ανάλογα με την εργασία. Μπορείτε επίσης να δημιουργήσετε τους δικούς σας custom agents.
+
+- **Code** - Ο προεπιλεγμένος. Υλοποιεί και επεξεργάζεται κώδικα από φυσική γλώσσα.
+- **Plan** - Σχεδιάζει αρχιτεκτονική και γράφει πλάνα υλοποίησης πριν γραφτεί κώδικας.
+- **Ask** - Απαντά σε ερωτήσεις για το codebase σας χωρίς να πειράζει αρχεία.
+- **Debug** - Αντιμετωπίζει και εντοπίζει προβλήματα.
+- **Review** - Ελέγχει τις αλλαγές σας και εντοπίζει ζητήματα απόδοσης, ασφάλειας, στυλ και κάλυψης δοκιμών.
+
+Μάθετε περισσότερα για τους [agents και custom agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Τι κάνει
+
+- **Παραγωγή κώδικα** από φυσική γλώσσα, σε πολλά αρχεία.
+- **Inline autocomplete** με ghost-text προτάσεις και Tab για αποδοχή.
+- **Αυτοέλεγχος** ώστε ο agent να ελέγχει και να διορθώνει τη δουλειά του.
+- **Έλεγχος terminal και browser** για εκτέλεση εντολών και αυτοματοποίηση του web.
+- **MCP marketplace** για εύρεση και σύνδεση MCP servers που επεκτείνουν τις δυνατότητες του agent.
+- **Περισσότερα από 500 μοντέλα** με αλλαγή στη μέση της εργασίας, ώστε να ταιριάζετε latency, κόστος και reasoning στη δουλειά.
+
+### Αυτόνομη λειτουργία (CI/CD)
+
+Εκτελέστε `kilo run` με `--auto` για πλήρως αυτόνομη λειτουργία χωρίς prompts, σχεδιασμένη για CI/CD pipelines:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+Το `--auto` απενεργοποιεί όλα τα prompts αδειών και επιτρέπει στον agent να εκτελεί οποιαδήποτε ενέργεια χωρίς επιβεβαίωση. Χρησιμοποιήστε το μόνο σε αξιόπιστα περιβάλλοντα.
+
+### Τεκμηρίωση
+
+Για ρυθμίσεις και όλα τα υπόλοιπα, δείτε την [τεκμηρίωση](https://kilo.ai/docs).
+
+### Συνεισφορά
+
+Οι συνεισφορές είναι ευπρόσδεκτες από developers, writers και όλους. Ξεκινήστε με τον [Contributing Guide](/CONTRIBUTING.md) για ρύθμιση περιβάλλοντος, πρότυπα κώδικα και άνοιγμα pull request. Δείτε το [RELEASING.md](../RELEASING.md) για τη διαδικασία release της επέκτασης VS Code και του CLI, και το [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) για το JetBrains plugin.
+
+Παρακαλούμε διαβάστε τον [Code of Conduct](/CODE_OF_CONDUCT.md) πριν συμμετάσχετε.
+
+### Άδεια
+
+MIT. Μπορείτε να χρησιμοποιήσετε, να τροποποιήσετε και να διανείμετε αυτόν τον κώδικα, ακόμη και εμπορικά, αρκεί να διατηρήσετε τις αναφορές απόδοσης και άδειας. Δείτε [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Από πού προήλθε το Kilo CLI;</summary>
+
+Το Kilo CLI είναι fork του [OpenCode](https://github.com/anomalyco/opencode), βελτιωμένο για να λειτουργεί μέσα στην Kilo agentic engineering platform.
+
+</details>
+
+---
+
+**Γίνετε μέλος της κοινότητας** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.it.md
+++ b/translations/README.it.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | Italiano | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">L'agente di coding open source per creare con l'IA in VS Code, JetBrains o nella CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code è un agente di coding con IA che ti segue ovunque lavori: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) e la [CLI](https://kilo.ai/cli). È open source con prezzi trasparenti. Puoi scegliere tra oltre 500 modelli, passare da uno all'altro durante un'attività e pagare la tariffa del provider del modello senza ricarichi. Non servono chiavi API per iniziare.
+
+### Installazione
+
+Scegli dove vuoi eseguire Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Installa direttamente l'[estensione Kilo Code](vscode:extension/kilocode.kilo-code), oppure scaricala dal [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Crea un account e avrai accesso a oltre 500 modelli, inclusi GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 e Gemini 3.1 Pro Preview, tutti al prezzo del provider.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Poi esegui `kilo` in qualsiasi directory di progetto per iniziare.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Installa il [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) dal JetBrains Marketplace, oppure cerca "Kilo Code" in `Settings → Plugins` dentro qualsiasi IDE JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Esegui Kilo dal web, senza una macchina locale, su [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Revisioni del codice</strong></summary>
+
+<br>
+
+Configura revisioni automatiche del codice con IA sulle tue pull request su [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Avvia il tuo agente IA sempre attivo su [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Installare la CLI da GitHub Releases (binari)</summary>
+
+Scarica il binario più recente dalla [pagina Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Piattaforma | Asset |
+|---|---|
+| Windows (la maggior parte dei PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Note: `x64-baseline` è una build di compatibilità per CPU più vecchie senza AVX. `musl` è la build collegata staticamente per Alpine o immagini Docker minimali senza glibc. `kilo-vscode-*.vsix` è il pacchetto dell'estensione VS Code, non la CLI. Gli archivi `Source code` servono per compilare dai sorgenti.
+
+</details>
+
+### Agents
+
+Kilo include agents specializzati tra cui puoi passare in base all'attività. Puoi anche creare agents personalizzati.
+
+- **Code** - Predefinito. Implementa e modifica codice da linguaggio naturale.
+- **Plan** - Progetta l'architettura e scrive piani di implementazione prima che venga scritto codice.
+- **Ask** - Risponde a domande sulla tua codebase senza modificare file.
+- **Debug** - Risolve e traccia problemi.
+- **Review** - Revisiona le modifiche e segnala problemi di performance, sicurezza, stile e copertura dei test.
+
+Scopri di più su [agents e agents personalizzati](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Cosa fa
+
+- **Generazione di codice** da linguaggio naturale, su più file.
+- **Autocompletamento inline** con suggerimenti ghost-text e Tab per accettare.
+- **Autoverifica** così l'agente rivede e corregge il proprio lavoro.
+- **Controllo di terminale e browser** per eseguire comandi e automatizzare il web.
+- **Marketplace MCP** per trovare e collegare server MCP che estendono ciò che l'agente può fare.
+- **Oltre 500 modelli** con cambio durante l'attività, per adattare latenza, costo e ragionamento al lavoro.
+
+### Modalità autonoma (CI/CD)
+
+Esegui `kilo run` con `--auto` per un funzionamento completamente autonomo senza prompt, pensato per pipeline CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` disabilita tutti i prompt di autorizzazione e consente all'agente di eseguire qualsiasi azione senza conferma. Usalo solo in ambienti attendibili.
+
+### Documentazione
+
+Per configurazione e tutto il resto, consulta la [documentazione](https://kilo.ai/docs).
+
+### Contribuire
+
+Sono benvenuti contributi da sviluppatori, autori e chiunque altro. Inizia dalla [Guida al contributo](/CONTRIBUTING.md) per configurazione dell'ambiente, standard di codice e apertura di una pull request. Consulta [RELEASING.md](../RELEASING.md) per il processo di rilascio dell'estensione VS Code e della CLI, e [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) per il plugin JetBrains.
+
+Leggi il nostro [Codice di condotta](/CODE_OF_CONDUCT.md) prima di partecipare.
+
+### Licenza
+
+MIT. Puoi usare, modificare e distribuire questo codice, anche commercialmente, purché mantieni le note di attribuzione e licenza. Vedi [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Da dove viene Kilo CLI?</summary>
+
+Kilo CLI è un fork di [OpenCode](https://github.com/anomalyco/opencode), migliorato per funzionare nella piattaforma di ingegneria agentica Kilo.
+
+</details>
+
+---
+
+**Unisciti alla community** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.ja.md
+++ b/translations/README.ja.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | 日本語 | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">VS Code、JetBrains、CLI で AI を使って開発するためのオープンソースのコーディングエージェント。</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code は、[VS Code](https://kilo.ai/landing/vs-code)、[JetBrains](https://kilo.ai/features/jetbrains-native)、[CLI](https://kilo.ai/cli) など、あなたが作業する場所で使える AI コーディングエージェントです。オープンソースで、透明な価格体系を採用しています。500 以上のモデルから選択し、タスクの途中で切り替え、追加料金なしでモデルプロバイダーの料金を支払います。開始に API キーは不要です。
+
+### インストール
+
+Kilo を実行する場所を選んでください。
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+[Kilo Code 拡張機能](vscode:extension/kilocode.kilo-code)を直接インストールするか、[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) から入手してください。アカウントを作成すると、GPT-5.5、Claude Opus 4.7、Claude Sonnet 4.6、Gemini 3.1 Pro Preview を含む 500 以上のモデルを、すべてプロバイダー価格で利用できます。
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+その後、任意のプロジェクトディレクトリで `kilo` を実行して開始します。
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+JetBrains Marketplace から [Kilo Code プラグイン](https://plugins.jetbrains.com/plugin/28350-kilo-code)をインストールするか、任意の JetBrains IDE の `Settings → Plugins` で "Kilo Code" を検索してください。
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+ローカルマシンなしで、Web から [app.kilo.ai/cloud](https://app.kilo.ai/cloud) で Kilo を実行できます。
+
+</details>
+
+<details>
+<summary><strong>コードレビュー</strong></summary>
+
+<br>
+
+[app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) で pull request に自動 AI コードレビューを設定できます。
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+[app.kilo.ai/claw](https://app.kilo.ai/claw) で常時稼働する AI エージェントを起動できます。
+
+</details>
+
+<details>
+<summary>GitHub Releases から CLI をインストールする（バイナリ）</summary>
+
+[Releases ページ](https://github.com/Kilo-Org/kilocode/releases)から最新のバイナリをダウンロードしてください。
+
+| プラットフォーム | アセット |
+|---|---|
+| Windows（ほとんどの PC） | `kilo-windows-x64.zip` |
+| macOS（Apple Silicon） | `kilo-darwin-arm64.zip` |
+| macOS（Intel） | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+注: `x64-baseline` は AVX のない古い CPU 向けの互換ビルドです。`musl` は Alpine や glibc のない最小 Docker イメージ向けの静的リンクビルドです。`kilo-vscode-*.vsix` は VS Code 拡張機能パッケージであり、CLI ではありません。`Source code` アーカイブはソースからビルドするためのものです。
+
+</details>
+
+### Agents
+
+Kilo には、タスクに応じて切り替えられる特化型 agents が含まれています。独自のカスタム agents も作成できます。
+
+- **Code** - デフォルト。自然言語からコードを実装、編集します。
+- **Plan** - コードを書く前にアーキテクチャを設計し、実装計画を作成します。
+- **Ask** - ファイルを変更せずにコードベースに関する質問に答えます。
+- **Debug** - 問題のトラブルシューティングと追跡を行います。
+- **Review** - 変更をレビューし、パフォーマンス、セキュリティ、スタイル、テストカバレッジの問題を検出します。
+
+[agents とカスタム agents](https://kilo.ai/docs/code-with-ai/agents/using-agents) について詳しく学べます。
+
+### 機能
+
+- 自然言語から複数ファイルにわたる **コード生成**。
+- ghost-text 提案と Tab での受け入れに対応した **インライン補完**。
+- エージェントが自分の作業をレビューして修正する **セルフチェック**。
+- コマンド実行と Web 自動化のための **ターミナルとブラウザ制御**。
+- エージェントの機能を拡張する MCP サーバーを見つけて接続する **MCP マーケットプレイス**。
+- レイテンシ、コスト、推論能力を作業に合わせるため、タスク途中の切り替えに対応した **500 以上のモデル**。
+
+### 自律モード（CI/CD）
+
+CI/CD パイプライン向けに、プロンプトなしで完全自律動作させるには `kilo run` に `--auto` を指定します。
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` はすべての権限プロンプトを無効にし、エージェントが確認なしで任意の操作を実行できるようにします。信頼できる環境でのみ使用してください。
+
+### ドキュメント
+
+設定やその他の内容については、[ドキュメント](https://kilo.ai/docs)をご覧ください。
+
+### コントリビューション
+
+開発者、ライター、その他すべての方からのコントリビューションを歓迎します。環境設定、コーディング標準、pull request の作成方法については [Contributing Guide](/CONTRIBUTING.md) から始めてください。VS Code 拡張機能と CLI のリリース手順は [RELEASING.md](../RELEASING.md)、JetBrains プラグインについては [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) を参照してください。
+
+参加する前に [Code of Conduct](/CODE_OF_CONDUCT.md) を確認してください。
+
+### ライセンス
+
+MIT。帰属表示とライセンス通知を保持する限り、商用利用を含め、このコードを使用、変更、配布できます。[License](/LICENSE) を参照してください。
+
+### FAQ
+
+<details>
+<summary>Kilo CLI はどこから来たのですか？</summary>
+
+Kilo CLI は [OpenCode](https://github.com/anomalyco/opencode) の fork であり、Kilo agentic engineering プラットフォーム内で動作するように強化されています。
+
+</details>
+
+---
+
+**コミュニティに参加** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.ko.md
+++ b/translations/README.ko.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | 한국어 | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">VS Code, JetBrains 또는 CLI에서 AI로 개발하기 위한 오픈 소스 코딩 에이전트입니다.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code는 [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native), [CLI](https://kilo.ai/cli) 등 작업하는 모든 곳에서 사용할 수 있는 AI 코딩 에이전트입니다. 오픈 소스이며 투명한 가격 정책을 제공합니다. 500개 이상의 모델 중에서 선택하고, 작업 중간에 모델을 전환하며, 추가 요금 없이 모델 제공업체의 요금만 지불합니다. 시작할 때 API 키가 필요하지 않습니다.
+
+### 설치
+
+Kilo를 실행할 위치를 선택하세요.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+[Kilo Code 확장](vscode:extension/kilocode.kilo-code)을 직접 설치하거나 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code)에서 설치하세요. 계정을 만들면 GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6, Gemini 3.1 Pro Preview를 포함한 500개 이상의 모델을 제공업체 가격으로 사용할 수 있습니다.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+그런 다음 아무 프로젝트 디렉터리에서 `kilo`를 실행해 시작하세요.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+JetBrains Marketplace에서 [Kilo Code 플러그인](https://plugins.jetbrains.com/plugin/28350-kilo-code)을 설치하거나, JetBrains IDE의 `Settings → Plugins`에서 "Kilo Code"를 검색하세요.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+로컬 머신 없이 웹에서 [app.kilo.ai/cloud](https://app.kilo.ai/cloud)로 Kilo를 실행하세요.
+
+</details>
+
+<details>
+<summary><strong>코드 리뷰</strong></summary>
+
+<br>
+
+[app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews)에서 pull request에 자동 AI 코드 리뷰를 설정하세요.
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+[app.kilo.ai/claw](https://app.kilo.ai/claw)에서 항상 켜져 있는 AI 에이전트를 시작하세요.
+
+</details>
+
+<details>
+<summary>GitHub Releases에서 CLI 설치하기(바이너리)</summary>
+
+[Releases 페이지](https://github.com/Kilo-Org/kilocode/releases)에서 최신 바이너리를 다운로드하세요.
+
+| 플랫폼 | 에셋 |
+|---|---|
+| Windows(대부분의 PC) | `kilo-windows-x64.zip` |
+| macOS(Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS(Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+참고: `x64-baseline`은 AVX가 없는 구형 CPU용 호환 빌드입니다. `musl`은 Alpine 또는 glibc가 없는 최소 Docker 이미지용 정적 링크 빌드입니다. `kilo-vscode-*.vsix`는 CLI가 아니라 VS Code 확장 패키지입니다. `Source code` 아카이브는 소스에서 빌드할 때 사용합니다.
+
+</details>
+
+### Agents
+
+Kilo에는 작업에 따라 전환할 수 있는 특화된 agents가 포함되어 있습니다. 사용자 지정 agents도 만들 수 있습니다.
+
+- **Code** - 기본값입니다. 자연어로 코드를 구현하고 편집합니다.
+- **Plan** - 코드가 작성되기 전에 아키텍처를 설계하고 구현 계획을 작성합니다.
+- **Ask** - 파일을 변경하지 않고 코드베이스에 대한 질문에 답합니다.
+- **Debug** - 문제를 해결하고 추적합니다.
+- **Review** - 변경 사항을 검토하고 성능, 보안, 스타일, 테스트 커버리지 문제를 찾아냅니다.
+
+[agents와 사용자 지정 agents](https://kilo.ai/docs/code-with-ai/agents/using-agents)에 대해 더 알아보세요.
+
+### 기능
+
+- 여러 파일에 걸친 자연어 기반 **코드 생성**.
+- ghost-text 제안과 Tab 수락을 지원하는 **인라인 자동완성**.
+- 에이전트가 자신의 작업을 검토하고 수정하는 **자체 점검**.
+- 명령 실행과 웹 자동화를 위한 **터미널 및 브라우저 제어**.
+- 에이전트 기능을 확장하는 MCP 서버를 찾고 연결하는 **MCP 마켓플레이스**.
+- 지연 시간, 비용, 추론 능력을 작업에 맞출 수 있는 작업 중 전환 지원 **500개 이상의 모델**.
+
+### 자율 모드(CI/CD)
+
+CI/CD 파이프라인용으로 프롬프트 없이 완전 자율 실행하려면 `kilo run`에 `--auto`를 사용하세요.
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto`는 모든 권한 프롬프트를 비활성화하고 에이전트가 확인 없이 모든 작업을 실행할 수 있게 합니다. 신뢰할 수 있는 환경에서만 사용하세요.
+
+### 문서
+
+설정과 기타 모든 내용은 [문서](https://kilo.ai/docs)를 참조하세요.
+
+### 기여
+
+개발자, 작성자 등 누구나 기여할 수 있습니다. 환경 설정, 코딩 표준, pull request 여는 방법은 [Contributing Guide](/CONTRIBUTING.md)에서 시작하세요. VS Code 확장과 CLI 릴리스 절차는 [RELEASING.md](../RELEASING.md)를, JetBrains 플러그인은 [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md)를 참조하세요.
+
+참여하기 전에 [Code of Conduct](/CODE_OF_CONDUCT.md)를 읽어 주세요.
+
+### 라이선스
+
+MIT. 저작자 표시와 라이선스 고지를 유지하는 한, 상업적 사용을 포함해 이 코드를 사용, 수정, 배포할 수 있습니다. [License](/LICENSE)를 참조하세요.
+
+### FAQ
+
+<details>
+<summary>Kilo CLI는 어디에서 왔나요?</summary>
+
+Kilo CLI는 [OpenCode](https://github.com/anomalyco/opencode)의 fork이며, Kilo agentic engineering 플랫폼에서 작동하도록 강화되었습니다.
+
+</details>
+
+---
+
+**커뮤니티 참여** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.no.md
+++ b/translations/README.no.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | Norsk | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Den åpne kildekodeagenten for å bygge med AI i VS Code, JetBrains eller CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code er en AI-kodeagent som møter deg overalt du jobber: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) og [CLI](https://kilo.ai/cli). Den er åpen kildekode med åpen prising. Du velger blant mer enn 500 modeller, bytter mellom dem midt i en oppgave og betaler modellleverandørens pris uten påslag. Ingen API-nøkler kreves for å starte.
+
+### Installasjon
+
+Velg hvor du vil kjøre Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Installer [Kilo Code-utvidelsen](vscode:extension/kilocode.kilo-code) direkte, eller hent den fra [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Opprett en konto, og du får tilgang til mer enn 500 modeller, inkludert GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 og Gemini 3.1 Pro Preview, alle til leverandørpris.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Kjør deretter `kilo` i en prosjektmappe for å starte.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Installer [Kilo Code-pluginen](https://plugins.jetbrains.com/plugin/28350-kilo-code) fra JetBrains Marketplace, eller søk etter "Kilo Code" i `Settings → Plugins` i en JetBrains IDE.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Kjør Kilo fra nettet, uten lokal maskin, på [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Kodegjennomganger</strong></summary>
+
+<br>
+
+Sett opp automatiske AI-kodegjennomganger på pull requestene dine på [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Start din alltid aktive AI-agent på [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Installer CLI fra GitHub Releases (binærfiler)</summary>
+
+Last ned den nyeste binærfilen fra [Releases-siden](https://github.com/Kilo-Org/kilocode/releases).
+
+| Plattform | Asset |
+|---|---|
+| Windows (de fleste PC-er) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Merknader: `x64-baseline` er en kompatibilitetsbygg for eldre CPU-er uten AVX. `musl` er den statisk lenkede byggen for Alpine eller minimale Docker-bilder uten glibc. `kilo-vscode-*.vsix` er VS Code-utvidelsespakken, ikke CLI-en. `Source code`-arkiver er for bygging fra kildekode.
+
+</details>
+
+### Agents
+
+Kilo leveres med spesialiserte agents du kan bytte mellom avhengig av oppgaven. Du kan også bygge dine egne egendefinerte agents.
+
+- **Code** - Standard. Implementerer og redigerer kode fra naturlig språk.
+- **Plan** - Designer arkitektur og skriver implementeringsplaner før kode skrives.
+- **Ask** - Svarer på spørsmål om kodebasen uten å endre filer.
+- **Debug** - Feilsøker og sporer problemer.
+- **Review** - Gjennomgår endringene dine og finner problemer med ytelse, sikkerhet, stil og testdekning.
+
+Les mer om [agents og egendefinerte agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Hva den gjør
+
+- **Kodegenerering** fra naturlig språk, på tvers av flere filer.
+- **Inline-autofullføring** med ghost-text-forslag og Tab for å godta.
+- **Selvsjekking** slik at agenten vurderer og retter sitt eget arbeid.
+- **Terminal- og nettleserkontroll** for å kjøre kommandoer og automatisere nettet.
+- **MCP-markedsplass** for å finne og koble til MCP-servere som utvider hva agenten kan gjøre.
+- **Mer enn 500 modeller** med bytte midt i oppgaven, slik at du kan matche latenstid, kostnad og resonnering til jobben.
+
+### Autonom modus (CI/CD)
+
+Kjør `kilo run` med `--auto` for helt autonom drift uten spørsmål, bygget for CI/CD-pipelines:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` deaktiverer alle tillatelsesspørsmål og lar agenten utføre enhver handling uten bekreftelse. Bruk det bare i betrodde miljøer.
+
+### Dokumentasjon
+
+For konfigurasjon og alt annet, se [dokumentasjonen](https://kilo.ai/docs).
+
+### Bidra
+
+Bidrag er velkomne fra utviklere, skribenter og alle andre. Start med [Contributing Guide](/CONTRIBUTING.md) for miljøoppsett, kodestandarder og hvordan du åpner en pull request. Se [RELEASING.md](../RELEASING.md) for releaseprosessen for VS Code-utvidelsen og CLI-en, og [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) for JetBrains-pluginen.
+
+Les vår [Code of Conduct](/CODE_OF_CONDUCT.md) før du deltar.
+
+### Lisens
+
+MIT. Du kan bruke, endre og distribuere denne koden, også kommersielt, så lenge du beholder attribusjons- og lisensmerknadene. Se [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Hvor kommer Kilo CLI fra?</summary>
+
+Kilo CLI er en fork av [OpenCode](https://github.com/anomalyco/opencode), forbedret for å fungere i Kilo agentic engineering-plattformen.
+
+</details>
+
+---
+
+**Bli med i fellesskapet** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | Polski | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Open source'owy agent kodujący do pracy z AI w VS Code, JetBrains lub CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code to agent kodujący z AI, który działa wszędzie tam, gdzie pracujesz: w [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) i [CLI](https://kilo.ai/cli). Jest open source i ma otwarte ceny. Wybierasz spośród ponad 500 modeli, przełączasz się między nimi w trakcie zadania i płacisz stawkę dostawcy modelu bez narzutów. Do rozpoczęcia nie są wymagane klucze API.
+
+### Instalacja
+
+Wybierz, gdzie chcesz uruchomić Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Zainstaluj bezpośrednio [rozszerzenie Kilo Code](vscode:extension/kilocode.kilo-code) albo pobierz je z [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Utwórz konto, a otrzymasz dostęp do ponad 500 modeli, w tym GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 i Gemini 3.1 Pro Preview, wszystkie w cenach dostawców.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Następnie uruchom `kilo` w dowolnym katalogu projektu.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Zainstaluj [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) z JetBrains Marketplace albo wyszukaj "Kilo Code" w `Settings → Plugins` w dowolnym IDE JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Uruchom Kilo z poziomu przeglądarki, bez lokalnej maszyny, na [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Przeglądy kodu</strong></summary>
+
+<br>
+
+Skonfiguruj automatyczne przeglądy kodu AI dla swoich pull requestów na [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Uruchom swojego zawsze aktywnego agenta AI na [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Zainstaluj CLI z GitHub Releases (pliki binarne)</summary>
+
+Pobierz najnowszy plik binarny ze [strony Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Platforma | Zasób |
+|---|---|
+| Windows (większość PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Uwagi: `x64-baseline` to build zgodności dla starszych CPU bez AVX. `musl` to statycznie linkowany build dla Alpine lub minimalnych obrazów Docker bez glibc. `kilo-vscode-*.vsix` to pakiet rozszerzenia VS Code, nie CLI. Archiwa `Source code` służą do budowania ze źródeł.
+
+</details>
+
+### Agents
+
+Kilo zawiera wyspecjalizowane agents, między którymi możesz przełączać się zależnie od zadania. Możesz też tworzyć własne niestandardowe agents.
+
+- **Code** - Domyślny. Implementuje i edytuje kod z języka naturalnego.
+- **Plan** - Projektuje architekturę i pisze plany implementacji przed napisaniem kodu.
+- **Ask** - Odpowiada na pytania o bazę kodu bez modyfikowania plików.
+- **Debug** - Diagnozuje i śledzi problemy.
+- **Review** - Przegląda zmiany i wykrywa problemy z wydajnością, bezpieczeństwem, stylem i pokryciem testami.
+
+Dowiedz się więcej o [agents i niestandardowych agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Co robi
+
+- **Generowanie kodu** z języka naturalnego, w wielu plikach.
+- **Autouzupełnianie inline** z sugestiami ghost-text i akceptacją przez Tab.
+- **Samokontrola**, dzięki której agent sprawdza i poprawia własną pracę.
+- **Sterowanie terminalem i przeglądarką** do uruchamiania poleceń i automatyzacji webu.
+- **Marketplace MCP** do znajdowania i podłączania serwerów MCP rozszerzających możliwości agenta.
+- **Ponad 500 modeli** z przełączaniem w trakcie zadania, aby dopasować opóźnienie, koszt i rozumowanie do pracy.
+
+### Tryb autonomiczny (CI/CD)
+
+Uruchom `kilo run` z `--auto`, aby działać w pełni autonomicznie bez promptów, z myślą o pipeline'ach CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` wyłącza wszystkie pytania o uprawnienia i pozwala agentowi wykonywać dowolne działania bez potwierdzenia. Używaj tylko w zaufanych środowiskach.
+
+### Dokumentacja
+
+Konfigurację i wszystko inne znajdziesz w [dokumentacji](https://kilo.ai/docs).
+
+### Wkład
+
+Zapraszamy do wkładu programistów, autorów i wszystkich innych. Zacznij od [Contributing Guide](/CONTRIBUTING.md), aby skonfigurować środowisko, poznać standardy kodowania i sposób otwierania pull requestów. Zobacz [RELEASING.md](../RELEASING.md) dla procesu wydawania rozszerzenia VS Code i CLI oraz [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) dla pluginu JetBrains.
+
+Przed zaangażowaniem przeczytaj nasz [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+### Licencja
+
+MIT. Możesz używać, modyfikować i dystrybuować ten kod, również komercyjnie, o ile zachowasz informacje o autorstwie i licencji. Zobacz [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Skąd pochodzi Kilo CLI?</summary>
+
+Kilo CLI jest forkiem [OpenCode](https://github.com/anomalyco/opencode), rozszerzonym do działania w platformie agentic engineering Kilo.
+
+</details>
+
+---
+
+**Dołącz do społeczności** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.ru.md
+++ b/translations/README.ru.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | Русский | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Open source-агент для разработки с ИИ в VS Code, JetBrains или CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code — это AI-агент для написания кода, который работает там, где работаете вы: в [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) и [CLI](https://kilo.ai/cli). Он имеет открытый исходный код и открытую модель ценообразования. Вы выбираете из более чем 500 моделей, переключаетесь между ними во время задачи и платите по тарифу поставщика модели без наценки. Для начала не нужны API-ключи.
+
+### Установка
+
+Выберите, где вы хотите запускать Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Установите [расширение Kilo Code](vscode:extension/kilocode.kilo-code) напрямую или скачайте его из [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Создайте аккаунт и получите доступ к более чем 500 моделям, включая GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 и Gemini 3.1 Pro Preview, все по ценам поставщиков.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Затем запустите `kilo` в любом каталоге проекта.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Установите [плагин Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) из JetBrains Marketplace или найдите "Kilo Code" в `Settings → Plugins` в любой IDE JetBrains.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Запускайте Kilo из веба без локальной машины на [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+Настройте автоматические AI-ревью кода для ваших pull request на [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Запустите своего постоянно активного AI-агента на [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Установить CLI из GitHub Releases (бинарные файлы)</summary>
+
+Скачайте последний бинарный файл со [страницы Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Платформа | Файл |
+|---|---|
+| Windows (большинство ПК) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Примечания: `x64-baseline` — совместимая сборка для старых CPU без AVX. `musl` — статически связанная сборка для Alpine или минимальных Docker-образов без glibc. `kilo-vscode-*.vsix` — пакет расширения VS Code, а не CLI. Архивы `Source code` предназначены для сборки из исходного кода.
+
+</details>
+
+### Agents
+
+Kilo поставляется со специализированными agents, между которыми можно переключаться в зависимости от задачи. Вы также можете создавать собственные agents.
+
+- **Code** - По умолчанию. Реализует и редактирует код по описанию на естественном языке.
+- **Plan** - Проектирует архитектуру и пишет планы реализации до написания кода.
+- **Ask** - Отвечает на вопросы о кодовой базе, не изменяя файлы.
+- **Debug** - Диагностирует и отслеживает проблемы.
+- **Review** - Проверяет ваши изменения и выявляет проблемы производительности, безопасности, стиля и покрытия тестами.
+
+Подробнее об [agents и пользовательских agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Возможности
+
+- **Генерация кода** из естественного языка в нескольких файлах.
+- **Встроенное автодополнение** с ghost-text-подсказками и принятием по Tab.
+- **Самопроверка**, чтобы агент проверял и исправлял собственную работу.
+- **Управление терминалом и браузером** для запуска команд и автоматизации веба.
+- **MCP marketplace** для поиска и подключения MCP-серверов, расширяющих возможности агента.
+- **Более 500 моделей** с переключением во время задачи, чтобы подобрать задержку, стоимость и reasoning под работу.
+
+### Автономный режим (CI/CD)
+
+Запустите `kilo run` с `--auto` для полностью автономной работы без prompts, предназначенной для CI/CD-пайплайнов:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` отключает все запросы разрешений и позволяет агенту выполнять любые действия без подтверждения. Используйте только в доверенных средах.
+
+### Документация
+
+Для настройки и всего остального перейдите к [документации](https://kilo.ai/docs).
+
+### Участие
+
+Мы приветствуем вклад разработчиков, авторов и всех желающих. Начните с [Contributing Guide](/CONTRIBUTING.md), чтобы настроить окружение, изучить стандарты кода и узнать, как открыть pull request. См. [RELEASING.md](../RELEASING.md) для процесса релиза расширения VS Code и CLI, а также [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) для плагина JetBrains.
+
+Перед участием ознакомьтесь с нашим [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+### Лицензия
+
+MIT. Вы можете использовать, изменять и распространять этот код, в том числе коммерчески, если сохраняете указания авторства и лицензионные уведомления. См. [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Откуда появился Kilo CLI?</summary>
+
+Kilo CLI — это fork [OpenCode](https://github.com/anomalyco/opencode), расширенный для работы в платформе agentic engineering Kilo.
+
+</details>
+
+---
+
+**Присоединяйтесь к сообществу** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.th.md
+++ b/translations/README.th.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | ไทย | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">เอเจนต์เขียนโค้ดโอเพนซอร์สสำหรับสร้างด้วย AI ใน VS Code, JetBrains หรือ CLI</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code คือเอเจนต์เขียนโค้ดด้วย AI ที่ทำงานได้ทุกที่ที่คุณทำงาน: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) และ [CLI](https://kilo.ai/cli) เป็นโอเพนซอร์สและมีราคาที่โปร่งใส คุณเลือกได้จากโมเดลมากกว่า 500 รายการ สลับโมเดลระหว่างทำงาน และจ่ายตามราคาของผู้ให้บริการโมเดลโดยไม่มีส่วนเพิ่ม ไม่ต้องใช้ API key เพื่อเริ่มต้น
+
+### การติดตั้ง
+
+เลือกตำแหน่งที่คุณต้องการใช้งาน Kilo
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+ติดตั้ง [ส่วนขยาย Kilo Code](vscode:extension/kilocode.kilo-code) โดยตรง หรือดาวน์โหลดจาก [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) สร้างบัญชีแล้วคุณจะเข้าถึงโมเดลมากกว่า 500 รายการ รวมถึง GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 และ Gemini 3.1 Pro Preview ทั้งหมดในราคาผู้ให้บริการ
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+จากนั้นรัน `kilo` ในไดเรกทอรีโปรเจกต์ใดก็ได้เพื่อเริ่มต้น
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+ติดตั้ง [ปลั๊กอิน Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) จาก JetBrains Marketplace หรือค้นหา "Kilo Code" ใน `Settings → Plugins` ภายใน JetBrains IDE ใดก็ได้
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+รัน Kilo จากเว็บโดยไม่ต้องใช้เครื่องภายในที่ [app.kilo.ai/cloud](https://app.kilo.ai/cloud)
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+ตั้งค่าการรีวิวโค้ดด้วย AI อัตโนมัติบน pull request ของคุณที่ [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews)
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+เริ่มเอเจนต์ AI ที่ทำงานตลอดเวลาของคุณที่ [app.kilo.ai/claw](https://app.kilo.ai/claw)
+
+</details>
+
+<details>
+<summary>ติดตั้ง CLI จาก GitHub Releases (ไบนารี)</summary>
+
+ดาวน์โหลดไบนารีล่าสุดจาก [หน้า Releases](https://github.com/Kilo-Org/kilocode/releases)
+
+| แพลตฟอร์ม | Asset |
+|---|---|
+| Windows (พีซีส่วนใหญ่) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+หมายเหตุ: `x64-baseline` คือ build ที่เข้ากันได้สำหรับ CPU รุ่นเก่าที่ไม่มี AVX ส่วน `musl` คือ build แบบ static link สำหรับ Alpine หรือ Docker image ขั้นต่ำที่ไม่มี glibc `kilo-vscode-*.vsix` คือแพ็กเกจส่วนขยาย VS Code ไม่ใช่ CLI ไฟล์ `Source code` ใช้สำหรับ build จากซอร์ส
+
+</details>
+
+### Agents
+
+Kilo มาพร้อม agents เฉพาะทางที่คุณสลับได้ตามงาน คุณยังสร้าง agents แบบกำหนดเองได้ด้วย
+
+- **Code** - ค่าเริ่มต้น ใช้ภาษาธรรมชาติในการเขียนและแก้ไขโค้ด
+- **Plan** - ออกแบบสถาปัตยกรรมและเขียนแผนการทำงานก่อนมีการเขียนโค้ด
+- **Ask** - ตอบคำถามเกี่ยวกับ codebase โดยไม่แตะไฟล์
+- **Debug** - แก้ไขและติดตามปัญหา
+- **Review** - รีวิวการเปลี่ยนแปลงและค้นหาปัญหาด้านประสิทธิภาพ ความปลอดภัย สไตล์ และ test coverage
+
+เรียนรู้เพิ่มเติมเกี่ยวกับ [agents และ agents แบบกำหนดเอง](https://kilo.ai/docs/code-with-ai/agents/using-agents)
+
+### ทำอะไรได้บ้าง
+
+- **สร้างโค้ด** จากภาษาธรรมชาติข้ามหลายไฟล์
+- **เติมโค้ดอัตโนมัติแบบ inline** พร้อมคำแนะนำ ghost-text และกด Tab เพื่อรับ
+- **ตรวจสอบตัวเอง** เพื่อให้เอเจนต์รีวิวและแก้งานของตนเอง
+- **ควบคุม terminal และ browser** เพื่อรันคำสั่งและทำงานบนเว็บอัตโนมัติ
+- **MCP marketplace** เพื่อค้นหาและเชื่อมต่อ MCP server ที่ขยายความสามารถของเอเจนต์
+- **โมเดลมากกว่า 500 รายการ** พร้อมการสลับระหว่างงาน เพื่อให้เหมาะกับ latency, cost และ reasoning ของงาน
+
+### โหมดอัตโนมัติ (CI/CD)
+
+รัน `kilo run` พร้อม `--auto` เพื่อทำงานอัตโนมัติเต็มรูปแบบโดยไม่มี prompts เหมาะสำหรับ CI/CD pipelines:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` ปิด prompt สิทธิ์ทั้งหมดและให้เอเจนต์ดำเนินการใดก็ได้โดยไม่ต้องยืนยัน ใช้เฉพาะในสภาพแวดล้อมที่เชื่อถือได้เท่านั้น
+
+### เอกสาร
+
+สำหรับการตั้งค่าและเรื่องอื่น ๆ ดูที่ [เอกสาร](https://kilo.ai/docs)
+
+### การมีส่วนร่วม
+
+ยินดีรับการมีส่วนร่วมจากนักพัฒนา นักเขียน และทุกคน เริ่มจาก [Contributing Guide](/CONTRIBUTING.md) สำหรับการตั้งค่าสภาพแวดล้อม มาตรฐานโค้ด และวิธีเปิด pull request ดู [RELEASING.md](../RELEASING.md) สำหรับกระบวนการ release ของส่วนขยาย VS Code และ CLI และ [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) สำหรับปลั๊กอิน JetBrains
+
+โปรดอ่าน [Code of Conduct](/CODE_OF_CONDUCT.md) ก่อนเข้าร่วม
+
+### License
+
+MIT คุณสามารถใช้ แก้ไข และแจกจ่ายโค้ดนี้ รวมถึงเชิงพาณิชย์ ตราบใดที่ยังเก็บ attribution และประกาศ license ไว้ ดู [License](/LICENSE)
+
+### FAQ
+
+<details>
+<summary>Kilo CLI มาจากไหน?</summary>
+
+Kilo CLI เป็น fork ของ [OpenCode](https://github.com/anomalyco/opencode) ที่ได้รับการปรับปรุงให้ทำงานในแพลตฟอร์ม Kilo agentic engineering
+
+</details>
+
+---
+
+**เข้าร่วมชุมชน** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.tr.md
+++ b/translations/README.tr.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | Türkçe | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">VS Code, JetBrains veya CLI'de AI ile geliştirme yapmak için açık kaynak kodlama ajanı.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code, çalıştığınız her yerde size eşlik eden bir AI kodlama ajanıdır: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) ve [CLI](https://kilo.ai/cli). Açık kaynaktır ve açık fiyatlandırma sunar. 500'den fazla model arasından seçim yapabilir, görev sırasında model değiştirebilir ve hiçbir ek ücret olmadan model sağlayıcısının fiyatını ödersiniz. Başlamak için API anahtarı gerekmez.
+
+### Kurulum
+
+Kilo'yu nerede çalıştırmak istediğinizi seçin.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+[Kilo Code uzantısını](vscode:extension/kilocode.kilo-code) doğrudan kurun veya [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) üzerinden edinin. Bir hesap oluşturduğunuzda GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 ve Gemini 3.1 Pro Preview dahil 500'den fazla modele sağlayıcı fiyatıyla erişebilirsiniz.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Ardından başlamak için herhangi bir proje dizininde `kilo` çalıştırın.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+[Kilo Code eklentisini](https://plugins.jetbrains.com/plugin/28350-kilo-code) JetBrains Marketplace'ten kurun veya herhangi bir JetBrains IDE içinde `Settings → Plugins` bölümünde "Kilo Code" arayın.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Kilo'yu yerel makine gerekmeden web üzerinden [app.kilo.ai/cloud](https://app.kilo.ai/cloud) adresinde çalıştırın.
+
+</details>
+
+<details>
+<summary><strong>Kod İncelemeleri</strong></summary>
+
+<br>
+
+Pull request'leriniz için otomatik AI kod incelemelerini [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) adresinde ayarlayın.
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Her zaman açık AI ajanınızı [app.kilo.ai/claw](https://app.kilo.ai/claw) adresinde başlatın.
+
+</details>
+
+<details>
+<summary>CLI'yi GitHub Releases üzerinden kurun (ikili dosyalar)</summary>
+
+En son ikili dosyayı [Releases sayfasından](https://github.com/Kilo-Org/kilocode/releases) indirin.
+
+| Platform | Asset |
+|---|---|
+| Windows (çoğu PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Notlar: `x64-baseline`, AVX olmayan eski CPU'lar için uyumluluk derlemesidir. `musl`, Alpine veya glibc olmayan minimal Docker imajları için statik bağlı derlemedir. `kilo-vscode-*.vsix` CLI değil VS Code uzantı paketidir. `Source code` arşivleri kaynaktan derlemek içindir.
+
+</details>
+
+### Agents
+
+Kilo, göreve göre aralarında geçiş yapabileceğiniz özelleşmiş agents ile gelir. Kendi özel agents'larınızı da oluşturabilirsiniz.
+
+- **Code** - Varsayılan. Doğal dilden kod uygular ve düzenler.
+- **Plan** - Kod yazılmadan önce mimari tasarlar ve uygulama planları yazar.
+- **Ask** - Dosyalara dokunmadan kod tabanınız hakkında soruları yanıtlar.
+- **Debug** - Sorunları giderir ve izler.
+- **Review** - Değişikliklerinizi inceler ve performans, güvenlik, stil ve test kapsamı sorunlarını ortaya çıkarır.
+
+[Agents ve özel agents](https://kilo.ai/docs/code-with-ai/agents/using-agents) hakkında daha fazla bilgi edinin.
+
+### Ne yapar
+
+- Birden çok dosyada doğal dilden **kod üretimi**.
+- Ghost-text önerileri ve kabul etmek için Tab ile **satır içi otomatik tamamlama**.
+- Ajanın kendi çalışmasını inceleyip düzeltmesi için **öz denetim**.
+- Komut çalıştırmak ve web'i otomatikleştirmek için **terminal ve tarayıcı kontrolü**.
+- Ajanın yapabileceklerini genişleten MCP sunucularını bulmak ve bağlamak için **MCP marketplace**.
+- Gecikme, maliyet ve akıl yürütmeyi işe uygun seçmek için görev sırasında geçiş destekli **500'den fazla model**.
+
+### Otonom Mod (CI/CD)
+
+CI/CD pipeline'ları için prompts olmadan tamamen otonom çalıştırmak üzere `kilo run` komutunu `--auto` ile çalıştırın:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` tüm izin istemlerini devre dışı bırakır ve ajanın herhangi bir işlemi onay olmadan yürütmesine izin verir. Yalnızca güvenilir ortamlarda kullanın.
+
+### Dokümantasyon
+
+Yapılandırma ve diğer her şey için [dokümantasyona](https://kilo.ai/docs) bakın.
+
+### Katkıda bulunma
+
+Geliştiricilerden, yazarlardan ve herkesten katkı bekliyoruz. Ortam kurulumu, kodlama standartları ve pull request açma hakkında bilgi için [Contributing Guide](/CONTRIBUTING.md) ile başlayın. VS Code uzantısı ve CLI yayın süreci için [RELEASING.md](../RELEASING.md), JetBrains eklentisi için [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) dosyasına bakın.
+
+Katılmadan önce lütfen [Code of Conduct](/CODE_OF_CONDUCT.md) belgemizi okuyun.
+
+### Lisans
+
+MIT. Atıf ve lisans bildirimlerini koruduğunuz sürece bu kodu ticari olarak da kullanabilir, değiştirebilir ve dağıtabilirsiniz. Bkz. [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Kilo CLI nereden geldi?</summary>
+
+Kilo CLI, Kilo agentic engineering platformunda çalışacak şekilde geliştirilmiş bir [OpenCode](https://github.com/anomalyco/opencode) fork'udur.
+
+</details>
+
+---
+
+**Topluluğa katılın** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.uk.md
+++ b/translations/README.uk.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | Українська | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Open source-агент для програмування з AI у VS Code, JetBrains або CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code — це AI-агент для програмування, який працює там, де працюєте ви: у [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) і [CLI](https://kilo.ai/cli). Він має відкритий код і відкриту модель ціноутворення. Ви обираєте з понад 500 моделей, перемикаєтеся між ними під час завдання і платите тариф постачальника моделі без націнки. Для старту API-ключі не потрібні.
+
+### Встановлення
+
+Оберіть, де ви хочете запускати Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Встановіть [розширення Kilo Code](vscode:extension/kilocode.kilo-code) напряму або завантажте його з [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Створіть обліковий запис і отримайте доступ до понад 500 моделей, зокрема GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 і Gemini 3.1 Pro Preview, усі за цінами постачальників.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Потім запустіть `kilo` у будь-якому каталозі проєкту.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Встановіть [плагін Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) з JetBrains Marketplace або знайдіть "Kilo Code" у `Settings → Plugins` у будь-якій JetBrains IDE.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Запускайте Kilo з вебу, без локальної машини, на [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+Налаштуйте автоматичні AI-рев'ю коду для ваших pull request на [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Запустіть свого постійно активного AI-агента на [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Встановити CLI з GitHub Releases (бінарні файли)</summary>
+
+Завантажте найновіший бінарний файл зі [сторінки Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Платформа | Файл |
+|---|---|
+| Windows (більшість ПК) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Примітки: `x64-baseline` — сумісна збірка для старих CPU без AVX. `musl` — статично зв'язана збірка для Alpine або мінімальних Docker-образів без glibc. `kilo-vscode-*.vsix` — пакет розширення VS Code, а не CLI. Архіви `Source code` призначені для збірки з вихідного коду.
+
+</details>
+
+### Agents
+
+Kilo постачається зі спеціалізованими agents, між якими можна перемикатися залежно від завдання. Ви також можете створювати власні agents.
+
+- **Code** - Типовий. Реалізує та редагує код з природної мови.
+- **Plan** - Проєктує архітектуру і пише плани реалізації до написання коду.
+- **Ask** - Відповідає на запитання про кодову базу, не змінюючи файли.
+- **Debug** - Діагностує та відстежує проблеми.
+- **Review** - Переглядає ваші зміни та виявляє проблеми продуктивності, безпеки, стилю і покриття тестами.
+
+Дізнайтеся більше про [agents і власні agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Що він робить
+
+- **Генерація коду** з природної мови в кількох файлах.
+- **Вбудоване автодоповнення** з ghost-text-підказками та прийняттям через Tab.
+- **Самоперевірка**, щоб агент перевіряв і виправляв власну роботу.
+- **Керування терміналом і браузером** для запуску команд і автоматизації вебу.
+- **MCP marketplace** для пошуку й підключення MCP-серверів, які розширюють можливості агента.
+- **Понад 500 моделей** з перемиканням під час завдання, щоб узгодити затримку, вартість і reasoning з роботою.
+
+### Автономний режим (CI/CD)
+
+Запустіть `kilo run` з `--auto` для повністю автономної роботи без prompts, створеної для CI/CD-пайплайнів:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` вимикає всі запити дозволів і дає агенту змогу виконувати будь-яку дію без підтвердження. Використовуйте лише в довірених середовищах.
+
+### Документація
+
+Для налаштування та всього іншого перегляньте [документацію](https://kilo.ai/docs).
+
+### Участь
+
+Ми вітаємо внески від розробників, авторів і всіх охочих. Почніть з [Contributing Guide](/CONTRIBUTING.md), щоб налаштувати середовище, ознайомитися зі стандартами коду та дізнатися, як відкрити pull request. Див. [RELEASING.md](../RELEASING.md) для процесу релізу розширення VS Code і CLI, а також [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) для плагіна JetBrains.
+
+Перед участю прочитайте наш [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+### Ліцензія
+
+MIT. Ви можете використовувати, змінювати й поширювати цей код, зокрема комерційно, якщо зберігаєте зазначення авторства та ліцензійні повідомлення. Див. [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Звідки взявся Kilo CLI?</summary>
+
+Kilo CLI — це fork [OpenCode](https://github.com/anomalyco/opencode), розширений для роботи в платформі agentic engineering Kilo.
+
+</details>
+
+---
+
+**Долучайтеся до спільноти** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.vi.md
+++ b/translations/README.vi.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | Tiếng Việt
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">Tác nhân lập trình mã nguồn mở để xây dựng với AI trong VS Code, JetBrains hoặc CLI.</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code là một tác nhân lập trình AI đồng hành với bạn ở mọi nơi bạn làm việc: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native) và [CLI](https://kilo.ai/cli). Dự án là mã nguồn mở với giá minh bạch. Bạn chọn trong hơn 500 mô hình, chuyển đổi giữa chúng giữa chừng một tác vụ và trả theo giá của nhà cung cấp mô hình, không có phụ phí. Không cần API key để bắt đầu.
+
+### Cài đặt
+
+Chọn nơi bạn muốn chạy Kilo.
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+Cài trực tiếp [tiện ích Kilo Code](vscode:extension/kilocode.kilo-code), hoặc tải từ [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Tạo tài khoản và bạn sẽ có quyền truy cập hơn 500 mô hình, bao gồm GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6 và Gemini 3.1 Pro Preview, tất cả theo giá của nhà cung cấp.
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+Sau đó chạy `kilo` trong bất kỳ thư mục dự án nào để bắt đầu.
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+Cài [plugin Kilo Code](https://plugins.jetbrains.com/plugin/28350-kilo-code) từ JetBrains Marketplace, hoặc tìm "Kilo Code" trong `Settings → Plugins` bên trong bất kỳ JetBrains IDE nào.
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+Chạy Kilo từ web, không cần máy cục bộ, tại [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
+
+</details>
+
+<details>
+<summary><strong>Code Reviews</strong></summary>
+
+<br>
+
+Thiết lập review code tự động bằng AI cho pull request của bạn tại [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+Khởi chạy AI agent luôn hoạt động của bạn tại [app.kilo.ai/claw](https://app.kilo.ai/claw).
+
+</details>
+
+<details>
+<summary>Cài CLI từ GitHub Releases (binary)</summary>
+
+Tải binary mới nhất từ [trang Releases](https://github.com/Kilo-Org/kilocode/releases).
+
+| Nền tảng | Asset |
+|---|---|
+| Windows (hầu hết PC) | `kilo-windows-x64.zip` |
+| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
+| macOS (Intel) | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+Ghi chú: `x64-baseline` là build tương thích cho CPU cũ không có AVX. `musl` là build liên kết tĩnh cho Alpine hoặc image Docker tối giản không có glibc. `kilo-vscode-*.vsix` là gói tiện ích VS Code, không phải CLI. Các archive `Source code` dùng để build từ mã nguồn.
+
+</details>
+
+### Agents
+
+Kilo đi kèm các agents chuyên biệt để bạn chuyển đổi tùy theo tác vụ. Bạn cũng có thể tạo agents tùy chỉnh của riêng mình.
+
+- **Code** - Mặc định. Triển khai và chỉnh sửa code từ ngôn ngữ tự nhiên.
+- **Plan** - Thiết kế kiến trúc và viết kế hoạch triển khai trước khi viết code.
+- **Ask** - Trả lời câu hỏi về codebase mà không chạm vào file.
+- **Debug** - Khắc phục và truy vết sự cố.
+- **Review** - Review thay đổi của bạn và phát hiện vấn đề về hiệu năng, bảo mật, phong cách và độ phủ test.
+
+Tìm hiểu thêm về [agents và agents tùy chỉnh](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+
+### Nó làm gì
+
+- **Sinh code** từ ngôn ngữ tự nhiên, trên nhiều file.
+- **Tự động hoàn thành inline** với gợi ý ghost-text và Tab để chấp nhận.
+- **Tự kiểm tra** để agent review và sửa công việc của chính nó.
+- **Điều khiển terminal và trình duyệt** để chạy lệnh và tự động hóa web.
+- **MCP marketplace** để tìm và kết nối MCP server mở rộng khả năng của agent.
+- **Hơn 500 mô hình** với chuyển đổi giữa chừng tác vụ, để bạn khớp độ trễ, chi phí và reasoning với công việc.
+
+### Chế độ tự động (CI/CD)
+
+Chạy `kilo run` với `--auto` để hoạt động hoàn toàn tự động không có prompts, dành cho pipeline CI/CD:
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` tắt mọi prompt xin quyền và cho phép agent thực hiện bất kỳ hành động nào mà không cần xác nhận. Chỉ dùng trong môi trường đáng tin cậy.
+
+### Tài liệu
+
+Về cấu hình và mọi thứ khác, hãy xem [tài liệu](https://kilo.ai/docs).
+
+### Đóng góp
+
+Chúng tôi chào đón đóng góp từ developer, writer và tất cả mọi người. Bắt đầu với [Contributing Guide](/CONTRIBUTING.md) để thiết lập môi trường, tiêu chuẩn code và cách mở pull request. Xem [RELEASING.md](../RELEASING.md) cho quy trình release tiện ích VS Code và CLI, và [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md) cho plugin JetBrains.
+
+Vui lòng đọc [Code of Conduct](/CODE_OF_CONDUCT.md) trước khi tham gia.
+
+### License
+
+MIT. Bạn có thể sử dụng, chỉnh sửa và phân phối code này, kể cả cho mục đích thương mại, miễn là giữ lại thông tin ghi nhận và thông báo license. Xem [License](/LICENSE).
+
+### FAQ
+
+<details>
+<summary>Kilo CLI đến từ đâu?</summary>
+
+Kilo CLI là một fork của [OpenCode](https://github.com/anomalyco/opencode), được cải tiến để hoạt động trong nền tảng Kilo agentic engineering.
+
+</details>
+
+---
+
+**Tham gia cộng đồng** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.zh.md
+++ b/translations/README.zh.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | 简体中文 | <a href="README.zht.md">繁體中文</a> | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">用于在 VS Code、JetBrains 或 CLI 中借助 AI 构建的开源编码代理。</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code 是一个 AI 编码代理，可以在你工作的任何地方使用：[VS Code](https://kilo.ai/landing/vs-code)、[JetBrains](https://kilo.ai/features/jetbrains-native) 和 [CLI](https://kilo.ai/cli)。它是开源的，并采用开放定价。你可以从 500 多个模型中选择，在任务中途切换模型，并按模型提供商的价格付费，没有加价。开始使用无需 API 密钥。
+
+### 安装
+
+选择你想运行 Kilo 的位置。
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+直接安装 [Kilo Code 扩展](vscode:extension/kilocode.kilo-code)，或从 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) 获取。创建账户后，你可以按提供商价格访问 500 多个模型，包括 GPT-5.5、Claude Opus 4.7、Claude Sonnet 4.6 和 Gemini 3.1 Pro Preview。
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+然后在任意项目目录中运行 `kilo` 即可开始。
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+从 JetBrains Marketplace 安装 [Kilo Code 插件](https://plugins.jetbrains.com/plugin/28350-kilo-code)，或在任意 JetBrains IDE 的 `Settings → Plugins` 中搜索 "Kilo Code"。
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+无需本地机器，在 Web 上通过 [app.kilo.ai/cloud](https://app.kilo.ai/cloud) 运行 Kilo。
+
+</details>
+
+<details>
+<summary><strong>代码审查</strong></summary>
+
+<br>
+
+在 [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) 为你的 Pull Request 设置自动 AI 代码审查。
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+在 [app.kilo.ai/claw](https://app.kilo.ai/claw) 启动你的常驻 AI 代理。
+
+</details>
+
+<details>
+<summary>从 GitHub Releases 安装 CLI（二进制文件）</summary>
+
+从 [Releases 页面](https://github.com/Kilo-Org/kilocode/releases) 下载最新二进制文件。
+
+| 平台 | 资源 |
+|---|---|
+| Windows（大多数 PC） | `kilo-windows-x64.zip` |
+| macOS（Apple Silicon） | `kilo-darwin-arm64.zip` |
+| macOS（Intel） | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+说明：`x64-baseline` 是面向不支持 AVX 的旧 CPU 的兼容构建。`musl` 是面向 Alpine 或无 glibc 的极简 Docker 镜像的静态链接构建。`kilo-vscode-*.vsix` 是 VS Code 扩展包，不是 CLI。`Source code` 压缩包用于从源码构建。
+
+</details>
+
+### Agents
+
+Kilo 内置了可按任务切换的专用 Agents。你也可以构建自己的自定义 Agents。
+
+- **Code** - 默认模式。根据自然语言实现和编辑代码。
+- **Plan** - 在编写任何代码之前设计架构并编写实现计划。
+- **Ask** - 回答有关代码库的问题，不修改任何文件。
+- **Debug** - 排查并追踪问题。
+- **Review** - 审查你的更改，并从性能、安全、风格和测试覆盖率等方面发现问题。
+
+了解更多关于 [agents 和自定义 agents](https://kilo.ai/docs/code-with-ai/agents/using-agents) 的信息。
+
+### 功能
+
+- **代码生成**：基于自然语言跨多个文件生成代码。
+- **内联自动补全**：提供 ghost-text 建议，按 Tab 接受。
+- **自检**：让代理审查并修正自己的工作。
+- **终端和浏览器控制**：运行命令并自动化网页操作。
+- **MCP 市场**：查找并连接 MCP 服务器，扩展代理能力。
+- **500 多个模型**：支持任务中途切换，让你根据延迟、成本和推理能力匹配任务。
+
+### 自主模式（CI/CD）
+
+使用 `--auto` 运行 `kilo run`，可在 CI/CD 流水线中实现无提示的完全自主操作：
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` 会禁用所有权限提示，并允许代理在无需确认的情况下执行任何操作。仅在可信环境中使用。
+
+### 文档
+
+关于配置和其他内容，请查看[文档](https://kilo.ai/docs)。
+
+### 贡献
+
+欢迎开发者、写作者以及所有人参与贡献。请先阅读 [Contributing Guide](/CONTRIBUTING.md)，了解环境设置、编码标准以及如何创建 Pull Request。VS Code 扩展和 CLI 的发布流程请参阅 [RELEASING.md](../RELEASING.md)，JetBrains 插件请参阅 [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md)。
+
+参与前请阅读我们的 [Code of Conduct](/CODE_OF_CONDUCT.md)。
+
+### 许可证
+
+MIT。你可以使用、修改和分发此代码，包括商业用途，只要保留署名和许可证声明。参见 [License](/LICENSE)。
+
+### FAQ
+
+<details>
+<summary>Kilo CLI 从哪里来？</summary>
+
+Kilo CLI 是 [OpenCode](https://github.com/anomalyco/opencode) 的一个 fork，并增强为可在 Kilo agentic engineering 平台中使用。
+
+</details>
+
+---
+
+**加入社区** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)

--- a/translations/README.zht.md
+++ b/translations/README.zht.md
@@ -1,0 +1,177 @@
+<p align="center">
+  <a href="../README.md">English</a> | <a href="README.zh.md">简体中文</a> | 繁體中文 | <a href="README.ko.md">한국어</a> | <a href="README.de.md">Deutsch</a> | <a href="README.es.md">Español</a> | <a href="README.fr.md">Français</a> | <a href="README.it.md">Italiano</a> | <a href="README.da.md">Dansk</a> | <a href="README.ja.md">日本語</a> | <a href="README.pl.md">Polski</a> | <a href="README.ru.md">Русский</a> | <a href="README.bs.md">Bosanski</a> | <a href="README.ar.md">العربية</a> | <a href="README.no.md">Norsk</a> | <a href="README.br.md">Português (Brasil)</a> | <a href="README.th.md">ไทย</a> | <a href="README.tr.md">Türkçe</a> | <a href="README.uk.md">Українська</a> | <a href="README.bn.md">বাংলা</a> | <a href="README.gr.md">Ελληνικά</a> | <a href="README.vi.md">Tiếng Việt</a>
+</p>
+
+<p align="center">
+  <a href="https://kilo.ai"><img width="250" alt="Kilo Code logo" src="https://github.com/user-attachments/assets/bdb0c174-b9fd-40ad-a47b-f3aab9b54e8d" /></a>
+</p>
+
+<p align="center">用於在 VS Code、JetBrains 或 CLI 中運用 AI 建構的開源編碼代理。</p>
+
+<p align="center">
+  <a href="https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code"><img src="https://raster.shields.io/badge/VS_Code_Marketplace-007ACC?style=flat&logo=visualstudiocode&logoColor=white" alt="VS Code Marketplace" height="20"></a>
+  <a href="https://www.npmjs.com/package/@kilocode/cli"><img alt="npm" src="https://raster.shields.io/npm/v/@kilocode/cli?style=flat" height="20" /></a>
+  <a href="https://x.com/kilocode"><img src="https://raster.shields.io/badge/kilocode-000000?style=flat&logo=x&logoColor=white" alt="X (Twitter)" height="20"></a>
+  <a href="https://blog.kilo.ai"><img src="https://raster.shields.io/badge/Blog-555?style=flat&logo=substack&logoColor=white" alt="Blog" height="20"></a>
+  <a href="https://kilo.ai/discord"><img src="https://raster.shields.io/badge/Join%20Discord-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" height="20"></a>
+  <a href="https://www.reddit.com/r/kilocode/"><img src="https://raster.shields.io/badge/Join%20r%2Fkilocode-D84315?style=flat&logo=reddit&logoColor=white" alt="Reddit" height="20"></a>
+</p>
+
+![Kilo-in-VS-Code-and-CLI](https://github.com/user-attachments/assets/0536ca59-ed81-4512-9e05-d186187a1b52)
+
+---
+
+Kilo Code 是一個 AI 編碼代理，可在你工作的任何地方使用：[VS Code](https://kilo.ai/landing/vs-code)、[JetBrains](https://kilo.ai/features/jetbrains-native) 和 [CLI](https://kilo.ai/cli)。它是開源專案，並採用開放定價。你可以從 500 多個模型中選擇，在任務中途切換模型，並按模型供應商的價格付費，沒有加價。開始使用不需要 API 金鑰。
+
+### 安裝
+
+選擇你想執行 Kilo 的位置。
+
+<details open>
+<summary><strong>VS Code</strong></summary>
+
+<br>
+
+直接安裝 [Kilo Code 擴充功能](vscode:extension/kilocode.kilo-code)，或從 [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code) 取得。建立帳戶後，你可以按供應商價格使用 500 多個模型，包括 GPT-5.5、Claude Opus 4.7、Claude Sonnet 4.6 和 Gemini 3.1 Pro Preview。
+
+</details>
+
+<details open>
+<summary><strong>CLI</strong></summary>
+
+<br>
+
+```bash
+# npm
+npm install -g @kilocode/cli
+
+# curl
+curl -fsSL https://kilo.ai/cli/install | bash
+
+# pnpm
+pnpm add -g @kilocode/cli
+
+# bun
+bun add -g @kilocode/cli
+
+# Homebrew (macOS / Linux)
+brew install Kilo-Org/tap/kilo
+
+# Arch Linux (AUR)
+paru -S kilo-bin
+```
+
+然後在任何專案目錄中執行 `kilo` 即可開始。
+
+</details>
+
+<details>
+<summary><strong>JetBrains</strong></summary>
+
+<br>
+
+從 JetBrains Marketplace 安裝 [Kilo Code 外掛](https://plugins.jetbrains.com/plugin/28350-kilo-code)，或在任何 JetBrains IDE 的 `Settings → Plugins` 中搜尋 "Kilo Code"。
+
+</details>
+
+<details>
+<summary><strong>Cloud Agent</strong></summary>
+
+<br>
+
+無需本機電腦，在 Web 上透過 [app.kilo.ai/cloud](https://app.kilo.ai/cloud) 執行 Kilo。
+
+</details>
+
+<details>
+<summary><strong>程式碼審查</strong></summary>
+
+<br>
+
+在 [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) 為你的 Pull Request 設定自動 AI 程式碼審查。
+
+</details>
+
+<details>
+<summary><strong>KiloClaw</strong></summary>
+
+<br>
+
+在 [app.kilo.ai/claw](https://app.kilo.ai/claw) 啟動你的常駐 AI 代理。
+
+</details>
+
+<details>
+<summary>從 GitHub Releases 安裝 CLI（二進位檔）</summary>
+
+從 [Releases 頁面](https://github.com/Kilo-Org/kilocode/releases) 下載最新二進位檔。
+
+| 平台 | 資源 |
+|---|---|
+| Windows（大多數 PC） | `kilo-windows-x64.zip` |
+| macOS（Apple Silicon） | `kilo-darwin-arm64.zip` |
+| macOS（Intel） | `kilo-darwin-x64.zip` |
+| Linux x64 | `kilo-linux-x64.tar.gz` |
+| Linux ARM | `kilo-linux-arm64.tar.gz` |
+
+注意：`x64-baseline` 是面向不支援 AVX 的舊 CPU 的相容性建置。`musl` 是面向 Alpine 或沒有 glibc 的極簡 Docker 映像的靜態連結建置。`kilo-vscode-*.vsix` 是 VS Code 擴充功能套件，不是 CLI。`Source code` 封存檔用於從原始碼建置。
+
+</details>
+
+### Agents
+
+Kilo 內建可依任務切換的專用 Agents。你也可以建立自己的自訂 Agents。
+
+- **Code** - 預設。根據自然語言實作和編輯程式碼。
+- **Plan** - 在撰寫任何程式碼之前設計架構並撰寫實作計畫。
+- **Ask** - 回答關於程式碼庫的問題，不修改任何檔案。
+- **Debug** - 疑難排解並追蹤問題。
+- **Review** - 審查你的變更，並找出效能、安全性、風格和測試覆蓋率方面的問題。
+
+深入了解 [agents 和自訂 agents](https://kilo.ai/docs/code-with-ai/agents/using-agents)。
+
+### 功能
+
+- **程式碼產生**：以自然語言跨多個檔案產生程式碼。
+- **行內自動完成**：提供 ghost-text 建議，按 Tab 接受。
+- **自我檢查**：讓代理審查並修正自己的工作。
+- **終端機和瀏覽器控制**：執行命令並自動化網頁操作。
+- **MCP 市集**：尋找並連接 MCP 伺服器，擴充代理能力。
+- **500 多個模型**：支援任務中途切換，讓你根據延遲、成本和推理能力匹配任務。
+
+### 自主模式（CI/CD）
+
+使用 `--auto` 執行 `kilo run`，可在 CI/CD 管線中進行無提示的完全自主操作：
+
+```bash
+kilo run --auto "run tests and fix any failures"
+```
+
+`--auto` 會停用所有權限提示，並允許代理在無需確認的情況下執行任何操作。僅在可信任環境中使用。
+
+### 文件
+
+關於設定和其他內容，請查看[文件](https://kilo.ai/docs)。
+
+### 貢獻
+
+歡迎開發者、作者以及所有人參與貢獻。請先閱讀 [Contributing Guide](/CONTRIBUTING.md)，了解環境設定、程式碼標準以及如何建立 Pull Request。VS Code 擴充功能和 CLI 的發布流程請參閱 [RELEASING.md](../RELEASING.md)，JetBrains 外掛請參閱 [packages/kilo-jetbrains/RELEASING.md](../packages/kilo-jetbrains/RELEASING.md)。
+
+參與前請閱讀我們的 [Code of Conduct](/CODE_OF_CONDUCT.md)。
+
+### 授權
+
+MIT。你可以使用、修改和散布此程式碼，包括商業用途，只要保留署名和授權聲明。請參閱 [License](/LICENSE)。
+
+### FAQ
+
+<details>
+<summary>Kilo CLI 從何而來？</summary>
+
+Kilo CLI 是 [OpenCode](https://github.com/anomalyco/opencode) 的 fork，並增強為可在 Kilo agentic engineering 平台中使用。
+
+</details>
+
+---
+
+**加入社群** [Discord](https://kilo.ai/discord) | [X](https://x.com/kilocode) | [Reddit](https://www.reddit.com/r/kilocode/)


### PR DESCRIPTION
Add localized README variants directly under `translations/` after PR #11613 removes the root-level copies.

This keeps the final history consistent: translated READMEs are added in their intended Kilo-specific location instead of being added at root and moved later.

Merge after #11613.