### PR TITLE
feat(vscode): send inline review draft comments directly from diff

### DIFF
--- a/.changeset/send-inline-review-comments.md
+++ b/.changeset/send-inline-review-comments.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support sending inline review draft comments directly from the diff without first saving them as pending comments.

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -37,6 +37,7 @@ import {
   reviewComposerEdit,
   reviewDraftSpeechKey,
   reviewEditSpeechKey,
+  sendReviewComments,
   type AnnotationLabels,
   type AnnotationMeta,
   type ReviewComposer,
@@ -104,6 +105,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     placeholder: t("agentManager.review.commentPlaceholder"),
     cancel: t("common.cancel"),
     comment: t("agentManager.review.commentAction"),
+    send: t("prompt.action.send"),
     save: t("common.save"),
     sendToChat: t("agentManager.review.sendToChat"),
     edit: t("common.edit"),
@@ -289,6 +291,18 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     focusRoot()
   }
 
+  const sendComment = (file: string, side: AnnotationSide, line: number, text: string, selectedText: string) => {
+    const comment = { id: `c-${++nextId}-${Date.now()}`, file, side, line, comment: text, selectedText }
+    sendReviewComments([comment], props.activeTerminalId)
+    preserveScroll(() => {
+      setDraft(null)
+      draftMeta = null
+      composer().draft = null
+    })
+    props.onSendClick?.()
+    focusRoot()
+  }
+
   const updateComment = (id: string, text: string) => {
     preserveScroll(() => {
       updateComments((prev) => prev.map((c) => (c.id === id ? { ...c, comment: text } : c)))
@@ -400,6 +414,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
       editing: editing(),
       setEditing: setEditState,
       addComment,
+      sendComment,
       updateComment,
       deleteComment,
       cancelDraft,

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2297,8 +2297,13 @@ body.am-wt-dragging-active * {
   color: var(--text-base);
 }
 
-.am-annotation-btn:hover {
+.am-annotation-btn:hover:not(:disabled) {
   background: var(--surface-interactive-base);
+}
+
+.am-annotation-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .am-annotation-btn-submit {
@@ -2308,7 +2313,7 @@ body.am-wt-dragging-active * {
   font-weight: 500;
 }
 
-.am-annotation-btn-submit:hover {
+.am-annotation-btn-submit:hover:not(:disabled) {
   background: var(--surface-interactive-strong-hover, var(--vscode-button-hoverBackground, #0066b8));
 }
 

--- a/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
@@ -39,6 +39,7 @@ import {
   reviewComposerEdit,
   reviewDraftSpeechKey,
   reviewEditSpeechKey,
+  sendReviewComments,
   type AnnotationLabels,
   type AnnotationMeta,
   type ReviewComposer,
@@ -108,6 +109,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     placeholder: t("agentManager.review.commentPlaceholder"),
     cancel: t("common.cancel"),
     comment: t("agentManager.review.commentAction"),
+    send: t("prompt.action.send"),
     save: t("common.save"),
     sendToChat: t("agentManager.review.sendToChat"),
     edit: t("common.edit"),
@@ -295,6 +297,18 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     focusRoot()
   }
 
+  const sendComment = (file: string, side: AnnotationSide, line: number, text: string, selectedText: string) => {
+    const comment = { id: `c-${++nextId}-${Date.now()}`, file, side, line, comment: text, selectedText }
+    sendReviewComments([comment], props.activeTerminalId)
+    preserveScroll(() => {
+      setDraft(null)
+      draftMeta = null
+      composer().draft = null
+    })
+    props.onSendClick?.()
+    focusRoot()
+  }
+
   const updateComment = (id: string, text: string) => {
     preserveScroll(() => {
       updateComments((prev) => prev.map((c) => (c.id === id ? { ...c, comment: text } : c)))
@@ -411,6 +425,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
       editing: editing(),
       setEditing: setEditState,
       addComment,
+      sendComment,
       updateComment,
       deleteComment,
       cancelDraft,

--- a/packages/kilo-vscode/webview-ui/diff-viewer/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/review-annotations.ts
@@ -8,6 +8,7 @@ export interface AnnotationLabels {
   placeholder: string
   cancel: string
   comment: string
+  send: string
   save: string
   sendToChat: string
   edit: string
@@ -76,6 +77,7 @@ interface AnnotationHandlers {
   editing: string | null
   setEditing: (id: string | null) => void
   addComment: (file: string, side: AnnotationSide, line: number, text: string, selectedText: string) => void
+  sendComment: (file: string, side: AnnotationSide, line: number, text: string, selectedText: string) => void
   updateComment: (id: string, text: string) => void
   deleteComment: (id: string) => void
   cancelDraft: () => void
@@ -131,6 +133,19 @@ function makeActionButton(title: string, icon: SVGSVGElement, action: () => void
     action()
   })
   return button
+}
+
+export function sendReviewComments(comments: ReviewComment[], activeTerminalId?: string): void {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: {
+        type: activeTerminalId ? "appendReviewCommentsToTerminal" : "appendReviewComments",
+        comments,
+        autoSend: true,
+        targetTerminalId: activeTerminalId,
+      },
+    }),
+  )
 }
 
 export function buildFileAnnotations(
@@ -235,15 +250,28 @@ export function buildReviewAnnotation(
     submitButton.className = "am-annotation-btn am-annotation-btn-submit"
     submitButton.textContent = handlers.labels.comment
 
+    const sendButton = document.createElement("button")
+    sendButton.className = "am-annotation-btn am-annotation-btn-submit"
+    sendButton.textContent = handlers.labels.send
+    sendButton.title = handlers.labels.sendToChat
+
+    const update = () => {
+      const disabled = textarea.value.trim().length === 0
+      submitButton.disabled = disabled
+      sendButton.disabled = disabled
+    }
+
     const speech = handlers.speech?.render(meta, textarea)
     if (speech) actions.appendChild(speech)
     actions.appendChild(cancelButton)
     actions.appendChild(submitButton)
+    actions.appendChild(sendButton)
     wrapper.appendChild(header)
     wrapper.appendChild(textarea)
     wrapper.appendChild(actions)
 
     focusWhenConnected(textarea)
+    update()
 
     const submit = () => {
       if (handlers.speech?.active()) return
@@ -255,6 +283,16 @@ export function buildReviewAnnotation(
       handlers.addComment(meta.file, meta.side, meta.line, text, selected)
     }
 
+    const send = () => {
+      if (handlers.speech?.active()) return
+      const text = textarea.value.trim()
+      if (!text) return
+      const diff = handlers.diffs.find((item) => item.file === meta.file)
+      const content = meta.side === "deletions" ? (diff?.before ?? "") : (diff?.after ?? "")
+      const selected = extractLines(content, meta.line, meta.endLine ?? meta.line)
+      handlers.sendComment(meta.file, meta.side, meta.line, text, selected)
+    }
+
     cancelButton.addEventListener("click", (event) => {
       event.stopPropagation()
       handlers.cancelDraft()
@@ -263,6 +301,11 @@ export function buildReviewAnnotation(
     submitButton.addEventListener("click", (event) => {
       event.stopPropagation()
       submit()
+    })
+
+    sendButton.addEventListener("click", (event) => {
+      event.stopPropagation()
+      send()
     })
 
     textarea.addEventListener("keydown", (event) => {
@@ -276,6 +319,7 @@ export function buildReviewAnnotation(
         submit()
       }
     })
+    textarea.addEventListener("input", update)
 
     return wrapper
   }
@@ -360,16 +404,7 @@ export function buildReviewAnnotation(
 
   actions.appendChild(
     makeActionButton(handlers.labels.sendToChat, makeIcon("M1 1l14 7-14 7V9l10-1L1 7z"), () => {
-      window.dispatchEvent(
-        new MessageEvent("message", {
-          data: {
-            type: handlers.activeTerminalId ? "appendReviewCommentsToTerminal" : "appendReviewComments",
-            comments: [comment],
-            autoSend: true,
-            targetTerminalId: handlers.activeTerminalId,
-          },
-        }),
-      )
+      sendReviewComments([comment], handlers.activeTerminalId)
       handlers.deleteComment(comment.id)
     }),
   )


### PR DESCRIPTION
## Problem

When reviewing a diff in Agent Manager (and the full-screen diff view and the vscode diff view), the inline comment composer only offered a `Comment` action. That action saves the draft as a pending review comment in the footer. To actually send a single line comment to the chat, you had to save it as pending first and then use the per-comment "Send to chat" icon. There was no way to send one inline draft straight to the agent in a single step.

## What changed

The inline draft composer now has a `Send` button next to `Cancel` and `Comment`. Clicking it sends the current draft directly through the existing review-comment append path (`appendReviewComments` / `appendReviewCommentsToTerminal` with `autoSend: true`), the same path the saved-comment "Send to chat" icon already uses, then clears the draft without leaving a pending comment behind.

`Comment` keeps its existing behavior of saving a pending review comment.

Both action buttons are disabled while the textarea is empty or whitespace-only, and they now carry a proper disabled style (dimmed with a not-allowed cursor) so the unclickable state is visible rather than just functional. `Cancel` stays enabled.

The send dispatch was extracted into a shared `sendReviewComments` helper so the new draft `Send` button and the existing saved-comment send icon use one implementation. The change is wired into both review surfaces: the Agent Manager inline `DiffPanel` and the full-screen `FullScreenDiffView`.


<img width="738" height="198" alt="file-599b87ab0ff06c465c91756bad909109" src="https://github.com/user-attachments/assets/979545bd-09a8-43bb-b630-bb539766f062" />
<img width="736" height="206" alt="file-2962b7d274b3a7a2ae8d9e3a1d35320d" src="https://github.com/user-attachments/assets/9e86e51d-a907-402f-a6a1-24bc4e664981" />
