### PR TITLE
feat(cli): persist /sandbox toggle across new sessions

### DIFF
--- a/.changeset/persist-cli-sandbox-toggle.md
+++ b/.changeset/persist-cli-sandbox-toggle.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Persist the `/sandbox` toggle across new CLI sessions per project directory, mirroring the VS Code extension's sandbox button. New sessions now inherit the last toggled state instead of resetting to the config default each time.

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -11,6 +11,7 @@ import type { InstanceContext } from "@/project/instance-context"
 import type { SessionID } from "@/session/schema"
 import { Changed } from "./event"
 import * as Network from "./network"
+import { SandboxPreference } from "./preference"
 import * as SandboxState from "./state"
 import { SandboxStore } from "./store"
 
@@ -27,6 +28,25 @@ function secure(snapshot: Snapshot): Snapshot {
   if (Flag.KILO_SERVER_PASSWORD) return snapshot
   return { ...snapshot, enabled: true, mode: "deny" }
 }
+
+function initial(
+  chosen: boolean | undefined,
+  pref: boolean | undefined,
+  cfgDefault: boolean,
+  mode: Snapshot["mode"],
+): Snapshot {
+  if (chosen !== undefined) return { enabled: chosen, mode, version: 0 }
+  if (pref !== undefined) return { enabled: pref, mode, version: 0 }
+  return secure({ enabled: cfgDefault, mode, version: 0 })
+}
+
+const resolveInitial = Effect.fn("SandboxPolicy.resolveInitial")(function* (directory: string, sessionID: SessionID) {
+  const cfg = yield* (yield* Config.Service).get()
+  const chosen = yield* SandboxState.read(sessionID)
+  const pref = yield* Effect.promise(() => SandboxPreference.read(directory))
+  const mode = cfg.experimental?.sandbox_restrict_network === false ? "allow" : "deny"
+  return initial(chosen?.enabled, pref, cfg.experimental?.sandbox ?? false, mode)
+})
 
 function locked<A, E, R>(sessionID: SessionID, effect: Effect.Effect<A, E, R>) {
   return Effect.acquireUseRelease(
@@ -99,7 +119,7 @@ export function profile(ctx: InstanceContext, mode: Profile["network"]["mode"] =
   return {
     filesystem: {
       allowWrite: writable,
-      denyWrite: [root(SandboxStore.root)],
+      denyWrite: [root(SandboxStore.root), root(SandboxPreference.root)],
       denyNames: [".git"],
       temporaryDirectory: Global.Path.tmp,
     },
@@ -137,15 +157,11 @@ const snapshot = Effect.fn("SandboxPolicy.snapshot")(function* (sessionID: Sessi
     Effect.gen(function* () {
       const existing = yield* read(directory, sessionID)
       if (existing) return { directory, state: existing }
-      const cfg = yield* (yield* Config.Service).get()
       // A session's create-time kilocode.sandbox toggle takes precedence over the config default, so a
-      // session moved or created with an explicit choice keeps that choice instead of resetting.
-      const chosen = yield* SandboxState.read(sessionID)
-      const next = secure({
-        enabled: chosen?.enabled ?? cfg.experimental?.sandbox ?? false,
-        mode: cfg.experimental?.sandbox_restrict_network === false ? "allow" : "deny",
-        version: 0,
-      })
+      // session moved or created with an explicit choice keeps that choice instead of resetting. The
+      // persisted per-directory preference (last toggled state) is the next precedence, so new sessions
+      // inherit the last /sandbox choice. secure-by-default only applies when neither is present.
+      const next = yield* resolveInitial(directory, sessionID)
       yield* Effect.promise(() => SandboxStore.write(directory, sessionID, next))
       snapshots.set(key(directory, sessionID), next)
       return { directory, state: next }
@@ -179,14 +195,7 @@ function change<E, R>(sessionID: SessionID, guard: Effect.Effect<unknown, E, R>)
       Effect.gen(function* () {
         yield* guard
         const stored = yield* read(directory, sessionID)
-        const cfg = stored ? undefined : yield* (yield* Config.Service).get()
-        const current =
-          stored ??
-          secure({
-            enabled: cfg?.experimental?.sandbox ?? false,
-            mode: cfg?.experimental?.sandbox_restrict_network === false ? "allow" : "deny",
-            version: 0,
-          })
+        const current = stored ?? (yield* resolveInitial(directory, sessionID))
         const support = backendSupport({ mode: current.mode, allowedHosts: [] })
         const status = {
           directory,
@@ -199,6 +208,12 @@ function change<E, R>(sessionID: SessionID, guard: Effect.Effect<unknown, E, R>)
         const next: Snapshot = { ...current, enabled: !status.enabled, version: status.version + 1 }
         yield* Effect.promise(() => SandboxStore.write(directory, sessionID, next))
         snapshots.set(key(directory, sessionID), next)
+        // The per-session SandboxStore is the authoritative state; the per-directory
+        // preference only seeds future sessions. A preference write failure must not
+        // fail the toggle or desync the in-memory cache from the persisted snapshot.
+        yield* Effect.promise(() => SandboxPreference.write(directory, next.enabled)).pipe(
+          Effect.catch(() => Effect.void),
+        )
         const value = { ...status, enabled: next.enabled, version: next.version }
         yield* (yield* Bus.Service).publish(Changed, { sessionID, ...value })
         return value

--- a/packages/opencode/src/kilocode/sandbox/preference.ts
+++ b/packages/opencode/src/kilocode/sandbox/preference.ts
@@ -1,0 +1,35 @@
+import { createHash, randomUUID } from "node:crypto"
+import fs from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import path from "node:path"
+import { Global } from "@opencode-ai/core/global"
+
+export namespace SandboxPreference {
+  export const root = path.join(realpathSync.native(path.dirname(Global.Path.state)), "kilo-sandbox-preference")
+
+  function file(directory: string) {
+    return path.join(root, createHash("sha256").update(directory).digest("hex") + ".json")
+  }
+
+  export async function read(directory: string): Promise<boolean | undefined> {
+    const target = file(directory)
+    const text = await fs.readFile(target, "utf8").catch((err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") return undefined
+      throw err
+    })
+    if (text === undefined) return undefined
+    const value: unknown = JSON.parse(text)
+    return typeof value === "boolean" ? value : undefined
+  }
+
+  export async function write(directory: string, enabled: boolean) {
+    const target = file(directory)
+    const temp = path.join(root, `.${randomUUID()}.tmp`)
+    await fs.mkdir(root, { recursive: true, mode: 0o700 })
+    await fs.writeFile(temp, JSON.stringify(enabled), { encoding: "utf8", flag: "wx", mode: 0o600 })
+    await fs.rename(temp, target).catch(async (err) => {
+      await fs.rm(temp, { force: true })
+      throw err
+    })
+  }
+}

--- a/packages/opencode/test/kilocode/sandbox/policy.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/policy.test.ts
@@ -5,6 +5,7 @@ import { Global } from "@opencode-ai/core/global"
 import { assertWrite, run as runSandbox } from "@kilocode/sandbox"
 import { Effect, Exit } from "effect"
 import { profile } from "@/kilocode/sandbox/policy"
+import { SandboxPreference } from "@/kilocode/sandbox/preference"
 import { SandboxStore } from "@/kilocode/sandbox/store"
 import type { InstanceContext } from "@/project/instance-context"
 import { ProjectID } from "@/project/schema"
@@ -178,13 +179,22 @@ describe("sandbox policy", () => {
     const dirs = tmp.extra
     const ctx = context(dirs.a, dirs.a, dirs)
     const policy = profile(ctx)
-    const write = await Effect.runPromise(runSandbox(policy, assertWrite(SandboxStore.root)).pipe(Effect.exit))
+    const [storeWrite, prefWrite] = await Effect.runPromise(
+      Effect.all([
+        runSandbox(policy, assertWrite(SandboxStore.root)).pipe(Effect.exit),
+        runSandbox(policy, assertWrite(SandboxPreference.root)).pipe(Effect.exit),
+      ]),
+    )
 
     expect(new Set(roots(ctx))).toEqual(expected(dirs.a))
     expect(policy.filesystem.temporaryDirectory).toBe(Global.Path.tmp)
-    expect(policy.filesystem.denyWrite).toEqual([{ path: SandboxStore.root, kind: "subtree" }])
+    expect(policy.filesystem.denyWrite).toEqual([
+      { path: SandboxStore.root, kind: "subtree" },
+      { path: SandboxPreference.root, kind: "subtree" },
+    ])
     expect(policy.environment.deny).toEqual(["KILO_SERVER_PASSWORD", "KILO_SERVER_USERNAME"])
-    expect(Exit.isFailure(write)).toBe(true)
+    expect(Exit.isFailure(storeWrite)).toBe(true)
+    expect(Exit.isFailure(prefWrite)).toBe(true)
   })
 
   test("uses deny-by-default and configurable network profiles", async () => {

--- a/packages/opencode/test/kilocode/sandbox/state.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/state.test.ts
@@ -212,30 +212,50 @@ it.instance(
 )
 
 it.instance(
-  "overrides config off for only one session",
+  "persists a toggle so new sessions inherit the last choice",
   () =>
     Effect.gen(function* () {
-      const first = SessionID.make("ses_sandbox_override_off")
-      const second = SessionID.make("ses_sandbox_config_stays_on")
+      const first = SessionID.make("ses_sandbox_persist_off")
+      const second = SessionID.make("ses_sandbox_persist_inherit")
       if (!(yield* SandboxPolicy.status(first)).available) return
 
       expect((yield* SandboxPolicy.toggle(first)).enabled).toBe(false)
       expect(yield* execute(first, sandboxed)).toBe(false)
-      expect(yield* execute(second, sandboxed)).toBe(true)
+      expect((yield* SandboxPolicy.status(second)).enabled).toBe(false)
+      expect(yield* execute(second, sandboxed)).toBe(false)
     }),
   { config: { experimental: { sandbox: true } } },
 )
 
-it.instance("trusted toggles disable only one authless session", () =>
+it.instance("persists an authless toggle to later sessions", () =>
   Effect.gen(function* () {
-    const first = SessionID.make("ses_sandbox_override_on")
-    const second = SessionID.make("ses_sandbox_default_remains_off")
+    const first = SessionID.make("ses_sandbox_authless_persist")
+    const second = SessionID.make("ses_sandbox_authless_inherit")
     if (!(yield* SandboxPolicy.status(first)).available) return
 
     expect((yield* SandboxPolicy.toggle(first)).enabled).toBe(false)
     expect(yield* execute(first, sandboxed)).toBe(false)
-    expect(yield* execute(second, sandboxed)).toBe(true)
+    expect((yield* SandboxPolicy.status(second)).enabled).toBe(false)
+    expect(yield* execute(second, sandboxed)).toBe(false)
   }),
+)
+
+it.instance(
+  "remembers a later toggle back on for new sessions",
+  () =>
+    Effect.gen(function* () {
+      const first = SessionID.make("ses_sandbox_roundtrip_a")
+      const second = SessionID.make("ses_sandbox_roundtrip_b")
+      const third = SessionID.make("ses_sandbox_roundtrip_c")
+      if (!(yield* SandboxPolicy.status(first)).available) return
+
+      yield* SandboxPolicy.toggle(first)
+      expect((yield* SandboxPolicy.status(second)).enabled).toBe(false)
+      yield* SandboxPolicy.toggle(second)
+      expect((yield* SandboxPolicy.status(third)).enabled).toBe(true)
+      expect(yield* execute(third, sandboxed)).toBe(true)
+    }),
+  { config: { experimental: { sandbox: true } } },
 )
 
 it.instance("isolates concurrent session overrides and clears them", () =>
@@ -247,6 +267,9 @@ it.instance("isolates concurrent session overrides and clears them", () =>
       expect((yield* SandboxPolicy.toggle(first)).enabled).toBe(false)
       return
     }
+    // Seed second with its own stored snapshot before any toggle, so its state
+    // stays independent of the per-directory preference that toggles now persist.
+    expect((yield* SandboxPolicy.status(second)).enabled).toBe(true)
 
     expect((yield* SandboxPolicy.toggle(first)).enabled).toBe(false)
     expect((yield* SandboxPolicy.status(second)).enabled).toBe(true)
@@ -254,6 +277,8 @@ it.instance("isolates concurrent session overrides and clears them", () =>
     expect((yield* SandboxPolicy.toggle(second)).enabled).toBe(true)
     expect((yield* SandboxPolicy.status(first)).enabled).toBe(false)
     yield* SandboxPolicy.retire(first, (yield* TestInstance).directory, Effect.void)
+    // retire clears first's stored snapshot; it re-seeds from the persisted
+    // per-directory preference, which holds the last toggle (second -> true).
     expect((yield* SandboxPolicy.status(first)).enabled).toBe(true)
     expect((yield* SandboxPolicy.status(second)).enabled).toBe(true)
   }),


### PR DESCRIPTION
## What

The CLI `/sandbox` toggle was session-scoped: each new session reset to the static `experimental.sandbox` config default (or `secure()`-forced ON in authless mode where `KILO_SERVER_PASSWORD` is unset). The VS Code extension's sandbox button, by contrast, persists the last choice via `kilo.sandbox.newSessionDefault` workspace state, so new sessions inherit it. This PR makes the CLI match VS Code.

## Why

Users who toggle the sandbox off (or on) for a project expect that choice to stick the next time they start a session in the same directory. Forgetting the toggle on every new session is surprising and inconsistent with the extension, where the same control is persistent. The only existing "persistent" CLI option was the static config flag, which is a fixed default rather than "remember what I last chose."

## How it works

A new per-directory persisted store (`SandboxPreference`) records the last toggled boolean under `~/.local/state/kilo-sandbox-preference/<sha256(directory)>.json` (mirroring the existing `SandboxStore` layout). `SandboxPolicy` resolves a new session's sandbox state with precedence:

1. create-time `kilocode.sandbox` session metadata (existing)
2. the persisted per-directory preference (new)
3. the config default, with `secure()` (authless force-ON) only applying when neither explicit choice nor preference exists

`toggle()` persists the new state to the per-directory preference on every toggle. Secure-by-default is preserved for directories with no prior toggle (the very first session still starts sandboxed in authless mode).

## Security tradeoff

In authless (local TUI) mode, once a user toggles the sandbox off, new sessions in that project stay off until toggled back, since `secure()` no longer overrides an existing preference. This weakens the secure-by-default guarantee but matches VS Code's behavior, and the new preference store is protected by the sandbox profile's `denyWrite` list so a sandboxed process cannot plant a `false` preference to disable confinement for later sessions.

## Tests

Rewrote the two tests that encoded the old per-session isolation property to assert the new persistence, plus a round-trip test (toggle off, then on, new session inherits on). A third pre-existing test that exercises `retire` was adjusted since `retire` now re-seeds from the directory preference. Added a `denyWrite` assertion for `SandboxPreference.root` in `policy.test.ts`. All 64 sandbox tests pass.