### PR TITLE
fix(jetbrains): resolve workspace by project id

### DIFF
--- a/.changeset/smart-melons-float.md
+++ b/.changeset/smart-melons-float.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Keep JetBrains sessions scoped to the correct worktree when multiple IntelliJ windows are open.

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorkspaceRpcApiImpl.kt
@@ -40,6 +40,8 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.platform.project.ProjectId
+import com.intellij.platform.project.findProjectOrNull
 import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiFileSystemItem
 import com.intellij.psi.search.GlobalSearchScope
@@ -68,8 +70,8 @@ import kotlin.coroutines.resume
  * Backend implementation of [KiloWorkspaceRpcApi].
  *
  * Routes through the [KiloBackendWorkspaceManager] to get a workspace
- * for the given directory. No [ProjectManager] dependency — any
- * directory (including worktrees) can get a workspace.
+ * for the given directory. Project lookup is only used to resolve the
+ * calling frontend project to the correct backend directory.
  */
 class KiloWorkspaceRpcApiImpl : KiloWorkspaceRpcApi {
     companion object {
@@ -94,12 +96,15 @@ class KiloWorkspaceRpcApiImpl : KiloWorkspaceRpcApi {
     private val manager: KiloBackendWorkspaceManager
         get() = app.workspaces
 
-    override suspend fun resolveProjectDirectory(hint: String): String {
-        // In monolith mode, find the open project whose basePath matches the hint.
-        // In split mode, the backend's project.basePath is the real directory.
-        val projects = ProjectManager.getInstance().openProjects
-        val match = projects.firstOrNull { !it.isDefault }
-        return match?.basePath ?: hint
+    override suspend fun resolveProjectDirectory(projectId: ProjectId?, hint: String): String {
+        // Experimental IntelliJ ProjectId API: maps the calling frontend project
+        // to the matching backend project across monolith windows and split mode.
+        val base = projectId?.findProjectOrNull()?.takeIf { !it.isDefault }?.basePath
+        if (base != null) return base
+        val bases = ProjectManager.getInstance().openProjects
+            .filter { !it.isDefault }
+            .mapNotNull { it.basePath }
+        return resolveProjectDirectoryHint(hint, bases)
     }
 
     /**
@@ -443,6 +448,17 @@ internal fun normalizeWorkspacePath(path: String): String? {
     } catch (_: Exception) {
         null
     }
+}
+
+internal fun resolveProjectDirectoryHint(hint: String, bases: List<String>): String {
+    val clean = normalizeWorkspacePath(hint)
+    val match = bases.firstOrNull { base ->
+        val path = normalizeWorkspacePath(base)
+        path != null && clean != null && path == clean
+    }
+    if (match != null) return match
+    if (hint.isNotBlank()) return hint
+    return bases.firstOrNull() ?: hint
 }
 
 internal fun workspaceGitAvailable(base: Path, cache: ConcurrentHashMap<String, Boolean> = ConcurrentHashMap()): Boolean {

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/WorkspacePathScopingTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/WorkspacePathScopingTest.kt
@@ -78,6 +78,40 @@ class WorkspacePathScopingTest {
     }
 
     @Test
+    fun `project directory hint matches second open project`() {
+        assertEquals(
+            "/repo/wt-b",
+            resolveProjectDirectoryHint("/repo/wt-b", listOf("/repo/wt-a", "/repo/wt-b")),
+        )
+    }
+
+    @Test
+    fun `unmatched project directory hint is preserved`() {
+        assertEquals(
+            "/repo/wt-c",
+            resolveProjectDirectoryHint("/repo/wt-c", listOf("/repo/wt-a", "/repo/wt-b")),
+        )
+    }
+
+    @Test
+    fun `blank project directory hint falls back to first project`() {
+        assertEquals("/repo/wt-a", resolveProjectDirectoryHint("", listOf("/repo/wt-a", "/repo/wt-b")))
+    }
+
+    @Test
+    fun `blank project directory hint without projects stays blank`() {
+        assertEquals("", resolveProjectDirectoryHint("", emptyList()))
+    }
+
+    @Test
+    fun `project directory hint comparison normalizes paths`() {
+        assertEquals(
+            "/repo/wt-b",
+            resolveProjectDirectoryHint("/repo/wt-b/./", listOf("/repo/wt-a", "/repo/wt-b")),
+        )
+    }
+
+    @Test
     fun `git availability detects temp repository`() {
         val dir = repo() ?: return
         try {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/KiloToolWindowFactory.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/KiloToolWindowFactory.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.platform.project.projectIdOrNull
 import com.intellij.ui.content.ContentFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,9 +45,11 @@ internal class KiloToolWindowSetupService(
         try {
             val workspaces = service<KiloWorkspaceService>()
             val hint = project.basePath ?: ""
+            // Experimental IntelliJ ProjectId API keeps multi-window and split-mode routing exact.
+            val pid = project.projectIdOrNull()
 
             cs.launch {
-                val dir = workspaces.resolveProjectDirectory(hint)
+                val dir = workspaces.resolveProjectDirectory(pid, hint)
                 val workspace = workspaces.workspace(dir)
                 withContext(Dispatchers.Main) {
                     setup(project, toolWindow, workspace)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloWorkspaceService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloWorkspaceService.kt
@@ -12,6 +12,7 @@ import ai.kilocode.rpc.dto.ModelsWorkspaceDto
 import ai.kilocode.rpc.dto.WorkspaceFileDto
 import com.intellij.openapi.components.Service
 import ai.kilocode.log.KiloLog
+import com.intellij.platform.project.ProjectId
 import fleet.rpc.client.durable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
@@ -88,10 +89,10 @@ class KiloWorkspaceService internal constructor(
      * `/home/.cache/JetBrains/RemoteDev/...`). The backend resolves
      * it to the actual project root on the host.
      */
-    suspend fun resolveProjectDirectory(hint: String): String {
+    suspend fun resolveProjectDirectory(projectId: ProjectId?, hint: String): String {
         return try {
-            val resolved = call { resolveProjectDirectory(hint) }
-            LOG.info("Resolved project directory: hint=$hint → $resolved")
+            val resolved = call { resolveProjectDirectory(projectId, hint) }
+            LOG.info("Resolved project directory: projectId=$projectId hint=$hint -> $resolved")
             resolved
         } catch (e: Exception) {
             LOG.warn("Failed to resolve directory, falling back to hint=$hint", e)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/settings/base/BaseSettingsUi.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/settings/base/BaseSettingsUi.kt
@@ -79,7 +79,7 @@ internal abstract class BaseSettingsUi<C : BaseContentPanel, D, P, R, W>(
         jobs += scope.launch { app.connect() }
         val path = hint ?: return
         jobs += scope.launch {
-            val dir = workspaces.resolveProjectDirectory(path)
+            val dir = workspaces.resolveProjectDirectory(null, path)
             withContext(edt) {
                 projectDirectory = dir
                 workspaceLoaded = false

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeWorkspaceRpcApi.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeWorkspaceRpcApi.kt
@@ -7,6 +7,7 @@ import ai.kilocode.rpc.dto.KiloWorkspaceStateDto
 import ai.kilocode.rpc.dto.KiloWorkspaceStatusDto
 import ai.kilocode.rpc.dto.ModelsWorkspaceDto
 import ai.kilocode.rpc.dto.WorkspaceFileDto
+import com.intellij.platform.project.ProjectId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,7 +51,7 @@ class FakeWorkspaceRpcApi : KiloWorkspaceRpcApi {
     var globalConfigPathCalls = 0
         private set
 
-    override suspend fun resolveProjectDirectory(hint: String): String {
+    override suspend fun resolveProjectDirectory(projectId: ProjectId?, hint: String): String {
         assertNotEdt("resolveProjectDirectory")
         return directory
     }

--- a/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/KiloWorkspaceRpcApi.kt
+++ b/packages/kilo-jetbrains/shared/src/main/kotlin/ai/kilocode/rpc/KiloWorkspaceRpcApi.kt
@@ -5,6 +5,7 @@ import ai.kilocode.rpc.dto.FileSearchResultDto
 import ai.kilocode.rpc.dto.KiloWorkspaceStateDto
 import ai.kilocode.rpc.dto.ModelsWorkspaceDto
 import ai.kilocode.rpc.dto.WorkspaceFileDto
+import com.intellij.platform.project.ProjectId
 import com.intellij.platform.rpc.RemoteApiProviderService
 import fleet.rpc.RemoteApi
 import fleet.rpc.Rpc
@@ -29,11 +30,11 @@ interface KiloWorkspaceRpcApi : RemoteApi<Unit> {
     /**
      * Resolve the real project directory as seen by the backend.
      *
-     * In split mode, the frontend's [Project.getBasePath] returns a
-     * synthetic sandbox path. This method returns the backend's actual
-     * project directory so the frontend can use it for CLI server calls.
+     * [projectId] identifies the exact calling frontend project across the
+     * frontend/backend boundary. [hint] is the frontend's project path and is
+     * used as a fallback if the project cannot be resolved on the backend.
      */
-    suspend fun resolveProjectDirectory(hint: String): String
+    suspend fun resolveProjectDirectory(projectId: ProjectId?, hint: String): String
 
     /** Observe workspace state loading progress. */
     suspend fun state(directory: String): Flow<KiloWorkspaceStateDto>


### PR DESCRIPTION
## Issue

No linked issue. This fixes a reported JetBrains plugin bug where opening multiple IntelliJ frames on different git worktrees caused later Kilo sessions to use the first frame's worktree.

## Context

When several IntelliJ windows are open in the same IDE process, the JetBrains plugin shares one app-level backend service and one `kilo serve` process. Workspace isolation depends on passing the correct `directory` string for each frame.

The previous `resolveProjectDirectory(hint)` implementation ignored `hint` and returned the first non-default open project. That meant frame B could be bound to frame A's worktree, so file tools and saved plans operated in the wrong directory.

Research in the IntelliJ source showed the platform's project identity mechanism is `ProjectId`: frontend code can get `project.projectIdOrNull()`, pass the serializable ID over RPC, and backend code can resolve it with `ProjectId.findProjectOrNull()`. Platform VCS RPC APIs use the same pattern for project-scoped calls. This is why this PR chooses `ProjectId` over matching paths alone: it identifies the exact calling project across both local multi-window mode and split-mode/remote-dev.

Note: `ProjectId` is an experimental IntelliJ Platform API. The implementation uses null-safe calls and preserves hint-based fallbacks.

## Implementation

The workspace RPC now accepts `ProjectId?` alongside the existing path hint. The tool window setup passes the current project's ID to the backend, and the backend resolves that ID to the matching project base path before falling back to normalized hint matching.

A deterministic fallback helper preserves non-blank hints instead of collapsing unmatched directories to the first open project. This keeps arbitrary worktree paths safe even if project ID resolution is unavailable or races with project close.

Settings code that only has a hint now calls the new API with `null` project ID, so it uses the safer hint fallback path.

## Screenshots / Video

N/A, no visual changes.

## How to Test

### Manual/local verification

- Agent executed: `./gradlew :backend:test --tests "ai.kilocode.backend.rpc.WorkspacePathScopingTest"` from `packages/kilo-jetbrains/`.
- Agent executed: `./gradlew clean typecheck` from `packages/kilo-jetbrains/`.
- Agent executed: `bun run build --prepare-cli` from `packages/kilo-jetbrains/` after clean removed generated CLI artifacts.
- Agent executed: `./gradlew buildPlugin` from `packages/kilo-jetbrains/`.
- Push hook executed: `bun turbo typecheck` successfully.

### Reviewer test steps

1. Open IntelliJ frame A on one git worktree and open the Kilo tool window.
2. Open IntelliJ frame B on a different worktree in the same IDE process and open the Kilo tool window.
3. Start a Kilo session in frame B and ask it to inspect or create a file unique to worktree B.
4. Confirm the file tools operate in worktree B, not worktree A.
5. Confirm frame A still operates in worktree A.

### Blocked checks and substitute verification

- Initial `./gradlew test --tests "*WorkspacePathScopingTest*"` applied the test filter to `:frontend:test`, which has no matching tests. Substitute verification was the corrected backend target: `./gradlew :backend:test --tests "ai.kilocode.backend.rpc.WorkspacePathScopingTest"`.
- Initial `./gradlew clean buildPlugin` failed because `clean` removed `backend/build/generated/cli/cli`, required by `:backend:checkCli`. Substitute verification was to prepare CLI artifacts with `bun run build --prepare-cli`, then rerun `./gradlew buildPlugin` successfully.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

