### PR TITLE
fix(vscode): exclude .cli-version marker from VSIX packaging

### DIFF
--- a/.changeset/vscode-cli-version-marker-packaging.md
+++ b/.changeset/vscode-cli-version-marker-packaging.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Stop shipping the local-only `.cli-version` build marker in packaged VSIX installs, which previously made production installs detect as local builds and inject a dev-only bwrap fallback.

--- a/packages/kilo-vscode/.vscodeignore
+++ b/packages/kilo-vscode/.vscodeignore
@@ -25,6 +25,10 @@ AGENTS.md
 
 # Include bin/ directory for CLI binary (production)
 !bin/**
+# .cli-version is a local-source build marker written by local-bin.ts. It must
+# not ship in the VSIX, otherwise production installs are detected as local
+# builds and may inject a dev-only bwrap fallback (see ServerManager.localCli).
+bin/.cli-version
 
 # Include WAV assets used by extension-host notification playback
 !audio-wav/**


### PR DESCRIPTION
## What

Exclude the build-only `bin/.cli-version` marker from the packaged VSIX so production installs are no longer detected as local builds.

## Why

`local-bin.ts` writes `bin/.cli-version` during both dev (`compile`) and production (`package`) builds. `.vscodeignore` re-includes `bin/**` so the CLI binary ships, which also ships `.cli-version`. That made the `localCli` branch in `ServerManager.startServer` true outside F5 sessions:

```ts
const localCli =
  this.context.extensionMode === vscode.ExtensionMode.Development ||
  fs.existsSync(path.join(this.context.extensionPath, "bin", ".cli-version"))
const bwrapEnv = process.env.KILO_BWRAP_PATH ? {} : resolveLocalBwrapEnv(this.context.extensionPath, localCli)
```

As a result, production installs could inject `KILO_BWRAP_PATH` from `~/.cache/kilo-vscode/bwrap` whenever the bundled helper looked incomplete — broader than the local-only fallback this code intended to add.

## How

Add `bin/.cli-version` to `.vscodeignore` after the `!bin/**` re-include. The marker stays present in local source/dev checkouts (so source runs still work) but is absent from packaged installs, keeping `localCli` detection truly local-only. All runtime `bin/` artifacts (`kilo`, `bwrap`, `tree-sitter/**`, `licenses/**`, the sandbox worker) still ship — verified against the `ignore` library `vsce` uses.

This is a packaging-only change; no runtime code is touched.