### PR TITLE
feat(vscode): make Show more providers prominent and collapse disabled providers

### DIFF
--- a/.changeset/providers-tab-show-more.md
+++ b/.changeset/providers-tab-show-more.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make "Show more providers" a prominent entry in the Popular providers list and collapse Disabled Providers by default in the Providers settings.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/providers-configure-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/providers-configure-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4872106b43a1e7e505d0cb1807fa83455a739ec14e86b65a5369c56afc3e7df6
-size 26645
+oid sha256:2eda48e68c363fc34ac885ffb483111143bcd370e85b72e356d728efd68bf4a4
+size 21510

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/providers-disabled-expanded-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/providers-disabled-expanded-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db40a590fe11cde1de1bc0848b0b4255280e942758751b373162930ca0ba06db
+size 35595

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
@@ -425,105 +425,107 @@ const ProvidersTab: Component = () => {
       </Card>
 
       {/* Disabled providers — collapsed by default to keep the focus on active providers */}
-      <Collapsible variant="ghost" style={{ "margin-top": "24px" }}>
-        <Collapsible.Trigger>
-          <span
-            style={{
-              "font-size": "var(--kilo-font-size-12)",
-              "font-weight": "500",
-              color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-            }}
-          >
-            {language.t("settings.providers.disabled")}
-          </span>
-          <Collapsible.Arrow />
-        </Collapsible.Trigger>
-        <Collapsible.Content>
-          <Card style={{ "margin-top": "8px" }}>
-            <div
+      <div style={{ "margin-top": "24px" }}>
+        <Collapsible variant="ghost">
+          <Collapsible.Trigger>
+            <span
               style={{
                 "font-size": "var(--kilo-font-size-12)",
+                "font-weight": "500",
                 color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-                "padding-bottom": "8px",
-                "border-bottom": "1px solid var(--border-weak-base)",
               }}
             >
-              {language.t("settings.providers.disabled.description")}
-            </div>
-            <div
-              style={{
-                display: "flex",
-                gap: "8px",
-                "align-items": "center",
-                padding: "8px 0",
-                "border-bottom": disabledProviders().length > 0 ? "1px solid var(--border-weak-base)" : "none",
-              }}
-            >
-              <div style={{ flex: 1 }}>
-                <Select
-                  options={disabledOptions()}
-                  current={disabled()}
-                  value={(item) => item.value}
-                  label={(item) => item.label}
-                  onSelect={(item) => setDisabled(item)}
-                  variant="secondary"
-                  triggerVariant="settings"
-                  placeholder={language.t("settings.providers.select.placeholder")}
-                />
-              </div>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  const item = disabled()
-                  if (!item) return
-                  disableProvider(item.value)
-                  setDisabled(undefined)
+              {language.t("settings.providers.disabled")}
+            </span>
+            <Collapsible.Arrow />
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <Card style={{ "margin-top": "8px" }}>
+              <div
+                style={{
+                  "font-size": "var(--kilo-font-size-12)",
+                  color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                  "padding-bottom": "8px",
+                  "border-bottom": "1px solid var(--border-weak-base)",
                 }}
-                disabled={!disabled()}
               >
-                {language.t("common.add")}
-              </Button>
-            </div>
-            <For each={disabledProviders()}>
-              {(id, index) => (
-                <div
-                  style={{
-                    display: "flex",
-                    "flex-wrap": "wrap",
-                    "align-items": "center",
-                    "justify-content": "space-between",
-                    gap: "16px",
-                    "min-height": "56px",
-                    padding: "12px 0",
-                    "border-bottom":
-                      index() < disabledProviders().length - 1 ? "1px solid var(--border-weak-base)" : "none",
-                  }}
-                >
-                  <div style={{ display: "flex", "align-items": "center", gap: "12px", "min-width": 0 }}>
-                    <ProviderIcon id={providerIcon(id)} width={20} height={20} />
-                    <span
-                      style={{
-                        "font-size": "var(--kilo-font-size-14)",
-                        "font-weight": "500",
-                        color: "var(--vscode-foreground)",
-                        overflow: "hidden",
-                        "text-overflow": "ellipsis",
-                        "white-space": "nowrap",
-                      }}
-                    >
-                      {disabledName(id)}
-                    </span>
-                    <Tag>{language.t("settings.providers.disabled")}</Tag>
-                  </div>
-                  <Button size="large" variant="ghost" onClick={() => enableProvider(index())}>
-                    {language.t("settings.providers.disabled.enable")}
-                  </Button>
+                {language.t("settings.providers.disabled.description")}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "8px",
+                  "align-items": "center",
+                  padding: "8px 0",
+                  "border-bottom": disabledProviders().length > 0 ? "1px solid var(--border-weak-base)" : "none",
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <Select
+                    options={disabledOptions()}
+                    current={disabled()}
+                    value={(item) => item.value}
+                    label={(item) => item.label}
+                    onSelect={(item) => setDisabled(item)}
+                    variant="secondary"
+                    triggerVariant="settings"
+                    placeholder={language.t("settings.providers.select.placeholder")}
+                  />
                 </div>
-              )}
-            </For>
-          </Card>
-        </Collapsible.Content>
-      </Collapsible>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    const item = disabled()
+                    if (!item) return
+                    disableProvider(item.value)
+                    setDisabled(undefined)
+                  }}
+                  disabled={!disabled()}
+                >
+                  {language.t("common.add")}
+                </Button>
+              </div>
+              <For each={disabledProviders()}>
+                {(id, index) => (
+                  <div
+                    style={{
+                      display: "flex",
+                      "flex-wrap": "wrap",
+                      "align-items": "center",
+                      "justify-content": "space-between",
+                      gap: "16px",
+                      "min-height": "56px",
+                      padding: "12px 0",
+                      "border-bottom":
+                        index() < disabledProviders().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                    }}
+                  >
+                    <div style={{ display: "flex", "align-items": "center", gap: "12px", "min-width": 0 }}>
+                      <ProviderIcon id={providerIcon(id)} width={20} height={20} />
+                      <span
+                        style={{
+                          "font-size": "var(--kilo-font-size-14)",
+                          "font-weight": "500",
+                          color: "var(--vscode-foreground)",
+                          overflow: "hidden",
+                          "text-overflow": "ellipsis",
+                          "white-space": "nowrap",
+                        }}
+                      >
+                        {disabledName(id)}
+                      </span>
+                      <Tag>{language.t("settings.providers.disabled")}</Tag>
+                    </div>
+                    <Button size="large" variant="ghost" onClick={() => enableProvider(index())}>
+                      {language.t("settings.providers.disabled.enable")}
+                    </Button>
+                  </div>
+                )}
+              </For>
+            </Card>
+          </Collapsible.Content>
+        </Collapsible>
+      </div>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ProvidersTab.tsx
@@ -1,6 +1,8 @@
 import { Button } from "@kilocode/kilo-ui/button"
 import { Card } from "@kilocode/kilo-ui/card"
+import { Collapsible } from "@kilocode/kilo-ui/collapsible"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
+import { Icon } from "@kilocode/kilo-ui/icon"
 import { ProviderIcon } from "@kilocode/kilo-ui/provider-icon"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Tag } from "@kilocode/kilo-ui/tag"
@@ -350,6 +352,7 @@ const ProvidersTab: Component = () => {
             gap: "16px",
             "min-height": "56px",
             padding: "12px 0",
+            "border-bottom": "1px solid var(--border-weak-base)",
           }}
         >
           <div style={{ display: "flex", "flex-direction": "column", "min-width": 0 }}>
@@ -385,100 +388,142 @@ const ProvidersTab: Component = () => {
             {language.t("common.connect")}
           </Button>
         </div>
-      </Card>
 
-      {/* View all providers link */}
-      <div style={{ "margin-top": "16px" }}>
-        <Button variant="ghost" onClick={() => dialog.show(() => <ProviderSelectDialog />)} style={{ padding: "0" }}>
-          {language.t("dialog.provider.viewAll")}
-        </Button>
-      </div>
-
-      {/* Disabled providers */}
-      <h4 style={{ "margin-top": "24px", "margin-bottom": "8px" }}>{language.t("settings.providers.disabled")}</h4>
-      <Card>
-        <div
-          style={{
-            "font-size": "var(--kilo-font-size-12)",
-            color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
-            "padding-bottom": "8px",
-            "border-bottom": "1px solid var(--border-weak-base)",
-          }}
-        >
-          {language.t("settings.providers.disabled.description")}
-        </div>
-        <div
+        {/* Show more providers — prominent entry point to the full catalog */}
+        <button
+          type="button"
+          onClick={() => dialog.show(() => <ProviderSelectDialog />)}
           style={{
             display: "flex",
-            gap: "8px",
             "align-items": "center",
-            padding: "8px 0",
-            "border-bottom": disabledProviders().length > 0 ? "1px solid var(--border-weak-base)" : "none",
+            "justify-content": "space-between",
+            gap: "16px",
+            width: "100%",
+            "min-height": "56px",
+            padding: "12px 0",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            "text-align": "left",
+            color: "var(--vscode-foreground)",
+            font: "inherit",
           }}
         >
-          <div style={{ flex: 1 }}>
-            <Select
-              options={disabledOptions()}
-              current={disabled()}
-              value={(item) => item.value}
-              label={(item) => item.label}
-              onSelect={(item) => setDisabled(item)}
-              variant="secondary"
-              triggerVariant="settings"
-              placeholder={language.t("settings.providers.select.placeholder")}
-            />
+          <div style={{ display: "flex", "align-items": "center", gap: "12px", "min-width": 0 }}>
+            <Icon name="providers" size="small" />
+            <span
+              style={{
+                "font-size": "var(--kilo-font-size-14)",
+                "font-weight": "500",
+              }}
+            >
+              {language.t("dialog.provider.viewAll")}
+            </span>
           </div>
-          <Button
-            variant="secondary"
-            onClick={() => {
-              const item = disabled()
-              if (!item) return
-              disableProvider(item.value)
-              setDisabled(undefined)
+          <Icon name="chevron-right" size="small" />
+        </button>
+      </Card>
+
+      {/* Disabled providers — collapsed by default to keep the focus on active providers */}
+      <Collapsible variant="ghost" style={{ "margin-top": "24px" }}>
+        <Collapsible.Trigger>
+          <span
+            style={{
+              "font-size": "var(--kilo-font-size-12)",
+              "font-weight": "500",
+              color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
             }}
-            disabled={!disabled()}
           >
-            {language.t("common.add")}
-          </Button>
-        </div>
-        <For each={disabledProviders()}>
-          {(id, index) => (
+            {language.t("settings.providers.disabled")}
+          </span>
+          <Collapsible.Arrow />
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <Card style={{ "margin-top": "8px" }}>
+            <div
+              style={{
+                "font-size": "var(--kilo-font-size-12)",
+                color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                "padding-bottom": "8px",
+                "border-bottom": "1px solid var(--border-weak-base)",
+              }}
+            >
+              {language.t("settings.providers.disabled.description")}
+            </div>
             <div
               style={{
                 display: "flex",
-                "flex-wrap": "wrap",
+                gap: "8px",
                 "align-items": "center",
-                "justify-content": "space-between",
-                gap: "16px",
-                "min-height": "56px",
-                padding: "12px 0",
-                "border-bottom":
-                  index() < disabledProviders().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                padding: "8px 0",
+                "border-bottom": disabledProviders().length > 0 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <div style={{ display: "flex", "align-items": "center", gap: "12px", "min-width": 0 }}>
-                <ProviderIcon id={providerIcon(id)} width={20} height={20} />
-                <span
-                  style={{
-                    "font-size": "var(--kilo-font-size-14)",
-                    "font-weight": "500",
-                    color: "var(--vscode-foreground)",
-                    overflow: "hidden",
-                    "text-overflow": "ellipsis",
-                    "white-space": "nowrap",
-                  }}
-                >
-                  {disabledName(id)}
-                </span>
-                <Tag>{language.t("settings.providers.disabled")}</Tag>
+              <div style={{ flex: 1 }}>
+                <Select
+                  options={disabledOptions()}
+                  current={disabled()}
+                  value={(item) => item.value}
+                  label={(item) => item.label}
+                  onSelect={(item) => setDisabled(item)}
+                  variant="secondary"
+                  triggerVariant="settings"
+                  placeholder={language.t("settings.providers.select.placeholder")}
+                />
               </div>
-              <Button size="large" variant="ghost" onClick={() => enableProvider(index())}>
-                {language.t("settings.providers.disabled.enable")}
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  const item = disabled()
+                  if (!item) return
+                  disableProvider(item.value)
+                  setDisabled(undefined)
+                }}
+                disabled={!disabled()}
+              >
+                {language.t("common.add")}
               </Button>
             </div>
-          )}
-        </For>
-      </Card>
+            <For each={disabledProviders()}>
+              {(id, index) => (
+                <div
+                  style={{
+                    display: "flex",
+                    "flex-wrap": "wrap",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    gap: "16px",
+                    "min-height": "56px",
+                    padding: "12px 0",
+                    "border-bottom":
+                      index() < disabledProviders().length - 1 ? "1px solid var(--border-weak-base)" : "none",
+                  }}
+                >
+                  <div style={{ display: "flex", "align-items": "center", gap: "12px", "min-width": 0 }}>
+                    <ProviderIcon id={providerIcon(id)} width={20} height={20} />
+                    <span
+                      style={{
+                        "font-size": "var(--kilo-font-size-14)",
+                        "font-weight": "500",
+                        color: "var(--vscode-foreground)",
+                        overflow: "hidden",
+                        "text-overflow": "ellipsis",
+                        "white-space": "nowrap",
+                      }}
+                    >
+                      {disabledName(id)}
+                    </span>
+                    <Tag>{language.t("settings.providers.disabled")}</Tag>
+                  </div>
+                  <Button size="large" variant="ghost" onClick={() => enableProvider(index())}>
+                    {language.t("settings.providers.disabled.enable")}
+                  </Button>
+                </div>
+              )}
+            </For>
+          </Card>
+        </Collapsible.Content>
+      </Collapsible>
     </div>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -76,6 +76,30 @@ export const ProvidersConfigure: Story = {
   ),
 }
 
+/** Opens the Disabled Providers collapsible on mount so the expanded list has coverage. */
+function OpenDisabledProviders() {
+  let ref: HTMLDivElement | undefined
+  onMount(() => {
+    requestAnimationFrame(() => {
+      ref?.querySelector<HTMLButtonElement>('[data-slot="collapsible-trigger"]')?.click()
+    })
+  })
+  return (
+    <div ref={ref} style={{ "max-height": "700px", overflow: "auto" }}>
+      <ProvidersTab />
+    </div>
+  )
+}
+
+export const ProvidersDisabledExpanded: Story = {
+  name: "ProvidersTab — disabled providers expanded",
+  render: () => (
+    <StoryProviders config={{ disabled_providers: ["openai", "anthropic"] } as any}>
+      <OpenDisabledProviders />
+    </StoryProviders>
+  ),
+}
+
 export const ModelsAutocompleteOpen: Story = {
   name: "ModelsTab — autocomplete model picker open",
   render: () => (


### PR DESCRIPTION
## What

Improves the Providers settings tab layout:

- **"Show more providers"** is now a prominent row appended to the bottom of the **Popular providers** list, with a providers icon and a chevron, instead of a low-key ghost text link below the card.
- **Disabled Providers** is now a ghost `Collapsible` that is **collapsed by default** and rendered with a smaller, muted trigger, keeping the focus on active/connected providers.

## Why

The full provider catalog was hard to discover behind an unobtrusive text link, while the Disabled Providers section took up prominent space despite being rarely used. This rebalances visual weight toward the actions users take most often.

## Notes

- Button label (`dialog.provider.viewAll` = "Show more providers") is unchanged, so existing docs referencing it remain accurate.
- No screenshots were removed.