### PR TITLE
test(cli): stabilize websocket idle timeout coverage

### DIFF
--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -376,7 +376,7 @@ describe("plugin.openai.ws-pool", () => {
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 20,
+      idleTimeout: 100, // kilocode_change - leave enough time for WebSocket callbacks on loaded CI runners
       streamRetries: 1,
     })
 


### PR DESCRIPTION
## Summary
- Increase the OpenAI WebSocket idle-failure test timeout from 20ms to 100ms
- Preserve the timeout behavior under test while allowing loaded CI runners to deliver the WebSocket send callback before the idle timer races it

The linked failure is a test timing race: the same test passed on macOS and Windows and passed after the Linux job was rerun. Under load, the 20ms timeout can expire before the local socket's send callback runs, leaving a second timer that surfaces after HTTP fallback has already been selected.