### PR TITLE
fix(cli): expose off variant and add kilo gateway branch for GLM 5.2

### DIFF
--- a/.changeset/fix-glm-52-reasoning-variants.md
+++ b/.changeset/fix-glm-52-reasoning-variants.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore the off reasoning variant for GLM 5.2 and add the missing Kilo gateway branch so the effort selector shows all three supported levels (off/high/xhigh) instead of only two.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -669,21 +669,35 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   const adaptiveOpus = anthropicOpus47OrLater(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  if (glm52 && model.api.npm === "@kilocode/kilo-gateway") {
+    // kilocode_change - mirror the cloud's none/high/xhigh GLM-5.2 variants
+    // (see REASONING_VARIANTS_NONE_HIGH_XHIGH in cloud model-settings.ts) so the
+    // computed fallback matches the config the gateway pushes. Without this the
+    // generic GLM binary toggle (instant/thinking) below is used instead.
+    return {
+      none: { reasoning: { enabled: false, effort: "none" } },
+      high: { reasoning: { enabled: true, effort: "high" } },
+      xhigh: { reasoning: { enabled: true, effort: "xhigh" } },
+    }
+  }
   if (glm52 && model.api.npm === "@openrouter/ai-sdk-provider") {
     // OpenRouter maps xhigh to GLM-5.2's native max effort.
     return {
+      none: { reasoning: { enabled: false } },
       high: { reasoning: { effort: "high" } },
       xhigh: { reasoning: { effort: "xhigh" } },
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/openai-compatible") {
     return {
+      none: { reasoningEffort: "none" },
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/anthropic") {
     return {
+      none: { thinking: { type: "disabled" } },
       high: { effort: "high" },
       max: { effort: "max" },
     }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2539,6 +2539,7 @@ describe("ProviderTransform.variants", () => {
       },
     })
     expect(ProviderTransform.variants(model)).toEqual({
+      none: { reasoningEffort: "none" },
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     })
@@ -2555,6 +2556,7 @@ describe("ProviderTransform.variants", () => {
         },
       })
       expect(ProviderTransform.variants(model)).toEqual({
+        none: { reasoningEffort: "none" },
         high: { reasoningEffort: "high" },
         max: { reasoningEffort: "max" },
       })
@@ -2571,6 +2573,7 @@ describe("ProviderTransform.variants", () => {
       },
     })
     expect(ProviderTransform.variants(model)).toEqual({
+      none: { reasoningEffort: "none" },
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     })
@@ -2587,8 +2590,26 @@ describe("ProviderTransform.variants", () => {
       },
     })
     expect(ProviderTransform.variants(model)).toEqual({
+      none: { reasoning: { enabled: false } },
       high: { reasoning: { effort: "high" } },
       xhigh: { reasoning: { effort: "xhigh" } },
+    })
+  })
+
+  test("glm-5.2 returns effort variants for the kilo gateway", () => {
+    const model = createMockModel({
+      id: "kilo/z-ai/glm-5.2",
+      providerID: "kilo",
+      api: {
+        id: "z-ai/glm-5.2",
+        url: "https://gateway.kilo.ai",
+        npm: "@kilocode/kilo-gateway",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { reasoning: { enabled: false, effort: "none" } },
+      high: { reasoning: { enabled: true, effort: "high" } },
+      xhigh: { reasoning: { enabled: true, effort: "xhigh" } },
     })
   })
 
@@ -2603,6 +2624,7 @@ describe("ProviderTransform.variants", () => {
       },
     })
     expect(ProviderTransform.variants(model)).toEqual({
+      none: { thinking: { type: "disabled" } },
       high: { effort: "high" },
       max: { effort: "max" },
     })


### PR DESCRIPTION
## Problem

GLM 5.2 only showed two reasoning efforts in the selector instead of three, and through the Kilo gateway it collapsed to a binary thinking toggle.

Two gaps were introduced in #11555 (adapted from upstream `22cc758b1a`, "feat(opencode): expose High/Max thinking variants for GLM-5.2"):

1. **`@kilocode/kilo-gateway` was not covered.** The `variants()` mapping in `ProviderTransform` only handled `@openrouter`, `@ai-sdk/openai-compatible`, and `@ai-sdk/anthropic`. The gateway fell through to the generic GLM binary toggle (`instant`/`thinking`), exposing only two options while the cloud already pushes `none`/`high`/`xhigh` for GLM 5.2 (`REASONING_VARIANTS_NONE_HIGH_XHIGH` in `cloud/apps/web/src/lib/ai-gateway/providers/model-settings.ts`).

2. **The off (`none`) variant was dropped** from the openrouter, openai-compatible, and anthropic branches. Each returned only two variants, regressing custom openai-compatible providers (e.g. wafer) that previously exposed three effort levels.

## Fix

Mirror the cloud three-variant definition in `packages/opencode/src/provider/transform.ts`:

- `@kilocode/kilo-gateway` (new branch): `none`/`high`/`xhigh`
- `@openrouter/ai-sdk-provider`: `none`/`high`/`xhigh`
- `@ai-sdk/openai-compatible`: `none`/`high`/`max` (z.ai native naming)
- `@ai-sdk/anthropic`: `none`/`high`/`max`

The `none` variant uses each package native off shape (`reasoning.enabled: false` for openrouter/gateway, `reasoningEffort: "none"` for openai-compatible, `thinking: { type: "disabled" }` for anthropic), consistent with how other reasoning-capable models express the off tier in this file.

## Why no upstream cherry-pick

There is no upstream fix to cherry-pick:

- Upstream `22cc758b1a` is the twin of #11555 and has the same two gaps (no `none` variant, no gateway branch, since upstream has no Kilo gateway).
- Upstream `996a0628ef` ("feat(provider): use models.dev reasoning options") is a 694-line rewrite of `transform.ts` that drives variants from `model.reasoning_options`. It lives only on the unmerged upstream `reasoning-model-api` branch (not `upstream/dev` or `upstream/beta`), heavily conflicts with our `kilocode_change` modifications to `variants()`, and is not a targeted GLM fix. When it eventually merges upstream, the `kilocode_change` markers on these branches will surface during the fork merge and can be reconciled then.

No Kilo PRs track either upstream commit.

## Verification

- `bun test ./test/provider/transform.test.ts` (from `packages/opencode/`) — 265 pass
- `bun run typecheck` (opencode) — clean
- `bun run script/check-opencode-annotations.ts` — clean (new branch carries a `kilocode_change` marker)