### PR TITLE
fix(cli): make global config change-detection baseline single-owned

### DIFF
--- a/.changeset/global-config-stamp-baseline.md
+++ b/.changeset/global-config-stamp-baseline.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Reliably detect global config edits made by other Kilo processes by making the change-detection baseline single-owned and seeded at startup.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -594,13 +594,17 @@ export const layer = Layer.effect(
       return yield* loadConfig(text, { path: filepath }, env)
     })
 
-    let globalStamp = "" // kilocode_change
+    // kilocode_change start - track the on-disk global config content so edits made by other
+    // Kilo processes are detected. `globalStamp` is the change-detection baseline owned solely by
+    // refreshGlobal; loadGlobal must not write it, otherwise a reload could silently absorb an
+    // external edit that landed between invalidation and the reload, and the next refresh would
+    // miss the change. Seeded eagerly below so the first refresh can detect a change.
+    let globalStamp = yield* KilocodeGlobalConfigStamp.read(fs, Global.Path.config)
+    // kilocode_change end
 
     const loadGlobal = Effect.fnUntraced(function* (env?: Record<string, string>) {
-      // kilocode_change start
+      // kilocode_change
       yield* Effect.promise(() => KilocodeConfig.migrateBashPermission())
-      globalStamp = yield* KilocodeGlobalConfigStamp.read(fs, Global.Path.config)
-      // kilocode_change end
       let result: Info = {}
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
       // explicitly routes config through env-provided paths or content.
@@ -636,7 +640,6 @@ export const layer = Layer.effect(
         )
       }
 
-      globalStamp = yield* KilocodeGlobalConfigStamp.read(fs, Global.Path.config) // kilocode_change
       return result
     })
 
@@ -650,10 +653,12 @@ export const layer = Layer.effect(
       Duration.infinity,
     )
 
-    // kilocode_change start - detect global config edits made by other Kilo processes
+    // kilocode_change start - detect global config edits made by other Kilo processes.
+    // refreshGlobal is the sole owner of globalStamp: it advances the baseline only when the
+    // on-disk content actually differs, then invalidates the cache so the next read reloads.
     const refreshGlobal = Effect.fnUntraced(function* () {
       const stamp = yield* KilocodeGlobalConfigStamp.read(fs, Global.Path.config)
-      if (!globalStamp || stamp === globalStamp) return false
+      if (stamp === globalStamp) return false
       globalStamp = stamp
       yield* invalidateGlobal
       return true


### PR DESCRIPTION
## What

Make the kilocode global-config change-detection baseline (`globalStamp`) single-owned and seeded eagerly at service construction, in `packages/opencode/src/config/config.ts`.

## Why

`globalStamp` records the on-disk content of the global config so edits made by *other* Kilo processes can be detected and hot-reloaded. It had two problems:

1. **Two writers.** Both `loadGlobal` and `refreshGlobal` wrote `globalStamp`. A cache reload (`loadGlobal`) could advance the baseline to whatever was on disk *at reload time*, silently absorbing an external edit that landed between invalidation and the reload — so the next `refreshGlobal` would compare against the already-advanced baseline and miss the change.
2. **Empty-string swallow.** The baseline started as `""` and the guard `if (!globalStamp || …)` made the very first `refreshGlobal` a no-op that didn't record anything, leaving detection dependent on whichever writer ran first.

Combined with `Server.Default()` being memoized once per process (so the Config service closure — `globalStamp` + `cachedGlobal` — is shared), this is a latent flake surface: `test/kilocode/global-config-refresh.test.ts` ("detects external global config edits") intermittently fails on CI with `"ask"` instead of `"allow"`, even though it passes in isolation. The test and the affected code are identical on `main`; this is not specific to any feature branch.

## Change

- Seed `globalStamp` once when the Config service is built.
- Remove both `loadGlobal` writes of `globalStamp`.
- `refreshGlobal` is now the sole owner: it advances the baseline only when on-disk content actually differs, then invalidates the cache so the next read reloads.

A wrong initial seed (e.g. service built before the config dir is finalized) is self-correcting: the first `refreshGlobal` simply triggers one idempotent invalidate+reload — never stale data.

## Honesty note

This is a correctness/hardening change for multi-process config-edit detection and it removes the shared-state vector behind the CI flake. I could **not** write a regression test that fails on the old code and passes on the new one in a single process — the old single-process logic is self-correcting on every reload, and the flake only manifests via shared-closure leakage across the three tests in the file under the full parallel suite. Rather than add a test that passes on both versions (test theater), I left the existing suite as the guard. All 115 config-related tests pass; `global-config-refresh.test.ts` was run 8× in a loop with no failures.

## Testing

- `bun test ./test/kilocode/global-config-refresh.test.ts` (8 loops, green)
- `bun test` across config/permission/global suites: 115 pass
- `bun run typecheck`: clean
- opencode annotation guard: clean
