### PR TITLE
feat(sandbox): enforce Linux network isolation

### DIFF
--- a/.changeset/isolate-linux-network.md
+++ b/.changeset/isolate-linux-network.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+---
+
+Enforce the sandbox network restriction for agent commands on Linux, including TCP, UDP, IPv4, IPv6, and descendant processes.

--- a/packages/core/test/kilocode/linux-sandbox.test.ts
+++ b/packages/core/test/kilocode/linux-sandbox.test.ts
@@ -10,6 +10,7 @@ import { backendSupport, run, type Profile } from "@kilocode/sandbox"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 
 const linux = process.platform === "linux" ? test : test.skip
+const linuxIPv6 = process.platform === "linux" && supportsIPv6() ? test : test.skip
 
 function profile(
   allow: ReadonlyArray<string>,
@@ -53,6 +54,11 @@ async function fixture() {
   return { root, project, outside }
 }
 
+function requireNetwork() {
+  const support = backendSupport({ mode: "deny", allowedHosts: [] })
+  expect(support.available, support.reason).toBe(true)
+}
+
 function tcp(hostname = "127.0.0.1") {
   let accepted = 0
   const listener = Bun.listen({
@@ -68,6 +74,17 @@ function tcp(hostname = "127.0.0.1") {
     },
   })
   return { listener, accepted: () => accepted }
+}
+
+function supportsIPv6() {
+  if (process.platform !== "linux") return false
+  try {
+    const probe = tcp("::1")
+    probe.listener.stop(true)
+    return true
+  } catch {
+    return false
+  }
 }
 
 async function udp() {
@@ -141,8 +158,7 @@ linux("confines writes from spawned processes to the profile allowlist", async (
 })
 
 linux("allows host loopback TCP in network allow mode and blocks it in deny mode", async () => {
-  const support = backendSupport({ mode: "deny", allowedHosts: [] })
-  expect(support.available, support.reason).toBe(true)
+  requireNetwork()
   const root = await fixture()
   const allowed = tcp()
   const blocked = tcp()
@@ -162,6 +178,7 @@ linux("allows host loopback TCP in network allow mode and blocks it in deny mode
 })
 
 linux("blocks UDP datagrams in network deny mode", async () => {
+  requireNetwork()
   const root = await fixture()
   const allowed = await udp()
   const blocked = await udp()
@@ -180,31 +197,42 @@ linux("blocks UDP datagrams in network deny mode", async () => {
   }
 })
 
-linux("blocks localhost and IPv6 loopback connections in network deny mode", async () => {
+linux("blocks localhost connections in network deny mode", async () => {
+  requireNetwork()
   const root = await fixture()
-  const localhost = tcp("127.0.0.1")
-  const ipv6 = tcp("::1")
+  const listener = tcp()
   const deny = profile([root.project], [], "deny")
 
   try {
     expect(
-      Number(
-        await Effect.runPromise(spawn(tcpClient(localhost.listener.port, false, "localhost"), root.project, deny)),
-      ),
+      Number(await Effect.runPromise(spawn(tcpClient(listener.listener.port, false, "localhost"), root.project, deny))),
     ).toBe(0)
-    expect(
-      Number(await Effect.runPromise(spawn(tcpClient(ipv6.listener.port, false, "::1"), root.project, deny))),
-    ).toBe(0)
-    expect(localhost.accepted()).toBe(0)
-    expect(ipv6.accepted()).toBe(0)
+    expect(listener.accepted()).toBe(0)
   } finally {
-    localhost.listener.stop(true)
-    ipv6.listener.stop(true)
+    listener.listener.stop(true)
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linuxIPv6("blocks IPv6 loopback connections in network deny mode", async () => {
+  requireNetwork()
+  const root = await fixture()
+  const listener = tcp("::1")
+  const deny = profile([root.project], [], "deny")
+
+  try {
+    expect(
+      Number(await Effect.runPromise(spawn(tcpClient(listener.listener.port, false, "::1"), root.project, deny))),
+    ).toBe(0)
+    expect(listener.accepted()).toBe(0)
+  } finally {
+    listener.listener.stop(true)
     await fs.rm(root.root, { recursive: true, force: true })
   }
 })
 
 linux("keeps loopback available between processes inside the denied network namespace", async () => {
+  requireNetwork()
   const root = await fixture()
   const child = [
     'const net = require("node:net")',
@@ -232,6 +260,7 @@ linux("keeps loopback available between processes inside the denied network name
 })
 
 linux("keeps descendants in the denied network namespace", async () => {
+  requireNetwork()
   const root = await fixture()
   const blocked = tcp()
   const child = tcpClient(blocked.listener.port, false)
@@ -251,6 +280,7 @@ linux("keeps descendants in the denied network namespace", async () => {
 })
 
 linux("preserves filesystem confinement in network deny mode", async () => {
+  requireNetwork()
   const root = await fixture()
   const allowed = path.join(root.project, "network-deny.txt")
   const sentinel = path.join(root.outside, "network-deny.txt")

--- a/packages/core/test/kilocode/linux-sandbox.test.ts
+++ b/packages/core/test/kilocode/linux-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
+import { createSocket } from "node:dgram"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -10,14 +11,18 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 
 const linux = process.platform === "linux" ? test : test.skip
 
-function profile(allow: ReadonlyArray<string>, denyNames: ReadonlyArray<string> = []): Profile {
+function profile(
+  allow: ReadonlyArray<string>,
+  denyNames: ReadonlyArray<string> = [],
+  mode: Profile["network"]["mode"] = "allow",
+): Profile {
   return {
     filesystem: {
       allowWrite: allow.map((path) => ({ path, kind: "subtree" })),
       denyWrite: [],
       denyNames,
     },
-    network: { mode: "allow", allowedHosts: [] },
+    network: { mode, allowedHosts: [] },
     environment: { deny: [], set: {} },
   }
 }
@@ -48,6 +53,65 @@ async function fixture() {
   return { root, project, outside }
 }
 
+function tcp(hostname = "127.0.0.1") {
+  let accepted = 0
+  const listener = Bun.listen({
+    hostname,
+    port: 0,
+    socket: {
+      open(socket) {
+        accepted++
+        socket.write("sandbox-tcp-ok")
+        socket.end()
+      },
+      data() {},
+    },
+  })
+  return { listener, accepted: () => accepted }
+}
+
+async function udp() {
+  let received = 0
+  const socket = createSocket("udp4")
+  socket.on("message", (_message, peer) => {
+    received++
+    socket.send("sandbox-udp-ok", peer.port, peer.address)
+  })
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject)
+    socket.bind(0, "127.0.0.1", () => {
+      socket.off("error", reject)
+      resolve()
+    })
+  })
+  const address = socket.address()
+  if (typeof address === "string") throw new Error("UDP server did not expose an IP address")
+  return { socket, port: address.port, received: () => received }
+}
+
+function tcpClient(port: number, expected: boolean, hostname = "127.0.0.1") {
+  return [
+    'const net = require("node:net")',
+    `const socket = net.connect({ host: ${JSON.stringify(hostname)}, port: ${port} })`,
+    `const expected = ${expected}`,
+    'socket.on("data", (data) => process.exit(expected && data.toString() === "sandbox-tcp-ok" ? 0 : 2))',
+    'socket.on("error", () => process.exit(expected ? 3 : 0))',
+    "setTimeout(() => process.exit(expected ? 4 : 0), 1000)",
+  ].join("\n")
+}
+
+function udpClient(port: number, expected: boolean) {
+  return [
+    'const dgram = require("node:dgram")',
+    'const socket = dgram.createSocket("udp4")',
+    `const expected = ${expected}`,
+    'socket.on("message", (data) => process.exit(expected && data.toString() === "sandbox-udp-ok" ? 0 : 2))',
+    'socket.on("error", () => process.exit(expected ? 3 : 0))',
+    `socket.send("probe", ${port}, "127.0.0.1", (error) => { if (error) process.exit(expected ? 4 : 0) })`,
+    "setTimeout(() => process.exit(expected ? 5 : 0), 500)",
+  ].join("\n")
+}
+
 linux("confines writes from spawned processes to the profile allowlist", async () => {
   const support = backendSupport()
   expect(support.available, support.reason).toBe(true)
@@ -69,6 +133,141 @@ linux("confines writes from spawned processes to the profile allowlist", async (
 
   try {
     expect(Number(await Effect.runPromise(spawn(script, root.project, profile([root.project]))))).toBe(0)
+    expect(await fs.readFile(allowed, "utf8")).toBe("allowed")
+    expect(await fs.readFile(sentinel, "utf8")).toBe("original")
+  } finally {
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("allows host loopback TCP in network allow mode and blocks it in deny mode", async () => {
+  const support = backendSupport({ mode: "deny", allowedHosts: [] })
+  expect(support.available, support.reason).toBe(true)
+  const root = await fixture()
+  const allowed = tcp()
+  const blocked = tcp()
+
+  try {
+    const allow = profile([root.project], [], "allow")
+    const deny = profile([root.project], [], "deny")
+    expect(Number(await Effect.runPromise(spawn(tcpClient(allowed.listener.port, true), root.project, allow)))).toBe(0)
+    expect(Number(await Effect.runPromise(spawn(tcpClient(blocked.listener.port, false), root.project, deny)))).toBe(0)
+    expect(allowed.accepted()).toBe(1)
+    expect(blocked.accepted()).toBe(0)
+  } finally {
+    allowed.listener.stop(true)
+    blocked.listener.stop(true)
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("blocks UDP datagrams in network deny mode", async () => {
+  const root = await fixture()
+  const allowed = await udp()
+  const blocked = await udp()
+
+  try {
+    const allow = profile([root.project], [], "allow")
+    const deny = profile([root.project], [], "deny")
+    expect(Number(await Effect.runPromise(spawn(udpClient(allowed.port, true), root.project, allow)))).toBe(0)
+    expect(Number(await Effect.runPromise(spawn(udpClient(blocked.port, false), root.project, deny)))).toBe(0)
+    expect(allowed.received()).toBe(1)
+    expect(blocked.received()).toBe(0)
+  } finally {
+    allowed.socket.close()
+    blocked.socket.close()
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("blocks localhost and IPv6 loopback connections in network deny mode", async () => {
+  const root = await fixture()
+  const localhost = tcp("127.0.0.1")
+  const ipv6 = tcp("::1")
+  const deny = profile([root.project], [], "deny")
+
+  try {
+    expect(
+      Number(
+        await Effect.runPromise(spawn(tcpClient(localhost.listener.port, false, "localhost"), root.project, deny)),
+      ),
+    ).toBe(0)
+    expect(
+      Number(await Effect.runPromise(spawn(tcpClient(ipv6.listener.port, false, "::1"), root.project, deny))),
+    ).toBe(0)
+    expect(localhost.accepted()).toBe(0)
+    expect(ipv6.accepted()).toBe(0)
+  } finally {
+    localhost.listener.stop(true)
+    ipv6.listener.stop(true)
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("keeps loopback available between processes inside the denied network namespace", async () => {
+  const root = await fixture()
+  const child = [
+    'const net = require("node:net")',
+    "const port = Number(process.argv[1])",
+    'const socket = net.connect({ host: "127.0.0.1", port })',
+    'socket.on("connect", () => socket.write("sandbox-internal-ok"))',
+    'socket.on("data", (data) => process.exit(data.toString() === "sandbox-internal-ok" ? 0 : 2))',
+    'socket.on("error", () => process.exit(3))',
+  ].join("\n")
+  const script = [
+    'const child = require("node:child_process")',
+    'const net = require("node:net")',
+    'const server = net.createServer((socket) => socket.on("data", (data) => socket.end(data)))',
+    'server.listen(0, "127.0.0.1", () => {',
+    `  const proc = child.spawn(process.execPath, ["-e", ${JSON.stringify(child)}, String(server.address().port)])`,
+    '  proc.on("exit", (code) => process.exit(code ?? 4))',
+    "})",
+  ].join("\n")
+
+  try {
+    expect(Number(await Effect.runPromise(spawn(script, root.project, profile([root.project], [], "deny"))))).toBe(0)
+  } finally {
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("keeps descendants in the denied network namespace", async () => {
+  const root = await fixture()
+  const blocked = tcp()
+  const child = tcpClient(blocked.listener.port, false)
+  const script = [
+    'const child = require("node:child_process")',
+    `const result = child.spawnSync(process.execPath, ["-e", ${JSON.stringify(child)}])`,
+    "process.exit(result.status ?? 3)",
+  ].join("\n")
+
+  try {
+    expect(Number(await Effect.runPromise(spawn(script, root.project, profile([root.project], [], "deny"))))).toBe(0)
+    expect(blocked.accepted()).toBe(0)
+  } finally {
+    blocked.listener.stop(true)
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("preserves filesystem confinement in network deny mode", async () => {
+  const root = await fixture()
+  const allowed = path.join(root.project, "network-deny.txt")
+  const sentinel = path.join(root.outside, "network-deny.txt")
+  await fs.writeFile(sentinel, "original")
+  const script = [
+    'const fs = require("node:fs")',
+    `fs.writeFileSync(${JSON.stringify(allowed)}, "allowed")`,
+    "try {",
+    `  fs.writeFileSync(${JSON.stringify(sentinel)}, "escaped")`,
+    "  process.exit(2)",
+    "} catch {",
+    "  process.exit(0)",
+    "}",
+  ].join("\n")
+
+  try {
+    expect(Number(await Effect.runPromise(spawn(script, root.project, profile([root.project], [], "deny"))))).toBe(0)
     expect(await fs.readFile(allowed, "utf8")).toBe("allowed")
     expect(await fs.readFile(sentinel, "utf8")).toBe("original")
   } finally {
@@ -440,6 +639,48 @@ linux("rejects a Bubblewrap helper inside a writable root", async () => {
     const result = spawnSync(process.execPath, ["-e", script], {
       cwd: import.meta.dir,
       env: { ...process.env, KILO_BWRAP_PATH: link },
+      encoding: "utf8",
+    })
+    expect(result.status, result.stderr).toBe(0)
+  } finally {
+    await fs.rm(root.root, { recursive: true, force: true })
+  }
+})
+
+linux("reports network namespace support separately and fails deny mode closed", async () => {
+  const root = await fixture()
+  const source = process.env.KILO_BWRAP_PATH ?? "/usr/bin/bwrap"
+  const helper = path.join(root.outside, "bwrap-no-network")
+  await fs.writeFile(
+    helper,
+    [
+      "#!/bin/sh",
+      'for arg in "$@"; do',
+      '  if [ "$arg" = "--unshare-net" ]; then echo "network namespaces blocked" >&2; exit 42; fi',
+      "done",
+      `exec ${JSON.stringify(source)} "$@"`,
+      "",
+    ].join("\n"),
+  )
+  await fs.chmod(helper, 0o755)
+  const script = [
+    'import { Effect } from "effect"',
+    'import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"',
+    'import { backendSupport, run } from "@kilocode/sandbox"',
+    'import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"',
+    'const allow = backendSupport({ mode: "allow", allowedHosts: [] })',
+    'const deny = backendSupport({ mode: "deny", allowedHosts: [] })',
+    "if (!allow.available) process.exit(2)",
+    'if (deny.available || !deny.reason?.includes("Linux network sandbox")) process.exit(3)',
+    'const profile = { filesystem: { allowWrite: [], denyWrite: [], denyNames: [] }, network: { mode: "deny", allowedHosts: [] }, environment: { deny: [], set: {} } }',
+    'const effect = Effect.scoped(run(profile, ChildProcessSpawner.ChildProcessSpawner.use((spawner) => spawner.spawn(ChildProcess.make(process.execPath, ["-e", "process.exit(0)"])))).pipe(Effect.provide(CrossSpawnSpawner.defaultLayer)))',
+    "try { await Effect.runPromise(effect); process.exit(4) } catch { process.exit(0) }",
+  ].join("\n")
+
+  try {
+    const result = spawnSync(process.execPath, ["-e", script], {
+      cwd: import.meta.dir,
+      env: { ...process.env, KILO_BWRAP_PATH: helper },
       encoding: "utf8",
     })
     expect(result.status, result.stderr).toBe(0)

--- a/packages/kilo-sandbox/src/backend.ts
+++ b/packages/kilo-sandbox/src/backend.ts
@@ -20,7 +20,7 @@ export interface Support {
 }
 
 export interface Backend {
-  readonly support: () => Support
+  readonly support: (network?: Profile["network"]) => Support
   readonly prepare: (
     profile: Profile,
     launch: Launch,
@@ -83,7 +83,7 @@ export function confine(profile: Profile, launch: Launch) {
   return Effect.gen(function* () {
     const next = { ...launch, environment: environment(profile, launch) }
     yield* assertProcessNetwork(profile, launch.command)
-    const support = backend.support()
+    const support = backend.support(profile.network)
     if (!support.available) return yield* Effect.fail(unsupported(launch.command, "confine", support))
     return yield* backend.prepare(profile, next)
   })
@@ -114,6 +114,6 @@ export function prepareCommand(
   })
 }
 
-export function backendSupport() {
-  return backend.support()
+export function backendSupport(network?: Profile["network"]) {
+  return backend.support(network)
 }

--- a/packages/kilo-sandbox/src/bubblewrap.ts
+++ b/packages/kilo-sandbox/src/bubblewrap.ts
@@ -120,6 +120,7 @@ export function generate(
     "--unshare-user",
     "--disable-userns",
     "--unshare-pid",
+    ...(profile.network.mode === "deny" ? ["--unshare-net"] : []),
     "--die-with-parent",
     "--new-session",
     "--ro-bind",
@@ -163,13 +164,14 @@ function resolve(executable: string, expected?: string) {
   }
 }
 
-function probe(executable: string) {
+function probe(executable: string, network = false) {
   const result = spawnSync(
     executable,
     [
       "--unshare-user",
       "--disable-userns",
       "--unshare-pid",
+      ...(network ? ["--unshare-net"] : []),
       "--die-with-parent",
       "--new-session",
       "--ro-bind",
@@ -187,10 +189,17 @@ function probe(executable: string) {
   )
   if (result.status === 0) return undefined
   const detail = result.error?.message ?? (result.stderr.trim() || `exited with status ${result.status}`)
-  return `${executable} could not create the Linux sandbox: ${detail}`
+  const capability = network ? "Linux network sandbox" : "Linux sandbox"
+  return `${executable} could not create the ${capability}: ${detail}`
 }
 
-function select() {
+interface Selection {
+  readonly executable: string | undefined
+  readonly support: Support
+  network: Support | undefined
+}
+
+function select(): Selection {
   const override = process.env.KILO_BWRAP_PATH
   const candidates = override
     ? [{ executable: override }]
@@ -201,7 +210,7 @@ function select() {
     const executable = resolve(candidate.executable, candidate.expected)
     if (!executable) continue
     const failure = probe(executable)
-    if (!failure) return { executable, support: { available: true } satisfies Support }
+    if (!failure) return { executable, support: { available: true } satisfies Support, network: undefined }
     failures.push(failure)
   }
 
@@ -211,10 +220,9 @@ function select() {
       available: false,
       reason: failures.at(-1) ?? "No usable Bubblewrap executable is available",
     } satisfies Support,
+    network: undefined,
   }
 }
-
-type Selection = ReturnType<typeof select>
 
 let selected: Selection | undefined
 
@@ -223,8 +231,21 @@ function selection(): Selection {
   selected =
     process.platform === "linux"
       ? select()
-      : { executable: undefined, support: { available: false, reason: "Bubblewrap requires Linux" } satisfies Support }
+      : {
+          executable: undefined,
+          support: { available: false, reason: "Bubblewrap requires Linux" } satisfies Support,
+          network: undefined,
+        }
   return selected
+}
+
+function support(network?: Profile["network"]): Support {
+  const selected = selection()
+  if (!selected.support.available || network?.mode !== "deny" || !selected.executable) return selected.support
+  if (selected.network) return selected.network
+  const failure = probe(selected.executable, true)
+  selected.network = failure ? { available: false, reason: failure } : { available: true }
+  return selected.network
 }
 
 function setup(cause: unknown, launch: Launch) {
@@ -239,7 +260,7 @@ function setup(cause: unknown, launch: Launch) {
 }
 
 export const bubblewrap: Backend = {
-  support: () => selection().support,
+  support,
   prepare: (profile, launch) =>
     Effect.try({
       try: () => {

--- a/packages/kilo-sandbox/test/backend.test.ts
+++ b/packages/kilo-sandbox/test/backend.test.ts
@@ -75,7 +75,7 @@ describe("sandbox launch preparation", () => {
     expect(args.args.slice(-4)).toEqual(["--", "/bin/sh", "-c", "printf '%s' 'hello world'"])
   })
 
-  test("layers Linux writable roots before protected git metadata without changing the network namespace", () => {
+  test("keeps the host network namespace in Linux allow mode", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "kilo-bubblewrap-policy-"))
     const git = path.join(root, ".git")
     mkdirSync(git)
@@ -98,6 +98,28 @@ describe("sandbox launch preparation", () => {
       expect(protectedPath).toBeGreaterThan(writable)
       expect(result.args.slice(protectedPath, protectedPath + 3)).toEqual(["--ro-bind", git, git])
       expect(result.args).not.toContain("--unshare-net")
+      expect(result.args.slice(-3)).toEqual(["--", "/bin/echo", "hello"])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test("isolates the Linux network namespace in deny mode", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "kilo-bubblewrap-network-"))
+    const input = makeProfile("deny")
+    const profile: Profile = {
+      ...input,
+      filesystem: {
+        allowWrite: [{ path: root, kind: "subtree" }],
+        denyWrite: [],
+        denyNames: [],
+      },
+    }
+
+    try {
+      const result = generateBubblewrap(profile, { ...launch, cwd: root }, "/opt/kilo/bwrap")
+      expect(result.args).toContain("--unshare-net")
+      expect(result.args.indexOf("--unshare-net")).toBeGreaterThan(result.args.indexOf("--unshare-pid"))
       expect(result.args.slice(-3)).toEqual(["--", "/bin/echo", "hello"])
     } finally {
       rmSync(root, { recursive: true, force: true })
@@ -234,8 +256,10 @@ describe("sandbox launch preparation", () => {
   })
 
   test("reports backend support with a reason when unavailable", () => {
-    const support = backendSupport()
-    expect(typeof support.available).toBe("boolean")
-    if (!support.available) expect(support.reason?.length).toBeGreaterThan(0)
+    for (const network of [undefined, makeProfile("deny").network]) {
+      const support = backendSupport(network)
+      expect(typeof support.available).toBe("boolean")
+      if (!support.available) expect(support.reason?.length).toBeGreaterThan(0)
+    }
   })
 })

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -114,7 +114,8 @@ export const status = Effect.fn("SandboxPolicy.status")(function* (sessionID: Se
   const directory = yield* InstanceState.directory
   const override = overrides.get(key(directory, sessionID))
   const enabled = override?.enabled ?? cfg.experimental?.sandbox ?? false
-  const support = backendSupport()
+  const mode = cfg.experimental?.sandbox_restrict_network === false ? "allow" : "deny"
+  const support = backendSupport({ mode, allowedHosts: [] })
   return {
     directory,
     enabled: enabled && support.available,

--- a/packages/opencode/test/kilocode/sandbox/shell-network.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/shell-network.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import * as Network from "@/kilocode/sandbox/network"
+import * as SandboxPolicy from "@/kilocode/sandbox/policy"
 import { Plugin } from "@/plugin"
 import { Agent } from "@/agent/agent"
 import { ShellTool } from "@/tool/shell"
@@ -10,17 +12,33 @@ import { MessageID, SessionID } from "@/session/schema"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { run as runSandbox, type Profile } from "@kilocode/sandbox"
+import { TestConfig } from "../../fixture/config"
 import { provideInstance, tmpdirScoped } from "../../fixture/fixture"
 
-const layer = Layer.mergeAll(
+const base = Layer.mergeAll(
   CrossSpawnSpawner.defaultLayer,
   AppFileSystem.defaultLayer,
   Plugin.defaultLayer,
   Truncate.defaultLayer,
-  Config.defaultLayer,
   Agent.defaultLayer,
   RuntimeFlags.defaultLayer,
 )
+const layer = Layer.mergeAll(base, Config.defaultLayer)
+
+function configured(restrict: boolean) {
+  return Layer.mergeAll(
+    base,
+    TestConfig.layer({
+      get: () =>
+        Effect.succeed({
+          experimental: {
+            sandbox: true,
+            sandbox_restrict_network: restrict,
+          },
+        }),
+    }),
+  )
+}
 
 const ctx = {
   sessionID: SessionID.make("ses_sandbox_network"),
@@ -72,8 +90,19 @@ const execute = Effect.fn("ShellNetworkTest.execute")(function* (
   return yield* runSandbox(profile(root, mode), shell.execute({ command: `/usr/bin/nc -v 127.0.0.1 ${port}` }, ctx))
 })
 
+const executeConfigured = Effect.fn("ShellNetworkTest.executeConfigured")(function* (port: number) {
+  const info = yield* ShellTool
+  const shell = yield* info.init()
+  const tool = Network.builtin({ id: "bash" })
+  return yield* SandboxPolicy.executeTool(
+    ctx.sessionID,
+    tool,
+    shell.execute({ command: `/usr/bin/nc -v 127.0.0.1 ${port}` }, ctx),
+  )
+})
+
 describe("model shell network integration", () => {
-  test.skipIf(process.platform !== "darwin")(
+  test.skipIf(process.platform !== "darwin" && process.platform !== "linux")(
     "enforces allow and deny profiles through the actual shell tool and process spawner",
     async () => {
       const effect = Effect.gen(function* () {
@@ -92,12 +121,47 @@ describe("model shell network integration", () => {
         expect(allow.output).toContain("model-shell-network-ok")
         expect(allow.metadata.exit).toBe(0)
         expect(allowed.accepted()).toBe(1)
-        expect(deny.output).toContain("Operation not permitted")
+        if (process.platform === "darwin") expect(deny.output).toContain("Operation not permitted")
+        expect(deny.output).not.toContain("model-shell-network-ok")
         expect(deny.metadata.exit).not.toBe(0)
         expect(denied.accepted()).toBe(0)
       })
 
       await Effect.runPromise(Effect.scoped(effect.pipe(Effect.provide(layer))))
+    },
+  )
+
+  test.skipIf(process.platform !== "darwin" && process.platform !== "linux")(
+    "applies the network restriction setting to spawned shell commands",
+    async () => {
+      const effect = Effect.gen(function* () {
+        const root = yield* tmpdirScoped()
+        const allowed = server()
+        const denied = server()
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            allowed.listener.stop(true)
+            denied.listener.stop(true)
+          }),
+        )
+
+        const allow = yield* executeConfigured(allowed.listener.port).pipe(
+          provideInstance(root),
+          Effect.provide(configured(false)),
+        )
+        const deny = yield* executeConfigured(denied.listener.port).pipe(
+          provideInstance(root),
+          Effect.provide(configured(true)),
+        )
+        expect(allow.output).toContain("model-shell-network-ok")
+        expect(allow.metadata.exit).toBe(0)
+        expect(allowed.accepted()).toBe(1)
+        expect(deny.output).not.toContain("model-shell-network-ok")
+        expect(deny.metadata.exit).not.toBe(0)
+        expect(denied.accepted()).toBe(0)
+      })
+
+      await Effect.runPromise(Effect.scoped(effect.pipe(Effect.provide(CrossSpawnSpawner.defaultLayer))))
     },
   )
 })

--- a/packages/opencode/test/kilocode/sandbox/state.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/state.test.ts
@@ -23,7 +23,6 @@ function execute<A, E, R>(sessionID: SessionID, effect: Effect.Effect<A, E, R>) 
 
 linux("reports configured network namespace availability", async () => {
   const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "kilo-sandbox-status-"))
-  const source = process.env.KILO_BWRAP_PATH ?? "/usr/bin/bwrap"
   const helper = path.join(root, "bwrap-no-network")
   await fs.writeFile(
     helper,
@@ -32,7 +31,7 @@ linux("reports configured network namespace availability", async () => {
       'for arg in "$@"; do',
       '  if [ "$arg" = "--unshare-net" ]; then echo "network namespaces blocked" >&2; exit 42; fi',
       "done",
-      `exec ${JSON.stringify(source)} "$@"`,
+      "exit 0",
       "",
     ].join("\n"),
   )

--- a/packages/opencode/test/kilocode/sandbox/state.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/state.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises"
 import path from "node:path"
-import { expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -14,11 +14,56 @@ import { TestInstance } from "../../fixture/fixture"
 import { testEffect } from "../../lib/effect"
 
 const it = testEffect(Layer.mergeAll(Bus.layer, Config.defaultLayer, CrossSpawnSpawner.defaultLayer))
+const linux = process.platform === "linux" ? test : test.skip
 const tool = Network.builtin({ id: "read" })
 
 function execute<A, E, R>(sessionID: SessionID, effect: Effect.Effect<A, E, R>) {
   return SandboxPolicy.executeTool(sessionID, tool, effect)
 }
+
+linux("reports configured network namespace availability", async () => {
+  const root = await fs.mkdtemp(path.join(process.env.TMPDIR ?? "/tmp", "kilo-sandbox-status-"))
+  const source = process.env.KILO_BWRAP_PATH ?? "/usr/bin/bwrap"
+  const helper = path.join(root, "bwrap-no-network")
+  await fs.writeFile(
+    helper,
+    [
+      "#!/bin/sh",
+      'for arg in "$@"; do',
+      '  if [ "$arg" = "--unshare-net" ]; then echo "network namespaces blocked" >&2; exit 42; fi',
+      "done",
+      `exec ${JSON.stringify(source)} "$@"`,
+      "",
+    ].join("\n"),
+  )
+  await fs.chmod(helper, 0o755)
+  const script = [
+    'import { Effect, Layer } from "effect"',
+    'import { Config } from "@/config/config"',
+    'import { InstanceRef } from "@/effect/instance-ref"',
+    'import * as SandboxPolicy from "@/kilocode/sandbox/policy"',
+    'import { SessionID } from "@/session/schema"',
+    "const directory = process.cwd()",
+    'const context = { directory, worktree: directory, project: { id: "sandbox-status", worktree: directory, vcs: "git", time: { created: 0, updated: 0 }, sandboxes: [] } }',
+    "const status = (restrict) => SandboxPolicy.status(SessionID.make(`ses_sandbox_status_${restrict}`)).pipe(Effect.provide(Layer.mock(Config.Service, { get: () => Effect.succeed({ experimental: { sandbox: true, sandbox_restrict_network: restrict } }) })), Effect.provideService(InstanceRef, context), Effect.runPromise)",
+    "const deny = await status(true)",
+    "const allow = await status(false)",
+    'if (deny.available || deny.enabled || !deny.reason?.includes("Linux network sandbox")) process.exit(2)',
+    "if (!allow.available || !allow.enabled) process.exit(3)",
+  ].join("\n")
+
+  try {
+    const result = Bun.spawnSync([process.execPath, "-e", script], {
+      cwd: import.meta.dir,
+      env: { ...process.env, KILO_BWRAP_PATH: helper },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(result.exitCode, result.stderr.toString()).toBe(0)
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
 
 it.instance(
   "uses config as the default without persisting session toggles",


### PR DESCRIPTION
The Linux sandbox network setting currently blocks classified in-process HTTP tools but leaves spawned commands in the host network namespace. Shell commands and their descendants can therefore retain TCP and UDP access even when network restriction is enabled.

This change applies the scoped network profile to Bubblewrap launches. Deny mode creates a separate network namespace, while allow mode keeps host networking. The backend probes network namespace support separately from filesystem namespace support and fails explicit restricted launches closed when the host cannot provide the required capability. Unsupported proxy and host-allowlist profiles continue to fail closed.

Linux deny mode blocks host TCP and UDP over IPv4 and IPv6 while preserving loopback communication between processes inside the same sandbox namespace. This matches the macOS outbound-network guarantee, although Linux namespace isolation also prevents the host from initiating connections into the sandbox. Pathname Unix socket authority remains a separate boundary tracked in #11650.

Closes #11651.
