### PR TITLE
fix(cli): allow importing cloud-only sessions

### DIFF
--- a/.changeset/import-cloud-session-first.md
+++ b/.changeset/import-cloud-session-first.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow the default TUI to import cloud-only sessions without rejecting their IDs as missing locally.

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -13,7 +13,7 @@ import { Filesystem } from "@/util/filesystem"
 import type { GlobalEvent } from "@kilocode/sdk/v2"
 import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
-import { importCloudSession, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
+import { importCloudSession, localSessionID, validateCloudFork } from "@/kilocode/cloud-session" // kilocode_change
 import { createKiloClient } from "@kilocode/sdk/v2" // kilocode_change
 import { writeHeapSnapshot } from "v8"
 import { TuiConfig } from "./config/tui"
@@ -319,7 +319,7 @@ export const TuiThreadCommand = cmd({
       try {
         await validateSession({
           url: transport.url, // kilocode_change
-          sessionID: args.session,
+          sessionID: localSessionID(args), // kilocode_change
           directory: cwd,
           fetch: transport.fetch,
         })

--- a/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
@@ -3,7 +3,7 @@ import type { NetworkOptions } from "@/cli/network"
 import { errorMessage } from "@/util/error"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
 import { validateSession } from "@/cli/cmd/tui/validate-session"
-import { importCloudSession } from "@/kilocode/cloud-session"
+import { importCloudSession, localSessionID } from "@/kilocode/cloud-session"
 import { DaemonClient } from "@/kilocode/daemon/client"
 import { createKiloClient } from "@kilocode/sdk/v2"
 
@@ -55,7 +55,7 @@ export namespace KiloTuiThreadDaemon {
     try {
       await validateSession({
         url: daemon.url,
-        sessionID: input.args.session,
+        sessionID: localSessionID(input.args),
         directory: input.cwd,
         headers: daemon.headers,
       })

--- a/packages/opencode/src/kilocode/cloud-session.ts
+++ b/packages/opencode/src/kilocode/cloud-session.ts
@@ -13,6 +13,10 @@ export function validateCloudFork(args: {
   if (!args.session) return "--cloud-fork requires --session"
 }
 
+export function localSessionID(args: { cloudFork?: boolean; session?: string }) {
+  return args.cloudFork ? undefined : args.session
+}
+
 /**
  * Import a cloud session to local storage and return the new local session ID.
  * Wraps the SDK's `.kilo.cloud.session.import()` which returns `unknown` due to

--- a/packages/opencode/test/kilocode/cli/tui/thread.test.ts
+++ b/packages/opencode/test/kilocode/cli/tui/thread.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { tmpdir } from "../../../fixture/fixture"
 import { resolveThreadDirectory } from "../../../../src/cli/cmd/tui/thread"
+import { KiloTuiThreadDaemon } from "../../../../src/kilocode/cli/cmd/tui/thread"
+import { DaemonClient } from "../../../../src/kilocode/daemon/client"
 
 describe("kilo tui thread", () => {
   test("ignores stale PWD after cwd is changed by a process wrapper", async () => {
@@ -26,6 +28,58 @@ describe("kilo tui thread", () => {
     } finally {
       if (prev === undefined) delete process.env.KILO_DEV_CWD
       else process.env.KILO_DEV_CWD = prev
+    }
+  })
+
+  test("skips local validation before importing cloud sessions", async () => {
+    await using root = await tmpdir()
+    const cloud = "ses_cloud"
+    const local = "ses_local"
+    const calls: string[] = []
+    const opened: Array<string | undefined> = []
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const route = `${request.method} ${new URL(request.url).pathname}`
+        calls.push(route)
+        if (route === "POST /kilo/cloud/session/import") return Response.json({ id: local })
+        return new Response(null, { status: 404 })
+      },
+    })
+    const url = new URL(server.url)
+    const daemon = spyOn(DaemonClient, "maybe").mockResolvedValue({
+      url: url.origin,
+      headers: {},
+      state: {
+        pid: process.pid,
+        hostname: url.hostname,
+        port: Number(url.port),
+        url: url.origin,
+        username: "kilo",
+        password: "test",
+        token: "test",
+        version: "test",
+        startedAt: new Date().toISOString(),
+        log: path.join(root.path, "daemon.log"),
+      },
+    })
+    const args = { port: 0, hostname: "127.0.0.1", mdns: false, "mdns-domain": "kilo.local", cors: [] }
+    const start: Parameters<typeof KiloTuiThreadDaemon.attach>[0]["start"] = async (input) => {
+      opened.push(input.args.sessionID)
+    }
+
+    try {
+      await KiloTuiThreadDaemon.attach({
+        args: { ...args, session: cloud, cloudFork: true },
+        cwd: root.path,
+        input: async () => undefined,
+        start,
+      })
+
+      expect(calls).toEqual(["POST /kilo/cloud/session/import"])
+      expect(opened).toEqual([local])
+    } finally {
+      daemon.mockRestore()
     }
   })
 })


### PR DESCRIPTION
Fixes #11222

The default TUI validates `--session` against local storage before Kilo can process `--cloud-fork`. Cloud-only session IDs therefore fail with `Session not found` instead of reaching the existing import flow.

Skip that pre-import local lookup only while `--cloud-fork` is active, in both daemon and embedded-server paths. Ordinary local session validation remains unchanged, and the existing cloud import still creates and opens a fresh local session ID.

The implementation stays deliberately narrow to minimize divergence from upstream TUI control flow. A regression test exercises the daemon orchestration and verifies the cloud import request occurs without a preceding local session lookup.