### PR TITLE
fix(cli): deny subagent permission prompts

### DIFF
--- a/.changeset/subagent-permission-asks.md
+++ b/.changeset/subagent-permission-asks.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fail subagent permission prompts immediately instead of waiting for unavailable user input.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -176,6 +176,7 @@ export namespace KiloSessionPrompt {
       ...input.request,
       ruleset: Permission.merge(agent.permission, guardPermissions({ agent, session })),
       hardRuleset: hardPermissions({ agent }),
+      nonInteractive: agent.mode === "subagent",
     })
   })
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -120,6 +120,7 @@ export const AskInput = Schema.Struct({
   id: Schema.optional(PermissionID),
   ruleset: Ruleset,
   hardRuleset: Schema.optional(Ruleset), // kilocode_change
+  nonInteractive: Schema.optional(Schema.Boolean), // kilocode_change
 }).annotate({ identifier: "PermissionAskInput" })
 export type AskInput = Schema.Schema.Type<typeof AskInput>
 
@@ -245,7 +246,7 @@ export const layer = Layer.effect(
     const ask = Effect.fn("Permission.ask")(function* (input: AskInput) {
       const { approved, pending } = yield* InstanceState.get(state)
       // kilocode_change start
-      const { ruleset, hardRuleset, ...request } = input
+      const { ruleset, hardRuleset, nonInteractive, ...request } = input
       const s = yield* InstanceState.get(state)
       const local = s.session[request.sessionID] ?? []
       // kilocode_change end
@@ -275,6 +276,12 @@ export const layer = Layer.effect(
       }
 
       if (!needsAsk) return
+
+      // kilocode_change start - subagents cannot answer permission prompts
+      if (nonInteractive) {
+        return yield* new DeniedError({ ruleset: subset(request.permission, ruleset) })
+      }
+      // kilocode_change end
 
       const id = request.id ?? PermissionID.ascending()
       const info: Request = {

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -12,6 +12,7 @@ import { Bus } from "../../src/bus"
 import { Command } from "../../src/command"
 import { Config } from "../../src/config/config"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Env } from "../../src/env"
 import { Format } from "../../src/format"
@@ -288,5 +289,40 @@ it.live("active tool calls use permissions changed after model streaming starts"
         permission: { edit: "ask" },
       }),
     },
+  ),
+)
+
+it.live("subagent permission asks fail instead of waiting for a human reply", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const permission = yield* Permission.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Parent" })
+      const agent = {
+        name: "general",
+        mode: "subagent" as const,
+        permission: Permission.fromConfig({ bash: "ask" }),
+        options: {},
+      }
+
+      const err = yield* KiloSessionPrompt.askPermission({
+        permission,
+        agents: { get: () => Effect.succeed(agent) },
+        sessions,
+        agent,
+        session: chat,
+        request: {
+          sessionID: chat.id,
+          permission: "bash",
+          patterns: ["echo 1"],
+          always: ["echo 1"],
+          metadata: {},
+        },
+      }).pipe(Effect.flip)
+
+      expect(err).toBeInstanceOf(Permission.DeniedError)
+      expect(yield* permission.list()).toEqual([])
+    }),
+    { git: true },
   ),
 )


### PR DESCRIPTION
Fixes #11903

## Summary
- mark subagent permission asks as non-interactive
- make non-interactive permission asks fail immediately with `PermissionDeniedError` instead of queuing a prompt
- add regression coverage that a subagent `bash: ask` request leaves no pending permission ask

## Tests run
- `bun install`
- `bun test ./test/kilocode/session-prompt-permission-refresh.test.ts -t "subagent permission asks fail"`
- `bun run typecheck` from `packages/opencode`
- `bun run script/check-opencode-annotations.ts`
- `git diff --check`

## Notes / risk
- Running the whole `session-prompt-permission-refresh.test.ts` file on this Windows D-drive sparse checkout timed out in the pre-existing `active tool calls use permissions changed after model streaming starts` test after 5s; the new regression passed when run by name.
- Behavior change is limited to permission asks that would otherwise wait for a non-interactive subagent.