### PR TITLE
fix(agent-manager): apply reasoning-variant and mode picks in worktree dialog

### DIFF
--- a/.changeset/fix-worktree-reasoning-selector.md
+++ b/.changeset/fix-worktree-reasoning-selector.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the reasoning-variant (and mode) picker in the New Worktree dialog so selecting a variant actually applies. The pickers portaled their popover to the page body, where the dialog's modal overlay intercepted pointer events and swallowed the click before the option handler ran. Render the popovers inline (`portal={false}`), matching the model picker already fixed for the same reason.

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -474,7 +474,13 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
               <div class="prompt-input-hint">
                 <div class="prompt-input-hint-selectors">
                   <Show when={session.agents().length > 1}>
-                    <ModeSwitcherBase agents={session.agents()} value={agent()} onSelect={setAgent} deferDismiss />
+                    <ModeSwitcherBase
+                      agents={session.agents()}
+                      value={agent()}
+                      onSelect={setAgent}
+                      portal={false}
+                      deferDismiss
+                    />
                   </Show>
                   <Show when={!compareMode()}>
                     <ModelSelectorBase
@@ -490,6 +496,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                       variants={variants()}
                       value={effectiveVariant()}
                       onSelect={setVariant}
+                      portal={false}
                       deferDismiss
                     />
                     <Show when={overridden()}>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -35,6 +35,8 @@ export interface ModeSwitcherBaseProps {
   value: string
   /** Called when the user picks an agent */
   onSelect: (name: string) => void
+  /** Render inline instead of through a portal when nested in a dialog. */
+  portal?: boolean
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
 }
@@ -124,6 +126,7 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
         expanded={false}
         placement="top-start"
         minHeight={100}
+        portal={props.portal}
         deferDismiss={props.deferDismiss}
         open={open()}
         onOpenChange={onOpen}

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -32,6 +32,8 @@ export interface ThinkingSelectorBaseProps {
   clearLabel?: string
   /** Popover placement — defaults to top-start. */
   placement?: "top-start" | "bottom-start" | "bottom-end" | "top-end"
+  /** Render inline instead of through a portal when nested in a dialog. */
+  portal?: boolean
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
   /** Listen for the global prompt trigger event. Defaults to true. */
@@ -138,6 +140,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
         placement={props.placement ?? "top-start"}
         preferredWidth={180}
         minHeight={100}
+        portal={props.portal}
         deferDismiss={props.deferDismiss}
         open={open()}
         onOpenChange={onOpen}


### PR DESCRIPTION
## Problem

Selecting a reasoning variant (or mode) in the New Worktree dialog did nothing — the trigger label reverted to the previous value and the chosen variant never reached the created sessions.

## Root cause

The New Worktree dialog renders a full-screen modal overlay (`data-component="dialog-overlay"`, z-index 50, `pointer-events: auto`) behind its content. The reasoning-variant (`ThinkingSelector`) and mode (`ModeSwitcher`) pickers portaled their popover content to `<body>`, placing it **outside** the dialog content and therefore **under** the overlay. A real pointer click on an option hit the overlay first, which:

1. Dismissed the popover via outside-pointerdown handling
2. Never fired the option's `onClick`

so the selection did not apply. JS `.click()` (which bypasses hit-testing) worked, which is why the bug was easy to miss on inspection.

The model picker was unaffected because it already rendered inline via `portal={false}` (added in 09f0156bfc for the same class of click interception). The sidebar prompt was unaffected because it has no modal overlay.

## Fix

Forward a `portal` prop through `ThinkingSelectorBase` and `ModeSwitcherBase` (mirroring `ModelSelectorBase`) and pass `portal={false}` from `NewWorktreeDialog` so all three pickers render their popovers inline within the dialog content, above the overlay.

## Validation

Reproduced live in the isolated VS Code self-test harness before and after the fix:

- **Before:** opening the dialog and clicking a variant option via a real pointer timed out with `dialog-overlay ... intercepts pointer events`; the trigger label stayed unchanged.
- **After:** the popover nests inside `[dialog]` and clicking a variant applies in both directions (Instant <-> Thinking) with no console errors.

Automated checks: extension `bun run lint`, `bun run typecheck`, `bun run knip` clean; worktree dialog unit tests pass (11/11).