### PR TITLE
fix: preserve sessions across sandbox changes

### DIFF
--- a/.changeset/keep-sandbox-sessions-running.md
+++ b/.changeset/keep-sandbox-sessions-running.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Keep active sessions and terminals running when sandbox settings change, apply global sandbox changes to every session, and report the current sandbox state to the agent.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -129,6 +129,7 @@ import {
 import { fetchAndSendPendingSuggestions } from "./kilo-provider/handlers/suggestion"
 import { nativeTitle } from "./kilo-provider/native-tab-title"
 import { parseReview, reviewMetadata, type ReviewMessageData } from "./shared/review-comments"
+import { disposesInstances } from "./shared/config-update"
 
 import {
   buildActionContext,
@@ -2634,7 +2635,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const dir = this.getWorkspaceDirectory()
 
     try {
-      await this.connectionService.drainPendingPrompts()
+      const hot =
+        hasGlobal && !disposesInstances({ config: partial, globalUnset, projectConfig: project, projectUnset })
+      if (!hot) await this.connectionService.drainPendingPrompts()
       if (hasGlobal) {
         await this.client.config.overlayUpdate(
           { scope: "global", set: partial, unset: globalUnset, directory: dir },

--- a/packages/kilo-vscode/src/shared/config-update.ts
+++ b/packages/kilo-vscode/src/shared/config-update.ts
@@ -1,0 +1,31 @@
+const sandbox = new Set(["sandbox", "sandbox_restrict_network"])
+
+interface ConfigUpdate {
+  config: object
+  globalUnset?: readonly (readonly string[])[]
+  projectConfig?: object
+  projectUnset?: readonly (readonly string[])[]
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function hot(key: string, value: unknown) {
+  if (key === "console") return true
+  if (key !== "experimental" || !record(value)) return false
+  return Object.keys(value).every((name) => sandbox.has(name))
+}
+
+function unset(path: readonly string[]) {
+  if (path[0] === "console") return true
+  return path.length === 2 && path[0] === "experimental" && sandbox.has(path[1])
+}
+
+export function disposesInstances(input: ConfigUpdate) {
+  if (Object.keys(input.projectConfig ?? {}).length > 0 || (input.projectUnset?.length ?? 0) > 0) return true
+  const set = Object.entries(input.config)
+  const removed = input.globalUnset ?? []
+  if (set.length === 0 && removed.length === 0) return false
+  return !set.every(([key, value]) => hot(key, value)) || !removed.every(unset)
+}

--- a/packages/kilo-vscode/tests/unit/config-update.test.ts
+++ b/packages/kilo-vscode/tests/unit/config-update.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { disposesInstances } from "../../src/shared/config-update"
+
+describe("config update disposal", () => {
+  test("keeps sandbox and console-only global updates hot", () => {
+    expect(disposesInstances({ config: { experimental: { sandbox: true } } })).toBe(false)
+    expect(disposesInstances({ config: { experimental: { sandbox_restrict_network: false } } })).toBe(false)
+    expect(
+      disposesInstances({
+        config: {
+          console: { diff_style: "split" },
+          experimental: { sandbox: false, sandbox_restrict_network: true },
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("keeps sandbox and console unsets hot", () => {
+    expect(
+      disposesInstances({
+        config: {},
+        globalUnset: [
+          ["experimental", "sandbox"],
+          ["experimental", "sandbox_restrict_network"],
+          ["console", "diff_style"],
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  test("disposes instances for other global or project updates", () => {
+    expect(disposesInstances({ config: { experimental: { batch_tool: true } } })).toBe(true)
+    expect(disposesInstances({ config: { provider: {} } })).toBe(true)
+    expect(disposesInstances({ config: {}, globalUnset: [["experimental"]] })).toBe(true)
+    expect(
+      disposesInstances({ config: {}, projectConfig: { commit_message: { prompt: "Use conventional commits" } } }),
+    ).toBe(true)
+  })
+
+  test("does not dispose instances when no config update is pending", () => {
+    expect(disposesInstances({ config: {} })).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -109,6 +109,18 @@ describe("KiloProvider indexing refresh", () => {
     expect(indexing).toBe(0)
   })
 
+  it("does not drain active sessions for sandbox-only updates", async () => {
+    const conn = createConnection()
+    const provider = new KiloProvider({} as never, conn.service as never)
+    const internal = provider as unknown as Internals
+    internal.connectionState = "connected"
+
+    await internal.handleUpdateConfig({ experimental: { sandbox: true } })
+
+    expect(conn.drains()).toBe(0)
+    expect(conn.patches()).toHaveLength(1)
+  })
+
   it("refreshes providers when prompt-training model visibility changes", async () => {
     const conn = createConnection()
     const provider = new KiloProvider({} as never, conn.service as never)

--- a/packages/kilo-vscode/tests/unit/sandboxing-settings.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandboxing-settings.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { visible } from "../../webview-ui/src/components/settings/sandboxing"
+
+const experimental = readFileSync(
+  join(__dirname, "..", "..", "webview-ui", "src", "components", "settings", "ExperimentalTab.tsx"),
+  "utf8",
+)
+const sandboxing = readFileSync(
+  join(__dirname, "..", "..", "webview-ui", "src", "components", "settings", "SandboxingTab.tsx"),
+  "utf8",
+)
 
 const features = { indexing: false, sandboxControls: false }
 
@@ -10,5 +21,12 @@ describe("Sandboxing settings visibility", () => {
     expect(visible(features, { experimental: { sandbox: true } })).toBe(false)
     expect(visible({ ...features, sandboxControls: true }, { experimental: { sandbox: false } })).toBe(false)
     expect(visible({ ...features, sandboxControls: true }, { experimental: { sandbox: true } })).toBe(true)
+  })
+
+  test("saves sandbox controls as narrow hot-update patches", () => {
+    expect(experimental).toContain("experimental: { [key]: value }")
+    expect(sandboxing).toContain("experimental: { sandbox_restrict_network: checked }")
+    expect(experimental).not.toContain("...experimental()")
+    expect(sandboxing).not.toContain("...experimental()")
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -6,7 +6,7 @@ import { Card } from "@kilocode/kilo-ui/card"
 import { useConfig } from "../../context/config"
 import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
-import type { ExtensionMessage } from "../../types/messages"
+import type { ExperimentalConfig, ExtensionMessage } from "../../types/messages"
 import SettingsRow from "./SettingsRow"
 
 interface ShareOption {
@@ -40,10 +40,8 @@ const ExperimentalTab: Component = () => {
 
   const experimental = createMemo(() => config().experimental ?? {})
 
-  const updateExperimental = (key: string, value: unknown) => {
-    updateConfig({
-      experimental: { ...experimental(), [key]: value },
-    })
+  const updateExperimental = <K extends keyof ExperimentalConfig>(key: K, value: ExperimentalConfig[K]) => {
+    updateConfig({ experimental: { [key]: value } })
   }
 
   return (

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SandboxingTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SandboxingTab.tsx
@@ -23,14 +23,7 @@ const SandboxingTab: Component = () => {
         <Switch
           checked={experimental().sandbox_restrict_network !== false}
           inputProps={{ "aria-describedby": description }}
-          onChange={(checked) =>
-            updateConfig({
-              experimental: {
-                ...experimental(),
-                sandbox_restrict_network: checked,
-              },
-            })
-          }
+          onChange={(checked) => updateConfig({ experimental: { sandbox_restrict_network: checked } })}
           hideLabel
         >
           {language.t("settings.sandboxing.network.title")}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -38,7 +38,7 @@ const Settings: Component<SettingsProps> = (props) => {
   const server = useServer()
   const language = useLanguage()
   const vscode = useVSCode()
-  const { config, loading, isDirty, saving, saveError, saveConfig, discardConfig, features } = useConfig()
+  const { config, loading, isDirty, disruptive, saving, saveError, saveConfig, discardConfig, features } = useConfig()
   const session = useSession()
   const [active, setActive] = createSignal(props.tab ?? "models")
   const [errorExpanded, setErrorExpanded] = createSignal(false)
@@ -48,7 +48,7 @@ const Settings: Component<SettingsProps> = (props) => {
 
   const handleSave = () => {
     const busy = busyCount()
-    if (busy === 0) {
+    if (!disruptive() || busy === 0) {
       saveConfig()
       return
     }

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -5,7 +5,7 @@
  *
  * Changes are accumulated in a local draft and only sent to the extension
  * when saveConfig() is called. This allows batching multiple settings
- * changes into a single write (which triggers disposeAll on the CLI).
+ * changes into a single write.
  */
 
 import { createContext, useContext, createSignal, createMemo, onCleanup } from "solid-js"
@@ -21,6 +21,7 @@ import {
   resolveConfig,
 } from "../utils/config-utils"
 import { splitConfigByScope } from "../utils/config-scope"
+import { disposesInstances } from "../../../src/shared/config-update"
 
 function has(value: Record<string, unknown>) {
   return Object.keys(value).length > 0
@@ -39,6 +40,7 @@ interface ConfigContextValue {
   features: Accessor<FeatureFlags>
   loading: Accessor<boolean>
   isDirty: Accessor<boolean>
+  disruptive: Accessor<boolean>
   saving: Accessor<boolean>
   saveError: Accessor<SaveError | null>
   updateConfig: (partial: Partial<Config>) => void
@@ -71,6 +73,7 @@ export const ConfigProvider: ParentComponent = (props) => {
       has(projectDraft() as Record<string, unknown>) ||
       has(settingsDraft()),
   )
+  const disruptive = createMemo(() => disposesInstances(payload()))
   // Last config received from the server — used to revert on discard
   const [saved, setSaved] = createSignal<Config>({})
   const [savedGlobal, setSavedGlobal] = createSignal<Config>({})
@@ -238,6 +241,18 @@ export const ConfigProvider: ParentComponent = (props) => {
     setSaveError(null)
   }
 
+  function payload() {
+    const split = splitConfigByScope(draft())
+    const config = deepMerge(split.global as Config, globalDraft())
+    const projectConfig = deepMerge(split.project as Config, projectDraft())
+    return {
+      config: pruneConfigSet(config) as Config,
+      projectConfig: pruneConfigSet(projectConfig) as Config,
+      globalUnset: configUnsetPaths(config),
+      projectUnset: configUnsetPaths(projectConfig),
+    }
+  }
+
   function saveConfig() {
     const changes = draft()
     const globals = globalDraft()
@@ -266,16 +281,7 @@ export const ConfigProvider: ParentComponent = (props) => {
     // Split so per-project settings (e.g. commit_message.prompt) land in the
     // workspace's kilo.json instead of the global one. Send one message so the
     // extension confirms only after both scopes are saved.
-    const split = splitConfigByScope(changes)
-    const next = deepMerge(split.global as Config, globals)
-    const project = deepMerge(split.project as Config, projects)
-    vscode.postMessage({
-      type: "updateConfig",
-      config: pruneConfigSet(next) as Config,
-      projectConfig: pruneConfigSet(project) as Config,
-      globalUnset: configUnsetPaths(next),
-      projectUnset: configUnsetPaths(project),
-    })
+    vscode.postMessage({ type: "updateConfig", ...payload() })
   }
 
   function discardConfig() {
@@ -298,6 +304,7 @@ export const ConfigProvider: ParentComponent = (props) => {
     features,
     loading,
     isDirty,
+    disruptive,
     saving,
     saveError,
     updateConfig,

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -330,6 +330,7 @@ const ConfigWrapper: ParentComponent<{
       features,
       loading: () => false,
       isDirty: dirty,
+      disruptive: () => false,
       saving: () => false,
       saveError: () => null,
       updateConfig: (partial: Partial<Config>) => {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -54,6 +54,7 @@ import { primaryPaths } from "../kilocode/primary-worktree"
 import { Git } from "@/git"
 import { KilocodeDefaultPlugins } from "@/kilocode/config/default-plugins"
 import { KilocodeGlobalConfigStamp } from "@/kilocode/config/global-stamp"
+import { KilocodeConfigHotUpdate } from "@/kilocode/config/hot-update"
 import {
   IndexingConfig as KiloIndexingConfig,
   IndexingSchema as KiloIndexingSchema,
@@ -1155,7 +1156,7 @@ export const layer = Layer.effect(
       yield* invalidateGlobal
     })
 
-    // kilocode_change start - add dispose option to skip Instance.disposeAll for permission-only changes
+    // kilocode_change start - add dispose option for hot global config changes
     const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info, options?: { dispose?: boolean }) {
       const dispose = options?.dispose ?? true
       // kilocode_change end
@@ -1182,7 +1183,7 @@ export const layer = Layer.effect(
       // kilocode_change start - skip dispose when caller opts out
       if (!dispose) {
         yield* invalidateGlobal
-        yield* InstanceState.invalidate(state).pipe(Effect.catchCause(() => Effect.void))
+        yield* KilocodeConfigHotUpdate.invalidate(state).pipe(Effect.catchCause(() => Effect.void))
         yield* Effect.sync(() =>
           GlobalBus.emit("event", {
             directory: "global",

--- a/packages/opencode/src/kilocode/background-process/index.ts
+++ b/packages/opencode/src/kilocode/background-process/index.ts
@@ -11,7 +11,7 @@ import { zod, ZodOverride } from "@opencode-ai/core/effect-zod"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import * as Log from "@opencode-ai/core/util/log"
 import { spawn, type ChildProcess } from "child_process"
-import { Context, Effect, Layer, Schema, Types } from "effect"
+import { Context, Effect, Layer, Schema, ScopedCache, Types } from "effect"
 import net from "net"
 import path from "path"
 import z from "zod"
@@ -139,9 +139,10 @@ export namespace BackgroundProcess {
     processes: Map<ID, Active>
   }
 
-  class StateService extends Context.Service<StateService, { readonly get: () => Effect.Effect<State> }>()(
-    "@kilocode/BackgroundProcess.State",
-  ) {}
+  class StateService extends Context.Service<
+    StateService,
+    { readonly get: () => Effect.Effect<State>; readonly clear: () => Effect.Effect<void> }
+  >()("@kilocode/BackgroundProcess.State") {}
 
   function clone(info: Info): Info {
     return {
@@ -531,7 +532,10 @@ export namespace BackgroundProcess {
           return state
         }),
       )
-      return StateService.of({ get: () => InstanceState.get(ref) })
+      return StateService.of({
+        get: () => InstanceState.get(ref),
+        clear: () => ScopedCache.invalidateAll(ref.cache),
+      })
     }),
   )
 
@@ -587,5 +591,9 @@ export namespace BackgroundProcess {
     const current = await state()
     const list = Array.from(current.processes.values()).filter((active) => active.info.sessionID === sessionID)
     await Promise.all(list.map((active) => terminate(current, active, { remove: true })))
+  }
+
+  export async function stopAll() {
+    return runtime.runPromise((svc) => svc.clear())
   }
 }

--- a/packages/opencode/src/kilocode/config/hot-update.ts
+++ b/packages/opencode/src/kilocode/config/hot-update.ts
@@ -1,0 +1,20 @@
+import { ScopedCache } from "effect"
+import type { Config } from "@/config/config"
+import type * as InstanceState from "@/effect/instance-state"
+import { isRecord } from "@/util/record"
+
+const sandbox = new Set(["sandbox", "sandbox_restrict_network"])
+
+export namespace KilocodeConfigHotUpdate {
+  export function matches(patch: Config.Info) {
+    return Object.entries(patch).every(([key, value]) => {
+      if (key === "console") return true
+      if (key !== "experimental" || !isRecord(value)) return false
+      return Object.keys(value).every((name) => sandbox.has(name))
+    })
+  }
+
+  export function invalidate<A, E, R>(state: InstanceState.InstanceState<A, E, R>) {
+    return ScopedCache.invalidateAll(state.cache)
+  }
+}

--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -5,6 +5,7 @@ export interface EditorContext {
   openTabs?: string[]
   activeFile?: string
   shell?: string
+  sandbox?: boolean
 }
 
 /**
@@ -45,6 +46,9 @@ export function environmentDetails(ctx?: EditorContext): string {
   }
   if (ctx?.worktree) {
     lines.push(`Workspace root folder: ${ctx.worktree}`)
+  }
+  if (ctx?.sandbox !== undefined) {
+    lines.push(`Sandbox: ${ctx.sandbox ? "enabled" : "disabled"}`)
   }
   if (ctx?.activeFile) {
     lines.push(`Active file: ${ctx.activeFile}`)

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -153,6 +153,8 @@ export const clear = Effect.fn("SandboxPolicy.clear")(function* (sessionID: Sess
   yield* retire(sessionID, yield* InstanceState.directory, Effect.void)
 })
 
+export const reset = Effect.fn("SandboxPolicy.reset")(() => Effect.sync(() => overrides.clear()))
+
 export function retire<A, E, R>(
   sessionID: SessionID,
   directory: string,

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -13,6 +13,7 @@ import * as Network from "./network"
 
 const overrides = new Map<string, { enabled: boolean; version: number }>()
 const locks = new Map<SessionID, { semaphore: Semaphore.Semaphore; refs: number }>()
+const mutation = Semaphore.makeUnsafe(1)
 
 function key(directory: string, sessionID: SessionID) {
   return directory + "\0" + sessionID
@@ -125,22 +126,24 @@ export const status = Effect.fn("SandboxPolicy.status")(function* (sessionID: Se
 })
 
 function change<E, R>(sessionID: SessionID, guard: Effect.Effect<unknown, E, R>) {
-  return Effect.gen(function* () {
-    const directory = yield* InstanceState.directory
-    const id = key(directory, sessionID)
-    return yield* locked(
-      sessionID,
-      Effect.gen(function* () {
-        yield* guard
-        const current = yield* status(sessionID)
-        if (!current.enabled && !current.available) return current
-        const value = { ...current, enabled: !current.enabled, version: current.version + 1 }
-        overrides.set(id, { enabled: value.enabled, version: value.version })
-        yield* (yield* Bus.Service).publish(Changed, { sessionID, ...value })
-        return value
-      }),
-    )
-  })
+  return mutation.withPermits(1)(
+    Effect.gen(function* () {
+      const directory = yield* InstanceState.directory
+      const id = key(directory, sessionID)
+      return yield* locked(
+        sessionID,
+        Effect.gen(function* () {
+          yield* guard
+          const current = yield* status(sessionID)
+          if (!current.enabled && !current.available) return current
+          const value = { ...current, enabled: !current.enabled, version: current.version + 1 }
+          overrides.set(id, { enabled: value.enabled, version: value.version })
+          yield* (yield* Bus.Service).publish(Changed, { sessionID, ...value })
+          return value
+        }),
+      )
+    }),
+  )
 }
 
 export const toggle = Effect.fn("SandboxPolicy.toggle")((sessionID: SessionID) => change(sessionID, Effect.void))
@@ -153,7 +156,9 @@ export const clear = Effect.fn("SandboxPolicy.clear")(function* (sessionID: Sess
   yield* retire(sessionID, yield* InstanceState.directory, Effect.void)
 })
 
-export const reset = Effect.fn("SandboxPolicy.reset")(() => Effect.sync(() => overrides.clear()))
+export const reset = Effect.fn("SandboxPolicy.reset")(() =>
+  mutation.withPermits(1)(Effect.sync(() => overrides.clear())),
+)
 
 export function retire<A, E, R>(
   sessionID: SessionID,

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
@@ -83,16 +83,14 @@ export const configConsoleHandlers = HttpApiBuilder.group(InstanceHttpApi, "conf
       }
       if (body.scope === "global") {
         const hot = KilocodeConfigHotUpdate.matches(patch)
-        const before = hot ? yield* config.getGlobal() : undefined
         const sandbox = patch.experimental?.sandbox
-        const enabling = sandbox === true && before?.experimental?.sandbox !== true
+        const changesSandbox = Object.hasOwn(patch.experimental ?? {}, "sandbox")
+        const before = changesSandbox ? yield* config.getGlobal() : undefined
+        const enabling = changesSandbox && sandbox === true && before?.experimental?.sandbox !== true
         if (enabling) yield* Effect.promise(() => BackgroundProcess.stopAll())
         const result = yield* config.updateGlobal(patch, hot ? { dispose: false } : undefined)
         const toggled =
-          result.changed &&
-          patch.experimental !== undefined &&
-          "sandbox" in patch.experimental &&
-          before?.experimental?.sandbox !== result.info.experimental?.sandbox
+          result.changed && changesSandbox && before?.experimental?.sandbox !== result.info.experimental?.sandbox
         if (toggled) {
           yield* SandboxPolicy.reset()
           if (enabling) yield* Effect.promise(() => BackgroundProcess.stopAll())

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
@@ -87,7 +87,6 @@ export const configConsoleHandlers = HttpApiBuilder.group(InstanceHttpApi, "conf
         const changesSandbox = Object.hasOwn(patch.experimental ?? {}, "sandbox")
         const before = changesSandbox ? yield* config.getGlobal() : undefined
         const enabling = changesSandbox && sandbox === true && before?.experimental?.sandbox !== true
-        if (enabling) yield* Effect.promise(() => BackgroundProcess.stopAll())
         const result = yield* config.updateGlobal(patch, hot ? { dispose: false } : undefined)
         const toggled =
           result.changed && changesSandbox && before?.experimental?.sandbox !== result.info.experimental?.sandbox

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
@@ -2,9 +2,12 @@ import { Account } from "@/account/account"
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
 import * as InstanceState from "@/effect/instance-state"
+import { BackgroundProcess } from "@/kilocode/background-process"
+import { KilocodeConfigHotUpdate } from "@/kilocode/config/hot-update"
 import { KilocodeConfigOverlay } from "@/kilocode/config/overlay"
 import { KilocodeConfigSources } from "@/kilocode/config/sources"
 import { KilocodeModelState } from "@/kilocode/config/model-state"
+import * as SandboxPolicy from "@/kilocode/sandbox/policy"
 import { ConfigRules } from "@/kilocode/server/routes/config-rules"
 import { KilocodeKeybinds } from "@/kilocode/tui/keybinds"
 import { KilocodeTuiConfig } from "@/kilocode/tui/config"
@@ -79,8 +82,21 @@ export const configConsoleHandlers = HttpApiBuilder.group(InstanceHttpApi, "conf
         return yield* config.get()
       }
       if (body.scope === "global") {
-        const hot = Object.keys(patch).every((key) => key === "console")
+        const hot = KilocodeConfigHotUpdate.matches(patch)
+        const before = hot ? yield* config.getGlobal() : undefined
+        const sandbox = patch.experimental?.sandbox
+        const enabling = sandbox === true && before?.experimental?.sandbox !== true
+        if (enabling) yield* Effect.promise(() => BackgroundProcess.stopAll())
         const result = yield* config.updateGlobal(patch, hot ? { dispose: false } : undefined)
+        const toggled =
+          result.changed &&
+          patch.experimental !== undefined &&
+          "sandbox" in patch.experimental &&
+          before?.experimental?.sandbox !== result.info.experimental?.sandbox
+        if (toggled) {
+          yield* SandboxPolicy.reset()
+          if (enabling) yield* Effect.promise(() => BackgroundProcess.stopAll())
+        }
         if (result.changed && !hot) {
           yield* disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true }).pipe(
             Effect.catchCause(() => Effect.void),

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -20,6 +20,7 @@ import { environmentDetails, type EditorContext } from "@/kilocode/editor-contex
 import { Identifier } from "@/id/id"
 import { Filesystem } from "@/util/filesystem"
 import { InstanceState } from "@/effect/instance-state"
+import * as SandboxPolicy from "@/kilocode/sandbox/policy"
 import NATIVE_PLAN_PROMPT from "@/kilocode/session/native-plan-prompt.txt"
 import CODE_SWITCH from "@/session/prompt/code-switch.txt"
 
@@ -176,26 +177,28 @@ export namespace KiloSessionPrompt {
   })
 
   /**
-   * Mutable cache for environment details, keyed by user message ID
-   * so it recomputes when a new user message arrives.
+   * Mutable cache for environment details, keyed by user message ID and sandbox state
+   * so it recomputes when either changes.
    */
   export interface EnvCache {
     block?: string
     user?: string
+    sandbox?: boolean
   }
 
   /**
    * Ephemerally injects dynamic editor context (visible files, open tabs, etc.)
-   * into the last user message. Caches the result per user message ID so repeated
-   * loop iterations produce byte-identical messages (prompt caching).
+   * into the last user message. Caches the result per user message ID and sandbox state
+   * so unchanged loop iterations produce byte-identical messages (prompt caching).
    */
-  export function injectEditorContext(input: {
+  export const injectEditorContext = Effect.fn("KiloSessionPrompt.injectEditorContext")(function* (input: {
     msgs: MessageV2.WithParts[]
     lastUser: MessageV2.User
     sessionID: SessionID
     cache: EnvCache
   }) {
-    if (input.cache.user !== input.lastUser.id) {
+    const sandbox = (yield* SandboxPolicy.status(input.sessionID)).enabled
+    if (input.cache.user !== input.lastUser.id || input.cache.sandbox !== sandbox) {
       const ctx = (() => {
         try {
           return Instance.current
@@ -206,8 +209,10 @@ export namespace KiloSessionPrompt {
       input.cache.block = environmentDetails({
         ...input.lastUser.editorContext,
         ...(ctx ? { directory: ctx.directory, worktree: ctx.worktree } : {}),
+        sandbox,
       })
       input.cache.user = input.lastUser.id
+      input.cache.sandbox = sandbox
     }
     if (!input.cache.block) return
     const idx = input.msgs.findLastIndex((m) => m.info.role === "user")
@@ -226,7 +231,7 @@ export namespace KiloSessionPrompt {
         } satisfies MessageV2.TextPart,
       ],
     }
-  }
+  })
 
   /**
    * Creates StringDecoder-based helpers for shell stdout/stderr that correctly

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1633,7 +1633,9 @@ export const layer = Layer.effect(
           // kilocode_change start — ephemeral context injection + post-summary
           // media strip (keeps outgoing body under the gateway body-size limit
           // even when filterCompacted couldn't trim the pre-summary history).
-          KiloSessionPrompt.injectEditorContext({ msgs, lastUser, sessionID, cache: envCache })
+          yield* KiloSessionPrompt.injectEditorContext({ msgs, lastUser, sessionID, cache: envCache }).pipe(
+            Effect.provideService(Config.Service, config),
+          )
           msgs = KiloSessionPrompt.maybeStripHistoricalMedia(msgs)
           // kilocode_change end
 
@@ -1651,7 +1653,9 @@ export const layer = Layer.effect(
             msgs = KiloSessionPromptQueue.scope(sessionID, msgs)
             msgs = KiloSessionPrompt.trimBeforeLastSummary(msgs)
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-            KiloSessionPrompt.injectEditorContext({ msgs, lastUser, sessionID, cache: envCache })
+            yield* KiloSessionPrompt.injectEditorContext({ msgs, lastUser, sessionID, cache: envCache }).pipe(
+              Effect.provideService(Config.Service, config),
+            )
             msgs = KiloSessionPrompt.maybeStripHistoricalMedia(msgs)
             modelMsgs = yield* MessageV2.toModelMessagesEffect(msgs, model)
             const nextSize = Buffer.byteLength(JSON.stringify(modelMsgs))

--- a/packages/opencode/test/kilocode/background-process.test.ts
+++ b/packages/opencode/test/kilocode/background-process.test.ts
@@ -100,6 +100,34 @@ setInterval(() => {}, 1_000)
     }),
   )
 
+  it.instance("stops every process when sandboxing becomes global", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const sessionID = SessionID.descending()
+      const command = yield* Effect.promise(() =>
+        script(
+          test.directory,
+          "sandbox-transition.mjs",
+          `console.log("ready")
+setInterval(() => {}, 1_000)
+`,
+        ),
+      )
+      yield* Effect.promise(() =>
+        BackgroundProcess.start({
+          sessionID,
+          command,
+          cwd: test.directory,
+          ready: { pattern: "ready", timeout: 5_000 },
+        }),
+      )
+
+      expect(yield* Effect.promise(() => BackgroundProcess.list({ sessionID }))).toHaveLength(1)
+      yield* Effect.promise(() => BackgroundProcess.stopAll())
+      expect(yield* Effect.promise(() => BackgroundProcess.list({ sessionID }))).toEqual([])
+    }),
+  )
+
   it.instance("reports explicit readiness ports for VS Code clients", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance

--- a/packages/opencode/test/kilocode/sandbox/config-network.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/config-network.test.ts
@@ -1,7 +1,8 @@
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit, Layer, Ref } from "effect"
 import { expect } from "bun:test"
 import { HttpClient } from "effect/unstable/http"
 import { backendSupport } from "@kilocode/sandbox"
+import { Config } from "@/config/config"
 import { ProjectID } from "@/project/schema"
 import { InstanceRef } from "@/effect/instance-ref"
 import * as SandboxPolicy from "@/kilocode/sandbox/policy"
@@ -54,6 +55,7 @@ function server() {
 
 const restricted = testEffect(layer())
 const open = testEffect(layer(false))
+const transitions = testEffect(ToolNetwork.httpLayer)
 
 restricted.live("keeps network restriction enabled by default when the sandbox is available", () => {
   const target = server()
@@ -83,5 +85,34 @@ open.live("allows tool network traffic when network restriction is disabled", ()
     )
     expect(yield* response.text).toBe("sandbox-config-ok")
     expect(target.requests()).toBe(1)
+  }).pipe(Effect.ensuring(Effect.promise(() => target.server.stop(true))))
+})
+
+transitions.live("applies live network and sandbox changes without retaining a denied network profile", () => {
+  const target = server()
+  return Effect.gen(function* () {
+    const state = yield* Ref.make<Config.Info>({ experimental: { sandbox: true } })
+    const config = TestConfig.make({ get: () => Ref.get(state) })
+    const http = yield* HttpClient.HttpClient
+    const request = () =>
+      SandboxPolicy.executeTool(sessionID, tool, http.get(target.server.url)).pipe(
+        Effect.provideService(Config.Service, config),
+        Effect.provideService(InstanceRef, ctx),
+      )
+
+    const denied = yield* request().pipe(Effect.exit)
+    if (!backendSupport().available) {
+      expect(Exit.isSuccess(denied)).toBe(true)
+      return
+    }
+    expect(Exit.isFailure(denied)).toBe(true)
+    expect(target.requests()).toBe(0)
+
+    yield* Ref.set(state, { experimental: { sandbox: true, sandbox_restrict_network: false } })
+    expect(yield* (yield* request()).text).toBe("sandbox-config-ok")
+
+    yield* Ref.set(state, { experimental: { sandbox: false } })
+    expect(yield* (yield* request()).text).toBe("sandbox-config-ok")
+    expect(target.requests()).toBe(2)
   }).pipe(Effect.ensuring(Effect.promise(() => target.server.stop(true))))
 })

--- a/packages/opencode/test/kilocode/sandbox/state.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/state.test.ts
@@ -88,6 +88,20 @@ it.instance("overrides config off to sandbox only one session", () =>
   }),
 )
 
+it.instance(
+  "resets session overrides when the global sandbox default changes",
+  () =>
+    Effect.gen(function* () {
+      const id = SessionID.make("ses_sandbox_reset")
+      if (!(yield* SandboxPolicy.status(id)).available) return
+
+      expect((yield* SandboxPolicy.toggle(id)).enabled).toBe(false)
+      yield* SandboxPolicy.reset()
+      expect((yield* SandboxPolicy.status(id)).enabled).toBe(true)
+    }),
+  { config: { experimental: { sandbox: true } } },
+)
+
 it.instance("isolates concurrent session overrides and clears them", () =>
   Effect.gen(function* () {
     const first = SessionID.make("ses_sandbox_first")

--- a/packages/opencode/test/kilocode/sandbox/state.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/state.test.ts
@@ -102,6 +102,41 @@ it.instance(
   { config: { experimental: { sandbox: true } } },
 )
 
+it.instance(
+  "waits for an in-flight toggle before resetting every override",
+  () =>
+    Effect.gen(function* () {
+      const id = SessionID.make("ses_sandbox_reset_race")
+      if (!(yield* SandboxPolicy.status(id)).available) return
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const started = yield* Deferred.make<void>()
+      const done = yield* Deferred.make<void>()
+      const toggle = yield* SandboxPolicy.toggleGuarded(
+        id,
+        Effect.gen(function* () {
+          yield* Deferred.succeed(entered, undefined)
+          yield* Deferred.await(release)
+        }),
+      ).pipe(Effect.forkChild)
+      yield* Deferred.await(entered)
+      const reset = yield* Effect.gen(function* () {
+        yield* Deferred.succeed(started, undefined)
+        yield* SandboxPolicy.reset()
+        yield* Deferred.succeed(done, undefined)
+      }).pipe(Effect.forkChild)
+      yield* Deferred.await(started)
+      yield* Effect.yieldNow
+      expect(yield* Deferred.isDone(done)).toBe(false)
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(toggle)
+      yield* Fiber.join(reset)
+      expect(yield* SandboxPolicy.status(id)).toMatchObject({ enabled: true, version: 0 })
+    }),
+  { config: { experimental: { sandbox: true } } },
+)
+
 it.instance("isolates concurrent session overrides and clears them", () =>
   Effect.gen(function* () {
     const first = SessionID.make("ses_sandbox_first")

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -410,6 +410,43 @@ describe("config overlay routes", () => {
     expect(reset).toMatchObject({ enabled: false, version: 0 })
   })
 
+  test.serial("mixed global saves clear overrides when sandbox returns to its default", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir()
+    await setGlobal(global.path, { experimental: { sandbox: true } })
+    const session = await json<{ id: string }>(
+      await req(project.path, "/session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    )
+    const before = await json<{ available: boolean }>(await req(project.path, `/session/${session.id}/sandbox`))
+    if (!before.available) return
+
+    expect(
+      await json<{ enabled: boolean; version: number }>(
+        await req(project.path, `/session/${session.id}/sandbox/toggle`, { method: "POST" }),
+      ),
+    ).toMatchObject({ enabled: false, version: 1 })
+
+    await json(
+      await request(Server.Default().app, undefined, "/config/overlay", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          scope: "global",
+          set: { share: "disabled" },
+          unset: [["experimental", "sandbox"]],
+        }),
+      }),
+    )
+
+    expect(
+      await json<{ enabled: boolean; version: number }>(await req(project.path, `/session/${session.id}/sandbox`)),
+    ).toMatchObject({ enabled: false, version: 0 })
+  })
+
   test.serial("refreshes sandbox settings in every loaded project without disposing instances", async () => {
     await using global = await tmpdir()
     await using first = await tmpdir()

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -377,6 +377,39 @@ describe("config overlay routes", () => {
     expect(await provide({ directory: project.path, fn: () => BackgroundProcess.list() })).toEqual([])
   })
 
+  terminal("keeps background processes running when enabling sandbox fails to persist", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir()
+    await setGlobal(global.path, { experimental: { sandbox: false } })
+    const session = await json<{ id: string }>(
+      await req(project.path, "/session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    )
+
+    await provide({
+      directory: project.path,
+      fn: () =>
+        BackgroundProcess.start({
+          sessionID: SessionID.make(session.id),
+          command: "sleep 30",
+          cwd: project.path,
+        }),
+    })
+    expect(await provide({ directory: project.path, fn: () => BackgroundProcess.list() })).toHaveLength(1)
+    await Bun.write(path.join(global.path, "kilo.jsonc"), "{")
+
+    const response = await request(Server.Default().app, undefined, "/config/overlay", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "global", set: { experimental: { sandbox: true } } }),
+    })
+    expect(response.status).toBeGreaterThanOrEqual(400)
+    expect(await provide({ directory: project.path, fn: () => BackgroundProcess.list() })).toHaveLength(1)
+  })
+
   test.serial("global sandbox updates clear per-session overrides", async () => {
     await using global = await tmpdir()
     await using project = await tmpdir()

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -4,8 +4,11 @@ import * as Log from "@opencode-ai/core/util/log"
 import { Global } from "@opencode-ai/core/global"
 import { Server } from "../../../src/server/server"
 import { Config } from "../../../src/config/config"
+import { BackgroundProcess } from "../../../src/kilocode/background-process"
 import { KilocodeConfigOverlay } from "../../../src/kilocode/config/overlay"
+import { provide } from "../../../src/kilocode/instance"
 import { Permission } from "../../../src/permission"
+import { SessionID } from "../../../src/session/schema"
 import { PtyPaths } from "../../../src/server/routes/instance/httpapi/groups/pty"
 import { resetDatabase } from "../../fixture/db"
 import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
@@ -340,7 +343,99 @@ describe("config overlay routes", () => {
     )
   })
 
-  terminal("preserves active terminals after updating global console preferences", async () => {
+  terminal("stops model background processes before globally enabling sandbox", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir()
+    await setGlobal(global.path, { experimental: { sandbox: false } })
+    const session = await json<{ id: string }>(
+      await req(project.path, "/session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    )
+
+    await provide({
+      directory: project.path,
+      fn: () =>
+        BackgroundProcess.start({
+          sessionID: SessionID.make(session.id),
+          command: "sleep 30",
+          cwd: project.path,
+        }),
+    })
+    expect(await provide({ directory: project.path, fn: () => BackgroundProcess.list() })).toHaveLength(1)
+
+    await json(
+      await request(Server.Default().app, undefined, "/config/overlay", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope: "global", set: { experimental: { sandbox: true } } }),
+      }),
+    )
+
+    expect(await provide({ directory: project.path, fn: () => BackgroundProcess.list() })).toEqual([])
+  })
+
+  test.serial("global sandbox updates clear per-session overrides", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir()
+    await setGlobal(global.path, { experimental: { sandbox: true } })
+    const session = await json<{ id: string }>(
+      await req(project.path, "/session", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    )
+    const before = await json<{ available: boolean }>(await req(project.path, `/session/${session.id}/sandbox`))
+    if (!before.available) return
+
+    const overridden = await json<{ enabled: boolean; version: number }>(
+      await req(project.path, `/session/${session.id}/sandbox/toggle`, { method: "POST" }),
+    )
+    expect(overridden).toMatchObject({ enabled: false, version: 1 })
+
+    await json(
+      await request(Server.Default().app, undefined, "/config/overlay", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope: "global", set: { experimental: { sandbox: false } } }),
+      }),
+    )
+
+    const reset = await json<{ enabled: boolean; version: number }>(
+      await req(project.path, `/session/${session.id}/sandbox`),
+    )
+    expect(reset).toMatchObject({ enabled: false, version: 0 })
+  })
+
+  test.serial("refreshes sandbox settings in every loaded project without disposing instances", async () => {
+    await using global = await tmpdir()
+    await using first = await tmpdir()
+    await using second = await tmpdir()
+    await setGlobal(global.path, { experimental: { sandbox: false } })
+
+    const beforeFirst = await json<Config.Info>(await req(first.path, "/config"))
+    const beforeSecond = await json<Config.Info>(await req(second.path, "/config"))
+    expect(beforeFirst.experimental?.sandbox).toBe(false)
+    expect(beforeSecond.experimental?.sandbox).toBe(false)
+
+    await json(
+      await request(Server.Default().app, undefined, "/config/overlay", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope: "global", set: { experimental: { sandbox: true } } }),
+      }),
+    )
+
+    const afterFirst = await json<Config.Info>(await req(first.path, "/config"))
+    const afterSecond = await json<Config.Info>(await req(second.path, "/config"))
+    expect(afterFirst.experimental?.sandbox).toBe(true)
+    expect(afterSecond.experimental?.sandbox).toBe(true)
+  })
+
+  terminal("preserves active terminals after hot global config updates", async () => {
     await using global = await tmpdir()
     await using project = await tmpdir()
     ;(Global.Path as { config: string }).config = global.path
@@ -353,17 +448,24 @@ describe("config overlay routes", () => {
     const info = await json<{ id: string }>(created)
 
     try {
-      await json(
-        await request(Server.Default().app, undefined, "/config/overlay", {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ scope: "global", set: { console: { diff_style: "split" } } }),
-        }),
-      )
+      const patches: Config.Info[] = [
+        { console: { diff_style: "split" } },
+        { experimental: { sandbox: true } },
+        { experimental: { sandbox_restrict_network: false } },
+      ]
+      for (const set of patches) {
+        await json(
+          await request(Server.Default().app, undefined, "/config/overlay", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ scope: "global", set }),
+          }),
+        )
 
-      const found = await Server.Default().app.request(PtyPaths.get.replace(":ptyID", info.id), { headers })
-      expect(found.status).toBe(200)
-      expect(await found.json()).toMatchObject({ id: info.id, title: "console", status: "running" })
+        const found = await Server.Default().app.request(PtyPaths.get.replace(":ptyID", info.id), { headers })
+        expect(found.status).toBe(200)
+        expect(await found.json()).toMatchObject({ id: info.id, title: "console", status: "running" })
+      }
     } finally {
       await Server.Default().app.request(PtyPaths.remove.replace(":ptyID", info.id), { method: "DELETE", headers })
     }

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -128,15 +128,21 @@ describe("SystemPrompt.provider", () => {
 })
 
 describe("environmentDetails", () => {
-  test("includes cwd and worktree in dynamic context", () => {
+  test("includes cwd, worktree, and sandbox state in dynamic context", () => {
     const result = environmentDetails({
       directory: "/repo/.kilo/worktrees/feature",
       worktree: "/repo/.kilo/worktrees/feature",
       activeFile: "src/app.ts",
+      sandbox: true,
     })
 
     expect(result).toContain("Working directory: /repo/.kilo/worktrees/feature")
     expect(result).toContain("Workspace root folder: /repo/.kilo/worktrees/feature")
+    expect(result).toContain("Sandbox: enabled")
     expect(result).toContain("Active file: src/app.ts")
+  })
+
+  test("reports when sandboxing is disabled", () => {
+    expect(environmentDetails({ sandbox: false })).toContain("Sandbox: disabled")
   })
 })


### PR DESCRIPTION
Changing global sandbox settings currently disposes every loaded instance, interrupting active Agent Manager sessions and terminals. Session-level overrides can also mask a later global change, leaving different sessions on different effective policies.

This keeps sandbox-only global updates hot by invalidating config caches without tearing down instance services. A global sandbox change clears ephemeral session overrides so it reaches every session, and enabling the sandbox terminates agent-managed background processes around the transition. Subsequent tool executions read the effective policy, while the existing synthetic environment details report the current state to the model without adding a visible reminder or chat message.

Sandbox enforcement remains a launch-time boundary for foreground commands: a command already executing retains the OS policy it started with, while later tool calls use the new setting. Agent Manager PTYs stay attached, and non-sandbox configuration changes keep the existing disposal behavior.