### PR TITLE
docs: prefer one concise changeset per PR

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,7 +4,7 @@ This directory contains changeset files used to track changes for the next relea
 
 ## Adding a changeset
 
-When making a user-facing change, run:
+When making a user-facing change, prefer one concise changeset per PR, grouping related changes when possible. Run:
 
 ```sh
 bunx changeset add

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ Padding makes every content change rewrite the entire table, which blows up diff
 
 ## Changesets
 
-User-facing changes (features, fixes, breaking changes) require a changeset file for release notes. Run `bunx changeset add` or manually create `.changeset/<slug>.md`. Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. See `.changeset/README.md` for details.
+User-facing changes (features, fixes, breaking changes) require a changeset file for release notes. Prefer one concise changeset per PR, grouping related changes when possible. Run `bunx changeset add` or manually create `.changeset/<slug>.md`. Use `patch` for bug fixes, `minor` for new features, `major` for breaking changes. See `.changeset/README.md` for details.
 
 Changeset descriptions appear directly in release notes and are read by end users. Keep them concise and feature-oriented — describe **what changed from the user's perspective**, not implementation details. Write in imperative mood (e.g. "Support exporting conversations as markdown" not "Add a new export handler that serializes session messages to .md files").
 


### PR DESCRIPTION
## What

- Encourage one concise changeset per PR in agent guidance.
- Mirror the same guidance in the changeset README.

## Why

This keeps release notes concise while still allowing related changes to be grouped naturally.
