### PR TITLE
fix(vscode): stabilize sandbox button across session switches

### DIFF
--- a/.changeset/keep-sandbox-toggle-drafts.md
+++ b/.changeset/keep-sandbox-toggle-drafts.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Preserve new-chat prompts and attachments when toggling sandbox before sending the first message.
+Preserve new-chat prompts, attachments, and scroll position when toggling sandbox, and keep sandbox status stable while switching sessions.

--- a/packages/kilo-vscode/tests/unit/prompt-drafts.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-drafts.test.ts
@@ -60,17 +60,21 @@ describe("movePromptDraft", () => {
     const text = new Map([[source, "Keep this prompt"]])
     const comments = new Map([[source, [comment]]])
     const images = new Map([[source, [image]]])
+    const scrolls = new Map([[source, 128]])
 
-    expect(movePromptDraft({ text, comments, images }, source, target)).toEqual({
+    expect(movePromptDraft({ text, comments, images, scrolls }, source, target)).toEqual({
       text: "Keep this prompt",
       comments: [comment],
       images: [image],
+      scroll: 128,
     })
     expect(text.get(target)).toBe("Keep this prompt")
     expect(comments.get(target)).toEqual([comment])
     expect(images.get(target)).toEqual([image])
+    expect(scrolls.get(target)).toBe(128)
     expect(text.has(source)).toBe(false)
     expect(comments.has(source)).toBe(false)
     expect(images.has(source)).toBe(false)
+    expect(scrolls.has(source)).toBe(false)
   })
 })

--- a/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
@@ -41,7 +41,8 @@ describe("PromptInput sandbox toggle", () => {
     expect(toggle).toContain("sessionID,")
     expect(toggle).toContain("requestID,")
     expect(toggle).not.toContain("draftID:")
-    expect(toggle).toContain("setSandboxTarget(sessionID ?? null)")
+    expect(toggle).toContain('setSandboxRequests((current) => ({ ...current, [sessionID ?? ""]: requestID }))')
+    expect(toggle).not.toContain("setSandboxTarget")
     expect(toggle).not.toContain('type: "updateConfig"')
   })
 
@@ -58,6 +59,26 @@ describe("PromptInput sandbox toggle", () => {
     expect(end).toBeGreaterThan(start)
     expect(save).toBeGreaterThan(-1)
     expect(move).toBeGreaterThan(save)
+    expect(created).toContain("{ text: drafts, comments: reviewDrafts, images: imageDrafts, scrolls }")
+  })
+
+  it("restores each prompt draft's textarea and highlight scroll positions", () => {
+    expect(src).toContain("const scrolls = new Map<string, number>()")
+    expect(src).toContain("const scroll = scrolls.get(key) ?? 0")
+    expect(src).toContain("textareaRef.scrollTop = scroll")
+    expect(src).toContain("if (highlightRef) highlightRef.scrollTop = scroll")
+    expect(src).toContain("scrolls.set(draftKey(), textareaRef.scrollTop)")
+    expect(src).toContain("images: imageAttach.images(),\n    scroll: textareaRef?.scrollTop")
+    expect(src).toContain("draft.text, draft.comments, draft.images, draft.scroll")
+  })
+
+  it("tracks in-flight toggles per session while switching", () => {
+    expect(src).toContain("const [sandboxRequests, setSandboxRequests] = createSignal<Record<string, string>>({})")
+    expect(src).toContain('const sandboxRequest = (sessionID?: string) => sandboxRequests()[sessionID ?? ""]')
+    expect(src).toContain("sandboxRequest(sandboxID()) !== undefined")
+    expect(src).toContain("if (current[key] !== requestID) return current")
+    expect(src).toContain("clearSandboxRequest(message.sessionID, message.requestID!)")
+    expect(src).not.toContain("setSandboxTarget")
   })
 
   it("keeps persisted sandbox state visible independently of the configured default", () => {
@@ -70,11 +91,12 @@ describe("PromptInput sandbox toggle", () => {
     expect(src).toContain('if (!sandboxVisible()) hidden.add("sandbox")')
     expect(src).toContain("onToggle={toggleSandbox}")
     expect(src).toContain('message.type === "sandboxStatus"')
-    expect(src).toContain("message.sessionID !== sandboxID() && !matching")
-    expect(src).toContain("setSandboxState(state)")
-    expect(src).toContain("message.requestID === sandboxRequest()")
-    expect(src).toContain("const target = untrack(sandboxTarget)")
-    expect(src).toContain("if (target !== undefined && target !== sessionID) clearSandboxRequest()")
+    expect(src).not.toContain("message.sessionID !== sandboxID() && !matching")
+    expect(src).toContain("const next = applySandboxStates(current, message)")
+    expect(src).toContain("if (next !== current) setSandboxes(next)")
+    expect(src).toContain("message.requestID === sandboxRequest(message.sessionID)")
+    expect(src).toContain("if (message.sessionID === sandboxID())")
+    expect(src).toContain("if (message.sessionID === sandboxID()) retrySandbox(message.sessionID)")
     expect(src).toContain("sandboxID() ? sandbox()?.enabled : sandboxDefault()?.enabled")
     expect(src).toContain('type: "requestSandboxDefault", agentManagerContext: ctx()')
     expect(src).toContain("<SandboxButtonBase")
@@ -83,7 +105,7 @@ describe("PromptInput sandbox toggle", () => {
     expect(src).toContain("!sandboxReady()")
     expect(button).toContain("aria-pressed={props.enabled}")
     expect(button).toContain('class={`prompt-status-button ${props.enabled ? "prompt-status-button--active" : ""}`}')
-    expect(src).toContain("if (sandboxRequest() && target === null) return")
+    expect(src).toContain("if (sandboxRequest(undefined)) return")
     expect(src).not.toContain("if (state === current) return true")
   })
 

--- a/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-utils.test.ts
@@ -11,6 +11,7 @@ import {
   isQuestioning,
   isPathMention,
   applySandboxState,
+  applySandboxStates,
 } from "../../webview-ui/src/components/chat/prompt-input-utils"
 
 describe("applySandboxState", () => {
@@ -42,6 +43,17 @@ describe("applySandboxState", () => {
     expect(applySandboxState(state(true, 5), state(false, 6, "ses_1", "/worktree"))).toEqual(
       state(false, 6, "ses_1", "/worktree"),
     )
+  })
+
+  it("caches independently ordered statuses for worktree switching", () => {
+    const first = applySandboxStates({}, state(true, 5, "ses_1"))
+    const second = applySandboxStates(first, state(false, 1, "ses_2"))
+
+    expect(second).toEqual({
+      ses_1: state(true, 5, "ses_1"),
+      ses_2: state(false, 1, "ses_2"),
+    })
+    expect(applySandboxStates(second, state(false, 4, "ses_1"))).toBe(second)
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -44,7 +44,7 @@ import {
   insertSpacedText,
   isPromptBusy,
   isPathMention,
-  applySandboxState,
+  applySandboxStates,
   type SandboxDefaultState,
   type SandboxState,
 } from "./prompt-input-utils"
@@ -65,6 +65,7 @@ import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 const drafts = new Map<string, string>()
 const reviewDrafts = new Map<string, ReviewComment[]>()
 const imageDrafts = new Map<string, ImageAttachment[]>()
+const scrolls = new Map<string, number>()
 
 function mergeReviewComments(current: ReviewComment[], incoming: ReviewComment[]): ReviewComment[] {
   if (incoming.length === 0) return current
@@ -125,6 +126,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     adjustHeight()
   })
   const history = usePromptHistory()
+  let textareaRef: HTMLTextAreaElement | undefined
+  let highlightRef: HTMLDivElement | undefined
+  let dropdownRef: HTMLDivElement | undefined
+  let slashDropdownRef: HTMLDivElement | undefined
 
   const boxKey = () => props.boxId ?? "prompt:default"
   const rawKey = () =>
@@ -132,28 +137,36 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     pendingDraftKey(props.pendingSessionID ?? session.draftSessionID()) ??
     "new"
   const draftKey = () => scopeDraftKey(boxKey(), rawKey())
-  const saveDraft = (key: string, next: string, comments: ReviewComment[], imgs: ImageAttachment[]) => {
+  const saveDraft = (
+    key: string,
+    next: string,
+    comments: ReviewComment[],
+    imgs: ImageAttachment[],
+    scroll = textareaRef?.scrollTop ?? scrolls.get(key) ?? 0,
+  ) => {
     if (next) drafts.set(key, next)
     else drafts.delete(key)
     if (comments.length > 0) reviewDrafts.set(key, comments)
     else reviewDrafts.delete(key)
     if (imgs.length > 0) imageDrafts.set(key, imgs)
     else imageDrafts.delete(key)
+    if (next || comments.length > 0 || imgs.length > 0) scrolls.set(key, scroll)
+    else scrolls.delete(key)
   }
   const readDraft = () => ({
     text: text().trim(),
     comments: reviewComments(),
     images: imageAttach.images(),
+    scroll: textareaRef?.scrollTop ?? scrolls.get(draftKey()) ?? 0,
   })
 
   const [text, setText] = createSignal("")
   const [reviewComments, setReviewComments] = createSignal<ReviewComment[]>([])
   const [enhancing, setEnhancing] = createSignal(false)
   const [autoApprove, setAutoApprove] = createSignal(false)
-  const [sandboxState, setSandboxState] = createSignal<SandboxState>()
+  const [sandboxes, setSandboxes] = createSignal<Record<string, SandboxState>>({})
   const [sandboxDefault, setSandboxDefault] = createSignal<SandboxDefaultState>()
-  const [sandboxRequest, setSandboxRequest] = createSignal<string>()
-  const [sandboxTarget, setSandboxTarget] = createSignal<string | null>()
+  const [sandboxRequests, setSandboxRequests] = createSignal<Record<string, string>>({})
   let sandboxRetry: ReturnType<typeof setTimeout> | undefined
   let sandboxAttempts = 0
   const sandboxID = () => {
@@ -162,16 +175,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
   const sandboxVisible = () => features().sandboxControls && !session.currentSessionID()?.startsWith("cloud:")
   const sandbox = () => {
-    const state = sandboxState()
-    return state?.sessionID === sandboxID() ? state : undefined
+    const id = sandboxID()
+    return id ? sandboxes()[id] : undefined
   }
   const sandboxEnabled = () => (sandboxID() ? sandbox()?.enabled : sandboxDefault()?.enabled) ?? false
   const sandboxAvailable = () => (sandboxID() ? sandbox()?.available : sandboxDefault()?.available) ?? false
   const sandboxReason = () => (sandboxID() ? sandbox()?.reason : sandboxDefault()?.reason)
   const sandboxReady = () => (sandboxID() ? sandbox() !== undefined : sandboxDefault() !== undefined)
   const sandboxNetworkEnabled = () => config().experimental?.sandbox_restrict_network !== false
+  const sandboxRequest = (sessionID?: string) => sandboxRequests()[sessionID ?? ""]
   const sandboxDisabled = () =>
-    !server.isConnected() || !sandboxReady() || !sandboxAvailable() || sandboxRequest() !== undefined
+    !server.isConnected() || !sandboxReady() || !sandboxAvailable() || sandboxRequest(sandboxID()) !== undefined
   const requestSandbox = () => {
     if (server.connectionState() !== "connected") return
     const sessionID = sandboxID()
@@ -186,8 +200,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!sandboxVisible() || sandboxDisabled()) return
     const requestID = crypto.randomUUID()
     if (!sessionID) saveDraft(draftKey(), text(), reviewComments(), imageAttach.images())
-    setSandboxRequest(requestID)
-    setSandboxTarget(sessionID ?? null)
+    setSandboxRequests((current) => ({ ...current, [sessionID ?? ""]: requestID }))
     if (!sessionID) {
       vscode.postMessage({
         type: "setSandboxDefault",
@@ -214,9 +227,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return hidden
     },
   )
-  const clearSandboxRequest = () => {
-    setSandboxRequest(undefined)
-    setSandboxTarget(undefined)
+  const clearSandboxRequest = (sessionID: string | undefined, requestID: string) => {
+    setSandboxRequests((current) => {
+      const key = sessionID ?? ""
+      if (current[key] !== requestID) return current
+      const next = { ...current }
+      delete next[key]
+      return next
+    })
   }
   const retrySandbox = (sessionID: string) => {
     if (sandboxAttempts >= 2) return
@@ -233,20 +251,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   createEffect(() => {
     const sessionID = sandboxID()
     const connected = server.connectionState() === "connected"
-    const target = untrack(sandboxTarget)
     if (sandboxRetry) clearTimeout(sandboxRetry)
     sandboxRetry = undefined
     sandboxAttempts = 0
     if (!connected) {
-      clearSandboxRequest()
-      setSandboxState(undefined)
+      setSandboxRequests({})
+      setSandboxes({})
       setSandboxDefault(undefined)
       return
     }
-    if (target !== undefined && target !== sessionID) clearSandboxRequest()
     if (!sessionID) {
-      setSandboxState(undefined)
-      if (sandboxRequest() && target === null) return
+      if (sandboxRequest(undefined)) return
       requestSandbox()
       return
     }
@@ -271,10 +286,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     replaceReviewComments(reviewComments().filter((item) => item.id !== id))
   }
 
-  let textareaRef: HTMLTextAreaElement | undefined
-  let highlightRef: HTMLDivElement | undefined
-  let dropdownRef: HTMLDivElement | undefined
-  let slashDropdownRef: HTMLDivElement | undefined
   // Save/restore input text when switching sessions.
   // Uses `on()` to track only draftKey — avoids re-running on every keystroke.
   createEffect(
@@ -284,6 +295,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
       const draft = drafts.get(key) ?? ""
       const pending = reviewDrafts.get(key) ?? []
+      const scroll = scrolls.get(key) ?? 0
       setText(draft)
       setReviewComments(pending)
       imageAttach.replace(imageDrafts.get(key) ?? [])
@@ -295,6 +307,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         // Reset height then adjust
         textareaRef.style.height = "auto"
         textareaRef.style.height = `${Math.min(textareaRef.scrollHeight, 200)}px`
+        textareaRef.scrollTop = scroll
+        if (highlightRef) highlightRef.scrollTop = scroll
       }
       window.dispatchEvent(new Event("focusPrompt"))
     }),
@@ -347,10 +361,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const draft = text().trim()
     const comments = reviewComments()
     const imgs = imageAttach.images()
+    const scroll = textareaRef?.scrollTop ?? 0
     session.clearCurrentSession()
     // After clearing, draftKey() points to the "new" bucket — save there
     // so the session-switch effect restores the prompt in the new-task view.
-    saveDraft(draftKey(), draft, comments, imgs)
+    saveDraft(draftKey(), draft, comments, imgs, scroll)
   }
   window.addEventListener("newTaskRequest", onNewTaskRequest)
   onCleanup(() => window.removeEventListener("newTaskRequest", onNewTaskRequest))
@@ -372,7 +387,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const draft = captured.get(id)
     captured.delete(id)
     if (!draft) return
-    saveDraft(scopeDraftKey(box, sessionDraftKey(sid)), draft.text, draft.comments, draft.images)
+    saveDraft(scopeDraftKey(box, sessionDraftKey(sid)), draft.text, draft.comments, draft.images, draft.scroll)
   }
   window.addEventListener("agentManagerApplyDraft", onAgentManagerApplyDraft)
   onCleanup(() => window.removeEventListener("agentManagerApplyDraft", onAgentManagerApplyDraft))
@@ -486,10 +501,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const handleSandboxMessage = (message: ExtensionMessage) => {
     if (message.type === "sandboxDefaultStatus") {
-      const matching = message.requestID !== undefined && message.requestID === sandboxRequest()
+      const matching = message.requestID !== undefined && message.requestID === sandboxRequest(undefined)
       if (sandboxID() && !matching) return false
       if (!server.isConnected()) return true
-      if (matching) clearSandboxRequest()
+      if (matching) clearSandboxRequest(undefined, message.requestID!)
       const current = sandboxDefault()
       if (!current || current.revision <= message.revision) {
         setSandboxDefault({
@@ -511,16 +526,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (message.type === "sandboxStatus") {
-      const matching = message.requestID !== undefined && message.requestID === sandboxRequest()
-      if (message.sessionID !== sandboxID() && !matching) return false
+      const matching = message.requestID !== undefined && message.requestID === sandboxRequest(message.sessionID)
       if (!server.isConnected()) return true
-      const current = sandboxState()
-      if (matching) clearSandboxRequest()
-      const state = applySandboxState(current, message)
-      if (state !== current) setSandboxState(state)
-      sandboxAttempts = 0
-      if (sandboxRetry) clearTimeout(sandboxRetry)
-      sandboxRetry = undefined
+      const current = sandboxes()
+      if (matching) clearSandboxRequest(message.sessionID, message.requestID!)
+      const next = applySandboxStates(current, message)
+      if (next !== current) setSandboxes(next)
+      const state = next[message.sessionID]
+      if (message.sessionID === sandboxID()) {
+        sandboxAttempts = 0
+        if (sandboxRetry) clearTimeout(sandboxRetry)
+        sandboxRetry = undefined
+      }
       if (matching && !state.available) {
         showToast({
           variant: "error",
@@ -532,24 +549,26 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (message.type === "sandboxStatusError") {
-      const matching = message.requestID !== undefined && message.requestID === sandboxRequest()
-      if (message.sessionID !== sandboxID() && !matching) return false
+      const matching = message.requestID !== undefined && message.requestID === sandboxRequest(message.sessionID)
       if (!server.isConnected()) return true
-      const current = sandboxState()
-      if (matching) clearSandboxRequest()
-      if ((current?.revision ?? -1) > message.revision) return true
+      const current = sandboxes()
+      const state = current[message.sessionID]
+      if (matching) clearSandboxRequest(message.sessionID, message.requestID!)
+      if ((state?.revision ?? -1) > message.revision) return true
       if (!message.requestID) {
-        const same = current?.sessionID === message.sessionID && current.directory === message.directory
-        setSandboxState({
-          sessionID: message.sessionID,
-          directory: message.directory,
-          enabled: same ? current.enabled : false,
-          available: false,
-          reason: message.message,
-          version: same ? current.version : 0,
-          revision: message.revision,
-        })
-        retrySandbox(message.sessionID)
+        const same = state?.directory === message.directory
+        setSandboxes(
+          applySandboxStates(current, {
+            sessionID: message.sessionID,
+            directory: message.directory,
+            enabled: same ? state.enabled : false,
+            available: false,
+            reason: message.message,
+            version: same ? state.version : 0,
+            revision: message.revision,
+          }),
+        )
+        if (message.sessionID === sandboxID()) retrySandbox(message.sessionID)
       }
       if (matching) {
         showToast({
@@ -614,12 +633,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (message.type === "sessionCreated") {
-      const raw = createdDraftKey(message.draftID, sandboxRequest() !== undefined && sandboxTarget() === null)
+      const raw = createdDraftKey(message.draftID, sandboxRequest(undefined) !== undefined)
       if (raw) {
         const source = scopeDraftKey(boxKey(), raw)
         const target = scopeDraftKey(boxKey(), sessionDraftKey(message.session.id))
         if (source === draftKey()) saveDraft(source, text(), reviewComments(), imageAttach.images())
-        movePromptDraft({ text: drafts, comments: reviewDrafts, images: imageDrafts }, source, target)
+        movePromptDraft({ text: drafts, comments: reviewDrafts, images: imageDrafts, scrolls }, source, target)
       }
       if (
         message.draftID &&
@@ -696,9 +715,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const syncHighlightScroll = () => {
-    if (highlightRef && textareaRef) {
-      highlightRef.scrollTop = textareaRef.scrollTop
-    }
+    if (!textareaRef) return
+    scrolls.set(draftKey(), textareaRef.scrollTop)
+    if (highlightRef) highlightRef.scrollTop = textareaRef.scrollTop
   }
 
   const adjustHeight = () => {
@@ -918,6 +937,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       drafts.delete(draftKey())
       reviewDrafts.delete(draftKey())
       imageDrafts.delete(draftKey())
+      scrolls.delete(draftKey())
       if (textareaRef) textareaRef.style.height = "auto"
       matched.action()
       return
@@ -978,6 +998,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     drafts.delete(key)
     reviewDrafts.delete(key)
     imageDrafts.delete(key)
+    scrolls.delete(key)
     if (draftKey() !== key) return
 
     history.append(draft)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/prompt-input-utils.ts
@@ -25,6 +25,13 @@ export function applySandboxState(current: SandboxState | undefined, next: Sandb
   return next
 }
 
+export function applySandboxStates(current: Record<string, SandboxState>, next: SandboxState) {
+  const previous = current[next.sessionID]
+  const state = applySandboxState(previous, next)
+  if (state === previous) return current
+  return { ...current, [next.sessionID]: state }
+}
+
 export function fileName(path: string): string {
   const normalized = path.replaceAll("\\", "/").replace(/\/+$/, "")
   return normalized.split("/").pop() ?? normalized

--- a/packages/kilo-vscode/webview-ui/src/utils/prompt-drafts.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/prompt-drafts.ts
@@ -18,21 +18,24 @@ export function createdDraftKey(draftID?: string, sandbox = false): string | und
   return pendingDraftKey(draftID) ?? (sandbox ? "new" : undefined)
 }
 
-export function movePromptDraft<T, C, I>(
-  stores: { text: Map<string, T>; comments: Map<string, C>; images: Map<string, I> },
+export function movePromptDraft<T, C, I, S>(
+  stores: { text: Map<string, T>; comments: Map<string, C>; images: Map<string, I>; scrolls: Map<string, S> },
   source: string,
   target: string,
-): { text?: T; comments?: C; images?: I } {
+): { text?: T; comments?: C; images?: I; scroll?: S } {
   const draft = {
     text: stores.text.get(source),
     comments: stores.comments.get(source),
     images: stores.images.get(source),
+    scroll: stores.scrolls.get(source),
   }
   if (draft.text !== undefined) stores.text.set(target, draft.text)
   if (draft.comments !== undefined) stores.comments.set(target, draft.comments)
   if (draft.images !== undefined) stores.images.set(target, draft.images)
+  if (draft.scroll !== undefined) stores.scrolls.set(target, draft.scroll)
   stores.text.delete(source)
   stores.comments.delete(source)
   stores.images.delete(source)
+  stores.scrolls.delete(source)
   return draft
 }


### PR DESCRIPTION
The session sandbox toggle in the VS Code chat composer had two remaining rough edges after the initial sandbox controls landed.

When switching between worktrees or sessions, the lock button briefly reset to an unknown/inactive state and then snapped back once the backend status arrived, producing a visible flicker on every switch. The webview only held a single sandbox status, so any session change discarded the previously fetched state and re-rendered the button as "not ready" while the new request was in flight.

Separately, toggling the sandbox while composing the very first message reset the prompt's scroll position. Toggling before a session exists recreates the draft scope, and the textarea scroll offset was not part of the carried-over draft, so a long prompt jumped back to the top. The intent is for sandbox toggling to be invisible to the user: the draft, attachments, and scroll position should stay exactly where they were.

This change makes the sandbox state per session. Each session's status is cached and keyed by session id, so revisiting a session renders its last known state immediately with no flicker, while still honoring backend version/revision ordering. In-flight toggle requests are tracked per session rather than globally, so rapid back-and-forth switching during a pending toggle can no longer strand a button as disabled, and a late response for an inactive session can no longer cancel the active session's retry. The prompt scroll offset is now captured and restored alongside text, review comments, and image attachments, including when an initial draft is promoted to a newly created session and when Agent Manager carries a draft into a worktree session.

Disabling or enabling the sandbox mid-stream is unchanged and intentionally does not abort or restart the active turn: a tool already executing finishes under the policy it started with, and only subsequently started tool/MCP calls observe the new policy.
