### PR TITLE
fix(cli): select apply_patch from model family

### DIFF
--- a/.changeset/use-gpt-family-patching.md
+++ b/.changeset/use-gpt-family-patching.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use model family metadata when selecting the apply_patch tool for GPT models.

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -33,6 +33,17 @@ export namespace KiloToolRegistry {
     return config.indexing?.enabled ?? global?.indexing?.enabled
   }
 
+  export function usePatch(input: { modelID: string; family?: string }) {
+    if (process.env["KILO_E2E_LLM_URL"]) return true
+
+    const id = input.modelID.toLowerCase()
+    const family = input.family?.toLowerCase()
+    if (id.includes("gpt-4") || family?.startsWith("gpt-4")) return false
+    if (id.includes("oss") || family?.includes("oss") || family === "gpt-image") return false
+    if (id.includes("gpt-")) return true
+    return family?.startsWith("gpt") ?? false
+  }
+
   /** Resolve Kilo-specific tool Infos outside any InstanceState, so their Truncate/Agent deps are
    * satisfied at the outer registry scope instead of leaking into InstanceState's Effect. */
   export function infos(notebook?: Notebook.Interface) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -5,6 +5,8 @@ import { EffectBridge } from "@/effect/bridge" // kilocode_change
 import { InstanceState } from "@/effect/instance-state"
 import { MCP } from "@/mcp"
 import { Project } from "@/project/project"
+import { Provider } from "@/provider/provider" // kilocode_change
+import { ModelID } from "@/provider/schema" // kilocode_change
 import { Session } from "@/session/session"
 import { ToolJsonSchema } from "@/tool/json-schema"
 import { ToolRegistry } from "@/tool/registry"
@@ -41,6 +43,7 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
     const config = yield* Config.Service
     const mcp = yield* MCP.Service
     const project = yield* Project.Service
+    const provider = yield* Provider.Service // kilocode_change
     const registry = yield* ToolRegistry.Service
     const worktreeSvc = yield* Worktree.Service
 
@@ -96,9 +99,14 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
     })
 
     const tool = Effect.fn("ExperimentalHttpApi.tool")(function* (ctx: { query: typeof ToolListQuery.Type }) {
+      // kilocode_change start
+      const found = yield* provider.getModel(ctx.query.provider, ctx.query.model).pipe(Effect.option)
+      const model = Option.getOrUndefined(found)
+      // kilocode_change end
       const list = yield* registry.tools({
         providerID: ctx.query.provider,
-        modelID: ctx.query.model,
+        modelID: model ? ModelID.make(model.api.id) : ctx.query.model, // kilocode_change
+        family: model?.family, // kilocode_change
         agent: yield* agents.defaultInfo(),
       })
       return list.map((item) => ({

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -74,6 +74,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   for (const item of yield* registry.tools({
     modelID: ModelID.make(input.model.api.id),
     providerID: input.model.providerID,
+    family: input.model.family, // kilocode_change
     agent: input.agent,
   })) {
     const schema = ProviderTransform.schema(input.model, ToolJsonSchema.fromTool(item))

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -86,7 +86,14 @@ export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
   readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef }>
-  readonly tools: (model: { providerID: ProviderID; modelID: ModelID; agent: Agent.Info }) => Effect.Effect<Tool.Def[]>
+  // kilocode_change start
+  readonly tools: (model: {
+    providerID: ProviderID
+    modelID: ModelID
+    family?: string
+    agent: Agent.Info
+  }) => Effect.Effect<Tool.Def[]>
+  // kilocode_change end
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ToolRegistry") {}
@@ -361,11 +368,7 @@ export const layer: Layer.Layer<
           return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
         }
 
-        const usePatch =
-          // kilocode_change start
-          !!process.env["KILO_E2E_LLM_URL"] ||
-          (input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4"))
-        // kilocode_change end
+        const usePatch = KiloToolRegistry.usePatch(input) // kilocode_change
         if (tool.id === ApplyPatchTool.id) return usePatch
         if (tool.id === EditTool.id) return !usePatch // kilocode_change
 

--- a/packages/opencode/test/kilocode/server/httpapi-experimental.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-experimental.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { Session } from "../../../src/session/session"
+import { Server } from "../../../src/server/server"
+import { ExperimentalPaths } from "../../../src/server/routes/instance/httpapi/groups/experimental"
+import { disposeAllInstances, TestInstance } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+void Log.init({ print: false })
+
+const it = testEffect(Layer.mergeAll(Session.defaultLayer))
+
+function app() {
+  return Server.Default().app
+}
+
+function request(path: string, directory: string, init: RequestInit = {}) {
+  return Effect.promise(() => {
+    const headers = new Headers(init.headers)
+    headers.set("x-kilo-directory", directory)
+    return Promise.resolve(app().request(path, { ...init, headers }))
+  })
+}
+
+function json<T>(response: Response) {
+  return Effect.promise(() => response.json() as Promise<T>)
+}
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+describe("Kilo experimental HttpApi", () => {
+  it.instance(
+    "uses model family metadata for experimental editing tools",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* TestInstance
+        const family = yield* request(
+          `${ExperimentalPaths.tool}?provider=test-provider&model=routed-model`,
+          tmp.directory,
+        )
+        const fallback = yield* request(`${ExperimentalPaths.tool}?provider=missing&model=unknown`, tmp.directory)
+
+        expect(family.status).toBe(200)
+        const familyIDs = (yield* json<Array<{ id: string }>>(family)).map((tool) => tool.id)
+        expect(familyIDs).toContain("apply_patch")
+        expect(familyIDs).not.toContain("edit")
+
+        expect(fallback.status).toBe(200)
+        const fallbackIDs = (yield* json<Array<{ id: string }>>(fallback)).map((tool) => tool.id)
+        expect(fallbackIDs).toContain("edit")
+      }),
+    {
+      config: {
+        formatter: false,
+        lsp: false,
+        provider: {
+          "test-provider": {
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            models: {
+              "routed-model": {
+                id: "opaque-api-model",
+                family: "gpt-codex",
+              },
+            },
+          },
+        },
+      },
+    },
+    30_000,
+  )
+})

--- a/packages/opencode/test/kilocode/tool-registry-apply-patch.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-apply-patch.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Agent } from "../../src/agent/agent"
+import { KiloToolRegistry } from "../../src/kilocode/tool/registry"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { ToolRegistry } from "../../src/tool/registry"
+import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const node = CrossSpawnSpawner.defaultLayer
+const it = testEffect(Layer.mergeAll(Agent.defaultLayer, ToolRegistry.defaultLayer, node))
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+describe("apply_patch model selection", () => {
+  test("recognizes supported GPT families", () => {
+    const cases = [
+      { modelID: "routed-model", family: "gpt", expected: true },
+      { modelID: "routed-model", family: "gpt-codex", expected: true },
+      { modelID: "routed-model", family: "gpt-mini", expected: true },
+      { modelID: "routed-model", family: "gpt-oss", expected: false },
+      { modelID: "routed-model", family: "gpt-image", expected: false },
+      { modelID: "routed-model", family: "claude", expected: false },
+      { modelID: "gpt-4.1", family: undefined, expected: false },
+      { modelID: "gpt-5.3-codex", family: undefined, expected: true },
+      { modelID: "gpt-image-1", family: "gpt-image", expected: false },
+      { modelID: "gpt-5-alias", family: "gpt-oss", expected: false },
+    ]
+
+    for (const item of cases) {
+      expect(KiloToolRegistry.usePatch(item)).toBe(item.expected)
+    }
+  })
+
+  it.live("uses family metadata when filtering editing tools", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const agents = yield* Agent.Service
+          const agent = yield* agents.get("build")
+          const registry = yield* ToolRegistry.Service
+          const tools = yield* registry.tools({
+            providerID: ProviderID.make("kilo"),
+            modelID: ModelID.make("routed-model"),
+            family: "gpt-codex",
+            agent,
+          })
+          const ids = tools.map((tool) => tool.id)
+
+          expect(ids).toContain("apply_patch")
+          expect(ids).not.toContain("edit")
+        }),
+      { git: true },
+    ),
+  )
+})

--- a/packages/opencode/test/server/httpapi-experimental.test.ts
+++ b/packages/opencode/test/server/httpapi-experimental.test.ts
@@ -191,51 +191,7 @@ describe("experimental HttpApi", () => {
         },
       },
     },
-    15_000, // kilocode_change
   )
-
-  // kilocode_change start
-  it.instance(
-    "uses model family metadata for experimental editing tools",
-    () =>
-      Effect.gen(function* () {
-        const tmp = yield* TestInstance
-        const family = yield* request(
-          `${ExperimentalPaths.tool}?provider=test-provider&model=routed-model`,
-          tmp.directory,
-        )
-        const fallback = yield* request(`${ExperimentalPaths.tool}?provider=missing&model=unknown`, tmp.directory)
-
-        expect(family.status).toBe(200)
-        const familyIDs = (yield* json<Array<{ id: string }>>(family)).map((tool) => tool.id)
-        expect(familyIDs).toContain("apply_patch")
-        expect(familyIDs).not.toContain("edit")
-
-        expect(fallback.status).toBe(200)
-        const fallbackIDs = (yield* json<Array<{ id: string }>>(fallback)).map((tool) => tool.id)
-        expect(fallbackIDs).toContain("edit")
-      }),
-    {
-      config: {
-        formatter: false,
-        lsp: false,
-        provider: {
-          "test-provider": {
-            npm: "@ai-sdk/openai-compatible",
-            env: [],
-            models: {
-              "routed-model": {
-                id: "opaque-api-model",
-                family: "gpt-codex",
-              },
-            },
-          },
-        },
-      },
-    },
-    30_000,
-  )
-  // kilocode_change end
 
   it.instance("returns declared worktree errors", () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/server/httpapi-experimental.test.ts
+++ b/packages/opencode/test/server/httpapi-experimental.test.ts
@@ -191,7 +191,51 @@ describe("experimental HttpApi", () => {
         },
       },
     },
+    15_000, // kilocode_change
   )
+
+  // kilocode_change start
+  it.instance(
+    "uses model family metadata for experimental editing tools",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* TestInstance
+        const family = yield* request(
+          `${ExperimentalPaths.tool}?provider=test-provider&model=routed-model`,
+          tmp.directory,
+        )
+        const fallback = yield* request(`${ExperimentalPaths.tool}?provider=missing&model=unknown`, tmp.directory)
+
+        expect(family.status).toBe(200)
+        const familyIDs = (yield* json<Array<{ id: string }>>(family)).map((tool) => tool.id)
+        expect(familyIDs).toContain("apply_patch")
+        expect(familyIDs).not.toContain("edit")
+
+        expect(fallback.status).toBe(200)
+        const fallbackIDs = (yield* json<Array<{ id: string }>>(fallback)).map((tool) => tool.id)
+        expect(fallbackIDs).toContain("edit")
+      }),
+    {
+      config: {
+        formatter: false,
+        lsp: false,
+        provider: {
+          "test-provider": {
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            models: {
+              "routed-model": {
+                id: "opaque-api-model",
+                family: "gpt-codex",
+              },
+            },
+          },
+        },
+      },
+    },
+    30_000,
+  )
+  // kilocode_change end
 
   it.instance("returns declared worktree errors", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Use the model family supplied by provider metadata when deciding whether GPT models receive `apply_patch` instead of `edit`.

Gateway-routed models can have opaque API IDs, so the previous ID-only heuristic missed GPT and Codex models even though their family identified them correctly. The existing ID fallback remains in place, while GPT-4, OSS, and image families stay excluded.