### PR TITLE
docs: clarify local Ollama setup

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/ollama.md
+++ b/packages/kilo-docs/pages/ai-providers/ollama.md
@@ -10,6 +10,12 @@ Kilo Code supports running models locally using Ollama. This provides privacy, o
 
 **Website:** [https://ollama.com/](https://ollama.com/)
 
+{% callout type="info" title="Local Ollama vs. Ollama Cloud" %}
+Use the **Ollama** provider for a local Ollama daemon started with `ollama serve`. Local models use the `ollama/<model_name>` format, for example `ollama/qwen3-coder:30b`, and connect to your local base URL.
+
+**Ollama Cloud** appears in Kilo Gateway and BYOK flows. It is a hosted provider path and does not connect to `http://localhost:11434`.
+{% /callout %}
+
 <!-- <image src="/docs/img/providers/ollama-devstral-snake.png" alt="Vibe coding a Snake game using devstral" width="500" />
 *Vibe coding a Snake game using devstral* -->
 
@@ -68,7 +74,7 @@ You need to have at least 32k to get decent results, but increasing the context 
 
 To configure the context window, set "Context Window Size (num_ctx)" in the API Provider settings.
 
-### Configure the Timout
+### Configure the Timeout
 
 By default, API requests time out after 10 minutes. Local models can be slow, if you hit this timeout you can consider increasing it here: VS Code Extensions panel > Kilo Code gear menu > Settings > API Request Timeout.
 
@@ -94,6 +100,8 @@ The extension stores this in your `kilo.json` config file. You can also edit the
 {% tab label="CLI" %}
 
 Ollama runs locally, so no API key is needed. Configure the base URL if Ollama is running on a different host:
+
+Use `ollama/<model_name>` for the selected model. If you see `ollama-cloud/...`, you are using the hosted Kilo Gateway/BYOK provider instead of your local Ollama server.
 
 **Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
 


### PR DESCRIPTION
## Issue

Closes #6871

## Context

The Ollama docs mention local setup, while BYOK and Gateway docs also list Ollama Cloud. That can make CLI setup ambiguous for users who want to connect Kilo to a local `ollama serve` daemon.

## Implementation

Added a short callout that separates the local **Ollama** provider from hosted **Ollama Cloud** models, and repeated the `ollama/<model_name>` model ID guidance in the CLI tab. I also corrected the nearby timeout heading typo.

## Screenshots / Video

N/A - docs text only.

## How to Test

### Manual/local verification

- Reviewed `packages/kilo-docs/pages/ai-providers/ollama.md` against the docs Markdoc guidance.
- Ran `git diff --check`.

### Reviewer test steps

1. Open `/docs/ai-providers/ollama`.
2. Confirm the "Local Ollama vs. Ollama Cloud" callout appears near the top.
3. Confirm the CLI tab says local Ollama uses `ollama/<model_name>`, not `ollama-cloud/...`.

### Blocked checks and substitute verification

- `bun run --filter @kilocode/kilo-docs build` could not be run locally because `bun` is not installed in this Windows session. Substitute verification was static diff validation with `git diff --check` plus manual Markdoc syntax review.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes.
