### PR TITLE
feat: promote Kilo mobile app to Cloud Agent users

### DIFF
--- a/.changeset/mobile-app-promo-notice.md
+++ b/.changeset/mobile-app-promo-notice.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+---
+
+Show a dismissible notice promoting the Kilo mobile app to users who have previously used Cloud Agents (the `/remote` command in the CLI). The notice links to the mobile app announcement and stays hidden for everyone else, and once dismissed it never shows again.

--- a/packages/kilo-vscode/src/kilo-provider/notifications.ts
+++ b/packages/kilo-vscode/src/kilo-provider/notifications.ts
@@ -33,6 +33,29 @@ export interface NotificationsContext {
   notify: (id: string) => void
 }
 
+const MOBILE_APP_NOTICE_ID = "mobile-app-promo"
+const MOBILE_APP_NOTICE_URL = "https://blog.kilo.ai/p/kilo-app-for-ios-and-android-is-live"
+
+/**
+ * Purely local (non-server-fetched) notice promoting the Kilo mobile app. Gated by the
+ * local `kilo serve` instance's `kilocode.mobileAppNotice()` endpoint, which is only true
+ * for users who have previously enabled a Cloud Agent / remote session relay from the CLI
+ * (see `Notices.markCloudAgentUsed()` in `packages/opencode/src/kilocode/notices.ts`).
+ * Dismissal reuses the existing `kilo.dismissedNotificationIds` globalState flow below.
+ */
+async function localNotifications(client: KiloClient): Promise<NotificationItem[]> {
+  const res = await client.kilocode.mobileAppNotice().catch(() => null)
+  if (!res?.data?.show) return []
+  return [
+    {
+      id: MOBILE_APP_NOTICE_ID,
+      title: "Kilo Mobile App",
+      message: "Continue your /remote sessions in the Kilo mobile app.",
+      action: { actionText: "Open", actionURL: MOBILE_APP_NOTICE_URL },
+    },
+  ]
+}
+
 export async function fetchAndSendNotifications(ctx: NotificationsContext): Promise<void> {
   if (!ctx.client) {
     const cached = ctx.cached()
@@ -48,8 +71,11 @@ export async function fetchAndSendNotifications(ctx: NotificationsContext): Prom
   }
 
   try {
-    const { data: all } = await retry(() => ctx.client!.kilo.notifications(undefined, { throwOnError: true }))
-    const notifications = all.filter((n) => !n.showIn || n.showIn.includes("extension"))
+    const [{ data: all }, local] = await Promise.all([
+      retry(() => ctx.client!.kilo.notifications(undefined, { throwOnError: true })),
+      localNotifications(ctx.client),
+    ])
+    const notifications = [...local, ...all.filter((n) => !n.showIn || n.showIn.includes("extension"))]
     const existing = ctx.context?.globalState.get<string[]>(KEY, []) ?? []
     const active = new Set(notifications.map((n) => n.id))
     const dismissedIds = notifications.length > 0 ? existing.filter((id) => active.has(id)) : existing
@@ -66,6 +92,10 @@ export async function dismissNotification(ctx: NotificationsContext, id: string)
   if (!ctx.context) return
   const existing = ctx.context.globalState.get<string[]>(KEY, [])
   if (!existing.includes(id)) await ctx.context.globalState.update(KEY, [...existing, id])
+
+  // Also persist dismissal on the local kilo serve instance so the CLI/TUI (which shares
+  // the same machine-global notice flag) stops showing it too.
+  if (id === MOBILE_APP_NOTICE_ID) await ctx.client?.kilocode.dismissMobileAppNotice().catch(() => undefined)
 
   const cached = ctx.cached()
   if (cached && !cached.dismissedIds.includes(id)) {

--- a/packages/kilo-vscode/tests/unit/mobile-app-notice.test.ts
+++ b/packages/kilo-vscode/tests/unit/mobile-app-notice.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test"
+import {
+  dismissNotification,
+  fetchAndSendNotifications,
+  type NotificationsContext,
+} from "../../src/kilo-provider/notifications"
+
+function makeContext(input: { show: boolean; initialDismissed?: string[] }) {
+  const flag = new Map<string, unknown>(
+    input.initialDismissed ? [["kilo.dismissedNotificationIds", input.initialDismissed]] : [],
+  )
+  let dismissMobileAppNoticeCalls = 0
+  let cached: NotificationsContext["cached"] extends () => infer R ? R : never = null
+  const posted: unknown[] = []
+
+  const client = {
+    kilo: {
+      notifications: async () => ({ data: [] }),
+    },
+    kilocode: {
+      mobileAppNotice: async () => ({ data: { show: input.show } }),
+      dismissMobileAppNotice: async () => {
+        dismissMobileAppNoticeCalls++
+        return { data: true }
+      },
+    },
+  }
+
+  const ctx: NotificationsContext = {
+    context: {
+      globalState: {
+        get: <T>(key: string, fallback?: T) => (flag.has(key) ? (flag.get(key) as T) : fallback),
+        update: async (key: string, value: unknown) => {
+          flag.set(key, value)
+        },
+      },
+    } as any,
+    client: client as any,
+    cached: () => cached,
+    set: (message) => {
+      cached = message
+    },
+    post: (message) => {
+      posted.push(message)
+    },
+    notify: () => {},
+  }
+
+  return { ctx, flag, posted, dismissMobileAppNoticeCallCount: () => dismissMobileAppNoticeCalls }
+}
+
+describe("mobile app promo notice", () => {
+  it("is included when the local kilo serve reports Cloud Agent usage", async () => {
+    const { ctx, posted } = makeContext({ show: true })
+
+    await fetchAndSendNotifications(ctx)
+
+    const message = posted[0] as { notifications: { id: string }[] }
+    expect(message.notifications.some((n) => n.id === "mobile-app-promo")).toBe(true)
+  })
+
+  it("is omitted for users who have never used a Cloud Agent / remote session", async () => {
+    const { ctx, posted } = makeContext({ show: false })
+
+    await fetchAndSendNotifications(ctx)
+
+    const message = posted[0] as { notifications: { id: string }[] }
+    expect(message.notifications.some((n) => n.id === "mobile-app-promo")).toBe(false)
+  })
+
+  it("persists dismissal in globalState and propagates it to the local kilo serve instance", async () => {
+    const { ctx, flag, dismissMobileAppNoticeCallCount } = makeContext({ show: true })
+
+    await fetchAndSendNotifications(ctx)
+    await dismissNotification(ctx, "mobile-app-promo")
+
+    expect(flag.get("kilo.dismissedNotificationIds")).toContain("mobile-app-promo")
+    expect(dismissMobileAppNoticeCallCount()).toBe(1)
+  })
+
+  it("keeps the notice dismissed across subsequent fetches even though the server still reports show=true", async () => {
+    const { ctx, posted } = makeContext({ show: true, initialDismissed: ["mobile-app-promo"] })
+
+    await fetchAndSendNotifications(ctx)
+
+    const message = posted[0] as { notifications: { id: string }[]; dismissedIds: string[] }
+    expect(message.notifications.some((n) => n.id === "mobile-app-promo")).toBe(true)
+    expect(message.dismissedIds).toContain("mobile-app-promo")
+  })
+})

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -116,6 +116,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 import { DialogRetryAction } from "../../component/dialog-retry-action"
+import { useMobileAppNotice } from "@/kilocode/cli/cmd/tui/routes/session/mobile-app-notice" // kilocode_change
 import { SessionRetry } from "@/session/retry"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 import { KILO_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
@@ -459,6 +460,8 @@ export function Session() {
     const title = Locale.truncate(session()?.title ?? "", 50)
     return exit.message.set(banner(title, session()?.id, UI.Style.TEXT_DIM, UI.Style.TEXT_NORMAL))
   })
+
+  useMobileAppNotice({ sdk, dialog })
 
   const [exitPress, setExitPress] = createSignal(0)
   useBindings(() => ({

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -25,6 +25,7 @@ import { Vcs } from "@/project/vcs"
 import simpleGit from "simple-git"
 import { RemoteWS } from "@/kilo-sessions/remote-ws"
 import { RemoteSender } from "@/kilo-sessions/remote-sender"
+import { Notices } from "@/kilocode/notices" // kilocode_change
 import { SessionStatus } from "@/session/status"
 import { Telemetry } from "@kilocode/kilo-telemetry"
 import { Question } from "@/question"
@@ -465,6 +466,9 @@ export namespace KiloSessions {
       remote = { conn, sender }
       log.info("remote connection enabled", { connected: conn.connected })
       Telemetry.trackRemoteConnectionOpened()
+      // kilocode_change start - mark Cloud Agent (remote) usage so cross-surface promo notices can target these users
+      void Notices.markCloudAgentUsed().catch((err) => log.warn("failed to persist cloud agent usage", { error: String(err) }))
+      // kilocode_change end
       void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: true, connected: conn.connected })
     })()
       .catch((err) => {

--- a/packages/opencode/src/kilocode/cli/cmd/tui/routes/session/mobile-app-notice.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/routes/session/mobile-app-notice.tsx
@@ -1,0 +1,43 @@
+// kilocode_change - new file
+/**
+ * "Continue your /remote sessions in the Kilo mobile app" promo notice.
+ *
+ * Only shown to users who have previously enabled a Cloud Agent / remote session relay
+ * (`Notices.markCloudAgentUsed()` in `@/kilocode/notices`, set from `enableRemote()` in
+ * `src/kilo-sessions/kilo-sessions.ts`). Persists until the user explicitly dismisses it
+ * via the "don't show again" action.
+ */
+import { onMount } from "solid-js"
+import type { useDialog } from "@tui/ui/dialog"
+import { DialogRetryAction } from "@tui/component/dialog-retry-action"
+
+export const MOBILE_APP_NOTICE_URL = "https://blog.kilo.ai/p/kilo-app-for-ios-and-android-is-live"
+
+// Loosely typed to avoid coupling this module to the exact generated SDK client shape.
+type SDKLike = {
+  client: {
+    kilocode: {
+      mobileAppNotice: (...args: any[]) => Promise<{ data?: { show: boolean } }>
+      dismissMobileAppNotice: (...args: any[]) => Promise<unknown>
+    }
+  }
+}
+
+export function useMobileAppNotice(deps: { sdk: SDKLike; dialog: ReturnType<typeof useDialog> }) {
+  onMount(() => {
+    void (async () => {
+      if (deps.dialog.stack.length > 0) return
+      const res = await deps.sdk.client.kilocode.mobileAppNotice().catch(() => null)
+      if (!res?.data?.show) return
+      if (deps.dialog.stack.length > 0) return
+
+      const dontShowAgain = await DialogRetryAction.show(deps.dialog, {
+        title: "Kilo Mobile App",
+        message: "Continue your /remote sessions in the Kilo mobile app.",
+        label: "Open",
+        link: MOBILE_APP_NOTICE_URL,
+      })
+      if (dontShowAgain) await deps.sdk.client.kilocode.dismissMobileAppNotice().catch(() => undefined)
+    })()
+  })
+}

--- a/packages/opencode/src/kilocode/notices.ts
+++ b/packages/opencode/src/kilocode/notices.ts
@@ -1,0 +1,48 @@
+/**
+ * Persisted, machine-global "notice" flags shared by every Kilo surface (TUI, VS Code
+ * extension, etc.) that talks to a local `kilo serve` instance.
+ *
+ * Backed by a small JSON file under `Global.Path.state` so it survives across CLI
+ * invocations and is visible to the VS Code extension's embedded `kilo serve` process,
+ * without requiring a database or per-project scoping.
+ */
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { Flock } from "@opencode-ai/core/util/flock"
+import { Filesystem } from "@/util/filesystem"
+
+const CLOUD_AGENT_USED = "cloud_agent_used"
+const MOBILE_APP_NOTICE_DISMISSED = "mobile_app_notice_dismissed"
+
+export namespace Notices {
+  const filePath = path.join(Global.Path.state, "notices.json")
+  const lock = `kilo-notices:${filePath}`
+
+  async function read(): Promise<Record<string, boolean | undefined>> {
+    return Filesystem.readJson<Record<string, boolean | undefined>>(filePath).catch(() => ({}))
+  }
+
+  async function update(patch: Record<string, boolean>): Promise<void> {
+    await Flock.withLock(lock, async () => {
+      const current = await read()
+      await Filesystem.writeJson(filePath, { ...current, ...patch })
+    })
+  }
+
+  /** Record that the user has enabled a remote/Cloud Agent session relay at least once. */
+  export async function markCloudAgentUsed(): Promise<void> {
+    const current = await read()
+    if (current[CLOUD_AGENT_USED]) return
+    await update({ [CLOUD_AGENT_USED]: true })
+  }
+
+  /** Whether the "continue in the Kilo mobile app" notice should be shown. */
+  export async function shouldShowMobileAppNotice(): Promise<boolean> {
+    const current = await read()
+    return !!current[CLOUD_AGENT_USED] && !current[MOBILE_APP_NOTICE_DISMISSED]
+  }
+
+  export async function dismissMobileAppNotice(): Promise<void> {
+    await update({ [MOBILE_APP_NOTICE_DISMISSED]: true })
+  }
+}

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -25,6 +25,10 @@ export const RemoveSkillPayload = Schema.Struct({
   location: Schema.String,
 })
 
+export const MobileAppNotice = Schema.Struct({
+  show: Schema.Boolean,
+})
+
 export const RemoveAgentPayload = Schema.Struct({
   name: Schema.String,
 })
@@ -45,6 +49,8 @@ export const KilocodePaths = {
   notebookReply: `${root}/notebook/:requestID/reply`,
   notebookReject: `${root}/notebook/:requestID/reject`,
   sessionModelUsage: `/session/:sessionID/model-usage`,
+  mobileAppNotice: `${root}/notice/mobile-app`,
+  dismissMobileAppNotice: `${root}/notice/mobile-app/dismiss`,
 } as const
 
 export const KilocodeApi = HttpApi.make("kilocode")
@@ -143,6 +149,27 @@ export const KilocodeApi = HttpApi.make("kilocode")
             identifier: "kilocode.sessionModelUsage",
             summary: "Get session model usage",
             description: "Get token usage and direct cost by model for the complete top-level session tree.",
+          }),
+        ),
+        HttpApiEndpoint.get("mobileAppNotice", KilocodePaths.mobileAppNotice, {
+          query: WorkspaceRoutingQuery,
+          success: described(MobileAppNotice, "Mobile app notice visibility"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.mobileAppNotice",
+            summary: "Get mobile app notice visibility",
+            description:
+              "Whether to show the 'continue your /remote sessions in the Kilo mobile app' notice. Only true for users who have previously used a Cloud Agent / remote session relay and have not dismissed the notice.",
+          }),
+        ),
+        HttpApiEndpoint.post("dismissMobileAppNotice", KilocodePaths.dismissMobileAppNotice, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Notice dismissed"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.dismissMobileAppNotice",
+            summary: "Dismiss mobile app notice",
+            description: "Permanently dismiss the Kilo mobile app promo notice for this machine.",
           }),
         ),
       )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -4,10 +4,12 @@ import * as KiloAgent from "@/kilocode/agent"
 import * as KiloSkill from "@/kilocode/skill-remove"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
+import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { HeapSnapshot } from "@/kilocode/cli/heap-snapshot"
 import type { RequestID as NotebookRequestID } from "@/kilocode/notebook/protocol"
 import { Notebook } from "@/kilocode/notebook/service"
+import { Notices } from "@/kilocode/notices"
 import { ModelUsage } from "@/kilocode/session/model-usage"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
@@ -98,6 +100,16 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       return usage
     })
 
+    const mobileAppNotice = Effect.fn("KilocodeHttpApi.mobileAppNotice")(function* () {
+      const show = yield* EffectBridge.fromPromise(() => Notices.shouldShowMobileAppNotice())
+      return { show }
+    })
+
+    const dismissMobileAppNotice = Effect.fn("KilocodeHttpApi.dismissMobileAppNotice")(function* () {
+      yield* EffectBridge.fromPromise(() => Notices.dismissMobileAppNotice())
+      return true
+    })
+
     return handlers
       .handle("heapSnapshot", heapSnapshot)
       .handle("agentRequirements", agentRequirements)
@@ -107,5 +119,7 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       .handle("notebookReply", notebookReply)
       .handle("notebookReject", notebookReject)
       .handle("sessionModelUsage", sessionModelUsage)
+      .handle("mobileAppNotice", mobileAppNotice)
+      .handle("dismissMobileAppNotice", dismissMobileAppNotice)
   }),
 )

--- a/packages/opencode/test/kilocode/notices.test.ts
+++ b/packages/opencode/test/kilocode/notices.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { Notices } from "../../src/kilocode/notices"
+
+const noticesPath = path.join(Global.Path.state, "notices.json")
+
+beforeEach(async () => {
+  await fs.rm(noticesPath, { force: true }).catch(() => {})
+})
+
+afterEach(async () => {
+  await fs.rm(noticesPath, { force: true }).catch(() => {})
+})
+
+describe("Notices (mobile app promo targeting)", () => {
+  test("does not show the notice for users who have never used a Cloud Agent / remote session", async () => {
+    expect(await Notices.shouldShowMobileAppNotice()).toBe(false)
+  })
+
+  test("shows the notice once a Cloud Agent / remote session has been used", async () => {
+    await Notices.markCloudAgentUsed()
+    expect(await Notices.shouldShowMobileAppNotice()).toBe(true)
+  })
+
+  test("persists dismissal so the notice never shows again, even across separate reads", async () => {
+    await Notices.markCloudAgentUsed()
+    expect(await Notices.shouldShowMobileAppNotice()).toBe(true)
+
+    await Notices.dismissMobileAppNotice()
+    expect(await Notices.shouldShowMobileAppNotice()).toBe(false)
+
+    // Simulate re-marking cloud agent usage (e.g. re-enabling /remote) — must stay dismissed.
+    await Notices.markCloudAgentUsed()
+    expect(await Notices.shouldShowMobileAppNotice()).toBe(false)
+  })
+
+  test("is idempotent when Cloud Agent usage is marked more than once", async () => {
+    await Notices.markCloudAgentUsed()
+    await Notices.markCloudAgentUsed()
+    const raw = JSON.parse(await fs.readFile(noticesPath, "utf-8"))
+    expect(raw.cloud_agent_used).toBe(true)
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -160,8 +160,12 @@ import type {
   KiloCloudSessionsResponses,
   KilocodeAgentRequirementsErrors,
   KilocodeAgentRequirementsResponses,
+  KilocodeDismissMobileAppNoticeErrors,
+  KilocodeDismissMobileAppNoticeResponses,
   KilocodeHeapSnapshotErrors,
   KilocodeHeapSnapshotResponses,
+  KilocodeMobileAppNoticeErrors,
+  KilocodeMobileAppNoticeResponses,
   KilocodeNotebookListErrors,
   KilocodeNotebookListResponses,
   KilocodeNotebookRejectErrors,
@@ -7841,6 +7845,74 @@ export class Kilocode extends HeyApiClient {
       ThrowOnError
     >({
       url: "/session/{sessionID}/model-usage",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get mobile app notice visibility
+   *
+   * Whether to show the 'continue your /remote sessions in the Kilo mobile app' notice. Only true for users who have previously used a Cloud Agent / remote session relay and have not dismissed the notice.
+   */
+  public mobileAppNotice<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      KilocodeMobileAppNoticeResponses,
+      KilocodeMobileAppNoticeErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/notice/mobile-app",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Dismiss mobile app notice
+   *
+   * Permanently dismiss the Kilo mobile app promo notice for this machine.
+   */
+  public dismissMobileAppNotice<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeDismissMobileAppNoticeResponses,
+      KilocodeDismissMobileAppNoticeErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/notice/mobile-app/dismiss",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5,20 +5,10 @@ export type ClientOptions = {
 }
 
 export type Event =
+  | EventServerInstanceDisposed
   | EventServerConnected
   | EventGlobalDisposed
   | EventGlobalConfigUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow1
-  | EventTuiSessionSelect
-  | EventSandboxStatusChanged
-  | EventKilocodeAgentManagerStart
-  | EventKilocodeNotebookRequested
-  | EventKilocodeNotebookCancelled
-  | EventIndexingStatus
-  | EventIndexingWarning
-  | EventServerInstanceDisposed
   | EventFileEdited
   | EventFileWatcherUpdated
   | EventQuestionAsked
@@ -26,6 +16,10 @@ export type Event =
   | EventQuestionRejected
   | EventLspClientDiagnostics
   | EventLspUpdated
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow1
+  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventSessionNetworkAsked
@@ -42,6 +36,7 @@ export type Event =
   | EventInteractiveTerminalDeleted
   | EventSessionTurnOpen
   | EventSessionTurnClose
+  | EventSandboxStatusChanged
   | EventSessionDiff
   | EventSessionError
   | EventTodoUpdated
@@ -55,6 +50,9 @@ export type Event =
   | EventCommandExecuted
   | EventProjectUpdated
   | EventSessionCompacted
+  | EventKilocodeAgentManagerStart
+  | EventKilocodeNotebookRequested
+  | EventKilocodeNotebookCancelled
   | EventVcsBranchUpdated
   | EventKiloSessionsRemoteStatusChanged
   | EventWorkspaceReady
@@ -99,9 +97,11 @@ export type Event =
   | EventSessionNextCompactionStarted
   | EventSessionNextCompactionDelta
   | EventSessionNextCompactionEnded
+  | EventIndexingStatus
+  | EventIndexingWarning
+  | EventModelsDevRefreshed
   | EventPluginAdded
   | EventCatalogModelUpdated
-  | EventModelsDevRefreshed
   | EventAccountAdded
   | EventAccountRemoved
   | EventAccountSwitched
@@ -140,137 +140,6 @@ export type InvalidRequestError = {
   message: string
   kind?: string
   field?: string
-}
-
-export type EventTuiPromptAppend = {
-  id: string
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  id: string
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.line.up"
-      | "session.line.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  id: string
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    duration?: number
-  }
-}
-
-export type EventTuiSessionSelect = {
-  id: string
-  type: "tui.session.select"
-  properties: {
-    /**
-     * Session ID to navigate to
-     */
-    sessionID: string
-  }
-}
-
-export type NotebookRequestId = string
-
-export type NotebookReadRequest = {
-  id: NotebookRequestId
-  sessionID: string
-  path: string
-  operation: "read"
-  includeOutputs: boolean
-}
-
-export type NotebookEditRequest = {
-  id: NotebookRequestId
-  sessionID: string
-  path: string
-  operation: "edit"
-  /**
-   * Opaque notebook content revision; pass it back unchanged and do not parse or increment it
-   */
-  expectedRevision?: string
-  /**
-   * Zero-based cell index
-   */
-  index: number
-  edit:
-    | {
-        action: "insert"
-        kind: "code" | "markdown"
-        language?: string
-        source: string
-      }
-    | {
-        action: "replace"
-        kind: "code" | "markdown"
-        language?: string
-        source: string
-      }
-    | {
-        action: "delete"
-      }
-    | {
-        action: "create"
-      }
-}
-
-export type NotebookExecuteRequest = {
-  id: NotebookRequestId
-  sessionID: string
-  path: string
-  operation: "execute"
-  /**
-   * Opaque notebook content revision; pass it back unchanged and do not parse or increment it
-   */
-  expectedRevision: string
-  /**
-   * Zero-based cell index
-   */
-  index: number
-}
-
-export type NotebookRequest = NotebookReadRequest | NotebookEditRequest | NotebookExecuteRequest
-
-export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
-
-export type IndexingStatus = {
-  state: IndexingStatusState
-  message: string
-  processedFiles: number
-  totalFiles: number
-  percent: number
-}
-
-export type IndexingWarning = {
-  code: "qdrant.version-incompatible" | "qdrant.version-unavailable"
-  message: string
 }
 
 export type QuestionOption = {
@@ -333,6 +202,61 @@ export type QuestionReplied = {
 export type QuestionRejected = {
   sessionID: string
   requestID: string
+}
+
+export type EventTuiPromptAppend = {
+  id: string
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  id: string
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.line.up"
+      | "session.line.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  id: string
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    duration?: number
+  }
+}
+
+export type EventTuiSessionSelect = {
+  id: string
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
 }
 
 export type SessionNetworkWait = {
@@ -583,6 +507,67 @@ export type Project = {
   }
   sandboxes: Array<string>
 }
+
+export type NotebookRequestId = string
+
+export type NotebookReadRequest = {
+  id: NotebookRequestId
+  sessionID: string
+  path: string
+  operation: "read"
+  includeOutputs: boolean
+}
+
+export type NotebookEditRequest = {
+  id: NotebookRequestId
+  sessionID: string
+  path: string
+  operation: "edit"
+  /**
+   * Opaque notebook content revision; pass it back unchanged and do not parse or increment it
+   */
+  expectedRevision?: string
+  /**
+   * Zero-based cell index
+   */
+  index: number
+  edit:
+    | {
+        action: "insert"
+        kind: "code" | "markdown"
+        language?: string
+        source: string
+      }
+    | {
+        action: "replace"
+        kind: "code" | "markdown"
+        language?: string
+        source: string
+      }
+    | {
+        action: "delete"
+      }
+    | {
+        action: "create"
+      }
+}
+
+export type NotebookExecuteRequest = {
+  id: NotebookRequestId
+  sessionID: string
+  path: string
+  operation: "execute"
+  /**
+   * Opaque notebook content revision; pass it back unchanged and do not parse or increment it
+   */
+  expectedRevision: string
+  /**
+   * Zero-based cell index
+   */
+  index: number
+}
+
+export type NotebookRequest = NotebookReadRequest | NotebookEditRequest | NotebookExecuteRequest
 
 export type Pty = {
   id: string
@@ -1030,25 +1015,30 @@ export type Prompt = {
   references?: Array<PromptReferenceAttachment>
 }
 
+export type IndexingStatusState = "Disabled" | "In Progress" | "Complete" | "Error" | "Standby"
+
+export type IndexingStatus = {
+  state: IndexingStatusState
+  message: string
+  processedFiles: number
+  totalFiles: number
+  percent: number
+}
+
+export type IndexingWarning = {
+  code: "qdrant.version-incompatible" | "qdrant.version-unavailable"
+  message: string
+}
+
 export type GlobalEvent = {
   directory: string
   project?: string
   workspace?: string
   payload:
+    | EventServerInstanceDisposed
     | EventServerConnected
     | EventGlobalDisposed
     | EventGlobalConfigUpdated
-    | EventTuiPromptAppend
-    | EventTuiCommandExecute
-    | EventTuiToastShow
-    | EventTuiSessionSelect
-    | EventSandboxStatusChanged
-    | EventKilocodeAgentManagerStart
-    | EventKilocodeNotebookRequested
-    | EventKilocodeNotebookCancelled
-    | EventIndexingStatus
-    | EventIndexingWarning
-    | EventServerInstanceDisposed
     | EventFileEdited
     | EventFileWatcherUpdated
     | EventQuestionAsked
@@ -1056,6 +1046,10 @@ export type GlobalEvent = {
     | EventQuestionRejected
     | EventLspClientDiagnostics
     | EventLspUpdated
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventSessionNetworkAsked
@@ -1072,6 +1066,7 @@ export type GlobalEvent = {
     | EventInteractiveTerminalDeleted
     | EventSessionTurnOpen
     | EventSessionTurnClose
+    | EventSandboxStatusChanged
     | EventSessionDiff
     | EventSessionError
     | EventTodoUpdated
@@ -1085,6 +1080,9 @@ export type GlobalEvent = {
     | EventCommandExecuted
     | EventProjectUpdated
     | EventSessionCompacted
+    | EventKilocodeAgentManagerStart
+    | EventKilocodeNotebookRequested
+    | EventKilocodeNotebookCancelled
     | EventVcsBranchUpdated
     | EventKiloSessionsRemoteStatusChanged
     | EventWorkspaceReady
@@ -1129,9 +1127,11 @@ export type GlobalEvent = {
     | EventSessionNextCompactionStarted
     | EventSessionNextCompactionDelta
     | EventSessionNextCompactionEnded
+    | EventIndexingStatus
+    | EventIndexingWarning
+    | EventModelsDevRefreshed
     | EventPluginAdded
     | EventCatalogModelUpdated
-    | EventModelsDevRefreshed
     | EventAccountAdded
     | EventAccountRemoved
     | EventAccountSwitched
@@ -3338,6 +3338,14 @@ export type SyncEventSessionNextCompactionEnded = {
   }
 }
 
+export type EventServerInstanceDisposed = {
+  id: string
+  type: "server.instance.disposed"
+  properties: {
+    directory: string
+  }
+}
+
 export type EventServerConnected = {
   id: string
   type: "server.connected"
@@ -3359,78 +3367,6 @@ export type EventGlobalConfigUpdated = {
   type: "global.config.updated"
   properties: {
     [key: string]: unknown
-  }
-}
-
-export type EventSandboxStatusChanged = {
-  id: string
-  type: "sandbox.status.changed"
-  properties: {
-    sessionID: string
-    directory: string
-    enabled: boolean
-    available: boolean
-    reason?: string
-    version: number
-  }
-}
-
-export type EventKilocodeAgentManagerStart = {
-  id: string
-  type: "kilocode.agent_manager.start"
-  properties: {
-    requestID: string
-    sessionID: string
-    mode: "worktree" | "local"
-    versions?: boolean
-    tasks: Array<{
-      prompt?: string
-      name?: string
-      branchName?: string
-      model?: {
-        providerID: string
-        modelID: string
-      }
-      variant?: string
-    }>
-  }
-}
-
-export type EventKilocodeNotebookRequested = {
-  id: string
-  type: "kilocode.notebook.requested"
-  properties: NotebookRequest
-}
-
-export type EventKilocodeNotebookCancelled = {
-  id: string
-  type: "kilocode.notebook.cancelled"
-  properties: {
-    requestID: NotebookRequestId
-    sessionID: string
-    reason: "cancelled" | "disposed" | "timeout"
-  }
-}
-
-export type EventIndexingStatus = {
-  id: string
-  type: "indexing.status"
-  properties: {
-    status: IndexingStatus
-  }
-}
-
-export type EventIndexingWarning = {
-  id: string
-  type: "indexing.warning"
-  properties: IndexingWarning
-}
-
-export type EventServerInstanceDisposed = {
-  id: string
-  type: "server.instance.disposed"
-  properties: {
-    directory: string
   }
 }
 
@@ -3630,6 +3566,19 @@ export type EventSessionTurnClose = {
   }
 }
 
+export type EventSandboxStatusChanged = {
+  id: string
+  type: "sandbox.status.changed"
+  properties: {
+    sessionID: string
+    directory: string
+    enabled: boolean
+    available: boolean
+    reason?: string
+    version: number
+  }
+}
+
 export type EventSessionDiff = {
   id: string
   type: "session.diff"
@@ -3756,6 +3705,43 @@ export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
     sessionID: string
+  }
+}
+
+export type EventKilocodeAgentManagerStart = {
+  id: string
+  type: "kilocode.agent_manager.start"
+  properties: {
+    requestID: string
+    sessionID: string
+    mode: "worktree" | "local"
+    versions?: boolean
+    tasks: Array<{
+      prompt?: string
+      name?: string
+      branchName?: string
+      model?: {
+        providerID: string
+        modelID: string
+      }
+      variant?: string
+    }>
+  }
+}
+
+export type EventKilocodeNotebookRequested = {
+  id: string
+  type: "kilocode.notebook.requested"
+  properties: NotebookRequest
+}
+
+export type EventKilocodeNotebookCancelled = {
+  id: string
+  type: "kilocode.notebook.cancelled"
+  properties: {
+    requestID: NotebookRequestId
+    sessionID: string
+    reason: "cancelled" | "disposed" | "timeout"
   }
 }
 
@@ -4297,6 +4283,28 @@ export type EventSessionNextCompactionEnded = {
   }
 }
 
+export type EventIndexingStatus = {
+  id: string
+  type: "indexing.status"
+  properties: {
+    status: IndexingStatus
+  }
+}
+
+export type EventIndexingWarning = {
+  id: string
+  type: "indexing.warning"
+  properties: IndexingWarning
+}
+
+export type EventModelsDevRefreshed = {
+  id: string
+  type: "models-dev.refreshed"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
 export type EventPluginAdded = {
   id: string
   type: "plugin.added"
@@ -4408,14 +4416,6 @@ export type EventCatalogModelUpdated = {
   type: "catalog.model.updated"
   properties: {
     model: ModelV2Info
-  }
-}
-
-export type EventModelsDevRefreshed = {
-  id: string
-  type: "models-dev.refreshed"
-  properties: {
-    [key: string]: unknown
   }
 }
 
@@ -11336,6 +11336,66 @@ export type KilocodeSessionModelUsageResponses = {
 
 export type KilocodeSessionModelUsageResponse =
   KilocodeSessionModelUsageResponses[keyof KilocodeSessionModelUsageResponses]
+
+export type KilocodeMobileAppNoticeData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/notice/mobile-app"
+}
+
+export type KilocodeMobileAppNoticeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeMobileAppNoticeError = KilocodeMobileAppNoticeErrors[keyof KilocodeMobileAppNoticeErrors]
+
+export type KilocodeMobileAppNoticeResponses = {
+  /**
+   * Mobile app notice visibility
+   */
+  200: {
+    show: boolean
+  }
+}
+
+export type KilocodeMobileAppNoticeResponse = KilocodeMobileAppNoticeResponses[keyof KilocodeMobileAppNoticeResponses]
+
+export type KilocodeDismissMobileAppNoticeData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/notice/mobile-app/dismiss"
+}
+
+export type KilocodeDismissMobileAppNoticeErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeDismissMobileAppNoticeError =
+  KilocodeDismissMobileAppNoticeErrors[keyof KilocodeDismissMobileAppNoticeErrors]
+
+export type KilocodeDismissMobileAppNoticeResponses = {
+  /**
+   * Notice dismissed
+   */
+  200: boolean
+}
+
+export type KilocodeDismissMobileAppNoticeResponse =
+  KilocodeDismissMobileAppNoticeResponses[keyof KilocodeDismissMobileAppNoticeResponses]
 
 export type AnacondaDesktopStatusData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -13021,6 +13021,16 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
           }
         },
         "description": "List active human-driven terminal sessions for the current instance.",
@@ -13028,7 +13038,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.list({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.list({\n  ...\n})"
           }
         ]
       }
@@ -13074,6 +13084,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not found",
             "content": {
@@ -13090,7 +13110,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.get({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.get({\n  ...\n})"
           }
         ]
       }
@@ -13137,6 +13157,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not found",
             "content": {
@@ -13162,7 +13192,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.write({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.write({\n  ...\n})"
           }
         ]
       }
@@ -13209,6 +13239,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not found",
             "content": {
@@ -13234,7 +13274,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.resize({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.resize({\n  ...\n})"
           }
         ]
       }
@@ -13281,6 +13321,16 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not found",
             "content": {
@@ -13297,7 +13347,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.close({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.interactiveTerminal.close({\n  ...\n})"
           }
         ]
       }
@@ -15622,6 +15672,123 @@
         ]
       }
     },
+    "/kilocode/notice/mobile-app": {
+      "get": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.mobileAppNotice",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mobile app notice visibility",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "show": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["show"],
+                  "additionalProperties": false,
+                  "description": "Mobile app notice visibility"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Whether to show the 'continue your /remote sessions in the Kilo mobile app' notice. Only true for users who have previously used a Cloud Agent / remote session relay and have not dismissed the notice.",
+        "summary": "Get mobile app notice visibility",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.mobileAppNotice({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/notice/mobile-app/dismiss": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.dismissMobileAppNotice",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notice dismissed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "Notice dismissed"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Permanently dismiss the Kilo mobile app promo notice for this machine.",
+        "summary": "Dismiss mobile app notice",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.dismissMobileAppNotice({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/kilocode/anaconda-desktop/status": {
       "get": {
         "tags": ["anaconda-desktop"],
@@ -17853,6 +18020,9 @@
       "Event": {
         "anyOf": [
           {
+            "$ref": "#/components/schemas/EventServerInstanceDisposed"
+          },
+          {
             "$ref": "#/components/schemas/EventServerConnected"
           },
           {
@@ -17860,39 +18030,6 @@
           },
           {
             "$ref": "#/components/schemas/EventGlobalConfigUpdated"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.prompt.append"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.command.execute"
-          },
-          {
-            "$ref": "#/components/schemas/EventTuiToastShow1"
-          },
-          {
-            "$ref": "#/components/schemas/Event.tui.session.select"
-          },
-          {
-            "$ref": "#/components/schemas/EventSandboxStatusChanged"
-          },
-          {
-            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
-          },
-          {
-            "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
-          },
-          {
-            "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
-          },
-          {
-            "$ref": "#/components/schemas/EventIndexingStatus"
-          },
-          {
-            "$ref": "#/components/schemas/EventIndexingWarning"
-          },
-          {
-            "$ref": "#/components/schemas/EventServerInstanceDisposed"
           },
           {
             "$ref": "#/components/schemas/EventFileEdited"
@@ -17914,6 +18051,18 @@
           },
           {
             "$ref": "#/components/schemas/EventLspUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.prompt.append"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.command.execute"
+          },
+          {
+            "$ref": "#/components/schemas/EventTuiToastShow1"
+          },
+          {
+            "$ref": "#/components/schemas/Event.tui.session.select"
           },
           {
             "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -17964,6 +18113,9 @@
             "$ref": "#/components/schemas/EventSessionTurnClose"
           },
           {
+            "$ref": "#/components/schemas/EventSandboxStatusChanged"
+          },
+          {
             "$ref": "#/components/schemas/EventSessionDiff"
           },
           {
@@ -18001,6 +18153,15 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionCompacted"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
           },
           {
             "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -18135,10 +18296,28 @@
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
           },
           {
+            "$ref": "#/components/schemas/EventIndexingStatus"
+          },
+          {
+            "$ref": "#/components/schemas/EventIndexingWarning"
+          },
+          {
+            "$ref": "#/components/schemas/EventModels-devRefreshed"
+          },
+          {
             "$ref": "#/components/schemas/EventPluginAdded"
           },
           {
             "$ref": "#/components/schemas/EventCatalogModelUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountAdded"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountRemoved"
+          },
+          {
+            "$ref": "#/components/schemas/EventAccountSwitched"
           },
           {
             "$ref": "#/components/schemas/EventSessionNextAgentSwitched"
@@ -18217,18 +18396,6 @@
           },
           {
             "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-          },
-          {
-            "$ref": "#/components/schemas/EventModels-devRefreshed"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountAdded"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountRemoved"
-          },
-          {
-            "$ref": "#/components/schemas/EventAccountSwitched"
           }
         ]
       },
@@ -18338,366 +18505,6 @@
           }
         },
         "required": ["_tag", "message"],
-        "additionalProperties": false
-      },
-      "Event.tui.prompt.append": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.prompt.append"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "text": {
-                "type": "string"
-              }
-            },
-            "required": ["text"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.command.execute": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.command.execute"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "command": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "enum": [
-                      "session.list",
-                      "session.new",
-                      "session.share",
-                      "session.interrupt",
-                      "session.compact",
-                      "session.page.up",
-                      "session.page.down",
-                      "session.line.up",
-                      "session.line.down",
-                      "session.half.page.up",
-                      "session.half.page.down",
-                      "session.first",
-                      "session.last",
-                      "prompt.clear",
-                      "prompt.submit",
-                      "agent.cycle"
-                    ]
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "required": ["command"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.toast.show": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.toast.show"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              },
-              "variant": {
-                "type": "string",
-                "enum": ["info", "success", "warning", "error"]
-              },
-              "duration": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "required": ["message", "variant"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "Event.tui.session.select": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["tui.session.select"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses",
-                "description": "Session ID to navigate to"
-              }
-            },
-            "required": ["sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "NotebookRequestID": {
-        "type": "string"
-      },
-      "NotebookReadRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/NotebookRequestID"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses"
-          },
-          "path": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 4096
-          },
-          "operation": {
-            "type": "string",
-            "enum": ["read"]
-          },
-          "includeOutputs": {
-            "type": "boolean"
-          }
-        },
-        "required": ["id", "sessionID", "path", "operation", "includeOutputs"],
-        "additionalProperties": false
-      },
-      "NotebookEditRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/NotebookRequestID"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses"
-          },
-          "path": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 4096
-          },
-          "operation": {
-            "type": "string",
-            "enum": ["edit"]
-          },
-          "expectedRevision": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 200,
-            "description": "Opaque notebook content revision; pass it back unchanged and do not parse or increment it"
-          },
-          "index": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Zero-based cell index"
-          },
-          "edit": {
-            "anyOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": ["insert"]
-                  },
-                  "kind": {
-                    "type": "string",
-                    "enum": ["code", "markdown"]
-                  },
-                  "language": {
-                    "type": "string",
-                    "maxLength": 200
-                  },
-                  "source": {
-                    "type": "string",
-                    "maxLength": 200000
-                  }
-                },
-                "required": ["action", "kind", "source"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": ["replace"]
-                  },
-                  "kind": {
-                    "type": "string",
-                    "enum": ["code", "markdown"]
-                  },
-                  "language": {
-                    "type": "string",
-                    "maxLength": 200
-                  },
-                  "source": {
-                    "type": "string",
-                    "maxLength": 200000
-                  }
-                },
-                "required": ["action", "kind", "source"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": ["delete"]
-                  }
-                },
-                "required": ["action"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "action": {
-                    "type": "string",
-                    "enum": ["create"]
-                  }
-                },
-                "required": ["action"],
-                "additionalProperties": false
-              }
-            ]
-          }
-        },
-        "required": ["id", "sessionID", "path", "operation", "index", "edit"],
-        "additionalProperties": false
-      },
-      "NotebookExecuteRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/NotebookRequestID"
-          },
-          "sessionID": {
-            "type": "string",
-            "pattern": "^ses"
-          },
-          "path": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 4096
-          },
-          "operation": {
-            "type": "string",
-            "enum": ["execute"]
-          },
-          "expectedRevision": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 200,
-            "description": "Opaque notebook content revision; pass it back unchanged and do not parse or increment it"
-          },
-          "index": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Zero-based cell index"
-          }
-        },
-        "required": ["id", "sessionID", "path", "operation", "expectedRevision", "index"],
-        "additionalProperties": false
-      },
-      "NotebookRequest": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/NotebookReadRequest"
-          },
-          {
-            "$ref": "#/components/schemas/NotebookEditRequest"
-          },
-          {
-            "$ref": "#/components/schemas/NotebookExecuteRequest"
-          }
-        ]
-      },
-      "IndexingStatusState": {
-        "type": "string",
-        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
-      },
-      "IndexingStatus": {
-        "type": "object",
-        "properties": {
-          "state": {
-            "$ref": "#/components/schemas/IndexingStatusState"
-          },
-          "message": {
-            "type": "string"
-          },
-          "processedFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "totalFiles": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "percent": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 100
-          }
-        },
-        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
-        "additionalProperties": false
-      },
-      "IndexingWarning": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "enum": ["qdrant.version-incompatible", "qdrant.version-unavailable"]
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": ["code", "message"],
         "additionalProperties": false
       },
       "QuestionOption": {
@@ -18840,6 +18647,140 @@
           }
         },
         "required": ["sessionID", "requestID"],
+        "additionalProperties": false
+      },
+      "Event.tui.prompt.append": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.prompt.append"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.command.execute": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.command.execute"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "command": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "session.list",
+                      "session.new",
+                      "session.share",
+                      "session.interrupt",
+                      "session.compact",
+                      "session.page.up",
+                      "session.page.down",
+                      "session.line.up",
+                      "session.line.down",
+                      "session.half.page.up",
+                      "session.half.page.down",
+                      "session.first",
+                      "session.last",
+                      "prompt.clear",
+                      "prompt.submit",
+                      "agent.cycle"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": ["command"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.toast.show": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.toast.show"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "variant": {
+                "type": "string",
+                "enum": ["info", "success", "warning", "error"]
+              },
+              "duration": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["message", "variant"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.session.select": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.select"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "Session ID to navigate to"
+              }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
       "SessionNetworkWait": {
@@ -19613,6 +19554,188 @@
         },
         "required": ["id", "worktree", "time", "sandboxes"],
         "additionalProperties": false
+      },
+      "NotebookRequestID": {
+        "type": "string"
+      },
+      "NotebookReadRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/NotebookRequestID"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["read"]
+          },
+          "includeOutputs": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "sessionID", "path", "operation", "includeOutputs"],
+        "additionalProperties": false
+      },
+      "NotebookEditRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/NotebookRequestID"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["edit"]
+          },
+          "expectedRevision": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Opaque notebook content revision; pass it back unchanged and do not parse or increment it"
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based cell index"
+          },
+          "edit": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": ["insert"]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["code", "markdown"]
+                  },
+                  "language": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "source": {
+                    "type": "string",
+                    "maxLength": 200000
+                  }
+                },
+                "required": ["action", "kind", "source"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": ["replace"]
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["code", "markdown"]
+                  },
+                  "language": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "source": {
+                    "type": "string",
+                    "maxLength": 200000
+                  }
+                },
+                "required": ["action", "kind", "source"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": ["delete"]
+                  }
+                },
+                "required": ["action"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": ["create"]
+                  }
+                },
+                "required": ["action"],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "required": ["id", "sessionID", "path", "operation", "index", "edit"],
+        "additionalProperties": false
+      },
+      "NotebookExecuteRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/NotebookRequestID"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["execute"]
+          },
+          "expectedRevision": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": "Opaque notebook content revision; pass it back unchanged and do not parse or increment it"
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based cell index"
+          }
+        },
+        "required": ["id", "sessionID", "path", "operation", "expectedRevision", "index"],
+        "additionalProperties": false
+      },
+      "NotebookRequest": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/NotebookReadRequest"
+          },
+          {
+            "$ref": "#/components/schemas/NotebookEditRequest"
+          },
+          {
+            "$ref": "#/components/schemas/NotebookExecuteRequest"
+          }
+        ]
       },
       "Pty": {
         "type": "object",
@@ -21012,6 +21135,50 @@
         "required": ["text"],
         "additionalProperties": false
       },
+      "IndexingStatusState": {
+        "type": "string",
+        "enum": ["Disabled", "In Progress", "Complete", "Error", "Standby"]
+      },
+      "IndexingStatus": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/IndexingStatusState"
+          },
+          "message": {
+            "type": "string"
+          },
+          "processedFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalFiles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "percent": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        },
+        "required": ["state", "message", "processedFiles", "totalFiles", "percent"],
+        "additionalProperties": false
+      },
+      "IndexingWarning": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": ["qdrant.version-incompatible", "qdrant.version-unavailable"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      },
       "GlobalEvent": {
         "type": "object",
         "properties": {
@@ -21027,6 +21194,9 @@
           "payload": {
             "anyOf": [
               {
+                "$ref": "#/components/schemas/EventServerInstanceDisposed"
+              },
+              {
                 "$ref": "#/components/schemas/EventServerConnected"
               },
               {
@@ -21034,39 +21204,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventGlobalConfigUpdated"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.prompt.append"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.command.execute"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.toast.show"
-              },
-              {
-                "$ref": "#/components/schemas/Event.tui.session.select"
-              },
-              {
-                "$ref": "#/components/schemas/EventSandboxStatusChanged"
-              },
-              {
-                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
-              },
-              {
-                "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
-              },
-              {
-                "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
-              },
-              {
-                "$ref": "#/components/schemas/EventIndexingStatus"
-              },
-              {
-                "$ref": "#/components/schemas/EventIndexingWarning"
-              },
-              {
-                "$ref": "#/components/schemas/EventServerInstanceDisposed"
               },
               {
                 "$ref": "#/components/schemas/EventFileEdited"
@@ -21088,6 +21225,18 @@
               },
               {
                 "$ref": "#/components/schemas/EventLspUpdated"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.prompt.append"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.command.execute"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.toast.show"
+              },
+              {
+                "$ref": "#/components/schemas/Event.tui.session.select"
               },
               {
                 "$ref": "#/components/schemas/EventMcpToolsChanged"
@@ -21138,6 +21287,9 @@
                 "$ref": "#/components/schemas/EventSessionTurnClose"
               },
               {
+                "$ref": "#/components/schemas/EventSandboxStatusChanged"
+              },
+              {
                 "$ref": "#/components/schemas/EventSessionDiff"
               },
               {
@@ -21175,6 +21327,15 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionCompacted"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
               },
               {
                 "$ref": "#/components/schemas/EventVcsBranchUpdated"
@@ -21309,10 +21470,28 @@
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
               },
               {
+                "$ref": "#/components/schemas/EventIndexingStatus"
+              },
+              {
+                "$ref": "#/components/schemas/EventIndexingWarning"
+              },
+              {
+                "$ref": "#/components/schemas/EventModels-devRefreshed"
+              },
+              {
                 "$ref": "#/components/schemas/EventPluginAdded"
               },
               {
                 "$ref": "#/components/schemas/EventCatalogModelUpdated"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountAdded"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountRemoved"
+              },
+              {
+                "$ref": "#/components/schemas/EventAccountSwitched"
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextAgentSwitched"
@@ -21391,18 +21570,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventSessionNextCompactionEnded"
-              },
-              {
-                "$ref": "#/components/schemas/EventModels-devRefreshed"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountAdded"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountRemoved"
-              },
-              {
-                "$ref": "#/components/schemas/EventAccountSwitched"
               },
               {
                 "$ref": "#/components/schemas/SyncEventMessageUpdated"
@@ -21901,6 +22068,12 @@
           "mode": {
             "type": "string",
             "enum": ["subagent", "primary", "all"]
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
           },
           "hidden": {
             "type": "boolean"
@@ -23988,6 +24161,9 @@
             "type": "string"
           },
           "displayName": {
+            "type": "string"
+          },
+          "source": {
             "type": "string"
           },
           "description": {
@@ -26278,6 +26454,90 @@
         "required": ["_tag"],
         "additionalProperties": false
       },
+      "InteractiveTerminalInfo1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "pid": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "command": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["running", "closed"]
+          },
+          "cols": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "rows": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "exitCode": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "enum": ["NaN"]
+              },
+              {
+                "type": "string",
+                "enum": ["Infinity"]
+              },
+              {
+                "type": "string",
+                "enum": ["-Infinity"]
+              }
+            ]
+          },
+          "signal": {
+            "type": "string"
+          },
+          "closedBy": {
+            "type": "string",
+            "enum": ["exit", "user", "abort"]
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "started": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "updated": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "ended": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": ["started", "updated"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "sessionID", "pid", "command", "cwd", "status", "cols", "rows", "time"],
+        "additionalProperties": false
+      },
       "SyncEventMessageUpdated": {
         "type": "object",
         "properties": {
@@ -28142,6 +28402,30 @@
         "required": ["type", "name", "id", "seq", "aggregateID", "data"],
         "additionalProperties": false
       },
+      "EventServerInstanceDisposed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["server.instance.disposed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "type": "string"
+              }
+            },
+            "required": ["directory"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "EventServerConnected": {
         "type": "object",
         "properties": {
@@ -28191,231 +28475,6 @@
           "properties": {
             "type": "object",
             "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventSandboxStatusChanged": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["sandbox.status.changed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "directory": {
-                "type": "string"
-              },
-              "enabled": {
-                "type": "boolean"
-              },
-              "available": {
-                "type": "boolean"
-              },
-              "reason": {
-                "type": "string"
-              },
-              "version": {
-                "type": "integer"
-              }
-            },
-            "required": ["sessionID", "directory", "enabled", "available", "version"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventKilocodeAgent_managerStart": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["kilocode.agent_manager.start"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "requestID": {
-                "type": "string"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "mode": {
-                "type": "string",
-                "enum": ["worktree", "local"]
-              },
-              "versions": {
-                "type": "boolean"
-              },
-              "tasks": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "prompt": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "branchName": {
-                      "type": "string"
-                    },
-                    "model": {
-                      "type": "object",
-                      "properties": {
-                        "providerID": {
-                          "type": "string"
-                        },
-                        "modelID": {
-                          "type": "string"
-                        }
-                      },
-                      "required": ["providerID", "modelID"],
-                      "additionalProperties": false
-                    },
-                    "variant": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "minItems": 1,
-                "maxItems": 20
-              }
-            },
-            "required": ["requestID", "sessionID", "mode", "tasks"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventKilocodeNotebookRequested": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["kilocode.notebook.requested"]
-          },
-          "properties": {
-            "$ref": "#/components/schemas/NotebookRequest"
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventKilocodeNotebookCancelled": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["kilocode.notebook.cancelled"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "requestID": {
-                "$ref": "#/components/schemas/NotebookRequestID"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "reason": {
-                "type": "string",
-                "enum": ["cancelled", "disposed", "timeout"]
-              }
-            },
-            "required": ["requestID", "sessionID", "reason"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventIndexingStatus": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["indexing.status"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "status": {
-                "$ref": "#/components/schemas/IndexingStatus"
-              }
-            },
-            "required": ["status"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventIndexingWarning": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["indexing.warning"]
-          },
-          "properties": {
-            "$ref": "#/components/schemas/IndexingWarning"
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventServerInstanceDisposed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["server.instance.disposed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "directory": {
-                "type": "string"
-              }
-            },
-            "required": ["directory"],
-            "additionalProperties": false
           }
         },
         "required": ["id", "type", "properties"],
@@ -29019,6 +29078,46 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventSandboxStatusChanged": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["sandbox.status.changed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "directory": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "available": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["sessionID", "directory", "enabled", "available", "version"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "EventSessionDiff": {
         "type": "object",
         "properties": {
@@ -29402,6 +29501,126 @@
               }
             },
             "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeAgent_managerStart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.agent_manager.start"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "type": "string"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["worktree", "local"]
+              },
+              "versions": {
+                "type": "boolean"
+              },
+              "tasks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "prompt": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "branchName": {
+                      "type": "string"
+                    },
+                    "model": {
+                      "type": "object",
+                      "properties": {
+                        "providerID": {
+                          "type": "string"
+                        },
+                        "modelID": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["providerID", "modelID"],
+                      "additionalProperties": false
+                    },
+                    "variant": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 20
+              }
+            },
+            "required": ["requestID", "sessionID", "mode", "tasks"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeNotebookRequested": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.notebook.requested"]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/NotebookRequest"
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeNotebookCancelled": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.notebook.cancelled"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "$ref": "#/components/schemas/NotebookRequestID"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "reason": {
+                "type": "string",
+                "enum": ["cancelled", "disposed", "timeout"]
+              }
+            },
+            "required": ["requestID", "sessionID", "reason"],
             "additionalProperties": false
           }
         },
@@ -31037,6 +31256,65 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventIndexingStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.status"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "$ref": "#/components/schemas/IndexingStatus"
+              }
+            },
+            "required": ["status"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventIndexingWarning": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["indexing.warning"]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/IndexingWarning"
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventModels-devRefreshed": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["models-dev.refreshed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "EventPluginAdded": {
         "type": "object",
         "properties": {
@@ -31404,24 +31682,6 @@
             },
             "required": ["model"],
             "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventModels-devRefreshed": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["models-dev.refreshed"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
           }
         },
         "required": ["id", "type", "properties"],


### PR DESCRIPTION
## What

Adds a dismissible in-app notice promoting the Kilo mobile app to users who have used **Cloud Agents** (the CLI's `/remote` command), in both the VS Code extension and the CLI.

Copy: "Continue your /remote sessions in the Kilo mobile app." → links to https://blog.kilo.ai/p/kilo-app-for-ios-and-android-is-live

## Targeting signal: "has used Cloud Agents"

Investigated existing telemetry first: `TelemetryEvent.REMOTE_CONNECTION_OPENED` (`packages/kilo-telemetry/src/events.ts`) fires from `KiloSessions.enableRemote()` (`packages/opencode/src/kilo-sessions/kilo-sessions.ts`), which is exactly what the `/remote` TUI command (`packages/opencode/src/kilocode/kilo-commands.tsx`) calls, and what the docs (`packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md`, "Remote Connections") describe as the mechanism that links a local CLI session to a Cloud Agent session. However, that telemetry event isn't queryable locally — it only goes to PostHog — so it can't gate a UI notice.

There was no existing "Cloud Agent used" flag/setting accessible to the extension or CLI, so this PR adds a minimal local tracking mechanism:

- `packages/opencode/src/kilocode/notices.ts` (new) — a small JSON file (`notices.json`) under `Global.Path.state`, machine-global (not per-project), so it's visible both to the CLI/TUI process and to the VS Code extension's embedded `kilo serve` process (same machine, same XDG state dir).
- `Notices.markCloudAgentUsed()` is called once from `KiloSessions.enableRemote()`'s success path (`kilo-sessions.ts`) — i.e. the same place the existing `Telemetry.trackRemoteConnectionOpened()` call lives — so the flag flips the first time remote/Cloud Agent relay is actually enabled, regardless of whether it was triggered via the `/remote` command or the `remote_control` config.
- `Notices.shouldShowMobileAppNotice()` returns `true` only if `cloud_agent_used` is set and `mobile_app_notice_dismissed` is not.

This flag is exposed to any client via a new local `kilo serve` endpoint (`GET /kilocode/notice/mobile-app`, `POST /kilocode/notice/mobile-app/dismiss`), added to the existing `kilocode` HttpApi group (`packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts` + `handlers/kilocode.ts`). The SDK was regenerated (`script/generate.ts`) so both the TUI and the VS Code extension can call `client.kilocode.mobileAppNotice()` / `dismissMobileAppNotice()`.

## Where it appears

**CLI (TUI)** — `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` calls a new hook `useMobileAppNotice()` (mirror module: `packages/opencode/src/kilocode/cli/cmd/tui/routes/session/mobile-app-notice.tsx`, no `kilocode_change` markers needed) on session route mount. It reuses the existing `DialogRetryAction` component (title/message/link + "don't show again" button) already used for other one-off dialogs (e.g. the Go upsell dialog) instead of building new UI.

**VS Code** — `packages/kilo-vscode/src/kilo-provider/notifications.ts`'s `fetchAndSendNotifications()` merges a locally-constructed `NotificationItem` (id `mobile-app-promo`) into the existing server-driven notifications array whenever the local `kilo serve` reports `show: true`. This renders through the existing `KiloNotifications` banner component in the webview — no new UI was built.

## Dismissal persistence

- **CLI**: dismissing the `DialogRetryAction` dialog's "don't show again" button calls `client.kilocode.dismissMobileAppNotice()`, which sets `mobile_app_notice_dismissed: true` in `notices.json` under `Global.Path.state`. This is permanent — the notice never shows again on this machine.
- **VS Code**: dismissal reuses the extension's existing generic notification dismiss flow (`kilo.dismissedNotificationIds` in `vscode.ExtensionContext.globalState`, in `dismissNotification()`/`notifications.ts`). When the `mobile-app-promo` id is dismissed, the extension additionally calls `client.kilocode.dismissMobileAppNotice()` so the CLI-side flag is also set, keeping both surfaces in sync on the same machine.

Clicking the notice's "Open" action opens the mobile app blog post via the existing external-link mechanisms (`open` npm package in the TUI's `Link`/`DialogRetryAction`; `vscode.env.openExternal` via the existing `openExternal` postMessage handler in VS Code) — it does **not** dismiss the notice, matching the requirement that only an explicit dismissal is permanent.

## Tests

- `packages/opencode/test/kilocode/notices.test.ts` — targeting logic: no notice for users who never used Cloud Agents, notice appears after `markCloudAgentUsed()`, dismissal persists and survives re-marking usage.
- `packages/kilo-vscode/tests/unit/mobile-app-notice.test.ts` — the notice is merged into `fetchAndSendNotifications()` only when the local server reports `show: true`, dismissal persists in `globalState` and propagates to the CLI-side dismiss endpoint, and stays dismissed across subsequent fetches.

## Verification run

- `packages/opencode`: `bun run typecheck`, targeted `bun test test/kilocode/notices.test.ts`, `oxlint` on touched files.
- `packages/kilo-vscode`: `bun run typecheck`, `bun run lint`, `bun run check-kilocode-change`, targeted `bun test tests/unit/mobile-app-notice.test.ts`, `bun run format`.
- Regenerated SDK via `./script/generate.ts` (root).
- Could not run the JetBrains plugin's `./gradlew typecheck` locally — the sandbox has no trusted CA path to `services.gradle.org` to download the Gradle wrapper distribution. This PR does not touch `packages/kilo-jetbrains/`.

---

Built for [Arkadiy Kondrashov](https://kilo-code.slack.com/archives/D0ABA8UCFA7/p1783068019113379?thread_ts=1782827811.151709&cid=D0ABA8UCFA7) by [Kilo for Slack](https://kilo.ai/slack)
