### PR TITLE
docs: add deprecation notice to App Builder page

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/app-builder.md
+++ b/packages/kilo-docs/pages/code-with-ai/app-builder.md
@@ -5,6 +5,10 @@ description: "Build complete applications with Kilo Code"
 
 # App Builder
 
+{% callout type="warning" title="App Builder is deprecated" %}
+App Builder is deprecated and no longer available to new users. Only existing users who previously used App Builder can still access it.
+{% /callout %}
+
 Kilo's **App Builder** lets you create end-to-end applications through natural language conversation. Describe what you want to build, watch it come to life in a real-time preview, and deploy directly from your Kilo dashboard. No local environment setup required.
 
 ---


### PR DESCRIPTION
## What

Adds a deprecation notice callout to the top of the App Builder documentation page (`packages/kilo-docs/pages/code-with-ai/app-builder.md`).

## Why

App Builder is being deprecated/feature-flagged — it is only available to existing users who previously used it, and is no longer available to new users. The docs should reflect this so readers aren't misled into thinking they can sign up for it.

## Notes

- Minimal change: added a `warning` callout at the top of the page using the docs site's standard Markdoc callout syntax. Rest of the page content is unchanged.

---

Built for [Evgeny Shurakov](https://kilo-code.slack.com/archives/C0A98FQHRDJ/p1783413573617559?thread_ts=1783412392.543559&cid=C0A98FQHRDJ) by [Kilo for Slack](https://kilo.ai/slack)