### PR TITLE
docs: clarify MCP config fallback

### DIFF
--- a/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -29,6 +29,8 @@ You can edit MCP settings from the Kilo Code settings UI:
 
 From here you can add, edit, enable/disable, and delete MCP servers. Changes are written directly to the appropriate config file.
 
+If the UI cannot add a server, edit a Kilo config file directly and add the server under the top-level `mcp` key. For project-specific servers, use `./.kilo/kilo.json` or `./.kilo/kilo.jsonc`. For servers you want in every workspace, use `~/.config/kilo/kilo.json` or `~/.config/kilo/kilo.jsonc`.
+
 ### Config Format
 
 MCP servers are configured under the `mcp` key in `kilo.jsonc`:

--- a/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -29,7 +29,7 @@ You can edit MCP settings from the Kilo Code settings UI:
 
 From here you can add, edit, enable/disable, and delete MCP servers. Changes are written directly to the appropriate config file.
 
-If the UI cannot add a server, edit a Kilo config file directly and add the server under the top-level `mcp` key. For project-specific servers, use `./.kilo/kilo.json` or `./.kilo/kilo.jsonc`. For servers you want in every workspace, use `~/.config/kilo/kilo.json` or `~/.config/kilo/kilo.jsonc`.
+If the UI cannot add a server, edit a Kilo config file directly and add the server under the top-level `mcp` key. For project-specific servers, edit `./kilo.json` or `./kilo.jsonc` if your project already has one; otherwise use `./.kilo/kilo.json` or `./.kilo/kilo.jsonc` for a cleaner setup. For servers you want in every workspace, use `~/.config/kilo/kilo.json` or `~/.config/kilo/kilo.jsonc`.
 
 ### Config Format
 


### PR DESCRIPTION
## Issue

Fixes #7868

## Context

The MCP guide explains the settings UI flow, but it does not clearly say which config file to edit when adding a server through the UI is unavailable or fails.

## Implementation

Add a short fallback note to the MCP setup section that points users to the project and global Kilo config files and the top-level `mcp` key.

## Screenshots / Video

N/A, docs-only copy change.

## How to Test

### Manual/local verification

- Reviewed the updated MCP setup section for placement and Markdoc syntax.
- Ran `git diff --check`.

### Reviewer test steps

1. Open the MCP guide.
2. Confirm the "Editing MCP Settings" section now explains which Kilo config file to edit if the UI cannot add a server.

### Blocked checks and substitute verification

- `bun run --filter @kilocode/kilo-docs build` could not be run because Bun is not installed in this Windows session; substitute verification was the focused Markdown/Markdoc review and `git diff --check`.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes.
