### PR TITLE
fix(kiloclaw): restore slash command access

### DIFF
--- a/.changeset/fix-kiloclaw-slash.md
+++ b/.changeset/fix-kiloclaw-slash.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-gateway": patch
+"kilo-code": patch
+---
+
+Fix opening KiloClaw from the CLI and VS Code slash commands.

--- a/packages/kilo-gateway/src/index.ts
+++ b/packages/kilo-gateway/src/index.ts
@@ -76,6 +76,7 @@ export {
   getNotifications,
   getProfile,
   getToken,
+  normalizeClawStatus,
   setOrganization,
 } from "./server/handlers.js"
 

--- a/packages/kilo-gateway/src/server/handlers.ts
+++ b/packages/kilo-gateway/src/server/handlers.ts
@@ -120,7 +120,23 @@ export async function getClawStatus(auth: AuthStore) {
 
   const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/status`, { headers })
   if (!response.ok) throw new GatewayError(await response.text(), response.status)
-  return response.json()
+  return normalizeClawStatus(await response.json())
+}
+
+function normalizeTime(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString()
+  return value
+}
+
+export function normalizeClawStatus(input: unknown) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return input
+
+  const data = input as Record<string, unknown>
+  return {
+    ...data,
+    ...("lastStartedAt" in data ? { lastStartedAt: normalizeTime(data.lastStartedAt) } : {}),
+    ...("lastStoppedAt" in data ? { lastStoppedAt: normalizeTime(data.lastStoppedAt) } : {}),
+  }
 }
 
 export async function getClawChatCredentials(auth: AuthStore): Promise<ClawChatCredentials> {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1037,6 +1037,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         case "openSettingsPanel":
           vscode.commands.executeCommand("kilo-code.new.settingsButtonClicked", message.tab)
           break
+        case "openKiloClaw":
+          vscode.commands.executeCommand("kilo-code.new.kiloClawOpen")
+          break
         case "openVSCodeSettings":
           vscode.commands.executeCommand("workbench.action.openSettings", message.query)
           break

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -144,6 +144,14 @@ export function useSlashCommand(
       },
     },
     {
+      name: "kiloclaw",
+      description: "Open KiloClaw chat",
+      hints: ["claw"],
+      action: () => {
+        vscode.postMessage({ type: "openKiloClaw" })
+      },
+    },
+    {
       name: "sandbox",
       description: "Toggle sandbox",
       hints: [],

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -228,6 +228,10 @@ export interface OpenAdvancedWorktreeRequest {
   type: "openAdvancedWorktree"
 }
 
+export interface OpenKiloClawRequest {
+  type: "openKiloClaw"
+}
+
 export interface RequestAgentsMessage {
   type: "requestAgents"
 }
@@ -1172,6 +1176,7 @@ export type WebviewMessage =
   | OpenMarketplacePanelRequest
   | OpenAgentManagerRequest
   | OpenAdvancedWorktreeRequest
+  | OpenKiloClawRequest
   | OpenFileRequest
   | ValidateFilesRequest
   | CancelLoginRequest

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -6,6 +6,7 @@ import {
   getOrganizationId,
   getToken,
   importSessionToDb,
+  normalizeClawStatus,
 } from "@kilocode/kilo-gateway"
 import {
   HEADER_FEATURE,
@@ -360,7 +361,7 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
         try: async () => {
           const response = await fetch(`${KILO_API_BASE}/api/kiloclaw/status`, { headers })
           if (!response.ok) throw new GatewayError(await response.text(), response.status)
-          return Schema.decodeUnknownPromise(ClawStatus)(await response.json())
+          return Schema.decodeUnknownPromise(ClawStatus)(normalizeClawStatus(await response.json()))
         },
         catch: (err) => err,
       }).pipe(

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -183,6 +183,32 @@ describe("Kilo gateway HttpApi statuses", () => {
     }),
   )
 
+  it.live("normalizes numeric KiloClaw timestamps", () =>
+    Effect.gen(function* () {
+      const started = 1_700_000_000_000
+      yield* stub(() =>
+        Response.json({
+          status: "running",
+          sandboxId: "sandbox",
+          userId: "user",
+          lastStartedAt: started,
+          lastStoppedAt: null,
+        }),
+      )
+
+      const response = yield* HttpClient.get(KiloGatewayPaths.clawStatus)
+
+      expect(response.status).toBe(200)
+      expect(yield* response.json).toEqual({
+        status: "running",
+        sandboxId: "sandbox",
+        userId: "user",
+        lastStartedAt: new Date(started).toISOString(),
+        lastStoppedAt: null,
+      })
+    }),
+  )
+
   it.live("maps KiloClaw transport failures to bad gateway", () =>
     Effect.gen(function* () {
       yield* stub(() => Promise.reject(new TypeError("network error")))


### PR DESCRIPTION
## Issue

No linked issue. User-reported regression: `/kiloclaw` no longer opened KiloClaw in the TUI or VS Code extension, while the hosted web chat still worked.

Regression introduced on: https://github.com/Kilo-Org/kilocode/pull/10864

## Context

The hosted KiloClaw status API now returns numeric timestamp fields. The local CLI backend still decoded those fields as strings, so `/kilo/claw/status` returned `502 Failed to reach KiloClaw` even though chat credentials were valid. Both the TUI and VS Code KiloClaw panel gate startup on that local status endpoint.

## Implementation

Normalize numeric KiloClaw `lastStartedAt` and `lastStoppedAt` values to ISO strings at the Kilo Gateway boundary before the CLI HTTP API decodes the status schema. This preserves the existing local SDK/UI contract while accepting the current cloud response shape.

Also add `/kiloclaw` as a VS Code chat-local slash command that opens the existing KiloClaw panel, matching the toolbar command.

## Screenshots / Video

N/A - no visual changes.

## How to Test

### Manual/local verification

- Agent: Started a local dev backend with `bun run dev serve --port 0` and verified `/kilo/claw/status` returned `200` with normalized ISO `lastStartedAt`.
- Agent: Verified `/kilo/claw/chat-credentials` still returned `200` with the token redacted from logs.
- Agent: Ran `bun test test/kilocode/server/kilo-gateway-statuses.test.ts` from `packages/opencode/`.
- Agent: Ran `bun run typecheck` from `packages/opencode/`.
- Agent: Ran `bun run typecheck` from `packages/kilo-gateway/`.
- Agent: Ran `bun run typecheck` from `packages/kilo-vscode/`.
- Agent: Ran `bun run lint` from `packages/kilo-vscode/`.
- Agent: Push hook ran `bun turbo typecheck` successfully.

### Reviewer test steps

1. Sign in with a Kilo account that has a KiloClaw instance.
2. In the CLI TUI, enter `/kiloclaw` and confirm the KiloClaw chat view opens.
3. In the VS Code extension chat, enter `/kiloclaw` and confirm the KiloClaw panel opens.
4. Confirm the KiloClaw panel loads instance status and chat rather than showing the setup/upgrade fallback.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

GitHub: @catrielmuller
