### PR TITLE
docs(kilo-docs): clarify Cloud Agent PR authorship

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -20,6 +20,7 @@ Before using Cloud Agents:
 
 - **GitHub or GitLab Integration must be configured**
   Connect your account via the [Integrations tab](https://app.kilo.ai/integrations) so that Cloud Agents can access your repositories.
+  When you connect your GitHub account, PRs the agent opens are authored by you, with the Kilo bot included as co-author.
 
 ## Cost
 


### PR DESCRIPTION
## Summary
- Clarifies that connecting GitHub lets Cloud Agent pull requests appear authored by the user's GitHub account.
- Notes that the Kilo bot is included as co-author so users understand the PR attribution before starting Cloud Agent work.