### PR TITLE
docs(kilo-docs): improve navigation structure

### DIFF
--- a/packages/kilo-docs/lib/nav/automate.ts
+++ b/packages/kilo-docs/lib/nav/automate.ts
@@ -10,7 +10,6 @@ export const AutomateNav: NavSection[] = [
         href: "/automate/code-reviews/overview",
         children: "Code Reviews",
         subLinks: [
-          { href: "/automate/code-reviews/overview", children: "Overview" },
           { href: "/automate/code-reviews/github", children: "GitHub" },
           { href: "/automate/code-reviews/gitlab", children: "GitLab" },
         ],
@@ -19,7 +18,6 @@ export const AutomateNav: NavSection[] = [
         href: "/automate/agent-manager",
         children: "Agent Manager",
         subLinks: [
-          { href: "/automate/agent-manager", children: "Reference" },
           { href: "/automate/agent-manager-workflows", children: "Workflows" },
         ],
       },
@@ -42,7 +40,6 @@ export const AutomateNav: NavSection[] = [
         href: "/automate/mcp/overview",
         children: "MCP",
         subLinks: [
-          { href: "/automate/mcp/overview", children: "MCP Overview" },
           {
             href: "/automate/mcp/using-in-kilo-code",
             children: "Using MCP in Kilo Code",

--- a/packages/kilo-docs/lib/nav/code-with-ai.ts
+++ b/packages/kilo-docs/lib/nav/code-with-ai.ts
@@ -8,7 +8,7 @@ export const CodeWithAiNav: NavSection[] = [
       {
         href: "/code-with-ai/platforms/vscode",
         children: "VS Code Extension",
-        subLinks: [{ href: "/code-with-ai/platforms/vscode/whats-new", children: "Whats New" }],
+        subLinks: [{ href: "/code-with-ai/platforms/vscode/whats-new", children: "What's New" }],
       },
       {
         href: "/code-with-ai/platforms/jetbrains",

--- a/packages/kilo-docs/lib/nav/code-with-ai.ts
+++ b/packages/kilo-docs/lib/nav/code-with-ai.ts
@@ -8,7 +8,7 @@ export const CodeWithAiNav: NavSection[] = [
       {
         href: "/code-with-ai/platforms/vscode",
         children: "VS Code Extension",
-        subLinks: [{ href: "/code-with-ai/platforms/vscode/whats-new", children: "What's New" }],
+        subLinks: [{ href: "/code-with-ai/platforms/vscode/whats-new", children: "Whats New" }],
       },
       {
         href: "/code-with-ai/platforms/jetbrains",
@@ -30,6 +30,11 @@ export const CodeWithAiNav: NavSection[] = [
       },
       { href: "/code-with-ai/platforms/cloud-agent", children: "Cloud Agent" },
       { href: "/code-with-ai/platforms/mobile", children: "Mobile Apps" },
+    ],
+  },
+  {
+    title: "Features",
+    links: [
       { href: "/code-with-ai/app-builder", children: "App Builder" },
       {
         href: "/code-with-ai/gastown",
@@ -80,7 +85,6 @@ export const CodeWithAiNav: NavSection[] = [
         href: "/code-with-ai/agents/using-agents",
         children: "Agents",
         subLinks: [
-          { href: "/code-with-ai/agents/using-agents", children: "Using Agents" },
           {
             href: "/code-with-ai/agents/orchestrator-mode",
             children: "Orchestrator Mode",
@@ -89,7 +93,6 @@ export const CodeWithAiNav: NavSection[] = [
       },
     ],
   },
-
   {
     title: "Productivity Tools",
     links: [
@@ -113,11 +116,7 @@ export const CodeWithAiNav: NavSection[] = [
         href: "/code-with-ai/features/browser-use",
         children: "Agent Behavior",
         subLinks: [
-          { href: "/code-with-ai/features/browser-use", children: "Browser Use" },
-          {
-            href: "/code-with-ai/features/task-todo-list",
-            children: "Task Todo List",
-          },
+          { href: "/code-with-ai/features/task-todo-list", children: "Task Todo List" },
           { href: "/code-with-ai/features/checkpoints", children: "Checkpoints" },
           { href: "/code-with-ai/features/file-encoding", children: "File Encoding" },
         ],

--- a/packages/kilo-docs/lib/nav/collaborate.ts
+++ b/packages/kilo-docs/lib/nav/collaborate.ts
@@ -27,27 +27,26 @@ export const CollaborateNav: NavSection[] = [
       },
       { href: "/collaborate/teams/billing", children: "Billing" },
       { href: "/collaborate/teams/analytics", children: "Analytics" },
+    ],
+  },
+  {
+    title: "AI Adoption Dashboard",
+    links: [
       {
         href: "/collaborate/adoption-dashboard/overview",
-        children: "AI Adoption Dashboard",
-        subLinks: [
-          {
-            href: "/collaborate/adoption-dashboard/overview",
-            children: "Overview",
-          },
-          {
-            href: "/collaborate/adoption-dashboard/understanding-your-score",
-            children: "Understanding Your Score",
-          },
-          {
-            href: "/collaborate/adoption-dashboard/improving-your-score",
-            children: "Improving Your Score",
-          },
-          {
-            href: "/collaborate/adoption-dashboard/for-team-leads",
-            children: "For Team Leads",
-          },
-        ],
+        children: "Overview",
+      },
+      {
+        href: "/collaborate/adoption-dashboard/understanding-your-score",
+        children: "Understanding Your Score",
+      },
+      {
+        href: "/collaborate/adoption-dashboard/improving-your-score",
+        children: "Improving Your Score",
+      },
+      {
+        href: "/collaborate/adoption-dashboard/for-team-leads",
+        children: "For Team Leads",
       },
     ],
   },

--- a/packages/kilo-docs/lib/nav/getting-started.ts
+++ b/packages/kilo-docs/lib/nav/getting-started.ts
@@ -24,7 +24,6 @@ export const GettingStartedNav: NavSection[] = [
         href: "/getting-started/byok",
         children: "Bring Your Own Key (BYOK)",
       },
-      { href: "/ai-providers", children: "AI Providers" },
       {
         href: "/getting-started/settings",
         children: "Settings",
@@ -34,7 +33,10 @@ export const GettingStartedNav: NavSection[] = [
         ],
       },
       { href: "/getting-started/adding-credits", children: "Adding Credits" },
-      { href: "/getting-started/rate-limits-and-costs", children: "Cost Efficiency & Model Selection" },
+      {
+        href: "/getting-started/rate-limits-and-costs",
+        children: "Cost Efficiency & Model Selection",
+      },
       { href: "/getting-started/cost-controls-and-usage-safeguards", children: "Cost Controls and Usage Safeguards" },
     ],
   },

--- a/packages/kilo-docs/lib/nav/kiloclaw.ts
+++ b/packages/kilo-docs/lib/nav/kiloclaw.ts
@@ -12,7 +12,6 @@ export const KiloClawNav: NavSection[] = [
         href: "/kiloclaw/control-ui/overview",
         children: "Control UI",
         subLinks: [
-          { href: "/kiloclaw/control-ui/overview", children: "Overview" },
           { href: "/kiloclaw/control-ui/changing-models", children: "Changing Models" },
           { href: "/kiloclaw/control-ui/exec-approvals", children: "Exec Approvals" },
           { href: "/kiloclaw/control-ui/version-pinning", children: "Version Pinning" },
@@ -22,7 +21,6 @@ export const KiloClawNav: NavSection[] = [
         href: "/kiloclaw/chat-platforms",
         children: "Chat Platforms",
         subLinks: [
-          { href: "/kiloclaw/chat-platforms", children: "Overview" },
           { href: "/kiloclaw/chat-platforms/telegram", children: "Telegram" },
           { href: "/kiloclaw/chat-platforms/discord", children: "Discord" },
           { href: "/kiloclaw/chat-platforms/slack", children: "Slack" },
@@ -32,7 +30,6 @@ export const KiloClawNav: NavSection[] = [
         href: "/kiloclaw/development-tools",
         children: "Integrations",
         subLinks: [
-          { href: "/kiloclaw/development-tools", children: "Overview" },
           { href: "/kiloclaw/development-tools/github", children: "GitHub" },
           { href: "/kiloclaw/development-tools/google", children: "Google Workspace" },
           { href: "/kiloclaw/development-tools/linear", children: "Linear" },
@@ -47,7 +44,6 @@ export const KiloClawNav: NavSection[] = [
         href: "/kiloclaw/triggers",
         children: "Triggers",
         subLinks: [
-          { href: "/kiloclaw/triggers", children: "Overview" },
           { href: "/kiloclaw/triggers/webhooks", children: "Webhooks" },
           { href: "/kiloclaw/triggers/scheduled", children: "Scheduled" },
         ],


### PR DESCRIPTION
Improves the Kilo docs navigation structure for clarity and usability:

- Removes AI Providers link from Getting Started Configuration (it has its own top-level section)
- Removes redundant self-referencing subLinks (links pointing to parent pages)
- Separates AI Adoption Dashboard into its own top-level section in Collaborate
- Reduces confusing placement and duplicate entries throughout

These changes make the navigation cleaner and easier to scan without moving any page files.