### PR TITLE
test(jetbrains): stabilize workspace reload lifecycle

### DIFF
--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
@@ -221,6 +221,7 @@ class MockCliServer : AutoCloseable {
         if (!closed.compareAndSet(false, true)) return
         shutdownServer()
         executor.shutdownNow()
+        check(executor.awaitTermination(5, TimeUnit.SECONDS)) { "Mock CLI executor did not terminate" }
     }
 
     private fun shutdownServer() {

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
@@ -157,9 +157,7 @@ class MockCliServer : AutoCloseable {
     /** Reset all request counters. */
     fun resetCounts() { counts.clear() }
 
-    private val executor = Executors.newCachedThreadPool { r ->
-        Thread(r, "mock-cli-${Thread.currentThread().id}").apply { isDaemon = true }
-    }
+    private val executor = Executors.newVirtualThreadPerTaskExecutor()
     private val closed = AtomicBoolean(false)
 
     private var server: ServerSocket? = null

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
@@ -157,7 +157,9 @@ class MockCliServer : AutoCloseable {
     /** Reset all request counters. */
     fun resetCounts() { counts.clear() }
 
-    private val executor = Executors.newVirtualThreadPerTaskExecutor()
+    private val executor = Executors.newThreadPerTaskExecutor(
+        Thread.ofVirtual().name("mock-cli-", 0).factory(),
+    )
     private val closed = AtomicBoolean(false)
 
     private var server: ServerSocket? = null

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspaceTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspaceTest.kt
@@ -42,12 +42,14 @@ class KiloBackendWorkspaceTest {
     private val apps = mutableListOf<KiloBackendAppService>()
 
     @AfterTest
-    fun tearDown() = runBlocking {
-        apps.forEach { it.dispose() }
-        apps.clear()
-        scope.cancel()
-        mock.close()
-        withTimeout(10_000) { scope.coroutineContext[Job]?.join() }
+    fun tearDown() {
+        runBlocking {
+            apps.forEach { it.dispose() }
+            apps.clear()
+            scope.cancel()
+            mock.close()
+            withTimeout(10_000) { scope.coroutineContext[Job]?.join() }
+        }
     }
 
     private fun setup(): KiloBackendAppService =

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspaceTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/workspace/KiloBackendWorkspaceTest.kt
@@ -12,13 +12,16 @@ import ai.kilocode.backend.testing.MockCliServer
 import ai.kilocode.backend.testing.TestLog
 import ai.kilocode.jetbrains.api.client.DefaultApi
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -39,11 +42,12 @@ class KiloBackendWorkspaceTest {
     private val apps = mutableListOf<KiloBackendAppService>()
 
     @AfterTest
-    fun tearDown() {
+    fun tearDown() = runBlocking {
         apps.forEach { it.dispose() }
         apps.clear()
         scope.cancel()
         mock.close()
+        withTimeout(10_000) { scope.coroutineContext[Job]?.join() }
     }
 
     private fun setup(): KiloBackendAppService =
@@ -458,7 +462,7 @@ class KiloBackendWorkspaceTest {
         mock.skills = SKILLS_JSON
 
         val app = setup()
-        ready(app)
+        val initial = ready(app)
 
         // Change providers response then fire disposed event
         mock.providers = """{
@@ -474,26 +478,16 @@ class KiloBackendWorkspaceTest {
             "connected": ["openai"]
         }"""
 
-        mock.awaitSseConnection()
-        mock.pushEvent("global.disposed", """{"type":"global.disposed"}""")
-
-        // global.disposed triggers full app reload which restarts the
-        // workspace manager (stop + start), clearing all cached workspaces.
-        // Wait for app to reach Ready again after reload.
-        withTimeout(15_000) {
-            // App may briefly leave Ready during reload
-            while (true) {
-                val state = app.appState.value
-                if (state is KiloAppState.Ready) {
-                    delay(300)
-                    if (app.appState.value is KiloAppState.Ready) break
-                }
-                delay(100)
-            }
+        assertTrue(mock.awaitSseConnection())
+        val reload = async(start = CoroutineStart.UNDISPATCHED) {
+            app.appState.drop(1).first { it is KiloAppState.Ready }
         }
+        mock.pushEvent("global.disposed", """{"type":"global.disposed"}""")
+        withTimeout(15_000) { reload.await() }
 
         // Get a fresh workspace — old one was stopped during reload
         val ws = app.workspaces.get("/test/project")
+        assertTrue(ws !== initial)
         withTimeout(15_000) {
             ws.state.first { it is KiloWorkspaceState.Ready }
         }


### PR DESCRIPTION
## What changed

Make `KiloBackendWorkspaceTest` wait for its coroutine scope to finish during teardown and close the mock server before joining so blocked requests are released. The `global.disposed` test now subscribes before sending the SSE event, waits for the next `Ready` state instead of accepting the existing one after an arbitrary delay, and verifies that reload replaced the cached workspace.

## Why

The failed job timed out while setting up this test after the preceding concurrent-reload test. Teardown cancelled asynchronous work without joining it, allowing request and watcher jobs to outlive their test fixture. The disposed-event assertion also treated the pre-event `Ready` state as proof that reload finished. Causal event synchronization and complete fixture cleanup remove both races without extending normal test waits.

Investigated failure: https://github.com/Kilo-Org/kilocode/actions/runs/28236011741/job/83650998502?pr=11726