### PR TITLE
fix(opencode): update GitHub Copilot OAuth client ID to Kilo-Org

### DIFF
--- a/.changeset/copilot-oauth-kilo-app.md
+++ b/.changeset/copilot-oauth-kilo-app.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Update GitHub Copilot OAuth app to Kilo-Org app; existing users will need to re-authenticate.

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -162,10 +162,20 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             delete headers["x-api-key"]
             delete headers["authorization"]
 
-            return fetch(request, {
+            const res = await fetch(request, {
               ...init,
               headers,
             })
+
+            // kilocode_change start - clear stored token on 401 so the user is prompted to re-auth
+            if (res.status === 401) {
+              fetch(new URL(`/auth/github-copilot`, input.serverUrl), { method: "DELETE" }).catch((err) => {
+                log.error("failed to clear copilot auth on 401", { err })
+              })
+            }
+            // kilocode_change end
+
+            return res
           },
         }
       },

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -163,20 +163,20 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             delete headers["x-api-key"]
             delete headers["authorization"]
 
+            // kilocode_change start - clear stored token on 401 so the user is prompted to re-auth
             const res = await fetch(request, {
               ...init,
               headers,
             })
 
-            // kilocode_change start - clear stored token on 401 so the user is prompted to re-auth
             if (res.status === 401) {
-              fetch(new URL(`/auth/github-copilot`, input.serverUrl), { method: "DELETE", headers: ServerAuth.headers() }).catch((err) => { // kilocode_change
+              fetch(new URL(`/auth/github-copilot`, input.serverUrl), { method: "DELETE", headers: ServerAuth.headers() }).catch((err) => {
                 log.error("failed to clear copilot auth on 401", { err })
               })
             }
-            // kilocode_change end
 
             return res
+            // kilocode_change end
           },
         }
       },

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -6,6 +6,7 @@ import * as Log from "@opencode-ai/core/util/log"
 import { setTimeout as sleep } from "node:timers/promises"
 import { CopilotModels } from "./models"
 import { MessageV2 } from "@/session/message-v2"
+import { ServerAuth } from "@/server/auth" // kilocode_change
 
 const log = Log.create({ service: "plugin.copilot" })
 
@@ -169,7 +170,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
 
             // kilocode_change start - clear stored token on 401 so the user is prompted to re-auth
             if (res.status === 401) {
-              fetch(new URL(`/auth/github-copilot`, input.serverUrl), { method: "DELETE" }).catch((err) => {
+              fetch(new URL(`/auth/github-copilot`, input.serverUrl), { method: "DELETE", headers: ServerAuth.headers() }).catch((err) => { // kilocode_change
                 log.error("failed to clear copilot auth on 401", { err })
               })
             }

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -9,7 +9,7 @@ import { MessageV2 } from "@/session/message-v2"
 
 const log = Log.create({ service: "plugin.copilot" })
 
-const CLIENT_ID = "Ov23li8tweQw6odWQebz"
+const CLIENT_ID = "Ov23li5v4CagFoQACXl2" // kilocode_change
 // Add a small safety buffer when polling to avoid hitting the server
 // slightly too early due to clock skew / timer drift.
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000 // 3 seconds

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -64,6 +64,9 @@ function isOverflow(message: string) {
 function message(providerID: ProviderID, e: APICallError) {
   return iife(() => {
     // kilocode_change start - surface a branded reauth hint for expired Copilot tokens
+    if (providerID.includes("github-copilot") && e.statusCode === 401) {
+      return "Your GitHub Copilot session has expired or is no longer valid. Please sign in again."
+    }
     if (providerID.includes("github-copilot") && e.statusCode === 403) {
       return "Please reauthenticate with the copilot provider to ensure your credentials work properly with Kilo."
     }


### PR DESCRIPTION
Replace the hardcoded GitHub OAuth `CLIENT_ID` in the GitHub Copilot plugin with the Kilo-Org client ID (`Ov23li5v4CagFoQACXl2`), replacing the previous value (`Ov23li8tweQw6odWQebz`).

This ensures Copilot OAuth flows are registered under the Kilo-Org GitHub App rather than the old client.

**Re-auth error handling**: When the stored OAuth token returns a 401 (e.g. because the client ID changed), the plugin now:
- Clears the stored token automatically so the user is not retried with a bad credential
- Shows a clear message: "Your GitHub Copilot session has expired or is no longer valid. Please sign in again."

**Fix: authenticated token cleanup**: The DELETE `/auth/github-copilot` request sent on 401 now includes `ServerAuth` credentials via `ServerAuth.headers()`. Previously the raw `fetch` had no auth headers, so password-protected `kilo serve` instances would reject the cleanup request with a 403, leaving the stale token in place and keeping the user stuck in a 401 loop.

A changeset is included documenting this as a `patch` bump.

Built for [Remon Oldenbeuving](https://kilo-code.slack.com/archives/C0AFBRXUH2N/p1782303926803989?thread_ts=1782299968.561249&cid=C0AFBRXUH2N) by [Kilo for Slack](https://kilo.ai/slack)

Built for markijbema by [Kilo](https://kilo.ai)