### PR TITLE
fix(vscode): remove balance chip from session header

### DIFF
--- a/.changeset/remove-balance-session-chip.md
+++ b/.changeset/remove-balance-session-chip.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the balance chip from the session header.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -22,7 +22,6 @@ import { ContextProgress } from "./ContextProgress"
 import { TaskUsage } from "./TaskUsage"
 import { hasModelUsage, tokenSummary } from "../../context/model-usage"
 import { SessionRenameEditor } from "../shared/SessionRenameEditor"
-import { BalanceChip } from "../shared/BalanceChip"
 import { target as todoTarget } from "../../context/todo-revert"
 import type { Part, TodoItem, ExtensionMessage } from "../../types/messages"
 
@@ -185,7 +184,6 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
           </Show>
         </div>
         <div data-slot="task-header-stats">
-          <BalanceChip />
           <Show when={cost()}>
             {(c) => (
               <Tooltip value={costTooltip()} placement="bottom">


### PR DESCRIPTION
## Context

Remove the balance chip from the session header so the header only shows session-specific usage stats.

## Implementation

Removed the `BalanceChip` import and render from `TaskHeader`. Added a patch changeset for the visible VS Code extension change.

## Screenshots / Video

<img width="448" height="831" alt="Screenshot 2026-07-03 at 15 03 04" src="https://github.com/user-attachments/assets/cbdd939d-4c54-4ead-a183-b23bfd37a4d0" />

## How to Test

### Manual/local verification

- Codex ran `bun run format` from `packages/kilo-vscode/`.
- Codex ran `bun run typecheck` from `packages/kilo-vscode/`.
- Codex ran `bun run lint` from `packages/kilo-vscode/`.
- Pre-push hook ran `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains` successfully.

### Reviewer test steps

1. Open a Kilo session in the VS Code extension.
2. Confirm the session header no longer shows the balance chip.
3. Confirm cost/model usage stats still render when available.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

