### PR TITLE
feat(cli): preserve mcp structured content

### DIFF
--- a/.changeset/structured-mcp-content.md
+++ b/.changeset/structured-mcp-content.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"@kilocode/sdk": patch
+---
+
+Preserve validated MCP structured tool results in completed tool parts and SDK event types.

--- a/packages/opencode/src/kilocode/mcp/structured-content.ts
+++ b/packages/opencode/src/kilocode/mcp/structured-content.ts
@@ -1,0 +1,138 @@
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
+import type { JsonSchemaType, JsonSchemaValidator } from "@modelcontextprotocol/sdk/validation"
+import type { JSONSchema7 } from "ai"
+
+export namespace KiloMcpStructuredContent {
+  export const MAX_STRUCTURED_CONTENT_BYTES = 1 * 1024 * 1024
+
+  type Valid = {
+    status: "valid"
+    schema: JSONSchema7
+    validator: JsonSchemaValidator<Record<string, unknown>>
+  }
+
+  type Invalid = {
+    status: "invalid"
+    metadata: Record<string, unknown>
+  }
+
+  type None = {
+    status: "none"
+  }
+
+  export type Compiled = Valid | Invalid | None
+  export type Persisted = { structuredContent?: unknown; metadata?: Record<string, unknown> }
+
+  const ajv = new AjvJsonSchemaValidator()
+  const KILO_META = new Set(["structuredContentSchema"])
+
+  function record(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+  }
+
+  function message(err: unknown) {
+    return err instanceof Error ? err.message : String(err)
+  }
+
+  function invalid(reason: string, err?: unknown): Invalid {
+    return {
+      status: "invalid",
+      metadata: {
+        structuredContentSchema: {
+          valid: false,
+          reason,
+          ...(err === undefined ? {} : { error: message(err) }),
+        },
+      },
+    }
+  }
+
+  function omitted(result: CallToolResult, metadata?: Record<string, unknown>): CallToolResult {
+    const next = { ...result }
+    delete next.structuredContent
+    if (metadata) {
+      next._meta = {
+        ...(record(result._meta) ? result._meta : {}),
+        ...metadata,
+      }
+    }
+    return next
+  }
+
+  export class StructuredContentError extends Error {
+    constructor(tool: string, detail: string) {
+      super(`MCP tool "${tool}" returned invalid structured content: ${detail}`)
+      this.name = "McpStructuredContentError"
+    }
+  }
+
+  export function compile(schema: unknown): Compiled {
+    if (schema === undefined) return { status: "none" }
+    if (!record(schema)) return invalid("schema")
+
+    try {
+      return {
+        status: "valid",
+        schema: schema as JSONSchema7,
+        validator: ajv.getValidator<Record<string, unknown>>(schema as JsonSchemaType),
+      }
+    } catch (err) {
+      return invalid("compile", err)
+    }
+  }
+
+  export function validate(tool: string, compiled: Compiled, result: CallToolResult): CallToolResult {
+    if (result.isError === true) return omitted(result)
+    if (compiled.status === "none") return omitted(result)
+    if (compiled.status === "invalid") return omitted(result, compiled.metadata)
+
+    if (result.structuredContent === undefined) {
+      throw new StructuredContentError(tool, "missing structuredContent")
+    }
+
+    const validated = compiled.validator(result.structuredContent)
+    if (!validated.valid) {
+      throw new StructuredContentError(tool, validated.errorMessage)
+    }
+
+    return {
+      ...result,
+      structuredContent: validated.data,
+    }
+  }
+
+  export function persist(value: unknown, opts?: { maxBytes?: number }): Persisted {
+    if (value === undefined) return {}
+
+    const max = opts?.maxBytes ?? MAX_STRUCTURED_CONTENT_BYTES
+    const json = JSON.stringify(value)
+    if (json === undefined) return {}
+
+    const bytes = Buffer.byteLength(json)
+    if (bytes > max) {
+      return {
+        metadata: {
+          structuredContentOmitted: {
+            reason: "size",
+            bytes,
+            maxBytes: max,
+          },
+        },
+      }
+    }
+
+    return { structuredContent: value }
+  }
+
+  export function metadata(result: { _meta?: unknown; metadata?: unknown }) {
+    const meta = record(result.metadata) ? result.metadata : {}
+    if (!record(result._meta)) return meta
+
+    const out = { ...meta }
+    for (const key of KILO_META) {
+      if (key in result._meta) out[key] = result._meta[key]
+    }
+    return out
+  }
+}

--- a/packages/opencode/src/kilocode/server/httpapi/groups/session-import.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/session-import.ts
@@ -159,6 +159,7 @@ const ToolStateCompletedSchema = Schema.Struct({
   status: Schema.Literal("completed"),
   input: Schema.Record(Schema.String, Schema.Unknown),
   output: Schema.String,
+  structuredContent: Schema.optional(Schema.Unknown),
   title: Schema.String,
   metadata: Schema.Record(Schema.String, Schema.Unknown),
   time: Schema.Struct({

--- a/packages/opencode/src/kilocode/session-import/types.ts
+++ b/packages/opencode/src/kilocode/session-import/types.ts
@@ -92,6 +92,7 @@ export namespace SessionImportType {
     status: z.literal("completed"),
     input: z.record(z.string(), z.unknown()),
     output: z.string(),
+    structuredContent: z.unknown().optional(),
     title: z.string(),
     metadata: z.record(z.string(), z.unknown()),
     time: z.object({

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -8,6 +8,7 @@ if (process.platform === "win32" && !("type" in process)) {
 // kilocode_change end
 
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
+import * as z from "zod/v4" // kilocode_change
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -16,9 +17,12 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
+  ErrorCode, // kilocode_change
+  McpError, // kilocode_change
+  type CallToolResult, // kilocode_change
   ListToolsResultSchema,
   ToolSchema,
-  type Tool as MCPToolDef,
+  type Tool as MCPSDKToolDef,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "@/config/config"
@@ -41,6 +45,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import * as SandboxNetwork from "@/kilocode/sandbox/network" // kilocode_change
+import { KiloMcpStructuredContent } from "@/kilocode/mcp/structured-content" // kilocode_change
 
 const log = Log.create({ service: "mcp" })
 const DEFAULT_TIMEOUT = 30_000
@@ -59,9 +64,14 @@ export function ensureDockerRm(cmd: string, args: string[]): string[] {
 }
 // kilocode_change end
 
-const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
-  tools: ToolSchema.omit({ outputSchema: true }).array(),
+// kilocode_change start - preserve raw MCP outputSchema for Kilo validation after tolerant discovery
+const TolerantToolSchema = ToolSchema.omit({ outputSchema: true }).extend({
+  outputSchema: z.unknown().optional(),
 })
+const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
+  tools: TolerantToolSchema.array(),
+})
+// kilocode_change end
 
 export const Resource = Schema.Struct({
   name: Schema.String,
@@ -96,6 +106,10 @@ export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("MCP
 }) {}
 
 type MCPClient = Client
+// kilocode_change start - tolerant discovery keeps raw outputSchema for later compile/downgrade
+type MCPToolDef = Omit<MCPSDKToolDef, "outputSchema"> & { outputSchema?: unknown }
+type DynamicToolOptions = Parameters<typeof dynamicTool>[0]
+// kilocode_change end
 
 const StatusConnected = Schema.Struct({ status: Schema.Literal("connected") }).annotate({
   identifier: "MCPStatusConnected",
@@ -165,15 +179,7 @@ function listTools(key: string, client: MCPClient, timeout: number) {
             timeout,
           }),
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.map((result) =>
-          result.tools.map((tool) => ({
-            name: tool.name,
-            description: tool.description,
-            inputSchema: tool.inputSchema,
-          })),
-        ),
-      )
+      }).pipe(Effect.map((result) => result.tools as MCPToolDef[])) // kilocode_change
     }),
   )
 }
@@ -181,6 +187,7 @@ function listTools(key: string, client: MCPClient, timeout: number) {
 // Convert MCP tool definition to AI SDK Tool type
 function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Tool {
   const inputSchema = mcpTool.inputSchema
+  const output = KiloMcpStructuredContent.compile(mcpTool.outputSchema) // kilocode_change
 
   // Spread first, then override type to ensure it's always "object"
   const schema: JSONSchema7 = {
@@ -190,14 +197,25 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
     additionalProperties: false,
   }
 
-  return dynamicTool({
+  // kilocode_change start - Kilo validates MCP structuredContent separately from the AI SDK output contract
+  const options: DynamicToolOptions = {
     description: mcpTool.description ?? "",
     inputSchema: jsonSchema(schema),
     execute: async (args: unknown) => {
-      return client.callTool(
+      if (mcpTool.execution?.taskSupport === "required") {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Tool "${mcpTool.name}" requires task-based execution. Use client.experimental.tasks.callToolStream() instead.`,
+        )
+      }
+
+      const result = await client.request(
         {
-          name: mcpTool.name,
-          arguments: (args || {}) as Record<string, unknown>,
+          method: "tools/call",
+          params: {
+            name: mcpTool.name,
+            arguments: (args || {}) as Record<string, unknown>,
+          },
         },
         CallToolResultSchema,
         {
@@ -205,8 +223,11 @@ function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number
           timeout,
         },
       )
+      return KiloMcpStructuredContent.validate(mcpTool.name, output, result as CallToolResult)
     },
-  })
+  }
+  return dynamicTool(options)
+  // kilocode_change end
 }
 
 function defs(key: string, client: MCPClient, timeout?: number) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -279,6 +279,7 @@ export const ToolStateCompleted = Schema.Struct({
   status: Schema.Literal("completed"),
   input: Schema.Record(Schema.String, Schema.Any),
   output: Schema.String,
+  structuredContent: Schema.optional(Schema.Any), // kilocode_change
   title: Schema.String,
   metadata: Schema.Record(Schema.String, Schema.Any),
   time: Schema.Struct({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -58,6 +58,7 @@ export interface Handle {
       title: string
       metadata: Record<string, any>
       output: string
+      structuredContent?: unknown // kilocode_change
       attachments?: MessageV2.FilePart[]
     },
   ) => Effect.Effect<void>
@@ -249,6 +250,7 @@ export const layer = Layer.effect(
           title: string
           metadata: Record<string, any>
           output: string
+          structuredContent?: unknown // kilocode_change
           attachments?: MessageV2.FilePart[]
         },
       ) {
@@ -263,6 +265,9 @@ export const layer = Layer.effect(
             metadata: output.metadata,
             title: output.title,
             time: { start: match.part.state.time.start, end: Date.now() },
+            // kilocode_change start
+            ...(output.structuredContent !== undefined ? { structuredContent: output.structuredContent } : {}),
+            // kilocode_change end
             attachments: output.attachments,
           },
         })
@@ -371,12 +376,26 @@ export const layer = Layer.effect(
 
       const toolResultOutput = (
         value: Extract<StreamEvent, { type: "tool-result" }>,
-      ): { title: string; metadata: Record<string, any>; output: string; attachments?: MessageV2.FilePart[] } => {
+      ): {
+        title: string
+        metadata: Record<string, any>
+        output: string
+        structuredContent?: unknown // kilocode_change
+        attachments?: MessageV2.FilePart[]
+      } => {
         if (isRecord(value.result.value) && typeof value.result.value.output === "string") {
+          // kilocode_change start
+          const structured =
+            Object.hasOwn(value.result.value, "structuredContent") &&
+            value.result.value.structuredContent !== undefined
+              ? { structuredContent: value.result.value.structuredContent }
+              : {}
+          // kilocode_change end
           return {
             title: typeof value.result.value.title === "string" ? value.result.value.title : value.name,
             metadata: isRecord(value.result.value.metadata) ? value.result.value.metadata : {},
             output: value.result.value.output,
+            ...structured, // kilocode_change
             attachments: Array.isArray(value.result.value.attachments)
               ? value.result.value.attachments.filter(isFilePart)
               : undefined,

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -20,6 +20,7 @@ import { PartID } from "./schema"
 import * as Log from "@opencode-ai/core/util/log"
 import { EffectBridge } from "@/effect/bridge"
 import * as SandboxPolicy from "@/kilocode/sandbox/policy" // kilocode_change
+import { KiloMcpStructuredContent } from "@/kilocode/mcp/structured-content" // kilocode_change
 
 const log = Log.create({ service: "session.tools" })
 
@@ -90,7 +91,8 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               { args },
             )
             // kilocode_change start
-            const result = yield* SandboxPolicy.executeTool(ctx.sessionID, item, item.execute(args, ctx))
+            const effect: Effect.Effect<Tool.ExecuteResult> = item.execute(args, ctx)
+            const result = yield* (SandboxPolicy.executeTool(ctx.sessionID, item, effect) as Effect.Effect<Tool.ExecuteResult>)
             // kilocode_change end
             const output = {
               ...result,
@@ -182,8 +184,10 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           }
 
           const truncated = yield* truncate.output(textParts.join("\n\n"), {}, input.agent)
+          const persisted = KiloMcpStructuredContent.persist(result.structuredContent) // kilocode_change
           const metadata = {
-            ...result.metadata,
+            ...KiloMcpStructuredContent.metadata(result), // kilocode_change
+            ...persisted.metadata, // kilocode_change
             truncated: truncated.truncated,
             ...(truncated.truncated && { outputPath: truncated.outputPath }),
           }
@@ -198,6 +202,9 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               sessionID: ctx.sessionID,
               messageID: input.processor.message.id,
             })),
+            // kilocode_change start
+            ...(persisted.structuredContent !== undefined ? { structuredContent: persisted.structuredContent } : {}),
+            // kilocode_change end
             content: result.content,
           }
           if (opts.abortSignal?.aborted) {

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -47,6 +47,7 @@ export interface ExecuteResult<M extends Metadata = Metadata> {
   title: string
   metadata: M
   output: string
+  structuredContent?: unknown // kilocode_change
   attachments?: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[]
 }
 

--- a/packages/opencode/test/kilocode/mcp-structured-content.test.ts
+++ b/packages/opencode/test/kilocode/mcp-structured-content.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test"
+import { KiloMcpStructuredContent } from "../../src/kilocode/mcp/structured-content"
+
+const schema = {
+  type: "object",
+  properties: {
+    count: { type: "number" },
+  },
+  required: ["count"],
+  additionalProperties: false,
+}
+
+describe("Kilo MCP structured content", () => {
+  test("validates structured content against a valid output schema", () => {
+    const compiled = KiloMcpStructuredContent.compile(schema)
+    const result = KiloMcpStructuredContent.validate("count", compiled, {
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { count: 1 },
+    })
+
+    expect(compiled.status).toBe("valid")
+    expect(result.structuredContent).toEqual({ count: 1 })
+  })
+
+  test("rejects missing structured content for schema-backed tools", () => {
+    const compiled = KiloMcpStructuredContent.compile(schema)
+
+    expect(() =>
+      KiloMcpStructuredContent.validate("count", compiled, {
+        content: [{ type: "text", text: '{"count":1}' }],
+      }),
+    ).toThrow("missing structuredContent")
+  })
+
+  test("rejects invalid structured content for schema-backed tools", () => {
+    const compiled = KiloMcpStructuredContent.compile(schema)
+
+    expect(() =>
+      KiloMcpStructuredContent.validate("count", compiled, {
+        content: [{ type: "text", text: "bad" }],
+        structuredContent: { count: "one" },
+      }),
+    ).toThrow("must be number")
+  })
+
+  test("omits structured content from error results without validating it", () => {
+    const compiled = KiloMcpStructuredContent.compile(schema)
+    const result = KiloMcpStructuredContent.validate("count", compiled, {
+      content: [{ type: "text", text: "error" }],
+      structuredContent: { count: "one" },
+      isError: true,
+    })
+
+    expect(result.structuredContent).toBeUndefined()
+  })
+
+  test("downgrades invalid output schemas to untrusted text behavior", () => {
+    const compiled = KiloMcpStructuredContent.compile({
+      type: "object",
+      properties: { count: { $ref: "#/$defs/Missing" } },
+    })
+    const result = KiloMcpStructuredContent.validate("count", compiled, {
+      content: [{ type: "text", text: "ok" }],
+      structuredContent: { count: 1 },
+    })
+
+    expect(compiled.status).toBe("invalid")
+    expect(result.structuredContent).toBeUndefined()
+    expect(result._meta).toMatchObject({ structuredContentSchema: { valid: false, reason: "compile" } })
+  })
+
+  test("omits oversized structured content completely", () => {
+    const value = { text: "x".repeat(64) }
+    const result = KiloMcpStructuredContent.persist(value, { maxBytes: 16 })
+
+    expect(result).toEqual({
+      metadata: {
+        structuredContentOmitted: {
+          reason: "size",
+          bytes: Buffer.byteLength(JSON.stringify(value)),
+          maxBytes: 16,
+        },
+      },
+    })
+  })
+
+  test("keeps in-budget structured content complete", () => {
+    const value = { count: 1 }
+
+    expect(KiloMcpStructuredContent.persist(value, { maxBytes: 64 })).toEqual({ structuredContent: value })
+  })
+
+  test("keeps only Kilo-owned MCP metadata diagnostics", () => {
+    expect(
+      KiloMcpStructuredContent.metadata({
+        metadata: { truncated: false },
+        _meta: {
+          server: "mcp",
+          structuredContentSchema: { valid: false, reason: "compile" },
+        },
+      }),
+    ).toEqual({
+      truncated: false,
+      structuredContentSchema: { valid: false, reason: "compile" },
+    })
+  })
+})

--- a/packages/opencode/test/kilocode/server/httpapi-public.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-public.test.ts
@@ -16,6 +16,7 @@ type Schema = {
   anyOf?: Schema[]
   items?: Schema
   properties?: Record<string, Schema>
+  required?: string[]
   type?: string
   enum?: string[]
   minLength?: number
@@ -194,5 +195,13 @@ describe("Kilo PublicApi OpenAPI contract", () => {
     const body = spec.paths[KiloGatewayPaths.audioTranscriptions]?.post?.requestBody as Body | undefined
     const schema = body?.content?.["application/json"]?.schema
     expect(schema?.properties?.prompt).toEqual({ type: "string" })
+  })
+
+  test("exposes structured content on completed tool state", () => {
+    const spec = OpenApi.fromApi(PublicApi)
+    const schema = spec.components?.schemas?.ToolStateCompleted as Schema | undefined
+
+    expect(schema?.properties?.structuredContent).toBeDefined()
+    expect(schema?.required ?? []).not.toContain("structuredContent")
   })
 })

--- a/packages/opencode/test/kilocode/session-processor-structured-content.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-structured-content.test.ts
@@ -1,0 +1,278 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { expect } from "bun:test"
+import { tool } from "ai"
+import { Effect, Layer } from "effect"
+import path from "path"
+import z from "zod"
+import type { Agent } from "@/agent/agent"
+import { Agent as AgentSvc } from "@/agent/agent"
+import { Bus } from "@/bus"
+import { Config } from "@/config/config"
+import { Image } from "@/image/image"
+import { Permission } from "@/permission"
+import { Plugin } from "@/plugin"
+import { Provider } from "@/provider/provider"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { Session } from "@/session/session"
+import { LLM } from "@/session/llm"
+import { MessageV2 } from "@/session/message-v2"
+import { SessionProcessor } from "@/session/processor"
+import { MessageID, PartID, SessionID } from "@/session/schema"
+import { SessionStatus } from "@/session/status"
+import { SessionSummary } from "@/session/summary"
+import { Snapshot } from "@/snapshot"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { SyncEvent } from "@/sync"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { EventV2Bridge } from "@/event-v2-bridge"
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+const cfg = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+function agent(): Agent.Info {
+  return {
+    name: "build",
+    mode: "primary",
+    options: {},
+    permission: [{ permission: "*", pattern: "*", action: "allow" }],
+  }
+}
+
+const user = Effect.fn("TestSession.user")(function* (sessionID: SessionID, text: string) {
+  const session = yield* Session.Service
+  const msg = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return msg
+})
+
+const assistant = Effect.fn("TestSession.assistant")(function* (
+  sessionID: SessionID,
+  parentID: MessageID,
+  root: string,
+) {
+  const session = yield* Session.Service
+  const msg: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    sessionID,
+    mode: "build",
+    agent: "build",
+    path: { cwd: root, root },
+    cost: 0,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    parentID,
+    time: { created: Date.now() },
+    finish: "end_turn",
+  }
+  yield* session.updateMessage(msg)
+  return msg
+})
+
+const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+const deps = Layer.mergeAll(
+  Session.defaultLayer,
+  Snapshot.defaultLayer,
+  AgentSvc.defaultLayer,
+  Permission.defaultLayer,
+  Plugin.defaultLayer,
+  Config.defaultLayer,
+  LLM.defaultLayer,
+  Provider.defaultLayer,
+  status,
+  SyncEvent.defaultLayer,
+  EventV2Bridge.defaultLayer,
+).pipe(Layer.provideMerge(infra))
+const env = Layer.mergeAll(
+  TestLLMServer.layer,
+  SessionProcessor.layer.pipe(
+    Layer.provide(summary),
+    Layer.provide(Image.defaultLayer),
+    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provideMerge(deps),
+  ),
+)
+const it = testEffect(env)
+
+const boot = Effect.fn("test.boot")(function* () {
+  const processors = yield* SessionProcessor.Service
+  const session = yield* Session.Service
+  const provider = yield* Provider.Service
+  return { processors, session, provider }
+})
+
+function input(parent: MessageV2.User, mdl: Provider.Model, tools: LLM.StreamInput["tools"]): LLM.StreamInput {
+  return {
+    user: {
+      id: parent.id,
+      sessionID: parent.sessionID,
+      role: "user",
+      time: parent.time,
+      agent: parent.agent,
+      model: { providerID: ref.providerID, modelID: ref.modelID },
+    },
+    sessionID: parent.sessionID,
+    model: mdl,
+    agent: agent(),
+    system: [],
+    messages: [{ role: "user", content: "tool" }],
+    tools,
+  }
+}
+
+it.live("persists structuredContent from completed tool result objects", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.tool("lookup", { query: "weather" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        yield* handle.process(
+          input(parent, mdl, {
+            lookup: tool({
+              description: "Look up information",
+              inputSchema: z.object({ query: z.string() }),
+              execute: async (args) => ({
+                title: "Weather lookup",
+                output: `result:${args.query}`,
+                metadata: { source: "test" },
+                structuredContent: { forecast: "sunny" },
+              }),
+            }),
+          }),
+        )
+
+        const call = MessageV2.parts(msg.id).find((part): part is MessageV2.ToolPart => part.type === "tool")
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status !== "completed") return
+        expect(call.state.output).toBe("result:weather")
+        expect(call.state.structuredContent).toEqual({ forecast: "sunny" })
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("does not synthesize structuredContent from bare JSON output strings", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.tool("lookup", { query: "weather" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        yield* handle.process(
+          input(parent, mdl, {
+            lookup: tool({
+              description: "Look up information",
+              inputSchema: z.object({ query: z.string() }),
+              execute: async () => ({
+                title: "Weather lookup",
+                output: '{"forecast":"sunny"}',
+                metadata: { source: "test" },
+              }),
+            }),
+          }),
+        )
+
+        const call = MessageV2.parts(msg.id).find((part): part is MessageV2.ToolPart => part.type === "tool")
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status !== "completed") return
+        expect(call.state.output).toBe('{"forecast":"sunny"}')
+        expect(call.state.structuredContent).toBeUndefined()
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)

--- a/packages/opencode/test/kilocode/session-tools-mcp-structured-content.test.ts
+++ b/packages/opencode/test/kilocode/session-tools-mcp-structured-content.test.ts
@@ -1,0 +1,222 @@
+import { expect, beforeEach } from "bun:test"
+import { jsonSchema, type Tool as AITool, type ToolExecutionOptions } from "ai"
+import { Effect, Layer } from "effect"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Agent } from "@/agent/agent"
+import { Bus } from "@/bus"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { InstanceRef } from "@/effect/instance-ref"
+import { MCP } from "@/mcp"
+import { Permission } from "@/permission"
+import { ProjectID } from "@/project/schema"
+import type { InstanceContext } from "@/project/instance-context"
+import { Plugin } from "@/plugin"
+import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session/session"
+import { SessionTools } from "@/session/tools"
+import { MessageID, SessionID } from "@/session/schema"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { TestConfig } from "../fixture/config"
+import { tmpdirScoped } from "../fixture/fixture"
+import { ProviderTest } from "../fake/provider"
+import { testEffect } from "../lib/effect"
+
+const projectID = ProjectID.make("mcp-structured-content")
+const sessionID = SessionID.make("ses_mcp-structured-content")
+const model = ProviderTest.model()
+const agent: Agent.Info = {
+  name: "build",
+  mode: "primary",
+  permission: Permission.fromConfig({ "*": "allow" }),
+  options: {},
+}
+
+let result: Record<string, unknown> & { content: Array<Record<string, unknown>> }
+
+beforeEach(() => {
+  result = { content: [{ type: "text", text: "ok" }] }
+})
+
+function session(directory: string): Session.Info {
+  return {
+    id: sessionID,
+    slug: "mcp-structured-content",
+    projectID,
+    directory,
+    title: "MCP structured content",
+    version: "test",
+    permission: Permission.fromConfig({ "*": "allow" }),
+    time: { created: 0, updated: 0 },
+  }
+}
+
+function message(directory: string): MessageV2.Assistant {
+  return {
+    id: MessageID.make("msg_mcp-structured-content"),
+    role: "assistant",
+    parentID: MessageID.make("msg_mcp-structured-content-parent"),
+    sessionID,
+    mode: "build",
+    agent: agent.name,
+    path: { cwd: directory, root: directory },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: model.id,
+    providerID: model.providerID,
+    time: { created: 0 },
+  }
+}
+
+function context(directory: string): InstanceContext {
+  return {
+    directory,
+    worktree: directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      time: { created: 0, updated: 0 },
+      sandboxes: [],
+    },
+  }
+}
+
+const mcp = Layer.mock(MCP.Service)({
+  tools: () =>
+    Effect.succeed({
+      mcp_lookup: {
+        description: "MCP lookup",
+        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        execute: async () => result,
+      } satisfies AITool,
+    }),
+})
+const config = TestConfig.layer({
+  get: () => Effect.succeed({ experimental: { sandbox: false } }),
+})
+const agents = Layer.mock(Agent.Service)({
+  get: () => Effect.succeed(agent),
+})
+const sessions = Layer.mock(Session.Service)({
+  get: () => Effect.succeed(session("/workspace")),
+})
+const permission = Layer.mock(Permission.Service)({
+  ask: () => Effect.void,
+})
+const plugin = Layer.mock(Plugin.Service)({
+  trigger: (_name, _input, output) => Effect.succeed(output),
+})
+const registry = Layer.mock(ToolRegistry.Service)({
+  tools: () => Effect.succeed([]),
+})
+const truncate = Layer.mock(Truncate.Service)({
+  output: (text: string) => Effect.succeed({ content: text, truncated: false as const }),
+  limits: () => Effect.succeed({ maxLines: Truncate.MAX_LINES, maxBytes: Truncate.MAX_BYTES }),
+})
+const it = testEffect(
+  Layer.mergeAll(
+    config,
+    agents,
+    sessions,
+    permission,
+    plugin,
+    registry,
+    mcp,
+    truncate,
+    Bus.layer,
+    AppFileSystem.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    RuntimeFlags.layer(),
+  ),
+)
+
+function resolve(directory: string) {
+  return SessionTools.resolve({
+    agent,
+    model,
+    session: session(directory),
+    processor: {
+      message: message(directory),
+      metadata: () => Effect.void,
+      completeToolCall: () => Effect.void,
+    },
+    bypassAgentCheck: false,
+    messages: [],
+    promptOps: {
+      cancel: () => Effect.die(new Error("cancel is not used by this test")),
+      resolvePromptParts: () => Effect.die(new Error("resolvePromptParts is not used by this test")),
+      prompt: () => Effect.die(new Error("prompt is not used by this test")),
+    },
+  }).pipe(Effect.provideService(InstanceRef, context(directory)))
+}
+
+function call(tool: AITool) {
+  const options: ToolExecutionOptions = {
+    toolCallId: "call_mcp_lookup",
+    messages: [],
+    abortSignal: new AbortController().signal,
+  }
+  if (!tool.execute) return Effect.die(new Error("tool has no execute callback"))
+  return Effect.tryPromise({
+    try: () => Promise.resolve(tool.execute?.({}, options)),
+    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+  })
+}
+
+it.live("preserves MCP structured content separately from text output", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    result = {
+      content: [{ type: "text", text: "human-readable result" }],
+      structuredContent: { rows: [{ id: 1 }] },
+      _meta: { server: "mcp" },
+    }
+
+    const tools = yield* resolve(dir)
+    const tool = tools.mcp_lookup
+    if (!tool) return yield* Effect.die(new Error("expected MCP lookup tool"))
+    const output = (yield* call(tool)) as Record<string, unknown>
+
+    expect(output.output).toBe("human-readable result")
+    expect(output.structuredContent).toEqual({ rows: [{ id: 1 }] })
+    expect(output.metadata).toEqual({ truncated: false })
+  }),
+)
+
+it.live("does not parse JSON text content into structuredContent", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    result = { content: [{ type: "text", text: '{"rows":[{"id":1}]}' }] }
+
+    const tools = yield* resolve(dir)
+    const tool = tools.mcp_lookup
+    if (!tool) return yield* Effect.die(new Error("expected MCP lookup tool"))
+    const output = (yield* call(tool)) as Record<string, unknown>
+
+    expect(output.output).toBe('{"rows":[{"id":1}]}')
+    expect(output.structuredContent).toBeUndefined()
+  }),
+)
+
+it.live("omits oversized MCP structured content with metadata", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    result = {
+      content: [{ type: "text", text: "large result" }],
+      structuredContent: { text: "x".repeat(1024 * 1024) },
+    }
+
+    const tools = yield* resolve(dir)
+    const tool = tools.mcp_lookup
+    if (!tool) return yield* Effect.die(new Error("expected MCP lookup tool"))
+    const output = (yield* call(tool)) as Record<string, Record<string, unknown> | unknown>
+
+    expect(output.output).toBe("large result")
+    expect(output.structuredContent).toBeUndefined()
+    expect(output.metadata).toMatchObject({
+      structuredContentOmitted: { reason: "size", maxBytes: 1024 * 1024 },
+      truncated: false,
+    })
+  }),
+)

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, beforeEach } from "bun:test"
+import type { ToolExecutionOptions } from "ai" // kilocode_change
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
@@ -18,6 +19,8 @@ interface MockClientState {
   listResourcesShouldFail: boolean
   prompts: Array<{ name: string; description?: string }>
   resources: Array<{ name: string; uri: string; description?: string }>
+  callToolCalls: Array<{ request: { name: string; arguments?: Record<string, unknown> } }> // kilocode_change
+  callToolResult: Record<string, unknown> & { content: Array<Record<string, unknown>> } // kilocode_change
   closed: boolean
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -46,6 +49,8 @@ function getOrCreateClientState(name?: string): MockClientState {
       listResourcesShouldFail: false,
       prompts: [],
       resources: [],
+      callToolCalls: [], // kilocode_change
+      callToolResult: { content: [{ type: "text", text: "ok" }] }, // kilocode_change
       closed: false,
       notificationHandlers: new Map(),
     }
@@ -143,9 +148,18 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return { tools: this._state?.tools ?? [] }
     }
 
-    async request(request: { method: string }, schema: { parse: (value: unknown) => unknown }) {
+    async request(
+      request: { method: string; params?: { name: string; arguments?: Record<string, unknown> } },
+      schema: { parse: (value: unknown) => unknown },
+    ) {
       if (this._state) this._state.requestCalls++
       if (request.method === "tools/list") return schema.parse({ tools: this._state?.tools ?? [] })
+      // kilocode_change start
+      if (request.method === "tools/call" && request.params) {
+        this._state.callToolCalls.push({ request: request.params })
+        return schema.parse(this._state.callToolResult)
+      }
+      // kilocode_change end
       throw new Error(`unsupported request: ${request.method}`)
     }
 
@@ -199,6 +213,24 @@ function statusName(status: Record<string, MCPNS.Status> | MCPNS.Status, server:
   if ("status" in status) return status.status
   return status[server]?.status
 }
+
+// kilocode_change start
+function options(): ToolExecutionOptions {
+  return {
+    toolCallId: "call_mcp",
+    messages: [],
+    abortSignal: new AbortController().signal,
+  }
+}
+
+function execute(tool: { execute?: (input: unknown, options: ToolExecutionOptions) => unknown }, input: unknown) {
+  if (!tool.execute) return Effect.die(new Error("expected MCP tool execute callback"))
+  return Effect.tryPromise({
+    try: () => Promise.resolve(tool.execute?.(input, options())),
+    catch: (error) => (error instanceof Error ? error : new Error(String(error))),
+  })
+}
+// kilocode_change end
 
 // kilocode_change start
 it.instance(
@@ -519,6 +551,12 @@ it.instance(
             outputSchema: { type: "object", properties: { screen: { $ref: "#/$defs/ScreenInstance" } } },
           },
         ]
+        // kilocode_change start
+        serverState.callToolResult = {
+          content: [{ type: "text", text: "screen rendered" }],
+          structuredContent: { screen: { id: "screen_1" } },
+        }
+        // kilocode_change end
 
         const addResult = yield* mcp.add("stitch-like-server", {
           type: "local",
@@ -531,10 +569,113 @@ it.instance(
         expect(Object.keys(tools).some((key) => key.includes("render_screen"))).toBe(true)
         expect(serverState.listToolsCalls).toBe(1)
         expect(serverState.requestCalls).toBe(1)
+        // kilocode_change start
+        const tool = Object.entries(tools).find(([key]) => key.includes("render_screen"))?.[1]
+        if (!tool) return yield* Effect.die(new Error("expected fallback MCP tool"))
+        expect((tool as { outputSchema?: unknown }).outputSchema).toBeUndefined()
+        const result = (yield* execute(tool, { prompt: "draw" })) as { structuredContent?: unknown; _meta?: unknown }
+        expect(result.structuredContent).toBeUndefined()
+        expect(result._meta).toMatchObject({ structuredContentSchema: { valid: false, reason: "compile" } })
+        // kilocode_change end
       }),
     ),
   { config: { mcp: {} } },
 )
+
+// kilocode_change start
+it.instance(
+  "validates structured tool results without exposing a mismatched output schema",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "schema-server"
+        const serverState = getOrCreateClientState("schema-server")
+        serverState.tools = [
+          {
+            name: "tool.name",
+            description: "schema tool",
+            inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+            outputSchema: {
+              type: "object",
+              properties: { answer: { type: "string" } },
+              required: ["answer"],
+              additionalProperties: false,
+            },
+          },
+        ]
+        serverState.callToolResult = {
+          content: [{ type: "text", text: "ok" }],
+          structuredContent: { answer: "sunny" },
+        }
+
+        yield* mcp.add("schema-server", { type: "local", command: ["echo", "test"] })
+
+        const tools = yield* mcp.tools()
+        const tool = Object.entries(tools).find(([key]) => key.includes("tool_name"))?.[1]
+        if (!tool) return yield* Effect.die(new Error("expected schema MCP tool"))
+
+        expect((tool as { outputSchema?: unknown }).outputSchema).toBeUndefined()
+        const result = (yield* execute(tool, { query: "weather" })) as { structuredContent?: unknown }
+
+        expect(result.structuredContent).toEqual({ answer: "sunny" })
+        expect(serverState.callToolCalls[0]?.request.name).toBe("tool.name")
+        expect(serverState.callToolCalls[0]?.request.arguments).toEqual({ query: "weather" })
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "rejects missing or invalid structured content for valid MCP output schemas",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "reject-server"
+        const serverState = getOrCreateClientState("reject-server")
+        serverState.tools = [
+          {
+            name: "lookup",
+            inputSchema: { type: "object", properties: {} },
+            outputSchema: {
+              type: "object",
+              properties: { answer: { type: "string" } },
+              required: ["answer"],
+              additionalProperties: false,
+            },
+          },
+        ]
+
+        yield* mcp.add("reject-server", { type: "local", command: ["echo", "test"] })
+
+        const tools = yield* mcp.tools()
+        const tool = Object.entries(tools).find(([key]) => key.includes("lookup"))?.[1]
+        if (!tool) return yield* Effect.die(new Error("expected reject MCP tool"))
+
+        serverState.callToolResult = { content: [{ type: "text", text: "{}" }] }
+        const missing = yield* execute(tool, {}).pipe(Effect.exit)
+
+        serverState.callToolResult = {
+          content: [{ type: "text", text: "bad" }],
+          structuredContent: { answer: 123 },
+        }
+        const invalid = yield* execute(tool, {}).pipe(Effect.exit)
+
+        serverState.callToolResult = {
+          content: [{ type: "text", text: "error" }],
+          structuredContent: { answer: 123 },
+          isError: true,
+        }
+        const error = (yield* execute(tool, {})) as { structuredContent?: unknown; isError?: boolean }
+
+        expect(Exit.isFailure(missing)).toBe(true)
+        expect(Exit.isFailure(invalid)).toBe(true)
+        expect(error.isError).toBe(true)
+        expect(error.structuredContent).toBeUndefined()
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+// kilocode_change end
 
 it.instance(
   "does not fall back for non-schema MCP tool discovery errors",

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -336,6 +336,49 @@ function seedMessage(directory: string, sessionID: string) {
   )
 }
 
+// kilocode_change start
+function seedToolMessage(directory: string, sessionID: string) {
+  const id = SessionID.make(sessionID)
+  return InstanceStore.Service.use((store) =>
+    store.provide(
+      { directory },
+      SessionNs.Service.use((svc) =>
+        Effect.gen(function* () {
+          const message = yield* svc.updateMessage({
+            id: MessageID.ascending(),
+            sessionID: id,
+            role: "assistant",
+            parentID: MessageID.ascending(),
+            mode: "build",
+            agent: "test",
+            path: { cwd: directory, root: directory },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: ModelID.make("test"),
+            providerID: ProviderID.make("test"),
+            time: { created: Date.now() },
+          } satisfies MessageV2.Assistant)
+          const part = yield* svc.updatePart({
+            id: PartID.ascending(),
+            sessionID: id,
+            messageID: message.id,
+            type: "tool",
+            callID: "call_seeded",
+            tool: "lookup",
+            state: {
+              status: "running",
+              input: { query: "weather" },
+              time: { start: Date.now() },
+            },
+          } satisfies MessageV2.ToolPart)
+          return { message, part }
+        }),
+      ).pipe(Effect.provide(SessionNs.defaultLayer)),
+    ),
+  )
+}
+// kilocode_change end
+
 afterEach(async () => {
   Flag.KILO_SERVER_PASSWORD = original.KILO_SERVER_PASSWORD
   Flag.KILO_SERVER_USERNAME = original.KILO_SERVER_USERNAME
@@ -714,6 +757,80 @@ describe("HttpApi SDK", () => {
       }),
     ),
   )
+
+  // kilocode_change start
+  serverPathParity("streams completed tool structuredContent to /event subscribers", (serverPath) =>
+    withStandardProject(serverPath, ({ sdk, directory }) =>
+      Effect.gen(function* () {
+        const session = yield* capture(() => sdk.session.create({ title: "structured tool part event" }))
+        const sessionID = String(record(session.data).id)
+        const seeded = yield* seedToolMessage(directory, sessionID)
+
+        const controller = new AbortController()
+        yield* Effect.addFinalizer(() => Effect.sync(() => controller.abort()))
+        const events = yield* call(() => sdk.event.subscribe(undefined, { signal: controller.signal }))
+        yield* Effect.addFinalizer(() =>
+          call(async () => void (await events.stream.return?.(undefined))).pipe(Effect.ignore),
+        )
+
+        const ready = yield* Deferred.make<void>()
+        const received = yield* Deferred.make<unknown>()
+
+        yield* call(async () => {
+          for await (const event of events.stream) {
+            const payload = record(event).payload ?? event
+            const type = record(payload).type
+            if (type === "server.connected") {
+              Deferred.doneUnsafe(ready, Effect.void)
+              continue
+            }
+            if (type === MessageV2.Event.PartUpdated.type) {
+              Deferred.doneUnsafe(received, Effect.succeed(payload))
+              return
+            }
+          }
+        }).pipe(Effect.forkScoped)
+
+        yield* awaitWithTimeout(Deferred.await(ready), "timed out waiting for /event server.connected", "2 seconds")
+
+        const start = seeded.part.state.status === "running" ? seeded.part.state.time.start : Date.now()
+        const updated = yield* capture(() =>
+          sdk.part.update({
+            sessionID,
+            messageID: seeded.message.id,
+            partID: seeded.part.id,
+            part: {
+              ...seeded.part,
+              state: {
+                status: "completed",
+                input: { query: "weather" },
+                output: "result:weather",
+                title: "Weather lookup",
+                metadata: { source: "test" },
+                time: { start, end: Date.now() },
+                structuredContent: { forecast: "sunny" },
+              },
+            } as NonNullable<Parameters<Sdk["part"]["update"]>[0]["part"]>,
+          }),
+        )
+        expect(updated.status).toBe(200)
+
+        const event = yield* awaitWithTimeout(
+          Deferred.await(received),
+          "timed out waiting for structured message.part.updated bus payload over /event",
+          "5 seconds",
+        )
+        const properties = record(record(event).properties)
+        const part = record(properties.part)
+        const state = record(part.state)
+
+        expect(part).toMatchObject({ id: seeded.part.id, type: "tool" })
+        expect(state.structuredContent).toEqual({ forecast: "sunny" })
+        return { type: record(event).type, structuredContent: state.structuredContent }
+      }),
+    ),
+  )
+  // kilocode_change end
 
   serverPathParity("matches generated SDK prompt no-reply routes", (serverPath) =>
     withStandardProject(serverPath, ({ sdk }) =>

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -262,6 +262,7 @@ export type ToolStateCompleted = {
     [key: string]: unknown
   }
   output: string
+  structuredContent?: unknown
   title: string
   metadata: {
     [key: string]: unknown

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -7282,6 +7282,7 @@ export class SessionImport extends HeyApiClient {
                     [key: string]: unknown
                   }
                   output: string
+                  structuredContent?: unknown
                   title: string
                   metadata: {
                     [key: string]: unknown

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -702,6 +702,7 @@ export type ToolStateCompleted = {
     [key: string]: unknown
   }
   output: string
+  structuredContent?: unknown
   title: string
   metadata: {
     [key: string]: unknown
@@ -11063,6 +11064,7 @@ export type KilocodeSessionImportPartData = {
                   [key: string]: unknown
                 }
                 output: string
+                structuredContent?: unknown
                 title: string
                 metadata: {
                   [key: string]: unknown

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -5713,6 +5713,9 @@
                     "required": ["id", "providerID"],
                     "additionalProperties": false
                   },
+                  "metadata": {
+                    "type": "object"
+                  },
                   "permission": {
                     "$ref": "#/components/schemas/PermissionRuleset"
                   },
@@ -6039,6 +6042,9 @@
                 "properties": {
                   "title": {
                     "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object"
                   },
                   "permission": {
                     "$ref": "#/components/schemas/PermissionRuleset"
@@ -10708,11 +10714,14 @@
             }
           },
           "400": {
-            "description": "BadRequest | InvalidRequestError",
+            "description": "WorkspaceCreateError | BadRequest | InvalidRequestError",
             "content": {
               "application/json": {
                 "schema": {
                   "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/WorkspaceCreateError"
+                    },
                     {
                       "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
                     },
@@ -16093,6 +16102,7 @@
                                   "output": {
                                     "type": "string"
                                   },
+                                  "structuredContent": {},
                                   "title": {
                                     "type": "string"
                                   },
@@ -16589,20 +16599,32 @@
             "required": true
           },
           {
-            "name": "directory",
             "in": "query",
+            "name": "directory",
             "schema": {
               "type": "string"
-            },
-            "required": false
+            }
           },
           {
-            "name": "workspace",
             "in": "query",
+            "name": "workspace",
             "schema": {
               "type": "string"
-            },
-            "required": false
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ticket",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -16919,6 +16941,9 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
+          },
+          {
+            "$ref": "#/components/schemas/EventPluginAdded"
           },
           {
             "$ref": "#/components/schemas/EventCatalogModelUpdated"
@@ -18058,7 +18083,7 @@
           },
           "pid": {
             "type": "integer",
-            "exclusiveMinimum": 0
+            "minimum": 0
           },
           "sessionID": {
             "anyOf": [
@@ -18745,6 +18770,7 @@
           "output": {
             "type": "string"
           },
+          "structuredContent": {},
           "title": {
             "type": "string"
           },
@@ -19347,6 +19373,9 @@
           "version": {
             "type": "string"
           },
+          "metadata": {
+            "type": "object"
+          },
           "time": {
             "type": "object",
             "properties": {
@@ -19705,6 +19734,9 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
+              },
+              {
+                "$ref": "#/components/schemas/EventPluginAdded"
               },
               {
                 "$ref": "#/components/schemas/EventCatalogModelUpdated"
@@ -20380,7 +20412,20 @@
                     "enum": [false]
                   }
                 ],
-                "description": "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout."
+                "description": "Timeout in milliseconds for full requests to this provider. Set to false to disable timeout."
+              },
+              "headerTimeout": {
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  {
+                    "type": "boolean",
+                    "enum": [false]
+                  }
+                ],
+                "description": "Timeout in milliseconds to wait for response headers. Provider integrations may set defaults. Set to false to disable timeout."
               },
               "chunkTimeout": {
                 "type": "integer",
@@ -20529,7 +20574,6 @@
                       }
                     }
                   },
-                  "required": ["input", "output"],
                   "additionalProperties": false
                 },
                 "experimental": {
@@ -21220,16 +21264,20 @@
                 "type": "boolean"
               },
               "sandbox": {
-                "type": "boolean",
-                "description": "Run agent tools inside a sandbox that restricts writes to project and Kilo state directories and can restrict outbound network access"
+                "type": "boolean"
               },
               "sandbox_restrict_network": {
-                "type": "boolean",
-                "description": "Restrict outbound network access for model-originated commands and first-party HTTP tools; local MCP servers and plugin hooks are not covered (default: true)"
+                "type": "boolean"
               },
               "mcp_timeout": {
                 "type": "integer",
                 "exclusiveMinimum": 0
+              },
+              "policies": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ConfigV2ExperimentalPolicy"
+                }
               }
             },
             "additionalProperties": false
@@ -21904,6 +21952,9 @@
           },
           "version": {
             "type": "string"
+          },
+          "metadata": {
+            "type": "object"
           },
           "time": {
             "type": "object",
@@ -23254,6 +23305,27 @@
         "required": ["id", "type", "name", "projectID", "timeUsed"],
         "additionalProperties": false
       },
+      "WorkspaceCreateError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["WorkspaceCreateError"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": ["message"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "data"],
+        "additionalProperties": false
+      },
       "WorkspaceWarpError": {
         "type": "object",
         "properties": {
@@ -24338,6 +24410,16 @@
                       }
                     ]
                   },
+                  "metadata": {
+                    "anyOf": [
+                      {
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "time": {
                     "type": "object",
                     "properties": {
@@ -24561,7 +24643,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["id", "providerID", "variant"],
+                "required": ["id", "providerID"],
                 "additionalProperties": false
               }
             },
@@ -24793,7 +24875,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["id", "providerID", "variant"],
+                "required": ["id", "providerID"],
                 "additionalProperties": false
               },
               "snapshot": {
@@ -27394,7 +27476,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["id", "providerID", "variant"],
+                "required": ["id", "providerID"],
                 "additionalProperties": false
               }
             },
@@ -27657,7 +27739,7 @@
                     "type": "string"
                   }
                 },
-                "required": ["id", "providerID", "variant"],
+                "required": ["id", "providerID"],
                 "additionalProperties": false
               },
               "snapshot": {
@@ -28473,6 +28555,30 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventPluginAdded": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["plugin.added"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": ["id"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "ModelV2Info": {
         "type": "object",
         "properties": {
@@ -28990,6 +29096,27 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "PolicyEffect": {
+        "type": "string",
+        "enum": ["allow", "deny"]
+      },
+      "ConfigV2ExperimentalPolicy": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["provider.use"]
+          },
+          "effect": {
+            "$ref": "#/components/schemas/PolicyEffect"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "required": ["action", "effect", "resource"],
+        "additionalProperties": false
+      },
       "SessionInfo": {
         "type": "object",
         "properties": {
@@ -29027,7 +29154,7 @@
                 "type": "string"
               }
             },
-            "required": ["id", "providerID", "variant"],
+            "required": ["id", "providerID"],
             "additionalProperties": false
           },
           "cost": {
@@ -29155,7 +29282,7 @@
                 "type": "string"
               }
             },
-            "required": ["id", "providerID", "variant"],
+            "required": ["id", "providerID"],
             "additionalProperties": false
           }
         },
@@ -29534,7 +29661,7 @@
                 "type": "string"
               }
             },
-            "required": ["id", "providerID", "variant"],
+            "required": ["id", "providerID"],
             "additionalProperties": false
           },
           "content": {


### PR DESCRIPTION
## Why

Some tool results had data meant for apps to read, but Kilo only kept the text version. This made it hard for clients to show those results safely.

## What changed

Kilo now checks structured tool results before saving them. If the data is missing or wrong, the tool result is rejected instead of storing unsafe data. Error results and invalid schemas fall back to text only. Saved tool parts and SDK events now carry the checked structured data when it is safe.

## How to test

1. From `packages/opencode`, run `bun run typecheck`.
2. From `packages/opencode`, run `bun test ./test/kilocode/mcp-structured-content.test.ts ./test/mcp/lifecycle.test.ts ./test/kilocode/session-tools-mcp-structured-content.test.ts ./test/kilocode/session-processor-structured-content.test.ts ./test/kilocode/server/httpapi-public.test.ts ./test/server/httpapi-sdk.test.ts`.
3. From `packages/sdk/js`, run `bun run typecheck`.