### PR TITLE
fix(ci): stabilize Linux sandbox CLI release smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -194,8 +194,12 @@ jobs:
               test -x "$helper"
               grep -q '^SPDX-License-Identifier: LGPL-2.0-or-later$' "$(dirname "$binary")/licenses/bubblewrap/NOTICE"
               "$helper" --version
+              # The live user-namespace bootstrap depends on the runner's kernel/AppArmor policy
+              # (GitHub-hosted Ubuntu 24.04 sets kernel.apparmor_restrict_unprivileged_userns=1), not on
+              # the shipped artifact. The runtime probe degrades gracefully, so keep this check non-fatal.
               "$helper" --unshare-user --disable-userns --unshare-pid --die-with-parent --new-session \
-                --ro-bind / / --dev /dev --proc /proc -- "$helper" --version
+                --ro-bind / / --dev /dev --proc /proc -- "$helper" --version \
+                || echo "unprivileged user namespaces unavailable on this runner; skipping live sandbox check"
             fi
             root="$(mktemp -d)"
             trap 'rm -rf "$root"' RETURN
@@ -233,7 +237,7 @@ jobs:
               binary="/dist/$PACKAGE/bin/kilo" # kilocode_change
               "$binary" --version # kilocode_change
               "/dist/$PACKAGE/bin/bwrap" --version # kilocode_change
-              grep -q '^SPDX-License-Identifier: LGPL-2.0-or-later$' "/dist/$PACKAGE/bin/licenses/bubblewrap/NOTICE" # kilocode_change
+              grep -q '\''^SPDX-License-Identifier: LGPL-2.0-or-later$'\'' "/dist/$PACKAGE/bin/licenses/bubblewrap/NOTICE" # kilocode_change
               root="$(mktemp -d)"
               trap '\''rm -rf "$root"'\'' EXIT
               unset KILO_MODELS_PATH KILO_MODELS_URL KILO_CONFIG KILO_CONFIG_DIR


### PR DESCRIPTION
## Problem

The release `publish` workflow (`workflow_dispatch`) failed in the **Validate CLI** smoke-test step on all four Linux/Alpine targets, blocking releases. There were two separate root causes, both introduced when the Linux filesystem sandbox smoke checks were added.

**Host targets (linux-x64, linux-arm64):** `smoke_host` ran a live bubblewrap user-namespace bootstrap (`bwrap --unshare-user ... -- bwrap --version`) and treated failure as fatal under `bash -e`. GitHub-hosted Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1`, so the bootstrap aborts with `bwrap: setting up uid map: Permission denied`. `bwrap --version` succeeds, proving the binary and packaging are fine; only the namespace setup is blocked. This is a property of the runner's kernel/AppArmor policy, not of the shipped artifact, and the runtime already degrades gracefully when unprivileged user namespaces are unavailable.

**Alpine targets (alpine-x64, alpine-arm64):** The Alpine block never ran the live bootstrap. Its NOTICE license `grep` used a raw single-quoted pattern inside the outer `sh -c '...'` single-quoted script, while every other embedded quote in that block is escaped as `'\''`. The raw quotes prematurely closed the script string, so `grep` ran with no file argument (reading empty stdin → exit 1) and everything after it, including the models check, was shifted into `sh` positional arguments and never executed. The license check was effectively broken on Alpine.

## Change

- Make the host live sandbox bootstrap non-fatal (`|| echo ...`). The gate still fatally validates the artifact (`bwrap --version`, `test -x`, and the NOTICE license check) but no longer fails the release on the runner's userns policy. Where a runner does permit unprivileged user namespaces, the real sandbox is still exercised.
- Escape the Alpine NOTICE `grep` quotes as `'\''...'\''` so the license check runs against the real file and the remainder of the Alpine smoke script executes.

The smoke step only runs on a manual release publish, so it is not exercised by PR CI; the shell behavior was verified locally by reproducing both the failing and fixed paths (the broken Alpine quoting reproduces the exact `7.3.58` / `bubblewrap 0.11.2 for Kilo` / exit 1 signature, and the fix runs through to the models check).
