### PR TITLE
fix: show dismissed question content in chat history (#10361)

### DIFF
--- a/.changeset/show-dismissed-question-content.md
+++ b/.changeset/show-dismissed-question-content.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fixed dismissed question tool content not showing in chat history. Dismissed questions now render with a "Dismissed" label and "N dismissed" subtitle instead of being invisible.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1158,6 +1158,12 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const i18n = useI18n()
   const part = props.part as ToolPart
   const hideQuestion = createMemo(() => part.tool === "question" && busy(part.state.status))
+  const isDismissedQuestionError = createMemo(() => {
+    if (part.tool !== "question") return false
+    if (part.state.status !== "error" || !part.state.error) return false
+    const errStr = typeof part.state.error === "string" ? part.state.error : ""
+    return errStr.includes("dismissed this question")
+  })
 
   const emptyInput: Record<string, any> = {}
   const emptyMetadata: Record<string, any> = {}
@@ -1176,11 +1182,26 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
           <Match when={part.state.status === "error" && part.state.error}>
             {(error) => {
               const cleaned = error().replace("Error: ", "")
-              // dismissed questions fall through to the normal question
-              // tool renderer below so users can review the content.
-              if (part.tool === "question" && cleaned.includes("dismissed this question")) {
-                // Let the question tool renderer handle it
-              } else {
+              if (isDismissedQuestionError()) {
+                return (
+                  <Dynamic
+                    component={render()}
+                    input={input()}
+                    tool={part.tool}
+                    partID={part.id}
+                    callID={part.callID}
+                    metadata={meta()}
+                    partMetadata={top()}
+                    // @ts-expect-error
+                    output={part.state.output}
+                    status={part.state.status}
+                    hideDetails={props.hideDetails}
+                    defaultOpen={props.defaultOpen}
+                    animate
+                    reveal={props.animate}
+                  />
+                )
+              }
               const hint =
                 cleaned.includes("before overwriting it. Use the Read tool first") ||
                 cleaned.includes("has been modified since it was last read") ||
@@ -1225,7 +1246,6 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                   </div>
                 </Card>
               )
-              }
             }}
           </Match>
           <Match when={true}>

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1176,15 +1176,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
           <Match when={part.state.status === "error" && part.state.error}>
             {(error) => {
               const cleaned = error().replace("Error: ", "")
+              // kilocode_change: dismissed questions render through the normal
+              // question tool renderer so users can review the content.
               if (part.tool === "question" && cleaned.includes("dismissed this question")) {
-                return (
-                  <div style="width: 100%; display: flex; justify-content: flex-end;">
-                    <span class="text-13-regular text-text-weak cursor-default">
-                      {i18n.t("ui.messagePart.questions.dismissed")}
-                    </span>
-                  </div>
-                )
-              }
+                // Let the question tool renderer handle it
+              } else {
               const hint =
                 cleaned.includes("before overwriting it. Use the Read tool first") ||
                 cleaned.includes("has been modified since it was last read") ||
@@ -1229,6 +1225,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                   </div>
                 </Card>
               )
+              }
             }}
           </Match>
           <Match when={true}>
@@ -2786,12 +2783,15 @@ ToolRegistry.register({
     const i18n = useI18n()
     const questions = createMemo(() => (props.input.questions ?? []) as QuestionInfo[])
     const answers = createMemo(() => (props.metadata.answers ?? []) as QuestionAnswer[])
+    const dismissed = createMemo(() => props.metadata.dismissed === true || props.status === "error")
     const completed = createMemo(() => answers().length > 0)
     const pending = createMemo(() => busy(props.status))
+    const hasContent = createMemo(() => completed() || dismissed())
 
     const subtitle = createMemo(() => {
       const count = questions().length
       if (count === 0) return ""
+      if (dismissed()) return i18n.t("ui.question.subtitle.dismissed", { count })
       if (completed()) return i18n.t("ui.question.subtitle.answered", { count })
       return `${count} ${i18n.t(count > 1 ? "ui.common.question.other" : "ui.common.question.one")}`
     })
@@ -2810,15 +2810,19 @@ ToolRegistry.register({
           />
         }
       >
-        <Show when={completed()}>
-          <div data-component="question-answers">
+        <Show when={hasContent()}>
+          <div data-component="question-answers" data-dismissed={dismissed() ? "" : undefined}>
             <For each={questions()}>
               {(q, i) => {
                 const answer = () => answers()[i()] ?? []
+                const answerText = () => {
+                  if (dismissed()) return i18n.t("ui.question.answer.dismissed")
+                  return answer().join(", ") || i18n.t("ui.question.answer.none")
+                }
                 return (
                   <div data-slot="question-answer-item">
                     <div data-slot="question-text">{q.question}</div>
-                    <div data-slot="answer-text">{answer().join(", ") || i18n.t("ui.question.answer.none")}</div>
+                    <div data-slot="answer-text">{answerText()}</div>
                   </div>
                 )
               }}

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1176,11 +1176,12 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
           <Match when={part.state.status === "error" && part.state.error}>
             {(error) => {
               const cleaned = error().replace("Error: ", "")
-              // kilocode_change: dismissed questions render through the normal
-              // question tool renderer so users can review the content.
+              // kilocode_change start - dismissed questions fall through
+              // to the normal question renderer so users can review content.
               if (part.tool === "question" && cleaned.includes("dismissed this question")) {
                 // Let the question tool renderer handle it
               } else {
+              // kilocode_change end
               const hint =
                 cleaned.includes("before overwriting it. Use the Read tool first") ||
                 cleaned.includes("has been modified since it was last read") ||

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1176,12 +1176,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
           <Match when={part.state.status === "error" && part.state.error}>
             {(error) => {
               const cleaned = error().replace("Error: ", "")
-              // kilocode_change start - dismissed questions fall through
-              // to the normal question renderer so users can review content.
+              // dismissed questions fall through to the normal question
+              // tool renderer below so users can review the content.
               if (part.tool === "question" && cleaned.includes("dismissed this question")) {
                 // Let the question tool renderer handle it
               } else {
-              // kilocode_change end
               const hint =
                 cleaned.includes("before overwriting it. Use the Read tool first") ||
                 cleaned.includes("has been modified since it was last read") ||

--- a/packages/kilo-ui/src/stories/message-part.stories.tsx
+++ b/packages/kilo-ui/src/stories/message-part.stories.tsx
@@ -529,10 +529,146 @@ const hintErrors: ToolPart[] = [
 
 const mockDataHintErrors = createMockData(hintErrors)
 
+// --- Question tool: answered (reference) ---
+
+const questionAnsweredPart: ToolPart = {
+  id: "part-question-answered",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-question-answered",
+  tool: "question",
+  state: {
+    status: "completed",
+    input: {
+      questions: [
+        {
+          question: "Should I continue with this approach?",
+          header: "Continue?",
+          options: [
+            { label: "Yes", description: "Proceed with the current plan" },
+            { label: "No", description: "Stop and reconsider" },
+          ],
+        },
+        {
+          question: "Which library should I use for date formatting?",
+          header: "Library",
+          options: [
+            { label: "date-fns", description: "Lightweight, tree-shakeable" },
+            { label: "luxon", description: "Full-featured DateTime library" },
+            { label: "dayjs", description: "Moment.js compatible, 2kB" },
+          ],
+        },
+      ],
+    },
+    output: 'User answered: "Should I continue?"="Yes", "Which library?"="date-fns"',
+    title: "Asked 2 questions",
+    metadata: { answers: [["Yes"], ["date-fns"]] },
+    time: { start: now - 8000, end: now - 7000 },
+  },
+}
+
+// --- Question tool: dismissed (exercises the fix) ---
+
+const questionDismissedPart: ToolPart = {
+  id: "part-question-dismissed",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "tool",
+  callID: "call-question-dismissed",
+  tool: "question",
+  state: {
+    status: "completed",
+    input: {
+      questions: [
+        {
+          question: "Should I continue with this approach?",
+          header: "Continue?",
+          options: [
+            { label: "Yes", description: "Proceed with the current plan" },
+            { label: "No", description: "Stop and reconsider" },
+          ],
+        },
+        {
+          question: "Which library should I use for date formatting?",
+          header: "Library",
+          options: [
+            { label: "date-fns", description: "Lightweight, tree-shakeable" },
+            { label: "luxon", description: "Full-featured DateTime library" },
+          ],
+        },
+      ],
+    },
+    output: "User dismissed the question.",
+    title: "Question dismissed",
+    metadata: { answers: [], dismissed: true },
+    time: { start: now - 8000, end: now - 7000 },
+  },
+}
+
+const mockDataQuestionAnswered = createMockData([questionAnsweredPart, textPart])
+const mockDataQuestionDismissed = createMockData([questionDismissedPart, textPart])
+
 export const ToolHintErrors: Story = {
   render: () => (
     <AllProviders data={mockDataHintErrors}>
       <AssistantParts messages={[mockAssistantMessage]} />
     </AllProviders>
   ),
+}
+
+// --- Question tool: answered (collapsed) ---
+
+export const QuestionAnswered: Story = {
+  name: "QuestionAnswered",
+  render: () => (
+    <AllProviders data={mockDataQuestionAnswered}>
+      <AssistantParts messages={[mockAssistantMessage]} />
+    </AllProviders>
+  ),
+}
+
+// --- Question tool: answered (expanded) ---
+
+export const QuestionAnsweredExpanded: Story = {
+  name: "QuestionAnswered (expanded)",
+  render: () => (
+    <AllProviders data={mockDataQuestionAnswered}>
+      <AssistantParts messages={[mockAssistantMessage]} />
+    </AllProviders>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const trigger = canvasElement
+      .querySelector('[data-slot="basic-tool-tool-title"]')
+      ?.closest("button")
+    if (trigger) trigger.click()
+  },
+}
+
+// --- Question tool: dismissed (collapsed — "2 dismissed" subtitle) ---
+
+export const QuestionDismissed: Story = {
+  name: "QuestionDismissed",
+  render: () => (
+    <AllProviders data={mockDataQuestionDismissed}>
+      <AssistantParts messages={[mockAssistantMessage]} />
+    </AllProviders>
+  ),
+}
+
+// --- Question tool: dismissed (expanded — shows questions with "Dismissed" labels) ---
+
+export const QuestionDismissedExpanded: Story = {
+  name: "QuestionDismissed (expanded)",
+  render: () => (
+    <AllProviders data={mockDataQuestionDismissed}>
+      <AssistantParts messages={[mockAssistantMessage]} />
+    </AllProviders>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const trigger = canvasElement
+      .querySelector('[data-slot="basic-tool-tool-title"]')
+      ?.closest("button")
+    if (trigger) trigger.click()
+  },
 }

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1010,7 +1010,8 @@ function Question(props: ToolProps) {
     arrayValue(props.input.questions).flatMap((item) => (isRecord(item) ? [item] : [])),
   )
   const answers = createMemo(() => arrayValue(props.metadata.answers))
-  // kilocode_change start - show dismissed question content
+  // kilocode_change start - show dismissed question content; use questions()
+  // presence (not answers) so dismissed/answered/error states all render content.
   const dismissed = createMemo(
     () =>
       props.metadata.dismissed === true ||
@@ -1023,10 +1024,11 @@ function Question(props: ToolProps) {
   }
 
   const title = createMemo(() => (dismissed() ? "# Questions (dismissed)" : "# Questions"))
+  // kilocode_change end
 
   return (
     <Switch>
-      <Match when={answers().length > 0 || dismissed()}>
+      <Match when={questions().length > 0}>
         <BlockTool title={title()} part={props.part}>
           <box gap={1}>
             <For each={questions()}>
@@ -1034,7 +1036,6 @@ function Question(props: ToolProps) {
                 <box>
                   <text fg={theme.textMuted}>{stringValue(question.question)}</text>
                   <text fg={theme.text}>{format(answers()[index()])}</text>
-                  {/* kilocode_change end */}
                 </box>
               )}
             </For>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1015,7 +1015,7 @@ function Question(props: ToolProps) {
   const dismissed = createMemo(
     () =>
       props.metadata.dismissed === true ||
-      (props.part.state.status === "error" && String(props.part.state.error ?? "").includes("dismissed")),
+      (props.part.state.status === "error" && String(props.part.state.error?.message ?? "").includes("dismissed")),
   )
 
   function format(answer: unknown) {
@@ -1028,8 +1028,8 @@ function Question(props: ToolProps) {
 
   return (
     <Switch>
-      {/* kilocode_change start - use questions().length gate + dismissed-aware format */}
-      <Match when={questions().length > 0}>
+      {/* kilocode_change start - gate on dismissed or answers so dismissed/answered render, pending falls through to Asking... */}
+      <Match when={dismissed() || answers().length > 0}>
         <BlockTool title={title()} part={props.part}>
           <box gap={1}>
             <For each={questions()}>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1010,16 +1010,29 @@ function Question(props: ToolProps) {
     arrayValue(props.input.questions).flatMap((item) => (isRecord(item) ? [item] : [])),
   )
   const answers = createMemo(() => arrayValue(props.metadata.answers))
+  const dismissed = createMemo(
+    () =>
+      props.metadata.dismissed === true ||
+      (props.part.state.status === "error" && String(props.part.state.error ?? "").includes("dismissed")),
+  )
+
+  function format(answer: unknown) {
+    if (dismissed()) return "Dismissed"
+    return formatAnswer(answer)
+  }
+
+  const title = createMemo(() => (dismissed() ? "# Questions (dismissed)" : "# Questions"))
+
   return (
     <Switch>
-      <Match when={answers().length > 0}>
-        <BlockTool title="# Questions" part={props.part}>
+      <Match when={answers().length > 0 || dismissed()}>
+        <BlockTool title={title()} part={props.part}>
           <box gap={1}>
             <For each={questions()}>
               {(question, index) => (
                 <box>
                   <text fg={theme.textMuted}>{stringValue(question.question)}</text>
-                  <text fg={theme.text}>{formatAnswer(answers()[index()])}</text>
+                  <text fg={theme.text}>{format(answers()[index()])}</text>
                 </box>
               )}
             </For>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1028,6 +1028,7 @@ function Question(props: ToolProps) {
 
   return (
     <Switch>
+      {/* kilocode_change start - use questions().length gate + dismissed-aware format */}
       <Match when={questions().length > 0}>
         <BlockTool title={title()} part={props.part}>
           <box gap={1}>
@@ -1042,6 +1043,7 @@ function Question(props: ToolProps) {
           </box>
         </BlockTool>
       </Match>
+      {/* kilocode_change end */}
       <Match when={true}>
         <InlineTool icon="→" pending="Asking questions..." complete={questions().length} part={props.part}>
           Asked {questions().length} question{questions().length === 1 ? "" : "s"}

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx
@@ -1010,6 +1010,7 @@ function Question(props: ToolProps) {
     arrayValue(props.input.questions).flatMap((item) => (isRecord(item) ? [item] : [])),
   )
   const answers = createMemo(() => arrayValue(props.metadata.answers))
+  // kilocode_change start - show dismissed question content
   const dismissed = createMemo(
     () =>
       props.metadata.dismissed === true ||
@@ -1033,6 +1034,7 @@ function Question(props: ToolProps) {
                 <box>
                   <text fg={theme.textMuted}>{stringValue(question.question)}</text>
                   <text fg={theme.text}>{format(answers()[index()])}</text>
+                  {/* kilocode_change end */}
                 </box>
               )}
             </For>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2810,12 +2810,16 @@ function TodoWrite(props: ToolProps<typeof TodoWriteTool>) {
 function Question(props: ToolProps<typeof QuestionTool>) {
   const { theme } = useTheme()
   const count = createMemo(() => props.input.questions?.length ?? 0)
-  // kilocode_change start - show dismissed question content
+  // kilocode_change start - show dismissed question content with toggle;
+  // use input.questions presence (not metadata) so dismissed/answered/error
+  // states all render content.  Clicking the one-liner expands to the full
+  // block; clicking the block title collapses back.
   const dismissed = createMemo(
     () =>
       props.metadata.dismissed === true ||
-      (props.part.state.status === "error" && props.part.state.error?.includes("dismissed")),
+      (props.part.state.status === "error" && String(props.part.state.error ?? "").includes("dismissed")),
   )
+  const [expanded, setExpanded] = createSignal(false)
 
   function format(answer?: ReadonlyArray<string>) {
     if (dismissed()) return "Dismissed"
@@ -2824,25 +2828,43 @@ function Question(props: ToolProps<typeof QuestionTool>) {
   }
 
   const title = createMemo(() => (dismissed() ? "# Questions (dismissed)" : "# Questions"))
+  const subtitle = createMemo(() => {
+    if (dismissed()) return `${count()} dismissed`
+    if ((props.metadata.answers?.length ?? 0) > 0) return `${count()} answered`
+    return `${count()} question${count() !== 1 ? "s" : ""}`
+  })
   // kilocode_change end
 
   return (
     <Switch>
-      {/* kilocode_change start - match dismissed questions too */}
-      <Match when={props.metadata.answers || dismissed()}>
-        <BlockTool title={title()} part={props.part}>
-      {/* kilocode_change end */}
-          <box gap={1}>
-            <For each={props.input.questions ?? []}>
-              {(q, i) => (
-                <box flexDirection="column">
-                  <text fg={theme.textMuted}>{q.question}</text>
-                  <text fg={theme.text}>{format(props.metadata.answers?.[i()])}</text>
-                </box>
-              )}
-            </For>
-          </box>
-        </BlockTool>
+      <Match when={count() > 0}>
+        <Show
+          when={expanded()}
+          fallback={
+            <InlineTool
+              icon="→"
+              complete={count()}
+              pending="Asking questions..."
+              part={props.part}
+              onClick={() => setExpanded(true)}
+            >
+              {subtitle()}
+            </InlineTool>
+          }
+        >
+          <BlockTool title={title()} part={props.part} onClick={() => setExpanded(false)}>
+            <box gap={1}>
+              <For each={props.input.questions ?? []}>
+                {(q, i) => (
+                  <box flexDirection="column">
+                    <text fg={theme.textMuted}>{q.question}</text>
+                    <text fg={theme.text}>{format(props.metadata.answers?.[i()])}</text>
+                  </box>
+                )}
+              </For>
+            </box>
+          </BlockTool>
+        </Show>
       </Match>
       <Match when={true}>
         <InlineTool icon="→" pending="Asking questions..." complete={count()} part={props.part}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2810,6 +2810,7 @@ function TodoWrite(props: ToolProps<typeof TodoWriteTool>) {
 function Question(props: ToolProps<typeof QuestionTool>) {
   const { theme } = useTheme()
   const count = createMemo(() => props.input.questions?.length ?? 0)
+  // kilocode_change start - show dismissed question content
   const dismissed = createMemo(
     () =>
       props.metadata.dismissed === true ||
@@ -2823,11 +2824,14 @@ function Question(props: ToolProps<typeof QuestionTool>) {
   }
 
   const title = createMemo(() => (dismissed() ? "# Questions (dismissed)" : "# Questions"))
+  // kilocode_change end
 
   return (
     <Switch>
+      {/* kilocode_change start - match dismissed questions too */}
       <Match when={props.metadata.answers || dismissed()}>
         <BlockTool title={title()} part={props.part}>
+      {/* kilocode_change end */}
           <box gap={1}>
             <For each={props.input.questions ?? []}>
               {(q, i) => (

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2810,16 +2810,24 @@ function TodoWrite(props: ToolProps<typeof TodoWriteTool>) {
 function Question(props: ToolProps<typeof QuestionTool>) {
   const { theme } = useTheme()
   const count = createMemo(() => props.input.questions?.length ?? 0)
+  const dismissed = createMemo(
+    () =>
+      props.metadata.dismissed === true ||
+      (props.part.state.status === "error" && props.part.state.error?.includes("dismissed")),
+  )
 
   function format(answer?: ReadonlyArray<string>) {
+    if (dismissed()) return "Dismissed"
     if (!answer?.length) return "(no answer)"
     return answer.join(", ")
   }
 
+  const title = createMemo(() => (dismissed() ? "# Questions (dismissed)" : "# Questions"))
+
   return (
     <Switch>
-      <Match when={props.metadata.answers}>
-        <BlockTool title="# Questions" part={props.part}>
+      <Match when={props.metadata.answers || dismissed()}>
+        <BlockTool title={title()} part={props.part}>
           <box gap={1}>
             <For each={props.input.questions ?? []}>
               {(q, i) => (

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2837,6 +2837,7 @@ function Question(props: ToolProps<typeof QuestionTool>) {
 
   return (
     <Switch>
+      {/* kilocode_change start - toggle between one-liner and full block */}
       <Match when={count() > 0}>
         <Show
           when={expanded()}
@@ -2866,6 +2867,7 @@ function Question(props: ToolProps<typeof QuestionTool>) {
           </BlockTool>
         </Show>
       </Match>
+      {/* kilocode_change end */}
       <Match when={true}>
         <InlineTool icon="→" pending="Asking questions..." complete={count()} part={props.part}>
           Asked {count()} question{count() !== 1 ? "s" : ""}

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -171,7 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "مصحح",
 
   "ui.question.subtitle.answered": "{{count}} أجيب",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(لا توجد إجابة)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(لم يتم الرد)",
   "ui.question.multiHint": "حدد كل ما ينطبق",
   "ui.question.singleHint": "حدد إجابة واحدة",

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -171,9 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "مصحح",
 
   "ui.question.subtitle.answered": "{{count}} أجيب",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(لا توجد إجابة)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(لم يتم الرد)",
   "ui.question.multiHint": "حدد كل ما ينطبق",
   "ui.question.singleHint": "حدد إجابة واحدة",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -171,7 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Patch aplicado",
 
   "ui.question.subtitle.answered": "{{count}} respondidas",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(sem resposta)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(não respondida)",
   "ui.question.multiHint": "Selecione todas que se aplicam",
   "ui.question.singleHint": "Selecione uma resposta",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -171,9 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Patch aplicado",
 
   "ui.question.subtitle.answered": "{{count}} respondidas",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(sem resposta)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(não respondida)",
   "ui.question.multiHint": "Selecione todas que se aplicam",
   "ui.question.singleHint": "Selecione uma resposta",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -175,7 +175,9 @@ export const dict = {
   "ui.patch.action.patched": "Primijenjeno",
 
   "ui.question.subtitle.answered": "{{count}} odgovoreno",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(nema odgovora)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(nije odgovoreno)",
   "ui.question.multiHint": "Odaberi sve što važi",
   "ui.question.singleHint": "Odaberi jedan odgovor",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -175,9 +175,9 @@ export const dict = {
   "ui.patch.action.patched": "Primijenjeno",
 
   "ui.question.subtitle.answered": "{{count}} odgovoreno",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(nema odgovora)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(nije odgovoreno)",
   "ui.question.multiHint": "Odaberi sve što važi",
   "ui.question.singleHint": "Odaberi jedan odgovor",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -170,9 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Patchet",
 
   "ui.question.subtitle.answered": "{{count}} besvaret",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(intet svar)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(ikke besvaret)",
   "ui.question.multiHint": "Vælg alle der gælder",
   "ui.question.singleHint": "Vælg ét svar",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -170,7 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Patchet",
 
   "ui.question.subtitle.answered": "{{count}} besvaret",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(intet svar)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(ikke besvaret)",
   "ui.question.multiHint": "Vælg alle der gælder",
   "ui.question.singleHint": "Vælg ét svar",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -176,9 +176,9 @@ export const dict = {
   "ui.patch.action.patched": "Gepatched",
 
   "ui.question.subtitle.answered": "{{count}} beantwortet",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(keine Antwort)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(nicht beantwortet)",
   "ui.question.multiHint": "Alle zutreffenden auswählen",
   "ui.question.singleHint": "Eine Antwort auswählen",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -176,7 +176,9 @@ export const dict = {
   "ui.patch.action.patched": "Gepatched",
 
   "ui.question.subtitle.answered": "{{count}} beantwortet",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(keine Antwort)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(nicht beantwortet)",
   "ui.question.multiHint": "Alle zutreffenden auswählen",
   "ui.question.singleHint": "Eine Antwort auswählen",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -184,7 +184,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Patched",
 
   "ui.question.subtitle.answered": "{{count}} answered",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(no answer)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(not answered)",
   "ui.question.multiHint": "Select all answers that apply",
   "ui.question.singleHint": "Select one answer",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -184,9 +184,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Patched",
 
   "ui.question.subtitle.answered": "{{count}} answered",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(no answer)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(not answered)",
   "ui.question.multiHint": "Select all answers that apply",
   "ui.question.singleHint": "Select one answer",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -171,7 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Parcheado",
 
   "ui.question.subtitle.answered": "{{count}} respondidas",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(sin respuesta)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(no respondida)",
   "ui.question.multiHint": "Selecciona todas las que correspondan",
   "ui.question.singleHint": "Selecciona una respuesta",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -171,9 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Parcheado",
 
   "ui.question.subtitle.answered": "{{count}} respondidas",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(sin respuesta)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(no respondida)",
   "ui.question.multiHint": "Selecciona todas las que correspondan",
   "ui.question.singleHint": "Selecciona una respuesta",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -171,7 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Corrigé",
 
   "ui.question.subtitle.answered": "{{count}} répondu(s)",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(pas de réponse)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(non répondu)",
   "ui.question.multiHint": "Sélectionnez tout ce qui s'applique",
   "ui.question.singleHint": "Sélectionnez une réponse",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -171,9 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "Corrigé",
 
   "ui.question.subtitle.answered": "{{count}} répondu(s)",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(pas de réponse)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(non répondu)",
   "ui.question.multiHint": "Sélectionnez tout ce qui s'applique",
   "ui.question.singleHint": "Sélectionnez une réponse",

--- a/packages/ui/src/i18n/it.ts
+++ b/packages/ui/src/i18n/it.ts
@@ -186,7 +186,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Patch applicata",
 
   "ui.question.subtitle.answered": "{{count}} risposte",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(nessuna risposta)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(senza risposta)",
   "ui.question.multiHint": "Seleziona tutte le risposte applicabili",
   "ui.question.singleHint": "Seleziona una risposta",

--- a/packages/ui/src/i18n/it.ts
+++ b/packages/ui/src/i18n/it.ts
@@ -186,9 +186,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Patch applicata",
 
   "ui.question.subtitle.answered": "{{count}} risposte",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(nessuna risposta)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(senza risposta)",
   "ui.question.multiHint": "Seleziona tutte le risposte applicabili",
   "ui.question.singleHint": "Seleziona una risposta",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -170,9 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "パッチ適用済み",
 
   "ui.question.subtitle.answered": "{{count}}件回答済み",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(回答なし)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "該当するものをすべて選択",
   "ui.question.singleHint": "1 つ選択",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -170,7 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "パッチ適用済み",
 
   "ui.question.subtitle.answered": "{{count}}件回答済み",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(回答なし)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "該当するものをすべて選択",
   "ui.question.singleHint": "1 つ選択",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -171,9 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "패치됨",
 
   "ui.question.subtitle.answered": "{{count}}개 답변됨",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(답변 없음)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(답변되지 않음)",
   "ui.question.multiHint": "해당하는 항목 모두 선택",
   "ui.question.singleHint": "하나의 답변을 선택",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -171,7 +171,9 @@ export const dict = {
   "ui.patch.action.patched": "패치됨",
 
   "ui.question.subtitle.answered": "{{count}}개 답변됨",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(답변 없음)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(답변되지 않음)",
   "ui.question.multiHint": "해당하는 항목 모두 선택",
   "ui.question.singleHint": "하나의 답변을 선택",

--- a/packages/ui/src/i18n/nl.ts
+++ b/packages/ui/src/i18n/nl.ts
@@ -189,7 +189,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Gepatcht",
 
   "ui.question.subtitle.answered": "{{count}} beantwoord",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(geen antwoord)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(niet beantwoord)",
   "ui.question.multiHint": "Selecteer alle antwoorden die van toepassing zijn",
   "ui.question.singleHint": "Selecteer één antwoord",

--- a/packages/ui/src/i18n/nl.ts
+++ b/packages/ui/src/i18n/nl.ts
@@ -189,9 +189,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Gepatcht",
 
   "ui.question.subtitle.answered": "{{count}} beantwoord",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(geen antwoord)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(niet beantwoord)",
   "ui.question.multiHint": "Selecteer alle antwoorden die van toepassing zijn",
   "ui.question.singleHint": "Selecteer één antwoord",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -174,7 +174,9 @@ export const dict: Record<Keys, string> = {
   "ui.patch.action.patched": "Oppdatert",
 
   "ui.question.subtitle.answered": "{{count}} besvart",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(ingen svar)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(ikke besvart)",
   "ui.question.multiHint": "Velg alle som gjelder",
   "ui.question.singleHint": "Velg ett svar",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -174,9 +174,9 @@ export const dict: Record<Keys, string> = {
   "ui.patch.action.patched": "Oppdatert",
 
   "ui.question.subtitle.answered": "{{count}} besvart",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(ingen svar)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(ikke besvart)",
   "ui.question.multiHint": "Velg alle som gjelder",
   "ui.question.singleHint": "Velg ett svar",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -170,7 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Załatano",
 
   "ui.question.subtitle.answered": "{{count}} odpowiedzi",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(brak odpowiedzi)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(bez odpowiedzi)",
   "ui.question.multiHint": "Zaznacz wszystkie pasujące",
   "ui.question.singleHint": "Wybierz jedną odpowiedź",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -170,9 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Załatano",
 
   "ui.question.subtitle.answered": "{{count}} odpowiedzi",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(brak odpowiedzi)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(bez odpowiedzi)",
   "ui.question.multiHint": "Zaznacz wszystkie pasujące",
   "ui.question.singleHint": "Wybierz jedną odpowiedź",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -170,7 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Изменено",
 
   "ui.question.subtitle.answered": "{{count}} отвечено",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(нет ответа)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(не отвечено)",
   "ui.question.multiHint": "Выберите все подходящие",
   "ui.question.singleHint": "Выберите один ответ",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -170,9 +170,9 @@ export const dict = {
   "ui.patch.action.patched": "Изменено",
 
   "ui.question.subtitle.answered": "{{count}} отвечено",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(нет ответа)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(не отвечено)",
   "ui.question.multiHint": "Выберите все подходящие",
   "ui.question.singleHint": "Выберите один ответ",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -172,9 +172,9 @@ export const dict = {
   "ui.patch.action.patched": "แพตช์",
 
   "ui.question.subtitle.answered": "{{count}} ตอบแล้ว",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(ไม่มีคำตอบ)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(ไม่ได้ตอบ)",
   "ui.question.multiHint": "เลือกทั้งหมดที่ใช้",
   "ui.question.singleHint": "เลือกหนึ่งคำตอบ",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -172,7 +172,9 @@ export const dict = {
   "ui.patch.action.patched": "แพตช์",
 
   "ui.question.subtitle.answered": "{{count}} ตอบแล้ว",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(ไม่มีคำตอบ)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(ไม่ได้ตอบ)",
   "ui.question.multiHint": "เลือกทั้งหมดที่ใช้",
   "ui.question.singleHint": "เลือกหนึ่งคำตอบ",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -177,7 +177,9 @@ export const dict = {
   "ui.patch.action.patched": "Yamalandı",
 
   "ui.question.subtitle.answered": "{{count}} cevaplandı",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(cevap yok)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(cevaplanmadı)",
   "ui.question.multiHint": "Geçerli tüm cevapları seçin",
   "ui.question.singleHint": "Bir cevap seçin",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -177,9 +177,9 @@ export const dict = {
   "ui.patch.action.patched": "Yamalandı",
 
   "ui.question.subtitle.answered": "{{count}} cevaplandı",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(cevap yok)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(cevaplanmadı)",
   "ui.question.multiHint": "Geçerli tüm cevapları seçin",
   "ui.question.singleHint": "Bir cevap seçin",

--- a/packages/ui/src/i18n/uk.ts
+++ b/packages/ui/src/i18n/uk.ts
@@ -197,9 +197,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Застосовано патч", // kilocode_change
 
   "ui.question.subtitle.answered": "{{count}} відповідей",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(немає відповіді)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(не відповіли)",
   "ui.question.multiHint": "Виберіть усі відповідні варіанти",
   "ui.question.singleHint": "Виберіть одну відповідь",

--- a/packages/ui/src/i18n/uk.ts
+++ b/packages/ui/src/i18n/uk.ts
@@ -197,7 +197,9 @@ export const dict: Record<string, string> = {
   "ui.patch.action.patched": "Застосовано патч", // kilocode_change
 
   "ui.question.subtitle.answered": "{{count}} відповідей",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(немає відповіді)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(не відповіли)",
   "ui.question.multiHint": "Виберіть усі відповідні варіанти",
   "ui.question.singleHint": "Виберіть одну відповідь",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -174,9 +174,9 @@ export const dict = {
   "ui.patch.action.patched": "已应用补丁",
 
   "ui.question.subtitle.answered": "{{count}} 已回答",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(无答案)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "可多选",
   "ui.question.singleHint": "选择一个答案",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -174,7 +174,9 @@ export const dict = {
   "ui.patch.action.patched": "已应用补丁",
 
   "ui.question.subtitle.answered": "{{count}} 已回答",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(无答案)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "可多选",
   "ui.question.singleHint": "选择一个答案",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -174,7 +174,9 @@ export const dict = {
   "ui.patch.action.patched": "已套用修補",
 
   "ui.question.subtitle.answered": "{{count}} 已回答",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed",
   "ui.question.answer.none": "(無答案)",
+  "ui.question.answer.dismissed": "Dismissed",
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "可多選",
   "ui.question.singleHint": "選擇一個答案",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -174,9 +174,9 @@ export const dict = {
   "ui.patch.action.patched": "已套用修補",
 
   "ui.question.subtitle.answered": "{{count}} 已回答",
-  "ui.question.subtitle.dismissed": "{{count}} dismissed",
+  "ui.question.subtitle.dismissed": "{{count}} dismissed", // kilocode_change
   "ui.question.answer.none": "(無答案)",
-  "ui.question.answer.dismissed": "Dismissed",
+  "ui.question.answer.dismissed": "Dismissed", // kilocode_change
   "ui.question.review.notAnswered": "(未回答)",
   "ui.question.multiHint": "可多選",
   "ui.question.singleHint": "選擇一個答案",


### PR DESCRIPTION
## Issue

Fixes #10361

## Context

When a question prompt is dismissed (manually via "Dismiss" or automatically when a new prompt arrives), the question content becomes invisible in the chat history. The root cause is that the question tool renderers gate content visibility on `answers.length > 0`. Since dismissed questions have empty `answers`, the question text is hidden.

This fix makes dismissed questions always show their content, with a "Dismissed" label and muted visual treatment.

## Implementation

**VSCode/Web UI (`packages/kilo-ui/src/components/message-part.tsx`):**
- Question tool renderer: removed the `Show when={completed()}` gate. When `metadata.dismissed === true` or `status === "error"`, shows the question content with "Dismissed" labels and "N dismissed" subtitle
- Error dismissal handler: dismissed question errors now fall through to the normal renderer instead of showing a bare "Questions dismissed" label
- New i18n keys: `ui.question.subtitle.dismissed`, `ui.question.answer.dismissed`

**TUI main view (`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`):**
- Question component: when `metadata.dismissed` is true or error contains "dismissed", shows "Dismissed" labels and updated title "(dismissed)"

**TUI v2 view (`packages/opencode/src/cli/cmd/tui/feature-plugins/system/session-v2.tsx`):**
- Same dismissed treatment as the main TUI view

## Screenshots / Video

Will post in separate comment

## How to Test

### Manual/local verification

- Run Storybook: `cd packages/kilo-ui && bun run storybook`
- Open the QuestionAnswered and QuestionDismissed stories
- Expand both — confirm dismissed questions show content with "Dismissed" labels

### TUI verification

- Start a session that triggers a question tool call
- Dismiss the question (press Escape)
- Scroll back in the session — confirm the question content is visible with "Dismissed" labels

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
