### PR TITLE
docs(kilo-docs): add content gap audit

### DIFF
--- a/packages/kilo-docs/lib/nav/contributing.ts
+++ b/packages/kilo-docs/lib/nav/contributing.ts
@@ -13,6 +13,10 @@ export const ContributingNav: NavSection[] = [
         href: "/contributing/ecosystem",
         children: "Ecosystem",
       },
+      {
+        href: "/contributing/content-gap-audit",
+        children: "Content Gap Audit",
+      },
     ],
   },
   {

--- a/packages/kilo-docs/pages/contributing/content-gap-audit.md
+++ b/packages/kilo-docs/pages/contributing/content-gap-audit.md
@@ -1,0 +1,154 @@
+---
+title: "Content Gap Audit"
+description: "Documentation content gaps and improvement opportunities"
+---
+
+# Documentation Content Gap Audit
+
+This page tracks identified gaps in Kilo documentation and guides prioritization for new content creation. Use this as a roadmap for documentation improvements.
+
+## High-Priority Gaps
+
+### 1. Changelog / Release Notes
+
+**Status:** Missing
+
+**Gap:** No dedicated changelog or release notes page exists for users to track feature releases, bug fixes, and breaking changes.
+
+**Impact:** Users cannot easily discover what's new in each release or understand migration requirements.
+
+**Recommendation:** Create a `/docs/changelog` page with:
+- Release history (grouped by version)
+- Feature additions with links to relevant docs
+- Bug fixes and improvements
+- Breaking changes with migration guidance
+- Link to GitHub releases for full change details
+
+### 2. Comprehensive Troubleshooting Hub
+
+**Status:** Fragmented
+
+**Gap:** Troubleshooting is scattered across multiple pages (extension-specific, enterprise migration, technical migration) with no central troubleshooting index.
+
+**Impact:** Users struggle to find relevant troubleshooting content for their specific issue.
+
+**Recommendation:** Create a `/docs/troubleshooting` hub page with:
+- Issue categorization (installation, authentication, performance, etc.)
+- Diagnostic checklists
+- Links to platform-specific troubleshooting guides
+- Common error code reference
+- When to contact support
+
+### 3. Documentation Style Guide
+
+**Status:** Partial (only in AGENTS.md)
+
+**Gap:** No user-facing documentation style guide for contributors. The style guidance exists in AGENTS.md but isn't discoverable for non-agent contributors.
+
+**Impact:** Inconsistent documentation tone and format across contributors.
+
+**Recommendation:** Create `/docs/contributing/documentation-style` with:
+- Voice and tone guidelines
+- Writing conventions (headings, code blocks, callouts)
+- Link formatting standards
+- Image and screenshot guidelines
+- Markdoc component usage reference
+
+### 4. LLM-First Documentation Guidance
+
+**Status:** Minimal
+
+**Gap:** The "Using Docs with Agents" page exists but lacks depth on best practices for AI-assisted documentation consumption.
+
+**Impact:** Users working with AI tools may not optimize their doc usage effectively.
+
+**Recommendation:** Enhance with:
+- How to structure queries for documentation
+- Best practices for extracting actionable steps
+- Common patterns for AI-assisted troubleshooting
+- Section-specific query examples
+
+## Medium-Priority Gaps
+
+### 5. Migration Guides (Beyond Cursor/Windsurf)
+
+**Status:** Partial
+
+**Gap:** Enterprise migration exists, but migration guidance from other tools (GitHub Copilot, Tabnine, CodeWhisperer, Replit AI) is limited to high-level comparison tables.
+
+**Impact:** Teams evaluating Kilo face friction when migrating from popular alternatives.
+
+**Recommendation:** Create dedicated migration guides for:
+- `/docs/migration/github-copilot`
+- `/docs/migration/tabnine`
+- `/docs/migration/codewhisperer`
+- Each with: detailed comparison, step-by-step migration, feature mapping, timeline planning
+
+### 6. Deeper Reference Pages
+
+**Status:** Partial
+
+**Gap:** API reference exists for Gateway, but other components lack comprehensive reference documentation.
+
+**Impact:** Developers building integrations or debugging face friction finding detailed specifications.
+
+**Recommendation:** Add reference pages for:
+- CLI command reference (beyond quickstart)
+- Tool definitions and permissions
+- MCP server configuration reference
+- Custom mode schema reference
+
+### 7. Contribution Workflow Deep Dive
+
+**Status:** Basic
+
+**Gap:** Current contribution docs cover basics but lack detailed workflow guidance for complex contributions.
+
+**Impact:** New contributors may struggle with larger feature implementations.
+
+**Recommendation:** Add:
+- Feature proposal process details
+- Code review expectations
+- Testing requirements by package
+- Merge process and CI requirements
+
+## Lower-Priority Gaps
+
+### 8. Architecture Decision Records (ADRs)
+
+**Status:** Not present
+
+**Gap:** No documented architectural decisions or tradeoffs.
+
+**Impact:** Future contributors lack context for why certain decisions were made.
+
+**Recommendation:** Consider adding ADRs for major architectural choices.
+
+### 9. Performance Optimization Guides
+
+**Status:** Not present
+
+**Gap:** No guidance on optimizing Kilo performance for large codebases or teams.
+
+**Impact:** Users may not achieve optimal performance.
+
+**Recommendation:** Create performance tuning guides for:
+- Codebase indexing optimization
+- Team-scale configuration
+- Resource usage monitoring
+
+## Gap Tracking Instructions
+
+When working on documentation:
+
+1. **Check this audit first** - Verify if a gap is still relevant
+2. **Update status** - Mark completed items as done
+3. **Add new gaps** - Document newly discovered gaps with the same format
+4. **Prioritize** - Focus on high-impact, user-facing gaps first
+
+## Related Resources
+
+- [Contributing Overview](/docs/contributing)
+- [AGENTS.md](https://github.com/Kilo-Org/kilocode/blob/main/AGENTS.md)
+- [Feature Proposals](/docs/contributing/features)
+- [Development Environment](/docs/contributing/development-environment)


### PR DESCRIPTION
Adds a content gap audit page to document missing documentation areas and prioritize future content creation.

## What

- Created  page
- Added navigation link in the Contributing section

## Why

Identified high-priority documentation gaps including:
- Missing changelog/release notes
- Fragmented troubleshooting content
- No user-facing documentation style guide
- Limited migration guides beyond Cursor/Windsurf

## Content

The audit page identifies 9 content gaps across 3 priority levels:
1. **High**: Changelog, Troubleshooting Hub, Style Guide, LLM Docs Guidance
2. **Medium**: Migration guides, Reference pages, Contribution workflow
3. **Low**: ADRs, Performance guides

This serves as a roadmap for future documentation improvements.