### PR TITLE
test(jetbrains): stabilize mock cli server threads

### DIFF
--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/testing/MockCliServer.kt
@@ -157,10 +157,11 @@ class MockCliServer : AutoCloseable {
     /** Reset all request counters. */
     fun resetCounts() { counts.clear() }
 
-    private val executor = Executors.newThreadPerTaskExecutor(
-        Thread.ofVirtual().name("mock-cli-", 0).factory(),
-    )
     private val closed = AtomicBoolean(false)
+    private val threads = AtomicInteger(0)
+    private val executor = Executors.newCachedThreadPool { task ->
+        Thread(task, "mock-cli-${threads.incrementAndGet()}").apply { isDaemon = true }
+    }
 
     private var server: ServerSocket? = null
     private val connections = ConcurrentLinkedQueue<Socket>()


### PR DESCRIPTION
## What

Stabilize the JetBrains mock CLI server test harness by using daemon platform threads for raw socket request handling instead of virtual threads.

## Why

The JetBrains backend test run intermittently timed out while waiting for the mock SSE connection to move the app out of `Connecting`. Matching the stable platform-thread behavior used on `main` removes an extra scheduling variable from the raw-socket mock server.

## Validation

- `./gradlew :backend:test --tests ai.kilocode.backend.workspace.KiloBackendWorkspaceTest`
- `./gradlew :backend:test --tests 'ai.kilocode.backend.workspace.KiloBackendWorkspaceTest.partial failure reports failed resources' --rerun-tasks`

## Note

This branch was created from the current worktree HEAD, which already contained unrelated commits versus `main`.
