### PR TITLE
fix(cli): avoid full part-table scan in session model usage

### DIFF
--- a/.changeset/fix-model-usage-full-scan.md
+++ b/.changeset/fix-model-usage-full-scan.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix slow message loading when opening or switching sessions. The per-model token usage breakdown scanned the entire message history on every session open, which blocked the transcript from rendering for several seconds on large histories.

--- a/packages/opencode/src/kilocode/session/model-usage.ts
+++ b/packages/opencode/src/kilocode/session/model-usage.ts
@@ -94,19 +94,13 @@ export namespace ModelUsage {
     FROM family
     ORDER BY id`
 
-  const USAGE_SQL = `
-    WITH RECURSIVE family(id) AS (
-      SELECT id
-      FROM session
-      WHERE id = ? AND project_id = ?
-
-      UNION
-
-      SELECT child.id
-      FROM session AS child
-      JOIN family AS parent ON child.parent_id = parent.id
-      WHERE child.project_id = ?
-    ), step AS (
+  // Scope aggregation to the already-resolved family session IDs via an IN list.
+  // Re-deriving the family with an inline recursive CTE prevents SQLite from
+  // using part_session_idx and forces a full scan of the entire part table
+  // (seconds on large histories), which blocks the single-threaded server on
+  // every session open. A concrete IN list lets the planner seek the index.
+  const usageSql = (placeholders: string) => `
+    WITH step AS (
       SELECT
         coalesce(json_extract(part.data, '$.model.providerID'), json_extract(message.data, '$.providerID')) AS providerID,
         coalesce(json_extract(part.data, '$.model.modelID'), json_extract(message.data, '$.modelID')) AS modelID,
@@ -116,10 +110,10 @@ export namespace ModelUsage {
         max(0, cast(coalesce(json_extract(part.data, '$.tokens.reasoning'), 0) AS INTEGER)) AS reasoning,
         max(0, cast(coalesce(json_extract(part.data, '$.tokens.cache.read'), 0) AS INTEGER)) AS cache_read,
         max(0, cast(coalesce(json_extract(part.data, '$.tokens.cache.write'), 0) AS INTEGER)) AS cache_write
-      FROM family
-      JOIN part ON part.session_id = family.id
+      FROM part
       JOIN message ON message.id = part.message_id AND message.session_id = part.session_id
-      WHERE json_extract(part.data, '$.type') = 'step-finish'
+      WHERE part.session_id IN (${placeholders})
+        AND json_extract(part.data, '$.type') = 'step-finish'
         AND json_extract(message.data, '$.role') = 'assistant'
     )
     SELECT
@@ -163,7 +157,10 @@ export namespace ModelUsage {
         .prepare<{ id: SessionID }, [string, string, string]>(FAMILY_SQL)
         .all(...familyArgs)
         .map((item) => item.id)
-      const rows = db.prepare<Row, [string, string, string]>(USAGE_SQL).all(...familyArgs)
+      const rows =
+        sessionIDs.length === 0
+          ? []
+          : db.prepare<Row, string[]>(usageSql(sessionIDs.map(() => "?").join(","))).all(...sessionIDs)
       const totals = empty()
       const models = rows.map((row): Model => {
         totals.steps += row.steps


### PR DESCRIPTION
## Problem

Opening or switching sessions in the VS Code sidebar and Agent Manager stalls for several seconds before the transcript renders on large histories. The session header's per-model token usage breakdown is fetched on every session open, and its aggregation query re-derives the session family with an inline recursive CTE. SQLite cannot estimate the CTE size and chooses a plan that full-scans the entire `part` table, running `json_extract` on every row. The cost is proportional to total database size rather than the opened session, so it grows past a second on large histories (about 1.2s on a 3 GB, 425k-row database here). Because the query runs synchronously on the single-threaded server, it head-of-line blocks the otherwise fast messages request, so the transcript cannot load until the scan finishes.

## Change

The family session IDs are already resolved separately just before the usage query runs. This scopes the aggregation to those IDs with a concrete `IN (...)` list instead of re-deriving the family inline, which lets the planner seek the existing `part_session_idx` and read only the family's own parts. The aggregation output is unchanged.

## Impact

Session opening no longer blocks on a database-wide scan. The query drops from a full `part` scan (seconds, scaling with total history size) to an index seek (milliseconds, scaling with the opened session tree), and it no longer stalls message loading.

The regression was introduced by #11608 (the aggregation query) and made visible on the VS Code session-open path by #11746.