### PR TITLE
feat(vscode): persist model selector expand/collapse state

### DIFF
--- a/.changeset/persist-model-picker-state.md
+++ b/.changeset/persist-model-picker-state.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve the model picker preview panel expand/collapse state across reloads and restarts.

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -30,6 +30,7 @@ import { useProvider } from "../../context/provider"
 import type { EnrichedModel } from "../../context/provider"
 import { useSession, SessionContext } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { getVSCodeAPI } from "../../context/vscode"
 import type { ModelSelection } from "../../types/messages"
 import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 import {
@@ -135,6 +136,30 @@ export interface ModelSelectorBaseProps {
   description?: string
 }
 
+// Persisted via the VS Code webview state API so the preview-panel preference
+// survives reload and hide/show; defaults to expanded unless explicitly collapsed.
+const EXPANDED_STATE_KEY = "modelSelectorExpanded"
+
+function loadExpanded(): boolean {
+  try {
+    const state = getVSCodeAPI().getState() as Record<string, unknown> | undefined
+    return state?.[EXPANDED_STATE_KEY] !== false
+  } catch (err) {
+    console.warn("[Kilo New] model selector expanded load failed", err)
+    return true
+  }
+}
+
+function saveExpanded(val: boolean) {
+  try {
+    const api = getVSCodeAPI()
+    const state = (api.getState() as Record<string, unknown> | undefined) ?? {}
+    api.setState({ ...state, [EXPANDED_STATE_KEY]: val })
+  } catch (err) {
+    console.warn("[Kilo New] model selector expanded save failed", err)
+  }
+}
+
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const { connected, models, findModel } = useProvider()
   const language = useLanguage()
@@ -153,7 +178,9 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   })
 
   const [open, setOpen] = createSignal(false)
-  const [expanded, setExpanded] = createSignal(true)
+  const [expanded, setExpanded] = createSignal(loadExpanded())
+  // Persist the user's expand/collapse choice so it is restored on reopen.
+  createEffect(() => saveExpanded(expanded()))
   const [search, setSearch] = createSignal("")
   const [debouncedSearch, setDebouncedSearch] = createSignal("")
   const [selectedKey, setSelectedKey] = createSignal(CLEAR_KEY)

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -30,7 +30,7 @@ import { useProvider } from "../../context/provider"
 import type { EnrichedModel } from "../../context/provider"
 import { useSession, SessionContext } from "../../context/session"
 import { useLanguage } from "../../context/language"
-import { getVSCodeAPI } from "../../context/vscode"
+import { useVSCode } from "../../context/vscode"
 import type { ModelSelection } from "../../types/messages"
 import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 import {
@@ -136,33 +136,10 @@ export interface ModelSelectorBaseProps {
   description?: string
 }
 
-// Persisted via the VS Code webview state API so the preview-panel preference
-// survives reload and hide/show; defaults to expanded unless explicitly collapsed.
-const EXPANDED_STATE_KEY = "modelSelectorExpanded"
-
-function loadExpanded(): boolean {
-  try {
-    const state = getVSCodeAPI().getState() as Record<string, unknown> | undefined
-    return state?.[EXPANDED_STATE_KEY] !== false
-  } catch (err) {
-    console.warn("[Kilo New] model selector expanded load failed", err)
-    return true
-  }
-}
-
-function saveExpanded(val: boolean) {
-  try {
-    const api = getVSCodeAPI()
-    const state = (api.getState() as Record<string, unknown> | undefined) ?? {}
-    api.setState({ ...state, [EXPANDED_STATE_KEY]: val })
-  } catch (err) {
-    console.warn("[Kilo New] model selector expanded save failed", err)
-  }
-}
-
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   const { connected, models, findModel } = useProvider()
   const language = useLanguage()
+  const vscode = useVSCode()
   // Session context is optional — ModelSelectorBase is also used in Settings
   // where SessionProvider may not be mounted.
   const session = useContext(SessionContext)
@@ -178,9 +155,9 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
   })
 
   const [open, setOpen] = createSignal(false)
-  const [expanded, setExpanded] = createSignal(loadExpanded())
+  const [expanded, setExpanded] = createSignal(vscode.getModelSelectorExpanded())
   // Persist the user's expand/collapse choice so it is restored on reopen.
-  createEffect(() => saveExpanded(expanded()))
+  createEffect(() => vscode.setModelSelectorExpanded(expanded()))
   const [search, setSearch] = createSignal("")
   const [debouncedSearch, setDebouncedSearch] = createSignal("")
   const [selectedKey, setSelectedKey] = createSignal(CLEAR_KEY)

--- a/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
@@ -8,6 +8,7 @@ import type { VSCodeAPI, WebviewMessage, ExtensionMessage } from "../types/messa
 
 // Get the VS Code API (only available in webview context)
 let vscodeApi: VSCodeAPI | undefined
+const EXPANDED = "modelSelectorExpanded"
 
 export function getVSCodeAPI(): VSCodeAPI {
   if (!vscodeApi) {
@@ -33,6 +34,8 @@ interface VSCodeContextValue {
   onMessage: (handler: (message: ExtensionMessage) => void) => () => void
   getState: <T>() => T | undefined
   setState: <T>(state: T) => void
+  getModelSelectorExpanded: () => boolean
+  setModelSelectorExpanded: (value: boolean) => void
 }
 
 const VSCodeContext = createContext<VSCodeContextValue>()
@@ -64,6 +67,14 @@ export const VSCodeProvider: ParentComponent = (props) => {
     },
     getState: <T,>() => api.getState() as T | undefined,
     setState: <T,>(state: T) => api.setState(state),
+    getModelSelectorExpanded: () => {
+      const state = api.getState() as Record<string, unknown> | undefined
+      return state?.[EXPANDED] !== false
+    },
+    setModelSelectorExpanded: (value: boolean) => {
+      const state = (api.getState() as Record<string, unknown> | undefined) ?? {}
+      api.setState({ ...state, [EXPANDED]: value })
+    },
   }
 
   return <VSCodeContext.Provider value={value}>{props.children}</VSCodeContext.Provider>


### PR DESCRIPTION
## Context

The model picker preview panel expand/collapse state reset when the VS Code webview reloaded, hid/shown, or restarted. Persisting this preference keeps the picker in the user's chosen layout.

## Implementation

Save the preview-panel expand/collapse preference through the VS Code webview state API and restore it when the model picker initializes.

## Screenshots / Video

N/A. Behavior-only persistence change; no visual layout change.

## How to Test

### Manual/local verification

- Agent ran `bun turbo typecheck` via the pre-push hook.

### Reviewer test steps

1. Open the VS Code extension model picker.
2. Expand or collapse the preview panel.
3. Hide/show the webview, reload the extension host, or restart VS Code.
4. Reopen the model picker and confirm the preview panel keeps the prior state.


## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.