### PR TITLE
fix: skip unrelated JetBrains pre-push checks

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -17,4 +17,34 @@ if (process.versions.bun !== expectedBunVersion) {
   console.warn(`Warning: Bun version ${process.versions.bun} differs from expected ${expectedBunVersion}`);
 }
 '
-bun typecheck
+
+# kilocode_change start
+jetbrains=0
+zero=0000000000000000000000000000000000000000
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+  if [ "$local_oid" = "$zero" ]; then
+    continue
+  fi
+
+  base="$remote_oid"
+  if [ "$remote_oid" = "$zero" ]; then
+    base=$(git merge-base "$local_oid" "$1/main" 2>/dev/null || git hash-object -t tree /dev/null)
+  fi
+
+  if ! git diff --quiet "$base" "$local_oid" -- . \
+    ':(exclude).changeset/**' \
+    ':(exclude)packages/kilo-vscode/**' \
+    ':(exclude)packages/kilo-docs/**'; then
+    jetbrains=1
+  fi
+done
+
+bun typecheck --filter='!@kilocode/kilo-jetbrains'
+
+if [ "$jetbrains" -eq 1 ]; then
+  bun typecheck --filter='@kilocode/kilo-jetbrains'
+else
+  echo "Skipping JetBrains typecheck (no relevant changes)"
+fi
+# kilocode_change end

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -210,7 +210,7 @@ Agent limitations, local resource constraints, OOM constraints, or an agent prom
 
 ## Git Hooks
 
-This project uses [Husky](https://typicode.github.io/husky/) to manage Git hooks. The current pre-push hook checks the Bun version against root `package.json` and runs the repo-level typecheck.
+This project uses [Husky](https://typicode.github.io/husky/) to manage Git hooks. The current pre-push hook checks the Bun version against root `package.json` and runs the repo-level typecheck. The JetBrains typecheck runs only when the pushed changes can affect the JetBrains plugin, so VS Code-only, docs-only, and changeset-only pushes do not require Java.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- split the pre-push typecheck so the Java-backed JetBrains task runs only for changes that can affect the plugin
- mirror the CI relevance exclusions for VS Code, docs, and changeset-only pushes
- document when contributors need Java for the hook

This keeps the normal repository typecheck in place while avoiding an unnecessary Java requirement for contributors working exclusively on unrelated areas.