### PR TITLE
fix(cli): retain sandbox state when forking or moving a session to a worktree

### DIFF
--- a/.changeset/retain-sandbox-on-fork.md
+++ b/.changeset/retain-sandbox-on-fork.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Retain the sandbox toggle state when forking a session or moving it to a worktree, instead of resetting it to the workspace default.

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -11,9 +11,10 @@ import type { InstanceContext } from "@/project/instance-context"
 import type { SessionID } from "@/session/schema"
 import { Changed } from "./event"
 import * as Network from "./network"
+import * as SandboxState from "./state"
 import { SandboxStore } from "./store"
 
-type Snapshot = SandboxStore.Snapshot
+export type Snapshot = SandboxStore.Snapshot
 
 const snapshots = new Map<string, Snapshot>()
 const locks = new Map<SessionID, { semaphore: Semaphore.Semaphore; refs: number }>()
@@ -137,8 +138,11 @@ const snapshot = Effect.fn("SandboxPolicy.snapshot")(function* (sessionID: Sessi
       const existing = yield* read(directory, sessionID)
       if (existing) return { directory, state: existing }
       const cfg = yield* (yield* Config.Service).get()
+      // A session's create-time kilocode.sandbox toggle takes precedence over the config default, so a
+      // session moved or created with an explicit choice keeps that choice instead of resetting.
+      const chosen = yield* SandboxState.read(sessionID)
       const next = secure({
-        enabled: cfg.experimental?.sandbox ?? false,
+        enabled: chosen?.enabled ?? cfg.experimental?.sandbox ?? false,
         mode: cfg.experimental?.sandbox_restrict_network === false ? "allow" : "deny",
         version: 0,
       })
@@ -205,6 +209,11 @@ function change<E, R>(sessionID: SessionID, guard: Effect.Effect<unknown, E, R>)
 
 export const toggle = Effect.fn("SandboxPolicy.toggle")((sessionID: SessionID) => change(sessionID, Effect.void))
 
+/** Stored confinement for a session in an explicit directory, without seeding from config. */
+export const peek = Effect.fn("SandboxPolicy.peek")(function* (directory: string, sessionID: SessionID) {
+  return yield* read(directory, sessionID)
+})
+
 export const inherit = Effect.fn("SandboxPolicy.inherit")(function* (
   parentID: SessionID,
   sessionID: SessionID,
@@ -217,10 +226,9 @@ export const inherit = Effect.fn("SandboxPolicy.inherit")(function* (
       const stored = yield* read(directory, parentID)
       const parent = stored ?? (fallback && secure({ ...fallback, version: 0 }))
       if (!parent) return
-      if (!stored) {
-        yield* Effect.promise(() => SandboxStore.write(directory, parentID, parent))
-        snapshots.set(key(directory, parentID), parent)
-      }
+      // Only persist the parent snapshot when it actually belongs to this directory. A fallback
+      // carries confinement from another directory (e.g. forking into a worktree) and must not be
+      // written back under the parent's key here, or it leaks a phantom parent record.
       yield* locked(
         sessionID,
         Effect.gen(function* () {

--- a/packages/opencode/src/kilocode/server/routes/fork-routing.ts
+++ b/packages/opencode/src/kilocode/server/routes/fork-routing.ts
@@ -1,0 +1,16 @@
+/**
+ * Fork creates a new session that may live in a different directory than its source, for example
+ * when a session is moved into a git worktree. The shared workspace router resolves a
+ * `/session/:id/*` request to the source session's own directory, which would otherwise place the
+ * forked session (and its sandbox confinement) in the source's directory instead of the requested
+ * target. When the client targets a fork at an explicit directory, that directory must win.
+ */
+export function forkTargetDirectory(
+  method: string,
+  url: URL,
+  headers: Record<string, string | undefined>,
+): string | undefined {
+  if (method !== "POST") return undefined
+  if (!/^\/session\/[^/]+\/fork$/.test(url.pathname)) return undefined
+  return url.searchParams.get("directory") || headers["x-kilo-directory"] || undefined
+}

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -6,6 +6,7 @@ import { Session } from "@/session/session"
 import { HttpApiProxy } from "./proxy"
 import * as Fence from "@/server/shared/fence"
 import { getWorkspaceRouteSessionID, isLocalWorkspaceRoute, workspaceProxyURL } from "@/server/shared/workspace-routing"
+import { forkTargetDirectory } from "@/kilocode/server/routes/fork-routing" // kilocode_change - fork honors explicit target directory
 import { NotFoundError } from "@/storage/storage"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Context, Data, Effect, Layer, Option, Schema } from "effect"
@@ -178,10 +179,13 @@ function planRequest(
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 
+    // kilocode_change start - a fork targeting an explicit directory (e.g. a worktree) must not inherit the source session's directory
+    const forkDirectory = forkTargetDirectory(request.method, url, request.headers as Record<string, string | undefined>)
     return RequestPlan.Local({
-      directory: session?.directory || defaultDirectory(request, url),
+      directory: forkDirectory || session?.directory || defaultDirectory(request, url),
       workspaceID: envWorkspaceID ?? workspaceID,
     })
+    // kilocode_change end
   })
 }
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -571,6 +571,7 @@ export const layer: Layer.Layer<
       permission?: Permission.Ruleset
       platform?: string // kilocode_change - per-session platform override for telemetry attribution
       sourceID?: SessionID // kilocode_change - inherited sandbox policy source
+      sandboxFallback?: SandboxPolicy.Snapshot // kilocode_change - confinement to seed when source state lives in another directory
     }) {
       const ctx = yield* InstanceState.context
       const result: Info = {
@@ -599,7 +600,7 @@ export const layer: Layer.Layer<
       // kilocode_change start - initialize inherited state before session.created subscribers run
       KiloSession.register({ id: result.id, parentID: result.parentID, platform: input.platform })
       const source = input.sourceID ?? result.parentID
-      if (source) yield* SandboxPolicy.inherit(source, result.id)
+      if (source) yield* SandboxPolicy.inherit(source, result.id, input.sandboxFallback)
       // kilocode_change end
 
       yield* sync.run(Event.Created, { sessionID: result.id, info: result })
@@ -774,6 +775,9 @@ export const layer: Layer.Layer<
       const ctx = yield* InstanceState.context
       const original = yield* get(input.sessionID)
       const title = getForkedTitle(original.title)
+      // kilocode_change start - forks into another directory cannot read the source confinement from the new dir, so carry it over explicitly
+      const sandboxFallback = yield* SandboxPolicy.peek(original.directory, input.sessionID)
+      // kilocode_change end
       const session = yield* createNext({
         directory: ctx.directory,
         path: sessionPath(ctx.worktree, ctx.directory),
@@ -781,6 +785,7 @@ export const layer: Layer.Layer<
         title,
         metadata: structuredClone(original.metadata),
         sourceID: input.sessionID, // kilocode_change - forks preserve initialized confinement
+        sandboxFallback, // kilocode_change - seed confinement from the source session's original directory
       })
       const msgs = yield* messages({ sessionID: input.sessionID })
       const idMap = new Map<string, MessageID>()

--- a/packages/opencode/test/kilocode/sandbox/session.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/session.test.ts
@@ -46,6 +46,38 @@ describe("sandbox session cleanup", () => {
     }),
   )
 
+  it.live("forks into another directory carry the source confinement", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const dir = yield* tmpdirScoped({ git: true, config: { experimental: { sandbox: true } } })
+      const worktree = yield* tmpdirScoped({ git: true })
+      const source = yield* provideInstance(dir)(sessions.create({ title: "sandbox-source" }))
+      const status = yield* provideInstance(dir)(SandboxPolicy.status(source.id))
+      if (!status.available) return
+
+      // Move-to-worktree forks the source into a fresh directory where no snapshot exists yet.
+      const fork = yield* provideInstance(worktree)(sessions.fork({ sessionID: source.id }))
+      expect((yield* provideInstance(worktree)(SandboxPolicy.status(fork.id))).enabled).toBe(true)
+
+      // The carried-over confinement must not leak a phantom snapshot for the source in the worktree.
+      expect(yield* Effect.promise(() => SandboxStore.read(worktree, source.id))).toBeUndefined()
+    }),
+  )
+
+  it.live("creates honor the kilocode.sandbox metadata over the config default", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      // Config default is disabled; the create-time toggle asks for enabled.
+      const dir = yield* tmpdirScoped({ git: true, config: { experimental: { sandbox: false } } })
+      const session = yield* provideInstance(dir)(
+        sessions.create({ title: "sandbox-explicit", metadata: { "kilocode.sandbox": { enabled: true, version: 0 } } }),
+      )
+      const status = yield* provideInstance(dir)(SandboxPolicy.status(session.id))
+      if (!status.available) return
+      expect(status.enabled).toBe(true)
+    }),
+  )
+
   it.live("clears every directory snapshot when removing outside instance context", () =>
     Effect.gen(function* () {
       const session = yield* Session.Service

--- a/packages/opencode/test/kilocode/server/fork-routing.test.ts
+++ b/packages/opencode/test/kilocode/server/fork-routing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { forkTargetDirectory } from "@/kilocode/server/routes/fork-routing"
+
+function url(path: string) {
+  return new URL(path, "http://localhost")
+}
+
+describe("forkTargetDirectory", () => {
+  test("honors the explicit directory query on a fork request", () => {
+    expect(forkTargetDirectory("POST", url("/session/ses_abc/fork?directory=/repo/.kilo/worktrees/x"), {})).toBe(
+      "/repo/.kilo/worktrees/x",
+    )
+  })
+
+  test("falls back to the x-kilo-directory header when no query is present", () => {
+    expect(
+      forkTargetDirectory("POST", url("/session/ses_abc/fork"), { "x-kilo-directory": "/repo/.kilo/worktrees/y" }),
+    ).toBe("/repo/.kilo/worktrees/y")
+  })
+
+  test("returns undefined when the fork request carries no target directory", () => {
+    expect(forkTargetDirectory("POST", url("/session/ses_abc/fork"), {})).toBeUndefined()
+  })
+
+  test("ignores non-fork session routes so they keep using the session's own directory", () => {
+    expect(forkTargetDirectory("POST", url("/session/ses_abc/message?directory=/elsewhere"), {})).toBeUndefined()
+    expect(forkTargetDirectory("GET", url("/session/ses_abc/fork?directory=/elsewhere"), {})).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Forking a session or moving it to a worktree dropped the session's sandbox toggle and reset it to the workspace default. After a move, the worktree session showed the wrong confinement and its sandbox toggle could appear stuck until the session was used again.

The cause is in how a forked session's directory is resolved and how confinement is initialized:

- The workspace-routing middleware resolves any `/session/:id/*` request to the source session's own directory. For `fork`, this means the explicit target directory the client passes (the worktree) is ignored, so the new session is created in the source's directory. Its sandbox confinement is then stored under a directory the worktree view never queries, and the toggle falls back to stale metadata or the config default.
- Separately, a top-level session never seeded its sandbox policy from its create-time `kilocode.sandbox` metadata, and a fork could not read the source confinement from the new worktree directory because the source's state lives in a different directory.

This change makes confinement follow the session across a fork or move:

- A `fork` request honors an explicit target directory (query or `x-kilo-directory` header) instead of inheriting the source session's directory, so the forked session and its confinement are created in the worktree. Other session routes still use the session's own directory. The fork-specific decision lives in a Kilo-owned helper called behind a single marker in the shared router.
- A session's sandbox policy now initializes from its create-time `kilocode.sandbox` metadata, taking precedence over the workspace default, so an explicit toggle is preserved at creation.
- `Session.fork` reads the source session's confinement from the source's own directory and passes it as an explicit fallback when initializing the fork, since the source state does not exist in the new worktree directory. The fallback no longer writes a phantom snapshot under the source id in the new directory.

The result is that a sandbox-enabled session stays sandboxed after forking or moving to a worktree, and a disabled one stays disabled, with the toggle reflecting the correct state immediately.