### PR TITLE
fix: avoid repository-wide formatting during generation

### DIFF
--- a/script/generate.ts
+++ b/script/generate.ts
@@ -7,5 +7,3 @@ await $`bun ./packages/sdk/js/script/build.ts`
 await $`bun dev generate > ../sdk/openapi.json`.cwd("packages/opencode")
 
 await $`bun ./script/generate-cli-docs.ts`
-
-await $`./script/format.ts`


### PR DESCRIPTION
## Summary

Remove the repository-wide Prettier pass from SDK generation. Generated SDK sources and OpenAPI JSON already format themselves, while Markdown outputs are intentionally excluded from Prettier.

This prevents `./script/generate.ts` from rewriting unrelated files or leaving partial formatting changes when generation is interrupted.