### PR TITLE
feat: add CONFIG_REGRESSION sub-agent concern to upstream merge review

### DIFF
--- a/.kilo/command/review-upstream-merge.md
+++ b/.kilo/command/review-upstream-merge.md
@@ -64,12 +64,12 @@ When in doubt, add a finding. A human will verify it. Compiling code is not proo
 
 ## CONFIG_REGRESSION.md
 
-Check whether this PR introduces or re-introduces fallback logic for non-`.kilo` config files (e.g. `opencode.json`, `.kilocode` config paths), or accidentally breaks code that now correctly expects only `.kilo`-based configuration.
+Check whether this PR introduces or re-introduces fallback logic for `opencode` config files, or accidentally breaks code that now correctly expects only `.kilo`-based configuration.
 
-Kilo removed fallback support for non-`.kilo` config directories. Look for:
+Kilo removed fallback support for `opencode` config directories. Look for:
 
-- Any new or restored code that reads from `opencode`, `.kilocode`, or other non-`.kilo` config paths.
-- Upstream additions to config discovery, loading, or path resolution that add fallback candidates we stripped.
+- Any new or restored code that reads from `opencode` config paths.
+- Upstream additions to config discovery, loading, or path resolution that add `opencode` fallback candidates we stripped.
 - Changes that break `.kilo`-only config lookup by removing or reordering it in a multi-path search.
 
 When in doubt, add a finding. A human should verify config path changes manually.

--- a/.kilo/command/review-upstream-merge.md
+++ b/.kilo/command/review-upstream-merge.md
@@ -62,6 +62,18 @@ Pay special attention to:
 
 When in doubt, add a finding. A human will verify it. Compiling code is not proof the chain is intact.
 
+## CONFIG_REGRESSION.md
+
+Check whether this PR introduces or re-introduces fallback logic for non-`.kilo` config files (e.g. `opencode.json`, `.kilocode` config paths), or accidentally breaks code that now correctly expects only `.kilo`-based configuration.
+
+Kilo removed fallback support for non-`.kilo` config directories. Look for:
+
+- Any new or restored code that reads from `opencode`, `.kilocode`, or other non-`.kilo` config paths.
+- Upstream additions to config discovery, loading, or path resolution that add fallback candidates we stripped.
+- Changes that break `.kilo`-only config lookup by removing or reordering it in a multi-path search.
+
+When in doubt, add a finding. A human should verify config path changes manually.
+
 ## TESTS.md
 
 Check whether this PR removed any Kilo-specific tests.


### PR DESCRIPTION
## Summary

Adds a `CONFIG_REGRESSION.md` sub-agent concern to the `review-upstream-merge` command.

Kilo removed fallback support for non-`.kilo` config files (e.g. `opencode.json`, `.kilocode` paths). Without an explicit review step, upstream merges could silently re-introduce that fallback logic, or break the `.kilo`-only config lookup we now rely on.

The new concern follows the exact same pattern as the existing parallel sub-agents and instructs the reviewer to check for:
- Restored or new code reading non-`.kilo` config paths
- Upstream config discovery changes that add fallback candidates we stripped
- Changes that break `.kilo`-only lookup ordering