### PR TITLE
fix(vscode): allow shrinking prompt mention selections

### DIFF
--- a/.changeset/prompt-mention-selection.md
+++ b/.changeset/prompt-mention-selection.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow Shift+Arrow selections in the prompt input to shrink back across file mentions.

--- a/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
@@ -5,19 +5,29 @@ import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/type
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-function textarea(value: string, cursor: number, dir: "ltr" | "rtl") {
-  const state = { cursor }
+function textarea(
+  value: string,
+  cursor: number,
+  dir: "ltr" | "rtl",
+  selection?: { end: number; direction: SelectionDirection },
+) {
+  const state = { start: cursor, end: selection?.end ?? cursor, direction: selection?.direction ?? "none" }
   return {
     value,
     get selectionStart() {
-      return state.cursor
+      return state.start
     },
     get selectionEnd() {
-      return state.cursor
+      return state.end
+    },
+    get selectionDirection() {
+      return state.direction
     },
     matches: (selector: string) => selector === `:dir(${dir})`,
-    setSelectionRange: (start: number) => {
-      state.cursor = start
+    setSelectionRange: (start: number, end = start, direction: SelectionDirection = "none") => {
+      state.start = start
+      state.end = end
+      state.direction = direction
     },
   } as unknown as HTMLTextAreaElement
 }
@@ -269,6 +279,70 @@ describe("useFileMention", () => {
     expect(mention.handleArrowKey(right.event, input)).toBe(true)
     expect(input.selectionStart).toBe("فایل ".length)
     expect(right.state.prevented).toBe(1)
+
+    dispose.fn?.()
+  })
+
+  it("shrinks a left-to-right shift selection across a mention", async () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    const path = "README.md"
+    const text = `A @${path} B`
+    const start = text.indexOf("@")
+    const end = start + path.length + 1
+    mention.addPaths([path], "/repo")
+
+    const input = textarea(text, end - 1, "ltr", { end: text.length, direction: "backward" })
+    mention.snapSelection(input)
+    expect(input.selectionStart).toBe(start)
+    expect(input.selectionEnd).toBe(text.length)
+
+    input.setSelectionRange(start + 1, text.length, "backward")
+    mention.snapSelection(input)
+    expect(input.selectionStart).toBe(end)
+    expect(input.selectionEnd).toBe(text.length)
+    expect(input.selectionDirection).toBe("backward")
+
+    dispose.fn?.()
+  })
+
+  it("shrinks a right-to-left shift selection across a mention", async () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    const path = "README.md"
+    const text = `ی @${path} س`
+    const start = text.indexOf("@")
+    const end = start + path.length + 1
+    mention.addPaths([path], "/repo")
+
+    const input = textarea(text, end - 1, "rtl", { end: text.length, direction: "backward" })
+    mention.snapSelection(input)
+    expect(input.selectionStart).toBe(start)
+    expect(input.selectionEnd).toBe(text.length)
+
+    input.setSelectionRange(start + 1, text.length, "backward")
+    mention.snapSelection(input)
+    expect(input.selectionStart).toBe(end)
+    expect(input.selectionEnd).toBe(text.length)
+    expect(input.selectionDirection).toBe("backward")
 
     dispose.fn?.()
   })

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -299,11 +299,16 @@ export function useFileMention(
   }
 
   let snapping = false
+  let last: { start: number; end: number } | undefined
   const snapSelection = (textarea: HTMLTextAreaElement): void => {
     if (snapping) return
     const start = textarea.selectionStart
     const end = textarea.selectionEnd
-    if (start === end) return // cursor, not a selection
+    const dir = textarea.selectionDirection
+    if (start === end) {
+      last = undefined
+      return // cursor, not a selection
+    }
 
     const val = textarea.value
     const paths = mentionedPaths()
@@ -311,16 +316,23 @@ export function useFileMention(
     let snappedEnd = end
 
     const startRange = findMentionRange(val, start, paths)
-    if (startRange) snapped = startRange.start
+    if (startRange) {
+      const shrink = dir === "backward" && last?.start === startRange.start && last.end === end
+      snapped = shrink ? startRange.end : startRange.start
+    }
 
     const endRange = findMentionRange(val, end, paths)
-    if (endRange) snappedEnd = endRange.end
+    if (endRange) {
+      const shrink = dir === "forward" && last?.start === start && last.end === endRange.end
+      snappedEnd = shrink ? endRange.start : endRange.end
+    }
 
     if (snapped !== start || snappedEnd !== end) {
       snapping = true
-      textarea.setSelectionRange(snapped, snappedEnd, textarea.selectionDirection)
+      textarea.setSelectionRange(snapped, snappedEnd, dir)
       snapping = false
     }
+    last = { start: snapped, end: snappedEnd }
   }
 
   const seedFromText = (text: string) => {


### PR DESCRIPTION
## Issue

Prompt input treats file mentions as atomic selection units when growing a Shift+Arrow selection, but shrinking the selection back across the same mention gets stuck. This makes it hard to correct or adjust selected prompt text once a file mention has been included.

## Context

This fixes Shift+Arrow selection behavior in the VS Code prompt input when the selection crosses an inline file mention.

Before this change, selection growth could snap over the full mention, but shrinking back into the mention would immediately snap back to the full mention again, so the selection appeared not to move.

## Implementation

The fix stays in the existing `snapSelection` path that already makes partially selected file mentions atomic.

`scanSelection` now remembers the previous snapped selection bounds. When the next native selection still has the same anchor but moves the active edge back into a mention, it treats that as a shrink operation and snaps to the opposite mention boundary instead of expanding back over the full mention.

This keeps normal grow behavior unchanged and avoids adding special Shift+Arrow key handling.

## Screenshots / Video

| before | after |
|---|---|
| <video src="https://github.com/user-attachments/assets/a55229bf-cd14-4df6-b72d-90f1c06e0ef2"/> | <video src="https://github.com/user-attachments/assets/b76ffbe1-6c72-40ac-b0b3-ba1ec6a79243"/> |

## How to Test

### Manual/local verification

- Manually built and tested the prompt input behavior using both left-to-right and right-to-left text.
- Ran `bun test tests/unit/use-file-mention.test.ts`.
- Ran `bun run lint`.
- Ran `bun run typecheck`.
- Push pre-hook ran workspace typecheck, including JetBrains Gradle typecheck.

### Reviewer test steps

1. Open the VS Code extension prompt input.
2. Type `A @README.md B`.
3. Place the cursor after `B`.
4. Hold Shift and press Left twice.
5. Press Shift+Left once more so the selection expands over `@README.md`.
6. Press Shift+Right.
7. Confirm the selection shrinks back to the point after file mention.
8. Repeat with RTL text: `ی @README.md س`.
9. Place the cursor after `س`.
10. Hold Shift and press Right twice.
11. Press Shift+Right once more so the selection expands over `@README.md`.
12. Press Shift+Left.
13. Confirm the selection shrinks back to the point after file mention.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
