### PR TITLE
chore(ci): reduce test log noise

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "test": "bun test",
-    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "typecheck": "tsgo --noEmit"
   },
   "bin": {

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "test": "bun test --timeout 30000",
-    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "typecheck": "tsgo --noEmit"
   },
   "exports": {

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "test": "bun test --timeout 30000",
-    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "typecheck": "tsgo --noEmit"
   },
   "exports": {

--- a/packages/kilo-gateway/package.json
+++ b/packages/kilo-gateway/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "tsc",
-    "test:ci": "mkdir -p .artifacts/unit && bun test test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
+    "test:ci": "mkdir -p .artifacts/unit && bun test test --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
   },
   "dependencies": {
     "@kilocode/plugin": "workspace:*",

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -3,7 +3,8 @@
 /**
  * CI test runner for the JetBrains plugin.
  *
- * Runs ./gradlew clean test --continue --no-build-cache --stacktrace so all modules run even when some fail,
+ * Runs ./gradlew clean test --continue --no-build-cache --stacktrace --console=plain
+ * so all modules run even when some fail,
  * then collects per-module JUnit XML results into .artifacts/unit/junit.xml
  * so mikepenz/action-junit-report can find them at the standard path.
  * The generated OpenAPI client can otherwise restore stale compile outputs
@@ -20,7 +21,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 
 
 const root = join(import.meta.dir, "..")
 const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew"
-const args = ["clean", "test", "--continue", "--no-build-cache", "--stacktrace"]
+const args = ["clean", "test", "--continue", "--no-build-cache", "--stacktrace", "--console=plain"]
 const cmd = process.platform === "win32" ? ["cmd.exe", "/c", gradlew, ...args] : [gradlew, ...args]
 const fallback = 45 * 60 * 1000
 const parsed = Number(process.env.KILO_JETBRAINS_TEST_TIMEOUT_MS ?? fallback)

--- a/packages/kilo-sandbox/package.json
+++ b/packages/kilo-sandbox/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000",
-    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
   },
   "dependencies": {
     "effect": "catalog:"

--- a/packages/kilo-ui/playwright.config.ts
+++ b/packages/kilo-ui/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   workers: process.env["PLAYWRIGHT_WORKERS"]
     ? Number.parseInt(process.env["PLAYWRIGHT_WORKERS"]!, 10) || undefined
     : undefined,
-  reporter: [["html", { open: "never" }], ["list"]],
+  reporter: process.env["CI"] ? [["dot"]] : [["list"]],
   use: {
     baseURL: "http://localhost:6006",
     viewport: { width: 1280, height: 720 },

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1078,7 +1078,7 @@
     "check-kilocode-change": "! grep -rIn 'kilocode_change' . ../kilo-ui/ --exclude='package.json' --exclude='*.md' --exclude-dir='node_modules' --exclude-dir='dist' | grep -v '`kilocode_change`'",
     "lint": "eslint src webview-ui",
     "test": "vscode-test",
-    "test:unit": "bun test tests/unit/",
+    "test:unit": "bun test tests/unit/ --dots",
     "rebuild-sdk": "bun run --cwd ../sdk/js build",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build -o storybook-static",

--- a/packages/kilo-vscode/playwright.config.ts
+++ b/packages/kilo-vscode/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   workers: process.env["PLAYWRIGHT_WORKERS"]
     ? Number.parseInt(process.env["PLAYWRIGHT_WORKERS"]!, 10) || undefined
     : undefined,
-  reporter: [["html", { open: "never" }], ["list"]],
+  reporter: process.env["CI"] ? [["dot"]] : [["list"]],
   use: {
     baseURL: "http://localhost:6007",
     // VS Code sidebar is typically 350-450px wide

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -32,6 +32,7 @@ if (argv.includes("--help") || argv.includes("-h")) {
       "  --retries <N>        Extra attempts for failing files (default: 1)",
       "  --profile <name>     Run a curated test profile (env: KILO_TEST_PROFILE)",
       "  --bail               Stop on first failure",
+      "  --dots               Show compact dot progress",
       "  --verbose            Show full output for every file",
       "  -h, --help           Show this help",
       "",
@@ -64,6 +65,7 @@ function text(name: string) {
 const ci = argv.includes("--ci")
 const bail = argv.includes("--bail")
 const verbose = argv.includes("--verbose")
+const dots = !verbose && (ci || argv.includes("--dots"))
 // Cap concurrency at 4 even on bigger runners: the bottleneck is shared
 // resources (ports, global filesystem like ~/.local/share/kilo), not CPU.
 // Eight parallel processes was triggering port/FS races, not going faster.
@@ -164,6 +166,14 @@ if (ci) await fs.mkdir(xmldir, { recursive: true })
 
 const counter = { done: 0 }
 const pad = String(files.length).length
+const progress = { width: 80 }
+const marks = {
+  pass: ".",
+  retry: "R",
+  fail: "F",
+  timeout: "T",
+} as const
+const legend = `Legend: ${marks.pass}=pass ${marks.retry}=pass-after-retry ${marks.fail}=fail ${marks.timeout}=timeout`
 
 // ---------------------------------------------------------------------------
 // Run a single test file
@@ -216,8 +226,21 @@ async function run(file: string): Promise<Result> {
 // Report a single result
 // ---------------------------------------------------------------------------
 
+function mark(result: Result) {
+  if (result.timedout) return marks.timeout
+  if (!result.passed) return marks.fail
+  if (result.attempts > 1) return marks.retry
+  return marks.pass
+}
+
 function report(result: Result) {
   counter.done++
+  if (dots) {
+    process.stdout.write(mark(result))
+    if (counter.done % progress.width === 0) process.stdout.write("\n")
+    return
+  }
+
   const idx = String(counter.done).padStart(pad)
   const secs = (result.duration / 1000).toFixed(1)
   const tries = result.attempts > 1 ? dim(` [attempt ${result.attempts}/${retries + 1}]`) : ""
@@ -250,7 +273,9 @@ function report(result: Result) {
 // Parallel execution
 // ---------------------------------------------------------------------------
 
-console.log(`\nRunning ${bold(String(files.length))} test files with concurrency ${bold(String(concurrency))}\n`)
+console.log(`\nRunning ${bold(String(files.length))} test files with concurrency ${bold(String(concurrency))}`)
+if (dots) console.log(dim(legend))
+console.log()
 
 const start = performance.now()
 const results: Result[] = []
@@ -277,6 +302,8 @@ const workers = Array.from({ length: Math.min(concurrency, files.length) }, asyn
 })
 
 await Promise.all(workers)
+
+if (dots && counter.done % progress.width !== 0) console.log()
 
 const elapsed = (performance.now() - start) / 1000
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "test": "bun test src",
-    "test:ci": "mkdir -p .artifacts/unit && bun test src --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test src --dots --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "dev": "vite",
     "generate:tailwind": "bun run script/tailwind.ts"
   },


### PR DESCRIPTION
CI test logs currently spend a lot of space on successful test-file progress, which makes real failures harder to find in GitHub Actions output.

This change switches the noisy Bun and Playwright test paths to compact standard reporters while preserving failure diagnostics, summaries, retries, timeouts, and JUnit artifacts. The custom CLI test runner now uses compact progress automatically in CI, exposes the same mode as an explicit `--dots` option, and prints a legend for the fixed symbols. The JetBrains test wrapper keeps Gradle diagnostics intact but forces plain console output so CI logs do not include rich/progress rendering.