### PR TITLE
fix: allowlist translations/ in forbidden strings check

### DIFF
--- a/script/check-forbidden-strings.ts
+++ b/script/check-forbidden-strings.ts
@@ -27,6 +27,7 @@ const forbidden: { pattern: string; reason: string; allow?: string[] }[] = [
     allow: [
       "AGENTS.md",
       "README.md",
+      "translations/",
       ".opencode/glossary/",
       "packages/kilo-vscode/AGENTS.md",
       "packages/kilo-docs/source-links.md",


### PR DESCRIPTION
## What
Add `translations/` to the allowlist for the `github.com/anomalyco/opencode` rule in `script/check-forbidden-strings.ts`.

## Why
The "Check forbidden strings" CI job was failing on all `translations/README.*.md` files at line ~171. These files are translations of the main `README.md` "Kilo CLI is a fork of [OpenCode](https://github.com/anomalyco/opencode)" line. That upstream link legitimately documents the fork lineage and `README.md` is already allowlisted for the same reason — the translations were simply never added to the allowlist.