### PR TITLE
feat(vscode): support bidirectional prompt input

### DIFF
--- a/.changeset/add-prompt-input-bidirectional-support.md
+++ b/.changeset/add-prompt-input-bidirectional-support.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support bidirectional text in the prompt input.

--- a/packages/kilo-vscode/tests/unit/prompt-input-bidirectional.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-bidirectional.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const path = join(__dirname, "..", "..", "webview-ui", "src", "components", "chat", "PromptInput.tsx")
+const src = readFileSync(path, "utf8")
+
+describe("PromptInput bidirectional text support", () => {
+  it("lets the textarea and visible overlay resolve text direction automatically", () => {
+    const overlay = src.match(/<div class="prompt-input-highlight-overlay"[\s\S]*?>/)?.[0]
+    const input = src.match(/<textarea[\s\S]*?\n\s*\/>/)?.[0]
+
+    expect(overlay).toContain('dir="auto"')
+    expect(input).toContain('class="prompt-input"')
+    expect(input).toContain('dir="auto"')
+  })
+})

--- a/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
@@ -5,6 +5,34 @@ import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/type
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+function textarea(value: string, cursor: number, dir: "ltr" | "rtl") {
+  const state = { cursor }
+  return {
+    value,
+    get selectionStart() {
+      return state.cursor
+    },
+    get selectionEnd() {
+      return state.cursor
+    },
+    matches: (selector: string) => selector === `:dir(${dir})`,
+    setSelectionRange: (start: number) => {
+      state.cursor = start
+    },
+  } as unknown as HTMLTextAreaElement
+}
+
+function key(key: "ArrowLeft" | "ArrowRight") {
+  const state = { prevented: 0 }
+  return {
+    state,
+    event: {
+      key,
+      preventDefault: () => state.prevented++,
+    } as unknown as KeyboardEvent,
+  }
+}
+
 describe("useFileMention", () => {
   it("keeps previous file results visible while the next search is pending", async () => {
     const posted: WebviewMessage[] = []
@@ -183,6 +211,64 @@ describe("useFileMention", () => {
     mention.onInput("@gi", 3)
 
     expect(mention.mentionResults()).toEqual([{ type: "file", value: "src/git.ts" }])
+
+    dispose.fn?.()
+  })
+
+  it("keeps mention block arrow navigation aligned with left-to-right prompt direction", async () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    const text = "See @src/main.ts now"
+    mention.addPaths(["src/main.ts"], "/repo")
+
+    const right = key("ArrowRight")
+    const input = textarea(text, "See ".length, "ltr")
+    expect(mention.handleArrowKey(right.event, input)).toBe(true)
+    expect(input.selectionStart).toBe("See @src/main.ts".length)
+    expect(right.state.prevented).toBe(1)
+
+    const left = key("ArrowLeft")
+    expect(mention.handleArrowKey(left.event, input)).toBe(true)
+    expect(input.selectionStart).toBe("See ".length)
+    expect(left.state.prevented).toBe(1)
+
+    dispose.fn?.()
+  })
+
+  it("keeps mention block arrow navigation aligned for right-to-left languages", async () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    const text = "فایل @src/main.ts را ببین"
+    mention.addPaths(["src/main.ts"], "/repo")
+
+    const left = key("ArrowLeft")
+    const input = textarea(text, "فایل ".length, "rtl")
+    expect(mention.handleArrowKey(left.event, input)).toBe(true)
+    expect(input.selectionStart).toBe("فایل @src/main.ts".length)
+    expect(left.state.prevented).toBe(1)
+
+    const right = key("ArrowRight")
+    expect(mention.handleArrowKey(right.event, input)).toBe(true)
+    expect(input.selectionStart).toBe("فایل ".length)
+    expect(right.state.prevented).toBe(1)
 
     dispose.fn?.()
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1186,7 +1186,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       </Show>
       <div class="prompt-input-wrapper">
         <div class="prompt-input-ghost-wrapper">
-          <div class="prompt-input-highlight-overlay" ref={highlightRef} aria-hidden="true">
+          <div class="prompt-input-highlight-overlay" ref={highlightRef} aria-hidden="true" dir="auto">
             <Index each={buildHighlightSegments(text(), highlightMentions())}>
               {(seg) => (
                 <Show when={seg().highlight} fallback={<span>{seg().text}</span>}>
@@ -1236,6 +1236,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             aria-disabled={isDisabled()}
             aria-describedby={props.blockedReason?.() ? blockedHelpId() : undefined}
             rows={1}
+            dir="auto"
           />
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -15,6 +15,12 @@ import {
 
 const FILE_SEARCH_DEBOUNCE_MS = 150
 
+const rtl = (textarea: HTMLTextAreaElement): boolean => {
+  if (textarea.matches(":dir(rtl)")) return true
+  if (textarea.matches(":dir(ltr)")) return false
+  return getComputedStyle(textarea).direction === "rtl"
+}
+
 interface VSCodeContext {
   postMessage: (message: WebviewMessage) => void
   onMessage: (handler: (message: ExtensionMessage) => void) => () => void
@@ -280,13 +286,14 @@ export function useFileMention(
     // Only when there's no active selection
     if (textarea.selectionStart !== textarea.selectionEnd) return false
 
+    const forward = e.key === (rtl(textarea) ? "ArrowLeft" : "ArrowRight")
     // Check where the cursor WOULD land after the native move
-    const next = e.key === "ArrowRight" ? cursor + 1 : cursor - 1
+    const next = forward ? cursor + 1 : cursor - 1
     const range = findMentionRange(textarea.value, next, mentionedPaths())
     if (!range) return false
 
     e.preventDefault()
-    const pos = e.key === "ArrowRight" ? range.end : range.start
+    const pos = forward ? range.end : range.start
     textarea.setSelectionRange(pos, pos)
     return true
   }


### PR DESCRIPTION
## Issue

Using right-to-left languages in the prompt input is difficult because the input does not resolve text direction from the prompt content. Right-to-left prompts that include left-to-right content such as file paths, code, URLs, or mentions can appear in the wrong visual/logical order, making them hard to read, navigate, and edit.

## Context

Add bidirectional text support to the VS Code prompt input.

The prompt can contain right-to-left languages mixed with left-to-right content such as file paths, code, URLs, and file mentions. The prompt input also has two visual layers: the real textarea and the overlay that renders highlighted mentions / ghost text. Both layers need to resolve direction the same way so mixed-direction prompts render and edit correctly.

## Implementation

The textarea and highlight overlay now use `dir="auto"` so the browser resolves the base direction from the prompt text and applies bidirectional text layout consistently across both layers.

This also required updating file-mention arrow navigation. Previously `handleArrowKey` assumed `ArrowRight` always moved forward through the textarea value and `ArrowLeft` always moved backward. That was correct before bidirectional prompt support, but right-to-left text reverses the visual meaning of horizontal arrow keys. The mention-skip logic now checks the textarea’s resolved direction before deciding which side of an atomic mention block to jump to.

## Screenshots

| before | after |
|---|---|
| <img width="970" height="224" alt="before" src="https://github.com/user-attachments/assets/4d8a70a2-24c7-402b-ab3c-aaa7f85a35d9" /> | <img width="970" height="224" alt="after" src="https://github.com/user-attachments/assets/b7dc07ad-708b-40d3-b642-57e1c7fbca27" /> |

## How to Test

### Manual/local verification

- Ran focused unit tests for bidirectional prompt support and mention arrow navigation.
- Ran lint on the touched hook and test files.
- Manually built the extension and exercised the prompt input with right-to-left, left-to-right, and mixed-direction content, both with and without file mentions; confirmed rendering, editing, and mention navigation work correctly.
- Pushed branch and the pre-push typecheck hook completed successfully.

### Reviewer test steps

1. Open the Kilo VS Code extension webview.
2. Type a prompt in a right-to-left language, optionally mixed with file paths or code.
3. Confirm the prompt text direction resolves naturally.
4. Add a file mention in the prompt.
5. Move the caret across the mention with left/right arrow keys.
6. Confirm the caret skips over the mention block in the expected visual direction.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
