### PR TITLE
chore(jetbrains): use IPGP snapshot

### DIFF
--- a/packages/kilo-jetbrains/gradle/libs.versions.toml
+++ b/packages/kilo-jetbrains/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 intellij-platform = "2026.1"
-intellij-gradle-plugin = "2.16.0"
+intellij-gradle-plugin = "2.16.1-SNAPSHOT"
 intellij-rpc-plugin = "2.3.20-RC2-0.1"
 kotlin-jvm-plugin = "2.3.20"
 kotlin-serialization-plugin = "2.3.20"

--- a/packages/kilo-jetbrains/gradle/libs.versions.toml
+++ b/packages/kilo-jetbrains/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 intellij-platform = "2026.1"
-intellij-gradle-plugin = "2.16.1-SNAPSHOT"
+intellij-gradle-plugin = "2.16.1-20260623.221413-11"
 intellij-rpc-plugin = "2.3.20-RC2-0.1"
 kotlin-jvm-plugin = "2.3.20"
 kotlin-serialization-plugin = "2.3.20"

--- a/packages/kilo-jetbrains/settings.gradle.kts
+++ b/packages/kilo-jetbrains/settings.gradle.kts
@@ -7,6 +7,7 @@ include("backend")
 pluginManagement {
     includeBuild("build-tasks")
     repositories {
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
         mavenCentral()
         gradlePluginPortal()
         maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/")

--- a/packages/kilo-jetbrains/settings.gradle.kts
+++ b/packages/kilo-jetbrains/settings.gradle.kts
@@ -6,8 +6,19 @@ include("backend")
 
 pluginManagement {
     includeBuild("build-tasks")
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "org.jetbrains.intellij.platform") {
+                useModule("org.jetbrains.intellij.platform:intellij-platform-gradle-plugin:${requested.version}")
+            }
+        }
+    }
     repositories {
-        maven("https://central.sonatype.com/repository/maven-snapshots/")
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            content {
+                includeGroup("org.jetbrains.intellij.platform")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
         maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies/")


### PR DESCRIPTION
## What
- Use the public IntelliJ Platform Gradle Plugin 2.16.1-SNAPSHOT for the JetBrains plugin build.
- Add the Sonatype Central snapshots repository to plugin resolution.

## Why
- The upstream IPGP split-mode improvements from JetBrains/intellij-platform-gradle-plugin#2164 are now available in the published snapshot, and we need them before the next stable IPGP release.

## Verification
- ./gradlew buildEnvironment --refresh-dependencies from packages/kilo-jetbrains confirmed org.jetbrains.intellij.platform:intellij-platform-gradle-plugin:2.16.1-SNAPSHOT.
- ./gradlew --refresh-dependencies tasks --all from packages/kilo-jetbrains succeeded and showed runIdeSplitMode.
- bun turbo typecheck passed during push.