### PR TITLE
fix(ci): use local node headers for native deps

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -52,6 +52,7 @@ runs:
 
     - name: Configure node-gyp Node headers
       if: runner.os != 'Windows'
+      id: node-gyp
       run: |
         node <<'NODE'
         const fs = require("node:fs")
@@ -64,7 +65,7 @@ runs:
           throw new Error(`Node headers not found under ${dirs.join(", ")}`)
         }
 
-        fs.appendFileSync(process.env.GITHUB_ENV, `npm_config_nodedir=${root}\n`)
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `nodedir=${root}\n`)
         NODE
       shell: bash
     # kilocode_change end
@@ -75,6 +76,12 @@ runs:
 
     - name: Install dependencies
       run: |
+        # kilocode_change start
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          export npm_config_nodedir="${{ steps.node-gyp.outputs.nodedir }}"
+        fi
+        # kilocode_change end
+
         # Workaround for patched peer variants
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -44,12 +44,14 @@ runs:
 
     # kilocode_change start
     - name: Setup Node for native dependency builds
+      if: runner.os != 'Windows'
       uses: actions/setup-node@v6
       with:
         node-version: "24"
         package-manager-cache: false
 
     - name: Configure node-gyp Node headers
+      if: runner.os != 'Windows'
       run: |
         node <<'NODE'
         const fs = require("node:fs")

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -42,6 +42,31 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
+    # kilocode_change start
+    - name: Setup Node for native dependency builds
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+        package-manager-cache: false
+
+    - name: Configure node-gyp Node headers
+      run: |
+        node <<'NODE'
+        const fs = require("node:fs")
+        const path = require("node:path")
+
+        const exe = path.dirname(fs.realpathSync(process.execPath))
+        const dirs = [exe, path.dirname(exe)]
+        const root = dirs.find((dir) => fs.existsSync(path.join(dir, "include", "node", "node.h")))
+        if (!root) {
+          throw new Error(`Node headers not found under ${dirs.join(", ")}`)
+        }
+
+        fs.appendFileSync(process.env.GITHUB_ENV, `npm_config_nodedir=${root}\n`)
+        NODE
+      shell: bash
+    # kilocode_change end
+
     - name: Install setuptools for distutils compatibility
       run: python3 -m pip install setuptools || pip install setuptools || true
       shell: bash


### PR DESCRIPTION
What changed:
- Configure the shared setup-bun action to install Node 24 before dependency installation.
- Export npm_config_nodedir to Node's local headers so node-gyp can build native dependencies without downloading headers from nodejs.org during bun install.

Why:
- typecheck-jetbrains failed before Gradle ran because tree-sitter-powershell invoked node-gyp and timed out fetching Node headers.
- Using local headers makes native dependency installs less dependent on external network availability during CI.

Validation:
- bun run script/check-opencode-annotations.ts
- bun run script/check-workflows.ts
- bunx prettier --check .github/actions/setup-bun/action.yml
- git diff --check
