### PR TITLE
test(cli): loosen flaky header-timeout no-abort case

### DIFF
--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -23,7 +23,7 @@ const it = testEffect(
 it.live("headerTimeout does not abort delayed SSE body after headers arrive", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
-      Effect.promise(() => delayedBodyServer(250, ":\n\n")), // kilocode_change
+      Effect.promise(() => delayedBodyServer(1000, ":\n\n")), // kilocode_change
       (server) => Effect.sync(() => server.server.close()),
     )
 
@@ -39,7 +39,7 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
 
           expect(yield* Effect.promise(() => result.text)).toBe("late")
         }),
-      { config: providerConfig(server.url, { headerTimeout: 50 }) },
+      { config: providerConfig(server.url, { headerTimeout: 500 }) }, // kilocode_change
     )
   }),
 )


### PR DESCRIPTION
The `provider/header-timeout.test.ts` suite intermittently fails one case on CI, and a recent attempt to stabilize it (c319334d9d) didn't fully fix the flake.

## Problem

The `headerTimeout does not abort delayed SSE body after headers arrive` test (the only case that expects the timeout to *not* fire) used a 50ms header window with a 250ms delayed body. On a loaded CI runner the in-process server's headers and SSE prelude don't reach the client within 50ms, so the header-timeout timer fires and aborts the stream. `result.text` then rejects instead of resolving to `"late"`, and the file fails on both attempts.

The other two timing cases (`chunkTimeout` and `headerTimeout aborts when headers don't arrive`) *want* the timeout to fire, so CI slowness makes them more reliable, not less. Only this one race-fails.

## Change

- `headerTimeout: 50` -> `500` (10x margin for CI jank)
- body delay `250` -> `1000`

The body still lands well past the header window, so the assertion keeps its meaning: a healthy stream whose body arrives after headers should not be aborted by the header timeout (the timer is cleared on header arrival). Both edited lines are in a shared upstream test file, so they carry `kilocode_change` markers.

Could not run the suite locally (worktree has no node_modules and this sandbox has no network to `bun install`); the change is two numeric literals with no typecheck/lint impact.