### PR TITLE
fix(cli): close read-only bash exec-flag escapes

### DIFF
--- a/.changeset/fix-readonly-bash-exec-flag-escapes.md
+++ b/.changeset/fix-readonly-bash-exec-flag-escapes.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Close read-only bash escapes where allowed commands could still run arbitrary programs via flags (`sort --compress-program`, `rg --pre`, `ag --pager`, `man -P`/`-H`).

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -109,24 +109,37 @@ export const readOnlyBash: Record<string, "allow" | "ask" | "deny"> = {
   "git branch -r *": "allow",
   "git remote -v *": "allow",
   "gh *": "ask",
+  // Everything below is a blocklist layered on the allowlist above: it catches ways
+  // an "allowed" read-only command can still write files, chain commands, or exec an
+  // arbitrary program. This is defense-in-depth, not a sandbox — the durable fix is
+  // OS-level sandboxing, not command-line string matching.
+  // `*` matches any run of characters (including spaces and empty), so each rule
+  // catches its operator anywhere. Broad forms subsume narrow ones: `*&*` covers
+  // `&&`, and `*>*` covers `>`, `>>`, `>|`, and `>(` in any spacing.
   "*\n*": "deny",
   "*<(*": "deny",
   "*|*": "deny",
   "*;*": "deny",
-  "*&&*": "deny",
   "*&*": "deny",
   "*$(*": "deny",
   "*`*": "deny",
   "*>*": "deny",
-  "* > *": "deny",
-  "*>>*": "deny",
-  "* >> *": "deny",
-  "*>|*": "deny",
-  "* >| *": "deny",
+  // Short -o is space-anchored (two forms) so it never matches filenames like
+  // `foo-o bar`; long flags use `*--flag*`, which is specific enough to bridge both
+  // "flag first" and "flag after args" positions in one rule.
   "sort -o *": "deny",
   "sort * -o *": "deny",
-  "sort --output*": "deny",
-  "sort * --output*": "deny",
+  "sort *--output*": "deny",
+  // Flags that make otherwise "read-only" commands exec an arbitrary program.
+  "sort *--compress-program*": "deny",
+  "sort *--files0-from*": "deny",
+  "rg *--pre *": "deny",
+  "rg *--pre=*": "deny",
+  "rg *--hostname-bin*": "deny",
+  "ag *--pager*": "deny",
+  "man *-P*": "deny",
+  "man *--pager*": "deny",
+  "man *-H*": "deny",
 }
 
 function askGuard(mcp: Record<string, "allow" | "ask" | "deny"> = {}) {

--- a/packages/opencode/test/kilocode/ask-agent-permissions.test.ts
+++ b/packages/opencode/test/kilocode/ask-agent-permissions.test.ts
@@ -121,6 +121,16 @@ describe("Ask agent bash permissions", () => {
       "sort names.txt --output=names.txt",
       "echo ok\ntouch ask-bypass.txt",
       "cat <(touch ask-bypass.txt)",
+      // Exec-via-flag escapes on otherwise read-only commands
+      'sort -S 1b --compress-program "sh" names.txt',
+      "sort --compress-program=sh names.txt",
+      "sort --files0-from=list names.txt",
+      "rg --pre sh -e . names.txt",
+      "rg --pre=sh -e . names.txt",
+      "ag --pager sh foo",
+      "man -P sh ls",
+      "man -Psh ls",
+      "man --pager=sh ls",
     ]
 
     for (const cmd of denied) {


### PR DESCRIPTION
## What

Harden the `readOnlyBash` permission allowlist (used by the ask/plan/explore agents) against commands that are "read-only" in spirit but can still execute an arbitrary program through a flag.

The allowlist permits `sort`, `rg`, `ag`, `man`, etc., and previously relied on blocklisting only a couple of `sort` writer flags (`-o`, `--output`). That approach missed several exec-via-flag escapes:

- `sort --compress-program <prog>` — GNU sort execs the program (the reported bypass: `echo ... | sort -S 1b --compress-program "sh"`), plus `--files0-from`
- `rg --pre <prog>` / `--pre=<prog>` / `--hostname-bin` — ripgrep runs an arbitrary preprocessor
- `ag --pager <prog>`
- `man -P <prog>` / `--pager` / `-H` — man runs an arbitrary pager/browser (including the glued short form `man -Psh`)

These are now denied. While in there, the operator and sort-output deny rules were deduplicated: since `*` matches any run of characters (spaces and empty), `*>*` already subsumes `>>`/`>|`/spaced variants and `*&*` subsumes `&&`, so the redundant lines were collapsed and commented.

## Why

An allowed but prompt-injected/untrusted agent could run `sort --compress-program sh` (and friends) to execute arbitrary shell without triggering an approval prompt.

## Note

This is defense-in-depth on top of a string-matching allowlist, not a real sandbox. Command-line blocklists are inherently leaky (env-based vectors like `LESSOPEN`, `GIT_PAGER`, etc. remain). The durable fix is OS-level sandboxing of bash execution — worth a separate follow-up. Comments in the file now say as much.

## Testing

Added deny cases in `test/kilocode/ask-agent-permissions.test.ts` for every new vector (including the glued `man -Psh` form). Rule logic was validated against the exact `Wildcard.match` + `findLast` semantics (all deny vectors caught; `sort foo-o bar`, `rg --pre-glob`, `man --help`, `sort -S 1b` remain allowed — no false positives).
