### PR TITLE
fix(cli): dismiss permissions when tools abort

### DIFF
--- a/.changeset/clear-aborted-permissions.md
+++ b/.changeset/clear-aborted-permissions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Dismiss permission prompts immediately when their tool execution is aborted.

--- a/packages/opencode/src/effect/bridge.ts
+++ b/packages/opencode/src/effect/bridge.ts
@@ -6,7 +6,9 @@ import { attachWith } from "./run-service"
 import { Instance, type InstanceContext } from "@/kilocode/instance" // kilocode_change
 
 export interface Shape {
-  readonly promise: <A, E, R>(effect: Effect.Effect<A, E, R>) => Promise<A>
+  // kilocode_change start - propagate callback abort signals
+  readonly promise: <A, E, R>(effect: Effect.Effect<A, E, R>, options?: Effect.RunOptions) => Promise<A>
+  // kilocode_change end
   readonly fork: <A, E, R>(effect: Effect.Effect<A, E, R>) => Fiber.Fiber<A, E>
   readonly run: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E>
   readonly bind: <Args extends readonly unknown[], Result>(fn: (...args: Args) => Result) => (...args: Args) => Result
@@ -72,8 +74,10 @@ export function make(): Effect.Effect<Shape> {
       attachWith(effect.pipe(Effect.provide(ctx)) as Effect.Effect<A, E, never>, { instance, workspace })
 
     return {
-      promise: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-        restore(instance, workspace, () => Effect.runPromise(wrap(effect))), // kilocode_change
+      // kilocode_change start - propagate callback abort signals while preserving Kilo contexts
+      promise: <A, E, R>(effect: Effect.Effect<A, E, R>, options?: Effect.RunOptions) =>
+        restore(instance, workspace, () => Effect.runPromise(wrap(effect), options)),
+      // kilocode_change end
       fork: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
         restore(instance, workspace, () => Effect.runFork(wrap(effect))), // kilocode_change
       run: <A, E, R>(effect: Effect.Effect<A, E, R>) =>

--- a/packages/opencode/src/kilocode/permission/lifecycle.ts
+++ b/packages/opencode/src/kilocode/permission/lifecycle.ts
@@ -1,6 +1,21 @@
 import { Effect } from "effect"
 
 export namespace KiloPermission {
+  export const abort = (signal: AbortSignal) => {
+    if (signal.aborted) return Effect.interrupt
+    return Effect.callback<never>((resume) => {
+      const state = { done: false }
+      const stop = () => {
+        if (state.done) return
+        state.done = true
+        resume(Effect.interrupt)
+      }
+      signal.addEventListener("abort", stop, { once: true })
+      if (signal.aborted) stop()
+      return Effect.sync(() => signal.removeEventListener("abort", stop))
+    })
+  }
+
   export const finalize = <ID, Value>(input: { pending: Map<ID, Value>; id: ID; publish: () => Effect.Effect<void> }) =>
     Effect.gen(function* () {
       if (!input.pending.delete(input.id)) return

--- a/packages/opencode/src/kilocode/permission/lifecycle.ts
+++ b/packages/opencode/src/kilocode/permission/lifecycle.ts
@@ -1,0 +1,9 @@
+import { Effect } from "effect"
+
+export namespace KiloPermission {
+  export const finalize = <ID, Value>(input: { pending: Map<ID, Value>; id: ID; publish: () => Effect.Effect<void> }) =>
+    Effect.gen(function* () {
+      if (!input.pending.delete(input.id)) return
+      yield* input.publish()
+    })
+}

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -15,6 +15,7 @@ import { PlanFile } from "@/kilocode/plan-file"
 import { KiloSession } from "@/kilocode/session"
 import { KiloSessionMessageOrder } from "@/kilocode/session/message-order"
 import { Permission } from "@/permission"
+import { KiloPermission } from "@/kilocode/permission/lifecycle"
 import { Question } from "@/question"
 import { environmentDetails, type EditorContext } from "@/kilocode/editor-context"
 import { Identifier } from "@/id/id"
@@ -163,16 +164,19 @@ export namespace KiloSessionPrompt {
     agent: Agent.Info
     session: Session.Info
     request: Omit<Permission.AskInput, "ruleset" | "hardRuleset">
+    abort: AbortSignal
   }) {
     const agent = (yield* input.agents.get(input.agent.name)) ?? input.agent
     const session = yield* input.sessions
       .get(input.session.id)
       .pipe(Effect.catchCause(() => Effect.succeed(input.session)))
-    yield* input.permission.ask({
-      ...input.request,
-      ruleset: Permission.merge(agent.permission, guardPermissions({ agent, session })),
-      hardRuleset: hardPermissions({ agent }),
-    })
+    yield* input.permission
+      .ask({
+        ...input.request,
+        ruleset: Permission.merge(agent.permission, guardPermissions({ agent, session })),
+        hardRuleset: hardPermissions({ agent }),
+      })
+      .pipe(Effect.raceFirst(KiloPermission.abort(input.abort)))
   })
 
   /**

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -193,7 +193,9 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
   return dynamicTool({
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
-    execute: async (args: unknown) => {
+    // kilocode_change start - accept the AI SDK cancellation signal
+    execute: async (args: unknown, opts) => {
+      // kilocode_change end
       return client.callTool(
         {
           name: mcpTool.name,
@@ -203,6 +205,7 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
         {
           resetTimeoutOnProgress: true,
           timeout,
+          signal: opts.abortSignal, // kilocode_change - cancel the remote MCP request with its tool execution
         },
       )
     },

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -21,6 +21,7 @@ import { ConfigProtection } from "@/kilocode/permission/config-paths"
 import { drainCovered } from "@/kilocode/permission/drain"
 import { ReadPermission } from "@/kilocode/permission/read"
 import { ExternalDirectoryPermission } from "@/kilocode/permission/external-directory"
+import { KiloPermission } from "@/kilocode/permission/lifecycle"
 // kilocode_change end
 
 const log = Log.create({ service: "permission" })
@@ -294,14 +295,25 @@ export const layer = Layer.effect(
       log.info("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()
-      pending.set(id, { info, ruleset, hardRuleset, deferred }) // kilocode_change
-      yield* bus.publish(Event.Asked, info)
+      // kilocode_change start - arm terminal cleanup before publishing the pending request
       return yield* Effect.ensuring(
-        Deferred.await(deferred),
-        Effect.sync(() => {
-          pending.delete(id)
+        Effect.gen(function* () {
+          pending.set(id, { info, ruleset, hardRuleset, deferred })
+          yield* bus.publish(Event.Asked, info)
+          return yield* Deferred.await(deferred)
+        }),
+        KiloPermission.finalize({
+          pending,
+          id,
+          publish: () =>
+            bus.publish(Event.Replied, {
+              sessionID: info.sessionID,
+              requestID: info.id,
+              reply: "reject",
+            }),
         }),
       )
+      // kilocode_change end
     })
 
     const reply = Effect.fn("Permission.reply")(function* (input: ReplyInput) {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -234,6 +234,7 @@ const live: Layer.Layer<
                 always: uniquePatterns,
                 ruleset: [],
               }),
+              { signal: input.abort }, // kilocode_change - abort detached workflow approval waits with the session
             )
             for (const name of uniqueNames) approvedToolsForSession.add(name)
             workflowModel.sessionPreapprovedTools = [...(workflowModel.sessionPreapprovedTools ?? []), ...uniqueNames]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -427,6 +427,7 @@ export const layer = Layer.effect(
                 ...req,
                 sessionID,
               },
+              abort: taskAbort.signal,
             }).pipe(Effect.orDie),
           // kilocode_change end
         })

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -111,6 +111,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             }
             return output
           }),
+          { signal: options.abortSignal }, // kilocode_change - interrupt the Effect tool with the AI SDK cancellation
         )
       },
     })
@@ -204,6 +205,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           }
           return output
         }),
+        { signal: opts.abortSignal }, // kilocode_change - interrupt the Effect tool with the AI SDK cancellation
       )
     tools[key] = item
   }

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -67,6 +67,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           sessionID: input.session.id,
           tool: { messageID: input.processor.message.id, callID: options.toolCallId },
         },
+        abort: options.abortSignal!,
       }).pipe(Effect.orDie),
   })
   // kilocode_change end
@@ -111,7 +112,6 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             }
             return output
           }),
-          { signal: options.abortSignal }, // kilocode_change - interrupt the Effect tool with the AI SDK cancellation
         )
       },
     })
@@ -205,7 +205,6 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           }
           return output
         }),
-        { signal: opts.abortSignal }, // kilocode_change - interrupt the Effect tool with the AI SDK cancellation
       )
     tools[key] = item
   }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -182,7 +182,7 @@ export const layer: Layer.Layer<
                 const bridge = yield* EffectBridge.make()
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
-                  ask: (req) => bridge.promise(toolCtx.ask(req)),
+                  ask: (req) => bridge.promise(toolCtx.ask(req), { signal: toolCtx.abort }), // kilocode_change
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }

--- a/packages/opencode/test/kilocode/permission-cancel.test.ts
+++ b/packages/opencode/test/kilocode/permission-cancel.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, expect } from "bun:test"
-import { Effect, Layer, Queue } from "effect"
+import { Effect, Exit, Layer, Queue } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Agent } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
 import { Config } from "../../src/config/config"
 import { EffectBridge } from "../../src/effect/bridge"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { KiloPermission } from "../../src/kilocode/permission/lifecycle"
+import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
 import { Permission } from "../../src/permission"
 import { PermissionID } from "../../src/permission/schema"
 import { InstanceBootstrap } from "../../src/project/bootstrap-service"
 import { InstanceStore } from "../../src/project/instance-store"
+import { ProjectID } from "../../src/project/schema"
+import { Session } from "../../src/session/session"
 import { SessionID } from "../../src/session/schema"
 import { disposeAllInstances } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -27,13 +32,41 @@ afterEach(async () => {
   await disposeAllInstances()
 })
 
+it.effect("does not miss an abort while installing its listener", () =>
+  Effect.gen(function* () {
+    const ctl = new AbortController()
+    const exit = yield* Effect.raceFirst(
+      Effect.sync(() => ctl.abort()).pipe(Effect.andThen(Effect.never)),
+      KiloPermission.abort(ctl.signal),
+    ).pipe(Effect.timeout("2 seconds"), Effect.exit)
+
+    expect(Exit.hasInterrupts(exit)).toBe(true)
+  }),
+)
+
 it.instance(
-  "publishes rejection when a bridged permission wait is aborted",
+  "publishes rejection when a tool aborts its pending permission",
   () =>
     Effect.gen(function* () {
       const permission = yield* Permission.Service
       const events = yield* Bus.Service
       const bridge = yield* EffectBridge.make()
+      const agent: Agent.Info = {
+        name: "build",
+        mode: "primary",
+        permission: [{ permission: "edit", pattern: "*", action: "ask" }],
+        options: {},
+      }
+      const session: Session.Info = {
+        id: SessionID.make("ses_abort"),
+        slug: "permission-abort",
+        projectID: ProjectID.make("permission-abort"),
+        directory: "/workspace",
+        title: "Permission abort",
+        version: "test",
+        permission: [],
+        time: { created: 0, updated: 0 },
+      }
       const asked = yield* Queue.unbounded<{ properties: Permission.Request }>()
       const replied = yield* Queue.unbounded<{
         properties: { sessionID: SessionID; requestID: PermissionID; reply: Permission.Reply }
@@ -49,16 +82,22 @@ it.instance(
       const ctl = new AbortController()
       const wait = bridge
         .promise(
-          permission.ask({
-            id: PermissionID.make("per_abort"),
-            sessionID: SessionID.make("ses_abort"),
-            permission: "edit",
-            patterns: ["config.json"],
-            metadata: {},
-            always: [],
-            ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+          KiloSessionPrompt.askPermission({
+            permission,
+            agents: { get: () => Effect.succeed(agent) },
+            sessions: { get: () => Effect.succeed(session) },
+            agent,
+            session,
+            request: {
+              id: PermissionID.make("per_abort"),
+              sessionID: session.id,
+              permission: "edit",
+              patterns: ["config.json"],
+              metadata: {},
+              always: [],
+            },
+            abort: ctl.signal,
           }),
-          { signal: ctl.signal },
         )
         .then(
           () => "success" as const,

--- a/packages/opencode/test/kilocode/permission-cancel.test.ts
+++ b/packages/opencode/test/kilocode/permission-cancel.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, expect } from "bun:test"
+import { Effect, Layer, Queue } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Bus } from "../../src/bus"
+import { Config } from "../../src/config/config"
+import { EffectBridge } from "../../src/effect/bridge"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { Permission } from "../../src/permission"
+import { PermissionID } from "../../src/permission/schema"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { InstanceStore } from "../../src/project/instance-store"
+import { SessionID } from "../../src/session/schema"
+import { disposeAllInstances } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const bus = Bus.layer
+const bootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+const env = Layer.mergeAll(
+  Permission.layer.pipe(Layer.provide(bus)),
+  bus,
+  CrossSpawnSpawner.defaultLayer,
+  InstanceStore.defaultLayer.pipe(Layer.provide(bootstrap)),
+).pipe(Layer.provide(RuntimeFlags.layer()), Layer.provide(Config.defaultLayer))
+const it = testEffect(Layer.mergeAll(env, RuntimeFlags.layer()))
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+it.instance(
+  "publishes rejection when a bridged permission wait is aborted",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const events = yield* Bus.Service
+      const bridge = yield* EffectBridge.make()
+      const asked = yield* Queue.unbounded<{ properties: Permission.Request }>()
+      const replied = yield* Queue.unbounded<{
+        properties: { sessionID: SessionID; requestID: PermissionID; reply: Permission.Reply }
+      }>()
+      const offAsked = yield* events.subscribeCallback(Permission.Event.Asked, (event) =>
+        Queue.offerUnsafe(asked, event),
+      )
+      const offReplied = yield* events.subscribeCallback(Permission.Event.Replied, (event) =>
+        Queue.offerUnsafe(replied, event),
+      )
+      yield* Effect.addFinalizer(() => Effect.sync(() => [offAsked(), offReplied()]))
+
+      const ctl = new AbortController()
+      const wait = bridge
+        .promise(
+          permission.ask({
+            id: PermissionID.make("per_abort"),
+            sessionID: SessionID.make("ses_abort"),
+            permission: "edit",
+            patterns: ["config.json"],
+            metadata: {},
+            always: [],
+            ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+          }),
+          { signal: ctl.signal },
+        )
+        .then(
+          () => "success" as const,
+          () => "aborted" as const,
+        )
+
+      const request = yield* Queue.take(asked).pipe(Effect.timeout("2 seconds"))
+      ctl.abort()
+
+      expect(yield* Effect.promise(() => wait)).toBe("aborted")
+      const event = yield* Queue.take(replied).pipe(Effect.timeout("2 seconds"))
+      expect(event.properties).toEqual({
+        sessionID: request.properties.sessionID,
+        requestID: request.properties.id,
+        reply: "reject",
+      })
+      expect(yield* permission.list()).toEqual([])
+    }),
+  { git: true },
+)


### PR DESCRIPTION
Permission prompts are removed from clients only after the backend emits a terminal permission event. Aborting a session could mark the tool as aborted while leaving its Effect-backed permission wait alive, so the permission card remained visible and interactive even though the tool could no longer run.

Before:
- Cancellation reached running tools, but not every detached permission wait created around native, plugin, workflow, and MCP execution.
- Interrupted permission waits were removed from backend state without publishing the terminal event clients use for cleanup.
- The VS Code permission card could remain stuck after `Tool execution aborted`.

After:
- Cancellation is scoped to permission waits instead of force-interrupting whole native tools, preserving cooperative shutdown such as bash output flushing and truncation.
- Plugin and workflow permission bridges receive abort signals directly, while MCP requests retain remote cancellation.
- Permission registration and cleanup share one interruption-safe lifecycle. If an unresolved wait is interrupted, the backend removes it and publishes one rejection event.
- Existing user replies still win normally, while aborted permission cards are dismissed immediately and cannot be rehydrated as pending.