### PR TITLE
fix(vscode): improve question option contrast

### DIFF
--- a/.changeset/fix-question-option-contrast.md
+++ b/.changeset/fix-question-option-contrast.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Improve question option visibility in light VS Code themes.

--- a/packages/kilo-vscode/webview-ui/src/styles/question-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/question-dock.css
@@ -211,7 +211,7 @@
     height: 14px;
     padding: 1px;
     border-radius: var(--radius-sm);
-    border: 1px solid var(--border-base);
+    border: 1px solid var(--vscode-button-background);
     display: inline-flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## What changed

Use VS Code's `button.background` theme color for QuestionDock option borders so radio and checkbox controls remain visible in low-contrast light themes such as Eva Light.

## Why

The previous generic border token can blend into the background in some light themes, making unselected option controls difficult to locate. The button background token provides a theme-defined, visible accent while preserving selected, focus, and high-contrast behavior.

## Validation

- `bun run format` (`packages/kilo-vscode`)
- `bun run typecheck` (`packages/kilo-vscode`)
- `bun run lint` (`packages/kilo-vscode`)
- `bun test tests/unit/question-dock-contract.test.ts` (5 passed)
- `bun run build-storybook` (`packages/kilo-vscode`)
- pre-push cross-package typecheck (19 passed)

The full VS Code unit suite completed 3024/3025 tests; the unrelated existing `WorktreeManager.resolveStartPoint` test expected `remote` but received `local-tracking`.

Fixes #11794