### PR TITLE
fix(agent-manager): collapse sessions by default

### DIFF
--- a/.changeset/collapse-agent-sessions.md
+++ b/.changeset/collapse-agent-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start the Agent Manager with the Sessions list collapsed while preserving each workspace's saved choice.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -99,7 +99,7 @@ export class WorktreeStateManager {
   private sections = new Map<string, Section>()
   private tabOrder: Record<string, string[]> = {}
   private worktreeOrder: string[] = []
-  private collapsed = false
+  private collapsed = true
   private sidebar = false
   private reviewDiffStyle: "unified" | "split" = "unified"
   private defaultBase: string | undefined
@@ -650,6 +650,7 @@ export class WorktreeStateManager {
       this.worktreeOrder = data.worktreeOrder
     }
     const repaired = this.setNormalizedWorktreeOrder(this.worktreeOrder)
+    // State files from before this preference was explicit used the expanded layout.
     this.collapsed = data.sessionsCollapsed ?? false
     this.sidebar = data.sidebarCollapsed ?? false
     if (data.reviewDiffStyle === "split") {
@@ -754,9 +755,7 @@ export class WorktreeStateManager {
     if (this.worktreeOrder.length > 0) {
       data.worktreeOrder = this.worktreeOrder
     }
-    if (this.collapsed) {
-      data.sessionsCollapsed = true
-    }
+    data.sessionsCollapsed = this.collapsed
     if (this.sidebar) {
       data.sidebarCollapsed = true
     }

--- a/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-state-manager.test.ts
@@ -392,7 +392,18 @@ describe("WorktreeStateManager", () => {
   })
 
   describe("sessionsCollapsed", () => {
-    it("defaults to false", () => {
+    it("defaults to true when state is missing", async () => {
+      await manager.load()
+
+      expect(manager.getSessionsCollapsed()).toBe(true)
+    })
+
+    it("preserves the expanded default from legacy state", async () => {
+      const file = path.join(root, ".kilo", "agent-manager.json")
+      fs.writeFileSync(file, JSON.stringify({ worktrees: {}, sessions: {} }))
+
+      await manager.load()
+
       expect(manager.getSessionsCollapsed()).toBe(false)
     })
 
@@ -414,14 +425,18 @@ describe("WorktreeStateManager", () => {
       expect(loaded.getSessionsCollapsed()).toBe(true)
     })
 
-    it("does not persist when false", async () => {
+    it("persists and loads expanded state", async () => {
       manager.setSessionsCollapsed(false)
       await manager.flush()
       await manager.save()
 
       const content = fs.readFileSync(path.join(root, ".kilo", "agent-manager.json"), "utf-8")
       const data = JSON.parse(content)
-      expect(data.sessionsCollapsed).toBeUndefined()
+      expect(data.sessionsCollapsed).toBe(false)
+
+      const loaded = new WorktreeStateManager(root, () => {})
+      await loaded.load()
+      expect(loaded.getSessionsCollapsed()).toBe(false)
     })
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -234,7 +234,7 @@ const AgentManagerContent: Component = () => {
   const evictLocal = (sid: string) =>
     setLocalSessionIDs((prev) => (prev.includes(sid) ? prev.filter((id) => id !== sid) : prev))
   const [sidebarWidth, setSidebarWidth] = createSignal(persisted?.sidebarWidth ?? DEFAULT_SIDEBAR_WIDTH)
-  const [sessionsCollapsed, setSessionsCollapsed] = createSignal(false)
+  const [sessionsCollapsed, setSessionsCollapsed] = createSignal(true)
   const sidebar = createSidebarCollapse(vscode)
   const sidebarCollapsed = sidebar.collapsed
   const expandSidebar = sidebar.expand


### PR DESCRIPTION
The Agent Manager currently expands the unassigned Sessions list on first use, reducing the sidebar space available for worktrees.

New workspaces now start with Sessions collapsed. Both expanded and collapsed choices are persisted explicitly, while state files created before this preference was explicit continue to restore the expanded layout so existing users keep their chosen experience.