### PR TITLE
fix(agent-manager): persist sandbox default in worktree dialog

### DIFF
--- a/.changeset/agent-manager-sandbox-default.md
+++ b/.changeset/agent-manager-sandbox-default.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember the Agent Manager new-worktree sandbox toggle for future sessions.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1167,7 +1167,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           await this.fetchAndSendSandboxStatus(message.sessionID)
           break
         case "requestSandboxDefault":
-          await this.fetchAndSendSandboxDefault(message.contextDirectory)
+          await this.fetchAndSendSandboxDefault(message.contextDirectory, message.requestID)
           break
         case "setSandboxDefault":
           await this.handleSetSandboxDefault(message.enabled, message.requestID, message.contextDirectory)

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -643,6 +643,7 @@ interface SendCommandIn {
 
 interface RequestSandboxDefaultIn {
   type: "requestSandboxDefault"
+  requestID?: string
   agentManagerContext?: string
   contextDirectory?: string
 }

--- a/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
+++ b/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const path = join(__dirname, "..", "..", "webview-ui", "agent-manager", "NewWorktreeDialog.tsx")
+const providerPath = join(__dirname, "..", "..", "src", "KiloProvider.ts")
+const src = readFileSync(path, "utf8")
+const provider = readFileSync(providerPath, "utf8")
+
+describe("NewWorktreeDialog sandbox toggle", () => {
+  it("uses the persisted default and only sends explicit modal overrides", () => {
+    expect(src).toContain('vscode.postMessage({ type: "requestSandboxDefault", requestID: sandboxRequestID })')
+    expect(src).toContain('if (message.type !== "sandboxDefaultStatus") return')
+    expect(src).toContain("if (message.requestID !== sandboxRequestID) return")
+    expect(src).toContain("setSandbox(message.enabled)")
+    expect(src).toContain("setSandboxOverride(next === sandboxDefault() ? undefined : next)")
+    expect(src).toContain(
+      'vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })',
+    )
+    expect(src).toContain("sandbox: sandboxVisible() ? sandboxOverride() : undefined")
+    expect(src).toContain("const sandboxVisible = () => features().sandboxControls")
+    expect(provider).toContain("await this.fetchAndSendSandboxDefault(message.contextDirectory, message.requestID)")
+    expect(src).not.toContain("createSignal(config().experimental?.sandbox === true)")
+    expect(src).not.toContain("visible as isSandboxVisible")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
@@ -123,10 +123,15 @@ describe("Agent Manager sandbox startup", () => {
     expect(provider).toContain("wt.result.path, wt.result.branch, session.id")
   })
 
-  test("uses the experiment-aware visibility condition for UI and payload", () => {
-    expect(dialog).toContain("const sandboxVisible = () => isSandboxVisible(features(), config())")
-    expect(dialog).toContain("sandbox: sandboxVisible() ? sandbox() : undefined")
+  test("uses the persisted sandbox default for UI and only sends explicit overrides", () => {
+    expect(dialog).toContain("const sandboxVisible = () => features().sandboxControls")
+    expect(dialog).toContain('vscode.postMessage({ type: "requestSandboxDefault", requestID: sandboxRequestID })')
+    expect(dialog).toContain(
+      'vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })',
+    )
+    expect(dialog).toContain("sandbox: sandboxVisible() ? sandboxOverride() : undefined")
     expect(dialog).toContain("<Show when={sandboxVisible()}>")
+    expect(dialog).not.toContain("visible as isSandboxVisible")
   })
 
   test("places the sandbox toggle with prompt actions instead of model selectors", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -20,7 +20,6 @@ import { ModelSelectorBase } from "../src/components/shared/ModelSelector"
 import { ModeSwitcherBase } from "../src/components/shared/ModeSwitcher"
 import { SpeechToTextButton } from "../src/components/speech-to-text/SpeechToTextButton"
 import { canUseSpeechToText, selectedSpeechToTextModel } from "../src/components/speech-to-text/availability"
-import { visible as isSandboxVisible } from "../src/components/settings/sandboxing"
 import { ThinkingSelectorBase } from "../src/components/shared/ThinkingSelector"
 import { SandboxButtonBase, SandboxTooltipContent } from "../src/components/shared/SandboxButton"
 import {
@@ -104,8 +103,14 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const [compareOpen, setCompareOpen] = createSignal(false)
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
   const [variant, setVariant] = createSignal<string | undefined>(session.currentVariant())
-  const [sandbox, setSandbox] = createSignal(config().experimental?.sandbox === true)
-  const sandboxVisible = () => isSandboxVisible(features(), config())
+  const [sandbox, setSandbox] = createSignal<boolean | undefined>()
+  const [sandboxDefault, setSandboxDefault] = createSignal<boolean | undefined>()
+  const [sandboxOverride, setSandboxOverride] = createSignal<boolean | undefined>()
+  const [sandboxAvailable, setSandboxAvailable] = createSignal(true)
+  const [sandboxReason, setSandboxReason] = createSignal<string | undefined>()
+  const [sandboxRevision, setSandboxRevision] = createSignal(-1)
+  const sandboxRequestID = crypto.randomUUID()
+  const sandboxVisible = () => features().sandboxControls
   const speech = useSpeechToText(vscode, server, { t })
   const canUseSpeech = () => canUseSpeechToText(config(), provider.authStates())
   const speechModel = () => selectedSpeechToTextModel(config())
@@ -145,6 +150,45 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
     const stored = variant()
     if (!stored || !list.includes(stored)) setVariant(list[0])
   })
+
+  createEffect(() => {
+    if (!sandboxVisible()) return
+    if (server.connectionState() !== "connected") {
+      setSandbox(undefined)
+      setSandboxDefault(undefined)
+      setSandboxOverride(undefined)
+      return
+    }
+    vscode.postMessage({ type: "requestSandboxDefault", requestID: sandboxRequestID })
+  })
+
+  const unsubSandbox = vscode.onMessage((message) => {
+    if (message.type !== "sandboxDefaultStatus") return
+    if (message.requestID !== sandboxRequestID) return
+    if (message.revision < sandboxRevision()) return
+
+    setSandboxRevision(message.revision)
+    setSandboxDefault(message.desired)
+    setSandboxAvailable(message.available)
+    setSandboxReason(message.reason)
+
+    const override = sandboxOverride()
+    if (override === undefined) {
+      setSandbox(message.enabled)
+      return
+    }
+    if (override === message.desired) setSandboxOverride(undefined)
+  })
+  onCleanup(unsubSandbox)
+
+  const toggleSandbox = () => {
+    const current = sandbox()
+    if (current === undefined || !sandboxAvailable()) return
+    const next = !current
+    setSandbox(next)
+    setSandboxOverride(next === sandboxDefault() ? undefined : next)
+    vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })
+  }
 
   const imageAttach = useImageAttachments()
   imageAttach.setFilePathDropHandler((paths) => {
@@ -250,7 +294,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
       baseBranch: advanced ? (baseBranch() ?? undefined) : undefined,
       branchName: customBranch,
       modelAllocations: allocations,
-      sandbox: sandboxVisible() ? sandbox() : undefined,
+      sandbox: sandboxVisible() ? sandboxOverride() : undefined,
       files: imgFiles,
     })
 
@@ -467,20 +511,20 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                 <div class="prompt-input-hint-actions">
                   <Show when={sandboxVisible()}>
                     <SandboxButtonBase
-                      enabled={sandbox()}
+                      enabled={sandbox() ?? false}
+                      available={sandbox() === undefined ? undefined : sandboxAvailable()}
+                      reason={sandboxReason()}
+                      disabled={sandbox() === undefined}
                       tooltip={
                         <SandboxTooltipContent
-                          enabled={sandbox()}
+                          enabled={sandbox() ?? false}
                           network={config().experimental?.sandbox_restrict_network !== false}
                         />
                       }
                       tooltipClass="prompt-sandbox-tooltip-content"
-                      onToggle={click(
-                        "sandbox_toggle",
-                        "configure_worktree_dialog",
-                        () => setSandbox(!sandbox()),
-                        () => ({ enabled: !sandbox() }),
-                      )}
+                      onToggle={click("sandbox_toggle", "configure_worktree_dialog", toggleSandbox, () => ({
+                        enabled: !(sandbox() ?? false),
+                      }))}
                     />
                   </Show>
                   <Show when={canUseSpeech()}>

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -954,6 +954,7 @@ export interface RequestSandboxStatusMessage {
 
 export interface RequestSandboxDefaultMessage {
   type: "requestSandboxDefault"
+  requestID?: string
   agentManagerContext?: string
   contextDirectory?: string
 }


### PR DESCRIPTION
This fixes a merge regression.

The Agent Manager new-worktree modal was deriving its sandbox toggle from the experimental sandbox config instead of the persisted new-session sandbox default. When sandboxing was disabled as the default, reopening the modal still showed sandboxing enabled and newly created Agent Manager sessions could be forced back into sandbox mode.

This changes the modal to load the persisted sandbox default, save modal toggle changes through the same default-setting path used by the prompt input, and correlate sandbox default responses with the modal request. The modal now only sends a create-session sandbox override while a local change is still pending, so new worktree sessions follow the saved preference instead of reverting to the config default.

This fixes unselecting sandboxing in the Agent Manager create modal, closing and reopening the modal, and seeing sandboxing selected again.

<img width="508" height="206" alt="file-66bae27dfcf107d2a1d8b044938de184" src="https://github.com/user-attachments/assets/1b2df142-9d2f-488c-ac8a-c34a190e22ce" />
