### PR TITLE
fix: allow upstream fork-lineage URL in translated READMEs

### DIFF
--- a/packages/opencode/test/kilocode/modes-migrator.test.ts
+++ b/packages/opencode/test/kilocode/modes-migrator.test.ts
@@ -171,6 +171,30 @@ describe("ModesMigrator", () => {
     })
   })
 
+  describe("convertOrganizationMode", () => {
+    const mode = {
+      id: "11111111-1111-1111-1111-111111111111",
+      organization_id: "org-1",
+      name: "Code Review custom Agent",
+      slug: "code-review",
+      created_by: "user-1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      config: {
+        roleDefinition: "You are a reviewer.",
+        groups: ["read"],
+      },
+    }
+
+    test("carries displayName and source as typed fields, not provider options", () => {
+      const agent = ModesMigrator.convertOrganizationMode(mode)
+      expect(agent.displayName).toBe("Code Review custom Agent")
+      expect(agent.source).toBe("organization")
+      // The metadata must never live in `options`, which is forwarded to the provider.
+      expect(agent.options).toBeUndefined()
+    })
+  })
+
   describe("readModesFile", () => {
     test("returns empty array for non-existent file", async () => {
       const modes = await ModesMigrator.readModesFile("/non/existent/path.yaml")

--- a/script/check-forbidden-strings.ts
+++ b/script/check-forbidden-strings.ts
@@ -27,6 +27,7 @@ const forbidden: { pattern: string; reason: string; allow?: string[] }[] = [
     allow: [
       "AGENTS.md",
       "README.md",
+      "translations/", // translated READMEs mirror the README.md fork-lineage reference
       ".opencode/glossary/",
       "packages/kilo-vscode/AGENTS.md",
       "packages/kilo-docs/source-links.md",


### PR DESCRIPTION
## Summary

The **Check forbidden strings** CI job is failing on all translated READMEs:

```
translations/README.<lang>.md:171: github.com/anomalyco/opencode (upstream repo URL -- should be Kilo-Org/kilocode)
```

Each of those lines is a translation of `README.md:171`:

> Kilo CLI is a fork of [OpenCode](https://github.com/anomalyco/opencode), enhanced to work within the Kilo agentic engineering platform.

This is a deliberate, factually-correct reference to the upstream OpenCode repo describing the fork lineage — which is exactly why `README.md` is already on the allowlist for this rule. The translated READMEs mirror the same sentence but were never allowlisted, so they trip the check.

## Fix

Add `translations/` to the allowlist for the `github.com/anomalyco/opencode` rule, consistent with the existing `README.md` entry. Rewriting the URL to `Kilo-Org/kilocode` was rejected as it would be factually wrong (OpenCode's upstream is not the Kilo repo).

Verified locally: `bun run script/check-forbidden-strings.ts` → `7584 file(s) checked, no forbidden strings found.`