### PR TITLE
fix(ci): retry transient JetBrains typecheck failure

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -74,8 +74,22 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Run JetBrains typecheck
-        run: ./gradlew typecheck
         working-directory: packages/kilo-jetbrains
+        run: |
+          set +e
+          ./gradlew typecheck 2>&1 | tee "$RUNNER_TEMP/jetbrains-typecheck.log"
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          if ! grep -F -A1 'Unable to read plugin descriptor' "$RUNNER_TEMP/jetbrains-typecheck.log" |
+            grep -qF 'java.nio.file.ClosedFileSystemException'; then
+            exit "$status"
+          fi
+          echo '::warning::Retrying JetBrains typecheck after a transient Gradle filesystem failure'
+          ./gradlew --stop
+          ./gradlew typecheck
 
   required:
     name: typecheck


### PR DESCRIPTION
## Summary

Retry the JetBrains typecheck once when Gradle fails with the observed `ClosedFileSystemException` while reading an IntelliJ plugin descriptor.

PR #11644 legitimately triggers JetBrains typechecking because its CLI and OpenAPI changes feed the generated Kotlin client, so path filtering would be unsafe. The unchanged rerun passed; this narrowly handles that transient Gradle filesystem failure while preserving all other failures.