### PR TITLE
fix(vscode): localize autocomplete labels

### DIFF
--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -197,23 +197,23 @@
       },
       {
         "command": "kilo-code.new.autocomplete.generateSuggestions",
-        "title": "Generate Suggested Edits",
-        "category": "Kilo Code"
+        "title": "%kilocode:autocomplete.commands.generateSuggestions.title%",
+        "category": "%kilocode:autocomplete.commands.category%"
       },
       {
         "command": "kilo-code.new.autocomplete.cancelSuggestions",
-        "title": "Cancel Suggested Edits",
-        "category": "Kilo Code"
+        "title": "%kilocode:autocomplete.commands.cancelSuggestions%",
+        "category": "%kilocode:autocomplete.commands.category%"
       },
       {
         "command": "kilo-code.new.autocomplete.nextEdit.acceptOrJump",
-        "title": "Next Edit: Accept or Jump to Suggested Edit",
-        "category": "Kilo Code"
+        "title": "%kilocode:autocomplete.commands.nextEdit.acceptOrJump%",
+        "category": "%kilocode:autocomplete.commands.category%"
       },
       {
         "command": "kilo-code.new.autocomplete.nextEdit.dismiss",
-        "title": "Next Edit: Dismiss Pending Suggestion",
-        "category": "Kilo Code"
+        "title": "%kilocode:autocomplete.commands.nextEdit.dismiss%",
+        "category": "%kilocode:autocomplete.commands.category%"
       },
       {
         "command": "kilo-code.new.agentManager.previousSession",
@@ -886,14 +886,14 @@
             "mercury-next-edit"
           ],
           "enumDescriptions": [
-            "Codestral via Kilo Gateway",
-            "Mercury Edit 2 (FIM) via Kilo Gateway",
-            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
-            "Codestral via your connected Mistral provider API key",
-            "Mercury Edit 2 (FIM) via your connected Inception provider API key",
-            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key"
+            "%kilocode:autocomplete.configuration.model.enum.codestralGateway%",
+            "%kilocode:autocomplete.configuration.model.enum.mercuryFimGateway%",
+            "%kilocode:autocomplete.configuration.model.enum.mercuryNextEditGateway%",
+            "%kilocode:autocomplete.configuration.model.enum.codestralMistral%",
+            "%kilocode:autocomplete.configuration.model.enum.mercuryFimInception%",
+            "%kilocode:autocomplete.configuration.model.enum.mercuryNextEditInception%"
           ],
-          "description": "Model to use for inline autocomplete suggestions. If unset, the recommended default is used."
+          "description": "%kilocode:autocomplete.configuration.model.description%"
         },
         "kilo-code.new.autocomplete.provider": {
           "type": "string",
@@ -903,26 +903,26 @@
             "inception"
           ],
           "enumDescriptions": [
-            "Use autocomplete models through Kilo Gateway",
-            "Use autocomplete models through your connected Mistral provider API key",
-            "Use autocomplete models through your connected Inception provider API key"
+            "%kilocode:autocomplete.configuration.provider.enum.kilo%",
+            "%kilocode:autocomplete.configuration.provider.enum.mistral%",
+            "%kilocode:autocomplete.configuration.provider.enum.inception%"
           ],
-          "description": "Provider to use for inline autocomplete suggestions. If unset, Kilo Gateway is used."
+          "description": "%kilocode:autocomplete.configuration.provider.description%"
         },
         "kilo-code.new.autocomplete.enableAutoTrigger": {
           "type": "boolean",
           "default": true,
-          "description": "Enable automatic inline completion suggestions"
+          "description": "%kilocode:autocomplete.configuration.enableAutoTrigger.description%"
         },
         "kilo-code.new.autocomplete.enableSmartInlineTaskKeybinding": {
           "type": "boolean",
           "default": false,
-          "description": "Enable smart inline task keybinding"
+          "description": "%kilocode:autocomplete.configuration.enableSmartInlineTaskKeybinding.description%"
         },
         "kilo-code.new.autocomplete.enableChatAutocomplete": {
           "type": "boolean",
           "default": false,
-          "description": "Enable chat textarea autocomplete"
+          "description": "%kilocode:autocomplete.configuration.enableChatAutocomplete.description%"
         },
         "kilo-code.new.indexing.showButtonWhenDisabled": {
           "type": "boolean",

--- a/packages/kilo-vscode/package.nls.json
+++ b/packages/kilo-vscode/package.nls.json
@@ -1,0 +1,21 @@
+{
+  "kilocode:autocomplete.commands.generateSuggestions.title": "Generate Suggested Edits",
+  "kilocode:autocomplete.commands.cancelSuggestions": "Cancel Suggested Edits",
+  "kilocode:autocomplete.commands.nextEdit.acceptOrJump": "Next Edit: Accept or Jump to Suggested Edit",
+  "kilocode:autocomplete.commands.nextEdit.dismiss": "Next Edit: Dismiss Pending Suggestion",
+  "kilocode:autocomplete.commands.category": "Kilo Code",
+  "kilocode:autocomplete.configuration.model.enum.codestralGateway": "Codestral via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.mercuryFimGateway": "Mercury Edit 2 (FIM) via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.mercuryNextEditGateway": "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.codestralMistral": "Codestral via your connected Mistral provider API key",
+  "kilocode:autocomplete.configuration.model.enum.mercuryFimInception": "Mercury Edit 2 (FIM) via your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.model.enum.mercuryNextEditInception": "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.model.description": "Model to use for inline autocomplete suggestions. If unset, the recommended default is used.",
+  "kilocode:autocomplete.configuration.provider.enum.kilo": "Use autocomplete models through Kilo Gateway",
+  "kilocode:autocomplete.configuration.provider.enum.mistral": "Use autocomplete models through your connected Mistral provider API key",
+  "kilocode:autocomplete.configuration.provider.enum.inception": "Use autocomplete models through your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.provider.description": "Provider to use for inline autocomplete suggestions. If unset, Kilo Gateway is used.",
+  "kilocode:autocomplete.configuration.enableAutoTrigger.description": "Enable automatic inline completion suggestions",
+  "kilocode:autocomplete.configuration.enableSmartInlineTaskKeybinding.description": "Enable smart inline task keybinding",
+  "kilocode:autocomplete.configuration.enableChatAutocomplete.description": "Enable chat textarea autocomplete"
+}

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/AutocompleteInlineCompletionProvider.ts
@@ -23,6 +23,7 @@ import {
 import { FimPromptBuilder } from "./FillInTheMiddle"
 import { hasValidCredentials } from "../fim"
 import type { KiloConnectionService } from "../../cli-backend"
+import { t } from "../shims/i18n"
 import { getAutocompleteModelById } from "../../../shared/autocomplete-models"
 import { ContextRetrievalService } from "../continuedev/core/autocomplete/context/ContextRetrievalService"
 import { VsCodeIde } from "../continuedev/core/vscode-test-harness/src/VSCodeIde"
@@ -110,7 +111,7 @@ export function stringToInlineCompletions(text: string, position: vscode.Positio
 
   const item = new vscode.InlineCompletionItem(text, new vscode.Range(position, position), {
     command: INLINE_COMPLETION_ACCEPTED_COMMAND,
-    title: "Autocomplete Accepted",
+    title: t("kilocode:autocomplete.inlineCompletion.acceptedCommandTitle"),
   })
   return [item]
 }

--- a/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/i18n/en.ts
@@ -28,12 +28,44 @@ export const dict = {
   "kilocode:autocomplete.input.title": "Kilo Code: Quick Task",
   "kilocode:autocomplete.input.placeholder": "e.g., 'refactor this function to be more efficient'",
   "kilocode:autocomplete.commands.generateSuggestions": "Kilo Code: Generate Suggested Edits",
+  "kilocode:autocomplete.commands.generateSuggestions.title": "Generate Suggested Edits",
   "kilocode:autocomplete.commands.displaySuggestions": "Display Suggested Edits",
   "kilocode:autocomplete.commands.cancelSuggestions": "Cancel Suggested Edits",
+  "kilocode:autocomplete.commands.nextEdit.acceptOrJump": "Next Edit: Accept or Jump to Suggested Edit",
+  "kilocode:autocomplete.commands.nextEdit.dismiss": "Next Edit: Dismiss Pending Suggestion",
   "kilocode:autocomplete.commands.applyCurrentSuggestion": "Apply Current Suggested Edit",
   "kilocode:autocomplete.commands.applyAllSuggestions": "Apply All Suggested Edits",
   "kilocode:autocomplete.commands.category": "Kilo Code",
   "kilocode:autocomplete.codeAction.title": "Kilo Code: Suggested Edits",
+  "kilocode:autocomplete.inlineCompletion.acceptedCommandTitle": "Autocomplete Accepted",
+  "kilocode:autocomplete.nextEdit.outputChannel": "Kilo Code · Next Edit",
+  "kilocode:autocomplete.nextEdit.acceptedCommandTitle": "Next Edit Accepted",
+  "kilocode:autocomplete.nextEdit.decoration.removed": "→ (removed)",
+  "kilocode:autocomplete.nextEdit.hint.apply": "  ↳ Tab to apply · Esc to dismiss",
+  "kilocode:autocomplete.nextEdit.hint.jump": "  ↳ Tab to jump here · Esc to dismiss",
+  "kilocode:autocomplete.configuration.model.enum.codestralGateway": "Codestral via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.mercuryFimGateway": "Mercury Edit 2 (FIM) via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.mercuryNextEditGateway":
+    "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
+  "kilocode:autocomplete.configuration.model.enum.codestralMistral":
+    "Codestral via your connected Mistral provider API key",
+  "kilocode:autocomplete.configuration.model.enum.mercuryFimInception":
+    "Mercury Edit 2 (FIM) via your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.model.enum.mercuryNextEditInception":
+    "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.model.description":
+    "Model to use for inline autocomplete suggestions. If unset, the recommended default is used.",
+  "kilocode:autocomplete.configuration.provider.enum.kilo": "Use autocomplete models through Kilo Gateway",
+  "kilocode:autocomplete.configuration.provider.enum.mistral":
+    "Use autocomplete models through your connected Mistral provider API key",
+  "kilocode:autocomplete.configuration.provider.enum.inception":
+    "Use autocomplete models through your connected Inception provider API key",
+  "kilocode:autocomplete.configuration.provider.description":
+    "Provider to use for inline autocomplete suggestions. If unset, Kilo Gateway is used.",
+  "kilocode:autocomplete.configuration.enableAutoTrigger.description": "Enable automatic inline completion suggestions",
+  "kilocode:autocomplete.configuration.enableSmartInlineTaskKeybinding.description":
+    "Enable smart inline task keybinding",
+  "kilocode:autocomplete.configuration.enableChatAutocomplete.description": "Enable chat textarea autocomplete",
   "kilocode:autocomplete.chatParticipant.fullName": "Kilo Code Agent",
   "kilocode:autocomplete.chatParticipant.name": "Agent",
   "kilocode:autocomplete.chatParticipant.description": "I can help you with quick tasks and suggested edits.",

--- a/packages/kilo-vscode/src/services/autocomplete/next-edit/NextEditInlineCompletionProvider.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/next-edit/NextEditInlineCompletionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 import type { KiloConnectionService } from "../../cli-backend"
+import { t } from "../shims/i18n"
 import { computeEditableRegion } from "./editableRegion"
 import { EditHistoryTracker } from "./editHistoryTracker"
 import { nesLog } from "./log"
@@ -259,7 +260,7 @@ export class NextEditInlineCompletionProvider implements vscode.InlineCompletion
 
     const item = new vscode.InlineCompletionItem(insertText, renderRange, {
       command: INLINE_COMPLETION_ACCEPTED_COMMAND,
-      title: "Next Edit Accepted",
+      title: t("kilocode:autocomplete.nextEdit.acceptedCommandTitle"),
     })
     nesLog(
       `RENDER range=[${renderRange.start.line}:${renderRange.start.character}..${renderRange.end.line}:${renderRange.end.character}] insertChars=${insertText.length}`,

--- a/packages/kilo-vscode/src/services/autocomplete/next-edit/NextEditSuggestionManager.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/next-edit/NextEditSuggestionManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { t } from "../shims/i18n"
 import { nesLog } from "./log"
 import { planInsertion, planReplacement } from "./pendingEdit"
 
@@ -252,7 +253,7 @@ export class NextEditSuggestionManager implements vscode.Disposable {
         removedRanges.push(lineRange)
         proposedAnnotations.push({
           range: new vscode.Range(lineRange.end, lineRange.end),
-          renderOptions: { after: { contentText: `→ (removed)` } },
+          renderOptions: { after: { contentText: t("kilocode:autocomplete.nextEdit.decoration.removed") } },
         })
       }
       // Additions inside a replace — anchor on last shared line
@@ -292,7 +293,9 @@ export class NextEditSuggestionManager implements vscode.Disposable {
       p.kind === "replace"
         ? cursor.line >= p.diffStartLine && cursor.line <= p.diffEndLine
         : cursor.line === p.diffStartLine || cursor.line === p.diffStartLine - 1
-    const hintText = cursorAtDiff ? "  ↳ Tab to apply · Esc to dismiss" : "  ↳ Tab to jump here · Esc to dismiss"
+    const hintText = cursorAtDiff
+      ? t("kilocode:autocomplete.nextEdit.hint.apply")
+      : t("kilocode:autocomplete.nextEdit.hint.jump")
     const hintOptions: vscode.DecorationOptions[] = [
       {
         range: new vscode.Range(hintLineEnd, hintLineEnd),

--- a/packages/kilo-vscode/src/services/autocomplete/next-edit/log.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/next-edit/log.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
+import { t } from "../shims/i18n"
 
-const CHANNEL_NAME = "Kilo Code · Next Edit"
+const CHANNEL_NAME = t("kilocode:autocomplete.nextEdit.outputChannel")
 
 let channel: vscode.OutputChannel | null = null
 

--- a/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
+++ b/packages/kilo-vscode/tests/unit/i18n-keys.test.ts
@@ -116,6 +116,8 @@ import { dict as cliUk } from "../../src/services/cli-backend/i18n/uk"
 import { dict as cliIt } from "../../src/services/cli-backend/i18n/it"
 
 import { dict as acEn } from "../../src/services/autocomplete/i18n/en"
+import pkg from "../../package.json"
+import nls from "../../package.nls.json"
 
 // ── Locale maps ─────────────────────────────────────────────────────────────
 
@@ -217,6 +219,7 @@ const cliLocales: Record<string, Record<string, string>> = {
 const webviewKeys = new Set(Object.keys({ ...appEn, ...uiEn, ...kiloEn, ...amEn }))
 const cliKeys = new Set(Object.keys(cliEn))
 const acKeys = new Set(Object.keys(acEn))
+const nlsKeys = new Set(Object.keys(nls))
 
 // ── File scanning ───────────────────────────────────────────────────────────
 
@@ -254,6 +257,23 @@ function extractKeys(content: string): Array<{ line: number; key: string }> {
     if (key) results.push({ line: offsetToLine(content, match.index), key })
   }
   return results
+}
+
+function collectManifestKeys(value: unknown): string[] {
+  if (typeof value === "string") {
+    const matches = value.matchAll(/^%([^%]+)%$/g)
+    return Array.from(matches, (match) => match[1]).filter((key): key is string => key !== undefined)
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectManifestKeys)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap(collectManifestKeys)
+  }
+
+  return []
 }
 
 async function collectFiles(glob: Glob, dir: string): Promise<string[]> {
@@ -437,6 +457,18 @@ describe("i18n locale completeness — every English key exists in all locales",
         `Found ${missing.length} missing cli-backend translation(s):\n${formatLocaleReport(missing)}`,
       ).toEqual([])
     }
+    expect(missing).toEqual([])
+  })
+})
+
+describe("package manifest localization", () => {
+  it("all package.json localization placeholders exist in package.nls.json", () => {
+    const missing = collectManifestKeys(pkg).filter((key) => !nlsKeys.has(key))
+    expect(missing).toEqual([])
+  })
+
+  it("all autocomplete package.nls.json keys mirror the autocomplete dictionary", () => {
+    const missing = Object.keys(nls).filter((key) => key.startsWith("kilocode:autocomplete.") && !acKeys.has(key))
     expect(missing).toEqual([])
   })
 })


### PR DESCRIPTION
## What
- Add autocomplete runtime translations for inline completion command titles, Next Edit output/decorations, and manifest strings.
- Localize autocomplete command and setting contributions through `package.nls.json` so VS Code resolves the labels/descriptions for users.
- Add tests that keep package manifest placeholders synced with `package.nls.json` and the autocomplete dictionary.

## Why
Autocomplete had user-facing strings missing from the runtime dictionary, and package contribution labels were hardcoded in `package.json` so users could not receive localized VS Code UI strings.

## Checks
- `bun run format`
- `bun test tests/unit/i18n-keys.test.ts tests/unit/i18n-shim.test.ts tests/unit/autocomplete-models-sync.test.ts`
- `bun run typecheck`
