### PR TITLE
fix(vscode): use models sparkle icon for auto model

### DIFF
--- a/.changeset/model-selector-auto-icon.md
+++ b/.changeset/model-selector-auto-icon.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use the models sparkle icon for Auto models in the model selector.

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelPreview.tsx
@@ -108,7 +108,7 @@ export const ModelPreview: Component<Props> = (props) => {
                       <Show when={isAuto(model())}>
                         <Tooltip value={autoLabel()} placement="top">
                           <span class="model-preview-auto-icon" aria-label={autoLabel()}>
-                            <Icon name="branch" size="small" />
+                            <Icon name="models" size="small" />
                           </span>
                         </Tooltip>
                       </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -965,7 +965,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                 <Show when={isAuto(model)}>
                                   <Tooltip value={autoLabel(model)} placement="top">
                                     <span class="model-selector-auto-icon" aria-label={autoLabel(model)}>
-                                      <Icon name="branch" size="small" />
+                                      <Icon name="models" size="small" />
                                     </span>
                                   </Tooltip>
                                 </Show>


### PR DESCRIPTION
## Context

Auto model entries were using the branch icon, which reads like source-control branching instead of automatic model selection.

## Implementation

Use the existing models sparkle icon for Auto model display in the shared model preview and selector surfaces.

## Screenshots / Video

<img width="277" height="729" alt="Screenshot 2026-06-29 at 11 52 26" src="https://github.com/user-attachments/assets/1289666a-84b5-4446-8667-89abacc4c695" />

## How to Test

### Manual/local verification

- Agent: `bun turbo typecheck` during pre-push; passed.
- Executed extension to validate the change

### Reviewer test steps

1. Open the VS Code extension model selector.
2. Select or view an Auto model entry.
3. Confirm the Auto model uses the models sparkle icon instead of the branch icon.

## Checklist

- [ ] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.