### PR TITLE
fix(opencode): preserve json config keys

### DIFF
--- a/.changeset/quiet-configs-preserve.md
+++ b/.changeset/quiet-configs-preserve.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve unknown nested keys when saving plain JSON config files.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -481,7 +481,15 @@ function globalConfigFile() {
 
 function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
   if (!isRecord(patch)) {
-    const edits = modify(input, path, patch === null ? undefined : patch, {
+    // kilocode_change start - deleting an absent JSONC node is a no-op.
+    const value = patch === null ? undefined : patch
+    if (value === undefined && path.length > 0) {
+      const tree = parseTree(input)
+      const node = tree ? findNodeAtLocation(tree, path) : undefined
+      if (node === undefined) return input
+    }
+    // kilocode_change end
+    const edits = modify(input, path, value, {
       // kilocode_change
       formattingOptions: {
         insertSpaces: true,
@@ -1169,21 +1177,12 @@ export const layer = Layer.effect(
       const before = (yield* readConfigFile(file)) ?? "{}"
       const patch = writableGlobal(config)
 
-      let next: Info
-      let changed: boolean
-      if (!file.endsWith(".jsonc")) {
-        const existing = ConfigParse.schema(Info, ConfigParse.jsonc(before, file), file)
-        const merged = KilocodeConfig.mergeConfig(writable(existing), patch) // kilocode_change
-        const serialized = JSON.stringify(merged, null, 2)
-        changed = serialized !== before
-        if (changed) yield* fs.writeFileString(file, serialized).pipe(Effect.orDie)
-        next = merged
-      } else {
-        const updated = patchJsonc(before, patch)
-        next = ConfigParse.schema(Info, ConfigParse.jsonc(updated, file), file)
-        changed = updated !== before
-        if (changed) yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
-      }
+      // kilocode_change start - patch plain JSON with the same JSONC-aware path so nested unknown keys survive saves.
+      const updated = patchJsonc(before, patch)
+      const next = ConfigParse.schema(Info, ConfigParse.jsonc(updated, file), file)
+      const changed = updated !== before
+      if (changed) yield* fs.writeFileString(file, updated).pipe(Effect.orDie)
+      // kilocode_change end
 
       // kilocode_change start - skip dispose when caller opts out
       if (!dispose) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -503,13 +503,13 @@ function patchJsonc(input: string, patch: unknown, path: string[] = []): string 
   // scalar (e.g. permission.bash is "ask" as a string), jsonc-parser cannot
   // add child keys to it. Detect this case and replace the whole node with
   // the patch object in a single modify() call instead of recursing.
-  // For permission keys, promote the scalar to { "*": scalarValue } so the
+  // For permission paths, promote the scalar to { "*": scalarValue } so the
   // wildcard default is preserved. For other keys, replace directly.
   if (path.length > 0) {
     const tree = parseTree(input)
     const node = tree && findNodeAtLocation(tree, path)
     if (node && node.type !== "object") {
-      const isPermissionKey = path[0] === "permission" && path.length === 2
+      const isPermissionKey = path[0] === "permission"
       const replacement = isPermissionKey ? { "*": node.value, ...patch } : patch
       const edits = modify(input, path, replacement, {
         formattingOptions: { insertSpaces: true, tabSize: 2 },
@@ -519,7 +519,25 @@ function patchJsonc(input: string, patch: unknown, path: string[] = []): string 
   }
   // kilocode_change end
 
-  return Object.entries(patch).reduce((result, [key, value]) => patchJsonc(result, value, [...path, key]), input)
+  // kilocode_change start - remove a parent only when this patch empties it,
+  // matching stripNulls without touching unrelated preserved objects.
+  const tree = path.length > 0 ? parseTree(input) : undefined
+  const node = tree ? findNodeAtLocation(tree, path) : undefined
+  const populated = node?.type === "object" && !!node.children?.length
+  const updated = Object.entries(patch).reduce(
+    (result, [key, value]) => patchJsonc(result, value, [...path, key]),
+    input,
+  )
+  if (!populated) return updated
+
+  const next = parseTree(updated)
+  const current = next ? findNodeAtLocation(next, path) : undefined
+  if (current?.type !== "object" || current.children?.length) return updated
+  const edits = modify(updated, path, undefined, {
+    formattingOptions: { insertSpaces: true, tabSize: 2 },
+  })
+  return applyEdits(updated, edits)
+  // kilocode_change end
 }
 
 function writable(info: Info) {

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -94,17 +94,9 @@ export namespace KilocodeConfig {
     const before = source ?? "{}"
     const patch = input.writable(input.config)
 
-    if (file.endsWith(".jsonc")) {
-      if (source === undefined && Object.keys(mergeConfig({}, patch)).length === 0) return
-      const updated = input.patch(before, patch)
-      yield* input.fs.writeWithDirs(file, updated).pipe(Effect.orDie)
-      return
-    }
-
-    const existing = input.parse(before, file)
-    const merged = mergeConfig(input.writable(existing), patch)
-    if (source === undefined && Object.keys(merged).length === 0) return
-    yield* input.fs.writeWithDirs(file, JSON.stringify(merged, null, 2)).pipe(Effect.orDie)
+    if (source === undefined && Object.keys(mergeConfig({}, patch)).length === 0) return
+    const updated = input.patch(before, patch)
+    yield* input.fs.writeWithDirs(file, updated).pipe(Effect.orDie)
   })
 
   export function scopeIndexing(info: Config.Info, scope: "global" | "local"): Config.Info {

--- a/packages/opencode/test/kilocode/project-config-update.test.ts
+++ b/packages/opencode/test/kilocode/project-config-update.test.ts
@@ -66,6 +66,10 @@ const clear = () =>
 type Saved = {
   snapshot?: boolean
   username?: string
+  provider?: Record<string, unknown>
+  future?: {
+    nested?: string
+  }
   indexing?: {
     provider?: string
     openai?: {
@@ -222,6 +226,50 @@ test("project config update deletes present permission in plain json", async () 
       const saved = await readConfig(tmp.path)
       expect(saved.username).toBe("alice")
       expect(saved.permission?.["*"]).toEqual({ bash: "ask" })
+    },
+  })
+})
+
+test("project config update preserves root permission shorthand during a granular update", async () => {
+  await using tmp = await tmpdir()
+  await writeConfig(tmp.path, { permission: "deny" })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      await save({ permission: { bash: { "npm *": "allow" } } } as Config.Info)
+
+      const saved = await readConfig(tmp.path)
+      expect(saved.permission).toEqual({
+        "*": "deny",
+        bash: { "npm *": "allow" },
+      })
+    },
+  })
+})
+
+test("project config update prunes the final custom provider and preserves adjacent unknown config", async () => {
+  await using tmp = await tmpdir()
+  await writeConfig(tmp.path, {
+    provider: {
+      custom: {
+        name: "Custom Provider",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    },
+    future: {
+      nested: "keep",
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      await save({ provider: { custom: null } } as Config.Info)
+
+      const saved = await readConfig(tmp.path)
+      expect(saved.provider).toBeUndefined()
+      expect(saved.future).toEqual({ nested: "keep" })
     },
   })
 })

--- a/packages/opencode/test/kilocode/project-config-update.test.ts
+++ b/packages/opencode/test/kilocode/project-config-update.test.ts
@@ -5,6 +5,7 @@ import fs from "fs/promises"
 import path from "path"
 import { Effect, Layer, Option } from "effect"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { Global } from "@opencode-ai/core/global"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { Config } from "../../src/config/config"
@@ -17,7 +18,7 @@ import { provideTestInstance } from "../fixture/fixture"
 import { Filesystem } from "../../src/util/filesystem"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { HttpClient } from "effect/unstable/http"
-import { tmpdir } from "../fixture/fixture"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 
 const infra = CrossSpawnSpawner.defaultLayer.pipe(
   Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)),
@@ -57,9 +58,55 @@ const layer = Config.layer.pipe(
 const load = () => Effect.runPromise(Config.Service.use((svc) => svc.get()).pipe(Effect.scoped, Effect.provide(layer)))
 const save = (config: Config.Info) =>
   Effect.runPromise(Config.Service.use((svc) => svc.update(config)).pipe(Effect.scoped, Effect.provide(layer)))
+const saveGlobal = (config: Config.Info) =>
+  Effect.runPromise(Config.Service.use((svc) => svc.updateGlobal(config)).pipe(Effect.scoped, Effect.provide(layer)))
+const clear = () =>
+  Effect.runPromise(Config.Service.use((svc) => svc.invalidate()).pipe(Effect.scoped, Effect.provide(layer)))
+
+type Saved = {
+  snapshot?: boolean
+  username?: string
+  indexing?: {
+    provider?: string
+    openai?: {
+      apiKey?: string
+      model?: string
+    }
+    lancedb?: {
+      directory?: string
+      apiKey?: string
+    }
+  }
+  permission?: Record<string, string | Record<string, string>>
+}
 
 async function writeConfig(dir: string, config: unknown) {
   await Filesystem.write(path.join(dir, "kilo.json"), JSON.stringify(config, null, 2))
+}
+
+async function readConfig(dir: string) {
+  return Filesystem.readJson<Saved>(path.join(dir, "kilo.json"))
+}
+
+function cleared(): Config.Info {
+  return { permission: { "*": { "*": null } } } as unknown as Config.Info
+}
+
+function canary(): Saved {
+  return {
+    username: "alice",
+    indexing: {
+      provider: "openai",
+      openai: {
+        apiKey: "test-openai-key",
+        model: "text-embedding-3-large",
+      },
+      lancedb: {
+        directory: ".kilo/index",
+        apiKey: "test-lancedb-key",
+      },
+    },
+  }
 }
 
 test("project config update creates .kilo/kilo.jsonc and reloads it", async () => {
@@ -126,4 +173,145 @@ test("project config update patches ancestor .kilo/kilo.json from nested directo
       await expect(fs.access(path.join(child, ".kilo", "kilo.json"))).rejects.toThrow()
     },
   })
+})
+
+test("project config update preserves nested unmodeled keys in plain json", async () => {
+  await using tmp = await tmpdir()
+  await writeConfig(tmp.path, canary())
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      await save({ snapshot: false })
+
+      const saved = await Filesystem.readJson<Saved>(path.join(tmp.path, "kilo.json"))
+      expect(saved.snapshot).toBe(false)
+      expect(saved.indexing?.openai?.apiKey).toBe("test-openai-key")
+      expect(saved.indexing?.openai?.model).toBe("text-embedding-3-large")
+      expect(saved.indexing?.lancedb?.directory).toBe(".kilo/index")
+      expect(saved.indexing?.lancedb?.apiKey).toBe("test-lancedb-key")
+    },
+  })
+})
+
+test("project config update ignores absent permission clear in plain json", async () => {
+  await using tmp = await tmpdir()
+  await writeConfig(tmp.path, { username: "alice" })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      await save(cleared())
+
+      const saved = await readConfig(tmp.path)
+      expect(saved.username).toBe("alice")
+      expect(saved.permission).toBeUndefined()
+    },
+  })
+})
+
+test("project config update deletes present permission in plain json", async () => {
+  await using tmp = await tmpdir()
+  await writeConfig(tmp.path, { username: "alice", permission: { "*": { "*": "allow", bash: "ask" } } })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      await save(cleared())
+
+      const saved = await readConfig(tmp.path)
+      expect(saved.username).toBe("alice")
+      expect(saved.permission?.["*"]).toEqual({ bash: "ask" })
+    },
+  })
+})
+
+test.serial("global config update preserves nested unmodeled keys in plain json", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear()
+  await disposeAllInstances()
+
+  try {
+    await writeConfig(globalTmp.path, canary())
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        await saveGlobal({ snapshot: false })
+
+        const saved = await Filesystem.readJson<Saved>(path.join(globalTmp.path, "kilo.json"))
+        expect(saved.snapshot).toBe(false)
+        expect(saved.indexing?.openai?.apiKey).toBe("test-openai-key")
+        expect(saved.indexing?.openai?.model).toBe("text-embedding-3-large")
+        expect(saved.indexing?.lancedb?.directory).toBe(".kilo/index")
+        expect(saved.indexing?.lancedb?.apiKey).toBe("test-lancedb-key")
+      },
+    })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+    await disposeAllInstances()
+  }
+})
+
+test.serial("global config update ignores absent permission clear in plain json", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear()
+  await disposeAllInstances()
+
+  try {
+    await writeConfig(globalTmp.path, { username: "alice" })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        await saveGlobal(cleared())
+
+        const saved = await readConfig(globalTmp.path)
+        expect(saved.username).toBe("alice")
+        expect(saved.permission).toBeUndefined()
+      },
+    })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+    await disposeAllInstances()
+  }
+})
+
+test.serial("global config update deletes present permission in plain json", async () => {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir()
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear()
+  await disposeAllInstances()
+
+  try {
+    await writeConfig(globalTmp.path, { username: "alice", permission: { "*": { "*": "allow", bash: "ask" } } })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        await saveGlobal(cleared())
+
+        const saved = await readConfig(globalTmp.path)
+        expect(saved.username).toBe("alice")
+        expect(saved.permission?.["*"]).toEqual({ bash: "ask" })
+      },
+    })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+    await disposeAllInstances()
+  }
 })


### PR DESCRIPTION
## Issue

Fixes #11847

## Context

Plain `.json` config saves could drop nested settings that load successfully but are not modeled by the typed config schema. That affected canary settings like `indexing.openai.model` and `indexing.lancedb.apiKey` when an unrelated config value was saved.

Thanks to `od28173` for confirming this scope and calling out that #11862 should stay separate.

## Implementation

This uses the same JSONC patch path for plain JSON saves that `.jsonc` files already use. The project and global save paths now patch the original file text, so untouched nested keys stay in place while the requested setting is still updated.

The patch helper also treats a null/undefined delete of an absent node as a no-op, while still deleting a present node. That keeps permission-clear saves from throwing on plain JSON config files that do not have the permission node yet.

The bash-permission migration stays unchanged because it is not part of the Settings save path for this issue.

## Screenshots / Video

Not a visual change.

## How to Test

### Manual/local verification

- `bun run script/test-runner.ts project-config-update` failed before the null-delete repair in the new absent permission-clear cases with `Can not delete in empty document`.
- `bun run script/test-runner.ts project-config-update` passed after the repair.
- `bun run script/test-runner.ts project-config-update kilocode/config/config patch-jsonc config` passed, 38 files.
- `bun run lint` passed with 0 errors.
- `bun run typecheck --filter=!@kilocode/kilo-jetbrains` passed.
- `git diff --check` passed.

### Reviewer test steps

1. Create a plain `kilo.json` with modeled `indexing` settings plus nested keys such as `indexing.openai.model` and `indexing.lancedb.apiKey`.
2. Save an unrelated config setting through the project or global config update path, then confirm the unrelated setting is updated and the nested `indexing` keys are still present.
3. Start from a plain `kilo.json` with no `permission` key, save a permission clear for `permission["*"]["*"]`, and confirm the save does not throw or create a permission tree.
4. Repeat with `permission["*"]["*"]` present next to a sibling permission entry, then confirm only the wildcard entry is removed and the sibling remains.

### Blocked checks and substitute verification

No relevant checks were blocked.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

GitHub is best for this thread.
