### PR TITLE
fix(core): preserve UTF-8 BOM in filesystem writes

### DIFF
--- a/.changeset/preserve-utf8-bom.md
+++ b/.changeset/preserve-utf8-bom.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Preserve UTF-8 BOM markers when reading and writing files through the shared filesystem service.

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -8,6 +8,21 @@ import { Context, Effect, FileSystem, Layer, Schema } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { Glob } from "./util/glob"
 import { serviceUse } from "./effect/service-use"
+const UTF8_BOM = new Uint8Array([0xef, 0xbb, 0xbf])
+const UTF8_BOM_CHAR = "\ufeff"
+
+function hasUtf8Bom(bytes: Uint8Array) {
+  return bytes.length >= UTF8_BOM.length && UTF8_BOM.every((byte, index) => bytes[index] === byte)
+}
+
+function hasStringBom(text: string) {
+  return text.charCodeAt(0) === 0xfeff
+}
+
+function withStringBom(text: string, bom: boolean) {
+  const stripped = hasStringBom(text) ? text.slice(1) : text
+  return bom ? UTF8_BOM_CHAR + stripped : stripped
+}
 
 export namespace AppFileSystem {
   export class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()("FileSystemError", {
@@ -52,10 +67,33 @@ export namespace AppFileSystem {
         return yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false))
       })
 
+      const readFileString = Effect.fn("FileSystem.readFileString")(function* (path: string, encoding?: string) {
+        const bytes = yield* fs.readFile(path)
+        const text = yield* fs.readFileString(path, encoding)
+        return hasUtf8Bom(bytes) ? withStringBom(text, true) : text
+      })
+
+      const fileHasUtf8Bom = Effect.fn("FileSystem.fileHasUtf8Bom")(function* (path: string) {
+        return yield* fs.readFile(path).pipe(
+          Effect.map(hasUtf8Bom),
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(false)),
+        )
+      })
+
+      const writeFileString = Effect.fn("FileSystem.writeFileString")(function* (
+        path: string,
+        content: string,
+        options?: Parameters<typeof fs.writeFileString>[2],
+      ) {
+        const shouldPreserveExistingBom = !options?.flag || options.flag.startsWith("w")
+        const bom = hasStringBom(content) || (shouldPreserveExistingBom && (yield* fileHasUtf8Bom(path)))
+        yield* fs.writeFileString(path, withStringBom(content, bom), options)
+      })
+
       const readFileStringSafe = Effect.fn("FileSystem.readFileStringSafe")(function* (path: string) {
-        return yield* fs
-          .readFileString(path)
-          .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+        return yield* readFileString(path).pipe(
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
+        )
       })
 
       const isDir = Effect.fn("FileSystem.isDir")(function* (path: string) {
@@ -84,13 +122,13 @@ export namespace AppFileSystem {
       })
 
       const readJson = Effect.fn("FileSystem.readJson")(function* (path: string) {
-        const text = yield* fs.readFileString(path)
+        const text = withStringBom(yield* readFileString(path), false)
         return JSON.parse(text)
       })
 
       const writeJson = Effect.fn("FileSystem.writeJson")(function* (path: string, data: unknown, mode?: number) {
         const content = JSON.stringify(data, null, 2)
-        yield* fs.writeFileString(path, content)
+        yield* writeFileString(path, content)
         if (mode) yield* fs.chmod(path, mode)
       })
 
@@ -103,7 +141,7 @@ export namespace AppFileSystem {
         content: string | Uint8Array,
         mode?: number,
       ) {
-        const write = typeof content === "string" ? fs.writeFileString(path, content) : fs.writeFile(path, content)
+        const write = typeof content === "string" ? writeFileString(path, content) : fs.writeFile(path, content)
 
         yield* write.pipe(
           Effect.catchIf(
@@ -173,6 +211,8 @@ export namespace AppFileSystem {
 
       return Service.of({
         ...fs,
+        readFileString,
+        writeFileString,
         existsSafe,
         readFileStringSafe,
         isDir,

--- a/packages/core/test/filesystem/filesystem-bom.test.ts
+++ b/packages/core/test/filesystem/filesystem-bom.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect } from "bun:test"
+import { Effect, FileSystem, Layer } from "effect"
+import { NodeFileSystem } from "@effect/platform-node"
+import { AppFileSystem } from "@opencode-ai/core/filesystem"
+import { testEffect } from "../lib/effect"
+import path from "path"
+
+const live = AppFileSystem.layer.pipe(Layer.provideMerge(NodeFileSystem.layer))
+const { effect: it } = testEffect(live)
+
+const UTF8_BOM_TEXT = String.fromCharCode(0xfeff)
+
+function startsWithUtf8Bom(bytes: Uint8Array) {
+  if (bytes[0] !== 0xef) return false
+  if (bytes[1] !== 0xbb) return false
+  return bytes[2] === 0xbf
+}
+
+function utf8BomBytes(text: string) {
+  const body = new TextEncoder().encode(text)
+  const bytes = new Uint8Array(body.length + 3)
+  bytes[0] = 0xef
+  bytes[1] = 0xbb
+  bytes[2] = 0xbf
+  bytes.set(body, 3)
+  return bytes
+}
+
+function decodeAfterUtf8Bom(bytes: Uint8Array) {
+  return new TextDecoder().decode(bytes.slice(3))
+}
+
+describe("UTF-8 BOM preservation", function () {
+  it(
+    "preserves the marker when reading BOM files",
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filesys = yield* FileSystem.FileSystem
+      const tmp = yield* filesys.makeTempDirectoryScoped()
+      const file = path.join(tmp, "bom.txt")
+      yield* filesys.writeFile(file, utf8BomBytes("hello"))
+
+      const result = yield* fs.readFileString(file)
+
+      expect(result).toBe(UTF8_BOM_TEXT + "hello")
+    }),
+  )
+
+  it(
+    "preserves the marker when overwriting BOM files",
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filesys = yield* FileSystem.FileSystem
+      const tmp = yield* filesys.makeTempDirectoryScoped()
+      const file = path.join(tmp, "bom-overwrite.txt")
+      yield* filesys.writeFile(file, utf8BomBytes("before"))
+
+      yield* fs.writeFileString(file, "after")
+      const bytes = yield* filesys.readFile(file)
+
+      expect(startsWithUtf8Bom(bytes)).toBe(true)
+      expect(decodeAfterUtf8Bom(bytes)).toBe("after")
+    }),
+  )
+
+  it(
+    "preserves the marker when editing through writeWithDirs",
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filesys = yield* FileSystem.FileSystem
+      const tmp = yield* filesys.makeTempDirectoryScoped()
+      const file = path.join(tmp, "bom-edit.txt")
+      yield* filesys.writeFile(file, utf8BomBytes("before"))
+
+      const edited = (yield* fs.readFileString(file)).replace("before", "after")
+      yield* fs.writeWithDirs(file, edited)
+      const bytes = yield* filesys.readFile(file)
+
+      expect(startsWithUtf8Bom(bytes)).toBe(true)
+      expect(decodeAfterUtf8Bom(bytes)).toBe("after")
+    }),
+  )
+
+  it(
+    "preserves the marker when reading and writing JSON",
+    Effect.gen(function* () {
+      const fs = yield* AppFileSystem.Service
+      const filesys = yield* FileSystem.FileSystem
+      const tmp = yield* filesys.makeTempDirectoryScoped()
+      const file = path.join(tmp, "bom.json")
+      yield* filesys.writeFile(file, utf8BomBytes(JSON.stringify({ old: true })))
+
+      expect(yield* fs.readJson(file)).toEqual({ old: true })
+
+      yield* fs.writeJson(file, { next: true })
+      const bytes = yield* filesys.readFile(file)
+
+      expect(startsWithUtf8Bom(bytes)).toBe(true)
+      expect(yield* fs.readJson(file)).toEqual({ next: true })
+    }),
+  )
+})


### PR DESCRIPTION
Fixes #11901

## Summary
- Wrap `AppFileSystem.readFileString` so UTF-8 BOM-prefixed files return the BOM marker that Effect's `TextDecoder` strips by default.
- Wrap `AppFileSystem.writeFileString` so overwriting an existing BOM-prefixed file preserves the marker unless the write is an append-style operation.
- Route `readJson`, `writeJson`, and string `writeWithDirs` through the BOM-aware helpers while keeping JSON parsing free of the marker.
- Add focused regression coverage for reading, direct overwrites, edit-style `writeWithDirs`, and JSON read/write behavior.

## Tests run
- `bunx prettier --check packages/core/src/filesystem.ts packages/core/test/filesystem/filesystem-bom.test.ts` (from repo root) - passed.
- `bun run lint packages/core/src/filesystem.ts packages/core/test/filesystem/filesystem-bom.test.ts` (from repo root) - passed: 0 warnings, 0 errors.
- `bun test test/filesystem/filesystem-bom.test.ts` (from `packages/core`) - passed: 4 pass, 0 fail.
- `bun test test/filesystem/filesystem.test.ts` (from `packages/core`) - passed: 26 pass, 0 fail.
- `bun run typecheck` (from `packages/core`) - passed.
- `git diff --check` - passed.

## Notes
- The issue referenced the older `packages/shared/src/filesystem.ts` path; on current `main`, this shared filesystem service lives at `packages/core/src/filesystem.ts`.
- To run the checks in this sparse D-drive checkout, I populated missing workspace packages with `git sparse-checkout add packages/kilo-sandbox`, `git sparse-checkout add packages/kilo-gateway`, and `git sparse-checkout add packages/sdk/js`. Git emitted Windows long-path warnings while scanning nested `node_modules`, but the commands completed.

## Risk / compatibility
- Low risk for normal UTF-8 files: files without an existing BOM continue to write without one.
- Existing BOM-prefixed files keep their marker across string overwrites and JSON writes.