### PR TITLE
fix(cli): surface Codex WebSocket no-content failures as errors

### DIFF
--- a/.changeset/fix-codex-ws-empty-turn.md
+++ b/.changeset/fix-codex-ws-empty-turn.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix ChatGPT/Codex sessions getting stuck on "Response ended without a finish reason" when the provider's WebSocket stream ends in a failure before producing any output. The turn now surfaces a real provider error and falls back to HTTP instead of silently replaying the same empty response on every resume.

--- a/packages/opencode/src/plugin/openai/ws.ts
+++ b/packages/opencode/src/plugin/openai/ws.ts
@@ -135,6 +135,7 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
   let cleanupSocket = () => {}
   let completed = false
   let emitted = false
+  let content = false // kilocode_change - track real content emitted before a terminal event
   let idleTimer: ReturnType<typeof setTimeout> | undefined
 
   function cleanup() {
@@ -210,6 +211,19 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
       }
     }
 
+    // kilocode_change start - a failure terminal that arrives before any content
+    // must surface as a stream error so the pool's onConnectionInvalid records
+    // the failure, tears down this lane's socket, and falls back to HTTP. Passing
+    // it through as a clean [DONE] yields an empty turn the loop persists as
+    // finish:"unknown", which permanently wedges the conversation's socket lane
+    // (every resume replays into the same failure). Once content has streamed the
+    // turn cannot be safely retried, so it still passes through below.
+    if (isFailureTerminal(event) && !content) {
+      invalidate(new ProviderError.ResponseStreamError(failureMessage(event)))
+      return
+    }
+    // kilocode_change end
+
     if (!emitted) options.onFirstEvent?.()
     controller?.enqueue(
       encoder.encode(
@@ -220,6 +234,7 @@ export function streamResponsesWebSocket(options: StreamResponsesWebSocketOption
       ),
     )
     emitted = true
+    if (isContentEvent(event)) content = true // kilocode_change - lifecycle events (e.g. response.created) are not retry-blocking content
     resetIdleTimeout("idle timeout waiting for websocket")
 
     if (!event) return
@@ -330,5 +345,37 @@ function closeMessage(message: string, code: number, reason: Buffer) {
   if (reason.length > 0) details.push(reason.toString())
   return `${message} (${details.join(": ")})`
 }
+
+// kilocode_change start - terminal events of the OpenAI Responses stream that
+// indicate the turn ended without a usable completion.
+function isFailureTerminal(event: Record<string, unknown> | undefined): event is Record<string, unknown> {
+  return event?.type === "response.failed" || event?.type === "response.incomplete" || event?.type === "error"
+}
+
+// Whether an event carries model output. Lifecycle events (response.created,
+// response.in_progress, response.queued) and terminal events do not — a failure
+// after only those still counts as a no-content turn that is safe to retry.
+function isContentEvent(event: Record<string, unknown> | undefined) {
+  const type = event?.type
+  if (typeof type !== "string" || !type.startsWith("response.")) return false
+  if (isFailureTerminal(event) || type === "response.completed" || type === "response.done") return false
+  return type !== "response.created" && type !== "response.in_progress" && type !== "response.queued"
+}
+
+// human-readable message for a no-content failure terminal.
+// Codex failure events carry the error under either `error` or `response.error`.
+function failureMessage(event: Record<string, unknown>) {
+  for (const source of [event, event.response]) {
+    if (typeof source !== "object" || source === null) continue
+    const error = (source as Record<string, unknown>).error
+    if (typeof error === "object" && error !== null) {
+      const message = (error as Record<string, unknown>).message
+      if (typeof message === "string" && message.length > 0) return message
+    }
+  }
+  if (typeof event.message === "string" && event.message.length > 0) return event.message
+  return `WebSocket response ${typeof event.type === "string" ? event.type : "failed"} before any content`
+}
+// kilocode_change end
 
 export * as OpenAIWebSocket from "./ws"

--- a/packages/opencode/test/kilocode/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/kilocode/plugin/openai-ws.test.ts
@@ -3,9 +3,9 @@ import { EventEmitter } from "node:events"
 import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http"
 import net, { type AddressInfo, type Socket } from "node:net"
 import WebSocket, { WebSocketServer } from "ws"
-import { ProviderError } from "../../src/provider/error"
-import { OpenAIWebSocket } from "../../src/plugin/openai/ws"
-import { OpenAIWebSocketPool, TITLE_HEADER } from "../../src/plugin/openai/ws-pool"
+import { ProviderError } from "../../../src/provider/error"
+import { OpenAIWebSocket } from "../../../src/plugin/openai/ws"
+import { OpenAIWebSocketPool, TITLE_HEADER } from "../../../src/plugin/openai/ws-pool"
 
 describe("plugin.openai.ws", () => {
   test("derives websocket URLs and sends auth plus protocol headers", async () => {
@@ -231,18 +231,26 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
-  test("invalidates but does not reuse a socket after terminal failure frames", async () => {
+  test("reuses the lane after a failure terminal that arrives mid-content", async () => {
     let connections = 0
     await using server = await createWebSocketServer((socket) => {
       connections += 1
       socket.once("message", () => {
-        socket.send(JSON.stringify({ type: connections === 1 ? "response.failed" : "response.completed" }))
+        if (connections === 1) {
+          socket.send(JSON.stringify({ type: "response.created" }))
+          socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "partial" }))
+          socket.send(JSON.stringify({ type: "response.failed" }))
+          return
+        }
+        socket.send(JSON.stringify({ type: "response.completed" }))
       })
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
     })
 
+    // Real output already streamed, so the failure terminal passes through as-is
+    // (the turn cannot be safely retried) and the socket is invalidated.
     const first = await fetch(server.url, streamRequest())
     expect(await first.text()).toContain('data: {"type":"response.failed"}')
 
@@ -250,6 +258,60 @@ describe("plugin.openai.ws-pool", () => {
     expect(await second.text()).toContain('data: {"type":"response.completed"}')
     expect(connections).toBe(2)
     expect(server.httpRequests).toHaveLength(0)
+    fetch.close()
+  })
+
+  test("errors and retries a failure terminal that arrives before any content", async () => {
+    let connections = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.once("message", () => {
+        socket.send(
+          JSON.stringify({
+            type: "response.failed",
+            response: { error: { message: "model produced no output" } },
+          }),
+        )
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+      streamRetries: 1,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    expect((await readTextError(first.text())).message).toContain("model produced no output")
+    const second = await fetch(server.url, streamRequest())
+    const third = await fetch(server.url, streamRequest())
+
+    // After the retry budget is exhausted the lane falls back to HTTP instead
+    // of replaying into the same no-content failure forever.
+    expect(await second.text()).toBe("http")
+    expect(await third.text()).toBe("http")
+    expect(connections).toBe(2)
+    expect(server.httpRequests).toHaveLength(2)
+    fetch.close()
+  })
+
+  test("errors a no-content failure that follows only lifecycle events", async () => {
+    await using server = await createWebSocketServer((socket) => {
+      socket.once("message", () => {
+        // response.created always precedes output. A failure after only lifecycle
+        // events is still an empty turn and must surface as an error instead of a
+        // silent [DONE] the loop would persist as finish:"unknown".
+        socket.send(JSON.stringify({ type: "response.created" }))
+        socket.send(JSON.stringify({ type: "response.in_progress" }))
+        socket.send(JSON.stringify({ type: "response.failed", response: { error: { message: "empty turn" } } }))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+    })
+
+    const first = await fetch(server.url, streamRequest())
+    const text = await readTextError(first.text())
+    expect(text.message).toContain("empty turn")
+    expect(text).toBeInstanceOf(ProviderError.ResponseStreamError)
     fetch.close()
   })
 


### PR DESCRIPTION
## Problem

Sessions on the Codex (ChatGPT) provider could get permanently stuck on "Response ended without a finish reason and may be incomplete." Every resume produced an empty assistant turn with `finish: "unknown"` and 0 tokens, and the session could never continue.

The cause is in the Codex Responses WebSocket transport. When the backend ends a stream with a failure terminal (`response.failed`, `response.incomplete`, or a top-level `error`) **before any content was streamed**, the handler treated it like a normal completion: it emitted `data: [DONE]` and closed the SSE stream cleanly. The model layer then saw a stream with no content and no finish reason and recorded an empty turn (`finish: "unknown"`, 0 tokens). Because the WebSocket pool is keyed per conversation (`sessionID:conversation`), that lane replayed the same empty terminal on every retry, so the conversation was wedged.

## Change

A failure terminal that arrives before any model output now surfaces as a stream error via the pool's `onConnectionInvalid` path, instead of a silent `[DONE]`. This means the pool records the failure, tears down the lane's socket, and falls back to HTTP after the retry budget, and the model layer sees a real provider error it can retry rather than an empty turn it persists.

Failures that arrive **after** content has already streamed are unchanged: they still pass through, because a partial turn cannot be safely retried. Lifecycle-only events (`response.created` / `response.in_progress` / `response.queued`) do not count as content, so a failure following only those is correctly treated as a no-content turn.

The inter-chunk idle timeout already produced a real `ResponseStreamError`, so it was never the silent path; this only changes the masked-terminal case.