### PR TITLE
test(jetbrains): synchronize workspace open calls

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/prompt/MentionNavigatorTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/prompt/MentionNavigatorTest.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import java.awt.event.InputEvent
 import java.awt.event.MouseEvent
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
 @Suppress("UnstableApiUsage")
@@ -47,10 +49,11 @@ class MentionNavigatorTest : BasePlatformTestCase() {
         editor = factory.createEditor(factory.createDocument(text), project) as EditorEx
         navigator = MentionNavigator(editor, provider)
         navigator.install()
-        provider.validate(text, -1) {}
-        waitFor {
-            provider.mentionAt(text, 6)?.resolved == true && provider.mentionAt(text, 20)?.resolved == false
-        }
+        val resolved = CountDownLatch(2)
+        provider.validate(text, -1) { resolved.countDown() }
+        assertTrue("mention validation did not complete", resolved.await(5, TimeUnit.SECONDS))
+        assertTrue(provider.mentionAt(text, 6)?.resolved == true)
+        assertTrue(provider.mentionAt(text, 20)?.resolved == false)
     }
 
     override fun tearDown() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeWorkspaceRpcApi.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeWorkspaceRpcApi.kt
@@ -10,6 +10,7 @@ import ai.kilocode.rpc.dto.WorkspaceFileDto
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Fake [KiloWorkspaceRpcApi] for testing.
@@ -41,7 +42,7 @@ class FakeWorkspaceRpcApi : KiloWorkspaceRpcApi {
     var globalConfigExists = true
     val fileCalls = mutableListOf<Pair<String, String>>()
     val searchQueries = mutableListOf<String>()
-    val opened = mutableListOf<String>()
+    val opened = CopyOnWriteArrayList<String>()
     val localConfigs = mutableListOf<String>()
     var globalConfigs = 0
     var localConfigPathCalls = 0


### PR DESCRIPTION
## Summary

Make the fake workspace RPC's file-open recorder thread-safe. Mention navigation launches file opening on a background coroutine while tests inspect calls from the EDT, so the previous mutable list had an unsynchronized visibility race that could make the click test time out.