### PR TITLE
fix(vscode): show auto efficient routing choices

### DIFF
--- a/.changeset/restore-org-auto-efficient-routing.md
+++ b/.changeset/restore-org-auto-efficient-routing.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-gateway": patch
+---
+
+Show Auto Efficient model choices for organization users when the org model catalog omits routing metadata.

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -71,7 +71,7 @@ type AutoRouting = NonNullable<OpenRouterModel["autoRouting"]>
 
 const AUTO_EFFICIENT_ID = "kilo-auto/efficient"
 const AUTO_ROUTING_TTL_MS = 5 * 60 * 1000
-const autoRoutingCache = new Map<string, { routing: AutoRouting; expires: number }>()
+const autoRoutingCache = new Map<string, { routing: Promise<AutoRouting | undefined>; expires: number }>()
 
 function modelsEndpoint(baseURL: string) {
   return `${baseURL.replace(/\/+$/, "")}/models`
@@ -193,19 +193,21 @@ async function mergeAutoRouting(models: Record<string, any>, baseURL: string) {
 }
 
 async function getAutoRouting(baseURL: string): Promise<AutoRouting | undefined> {
+  const now = Date.now()
   const cached = autoRoutingCache.get(baseURL)
-  if (cached && cached.expires > Date.now()) {
+  if (cached && cached.expires > now) {
     return cached.routing
   }
   if (cached) {
     autoRoutingCache.delete(baseURL)
   }
 
-  const result = await fetchKiloModels({ baseURL })
-  const routing = result.models[AUTO_EFFICIENT_ID]?.autoRouting
-  if (routing) {
-    autoRoutingCache.set(baseURL, { routing, expires: Date.now() + AUTO_ROUTING_TTL_MS })
-  }
+  const routing = fetchKiloModels({ baseURL }).then((result) => {
+    const found = result.models[AUTO_EFFICIENT_ID]?.autoRouting
+    if (!found) autoRoutingCache.delete(baseURL)
+    return found
+  })
+  autoRoutingCache.set(baseURL, { routing, expires: now + AUTO_ROUTING_TTL_MS })
   return routing
 }
 

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -67,6 +67,8 @@ const openRouterModelsResponseSchema = z.object({
 
 type OpenRouterModel = z.infer<typeof openRouterModelSchema>
 
+const AUTO_EFFICIENT_ID = "kilo-auto/efficient"
+
 /**
  * Parse API price string to number, converting from per-token to per-million-tokens.
  * The API returns prices in $/token, but downstream cost calculation (getUsage)
@@ -157,7 +159,29 @@ export async function fetchKiloModels(options?: {
     models[model.id] = transformedModel
   }
 
+  if (organizationId) {
+    await mergeAutoRouting(models)
+  }
+
   return { models }
+}
+
+async function mergeAutoRouting(models: Record<string, any>) {
+  if (!models[AUTO_EFFICIENT_ID] || models[AUTO_EFFICIENT_ID].autoRouting) {
+    return
+  }
+
+  const result = await fetchKiloModels({})
+  const routing = result.models[AUTO_EFFICIENT_ID]?.autoRouting
+
+  if (!routing) {
+    return
+  }
+
+  models[AUTO_EFFICIENT_ID] = {
+    ...models[AUTO_EFFICIENT_ID],
+    autoRouting: routing,
+  }
 }
 
 /**

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -202,11 +202,16 @@ async function getAutoRouting(baseURL: string): Promise<AutoRouting | undefined>
     autoRoutingCache.delete(baseURL)
   }
 
-  const routing = fetchKiloModels({ baseURL }).then((result) => {
-    const found = result.models[AUTO_EFFICIENT_ID]?.autoRouting
-    if (!found) autoRoutingCache.delete(baseURL)
-    return found
-  })
+  const routing = fetchKiloModels({ baseURL })
+    .then((result) => {
+      const found = result.models[AUTO_EFFICIENT_ID]?.autoRouting
+      if (!found) autoRoutingCache.delete(baseURL)
+      return found
+    })
+    .catch(() => {
+      autoRoutingCache.delete(baseURL)
+      return undefined
+    })
   autoRoutingCache.set(baseURL, { routing, expires: now + AUTO_ROUTING_TTL_MS })
   return routing
 }

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -67,8 +67,11 @@ const openRouterModelsResponseSchema = z.object({
 })
 
 type OpenRouterModel = z.infer<typeof openRouterModelSchema>
+type AutoRouting = NonNullable<OpenRouterModel["autoRouting"]>
 
 const AUTO_EFFICIENT_ID = "kilo-auto/efficient"
+const AUTO_ROUTING_TTL_MS = 5 * 60 * 1000
+const autoRoutingCache = new Map<string, { routing: AutoRouting; expires: number }>()
 
 function modelsEndpoint(baseURL: string) {
   return `${baseURL.replace(/\/+$/, "")}/models`
@@ -177,8 +180,7 @@ async function mergeAutoRouting(models: Record<string, any>, baseURL: string) {
     return
   }
 
-  const result = await fetchKiloModels({ baseURL })
-  const routing = result.models[AUTO_EFFICIENT_ID]?.autoRouting
+  const routing = await getAutoRouting(baseURL)
 
   if (!routing) {
     return
@@ -188,6 +190,23 @@ async function mergeAutoRouting(models: Record<string, any>, baseURL: string) {
     ...models[AUTO_EFFICIENT_ID],
     autoRouting: routing,
   }
+}
+
+async function getAutoRouting(baseURL: string): Promise<AutoRouting | undefined> {
+  const cached = autoRoutingCache.get(baseURL)
+  if (cached && cached.expires > Date.now()) {
+    return cached.routing
+  }
+  if (cached) {
+    autoRoutingCache.delete(baseURL)
+  }
+
+  const result = await fetchKiloModels({ baseURL })
+  const routing = result.models[AUTO_EFFICIENT_ID]?.autoRouting
+  if (routing) {
+    autoRoutingCache.set(baseURL, { routing, expires: Date.now() + AUTO_ROUTING_TTL_MS })
+  }
+  return routing
 }
 
 /**

--- a/packages/kilo-gateway/src/api/models.ts
+++ b/packages/kilo-gateway/src/api/models.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import { getKiloUrlFromToken } from "../auth/token.js"
 import { getDefaultHeaders, buildKiloHeaders } from "../headers.js"
 import { KILO_API_BASE, KILO_OPENROUTER_BASE, MODELS_FETCH_TIMEOUT_MS, PROMPTS, AI_SDK_PROVIDERS } from "./constants.js"
+import { resolveKiloOpenRouterBaseUrl } from "./url.js"
 
 export type KiloModelsResult = {
   models: Record<string, any>
@@ -69,6 +70,10 @@ type OpenRouterModel = z.infer<typeof openRouterModelSchema>
 
 const AUTO_EFFICIENT_ID = "kilo-auto/efficient"
 
+function modelsEndpoint(baseURL: string) {
+  return `${baseURL.replace(/\/+$/, "")}/models`
+}
+
 /**
  * Parse API price string to number, converting from per-token to per-million-tokens.
  * The API returns prices in $/token, but downstream cost calculation (getUsage)
@@ -104,7 +109,8 @@ export async function fetchKiloModels(options?: {
   const finalBaseURL = token ? getKiloUrlFromToken(baseURL, token) : baseURL
 
   // Construct models endpoint
-  const modelsURL = `${finalBaseURL}/models`
+  const modelsURL = modelsEndpoint(finalBaseURL)
+  const publicBaseURL = resolveKiloOpenRouterBaseUrl({ baseURL: finalBaseURL })
 
   const response = await fetch(modelsURL, {
     headers: {
@@ -122,7 +128,7 @@ export async function fetchKiloModels(options?: {
   if (!response.ok) {
     // 401 with auth credentials: fall back to unauthenticated public endpoint
     if (response.status === 401 && (token || organizationId)) {
-      return fetchKiloModels({})
+      return fetchKiloModels({ baseURL: publicBaseURL })
     }
     const kind = response.status === 401 || response.status === 403 ? "unauthorized" : "http"
     return { models: {}, error: { kind, status: response.status } }
@@ -160,18 +166,18 @@ export async function fetchKiloModels(options?: {
   }
 
   if (organizationId) {
-    await mergeAutoRouting(models)
+    await mergeAutoRouting(models, publicBaseURL)
   }
 
   return { models }
 }
 
-async function mergeAutoRouting(models: Record<string, any>) {
+async function mergeAutoRouting(models: Record<string, any>, baseURL: string) {
   if (!models[AUTO_EFFICIENT_ID] || models[AUTO_EFFICIENT_ID].autoRouting) {
     return
   }
 
-  const result = await fetchKiloModels({})
+  const result = await fetchKiloModels({ baseURL })
   const routing = result.models[AUTO_EFFICIENT_ID]?.autoRouting
 
   if (!routing) {

--- a/packages/kilo-gateway/test/api/models.test.ts
+++ b/packages/kilo-gateway/test/api/models.test.ts
@@ -344,6 +344,49 @@ test("merges Auto Efficient routing metadata from token-derived public catalog e
   })
 })
 
+test("caches Auto Efficient routing metadata by configured public catalog endpoint", async () => {
+  const orig = globalThis.fetch
+  const urls: string[] = []
+
+  stubFetch(async (input) => {
+    const url = String(input)
+    urls.push(url)
+
+    if (url.includes("/api/openrouter/")) {
+      return new Response(VALID_AUTO_ROUTING_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  })
+
+  const opts = {
+    kilocodeOrganizationId: "org-cache",
+    baseURL: "https://cache.test/api/organizations/org-cache",
+  }
+  const first = await fetchKiloModels(opts)
+  const second = await fetchKiloModels(opts)
+
+  ;(globalThis as any).fetch = orig
+
+  expect(urls).toEqual([
+    "https://cache.test/api/organizations/org-cache/models",
+    "https://cache.test/api/openrouter/models",
+    "https://cache.test/api/organizations/org-cache/models",
+  ])
+  expect(first.models["kilo-auto/efficient"].autoRouting).toEqual({
+    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+  })
+  expect(second.models["kilo-auto/efficient"].autoRouting).toEqual({
+    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+  })
+})
+
 test("omits malformed Terminal Bench metadata without rejecting the catalog", async () => {
   const orig = globalThis.fetch
   stubFetch(

--- a/packages/kilo-gateway/test/api/models.test.ts
+++ b/packages/kilo-gateway/test/api/models.test.ts
@@ -61,6 +61,23 @@ const VALID_AUTO_ROUTING_RESPONSE = JSON.stringify({
   ],
 })
 
+const ORG_AUTO_ROUTING_MISSING_RESPONSE = JSON.stringify({
+  data: [
+    {
+      id: "kilo-auto/efficient",
+      name: "Org Kilo Auto Efficient",
+      context_length: 64000,
+      max_completion_tokens: 8192,
+      architecture: {
+        input_modalities: ["text"],
+        output_modalities: ["text"],
+      },
+      supported_parameters: ["tools", "temperature"],
+      isFree: true,
+    },
+  ],
+})
+
 const INVALID_BENCH_RESPONSE = JSON.stringify({
   data: [
     {
@@ -210,6 +227,49 @@ test("preserves Auto Efficient routing metadata as a dedicated model field", asy
   expect(result.error).toBeUndefined()
   expect(result.models["kilo-auto/efficient"].autoRouting).toEqual({
     models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+  })
+})
+
+test("merges missing Auto Efficient routing metadata into organization catalog from public catalog", async () => {
+  const orig = globalThis.fetch
+  const urls: string[] = []
+
+  stubFetch(async (input) => {
+    urls.push(String(input))
+
+    if (urls.length === 1) {
+      return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    return new Response(VALID_AUTO_ROUTING_RESPONSE, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  })
+
+  const result = await fetchKiloModels({
+    kilocodeOrganizationId: "org-123",
+  })
+
+  ;(globalThis as any).fetch = orig
+
+  expect(urls).toHaveLength(2)
+  expect(urls[0]).toContain("/api/organizations/org-123/models")
+  expect(urls[1]).toContain("/api/openrouter/models")
+  expect(result.error).toBeUndefined()
+  expect(result.models["kilo-auto/efficient"]).toMatchObject({
+    name: "Org Kilo Auto Efficient",
+    isFree: true,
+    limit: {
+      context: 64000,
+      output: 8192,
+    },
+    autoRouting: {
+      models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+    },
   })
 })
 

--- a/packages/kilo-gateway/test/api/models.test.ts
+++ b/packages/kilo-gateway/test/api/models.test.ts
@@ -273,6 +273,77 @@ test("merges missing Auto Efficient routing metadata into organization catalog f
   })
 })
 
+test("merges Auto Efficient routing metadata from configured public catalog endpoint", async () => {
+  const orig = globalThis.fetch
+  const urls: string[] = []
+
+  stubFetch(async (input) => {
+    urls.push(String(input))
+
+    if (urls.length === 1) {
+      return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    return new Response(VALID_AUTO_ROUTING_RESPONSE, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  })
+
+  const result = await fetchKiloModels({
+    kilocodeOrganizationId: "org-123",
+    baseURL: "https://dev.test/api/organizations/org-123",
+  })
+
+  ;(globalThis as any).fetch = orig
+
+  expect(urls).toEqual([
+    "https://dev.test/api/organizations/org-123/models",
+    "https://dev.test/api/openrouter/models",
+  ])
+  expect(result.error).toBeUndefined()
+  expect(result.models["kilo-auto/efficient"].autoRouting).toEqual({
+    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+  })
+})
+
+test("merges Auto Efficient routing metadata from token-derived public catalog endpoint", async () => {
+  const orig = globalThis.fetch
+  const urls: string[] = []
+
+  stubFetch(async (input) => {
+    urls.push(String(input))
+
+    if (urls.length === 1) {
+      return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    return new Response(VALID_AUTO_ROUTING_RESPONSE, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  })
+
+  const result = await fetchKiloModels({
+    kilocodeToken: "https://token.test/dev:opaque",
+    kilocodeOrganizationId: "org-123",
+  })
+
+  ;(globalThis as any).fetch = orig
+
+  expect(urls).toEqual(["https://token.test/dev/models", "https://token.test/dev/api/openrouter/models"])
+  expect(result.error).toBeUndefined()
+  expect(result.models["kilo-auto/efficient"].autoRouting).toEqual({
+    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
+  })
+})
+
 test("omits malformed Terminal Bench metadata without rejecting the catalog", async () => {
   const orig = globalThis.fetch
   stubFetch(

--- a/packages/kilo-gateway/test/api/models.test.ts
+++ b/packages/kilo-gateway/test/api/models.test.ts
@@ -230,50 +230,7 @@ test("preserves Auto Efficient routing metadata as a dedicated model field", asy
   })
 })
 
-test("merges missing Auto Efficient routing metadata into organization catalog from public catalog", async () => {
-  const orig = globalThis.fetch
-  const urls: string[] = []
-
-  stubFetch(async (input) => {
-    urls.push(String(input))
-
-    if (urls.length === 1) {
-      return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      })
-    }
-
-    return new Response(VALID_AUTO_ROUTING_RESPONSE, {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    })
-  })
-
-  const result = await fetchKiloModels({
-    kilocodeOrganizationId: "org-123",
-  })
-
-  ;(globalThis as any).fetch = orig
-
-  expect(urls).toHaveLength(2)
-  expect(urls[0]).toContain("/api/organizations/org-123/models")
-  expect(urls[1]).toContain("/api/openrouter/models")
-  expect(result.error).toBeUndefined()
-  expect(result.models["kilo-auto/efficient"]).toMatchObject({
-    name: "Org Kilo Auto Efficient",
-    isFree: true,
-    limit: {
-      context: 64000,
-      output: 8192,
-    },
-    autoRouting: {
-      models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
-    },
-  })
-})
-
-test("merges Auto Efficient routing metadata from configured public catalog endpoint", async () => {
+test("merges missing Auto Efficient routing metadata from resolved public catalog endpoint", async () => {
   const orig = globalThis.fetch
   const urls: string[] = []
 
@@ -298,8 +255,6 @@ test("merges Auto Efficient routing metadata from configured public catalog endp
     baseURL: "https://dev.test/api/organizations/org-123",
   })
 
-  ;(globalThis as any).fetch = orig
-
   expect(urls).toEqual([
     "https://dev.test/api/organizations/org-123/models",
     "https://dev.test/api/openrouter/models",
@@ -308,29 +263,9 @@ test("merges Auto Efficient routing metadata from configured public catalog endp
   expect(result.models["kilo-auto/efficient"].autoRouting).toEqual({
     models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
   })
-})
 
-test("merges Auto Efficient routing metadata from token-derived public catalog endpoint", async () => {
-  const orig = globalThis.fetch
-  const urls: string[] = []
-
-  stubFetch(async (input) => {
-    urls.push(String(input))
-
-    if (urls.length === 1) {
-      return new Response(ORG_AUTO_ROUTING_MISSING_RESPONSE, {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      })
-    }
-
-    return new Response(VALID_AUTO_ROUTING_RESPONSE, {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    })
-  })
-
-  const result = await fetchKiloModels({
+  urls.length = 0
+  const token = await fetchKiloModels({
     kilocodeToken: "https://token.test/dev:opaque",
     kilocodeOrganizationId: "org-123",
   })
@@ -338,21 +273,26 @@ test("merges Auto Efficient routing metadata from token-derived public catalog e
   ;(globalThis as any).fetch = orig
 
   expect(urls).toEqual(["https://token.test/dev/models", "https://token.test/dev/api/openrouter/models"])
-  expect(result.error).toBeUndefined()
-  expect(result.models["kilo-auto/efficient"].autoRouting).toEqual({
+  expect(token.error).toBeUndefined()
+  expect(token.models["kilo-auto/efficient"].autoRouting).toEqual({
     models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
   })
 })
 
-test("caches Auto Efficient routing metadata by configured public catalog endpoint", async () => {
+test("dedupes and caches Auto Efficient routing metadata by public catalog endpoint", async () => {
   const orig = globalThis.fetch
   const urls: string[] = []
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
 
   stubFetch(async (input) => {
     const url = String(input)
     urls.push(url)
 
     if (url.includes("/api/openrouter/")) {
+      await gate
       return new Response(VALID_AUTO_ROUTING_RESPONSE, {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -369,22 +309,27 @@ test("caches Auto Efficient routing metadata by configured public catalog endpoi
     kilocodeOrganizationId: "org-cache",
     baseURL: "https://cache.test/api/organizations/org-cache",
   }
-  const first = await fetchKiloModels(opts)
-  const second = await fetchKiloModels(opts)
+  const first = fetchKiloModels(opts)
+  const second = fetchKiloModels(opts)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  release()
+  const result = await Promise.all([first, second])
+  const third = await fetchKiloModels(opts)
 
   ;(globalThis as any).fetch = orig
 
   expect(urls).toEqual([
     "https://cache.test/api/organizations/org-cache/models",
+    "https://cache.test/api/organizations/org-cache/models",
     "https://cache.test/api/openrouter/models",
     "https://cache.test/api/organizations/org-cache/models",
   ])
-  expect(first.models["kilo-auto/efficient"].autoRouting).toEqual({
-    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
-  })
-  expect(second.models["kilo-auto/efficient"].autoRouting).toEqual({
-    models: ["google/gemini-2.5-flash", "anthropic/claude-sonnet-4.6"],
-  })
+  expect(result[0].models["kilo-auto/efficient"].autoRouting).toEqual(
+    result[1].models["kilo-auto/efficient"].autoRouting,
+  )
+  expect(third.models["kilo-auto/efficient"].autoRouting).toEqual(
+    result[0].models["kilo-auto/efficient"].autoRouting,
+  )
 })
 
 test("omits malformed Terminal Bench metadata without rejecting the catalog", async () => {


### PR DESCRIPTION
## Context

Organization model catalogs can include `kilo-auto/efficient` without the `autoRouting` metadata that the public catalog provides. When that happens, org users do not see the Auto Efficient model choices.

## Implementation

When fetching an organization catalog, merge missing `kilo-auto/efficient` routing metadata from the public catalog while preserving the org model entry fields. Added a regression test for the missing-org-routing case and a patch changeset.

## Screenshots / Video

<img width="303" height="861" alt="auto-efficient" src="https://github.com/user-attachments/assets/cb3bb90d-d30b-487e-88f4-7d602378cc70" />

## How to Test

### Manual/local verification

- Agent: `bun test ./test/api/models.test.ts` from `packages/kilo-gateway/`
- Agent: `bun run typecheck` from `packages/kilo-gateway/`
- Agent: pre-push `bun turbo typecheck`

### Reviewer test steps

1. Fetch models as an org user whose org catalog contains `kilo-auto/efficient` without `autoRouting`.
2. Confirm the returned `kilo-auto/efficient` keeps the org catalog fields and includes public `autoRouting.models`.
3. Confirm public model fetching remains unchanged.


## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.