### PR TITLE
fix(test): make tool/shell.test.ts deterministic (fast commands lost output)

### DIFF
--- a/.changeset/shell-output-drop.md
+++ b/.changeset/shell-output-drop.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix shell tool occasionally returning "(no output)" for fast-exiting commands

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -2,6 +2,7 @@ import type * as Arr from "effect/Array"
 import { NodeFileSystem, NodeSink, NodeStream } from "@effect/platform-node"
 import * as NodePath from "@effect/platform-node/NodePath"
 import { prepareCommand as prepareSandbox } from "@kilocode/sandbox" // kilocode_change
+import { tap as tapStdio, tapped } from "./kilocode/stdio-tap" // kilocode_change - Bun drops buffered stdio on close
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
@@ -246,13 +247,13 @@ export const make = Effect.gen(function* () {
   ) => {
     let stdout = proc.stdout
       ? NodeStream.fromReadable({
-          evaluate: () => proc.stdout!,
+          evaluate: () => tapped(proc, "stdout"), // kilocode_change - read the spawn-time tap
           onError: (cause) => toPlatformError("fromReadable(stdout)", toError(cause), command),
         })
       : Stream.empty
     let stderr = proc.stderr
       ? NodeStream.fromReadable({
-          evaluate: () => proc.stderr!,
+          evaluate: () => tapped(proc, "stderr"), // kilocode_change - read the spawn-time tap
           onError: (cause) => toPlatformError("fromReadable(stderr)", toError(cause), command),
         })
       : Stream.empty
@@ -267,6 +268,7 @@ export const make = Effect.gen(function* () {
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
+      tapStdio(proc) // kilocode_change - must run in the same tick as spawn
       let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {

--- a/packages/core/src/kilocode/stdio-tap.ts
+++ b/packages/core/src/kilocode/stdio-tap.ts
@@ -1,0 +1,34 @@
+import type * as NodeChildProcess from "node:child_process"
+import { PassThrough, type Readable } from "node:stream"
+
+// Bun's child_process drops buffered stdio data once the child emits "close", so
+// stream readers that attach lazily (a tick or more after spawn) lose the output of
+// fast-exiting processes entirely. To retain it, stdout/stderr are piped into
+// PassThroughs synchronously at spawn time, before yielding to the event loop.
+// PassThrough backpressure (default highWaterMark) keeps unconsumed output bounded.
+
+const map = new WeakMap<NodeChildProcess.ChildProcess, { stdout: PassThrough | null; stderr: PassThrough | null }>()
+
+const wrap = (src: Readable | null) => {
+  if (!src) return null
+  const out = new PassThrough()
+  // A destroy(err) before the lazy consumer attaches would otherwise emit an
+  // unhandled "error" event and crash the process (a hazard that also existed
+  // when readers attached lazily to the raw stdio streams). Consumers attached
+  // by then still get the error via their own listeners; in the rare pre-attach
+  // window the error is dropped instead of crashing the CLI.
+  out.on("error", () => {})
+  src.on("error", (err) => out.destroy(err instanceof Error ? err : new Error(String(err))))
+  src.pipe(out)
+  return out
+}
+
+/** Tap a freshly spawned process. Must be called in the same tick as spawn. */
+export function tap(proc: NodeChildProcess.ChildProcess) {
+  map.set(proc, { stdout: wrap(proc.stdout), stderr: wrap(proc.stderr) })
+}
+
+/** The tapped stream for a process, falling back to the raw stdio stream. */
+export function tapped(proc: NodeChildProcess.ChildProcess, fd: "stdout" | "stderr") {
+  return map.get(proc)?.[fd] ?? proc[fd]!
+}

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect" // kilocode_change - Fiber
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -548,7 +548,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const reader = yield* Effect.forkScoped( // kilocode_change - keep the fiber so trailing output can be drained
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -620,6 +620,12 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          // kilocode_change start - closing the scope interrupts the reader fiber, which can drop
+          // buffered output that arrived just before the process exited. Wait for the stream to
+          // finish (it ends once stdio closes) so fast commands do not lose their final chunks.
+          yield* Fiber.await(reader).pipe(Effect.timeout("3 seconds"), Effect.ignore)
+          // kilocode_change end
 
           return exit.kind === "exit" ? exit.code : null
         }),


### PR DESCRIPTION
## This fixes a non-deterministic test

`test/tool/shell.test.ts` intermittently fails in CI, e.g. the original run reported:

```
(fail) tool.shell > falls back from terminal-only configured shell [159.79ms]
expect(result.output).toContain("fallback")
Received: "(no output)"
```

Locally it reproduced at ~13% (2/15 runs failing) across two test cases (`falls back from terminal-only configured shell` and `captures stderr in output`), so it is a genuine timing race, not a one-off flake. The failure is non-deterministic because it depends on whether the reader fiber attaches before the process exits, which varies with scheduler load.

## Root cause

Bun's `child_process` silently discards buffered stdout/stderr once the child emits `close`. Our `CrossSpawnSpawner` attaches stream readers lazily (the Effect stream consumer runs a tick or more after spawn), so any process that exits before the reader attaches loses all of its output. A standalone repro confirms a reader attached even 5ms after spawn gets zero bytes from `echo`.

The same path serves the live shell tool, so fast commands can return `(no output)` in the real product too — the test is correctly catching that, which is why it is worth fixing rather than deleting.

## Fix

1. **`packages/core/src/kilocode/stdio-tap.ts` (new)** — `tap(proc)` pipes `proc.stdout`/`stderr` into `PassThrough` streams synchronously at spawn time, before the event loop yields. The taps buffer the data (bounded by PassThrough highWaterMark) so it survives until the lazy reader attaches. Storage uses a `WeakMap` so taps are GC'd with the process.

2. **`packages/core/src/cross-spawn-spawner.ts`** — call `tap(proc)` in the same tick as `launch(...)`, and swap `setupOutput`'s `evaluate` callbacks to read the tapped streams via `tapped(proc, "stdout"/"stderr")` (falling back to the raw stream). Four single-line `kilocode_change` markers; no signature or structural changes, to keep upstream merges trivial.

3. **`packages/opencode/src/tool/shell.ts`** — the spawner fix retains the data, but scope teardown after exit can still interrupt the reader fiber before it drains the final chunks. Keep the reader fiber and `Fiber.await` it (3s timeout, errors ignored) after the exit/abort/timeout race resolves, so trailing output is not dropped.

## Verification

- `test/tool/shell.test.ts`: 30/30 green (was ~13% failure locally: 2/15 runs failing before the fix).
- Core package: 485 pass / 0 fail.
- `test/tool/`: 310 pass / 0 fail.
- Both packages typecheck; `check-opencode-annotations.ts` clean.

This affects upstream OpenCode equally (they also run on Bun), so it is a candidate to upstream, which would let us drop the markers.