### PR TITLE
docs: fix broken OpenRouter provider routing link

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/openrouter.md
+++ b/packages/kilo-docs/pages/ai-providers/openrouter.md
@@ -83,9 +83,9 @@ The middle-out transform is not exposed as a dedicated UI control in the VS Code
 
 ## Provider Routing
 
-OpenRouter can route to many different inference providers. This can be controlled directly via OpenRouter's [`provider` routing parameter](https://openrouter.ai/docs/features/provider-routing).
+OpenRouter can route to many different inference providers. This can be controlled directly via OpenRouter's [`provider` routing parameter](https://openrouter.ai/docs/guides/routing/provider-selection).
 
-Provider routing is not exposed as dedicated UI controls in the VS Code extension. To configure it, set OpenRouter's `provider` routing fields under the model's `options` in your `kilo.json` config file. Everything under `options` is forwarded to the OpenRouter AI SDK as `providerOptions.openrouter`, so any field from the [OpenRouter provider routing docs](https://openrouter.ai/docs/features/provider-routing) can be used.
+Provider routing is not exposed as dedicated UI controls in the VS Code extension. To configure it, set OpenRouter's `provider` routing fields under the model's `options` in your `kilo.json` config file. Everything under `options` is forwarded to the OpenRouter AI SDK as `providerOptions.openrouter`, so any field from the [OpenRouter provider routing docs](https://openrouter.ai/docs/guides/routing/provider-selection) can be used.
 
 ```jsonc
 {


### PR DESCRIPTION
The OpenRouter provider page linked to `https://openrouter.ai/docs/features/provider-routing`, which now returns 404. This broke the lychee link-check job in CI (the only failing link in the run).

Replace both references on the OpenRouter docs page with the current location, `https://openrouter.ai/docs/guides/routing/provider-selection`, which covers the same `provider` routing parameter (order, only, ignore, allow_fallbacks, sort, etc.). The new URL returns 200.

Docs-only change; no product behavior affected.