### PR TITLE
feat(gateway): send version headers on notification requests

### DIFF
--- a/packages/kilo-gateway/src/api/notifications.ts
+++ b/packages/kilo-gateway/src/api/notifications.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { KILO_API_BASE } from "./constants.js"
+import { getDefaultHeaders, buildKiloHeaders } from "../headers.js"
 
 /**
  * Kilo notification schema
@@ -44,8 +45,9 @@ export async function fetchKilocodeNotifications(options: {
   try {
     const response = await fetch(url, {
       headers: {
+        ...getDefaultHeaders(),
+        ...buildKiloHeaders(undefined, { kilocodeOrganizationId: options.kilocodeOrganizationId }),
         Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
       },
       signal: AbortSignal.timeout(NOTIFICATIONS_TIMEOUT_MS),
     })

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -142,6 +142,7 @@ export class ServerManager {
           KILO_MACHINE_ID: vscode.env.machineId,
           KILO_APP_VERSION: this.context.extension.packageJSON.version,
           KILO_VSCODE_VERSION: vscode.version,
+          KILOCODE_VERSION: this.context.extension.packageJSON.version,
           KILOCODE_EDITOR_NAME: `${vscode.env.appName} ${vscode.version}`,
           ...(!claudeCompat && { KILO_DISABLE_CLAUDE_CODE: "true" }),
           ...resolveTreeSitterEnv(this.context.extensionPath),


### PR DESCRIPTION
## What

Send the regular Kilo gateway headers (including version) on the notification endpoint request, so the backend can discriminate on the extension version.

Two changes:

1. **`fetchKilocodeNotifications`** (`packages/kilo-gateway/src/api/notifications.ts`) previously sent only `Authorization` + `Content-Type`, bypassing the shared header helpers. It now spreads `getDefaultHeaders()` + `buildKiloHeaders(...)`, so the request carries `User-Agent`, `X-KILOCODE-EDITORNAME`, and (when set) `X-KILOCODE-ORGANIZATIONID`.

2. **VS Code `server-manager.ts`** now sets `KILOCODE_VERSION` to the extension version when spawning `kilo serve`. `getUserAgent()` reads this env var, so all gateway requests from the VS Code backend now send `User-Agent: opencode-kilo-provider/<extensionVersion>`.

## Why

The notification endpoint was the only gateway call not using the shared headers, so it sent no version at all. Separately, the extension version (`KILO_APP_VERSION`) was never surfaced in a gateway header — only the VS Code app version (via `X-KILOCODE-EDITORNAME`). Setting `KILOCODE_VERSION` puts the actual extension version into `User-Agent`, giving the backend a reliable signal to discriminate notifications (and other responses) by extension version.

## Notes

- Setting `KILOCODE_VERSION` affects `User-Agent` on **all** gateway requests from the VS Code-spawned backend (intended). It does not affect `X-KILOCODE-EDITORNAME`, which is set explicitly and used verbatim.
- The TUI/standalone-CLI path still doesn't set `KILOCODE_VERSION`, so a `kilo serve` started outside VS Code sends `User-Agent: opencode-kilo-provider` with no version.
