### PR TITLE
feat(vscode): show sandbox experimental flag for all users (except Windows)

### DIFF
--- a/.changeset/expose-sandbox-controls.md
+++ b/.changeset/expose-sandbox-controls.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show experimental sandbox controls by default for non-Windows users.

--- a/packages/kilo-vscode/src/features.ts
+++ b/packages/kilo-vscode/src/features.ts
@@ -1,5 +1,4 @@
 import { hasIndexingPlugin } from "@kilocode/kilo-indexing/detect"
-import * as vscode from "vscode"
 
 type PluginSpec = string | [string, Record<string, unknown>]
 
@@ -15,6 +14,6 @@ export type Features = {
 export function configFeatures(config?: ConfigLike | null): Features {
   return {
     indexing: hasIndexingPlugin(config?.plugin ?? []),
-    sandboxControls: vscode.workspace.getConfiguration("kilo-code.new.internal").get("sandboxControls", false),
+    sandboxControls: process.platform !== "win32",
   }
 }

--- a/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
@@ -52,8 +52,10 @@ describe("PromptInput sandbox toggle", () => {
     expect(move).toBeGreaterThan(save)
   })
 
-  it("uses the internal flag for visibility and effective runtime state for the button", () => {
-    expect(src).toContain("features().sandboxControls")
+  it("requires the enabled experiment for visibility and uses effective runtime state for the button", () => {
+    expect(src).toContain(
+      'return features().sandboxControls && config().experimental?.sandbox === true && !id?.startsWith("cloud:")',
+    )
     expect(src).toContain("<Show when={sandboxVisible()}>")
     expect(src).toContain('message.type === "sandboxStatus"')
     expect(src).toContain("message.sessionID !== sandboxID() && !matching")

--- a/packages/kilo-vscode/tests/unit/sandboxing-settings.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandboxing-settings.test.ts
@@ -1,14 +1,37 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import { configFeatures } from "../../src/features"
 import { visible } from "../../webview-ui/src/components/settings/sandboxing"
 
 const features = { indexing: false, sandboxControls: false }
+const platform = Object.getOwnPropertyDescriptor(process, "platform")
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value, configurable: true })
+}
+
+afterEach(() => {
+  if (platform) Object.defineProperty(process, "platform", platform)
+})
 
 describe("Sandboxing settings visibility", () => {
-  test("requires both the internal feature flag and sandbox experiment", () => {
+  test("requires both sandbox control availability and the sandbox experiment", () => {
     expect(visible(features, {})).toBe(false)
     expect(visible({ ...features, sandboxControls: true }, {})).toBe(false)
     expect(visible(features, { experimental: { sandbox: true } })).toBe(false)
     expect(visible({ ...features, sandboxControls: true }, { experimental: { sandbox: false } })).toBe(false)
     expect(visible({ ...features, sandboxControls: true }, { experimental: { sandbox: true } })).toBe(true)
+  })
+
+  test("enables sandbox controls by default outside Windows", () => {
+    setPlatform("darwin")
+    expect(configFeatures().sandboxControls).toBe(true)
+
+    setPlatform("linux")
+    expect(configFeatures().sandboxControls).toBe(true)
+  })
+
+  test("hides sandbox controls on Windows", () => {
+    setPlatform("win32")
+    expect(configFeatures().sandboxControls).toBe(false)
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -162,7 +162,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
   const sandboxVisible = () => {
     const id = session.currentSessionID()
-    return features().sandboxControls && !id?.startsWith("cloud:")
+    return features().sandboxControls && config().experimental?.sandbox === true && !id?.startsWith("cloud:")
   }
   const sandbox = () => {
     const state = sandboxState()


### PR DESCRIPTION
Sandbox controls currently require an undeclared internal VS Code setting, which keeps the experimental sandbox option inaccessible to regular users even on supported hosts.

This exposes the experimental setting automatically on macOS and Linux while continuing to hide sandbox controls on Windows, where the backend is unavailable. Sandbox remains opt-in: the prompt lock and network settings only appear after `experimental.sandbox` is enabled.

This implements the settings-availability portion of #11630 without promoting sandboxing out of experimental status.