### PR TITLE
chore: show german translation diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,8 @@ packages/kilo-ui/tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 packages/kilo-vscode/tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 packages/kilo-docs/public/img/screenshot-tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 
-# Hide localization files except English and German by default in GitHub PR diffs.
+# Hide most localization files by default in GitHub PR diffs. Show English as the source
+# language and German so reviewers can catch untranslated copy-pasted English strings.
 **/i18n/*.ts linguist-generated=true
 **/i18n/en.ts linguist-generated=false
 **/i18n/en*.ts linguist-generated=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,15 +10,19 @@ packages/kilo-ui/tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 packages/kilo-vscode/tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 packages/kilo-docs/public/img/screenshot-tests/**/*.png filter=lfs diff=lfs merge=lfs -text
 
-# Hide non-English localization files by default in GitHub PR diffs.
+# Hide localization files except English and German by default in GitHub PR diffs.
 **/i18n/*.ts linguist-generated=true
 **/i18n/en.ts linguist-generated=false
 **/i18n/en*.ts linguist-generated=false
+**/i18n/de.ts linguist-generated=false
+**/i18n/de*.ts linguist-generated=false
 **/i18n/package-nls-en.ts linguist-generated=false
+**/i18n/package-nls-de.ts linguist-generated=false
 **/i18n/index.ts linguist-generated=false
 **/i18n/parity.test.ts linguist-generated=false
 packages/kilo-i18n/src/*.ts linguist-generated=true
 packages/kilo-i18n/src/en.ts linguist-generated=false
+packages/kilo-i18n/src/de.ts linguist-generated=false
 
 # Auto-generated CLI reference docs
 packages/kilo-docs/markdoc/partials/cli-commands-table.md linguist-generated=true


### PR DESCRIPTION
Shows German translation files in GitHub PR diffs alongside English, while keeping other localization files hidden by default.