### PR TITLE
feat(cli): load MCP servers from a shared external file via mcpConfig.file

### DIFF
--- a/.changeset/mcp-config-external-file.md
+++ b/.changeset/mcp-config-external-file.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add `mcpConfig.file` to load MCP servers from a shared external file (such as a canonical `.mcp.json` in the standard `mcpServers` format) instead of duplicating server definitions under `mcp`. Accepts a single path or a list, resolves relative paths from the project root, and lets inline `mcp` entries override servers from the file by name.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -322,6 +322,7 @@ export const Info = Schema.Struct({
       ]),
     ),
   ).annotate({ description: "MCP (Model Context Protocol) server configurations" }),
+  mcpConfig: KilocodeConfig.McpConfigSchema, // kilocode_change - load MCP servers from a shared external file
   formatter: Schema.optional(ConfigFormatter.Info).annotate({
     description:
       "Enable or configure formatters. Omit or set to false to disable, true to enable built-ins, or an object to enable built-ins with overrides.",
@@ -1081,6 +1082,10 @@ export const layer = Layer.effect(
         }
         // kilocode_change start — inject Kilo default plugins into both plugin list and origins
         KilocodeDefaultPlugins.apply(result, { disabled: Flag.KILO_DISABLE_DEFAULT_PLUGINS, log })
+        // kilocode_change end
+
+        // kilocode_change start - load MCP servers from a shared external file referenced by mcpConfig.file
+        yield* Effect.promise(() => KilocodeConfig.applyExternalMcp({ config: result, root: ctx.directory, warnings }))
         // kilocode_change end
 
         return {

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -35,6 +35,19 @@ export namespace KilocodeConfig {
     }),
   ).annotate({ description: "Configuration for AI-generated commit messages" })
 
+  /** Schema for loading MCP servers from a shared external file (e.g. a canonical .mcp.json). */
+  export const McpConfigSchema = Schema.optional(
+    Schema.Struct({
+      file: Schema.Union([Schema.String, Schema.mutable(Schema.Array(Schema.String))]).annotate({
+        description:
+          "Path, or list of paths, to a shared external MCP config file in the standard `mcpServers` format (e.g. a canonical .mcp.json). Relative paths resolve from the project root. Servers load from these files and any inline `mcp` entry with the same name overrides them.",
+      }),
+    }),
+  ).annotate({
+    description:
+      "Load MCP server definitions from a shared external file, such as a .mcp.json used by multiple agents, instead of duplicating them under `mcp`.",
+  })
+
   // ── Config file constants ────────────────────────────────────────────
 
   /** Kilo-specific config file names (highest-to-lowest precedence within kilo). */
@@ -290,6 +303,27 @@ export namespace KilocodeConfig {
     }
 
     return { config: result, warnings }
+  }
+
+  /**
+   * Apply MCP servers referenced from a shared external file via `mcpConfig.file`.
+   * Runs after the config chain is merged, so relative paths resolve from the project root.
+   * The shared file is the base; inline `mcp` entries override it by server name. Mutates
+   * `config.mcp` and appends any load warnings.
+   */
+  export async function applyExternalMcp(input: {
+    config: Config.Info
+    root: string
+    warnings: Config.Warning[]
+  }): Promise<void> {
+    const file = input.config.mcpConfig?.file
+    if (!file) return
+    const files = Array.isArray(file) ? file : [file]
+    const external = await McpMigrator.loadExternalMcpConfig({ files, root: input.root })
+    if (Object.keys(external.mcp).length > 0) {
+      input.config.mcp = { ...external.mcp, ...(input.config.mcp ?? {}) }
+    }
+    input.warnings.push(...external.warnings)
   }
 
   // ── Organization modes ───────────────────────────────────────────────

--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -1,19 +1,24 @@
 import * as fs from "fs/promises"
 import * as path from "path"
+import { parse as parseJsonc, type ParseError } from "jsonc-parser"
 import { Config } from "../config/config"
 import { ConfigMCP } from "../config/mcp"
 import * as Log from "@opencode-ai/core/util/log"
+import { isRecord } from "@/util/record"
 import { Filesystem } from "../util/filesystem"
 import { KilocodePaths } from "./paths"
 
 export namespace McpMigrator {
   const log = Log.create({ service: "kilocode.mcp-migrator" })
 
-  // Remote transport types used by the Kilocode extension
-  const REMOTE_TYPES = new Set(["streamable-http", "sse"])
+  // Remote transport types used by the Kilocode extension plus the standard
+  // `.mcp.json` spellings ("http"). Servers with a `url` but no `command` are
+  // also treated as remote, matching the shared `.mcp.json` shorthand.
+  const REMOTE_TYPES = new Set(["streamable-http", "http", "sse"])
 
   function isRemote(server: KilocodeMcpServer): boolean {
-    return !!server.type && REMOTE_TYPES.has(server.type)
+    if (server.type) return REMOTE_TYPES.has(server.type)
+    return !!server.url && !server.command
   }
 
   // Kilocode MCP server structure
@@ -177,5 +182,59 @@ export namespace McpMigrator {
       log.warn("failed to load kilocode MCP servers", { error: err })
       return {}
     }
+  }
+
+  /**
+   * Read a shared external MCP config file in the standard `mcpServers` format
+   * (JSON or JSONC, e.g. a canonical `.mcp.json`) and return its raw server map.
+   * Returns an `error` string instead of throwing so callers can surface it as a warning.
+   */
+  export async function readMcpServersFile(
+    filepath: string,
+  ): Promise<{ servers?: Record<string, KilocodeMcpServer>; error?: string }> {
+    if (!(await Filesystem.exists(filepath))) return { error: "file not found" }
+    const text = await fs.readFile(filepath, "utf-8").catch(() => undefined)
+    if (text === undefined) return { error: "could not read file" }
+
+    const errors: ParseError[] = []
+    const data = parseJsonc(text, errors, { allowTrailingComma: true })
+    if (errors.length > 0) return { error: "not valid JSON(C)" }
+    if (!isRecord(data)) return { error: "expected a JSON object" }
+
+    // The canonical shared format nests servers under `mcpServers`.
+    if (data.mcpServers === undefined) return { servers: {} }
+    if (!isRecord(data.mcpServers)) return { error: "`mcpServers` must be an object" }
+    return { servers: data.mcpServers as Record<string, KilocodeMcpServer> }
+  }
+
+  /**
+   * Load MCP servers from one or more shared external files referenced by
+   * `mcpConfig.file`. Relative paths resolve from `root` (the project directory).
+   * Later files win over earlier ones for the same server name.
+   */
+  export async function loadExternalMcpConfig(input: {
+    files: string[]
+    root: string
+  }): Promise<{ mcp: Record<string, ConfigMCP.Info>; warnings: Config.Warning[] }> {
+    const mcp: Record<string, ConfigMCP.Info> = {}
+    const warnings: Config.Warning[] = []
+
+    for (const entry of input.files) {
+      if (!entry) continue
+      const file = path.isAbsolute(entry) ? entry : path.resolve(input.root, entry)
+      const read = await readMcpServersFile(file)
+      if (read.error) {
+        warnings.push({ path: file, message: `Could not load MCP config file at ${file}: ${read.error}` })
+        log.warn("skipped external MCP config file", { file, error: read.error })
+        continue
+      }
+      for (const [name, server] of Object.entries(read.servers ?? {})) {
+        const converted = convertServer(name, server)
+        if (converted) mcp[name] = converted
+      }
+      log.debug("loaded external MCP config file", { file, count: Object.keys(read.servers ?? {}).length })
+    }
+
+    return { mcp, warnings }
   }
 }

--- a/packages/opencode/test/kilocode/mcp-external-config.test.ts
+++ b/packages/opencode/test/kilocode/mcp-external-config.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Config } from "../../src/config/config"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { McpMigrator } from "../../src/kilocode/mcp-migrator"
+import { Filesystem } from "../../src/util/filesystem"
+import { disposeAllInstances, provideTestInstance, tmpdir } from "../fixture/fixture"
+
+const load = () => AppRuntime.runPromise(Config.Service.use((svc) => svc.get()))
+const warnings = () => AppRuntime.runPromise(Config.Service.use((svc) => svc.warnings()))
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await AppRuntime.runPromise(Config.Service.use((svc) => svc.invalidate()))
+})
+
+describe("McpMigrator.loadExternalMcpConfig", () => {
+  test("converts local and remote servers from a shared .mcp.json", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              filesystem: {
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-filesystem", "."],
+                env: { NODE_ENV: "production" },
+              },
+              docs: { type: "http", url: "https://example.com/mcp", headers: { Authorization: "Bearer x" } },
+              bare: { url: "https://bare.example.com/mcp" },
+            },
+          }),
+        )
+      },
+    })
+
+    const result = await McpMigrator.loadExternalMcpConfig({ files: [".mcp.json"], root: tmp.path })
+
+    expect(result.warnings).toEqual([])
+    expect(result.mcp.filesystem).toEqual({
+      type: "local",
+      command: ["npx", "-y", "@modelcontextprotocol/server-filesystem", "."],
+      environment: { NODE_ENV: "production" },
+    })
+    // `type: "http"` and a bare `url` (no command) are both treated as remote.
+    expect(result.mcp.docs).toEqual({
+      type: "remote",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer x" },
+    })
+    expect(result.mcp.bare).toEqual({ type: "remote", url: "https://bare.example.com/mcp" })
+  })
+
+  test("supports JSONC comments and absolute paths", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, "shared.jsonc"),
+          `{
+            // servers shared across agents
+            "mcpServers": { "tool": { "command": "my-tool" } },
+          }`,
+        )
+      },
+    })
+
+    const result = await McpMigrator.loadExternalMcpConfig({
+      files: [path.join(tmp.path, "shared.jsonc")],
+      root: tmp.path,
+    })
+
+    expect(result.warnings).toEqual([])
+    expect(result.mcp.tool).toEqual({ type: "local", command: ["my-tool"] })
+  })
+
+  test("later files win for duplicate server names", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(path.join(dir, "a.json"), JSON.stringify({ mcpServers: { dup: { command: "a" } } }))
+        await Filesystem.write(path.join(dir, "b.json"), JSON.stringify({ mcpServers: { dup: { command: "b" } } }))
+      },
+    })
+
+    const result = await McpMigrator.loadExternalMcpConfig({ files: ["a.json", "b.json"], root: tmp.path })
+
+    expect(result.mcp.dup).toEqual({ type: "local", command: ["b"] })
+  })
+
+  test("warns when a referenced file is missing", async () => {
+    await using tmp = await tmpdir()
+
+    const result = await McpMigrator.loadExternalMcpConfig({ files: ["nope.json"], root: tmp.path })
+
+    expect(Object.keys(result.mcp)).toEqual([])
+    expect(result.warnings).toHaveLength(1)
+    expect(result.warnings[0].message).toContain("file not found")
+  })
+
+  test("warns when the file is not valid JSON", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(path.join(dir, "broken.json"), "{ not json !!!")
+      },
+    })
+
+    const result = await McpMigrator.loadExternalMcpConfig({ files: ["broken.json"], root: tmp.path })
+
+    expect(result.warnings[0].message).toContain("not valid JSON")
+  })
+})
+
+describe("mcpConfig.file integration", () => {
+  test("loads MCP servers referenced by mcpConfig.file", async () => {
+    await using tmp = await tmpdir({
+      config: { mcpConfig: { file: ".mcp.json" } },
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".mcp.json"),
+          JSON.stringify({ mcpServers: { shared: { command: "npx", args: ["-y", "server"] } } }),
+        )
+      },
+    })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await load()
+        expect(cfg.mcp?.shared).toEqual({ type: "local", command: ["npx", "-y", "server"] })
+      },
+    })
+  })
+
+  test("inline mcp entries override the external file by name", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        mcpConfig: { file: ".mcp.json" },
+        mcp: { shared: { type: "local", command: ["local-override"] } },
+      },
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".mcp.json"),
+          JSON.stringify({ mcpServers: { shared: { command: "from-file" }, extra: { command: "extra" } } }),
+        )
+      },
+    })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await load()
+        expect(cfg.mcp?.shared).toEqual({ type: "local", command: ["local-override"] })
+        expect(cfg.mcp?.extra).toEqual({ type: "local", command: ["extra"] })
+      },
+    })
+  })
+
+  test("accepts an array of files", async () => {
+    await using tmp = await tmpdir({
+      config: { mcpConfig: { file: [".mcp.json", "team.json"] } },
+      init: async (dir) => {
+        await Filesystem.write(path.join(dir, ".mcp.json"), JSON.stringify({ mcpServers: { one: { command: "one" } } }))
+        await Filesystem.write(path.join(dir, "team.json"), JSON.stringify({ mcpServers: { two: { command: "two" } } }))
+      },
+    })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await load()
+        expect(cfg.mcp?.one).toEqual({ type: "local", command: ["one"] })
+        expect(cfg.mcp?.two).toEqual({ type: "local", command: ["two"] })
+      },
+    })
+  })
+
+  test("surfaces a warning for a missing referenced file", async () => {
+    await using tmp = await tmpdir({
+      config: { mcpConfig: { file: "missing.json" } },
+    })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        await load()
+        const warns = await warnings()
+        expect(
+          warns.some((w) => w.path.includes("missing.json") && w.message.includes("Could not load MCP config file")),
+        ).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Problem

In a multi-agent workspace, MCP server configuration is often defined once in a canonical `.mcp.json` at the repo root and shared across several agents. Kilo only reads MCP servers from its own config (`mcp` in `kilo.json`/`opencode.json` and the migrated `.kilo/mcp.json`), so teams have to duplicate those definitions into a Kilo-specific file and keep them in sync by hand or via a copy/transform script. That drifts easily: edit the canonical file, forget to re-sync, and Kilo silently runs a stale server set.

## Behavior

Adds a `mcpConfig.file` key that points Kilo at one or more shared external MCP files:

```jsonc
{
  "mcpConfig": {
    "file": "../../.mcp.json"
  }
}
```

- The referenced file uses the standard `mcpServers` format (the same shape used by `.mcp.json` across other agents), read as JSON or JSONC.
- `file` accepts a single path or a list of paths. Relative paths resolve from the project root; later files win over earlier ones for the same server name.
- Servers from the external file(s) are the base, and any inline `mcp` entry with the same name overrides it, so a workspace can share most servers and still tweak or disable one locally.
- Both local (`command`/`args`/`env`) and remote (`type: "http"`/`"sse"`, or a bare `url`) server shapes are supported. A missing or invalid file surfaces as a config warning rather than failing the load.

This removes the need for a per-agent sync script and lets a Kilo config say "use the same MCP servers as the workspace".

## Notes

- The external-file reader and format conversion live in the Kilo-owned `mcp-migrator` (reusing the existing server-conversion logic); the shared `config.ts` change is limited to the schema field and a small post-merge resolution step, both behind `kilocode_change` markers.
- The config schema mirror in the cloud repo (`apps/web/src/app/config.json/extras.ts`) should get a matching `mcpConfig` entry as a follow-up.

Closes #11851
