### PR TITLE
fix(vscode): translate Anaconda Desktop provider strings in all locales

### DIFF
--- a/.changeset/anaconda-desktop-translations.md
+++ b/.changeset/anaconda-desktop-translations.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Translate the Anaconda Desktop provider strings into all supported languages instead of falling back to English.

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1,12 +1,57 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "تحقق مرة أخرى",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "توصيل Anaconda Desktop",
+  "provider.anaconda.title.manage": "إدارة Anaconda Desktop",
+  "provider.anaconda.status.checking": "جارٍ التحقق من Anaconda Desktop...",
+  "provider.anaconda.status.opening": "جارٍ فتح Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "جارٍ تحديث نماذج الموفر...",
+  "provider.anaconda.status.ready": "جاهز للتوصيل",
+  "provider.anaconda.status.waiting": "في انتظار Desktop",
+  "provider.anaconda.status.attention": "يحتاج إلى انتباه",
+  "provider.anaconda.status.unavailable": "غير متوفر",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop غير مدعوم على {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "ثبّت Anaconda Desktop على هذا الجهاز، ثم عُد إلى هنا. لا يقوم Kilo بتشغيل المثبّت نيابةً عنك.",
+  "provider.anaconda.state.notRunning": "افتح Anaconda Desktop، وأكمل الإعداد وسجّل الدخول، ثم اختر تحقق مرة أخرى.",
+  "provider.anaconda.state.invalidConfig":
+    "إعداد Anaconda Desktop غير مكتمل. افتح Desktop، وأكمل الإعداد، وأعد تشغيله إذا لزم الأمر.",
+  "provider.anaconda.state.signedOut": "افتح Anaconda Desktop وسجّل الدخول قبل توصيل Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "تعذّر على Kilo الوصول إلى Anaconda Desktop. افتح Desktop، وسجّل الدخول مرة أخرى، وأعد تشغيله إذا لزم الأمر.",
+  "provider.anaconda.state.unavailable":
+    "لا يستجيب Anaconda Desktop بعد. افتحه وانتظر حتى ينتهي التطبيق من بدء التشغيل.",
+  "provider.anaconda.state.noModel":
+    "في Anaconda Desktop، نزّل نموذجًا لتوليد النصوص. اختر نموذجًا يدعم استدعاء الأدوات إن أمكن، ثم شغّل خادمه.",
   "provider.anaconda.state.noServer_one":
     "يتوفر نموذج واحد مُنزّل لتوليد النصوص. في Anaconda Desktop، شغّل خادم نموذج. يوصى بشدة باستخدام نماذج تدعم استدعاء الأدوات.",
   "provider.anaconda.state.noServer_other":
     "تتوفر نماذج مُنزّلة لتوليد النصوص، وعددها {{count}}. في Anaconda Desktop، شغّل خادم نموذج. يوصى بشدة باستخدام نماذج تدعم استدعاء الأدوات.",
+  "provider.anaconda.state.unhealthy":
+    "خادم الاستدلال النشط ليس في حالة سليمة بعد. تحقق منه في Anaconda Desktop وأعد تشغيل الخادم إذا لزم الأمر.",
+  "provider.anaconda.state.ready":
+    "عثر Kilo على خادم محلي سليم لتوليد النصوص ويمكنه استيراد إعدادات الاتصال الحالية الخاصة به.",
+  "provider.anaconda.server": "خادم الاستدلال النشط",
+  "provider.anaconda.context": "نافذة السياق",
+  "provider.anaconda.contextValue": "{{count}} رمز",
+  "provider.anaconda.tools": "استدعاء الأدوات",
+  "provider.anaconda.tools.supported": "مدعوم",
+  "provider.anaconda.tools.unsupported": "غير مُفعّل",
+  "provider.anaconda.tools.unknown": "غير معروف",
+  "provider.anaconda.warning.title": "دعم الأدوات محدود",
+  "provider.anaconda.warning.description":
+    "لا يؤكد هذا الخادم استدعاء الأدوات. قد تفشل إجراءات وكيل البرمجة أو تكون غير متوفرة. تابع فقط إذا قبلت هذه القيود.",
+  "provider.anaconda.action.download": "تنزيل Anaconda Desktop",
+  "provider.anaconda.action.open": "فتح Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "تحقق مرة أخرى",
+  "provider.anaconda.action.continue": "تابع على أي حال",
+  "provider.anaconda.action.manage": "إدارة / تحديث",
+  "provider.anaconda.toast.refreshed.title": "تم تحديث Anaconda Desktop",
+  "provider.anaconda.toast.refreshed.description": "الخادم المحلي النشط والنماذج محدّثة في Kilo.",
+  "settings.providers.note.anacondaDesktop": "شغّل نموذجًا يُقدّم محليًا بواسطة Anaconda Desktop.",
+  "settings.providers.tag.local": "محلي",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "مقترح",
   "command.category.view": "عرض",
   "command.category.project": "مشروع",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Verificar novamente",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Conectar Anaconda Desktop",
+  "provider.anaconda.title.manage": "Gerenciar Anaconda Desktop",
+  "provider.anaconda.status.checking": "Verificando Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Abrindo Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Atualizando modelos do provedor...",
+  "provider.anaconda.status.ready": "Pronto para conectar",
+  "provider.anaconda.status.waiting": "Aguardando o Desktop",
+  "provider.anaconda.status.attention": "Precisa de atenção",
+  "provider.anaconda.status.unavailable": "Indisponível",
+  "provider.anaconda.state.unsupported": "O Anaconda Desktop não é compatível com {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Instale o Anaconda Desktop nesta máquina e depois volte aqui. O Kilo não executa o instalador para você.",
+  "provider.anaconda.state.notRunning":
+    "Abra o Anaconda Desktop, conclua a configuração e faça login, depois escolha Verificar novamente.",
+  "provider.anaconda.state.invalidConfig":
+    "A configuração do Anaconda Desktop está incompleta. Abra o Desktop, conclua a configuração e reinicie-o se necessário.",
+  "provider.anaconda.state.signedOut": "Abra o Anaconda Desktop e faça login antes de conectar o Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "O Kilo não conseguiu acessar o Anaconda Desktop. Abra o Desktop, faça login novamente e reinicie-o se necessário.",
+  "provider.anaconda.state.unavailable":
+    "O Anaconda Desktop ainda não está respondendo. Abra-o e aguarde o aplicativo terminar de iniciar.",
+  "provider.anaconda.state.noModel":
+    "No Anaconda Desktop, baixe um modelo de geração de texto. Escolha um com chamadas de ferramentas quando possível, depois inicie o servidor dele.",
   "provider.anaconda.state.noServer_one":
     "Há 1 modelo de geração de texto baixado disponível. No Anaconda Desktop, inicie um servidor de modelo. Modelos com suporte a chamadas de ferramentas são altamente recomendados.",
   "provider.anaconda.state.noServer_other":
     "Há {{count}} modelos de geração de texto baixados disponíveis. No Anaconda Desktop, inicie um servidor de modelo. Modelos com suporte a chamadas de ferramentas são altamente recomendados.",
+  "provider.anaconda.state.unhealthy":
+    "O servidor de inferência ativo ainda não está saudável. Verifique-o no Anaconda Desktop e reinicie o servidor se necessário.",
+  "provider.anaconda.state.ready":
+    "O Kilo encontrou um servidor local saudável de geração de texto e pode importar suas configurações de conexão atuais.",
+  "provider.anaconda.server": "Servidor de inferência ativo",
+  "provider.anaconda.context": "Janela de contexto",
+  "provider.anaconda.contextValue": "{{count}} tokens",
+  "provider.anaconda.tools": "Chamadas de ferramentas",
+  "provider.anaconda.tools.supported": "Compatível",
+  "provider.anaconda.tools.unsupported": "Não habilitado",
+  "provider.anaconda.tools.unknown": "Desconhecido",
+  "provider.anaconda.warning.title": "O suporte a ferramentas é limitado",
+  "provider.anaconda.warning.description":
+    "Este servidor não confirma chamadas de ferramentas. Ações do agente de código podem falhar ou ficar indisponíveis. Continue apenas se você aceitar essas limitações.",
+  "provider.anaconda.action.download": "Baixar Anaconda Desktop",
+  "provider.anaconda.action.open": "Abrir Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Verificar novamente",
+  "provider.anaconda.action.continue": "Continuar mesmo assim",
+  "provider.anaconda.action.manage": "Gerenciar / Atualizar",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop atualizado",
+  "provider.anaconda.toast.refreshed.description": "O servidor local ativo e os modelos estão atualizados no Kilo.",
+  "settings.providers.note.anacondaDesktop": "Execute um modelo servido localmente pelo Anaconda Desktop.",
+  "settings.providers.tag.local": "Local",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Sugerido",
   "command.category.view": "Visualizar",
   "command.category.project": "Projeto",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Provjeri ponovo",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Poveži Anaconda Desktop",
+  "provider.anaconda.title.manage": "Upravljaj Anaconda Desktopom",
+  "provider.anaconda.status.checking": "Provjeravanje Anaconda Desktopa...",
+  "provider.anaconda.status.opening": "Otvaranje Anaconda Desktopa...",
+  "provider.anaconda.status.syncing": "Osvježavanje modela provajdera...",
+  "provider.anaconda.status.ready": "Spremno za povezivanje",
+  "provider.anaconda.status.waiting": "Čekanje na Desktop",
+  "provider.anaconda.status.attention": "Potrebna pažnja",
+  "provider.anaconda.status.unavailable": "Nedostupno",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop nije podržan na {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Instalirajte Anaconda Desktop na ovom računaru, zatim se vratite ovdje. Kilo ne pokreće instalacijski program umjesto vas.",
+  "provider.anaconda.state.notRunning":
+    "Otvorite Anaconda Desktop, dovršite postavljanje i prijavite se, zatim odaberite Provjeri ponovo.",
+  "provider.anaconda.state.invalidConfig":
+    "Postavljanje Anaconda Desktopa nije dovršeno. Otvorite Desktop, dovršite postavljanje i ponovo ga pokrenite ako je potrebno.",
+  "provider.anaconda.state.signedOut": "Otvorite Anaconda Desktop i prijavite se prije povezivanja Kila.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo nije mogao pristupiti Anaconda Desktopu. Otvorite Desktop, ponovo se prijavite i ponovo ga pokrenite ako je potrebno.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop još ne odgovara. Otvorite ga i sačekajte da se aplikacija u potpunosti pokrene.",
+  "provider.anaconda.state.noModel":
+    "U Anaconda Desktopu preuzmite model za generisanje teksta. Odaberite onaj s pozivanjem alata kad je moguće, zatim pokrenite njegov server.",
   "provider.anaconda.state.noServer_one":
     "Dostupan je 1 preuzeti model za generisanje teksta. U Anaconda Desktopu pokrenite server modela. Modeli s podrškom za pozivanje alata se snažno preporučuju.",
   "provider.anaconda.state.noServer_other":
     "Preuzeti modeli za generisanje teksta dostupni su (ukupno: {{count}}). U Anaconda Desktopu pokrenite server modela. Modeli s podrškom za pozivanje alata se snažno preporučuju.",
+  "provider.anaconda.state.unhealthy":
+    "Aktivni server za zaključivanje još nije ispravan. Provjerite ga u Anaconda Desktopu i ponovo pokrenite server ako je potrebno.",
+  "provider.anaconda.state.ready":
+    "Kilo je pronašao ispravan lokalni server za generisanje teksta i može uvesti njegove trenutne postavke veze.",
+  "provider.anaconda.server": "Aktivni server za zaključivanje",
+  "provider.anaconda.context": "Kontekstni prozor",
+  "provider.anaconda.contextValue": "{{count}} tokena",
+  "provider.anaconda.tools": "Pozivanje alata",
+  "provider.anaconda.tools.supported": "Podržano",
+  "provider.anaconda.tools.unsupported": "Nije omogućeno",
+  "provider.anaconda.tools.unknown": "Nepoznato",
+  "provider.anaconda.warning.title": "Podrška za alate je ograničena",
+  "provider.anaconda.warning.description":
+    "Ovaj server ne potvrđuje pozivanje alata. Radnje agenta za kodiranje mogu biti neuspješne ili nedostupne. Nastavite samo ako prihvatate ova ograničenja.",
+  "provider.anaconda.action.download": "Preuzmi Anaconda Desktop",
+  "provider.anaconda.action.open": "Otvori Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Provjeri ponovo",
+  "provider.anaconda.action.continue": "Ipak nastavi",
+  "provider.anaconda.action.manage": "Upravljaj / Osvježi",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop osvježen",
+  "provider.anaconda.toast.refreshed.description": "Aktivni lokalni server i modeli su ažurirani u Kilu.",
+  "settings.providers.note.anacondaDesktop": "Pokrenite model koji lokalno poslužuje Anaconda Desktop.",
+  "settings.providers.tag.local": "Lokalno",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Predloženo",
   "command.category.view": "Prikaz",
   "command.category.project": "Projekat",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Tjek igen",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Forbind Anaconda Desktop",
+  "provider.anaconda.title.manage": "Administrer Anaconda Desktop",
+  "provider.anaconda.status.checking": "Tjekker Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Åbner Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Opdaterer udbydermodeller...",
+  "provider.anaconda.status.ready": "Klar til at forbinde",
+  "provider.anaconda.status.waiting": "Venter på Desktop",
+  "provider.anaconda.status.attention": "Kræver opmærksomhed",
+  "provider.anaconda.status.unavailable": "Utilgængelig",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop understøttes ikke på {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Installer Anaconda Desktop på denne maskine, og vend derefter tilbage hertil. Kilo kører ikke installationsprogrammet for dig.",
+  "provider.anaconda.state.notRunning":
+    "Åbn Anaconda Desktop, færdiggør opsætningen og log ind, og vælg derefter Tjek igen.",
+  "provider.anaconda.state.invalidConfig":
+    "Opsætningen af Anaconda Desktop er ufuldstændig. Åbn Desktop, færdiggør opsætningen, og genstart den om nødvendigt.",
+  "provider.anaconda.state.signedOut": "Åbn Anaconda Desktop og log ind, før du forbinder Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo kunne ikke få adgang til Anaconda Desktop. Åbn Desktop, log ind igen, og genstart den om nødvendigt.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop svarer ikke endnu. Åbn den, og vent på, at applikationen er færdig med at starte.",
+  "provider.anaconda.state.noModel":
+    "Download en tekstgenereringsmodel i Anaconda Desktop. Vælg en med understøttelse af værktøjskald, når det er muligt, og start derefter dens server.",
   "provider.anaconda.state.noServer_one":
     "Der er 1 downloadet tekstgenereringsmodel tilgængelig. Start en modelserver i Anaconda Desktop. Modeller med understøttelse af værktøjskald anbefales kraftigt.",
   "provider.anaconda.state.noServer_other":
     "Der er {{count}} downloadede tekstgenereringsmodeller tilgængelige. Start en modelserver i Anaconda Desktop. Modeller med understøttelse af værktøjskald anbefales kraftigt.",
+  "provider.anaconda.state.unhealthy":
+    "Den aktive inferensserver er ikke sund endnu. Tjek den i Anaconda Desktop, og genstart serveren om nødvendigt.",
+  "provider.anaconda.state.ready":
+    "Kilo fandt en sund lokal tekstgenereringsserver og kan importere dens aktuelle forbindelsesindstillinger.",
+  "provider.anaconda.server": "Aktiv inferensserver",
+  "provider.anaconda.context": "Kontekstvindue",
+  "provider.anaconda.contextValue": "{{count}} tokens",
+  "provider.anaconda.tools": "Værktøjskald",
+  "provider.anaconda.tools.supported": "Understøttet",
+  "provider.anaconda.tools.unsupported": "Ikke aktiveret",
+  "provider.anaconda.tools.unknown": "Ukendt",
+  "provider.anaconda.warning.title": "Værktøjsunderstøttelse er begrænset",
+  "provider.anaconda.warning.description":
+    "Denne server bekræfter ikke værktøjskald. Handlinger fra kodningsagenten kan mislykkes eller være utilgængelige. Fortsæt kun, hvis du accepterer disse begrænsninger.",
+  "provider.anaconda.action.download": "Download Anaconda Desktop",
+  "provider.anaconda.action.open": "Åbn Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Tjek igen",
+  "provider.anaconda.action.continue": "Fortsæt alligevel",
+  "provider.anaconda.action.manage": "Administrer / Opdater",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop opdateret",
+  "provider.anaconda.toast.refreshed.description": "Den aktive lokale server og modeller er opdaterede i Kilo.",
+  "settings.providers.note.anacondaDesktop": "Kør en model, der serveres lokalt af Anaconda Desktop.",
+  "settings.providers.tag.local": "Lokal",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Foreslået",
   "command.category.view": "Vis",
   "command.category.project": "Projekt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1,14 +1,64 @@
-import { anacondaDesktopDict, dict as en } from "./en"
+import { dict as en } from "./en"
 
 type Keys = keyof typeof en
 
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Erneut prüfen",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Anaconda Desktop verbinden",
+  "provider.anaconda.title.manage": "Anaconda Desktop verwalten",
+  "provider.anaconda.status.checking": "Anaconda Desktop wird geprüft...",
+  "provider.anaconda.status.opening": "Anaconda Desktop wird geöffnet...",
+  "provider.anaconda.status.syncing": "Anbietermodelle werden aktualisiert...",
+  "provider.anaconda.status.ready": "Bereit zum Verbinden",
+  "provider.anaconda.status.waiting": "Warten auf Desktop",
+  "provider.anaconda.status.attention": "Erfordert Aufmerksamkeit",
+  "provider.anaconda.status.unavailable": "Nicht verfügbar",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop wird unter {{platform}} nicht unterstützt.",
+  "provider.anaconda.state.notInstalled":
+    "Installieren Sie Anaconda Desktop auf diesem Computer und kehren Sie dann hierher zurück. Kilo führt das Installationsprogramm nicht für Sie aus.",
+  "provider.anaconda.state.notRunning":
+    "Öffnen Sie Anaconda Desktop, schließen Sie die Einrichtung ab und melden Sie sich an. Wählen Sie dann Erneut prüfen.",
+  "provider.anaconda.state.invalidConfig":
+    "Die Einrichtung von Anaconda Desktop ist unvollständig. Öffnen Sie Desktop, schließen Sie die Einrichtung ab und starten Sie es bei Bedarf neu.",
+  "provider.anaconda.state.signedOut": "Öffnen Sie Anaconda Desktop und melden Sie sich an, bevor Sie Kilo verbinden.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo konnte nicht auf Anaconda Desktop zugreifen. Öffnen Sie Desktop, melden Sie sich erneut an und starten Sie es bei Bedarf neu.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop antwortet noch nicht. Öffnen Sie es und warten Sie, bis die Anwendung vollständig gestartet ist.",
+  "provider.anaconda.state.noModel":
+    "Laden Sie in Anaconda Desktop ein Textgenerierungsmodell herunter. Wählen Sie nach Möglichkeit eines mit Unterstützung für Tool-Aufrufe und starten Sie dann dessen Server.",
   "provider.anaconda.state.noServer_one":
     "1 heruntergeladenes Textgenerierungsmodell ist verfügbar. Starten Sie in Anaconda Desktop einen Modellserver. Modelle mit Unterstützung für Tool-Aufrufe werden dringend empfohlen.",
   "provider.anaconda.state.noServer_other":
     "{{count}} heruntergeladene Textgenerierungsmodelle sind verfügbar. Starten Sie in Anaconda Desktop einen Modellserver. Modelle mit Unterstützung für Tool-Aufrufe werden dringend empfohlen.",
+  "provider.anaconda.state.unhealthy":
+    "Der aktive Inferenzserver ist noch nicht funktionsfähig. Überprüfen Sie ihn in Anaconda Desktop und starten Sie den Server bei Bedarf neu.",
+  "provider.anaconda.state.ready":
+    "Kilo hat einen funktionsfähigen lokalen Textgenerierungsserver gefunden und kann dessen aktuelle Verbindungseinstellungen importieren.",
+  "provider.anaconda.server": "Aktiver Inferenzserver",
+  "provider.anaconda.context": "Kontextfenster",
+  "provider.anaconda.contextValue": "{{count}} Token",
+  "provider.anaconda.tools": "Tool-Aufrufe",
+  "provider.anaconda.tools.supported": "Unterstützt",
+  "provider.anaconda.tools.unsupported": "Nicht aktiviert",
+  "provider.anaconda.tools.unknown": "Unbekannt",
+  "provider.anaconda.warning.title": "Tool-Unterstützung ist eingeschränkt",
+  "provider.anaconda.warning.description":
+    "Dieser Server bestätigt keine Tool-Aufrufe. Aktionen des Coding-Agenten können fehlschlagen oder nicht verfügbar sein. Fahren Sie nur fort, wenn Sie diese Einschränkungen akzeptieren.",
+  "provider.anaconda.action.download": "Anaconda Desktop herunterladen",
+  "provider.anaconda.action.open": "Anaconda Desktop öffnen",
+  "provider.anaconda.action.checkAgain": "Erneut prüfen",
+  "provider.anaconda.action.continue": "Trotzdem fortfahren",
+  "provider.anaconda.action.manage": "Verwalten / Aktualisieren",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop aktualisiert",
+  "provider.anaconda.toast.refreshed.description":
+    "Der aktive lokale Server und die Modelle sind in Kilo auf dem neuesten Stand.",
+  "settings.providers.note.anacondaDesktop":
+    "Führen Sie ein Modell aus, das lokal von Anaconda Desktop bereitgestellt wird.",
+  "settings.providers.tag.local": "Lokal",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Vorgeschlagen",
   "command.category.view": "Ansicht",
   "command.category.project": "Projekt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Comprobar de nuevo",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Conectar Anaconda Desktop",
+  "provider.anaconda.title.manage": "Administrar Anaconda Desktop",
+  "provider.anaconda.status.checking": "Comprobando Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Abriendo Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Actualizando modelos del proveedor...",
+  "provider.anaconda.status.ready": "Listo para conectar",
+  "provider.anaconda.status.waiting": "Esperando a Desktop",
+  "provider.anaconda.status.attention": "Requiere atención",
+  "provider.anaconda.status.unavailable": "No disponible",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop no es compatible con {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Instala Anaconda Desktop en este equipo y luego vuelve aquí. Kilo no ejecuta el instalador por ti.",
+  "provider.anaconda.state.notRunning":
+    "Abre Anaconda Desktop, completa la configuración e inicia sesión, luego elige Comprobar de nuevo.",
+  "provider.anaconda.state.invalidConfig":
+    "La configuración de Anaconda Desktop está incompleta. Abre Desktop, completa la configuración y reinícialo si es necesario.",
+  "provider.anaconda.state.signedOut": "Abre Anaconda Desktop e inicia sesión antes de conectar Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo no pudo acceder a Anaconda Desktop. Abre Desktop, inicia sesión de nuevo y reinícialo si es necesario.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop aún no responde. Ábrelo y espera a que la aplicación termine de iniciarse.",
+  "provider.anaconda.state.noModel":
+    "En Anaconda Desktop, descarga un modelo de generación de texto. Elige uno con llamadas a herramientas cuando sea posible y luego inicia su servidor.",
   "provider.anaconda.state.noServer_one":
     "Hay 1 modelo de generación de texto descargado disponible. En Anaconda Desktop, inicia un servidor de modelos. Se recomienda encarecidamente usar modelos compatibles con llamadas a herramientas.",
   "provider.anaconda.state.noServer_other":
     "Hay {{count}} modelos de generación de texto descargados disponibles. En Anaconda Desktop, inicia un servidor de modelos. Se recomienda encarecidamente usar modelos compatibles con llamadas a herramientas.",
+  "provider.anaconda.state.unhealthy":
+    "El servidor de inferencia activo aún no está en buen estado. Compruébalo en Anaconda Desktop y reinicia el servidor si es necesario.",
+  "provider.anaconda.state.ready":
+    "Kilo encontró un servidor local de generación de texto en buen estado y puede importar su configuración de conexión actual.",
+  "provider.anaconda.server": "Servidor de inferencia activo",
+  "provider.anaconda.context": "Ventana de contexto",
+  "provider.anaconda.contextValue": "{{count}} tokens",
+  "provider.anaconda.tools": "Llamadas a herramientas",
+  "provider.anaconda.tools.supported": "Compatible",
+  "provider.anaconda.tools.unsupported": "No habilitado",
+  "provider.anaconda.tools.unknown": "Desconocido",
+  "provider.anaconda.warning.title": "La compatibilidad con herramientas es limitada",
+  "provider.anaconda.warning.description":
+    "Este servidor no confirma las llamadas a herramientas. Las acciones del agente de programación pueden fallar o no estar disponibles. Continúa solo si aceptas estas limitaciones.",
+  "provider.anaconda.action.download": "Descargar Anaconda Desktop",
+  "provider.anaconda.action.open": "Abrir Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Comprobar de nuevo",
+  "provider.anaconda.action.continue": "Continuar de todos modos",
+  "provider.anaconda.action.manage": "Administrar / Actualizar",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop actualizado",
+  "provider.anaconda.toast.refreshed.description": "El servidor local activo y los modelos están actualizados en Kilo.",
+  "settings.providers.note.anacondaDesktop": "Ejecuta un modelo servido localmente por Anaconda Desktop.",
+  "settings.providers.tag.local": "Local",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Sugerido",
   "command.category.view": "Ver",
   "command.category.project": "Proyecto",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Vérifier à nouveau",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Connecter Anaconda Desktop",
+  "provider.anaconda.title.manage": "Gérer Anaconda Desktop",
+  "provider.anaconda.status.checking": "Vérification d’Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Ouverture d’Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Actualisation des modèles du fournisseur...",
+  "provider.anaconda.status.ready": "Prêt à se connecter",
+  "provider.anaconda.status.waiting": "En attente de Desktop",
+  "provider.anaconda.status.attention": "Nécessite une attention",
+  "provider.anaconda.status.unavailable": "Indisponible",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop n’est pas pris en charge sur {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Installez Anaconda Desktop sur cette machine, puis revenez ici. Kilo n’exécute pas l’installateur à votre place.",
+  "provider.anaconda.state.notRunning":
+    "Ouvrez Anaconda Desktop, terminez la configuration et connectez-vous, puis choisissez Vérifier à nouveau.",
+  "provider.anaconda.state.invalidConfig":
+    "La configuration d’Anaconda Desktop est incomplète. Ouvrez Desktop, terminez la configuration et redémarrez-le si nécessaire.",
+  "provider.anaconda.state.signedOut": "Ouvrez Anaconda Desktop et connectez-vous avant de connecter Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo n’a pas pu accéder à Anaconda Desktop. Ouvrez Desktop, reconnectez-vous et redémarrez-le si nécessaire.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop ne répond pas encore. Ouvrez-le et attendez que l’application finisse de démarrer.",
+  "provider.anaconda.state.noModel":
+    "Dans Anaconda Desktop, téléchargez un modèle de génération de texte. Choisissez-en un prenant en charge l’appel d’outils si possible, puis démarrez son serveur.",
   "provider.anaconda.state.noServer_one":
     "1 modèle de génération de texte téléchargé est disponible. Dans Anaconda Desktop, démarrez un serveur de modèle. Les modèles prenant en charge l’appel d’outils sont vivement recommandés.",
   "provider.anaconda.state.noServer_other":
     "{{count}} modèles de génération de texte téléchargés sont disponibles. Dans Anaconda Desktop, démarrez un serveur de modèle. Les modèles prenant en charge l’appel d’outils sont vivement recommandés.",
+  "provider.anaconda.state.unhealthy":
+    "Le serveur d’inférence actif n’est pas encore sain. Vérifiez-le dans Anaconda Desktop et redémarrez le serveur si nécessaire.",
+  "provider.anaconda.state.ready":
+    "Kilo a trouvé un serveur local sain de génération de texte et peut importer ses paramètres de connexion actuels.",
+  "provider.anaconda.server": "Serveur d’inférence actif",
+  "provider.anaconda.context": "Fenêtre de contexte",
+  "provider.anaconda.contextValue": "{{count}} jetons",
+  "provider.anaconda.tools": "Appel d’outils",
+  "provider.anaconda.tools.supported": "Pris en charge",
+  "provider.anaconda.tools.unsupported": "Non activé",
+  "provider.anaconda.tools.unknown": "Inconnu",
+  "provider.anaconda.warning.title": "La prise en charge des outils est limitée",
+  "provider.anaconda.warning.description":
+    "Ce serveur ne confirme pas l’appel d’outils. Les actions de l’agent de codage peuvent échouer ou être indisponibles. Ne continuez que si vous acceptez ces limitations.",
+  "provider.anaconda.action.download": "Télécharger Anaconda Desktop",
+  "provider.anaconda.action.open": "Ouvrir Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Vérifier à nouveau",
+  "provider.anaconda.action.continue": "Continuer quand même",
+  "provider.anaconda.action.manage": "Gérer / Actualiser",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop actualisé",
+  "provider.anaconda.toast.refreshed.description": "Le serveur local actif et les modèles sont à jour dans Kilo.",
+  "settings.providers.note.anacondaDesktop": "Exécutez un modèle servi localement par Anaconda Desktop.",
+  "settings.providers.tag.local": "Local",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Suggéré",
   "command.category.view": "Affichage",
   "command.category.project": "Projet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Controlla di nuovo",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Connetti Anaconda Desktop",
+  "provider.anaconda.title.manage": "Gestisci Anaconda Desktop",
+  "provider.anaconda.status.checking": "Controllo di Anaconda Desktop in corso...",
+  "provider.anaconda.status.opening": "Apertura di Anaconda Desktop in corso...",
+  "provider.anaconda.status.syncing": "Aggiornamento dei modelli del provider in corso...",
+  "provider.anaconda.status.ready": "Pronto per la connessione",
+  "provider.anaconda.status.waiting": "In attesa di Desktop",
+  "provider.anaconda.status.attention": "Richiede attenzione",
+  "provider.anaconda.status.unavailable": "Non disponibile",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop non è supportato su {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Installa Anaconda Desktop su questo computer, poi torna qui. Kilo non esegue il programma di installazione per te.",
+  "provider.anaconda.state.notRunning":
+    "Apri Anaconda Desktop, completa la configurazione e accedi, poi scegli Controlla di nuovo.",
+  "provider.anaconda.state.invalidConfig":
+    "La configurazione di Anaconda Desktop è incompleta. Apri Desktop, completa la configurazione e riavvialo se necessario.",
+  "provider.anaconda.state.signedOut": "Apri Anaconda Desktop e accedi prima di connettere Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo non è riuscito ad accedere ad Anaconda Desktop. Apri Desktop, accedi di nuovo e riavvialo se necessario.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop non risponde ancora. Aprilo e attendi che l'applicazione finisca di avviarsi.",
+  "provider.anaconda.state.noModel":
+    "In Anaconda Desktop, scarica un modello di generazione del testo. Quando possibile, scegline uno con il supporto alle chiamate agli strumenti, poi avvia il suo server.",
   "provider.anaconda.state.noServer_one":
     "È disponibile 1 modello di generazione del testo scaricato. In Anaconda Desktop, avvia un server di modelli. I modelli che supportano le chiamate agli strumenti sono fortemente consigliati.",
   "provider.anaconda.state.noServer_other":
     "Sono disponibili {{count}} modelli di generazione del testo scaricati. In Anaconda Desktop, avvia un server di modelli. I modelli che supportano le chiamate agli strumenti sono fortemente consigliati.",
+  "provider.anaconda.state.unhealthy":
+    "Il server di inferenza attivo non è ancora integro. Controllalo in Anaconda Desktop e riavvia il server se necessario.",
+  "provider.anaconda.state.ready":
+    "Kilo ha trovato un server locale di generazione del testo integro e può importare le sue attuali impostazioni di connessione.",
+  "provider.anaconda.server": "Server di inferenza attivo",
+  "provider.anaconda.context": "Finestra di contesto",
+  "provider.anaconda.contextValue": "{{count}} token",
+  "provider.anaconda.tools": "Chiamata agli strumenti",
+  "provider.anaconda.tools.supported": "Supportata",
+  "provider.anaconda.tools.unsupported": "Non abilitata",
+  "provider.anaconda.tools.unknown": "Sconosciuta",
+  "provider.anaconda.warning.title": "Il supporto agli strumenti è limitato",
+  "provider.anaconda.warning.description":
+    "Questo server non conferma la chiamata agli strumenti. Le azioni dell'agente di programmazione potrebbero non riuscire o non essere disponibili. Continua solo se accetti queste limitazioni.",
+  "provider.anaconda.action.download": "Scarica Anaconda Desktop",
+  "provider.anaconda.action.open": "Apri Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Controlla di nuovo",
+  "provider.anaconda.action.continue": "Continua comunque",
+  "provider.anaconda.action.manage": "Gestisci / Aggiorna",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop aggiornato",
+  "provider.anaconda.toast.refreshed.description": "Il server locale attivo e i modelli sono aggiornati in Kilo.",
+  "settings.providers.note.anacondaDesktop": "Esegui un modello servito localmente da Anaconda Desktop.",
+  "settings.providers.tag.local": "Locale",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Suggeriti",
   "command.category.view": "Vista",
   "command.category.project": "Progetto",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "再確認",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Anaconda Desktop に接続",
+  "provider.anaconda.title.manage": "Anaconda Desktop を管理",
+  "provider.anaconda.status.checking": "Anaconda Desktop を確認しています...",
+  "provider.anaconda.status.opening": "Anaconda Desktop を開いています...",
+  "provider.anaconda.status.syncing": "プロバイダーのモデルを更新しています...",
+  "provider.anaconda.status.ready": "接続の準備ができました",
+  "provider.anaconda.status.waiting": "Desktop を待機しています",
+  "provider.anaconda.status.attention": "対応が必要です",
+  "provider.anaconda.status.unavailable": "利用できません",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop は {{platform}} ではサポートされていません。",
+  "provider.anaconda.state.notInstalled":
+    "このマシンに Anaconda Desktop をインストールしてから、ここに戻ってください。Kilo はインストーラーを実行しません。",
+  "provider.anaconda.state.notRunning":
+    "Anaconda Desktop を開いてセットアップを完了しサインインしてから、再確認を選択してください。",
+  "provider.anaconda.state.invalidConfig":
+    "Anaconda Desktop のセットアップが完了していません。Desktop を開いてセットアップを完了し、必要に応じて再起動してください。",
+  "provider.anaconda.state.signedOut": "Kilo を接続する前に、Anaconda Desktop を開いてサインインしてください。",
+  "provider.anaconda.state.unauthorized":
+    "Kilo は Anaconda Desktop にアクセスできませんでした。Desktop を開いて再度サインインし、必要に応じて再起動してください。",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop はまだ応答していません。開いてアプリケーションの起動が完了するまでお待ちください。",
+  "provider.anaconda.state.noModel":
+    "Anaconda Desktop で、テキスト生成モデルをダウンロードしてください。可能であればツール呼び出しに対応したモデルを選び、そのサーバーを起動してください。",
   "provider.anaconda.state.noServer_one":
     "ダウンロード済みのテキスト生成モデルが1つ利用可能です。Anaconda Desktopでモデルサーバーを起動してください。ツール呼び出しに対応したモデルの使用を強く推奨します。",
   "provider.anaconda.state.noServer_other":
     "ダウンロード済みのテキスト生成モデルが{{count}}個利用可能です。Anaconda Desktopでモデルサーバーを起動してください。ツール呼び出しに対応したモデルの使用を強く推奨します。",
+  "provider.anaconda.state.unhealthy":
+    "アクティブな推論サーバーはまだ正常ではありません。Anaconda Desktop で確認し、必要に応じてサーバーを再起動してください。",
+  "provider.anaconda.state.ready":
+    "Kilo は正常なローカルのテキスト生成サーバーを見つけ、現在の接続設定をインポートできます。",
+  "provider.anaconda.server": "アクティブな推論サーバー",
+  "provider.anaconda.context": "コンテキストウィンドウ",
+  "provider.anaconda.contextValue": "{{count}} トークン",
+  "provider.anaconda.tools": "ツール呼び出し",
+  "provider.anaconda.tools.supported": "対応",
+  "provider.anaconda.tools.unsupported": "無効",
+  "provider.anaconda.tools.unknown": "不明",
+  "provider.anaconda.warning.title": "ツールのサポートは限定的です",
+  "provider.anaconda.warning.description":
+    "このサーバーはツール呼び出しを確認できません。コーディングエージェントの操作が失敗したり利用できなかったりする場合があります。これらの制限を受け入れる場合のみ続行してください。",
+  "provider.anaconda.action.download": "Anaconda Desktop をダウンロード",
+  "provider.anaconda.action.open": "Anaconda Desktop を開く",
+  "provider.anaconda.action.checkAgain": "再確認",
+  "provider.anaconda.action.continue": "このまま続行",
+  "provider.anaconda.action.manage": "管理 / 更新",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop を更新しました",
+  "provider.anaconda.toast.refreshed.description": "アクティブなローカルサーバーとモデルが Kilo で最新になりました。",
+  "settings.providers.note.anacondaDesktop": "Anaconda Desktop によってローカルで提供されるモデルを実行します。",
+  "settings.providers.tag.local": "ローカル",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "おすすめ",
   "command.category.view": "表示",
   "command.category.project": "プロジェクト",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1,14 +1,62 @@
-import { anacondaDesktopDict, dict as en } from "./en"
+import { dict as en } from "./en"
+
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Anaconda Desktop 연결",
+  "provider.anaconda.title.manage": "Anaconda Desktop 관리",
+  "provider.anaconda.status.checking": "Anaconda Desktop 확인 중...",
+  "provider.anaconda.status.opening": "Anaconda Desktop 여는 중...",
+  "provider.anaconda.status.syncing": "공급자 모델 새로 고치는 중...",
+  "provider.anaconda.status.ready": "연결할 준비됨",
+  "provider.anaconda.status.waiting": "Desktop 대기 중",
+  "provider.anaconda.status.attention": "주의 필요",
+  "provider.anaconda.status.unavailable": "사용할 수 없음",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop은 {{platform}}에서 지원되지 않습니다.",
+  "provider.anaconda.state.notInstalled":
+    "이 컴퓨터에 Anaconda Desktop을 설치한 후 여기로 돌아오세요. Kilo는 설치 프로그램을 대신 실행하지 않습니다.",
+  "provider.anaconda.state.notRunning":
+    "Anaconda Desktop을 열고 설정을 완료한 후 로그인한 다음 다시 확인을 선택하세요.",
+  "provider.anaconda.state.invalidConfig":
+    "Anaconda Desktop 설정이 완료되지 않았습니다. Desktop을 열고 설정을 완료한 후 필요하면 다시 시작하세요.",
+  "provider.anaconda.state.signedOut": "Kilo를 연결하기 전에 Anaconda Desktop을 열고 로그인하세요.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo가 Anaconda Desktop에 접근할 수 없습니다. Desktop을 열고 다시 로그인한 후 필요하면 다시 시작하세요.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop이 아직 응답하지 않습니다. 열어서 애플리케이션이 완전히 시작될 때까지 기다리세요.",
+  "provider.anaconda.state.noModel":
+    "Anaconda Desktop에서 텍스트 생성 모델을 다운로드하세요. 가능하면 도구 호출을 지원하는 모델을 선택한 후 서버를 시작하세요.",
+  "provider.anaconda.state.noServer_one":
+    "다운로드된 텍스트 생성 모델 1개를 사용할 수 있습니다. Anaconda Desktop에서 모델 서버를 시작하세요. 도구 호출을 지원하는 모델을 강력히 권장합니다.",
+  "provider.anaconda.state.noServer_other":
+    "다운로드된 텍스트 생성 모델 {{count}}개를 사용할 수 있습니다. Anaconda Desktop에서 모델 서버를 시작하세요. 도구 호출을 지원하는 모델을 강력히 권장합니다.",
+  "provider.anaconda.state.unhealthy":
+    "활성 추론 서버가 아직 정상이 아닙니다. Anaconda Desktop에서 확인하고 필요하면 서버를 다시 시작하세요.",
+  "provider.anaconda.state.ready":
+    "Kilo가 정상적인 로컬 텍스트 생성 서버를 찾았으며 현재 연결 설정을 가져올 수 있습니다.",
+  "provider.anaconda.server": "활성 추론 서버",
+  "provider.anaconda.context": "컨텍스트 창",
+  "provider.anaconda.contextValue": "{{count}} 토큰",
+  "provider.anaconda.tools": "도구 호출",
+  "provider.anaconda.tools.supported": "지원됨",
+  "provider.anaconda.tools.unsupported": "사용 안 함",
+  "provider.anaconda.tools.unknown": "알 수 없음",
+  "provider.anaconda.warning.title": "도구 지원이 제한적입니다",
+  "provider.anaconda.warning.description":
+    "이 서버는 도구 호출을 확인하지 않습니다. 코딩 에이전트 작업이 실패하거나 사용할 수 없을 수 있습니다. 이러한 제한을 감수하는 경우에만 계속하세요.",
+  "provider.anaconda.action.download": "Anaconda Desktop 다운로드",
+  "provider.anaconda.action.open": "Anaconda Desktop 열기",
+  "provider.anaconda.action.checkAgain": "다시 확인",
+  "provider.anaconda.action.continue": "계속하기",
+  "provider.anaconda.action.manage": "관리 / 새로 고침",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop 새로 고침됨",
+  "provider.anaconda.toast.refreshed.description": "활성 로컬 서버와 모델이 Kilo에서 최신 상태입니다.",
+  "settings.providers.note.anacondaDesktop": "Anaconda Desktop이 로컬에서 제공하는 모델을 실행합니다.",
+  "settings.providers.tag.local": "로컬",
+} as const
 
 type Keys = keyof typeof en
 
 export const dict = {
   ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "다시 확인",
-  "provider.anaconda.state.noServer_one":
-    "다운로드된 텍스트 생성 모델 1개를 사용할 수 있습니다. Anaconda Desktop에서 모델 서버를 시작하세요. 도구 호출을 지원하는 모델을 강력히 권장합니다.",
-  "provider.anaconda.state.noServer_other":
-    "다운로드된 텍스트 생성 모델 {{count}}개를 사용할 수 있습니다. Anaconda Desktop에서 모델 서버를 시작하세요. 도구 호출을 지원하는 모델을 강력히 권장합니다.",
   "command.category.suggested": "추천",
   "command.category.view": "보기",
   "command.category.project": "프로젝트",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Opnieuw controleren",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Anaconda Desktop verbinden",
+  "provider.anaconda.title.manage": "Anaconda Desktop beheren",
+  "provider.anaconda.status.checking": "Anaconda Desktop controleren...",
+  "provider.anaconda.status.opening": "Anaconda Desktop openen...",
+  "provider.anaconda.status.syncing": "Providermodellen vernieuwen...",
+  "provider.anaconda.status.ready": "Klaar om te verbinden",
+  "provider.anaconda.status.waiting": "Wachten op Desktop",
+  "provider.anaconda.status.attention": "Vereist aandacht",
+  "provider.anaconda.status.unavailable": "Niet beschikbaar",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop wordt niet ondersteund op {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Installeer Anaconda Desktop op deze machine en kom hier dan terug. Kilo voert het installatieprogramma niet voor je uit.",
+  "provider.anaconda.state.notRunning":
+    "Open Anaconda Desktop, voltooi de installatie en meld je aan, kies daarna Opnieuw controleren.",
+  "provider.anaconda.state.invalidConfig":
+    "De installatie van Anaconda Desktop is onvolledig. Open Desktop, voltooi de installatie en herstart het indien nodig.",
+  "provider.anaconda.state.signedOut": "Open Anaconda Desktop en meld je aan voordat je Kilo verbindt.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo kon geen toegang krijgen tot Anaconda Desktop. Open Desktop, meld je opnieuw aan en herstart het indien nodig.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop reageert nog niet. Open het en wacht tot de applicatie volledig is opgestart.",
+  "provider.anaconda.state.noModel":
+    "Download in Anaconda Desktop een tekstgeneratiemodel. Kies er indien mogelijk een met ondersteuning voor toolaanroepen en start daarna de server.",
   "provider.anaconda.state.noServer_one":
     "Er is 1 gedownload tekstgeneratiemodel beschikbaar. Start een modelserver in Anaconda Desktop. Modellen met ondersteuning voor toolaanroepen worden sterk aanbevolen.",
   "provider.anaconda.state.noServer_other":
     "Er zijn {{count}} gedownloade tekstgeneratiemodellen beschikbaar. Start een modelserver in Anaconda Desktop. Modellen met ondersteuning voor toolaanroepen worden sterk aanbevolen.",
+  "provider.anaconda.state.unhealthy":
+    "De actieve inferentieserver is nog niet gezond. Controleer deze in Anaconda Desktop en herstart de server indien nodig.",
+  "provider.anaconda.state.ready":
+    "Kilo heeft een gezonde lokale tekstgeneratieserver gevonden en kan de huidige verbindingsinstellingen importeren.",
+  "provider.anaconda.server": "Actieve inferentieserver",
+  "provider.anaconda.context": "Contextvenster",
+  "provider.anaconda.contextValue": "{{count}} tokens",
+  "provider.anaconda.tools": "Toolaanroepen",
+  "provider.anaconda.tools.supported": "Ondersteund",
+  "provider.anaconda.tools.unsupported": "Niet ingeschakeld",
+  "provider.anaconda.tools.unknown": "Onbekend",
+  "provider.anaconda.warning.title": "Toolondersteuning is beperkt",
+  "provider.anaconda.warning.description":
+    "Deze server bevestigt geen toolaanroepen. Acties van de codeeragent kunnen mislukken of niet beschikbaar zijn. Ga alleen verder als je deze beperkingen accepteert.",
+  "provider.anaconda.action.download": "Anaconda Desktop downloaden",
+  "provider.anaconda.action.open": "Anaconda Desktop openen",
+  "provider.anaconda.action.checkAgain": "Opnieuw controleren",
+  "provider.anaconda.action.continue": "Toch doorgaan",
+  "provider.anaconda.action.manage": "Beheren / Vernieuwen",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop vernieuwd",
+  "provider.anaconda.toast.refreshed.description": "De actieve lokale server en modellen zijn up-to-date in Kilo.",
+  "settings.providers.note.anacondaDesktop": "Voer een model uit dat lokaal door Anaconda Desktop wordt aangeboden.",
+  "settings.providers.tag.local": "Lokaal",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Voorgesteld",
   "command.category.view": "Weergave",
   "command.category.project": "Project",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1,13 +1,61 @@
-import { anacondaDesktopDict, dict as en } from "./en"
+import { dict as en } from "./en"
 type Keys = keyof typeof en
 
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Sjekk igjen",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Koble til Anaconda Desktop",
+  "provider.anaconda.title.manage": "Administrer Anaconda Desktop",
+  "provider.anaconda.status.checking": "Sjekker Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Åpner Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Oppdaterer leverandørmodeller...",
+  "provider.anaconda.status.ready": "Klar til å koble til",
+  "provider.anaconda.status.waiting": "Venter på Desktop",
+  "provider.anaconda.status.attention": "Trenger oppmerksomhet",
+  "provider.anaconda.status.unavailable": "Utilgjengelig",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop støttes ikke på {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Installer Anaconda Desktop på denne maskinen, og kom deretter tilbake hit. Kilo kjører ikke installasjonsprogrammet for deg.",
+  "provider.anaconda.state.notRunning":
+    "Åpne Anaconda Desktop, fullfør oppsettet og logg inn, og velg deretter Sjekk igjen.",
+  "provider.anaconda.state.invalidConfig":
+    "Oppsettet av Anaconda Desktop er ufullstendig. Åpne Desktop, fullfør oppsettet, og start det på nytt om nødvendig.",
+  "provider.anaconda.state.signedOut": "Åpne Anaconda Desktop og logg inn før du kobler til Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo fikk ikke tilgang til Anaconda Desktop. Åpne Desktop, logg inn på nytt, og start det på nytt om nødvendig.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop svarer ikke ennå. Åpne det og vent til applikasjonen er ferdig med å starte.",
+  "provider.anaconda.state.noModel":
+    "Last ned en tekstgenereringsmodell i Anaconda Desktop. Velg en med støtte for verktøykall når det er mulig, og start deretter serveren.",
   "provider.anaconda.state.noServer_one":
     "1 nedlastet tekstgenereringsmodell er tilgjengelig. Start en modellserver i Anaconda Desktop. Modeller med støtte for verktøykall anbefales på det sterkeste.",
   "provider.anaconda.state.noServer_other":
     "{{count}} nedlastede tekstgenereringsmodeller er tilgjengelige. Start en modellserver i Anaconda Desktop. Modeller med støtte for verktøykall anbefales på det sterkeste.",
+  "provider.anaconda.state.unhealthy":
+    "Den aktive inferensserveren er ikke sunn ennå. Sjekk den i Anaconda Desktop og start serveren på nytt om nødvendig.",
+  "provider.anaconda.state.ready":
+    "Kilo fant en sunn lokal tekstgenereringsserver og kan importere de gjeldende tilkoblingsinnstillingene.",
+  "provider.anaconda.server": "Aktiv inferensserver",
+  "provider.anaconda.context": "Kontekstvindu",
+  "provider.anaconda.contextValue": "{{count}} tokens",
+  "provider.anaconda.tools": "Verktøykall",
+  "provider.anaconda.tools.supported": "Støttet",
+  "provider.anaconda.tools.unsupported": "Ikke aktivert",
+  "provider.anaconda.tools.unknown": "Ukjent",
+  "provider.anaconda.warning.title": "Verktøystøtte er begrenset",
+  "provider.anaconda.warning.description":
+    "Denne serveren bekrefter ikke verktøykall. Handlinger fra kodeagenten kan mislykkes eller være utilgjengelige. Fortsett bare hvis du godtar disse begrensningene.",
+  "provider.anaconda.action.download": "Last ned Anaconda Desktop",
+  "provider.anaconda.action.open": "Åpne Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Sjekk igjen",
+  "provider.anaconda.action.continue": "Fortsett likevel",
+  "provider.anaconda.action.manage": "Administrer / Oppdater",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop oppdatert",
+  "provider.anaconda.toast.refreshed.description": "Den aktive lokale serveren og modellene er oppdatert i Kilo.",
+  "settings.providers.note.anacondaDesktop": "Kjør en modell som serveres lokalt av Anaconda Desktop.",
+  "settings.providers.tag.local": "Lokal",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Foreslått",
   "command.category.view": "Visning",
   "command.category.project": "Prosjekt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Sprawdź ponownie",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Połącz Anaconda Desktop",
+  "provider.anaconda.title.manage": "Zarządzaj Anaconda Desktop",
+  "provider.anaconda.status.checking": "Sprawdzanie Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Otwieranie Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Odświeżanie modeli dostawcy...",
+  "provider.anaconda.status.ready": "Gotowy do połączenia",
+  "provider.anaconda.status.waiting": "Oczekiwanie na Desktop",
+  "provider.anaconda.status.attention": "Wymaga uwagi",
+  "provider.anaconda.status.unavailable": "Niedostępny",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop nie jest obsługiwana w systemie {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Zainstaluj Anaconda Desktop na tym komputerze, a następnie wróć tutaj. Kilo nie uruchamia instalatora za Ciebie.",
+  "provider.anaconda.state.notRunning":
+    "Otwórz Anaconda Desktop, dokończ konfigurację i zaloguj się, a następnie wybierz Sprawdź ponownie.",
+  "provider.anaconda.state.invalidConfig":
+    "Konfiguracja Anaconda Desktop jest niekompletna. Otwórz Desktop, dokończ konfigurację i w razie potrzeby uruchom ją ponownie.",
+  "provider.anaconda.state.signedOut": "Otwórz Anaconda Desktop i zaloguj się przed połączeniem Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo nie mógł uzyskać dostępu do Anaconda Desktop. Otwórz Desktop, zaloguj się ponownie i w razie potrzeby uruchom ją ponownie.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop jeszcze nie odpowiada. Otwórz ją i poczekaj, aż aplikacja zakończy uruchamianie.",
+  "provider.anaconda.state.noModel":
+    "W Anaconda Desktop pobierz model generowania tekstu. Jeśli to możliwe, wybierz model obsługujący wywoływanie narzędzi, a następnie uruchom jego serwer.",
   "provider.anaconda.state.noServer_one":
     "Dostępny jest 1 pobrany model generowania tekstu. W Anaconda Desktop uruchom serwer modelu. Zdecydowanie zalecamy modele obsługujące wywoływanie narzędzi.",
   "provider.anaconda.state.noServer_other":
     "Dostępne są pobrane modele generowania tekstu (łącznie: {{count}}). W Anaconda Desktop uruchom serwer modelu. Zdecydowanie zalecamy modele obsługujące wywoływanie narzędzi.",
+  "provider.anaconda.state.unhealthy":
+    "Aktywny serwer wnioskowania nie jest jeszcze sprawny. Sprawdź go w Anaconda Desktop i w razie potrzeby uruchom serwer ponownie.",
+  "provider.anaconda.state.ready":
+    "Kilo znalazł sprawny lokalny serwer generowania tekstu i może zaimportować jego bieżące ustawienia połączenia.",
+  "provider.anaconda.server": "Aktywny serwer wnioskowania",
+  "provider.anaconda.context": "Okno kontekstu",
+  "provider.anaconda.contextValue": "{{count}} tokenów",
+  "provider.anaconda.tools": "Wywoływanie narzędzi",
+  "provider.anaconda.tools.supported": "Obsługiwane",
+  "provider.anaconda.tools.unsupported": "Nie włączone",
+  "provider.anaconda.tools.unknown": "Nieznane",
+  "provider.anaconda.warning.title": "Obsługa narzędzi jest ograniczona",
+  "provider.anaconda.warning.description":
+    "Ten serwer nie potwierdza wywoływania narzędzi. Działania agenta kodującego mogą się nie powieść lub być niedostępne. Kontynuuj tylko wtedy, gdy akceptujesz te ograniczenia.",
+  "provider.anaconda.action.download": "Pobierz Anaconda Desktop",
+  "provider.anaconda.action.open": "Otwórz Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Sprawdź ponownie",
+  "provider.anaconda.action.continue": "Kontynuuj mimo to",
+  "provider.anaconda.action.manage": "Zarządzaj / Odśwież",
+  "provider.anaconda.toast.refreshed.title": "Odświeżono Anaconda Desktop",
+  "provider.anaconda.toast.refreshed.description": "Aktywny serwer lokalny i modele są aktualne w Kilo.",
+  "settings.providers.note.anacondaDesktop": "Uruchom model serwowany lokalnie przez Anaconda Desktop.",
+  "settings.providers.tag.local": "Lokalny",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Sugerowane",
   "command.category.view": "Widok",
   "command.category.project": "Projekt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Проверить снова",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Подключить Anaconda Desktop",
+  "provider.anaconda.title.manage": "Управление Anaconda Desktop",
+  "provider.anaconda.status.checking": "Проверка Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Открытие Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Обновление моделей провайдера...",
+  "provider.anaconda.status.ready": "Готово к подключению",
+  "provider.anaconda.status.waiting": "Ожидание Desktop",
+  "provider.anaconda.status.attention": "Требуется внимание",
+  "provider.anaconda.status.unavailable": "Недоступно",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop не поддерживается на {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Установите Anaconda Desktop на этом компьютере, затем вернитесь сюда. Kilo не запускает установщик за вас.",
+  "provider.anaconda.state.notRunning":
+    "Откройте Anaconda Desktop, завершите настройку и войдите в систему, затем выберите «Проверить снова».",
+  "provider.anaconda.state.invalidConfig":
+    "Настройка Anaconda Desktop не завершена. Откройте Desktop, завершите настройку и при необходимости перезапустите его.",
+  "provider.anaconda.state.signedOut": "Откройте Anaconda Desktop и войдите в систему перед подключением Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo не удалось получить доступ к Anaconda Desktop. Откройте Desktop, войдите снова и при необходимости перезапустите его.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop пока не отвечает. Откройте его и дождитесь завершения запуска приложения.",
+  "provider.anaconda.state.noModel":
+    "В Anaconda Desktop загрузите модель генерации текста. По возможности выберите модель с поддержкой вызова инструментов, затем запустите её сервер.",
   "provider.anaconda.state.noServer_one":
     "Доступна 1 загруженная модель генерации текста. Запустите сервер модели в Anaconda Desktop. Настоятельно рекомендуется использовать модели с поддержкой вызова инструментов.",
   "provider.anaconda.state.noServer_other":
     "Доступно загруженных моделей генерации текста: {{count}}. Запустите сервер модели в Anaconda Desktop. Настоятельно рекомендуется использовать модели с поддержкой вызова инструментов.",
+  "provider.anaconda.state.unhealthy":
+    "Активный сервер вывода пока не работает исправно. Проверьте его в Anaconda Desktop и при необходимости перезапустите сервер.",
+  "provider.anaconda.state.ready":
+    "Kilo обнаружил исправный локальный сервер генерации текста и может импортировать его текущие настройки подключения.",
+  "provider.anaconda.server": "Активный сервер вывода",
+  "provider.anaconda.context": "Контекстное окно",
+  "provider.anaconda.contextValue": "{{count}} токенов",
+  "provider.anaconda.tools": "Вызов инструментов",
+  "provider.anaconda.tools.supported": "Поддерживается",
+  "provider.anaconda.tools.unsupported": "Не включено",
+  "provider.anaconda.tools.unknown": "Неизвестно",
+  "provider.anaconda.warning.title": "Поддержка инструментов ограничена",
+  "provider.anaconda.warning.description":
+    "Этот сервер не подтверждает вызов инструментов. Действия агента-программиста могут завершаться сбоем или быть недоступными. Продолжайте только если вы принимаете эти ограничения.",
+  "provider.anaconda.action.download": "Скачать Anaconda Desktop",
+  "provider.anaconda.action.open": "Открыть Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Проверить снова",
+  "provider.anaconda.action.continue": "Всё равно продолжить",
+  "provider.anaconda.action.manage": "Управление / Обновить",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop обновлён",
+  "provider.anaconda.toast.refreshed.description": "Активный локальный сервер и модели актуальны в Kilo.",
+  "settings.providers.note.anacondaDesktop": "Запустите модель, обслуживаемую локально через Anaconda Desktop.",
+  "settings.providers.tag.local": "Локально",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Предложено",
   "command.category.view": "Просмотр",
   "command.category.project": "Проект",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1,12 +1,57 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "ตรวจสอบอีกครั้ง",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "เชื่อมต่อ Anaconda Desktop",
+  "provider.anaconda.title.manage": "จัดการ Anaconda Desktop",
+  "provider.anaconda.status.checking": "กำลังตรวจสอบ Anaconda Desktop...",
+  "provider.anaconda.status.opening": "กำลังเปิด Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "กำลังรีเฟรชโมเดลของผู้ให้บริการ...",
+  "provider.anaconda.status.ready": "พร้อมเชื่อมต่อ",
+  "provider.anaconda.status.waiting": "กำลังรอ Desktop",
+  "provider.anaconda.status.attention": "ต้องการการดำเนินการ",
+  "provider.anaconda.status.unavailable": "ไม่พร้อมใช้งาน",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop ไม่รองรับบน {{platform}}",
+  "provider.anaconda.state.notInstalled":
+    "ติดตั้ง Anaconda Desktop บนเครื่องนี้ แล้วกลับมาที่นี่ Kilo จะไม่เรียกใช้ตัวติดตั้งให้คุณ",
+  "provider.anaconda.state.notRunning":
+    "เปิด Anaconda Desktop ตั้งค่าให้เสร็จและลงชื่อเข้าใช้ แล้วเลือกตรวจสอบอีกครั้ง",
+  "provider.anaconda.state.invalidConfig":
+    "การตั้งค่า Anaconda Desktop ยังไม่สมบูรณ์ เปิด Desktop ตั้งค่าให้เสร็จ และรีสตาร์ทหากจำเป็น",
+  "provider.anaconda.state.signedOut": "เปิด Anaconda Desktop และลงชื่อเข้าใช้ก่อนเชื่อมต่อ Kilo",
+  "provider.anaconda.state.unauthorized":
+    "Kilo ไม่สามารถเข้าถึง Anaconda Desktop ได้ เปิด Desktop ลงชื่อเข้าใช้อีกครั้ง และรีสตาร์ทหากจำเป็น",
+  "provider.anaconda.state.unavailable": "Anaconda Desktop ยังไม่ตอบสนอง เปิดและรอให้แอปพลิเคชันเริ่มทำงานเสร็จ",
+  "provider.anaconda.state.noModel":
+    "ใน Anaconda Desktop ดาวน์โหลดโมเดลสร้างข้อความ เลือกโมเดลที่รองรับการเรียกใช้เครื่องมือเมื่อเป็นไปได้ แล้วเริ่มเซิร์ฟเวอร์ของโมเดลนั้น",
   "provider.anaconda.state.noServer_one":
     "มีโมเดลสร้างข้อความที่ดาวน์โหลดไว้แล้วพร้อมใช้งานอยู่ 1 โมเดล โปรดเริ่มเซิร์ฟเวอร์โมเดลใน Anaconda Desktop ขอแนะนำอย่างยิ่งให้ใช้โมเดลที่รองรับการเรียกใช้เครื่องมือ",
   "provider.anaconda.state.noServer_other":
     "มีโมเดลสร้างข้อความที่ดาวน์โหลดไว้แล้วพร้อมใช้งานอยู่ {{count}} โมเดล โปรดเริ่มเซิร์ฟเวอร์โมเดลใน Anaconda Desktop ขอแนะนำอย่างยิ่งให้ใช้โมเดลที่รองรับการเรียกใช้เครื่องมือ",
+  "provider.anaconda.state.unhealthy":
+    "เซิร์ฟเวอร์การอนุมานที่ใช้งานอยู่ยังไม่พร้อมใช้งาน ตรวจสอบใน Anaconda Desktop และรีสตาร์ทเซิร์ฟเวอร์หากจำเป็น",
+  "provider.anaconda.state.ready":
+    "Kilo พบเซิร์ฟเวอร์สร้างข้อความในเครื่องที่พร้อมใช้งาน และสามารถนำเข้าการตั้งค่าการเชื่อมต่อปัจจุบันได้",
+  "provider.anaconda.server": "เซิร์ฟเวอร์การอนุมานที่ใช้งานอยู่",
+  "provider.anaconda.context": "หน้าต่างบริบท",
+  "provider.anaconda.contextValue": "{{count}} โทเค็น",
+  "provider.anaconda.tools": "การเรียกใช้เครื่องมือ",
+  "provider.anaconda.tools.supported": "รองรับ",
+  "provider.anaconda.tools.unsupported": "ไม่ได้เปิดใช้งาน",
+  "provider.anaconda.tools.unknown": "ไม่ทราบ",
+  "provider.anaconda.warning.title": "การรองรับเครื่องมือมีข้อจำกัด",
+  "provider.anaconda.warning.description":
+    "เซิร์ฟเวอร์นี้ไม่ยืนยันการเรียกใช้เครื่องมือ การทำงานของเอเจนต์เขียนโค้ดอาจล้มเหลวหรือไม่พร้อมใช้งาน ดำเนินการต่อเฉพาะเมื่อคุณยอมรับข้อจำกัดเหล่านี้",
+  "provider.anaconda.action.download": "ดาวน์โหลด Anaconda Desktop",
+  "provider.anaconda.action.open": "เปิด Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "ตรวจสอบอีกครั้ง",
+  "provider.anaconda.action.continue": "ดำเนินการต่อ",
+  "provider.anaconda.action.manage": "จัดการ / รีเฟรช",
+  "provider.anaconda.toast.refreshed.title": "รีเฟรช Anaconda Desktop แล้ว",
+  "provider.anaconda.toast.refreshed.description": "เซิร์ฟเวอร์ในเครื่องและโมเดลที่ใช้งานอยู่เป็นปัจจุบันใน Kilo แล้ว",
+  "settings.providers.note.anacondaDesktop": "เรียกใช้โมเดลที่ให้บริการในเครื่องโดย Anaconda Desktop",
+  "settings.providers.tag.local": "ในเครื่อง",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "แนะนำ",
   "command.category.view": "มุมมอง",
   "command.category.project": "โปรเจกต์",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Tekrar kontrol et",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Anaconda Desktop'a bağlan",
+  "provider.anaconda.title.manage": "Anaconda Desktop'ı yönet",
+  "provider.anaconda.status.checking": "Anaconda Desktop kontrol ediliyor...",
+  "provider.anaconda.status.opening": "Anaconda Desktop açılıyor...",
+  "provider.anaconda.status.syncing": "Sağlayıcı modelleri yenileniyor...",
+  "provider.anaconda.status.ready": "Bağlanmaya hazır",
+  "provider.anaconda.status.waiting": "Desktop bekleniyor",
+  "provider.anaconda.status.attention": "İlgi gerekiyor",
+  "provider.anaconda.status.unavailable": "Kullanılamıyor",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop {{platform}} üzerinde desteklenmiyor.",
+  "provider.anaconda.state.notInstalled":
+    "Anaconda Desktop'ı bu makineye kurun, ardından buraya dönün. Kilo kurulumu sizin için çalıştırmaz.",
+  "provider.anaconda.state.notRunning":
+    "Anaconda Desktop'ı açın, kurulumu tamamlayıp oturum açın, ardından Tekrar kontrol et'i seçin.",
+  "provider.anaconda.state.invalidConfig":
+    "Anaconda Desktop kurulumu eksik. Desktop'ı açın, kurulumu tamamlayın ve gerekirse yeniden başlatın.",
+  "provider.anaconda.state.signedOut": "Kilo'yu bağlamadan önce Anaconda Desktop'ı açın ve oturum açın.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo Anaconda Desktop'a erişemedi. Desktop'ı açın, tekrar oturum açın ve gerekirse yeniden başlatın.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop henüz yanıt vermiyor. Açın ve uygulamanın başlamasını bekleyin.",
+  "provider.anaconda.state.noModel":
+    "Anaconda Desktop'ta bir metin üretme modeli indirin. Mümkünse araç çağırma destekli bir model seçin, ardından sunucusunu başlatın.",
   "provider.anaconda.state.noServer_one":
     "İndirilmiş 1 metin üretme modeli kullanılabilir. Anaconda Desktop'ta bir model sunucusu başlatın. Araç çağırma desteği olan modeller önemle tavsiye edilir.",
   "provider.anaconda.state.noServer_other":
     "İndirilmiş {{count}} metin üretme modeli kullanılabilir. Anaconda Desktop'ta bir model sunucusu başlatın. Araç çağırma desteği olan modeller önemle tavsiye edilir.",
+  "provider.anaconda.state.unhealthy":
+    "Etkin çıkarım sunucusu henüz sağlıklı değil. Anaconda Desktop'ta kontrol edin ve gerekirse sunucuyu yeniden başlatın.",
+  "provider.anaconda.state.ready":
+    "Kilo sağlıklı bir yerel metin üretme sunucusu buldu ve mevcut bağlantı ayarlarını içe aktarabilir.",
+  "provider.anaconda.server": "Etkin çıkarım sunucusu",
+  "provider.anaconda.context": "Bağlam penceresi",
+  "provider.anaconda.contextValue": "{{count}} token",
+  "provider.anaconda.tools": "Araç çağırma",
+  "provider.anaconda.tools.supported": "Destekleniyor",
+  "provider.anaconda.tools.unsupported": "Etkin değil",
+  "provider.anaconda.tools.unknown": "Bilinmiyor",
+  "provider.anaconda.warning.title": "Araç desteği sınırlı",
+  "provider.anaconda.warning.description":
+    "Bu sunucu araç çağırmayı doğrulamıyor. Kodlama aracısı eylemleri başarısız olabilir veya kullanılamayabilir. Yalnızca bu sınırlamaları kabul ediyorsanız devam edin.",
+  "provider.anaconda.action.download": "Anaconda Desktop'ı indir",
+  "provider.anaconda.action.open": "Anaconda Desktop'ı aç",
+  "provider.anaconda.action.checkAgain": "Tekrar kontrol et",
+  "provider.anaconda.action.continue": "Yine de devam et",
+  "provider.anaconda.action.manage": "Yönet / Yenile",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop yenilendi",
+  "provider.anaconda.toast.refreshed.description": "Etkin yerel sunucu ve modeller Kilo'da güncel.",
+  "settings.providers.note.anacondaDesktop": "Anaconda Desktop tarafından yerel olarak sunulan bir model çalıştırın.",
+  "settings.providers.tag.local": "Yerel",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Önerilen",
   "command.category.view": "Görünüm",
   "command.category.project": "Proje",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1,12 +1,58 @@
-import { anacondaDesktopDict } from "./en"
-
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "Перевірити ще раз",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "Підключити Anaconda Desktop",
+  "provider.anaconda.title.manage": "Керувати Anaconda Desktop",
+  "provider.anaconda.status.checking": "Перевірка Anaconda Desktop...",
+  "provider.anaconda.status.opening": "Відкриття Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "Оновлення моделей провайдера...",
+  "provider.anaconda.status.ready": "Готово до підключення",
+  "provider.anaconda.status.waiting": "Очікування Desktop",
+  "provider.anaconda.status.attention": "Потребує уваги",
+  "provider.anaconda.status.unavailable": "Недоступно",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop не підтримується на {{platform}}.",
+  "provider.anaconda.state.notInstalled":
+    "Встановіть Anaconda Desktop на цьому комп'ютері, а потім поверніться сюди. Kilo не запускає інсталятор за вас.",
+  "provider.anaconda.state.notRunning":
+    "Відкрийте Anaconda Desktop, завершіть налаштування та увійдіть, потім виберіть «Перевірити ще раз».",
+  "provider.anaconda.state.invalidConfig":
+    "Налаштування Anaconda Desktop неповне. Відкрийте Desktop, завершіть налаштування та перезапустіть його за потреби.",
+  "provider.anaconda.state.signedOut": "Відкрийте Anaconda Desktop та увійдіть перед підключенням Kilo.",
+  "provider.anaconda.state.unauthorized":
+    "Kilo не вдалося отримати доступ до Anaconda Desktop. Відкрийте Desktop, увійдіть знову та перезапустіть його за потреби.",
+  "provider.anaconda.state.unavailable":
+    "Anaconda Desktop ще не відповідає. Відкрийте його та зачекайте, доки програма завершить запуск.",
+  "provider.anaconda.state.noModel":
+    "В Anaconda Desktop завантажте модель генерації тексту. За можливості виберіть модель із підтримкою виклику інструментів, потім запустіть її сервер.",
   "provider.anaconda.state.noServer_one":
     "Доступна 1 завантажена модель генерації тексту. Запустіть сервер моделі в Anaconda Desktop. Наполегливо рекомендуємо використовувати моделі з підтримкою виклику інструментів.",
   "provider.anaconda.state.noServer_other":
     "Доступно завантажених моделей генерації тексту: {{count}}. Запустіть сервер моделі в Anaconda Desktop. Наполегливо рекомендуємо використовувати моделі з підтримкою виклику інструментів.",
+  "provider.anaconda.state.unhealthy":
+    "Активний сервер інференсу ще не справний. Перевірте його в Anaconda Desktop та перезапустіть сервер за потреби.",
+  "provider.anaconda.state.ready":
+    "Kilo знайшов справний локальний сервер генерації тексту та може імпортувати його поточні налаштування підключення.",
+  "provider.anaconda.server": "Активний сервер інференсу",
+  "provider.anaconda.context": "Вікно контексту",
+  "provider.anaconda.contextValue": "{{count}} токенів",
+  "provider.anaconda.tools": "Виклик інструментів",
+  "provider.anaconda.tools.supported": "Підтримується",
+  "provider.anaconda.tools.unsupported": "Не увімкнено",
+  "provider.anaconda.tools.unknown": "Невідомо",
+  "provider.anaconda.warning.title": "Підтримка інструментів обмежена",
+  "provider.anaconda.warning.description":
+    "Цей сервер не підтверджує виклик інструментів. Дії агента кодування можуть не спрацювати або бути недоступними. Продовжуйте, лише якщо приймаєте ці обмеження.",
+  "provider.anaconda.action.download": "Завантажити Anaconda Desktop",
+  "provider.anaconda.action.open": "Відкрити Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "Перевірити ще раз",
+  "provider.anaconda.action.continue": "Усе одно продовжити",
+  "provider.anaconda.action.manage": "Керувати / Оновити",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop оновлено",
+  "provider.anaconda.toast.refreshed.description": "Активний локальний сервер та моделі актуальні в Kilo.",
+  "settings.providers.note.anacondaDesktop": "Запустіть модель, що обслуговується локально через Anaconda Desktop.",
+  "settings.providers.tag.local": "Локальний",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "Запропоновані",
   "command.category.view": "Вигляд",
   "command.category.project": "Проєкт",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1,14 +1,59 @@
-import { anacondaDesktopDict, dict as en } from "./en"
+import { dict as en } from "./en"
 
 type Keys = keyof typeof en
 
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "再次检查",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "连接 Anaconda Desktop",
+  "provider.anaconda.title.manage": "管理 Anaconda Desktop",
+  "provider.anaconda.status.checking": "正在检查 Anaconda Desktop…",
+  "provider.anaconda.status.opening": "正在打开 Anaconda Desktop…",
+  "provider.anaconda.status.syncing": "正在刷新提供商模型…",
+  "provider.anaconda.status.ready": "准备连接",
+  "provider.anaconda.status.waiting": "正在等待 Desktop",
+  "provider.anaconda.status.attention": "需要处理",
+  "provider.anaconda.status.unavailable": "不可用",
+  "provider.anaconda.state.unsupported": "{{platform}} 不支持 Anaconda Desktop。",
+  "provider.anaconda.state.notInstalled":
+    "请在此设备上安装 Anaconda Desktop，然后返回此处。Kilo 不会为你运行安装程序。",
+  "provider.anaconda.state.notRunning": "请打开 Anaconda Desktop，完成设置并登录，然后选择“再次检查”。",
+  "provider.anaconda.state.invalidConfig":
+    "Anaconda Desktop 设置不完整。请打开 Desktop，完成设置，并在需要时重新启动它。",
+  "provider.anaconda.state.signedOut": "请打开 Anaconda Desktop 并登录，然后再连接 Kilo。",
+  "provider.anaconda.state.unauthorized":
+    "Kilo 无法访问 Anaconda Desktop。请打开 Desktop，重新登录，并在需要时重新启动它。",
+  "provider.anaconda.state.unavailable": "Anaconda Desktop 尚未响应。请打开它并等待应用程序完成启动。",
+  "provider.anaconda.state.noModel":
+    "请在 Anaconda Desktop 中下载一个文本生成模型。请尽可能选择支持工具调用的模型，然后启动其服务器。",
   "provider.anaconda.state.noServer_one":
     "有 1 个已下载的文本生成模型可用。请在 Anaconda Desktop 中启动一个模型服务器。强烈建议使用支持工具调用的模型。",
   "provider.anaconda.state.noServer_other":
     "有 {{count}} 个已下载的文本生成模型可用。请在 Anaconda Desktop 中启动一个模型服务器。强烈建议使用支持工具调用的模型。",
+  "provider.anaconda.state.unhealthy":
+    "当前推理服务器尚不健康。请在 Anaconda Desktop 中检查它，并在需要时重新启动服务器。",
+  "provider.anaconda.state.ready": "Kilo 找到了一个健康的本地文本生成服务器，可以导入其当前的连接设置。",
+  "provider.anaconda.server": "当前推理服务器",
+  "provider.anaconda.context": "上下文窗口",
+  "provider.anaconda.contextValue": "{{count}} 个 token",
+  "provider.anaconda.tools": "工具调用",
+  "provider.anaconda.tools.supported": "支持",
+  "provider.anaconda.tools.unsupported": "未启用",
+  "provider.anaconda.tools.unknown": "未知",
+  "provider.anaconda.warning.title": "工具支持有限",
+  "provider.anaconda.warning.description":
+    "此服务器未确认支持工具调用。编码智能体的操作可能会失败或不可用。仅在你接受这些限制时才继续。",
+  "provider.anaconda.action.download": "下载 Anaconda Desktop",
+  "provider.anaconda.action.open": "打开 Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "再次检查",
+  "provider.anaconda.action.continue": "仍然继续",
+  "provider.anaconda.action.manage": "管理 / 刷新",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop 已刷新",
+  "provider.anaconda.toast.refreshed.description": "当前本地服务器和模型在 Kilo 中已是最新。",
+  "settings.providers.note.anacondaDesktop": "运行由 Anaconda Desktop 在本地提供的模型。",
+  "settings.providers.tag.local": "本地",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "建议",
   "command.category.view": "视图",
   "command.category.project": "项目",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1,14 +1,59 @@
-import { anacondaDesktopDict, dict as en } from "./en"
+import { dict as en } from "./en"
 
 type Keys = keyof typeof en
 
-export const dict = {
-  ...anacondaDesktopDict,
-  "provider.anaconda.action.checkAgain": "再次檢查",
+export const anacondaDesktopDict = {
+  "provider.anaconda.title.connect": "連接 Anaconda Desktop",
+  "provider.anaconda.title.manage": "管理 Anaconda Desktop",
+  "provider.anaconda.status.checking": "正在檢查 Anaconda Desktop...",
+  "provider.anaconda.status.opening": "正在開啟 Anaconda Desktop...",
+  "provider.anaconda.status.syncing": "正在重新整理供應商模型...",
+  "provider.anaconda.status.ready": "已準備好連接",
+  "provider.anaconda.status.waiting": "正在等待 Desktop",
+  "provider.anaconda.status.attention": "需要注意",
+  "provider.anaconda.status.unavailable": "無法使用",
+  "provider.anaconda.state.unsupported": "Anaconda Desktop 不支援 {{platform}}。",
+  "provider.anaconda.state.notInstalled":
+    "請在此機器上安裝 Anaconda Desktop，然後返回此處。Kilo 不會為您執行安裝程式。",
+  "provider.anaconda.state.notRunning": "請開啟 Anaconda Desktop，完成設定並登入，然後選擇再次檢查。",
+  "provider.anaconda.state.invalidConfig":
+    "Anaconda Desktop 設定尚未完成。請開啟 Desktop，完成設定，並在需要時重新啟動它。",
+  "provider.anaconda.state.signedOut": "請開啟 Anaconda Desktop 並登入，然後再連接 Kilo。",
+  "provider.anaconda.state.unauthorized":
+    "Kilo 無法存取 Anaconda Desktop。請開啟 Desktop，重新登入，並在需要時重新啟動它。",
+  "provider.anaconda.state.unavailable": "Anaconda Desktop 尚未回應。請開啟它並等待應用程式完成啟動。",
+  "provider.anaconda.state.noModel":
+    "請在 Anaconda Desktop 中下載一個文字生成模型。可能的話請選擇支援工具呼叫的模型，然後啟動其伺服器。",
   "provider.anaconda.state.noServer_one":
     "有 1 個已下載的文字生成模型可用。請在 Anaconda Desktop 中啟動一個模型伺服器。強烈建議使用支援工具呼叫的模型。",
   "provider.anaconda.state.noServer_other":
     "有 {{count}} 個已下載的文字生成模型可用。請在 Anaconda Desktop 中啟動一個模型伺服器。強烈建議使用支援工具呼叫的模型。",
+  "provider.anaconda.state.unhealthy":
+    "使用中的推論伺服器尚未正常運作。請在 Anaconda Desktop 中檢查它，並在需要時重新啟動伺服器。",
+  "provider.anaconda.state.ready": "Kilo 找到了一個正常運作的本機文字生成伺服器，並可匯入其目前的連接設定。",
+  "provider.anaconda.server": "使用中的推論伺服器",
+  "provider.anaconda.context": "上下文視窗",
+  "provider.anaconda.contextValue": "{{count}} 個權杖",
+  "provider.anaconda.tools": "工具呼叫",
+  "provider.anaconda.tools.supported": "支援",
+  "provider.anaconda.tools.unsupported": "未啟用",
+  "provider.anaconda.tools.unknown": "未知",
+  "provider.anaconda.warning.title": "工具支援有限",
+  "provider.anaconda.warning.description":
+    "此伺服器未確認支援工具呼叫。編碼代理程式的動作可能會失敗或無法使用。只有在您接受這些限制的情況下才繼續。",
+  "provider.anaconda.action.download": "下載 Anaconda Desktop",
+  "provider.anaconda.action.open": "開啟 Anaconda Desktop",
+  "provider.anaconda.action.checkAgain": "再次檢查",
+  "provider.anaconda.action.continue": "仍要繼續",
+  "provider.anaconda.action.manage": "管理 / 重新整理",
+  "provider.anaconda.toast.refreshed.title": "Anaconda Desktop 已重新整理",
+  "provider.anaconda.toast.refreshed.description": "使用中的本機伺服器與模型在 Kilo 中已是最新狀態。",
+  "settings.providers.note.anacondaDesktop": "執行由 Anaconda Desktop 在本機提供的模型。",
+  "settings.providers.tag.local": "本機",
+} as const
+
+export const dict = {
+  ...anacondaDesktopDict,
   "command.category.suggested": "建議",
   "command.category.view": "檢視",
   "command.category.project": "專案",


### PR DESCRIPTION
## What changed

Each non-English webview locale now ships its own translated `anacondaDesktopDict` for the Anaconda Desktop provider, mirroring the construct in `en.ts`. Previously every other locale imported and spread the English `anacondaDesktopDict` from `./en`, so all Anaconda Desktop strings (titles, statuses, state guidance, tool-support warning, actions, toasts) rendered in English regardless of the selected language.

## Why

PR #11714 added the Anaconda Desktop provider but only translated three keys per locale (`checkAgain`, `noServer_one`, `noServer_other`) and left the remaining ~36 keys falling back to English via the shared import. This makes those strings actually localized.

## How

- Removed the `import { anacondaDesktopDict } from "./en"` from the 14 locales that only used it for the spread, and dropped it from the import (keeping `dict as en`) in the 5 locales that also use `dict as en` for their `Keys` type (`de`, `ko`, `no`, `zh`, `zht`).
- Added a per-locale `export const anacondaDesktopDict = { ... } as const` with all 39 keys translated.
- Reused the existing translated `checkAgain` / `noServer_one` / `noServer_other` strings verbatim.
- Preserved `Anaconda Desktop` / `Kilo` product names and `{{platform}}` / `{{count}}` placeholders.

`en.ts` is unchanged.

## Validation

- `bun test tests/unit/i18n-keys.test.ts` passes (7/7).
- `bun run format` clean.
- Verified each locale has exactly 39 Anaconda keys, no duplicates, and the correct `anacondaDesktopDict` + `...anacondaDesktopDict` construct.
