### PR TITLE
feat(vscode): add Parakeet speech-to-text model

### DIFF
--- a/.changeset/add-parakeet-speech.md
+++ b/.changeset/add-parakeet-speech.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support NVIDIA Parakeet TDT 0.6B v3 for speech-to-text input.

--- a/packages/kilo-vscode/src/speech-to-text/models.ts
+++ b/packages/kilo-vscode/src/speech-to-text/models.ts
@@ -38,6 +38,11 @@ const models: SpeechToTextModelDef[] = [
     label: "Chirp 3",
     provider: "Google",
   },
+  {
+    id: "nvidia/parakeet-tdt-0.6b-v3",
+    label: "Parakeet TDT 0.6B v3",
+    provider: "NVIDIA",
+  },
 ]
 
 export const SPEECH_TO_TEXT_MODELS: readonly SpeechToTextModelDef[] = models

--- a/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
@@ -207,8 +207,8 @@ test("settings and mode editing expose distinct model field purposes", async ({ 
   const speech = page.getByRole("button", { name: "Speech to Text Model: Chirp 3" })
   await expect(speech).toBeEnabled()
   await speech.click()
-  await page.getByRole("option", { name: "GPT-4o Mini Transcribe (OpenAI)" }).click()
-  await expect(page.getByRole("button", { name: "Speech to Text Model: GPT-4o Mini Transcribe" })).toBeVisible()
+  await page.getByRole("option", { name: "Parakeet TDT 0.6B v3 (NVIDIA)" }).click()
+  await expect(page.getByRole("button", { name: "Speech to Text Model: Parakeet TDT 0.6B v3" })).toBeVisible()
 
   await load(page, "settings--mode-edit-export")
   await expect(page.getByRole("button", { name: /Model Override:/ })).toHaveAccessibleDescription(

--- a/packages/kilo-vscode/tests/unit/speech-to-text-models-sync.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-models-sync.test.ts
@@ -14,4 +14,15 @@ describe("speech-to-text model catalog", () => {
   it("falls back from unknown config model IDs", () => {
     expect(getSpeechToTextModel("unknown/model")).toBe(DEFAULT_SPEECH_TO_TEXT_MODEL)
   })
+
+  it("includes NVIDIA Parakeet without prompt conditioning", () => {
+    const model = getSpeechToTextModel("nvidia/parakeet-tdt-0.6b-v3")
+
+    expect(model).toMatchObject({
+      id: "nvidia/parakeet-tdt-0.6b-v3",
+      label: "Parakeet TDT 0.6B v3",
+      provider: "NVIDIA",
+    })
+    expect(model.verbatim).toBeUndefined()
+  })
 })


### PR DESCRIPTION
OpenRouter now serves `nvidia/parakeet-tdt-0.6b-v3` through the transcription endpoint already used by Kilo Gateway, but the VS Code extension uses a curated speech model catalog. That prevents users from selecting Parakeet even though the existing transport supports it.

Add Parakeet TDT 0.6B v3 to the shared catalog that drives the Models settings page and every speech-input surface. Keep Whisper Large V3 Turbo as the fallback, identify NVIDIA in the selector, and leave GPT-specific prompt conditioning disabled so Parakeet receives only the existing audio and language fields.