### PR TITLE
feat(vscode): bundle repeated file edits

### DIFF
--- a/.changeset/bundle-vscode-file-edits.md
+++ b/.changeset/bundle-vscode-file-edits.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Bundle consecutive edits to the same file into an animated chat update.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/repeated-file-edits-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/repeated-file-edits-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ca6d11213967cbeb3c977cde1d94fda5ee9a505330ae99f7db74309a58e2c30
+size 3795

--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -230,6 +230,12 @@ html[data-theme="kilo-vscode"] [data-component="tool-part-wrapper"][data-part-ty
       color: var(--text-weak);
     }
 
+    [data-slot="edit-bundle-count"] {
+      margin-left: 4px;
+      color: var(--text-weaker);
+      font-variant-numeric: tabular-nums;
+    }
+
     [data-slot="basic-tool-tool-title"],
     [data-slot="basic-tool-tool-subtitle"],
     [data-slot="basic-tool-tool-arg"],

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -146,6 +146,7 @@ export interface MessagePartProps {
   showTurnDiffSummary?: boolean
   turnDiffSummary?: () => JSX.Element
   animate?: boolean
+  bundleCount?: number
   working?: boolean
   feedback?: MessageFeedbackControls
 }
@@ -1025,6 +1026,7 @@ export function Part(props: MessagePartProps) {
         showTurnDiffSummary={props.showTurnDiffSummary}
         turnDiffSummary={props.turnDiffSummary}
         animate={props.animate}
+        bundleCount={props.bundleCount}
         working={props.working}
         feedback={props.feedback}
       />
@@ -1047,6 +1049,7 @@ export interface ToolProps {
   locked?: boolean
   animate?: boolean
   reveal?: boolean
+  bundleCount?: number
 }
 
 export type ToolComponent = Component<ToolProps>
@@ -1293,6 +1296,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               defaultOpen={props.defaultOpen}
               animate
               reveal={props.animate}
+              bundleCount={props.bundleCount}
             />
           </Match>
         </Switch>
@@ -2266,6 +2270,7 @@ ToolRegistry.register({
     const path = createMemo(() => props.metadata?.filediff?.file || props.input.filePath || "")
     const filename = () => getFilename(props.input.filePath ?? "")
     const pending = () => busy(props.status)
+    const count = () => (props.bundleCount && props.bundleCount > 1 ? props.bundleCount : undefined)
     const reveal = useToolReveal(pending, () => props.reveal !== false)
     const view = createMemo(() => {
       const diff = props.metadata?.filediff
@@ -2328,6 +2333,13 @@ ToolRegistry.register({
                 <div data-slot="message-part-title">
                   <span data-slot="message-part-title-text">
                     <TextShimmer text={i18n.t("ui.messagePart.title.edit")} active={pending()} />
+                    <Show when={count()}>
+                      {(value) => (
+                        <span data-slot="edit-bundle-count" aria-hidden="true">
+                          ×{value()}
+                        </span>
+                      )}
+                    </Show>
                   </span>
                   <Show when={filename()}>
                     {(name) => (

--- a/packages/kilo-vscode/tests/unit/edit-bundles.test.ts
+++ b/packages/kilo-vscode/tests/unit/edit-bundles.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test"
+import type { Part as SDKPart } from "@kilocode/sdk/v2"
+import { bundleEdits } from "../../webview-ui/src/components/chat/edit-bundles"
+
+function edit(id: string, file: string, status = "completed") {
+  return {
+    id,
+    sessionID: "session",
+    messageID: "message",
+    type: "tool",
+    callID: `call-${id}`,
+    tool: "edit",
+    state: {
+      status,
+      input: { filePath: file },
+      metadata: {},
+      output: "",
+      title: "Edit",
+      time: { start: 1, end: 2 },
+    },
+  } as unknown as SDKPart
+}
+
+function text(id: string) {
+  return {
+    id,
+    sessionID: "session",
+    messageID: "message",
+    type: "text",
+    text: "Done",
+  } as SDKPart
+}
+
+describe("edit bundles", () => {
+  it("bundles consecutive edits to the same file and keeps the latest part", () => {
+    const groups = bundleEdits([edit("one", "src/app.ts"), edit("two", "src/app.ts"), edit("three", "src/app.ts")])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({ key: "part:one", count: 3, part: { id: "three" } })
+  })
+
+  it("preserves ordering across files and non-edit parts", () => {
+    const groups = bundleEdits([
+      edit("one", "src/app.ts"),
+      edit("two", "src/other.ts"),
+      edit("three", "src/app.ts"),
+      text("text"),
+      edit("four", "src/app.ts"),
+    ])
+
+    expect(groups.map((group) => [group.key, group.count])).toEqual([
+      ["part:one", 1],
+      ["part:two", 1],
+      ["part:three", 1],
+      ["part:text", 1],
+      ["part:four", 1],
+    ])
+  })
+
+  it("keeps failed edits visible instead of bundling them", () => {
+    const groups = bundleEdits([
+      edit("one", "src/app.ts"),
+      edit("failed", "src/app.ts", "error"),
+      edit("two", "src/app.ts"),
+    ])
+
+    expect(groups.map((group) => group.key)).toEqual(["part:one", "part:failed", "part:two"])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -316,7 +316,7 @@ describe("AssistantMessage visible row contract (source)", () => {
   })
 
   it("uses the plan exit card only when plan metadata is renderable", () => {
-    expect(src).toContain("if (!planExitInfo(part)) return")
+    expect(src).toMatch(/if \(!planExitInfo\(part\(\)\)\) return/)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
@@ -18,6 +18,13 @@ const assistant = (id: string, parentID: string, opts: Partial<Message> = {}): M
   ...opts,
 })
 const part = (id: string, messageID: string): Part => ({ id, messageID, type: "text", text: id })
+const edit = (id: string, messageID: string, file: string): Part => ({
+  id,
+  messageID,
+  type: "tool",
+  tool: "edit",
+  state: { status: "pending", input: { filePath: file } },
+})
 const lookup = (values: Record<string, Part[]>) => (id: string) => values[id] ?? []
 
 describe("transcriptRows", () => {
@@ -47,6 +54,15 @@ describe("transcriptRows", () => {
       "u2:assistant",
     ])
     expect(rows.filter((row) => row.type === "assistant").map((row) => row.parts.length)).toEqual([8, 2, 1, 1])
+  })
+
+  it("keeps same-file edit runs together across chunk boundaries", () => {
+    const u1 = user("u1")
+    const a1 = assistant("a1", "u1")
+    const edits = Array.from({ length: 9 }, (_, i) => edit(`e${i}`, "a1", "src/app.ts"))
+    const rows = transcriptRows(messageTurns([u1, a1]), lookup({ a1: edits }), { size: 8 })
+
+    expect(rows.filter((row) => row.type === "assistant").map((row) => row.parts.length)).toEqual([9])
   })
 
   it("uses the configured bound and keeps an empty assistant renderable", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -7,7 +7,7 @@
  * Active questions render inline via QuestionDock; permissions are in the bottom dock.
  */
 
-import { Component, For, Show, createMemo } from "solid-js"
+import { Component, For, Show, createEffect, createMemo, onCleanup, type JSX } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import { Part, PART_MAPPING, ToolRegistry } from "@kilocode/kilo-ui/message-part"
 import type { MessageFeedbackControls } from "@kilocode/kilo-ui/message-part"
@@ -27,6 +27,7 @@ import { snapshotProgress } from "../../context/session-utils"
 import { planDisplayPath } from "../../utils/plan-path"
 import { QuestionDock } from "./QuestionDock"
 import { SuggestBar } from "./SuggestBar"
+import { bundleEdits } from "./edit-bundles"
 
 // Tools that the upstream message-part renderer suppresses (returns null for).
 // We render these ourselves via ToolRegistry when they complete,
@@ -122,6 +123,7 @@ interface AssistantMessageProps {
   parts?: SDKPart[]
   showAssistantCopyPartID?: string | null
   feedback?: MessageFeedbackControls
+  animateEdits?: boolean
 }
 
 type ToolStateProps = {
@@ -179,6 +181,31 @@ function BashToolCard(props: { part: ToolPart; defaultOpen: boolean }) {
   )
 }
 
+function EditBundleMotion(props: { id: string; count: number; enabled?: boolean; children: JSX.Element }) {
+  let ref: HTMLDivElement | undefined
+  let prior = props.id
+  createEffect(() => {
+    const id = props.id
+    if (id === prior) return
+    prior = id
+    if (!props.enabled || props.count < 2 || !ref || window.matchMedia("(prefers-reduced-motion: reduce)").matches)
+      return
+    const motion = ref.animate(
+      [
+        { opacity: 0, transform: "translateY(10px)" },
+        { opacity: 1, transform: "translateY(0)" },
+      ],
+      { duration: 180, easing: "cubic-bezier(0.2, 0.8, 0.2, 1)" },
+    )
+    onCleanup(() => motion.cancel())
+  })
+  return (
+    <div ref={ref} data-component="edit-bundle-motion">
+      {props.children}
+    </div>
+  )
+}
+
 export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const data = useData()
   const session = useSession()
@@ -198,94 +225,100 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
       return !!matchToolRequest(part, "question", session.questions())
     })
   })
+  const grouped = createMemo(() => {
+    const bundles = bundleEdits(parts())
+    return {
+      keys: bundles.map((bundle) => bundle.key),
+      items: new Map(bundles.map((bundle) => [bundle.key, bundle] as const)),
+    }
+  })
 
   return (
     <>
-      <For each={parts()}>
-        {(part) => {
-          // Upstream PART_MAPPING["tool"] returns null for todowrite/todoread,
-          // so we detect them here and render via ToolRegistry directly.
-          const isUpstreamSuppressed =
-            part.type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part as SDKPart & { tool: string }).tool)
-
-          // Active question tool parts render the interactive QuestionDock inline
-          const activeQuestion = createMemo(() => matchToolRequest(part, "question", session.questions()))
-
-          // Active suggestion tool parts render the interactive SuggestBar inline
-          const activeSuggestion = createMemo(() => matchToolRequest(part, "suggest", session.suggestions()))
+      <For each={grouped().keys}>
+        {(key) => {
+          const bundle = createMemo(() => grouped().items.get(key)!)
+          const part = createMemo(() => bundle().part)
+          const suppressed = createMemo(
+            () => part().type === "tool" && UPSTREAM_SUPPRESSED_TOOLS.has((part() as ToolPart).tool),
+          )
+          const activeQuestion = createMemo(() => matchToolRequest(part(), "question", session.questions()))
+          const activeSuggestion = createMemo(() => matchToolRequest(part(), "suggest", session.suggestions()))
           const bash = createMemo(() => {
-            if (part.type !== "tool") return
-            const tool = part as unknown as ToolPart
-            if (tool.tool !== "bash") return
-            if (tool.state?.status === "error") return
-            return part
+            if (part().type !== "tool") return
+            const tool = part() as unknown as ToolPart
+            if (tool.tool !== "bash" || tool.state?.status === "error") return
+            return tool
           })
           const planExit = createMemo(() => {
-            if (!planExitInfo(part)) return
-            return part as unknown as ToolPart
+            if (!planExitInfo(part())) return
+            return part() as unknown as ToolPart
           })
 
           return (
             <Show
               when={
-                isUpstreamSuppressed ||
+                suppressed() ||
                 activeQuestion() ||
                 activeSuggestion() ||
                 bash() ||
                 planExit() ||
-                PART_MAPPING[part.type]
+                PART_MAPPING[part().type]
               }
             >
-              <div data-component="tool-part-wrapper" data-part-type={part.type}>
-                <Show
-                  when={activeQuestion()}
-                  fallback={
-                    <Show
-                      when={activeSuggestion()}
-                      fallback={
-                        <Show
-                          when={planExit()}
-                          fallback={
-                            <Show
-                              when={bash()}
-                              fallback={
-                                <Show
-                                  when={isUpstreamSuppressed}
-                                  fallback={
-                                    <Part
-                                      part={part}
-                                      message={props.message as SDKMessage}
-                                      showAssistantCopyPartID={props.showAssistantCopyPartID}
-                                      defaultOpen={editOpen(part, edit())}
-                                      reasoningAutoCollapse={display.reasoningAutoCollapse()}
-                                      feedback={props.feedback}
-                                      animate={
-                                        part.type === "tool" &&
-                                        ((part as unknown as ToolPart).state?.status === "pending" ||
-                                          (part as unknown as ToolPart).state?.status === "running")
-                                      }
-                                    />
-                                  }
-                                >
-                                  <TodoToolCard part={part as unknown as ToolPart} />
-                                </Show>
-                              }
-                            >
-                              {(tool) => <BashToolCard part={tool() as unknown as ToolPart} defaultOpen={open()} />}
-                            </Show>
-                          }
-                        >
-                          {(tp) => <PlanExitCard part={tp()} />}
-                        </Show>
-                      }
-                    >
-                      {(req) => <SuggestBar request={req()} />}
-                    </Show>
-                  }
-                >
-                  {(req) => <QuestionDock request={req()} />}
-                </Show>
-              </div>
+              <EditBundleMotion id={bundle().part.id} count={bundle().count} enabled={props.animateEdits}>
+                <div data-component="tool-part-wrapper" data-part-type={part().type}>
+                  <Show
+                    when={activeQuestion()}
+                    fallback={
+                      <Show
+                        when={activeSuggestion()}
+                        fallback={
+                          <Show
+                            when={planExit()}
+                            fallback={
+                              <Show
+                                when={bash()}
+                                fallback={
+                                  <Show
+                                    when={suppressed()}
+                                    fallback={
+                                      <Part
+                                        part={part()}
+                                        message={props.message as SDKMessage}
+                                        bundleCount={bundle().count}
+                                        showAssistantCopyPartID={props.showAssistantCopyPartID}
+                                        defaultOpen={editOpen(part(), edit())}
+                                        reasoningAutoCollapse={display.reasoningAutoCollapse()}
+                                        feedback={props.feedback}
+                                        animate={
+                                          part().type === "tool" &&
+                                          ((part() as unknown as ToolPart).state?.status === "pending" ||
+                                            (part() as unknown as ToolPart).state?.status === "running")
+                                        }
+                                      />
+                                    }
+                                  >
+                                    <TodoToolCard part={part() as unknown as ToolPart} />
+                                  </Show>
+                                }
+                              >
+                                {(tool) => <BashToolCard part={tool()} defaultOpen={open()} />}
+                              </Show>
+                            }
+                          >
+                            {(tool) => <PlanExitCard part={tool()} />}
+                          </Show>
+                        }
+                      >
+                        {(request) => <SuggestBar request={request()} />}
+                      </Show>
+                    }
+                  >
+                    {(request) => <QuestionDock request={request()} />}
+                  </Show>
+                </div>
+              </EditBundleMotion>
             </Show>
           )
         }}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -76,6 +76,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               message={row().message as unknown as SDKAssistantMessage}
               parts={row().parts as unknown as SDKPart[]}
               showAssistantCopyPartID={row().copy}
+              animateEdits={row().live}
               feedback={{
                 enabled: feedback.telemetryEnabled(),
                 rating: feedback.getRating(row().message.id),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -156,6 +156,7 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                   <AssistantMessage
                     message={amsg}
                     showAssistantCopyPartID={showAssistantCopyPartID()}
+                    animateEdits={!props.queued}
                     feedback={{
                       enabled: feedback.telemetryEnabled(),
                       rating: feedback.getRating(amsg.id),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/edit-bundles.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/edit-bundles.ts
@@ -1,0 +1,29 @@
+import type { Part as SDKPart, ToolPart } from "@kilocode/sdk/v2"
+
+type PartBundle = {
+  key: string
+  count: number
+  part: SDKPart
+}
+
+function path(part: SDKPart) {
+  if (part.type !== "tool") return
+  const tool = part as unknown as ToolPart
+  if (tool.tool !== "edit" || tool.state.status === "error") return
+  const value = tool.state.input.filePath
+  return typeof value === "string" && value ? value : undefined
+}
+
+export function bundleEdits(parts: SDKPart[]) {
+  return parts.reduce<PartBundle[]>((result, part) => {
+    const file = path(part)
+    const prior = result.at(-1)
+    if (file && prior && path(prior.part) === file) {
+      prior.count += 1
+      prior.part = part
+      return result
+    }
+    result.push({ key: `part:${part.id}`, count: 1, part })
+    return result
+  }, [])
+}

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
@@ -1,6 +1,21 @@
 import type { Message, Part } from "../types/messages"
 import { visibleParts, type MessageTurn, type RevertBoundary } from "./session-queue"
 
+function editPath(part: Part | undefined) {
+  if (part?.type !== "tool" || part.tool !== "edit" || part.state.status === "error") return
+  const path = part.state.input.filePath
+  return typeof path === "string" && path ? path : undefined
+}
+
+function chunkEnd(parts: Part[], start: number, size: number) {
+  const end = Math.min(start + size, parts.length)
+  const path = editPath(parts[end - 1])
+  if (!path) return end
+  let next = end
+  while (next < parts.length && editPath(parts[next]) === path) next += 1
+  return next
+}
+
 interface TranscriptMeta {
   turn: string
   partial: boolean
@@ -165,8 +180,9 @@ export function transcriptRows(
         })
         continue
       }
-      for (let start = 0; start < visible.length; start += size) {
-        const chunk = visible.slice(start, start + size)
+      for (let start = 0; start < visible.length; ) {
+        const end = chunkEnd(visible, start, size)
+        const chunk = visible.slice(start, end)
         rows.push({
           ...meta,
           type: "assistant",
@@ -175,6 +191,7 @@ export function transcriptRows(
           parts: chunk,
           copy: copied,
         })
+        start = end
       }
     }
 

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -245,6 +245,32 @@ const fileError: ToolPart = {
   },
 }
 
+const repeatedEdits = [1, 2, 3].map(
+  (index): ToolPart => ({
+    id: `part-edit-${index}`,
+    sessionID: SESSION_ID,
+    messageID: ASST_MSG_ID,
+    type: "tool",
+    callID: `call-edit-${index}`,
+    tool: "edit",
+    state: {
+      status: "completed",
+      input: { filePath: "packages/opencode/src/kilocode/notebook/protocol.ts" },
+      output: "",
+      title: "Edit file",
+      metadata: {
+        filediff: {
+          file: "packages/opencode/src/kilocode/notebook/protocol.ts",
+          additions: index,
+          deletions: 1,
+          patch: "@@ -1 +1 @@\n-old\n+new",
+        },
+      },
+      time: { start: now - 5000 + index * 500, end: now - 4800 + index * 500 },
+    },
+  }),
+)
+
 const textPart: TextPart = {
   id: "part-text-001",
   sessionID: SESSION_ID,
@@ -735,6 +761,18 @@ export const MultipleToolCalls: Story = {
   name: "Multiple Tool Calls",
   render: () => {
     const data = dataWith([readCompleted, globCompleted, textPart])
+    return (
+      <StoryProviders data={data} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+export const RepeatedFileEdits: Story = {
+  name: "Repeated File Edits",
+  render: () => {
+    const data = dataWith(repeatedEdits)
     return (
       <StoryProviders data={data} sessionID={SESSION_ID}>
         <AssistantMessage message={baseAssistantMessage} />


### PR DESCRIPTION
## Summary
- collapse consecutive edits to the same file into one stable transcript row with an edit count
- animate each live replacement upward while respecting reduced-motion preferences
- keep edit runs intact across virtualized transcript chunks so historical and live rendering agree

Repeated writes to one file currently flood the chat with nearly identical rows. This keeps the transcript compact without losing the latest diff action or disrupting tool ordering.