### PR TITLE
fix(agent-manager): defer automatic branch naming until intent is clear

### DIFF
--- a/.changeset/defer-branch-naming.md
+++ b/.changeset/defer-branch-naming.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Defer Agent Manager automatic branch naming until the conversation shows a durable task. The first user message no longer renames the branch; naming waits for a second message (up to four) or for the worktree to contain changes, and renames only run while the session is idle. Read-only verification questions (for example "is X fixed?") no longer claim the branch name.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1110,8 +1110,8 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
 
-    const orphaned = state.removeWorktree(worktreeId)
     this.naming.forget(worktreeId)
+    const orphaned = state.removeWorktree(worktreeId)
     if (this.diffs.shouldStopForWorktree(worktree.path, orphaned)) {
       this.diffs.stop()
     }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1076,6 +1076,7 @@ export class AgentManagerProvider implements Disposable {
     this.statsPoller.skipWorktree(worktreeId)
     this.prBridge.remove(worktreeId)
     this.run.remove(worktreeId)
+    this.naming.forget(worktreeId)
     const orphaned = state.removeWorktree(worktreeId)
     if (this.diffs.shouldStopForWorktree(worktree.path, orphaned)) {
       this.diffs.stop()
@@ -1110,6 +1111,7 @@ export class AgentManagerProvider implements Disposable {
     }
 
     const orphaned = state.removeWorktree(worktreeId)
+    this.naming.forget(worktreeId)
     if (this.diffs.shouldStopForWorktree(worktree.path, orphaned)) {
       this.diffs.stop()
     }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -78,6 +78,7 @@ export class AgentManagerProvider implements Disposable {
   private cachedWorktreeStats: { type: "agentManager.worktreeStats"; stats: WorktreeStats[] } | undefined
   private cachedLocalStats: { type: "agentManager.localStats"; stats: LocalStats } | undefined
   private unsubTool: (() => void) | undefined
+  private unsubStatus: (() => void) | undefined
   private unsubFont: (() => void) | undefined
   private closing: Promise<void> | undefined
   private onVisibilityChange: ((visible: boolean) => void) | undefined
@@ -184,6 +185,19 @@ export class AgentManagerProvider implements Disposable {
       (event) => (event as { type?: string }).type === "kilocode.agent_manager.start",
       (event, directory) => this.onToolEvent(event, directory),
     )
+    this.unsubStatus = this.connectionService.onEventFiltered(
+      (event) => (event as { type?: string }).type === "session.status",
+      (event) => this.onSessionStatus(event),
+    )
+  }
+
+  private onSessionStatus(event: unknown): void {
+    const props = (event as { properties?: { sessionID?: string; status?: { type?: string } } }).properties
+    const sid = props?.sessionID
+    const type = props?.status?.type
+    if (!sid || !type) return
+    if (type === "idle") this.naming.idle(sid)
+    else this.naming.busy(sid)
   }
 
   private log(...args: unknown[]) {
@@ -1905,6 +1919,7 @@ export class AgentManagerProvider implements Disposable {
     await this.stateReady?.catch((err) => this.log("dispose: stateReady rejected:", err))
     await this.state?.flush().catch((err) => this.log("dispose: state flush failed:", err))
     this.unsubTool?.()
+    this.unsubStatus?.()
     this.unsubFont?.()
     this.connectionService.unregisterFocused("agent-manager")
     this.connectionService.registerOpen("agent-manager", [])

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -158,6 +158,22 @@ export class WorktreeManager {
     return this.withGitLock(() => this.renameBranchImpl(worktreePath, current, requested))
   }
 
+  /** Whether the worktree has uncommitted changes or commits ahead of base.
+   *  Used to defer automatic branch naming until the branch carries real work. */
+  async hasWork(worktreePath: string, base: string): Promise<boolean> {
+    if (!this.isManagedPath(worktreePath)) return false
+    return this.withGitLock(async () => {
+      const git = simpleGit(worktreePath)
+      const status = await git.status()
+      if (status.files.length > 0) return true
+      // When the base ref cannot be resolved, we cannot prove there is work.
+      return git
+        .raw(["rev-list", "--count", `${base}..HEAD`])
+        .then((count) => parseInt(count.trim(), 10) > 0)
+        .catch(() => false)
+    })
+  }
+
   private async ensureGitAvailable(): Promise<void> {
     try {
       await execWithShellEnv("git", ["--version"])

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -166,11 +166,15 @@ export class WorktreeManager {
       const git = simpleGit(worktreePath)
       const status = await git.status()
       if (status.files.length > 0) return true
-      // When the base ref cannot be resolved, we cannot prove there is work.
       return git
         .raw(["rev-list", "--count", `${base}..HEAD`])
         .then((count) => parseInt(count.trim(), 10) > 0)
-        .catch(() => false)
+        .catch((error) => {
+          // An unresolvable base ref means no work to compare; other git
+          // failures also fail safe to "no work", keeping the placeholder name.
+          this.log(`hasWork rev-list failed: ${error}`)
+          return false
+        })
     })
   }
 

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -38,6 +38,8 @@ export interface Worktree {
   branchOwned?: boolean
   /** Initial session whose prompts may name this placeholder branch once. */
   autoNameSessionId?: string
+  /** Number of prompts observed for the armed session; bounds rename attempts. */
+  autoNamePromptCount?: number
   /** Section this worktree belongs to, or undefined for ungrouped. */
   sectionId?: string
 }
@@ -234,6 +236,7 @@ export class WorktreeStateManager {
     this.log(`Updated worktree ${id} branch: ${wt.branch} → ${branch}`)
     wt.branch = branch
     wt.autoNameSessionId = undefined
+    wt.autoNamePromptCount = undefined
     void this.save()
     return true
   }
@@ -242,6 +245,7 @@ export class WorktreeStateManager {
     const wt = this.worktrees.get(id)
     if (!wt || wt.branchOwned !== true) return
     wt.autoNameSessionId = sessionId
+    wt.autoNamePromptCount = 0
     void this.save()
   }
 
@@ -249,7 +253,18 @@ export class WorktreeStateManager {
     const wt = this.worktrees.get(id)
     if (!wt?.autoNameSessionId) return
     wt.autoNameSessionId = undefined
+    wt.autoNamePromptCount = undefined
     void this.save()
+  }
+
+  /** Increment the prompt counter for an armed worktree and return the new
+   *  count, or undefined when the worktree is no longer armed. */
+  incrementAutoNameCount(id: string): number | undefined {
+    const wt = this.worktrees.get(id)
+    if (!wt?.autoNameSessionId) return undefined
+    wt.autoNamePromptCount = (wt.autoNamePromptCount ?? 0) + 1
+    void this.save()
+    return wt.autoNamePromptCount
   }
 
   renameOwnedBranch(id: string, current: string, branch: string): boolean {
@@ -258,6 +273,7 @@ export class WorktreeStateManager {
     wt.branch = branch
     wt.originalBranch = undefined
     wt.autoNameSessionId = undefined
+    wt.autoNamePromptCount = undefined
     this.log(`Automatically renamed worktree ${id} branch: ${current} → ${branch}`)
     void this.save()
     return true
@@ -310,6 +326,7 @@ export class WorktreeStateManager {
     const worktree = worktreeId ? this.worktrees.get(worktreeId) : undefined
     if (worktree?.autoNameSessionId && worktreeId && this.getSessions(worktreeId).length > 1) {
       worktree.autoNameSessionId = undefined
+      worktree.autoNamePromptCount = undefined
     }
     this.log(`Added session ${sessionId} to worktree ${worktreeId ?? "local"}`)
     void this.save()
@@ -321,10 +338,16 @@ export class WorktreeStateManager {
     const session = this.sessions.get(sessionId)
     if (!session) return
     const previous = session.worktreeId ? this.worktrees.get(session.worktreeId) : undefined
-    if (previous?.autoNameSessionId === sessionId) previous.autoNameSessionId = undefined
+    if (previous?.autoNameSessionId === sessionId) {
+      previous.autoNameSessionId = undefined
+      previous.autoNamePromptCount = undefined
+    }
     session.worktreeId = worktreeId
     const worktree = worktreeId ? this.worktrees.get(worktreeId) : undefined
-    if (worktree?.autoNameSessionId) worktree.autoNameSessionId = undefined
+    if (worktree?.autoNameSessionId) {
+      worktree.autoNameSessionId = undefined
+      worktree.autoNamePromptCount = undefined
+    }
     this.log(`Moved session ${sessionId} to ${worktreeId ?? "local"}`)
     void this.save()
   }

--- a/packages/kilo-vscode/src/agent-manager/branch-naming.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-naming.ts
@@ -1,5 +1,8 @@
 import { semanticBranchName } from "./branch-name"
-import type { WorktreeStateManager } from "./WorktreeStateManager"
+import { remoteRef, type WorktreeStateManager } from "./WorktreeStateManager"
+
+/** Maximum prompts considered for automatic naming before disarming. */
+const MAX_PROMPTS = 4
 
 interface Prompt {
   sessionID: string
@@ -25,6 +28,7 @@ interface Client {
 
 interface Manager {
   renameBranch: (path: string, current: string, branch: string) => Promise<string>
+  hasWork: (worktreePath: string, base: string) => Promise<boolean>
 }
 
 interface Deps {
@@ -36,34 +40,115 @@ interface Deps {
   log: (msg: string) => void
 }
 
+interface Pending {
+  sessionID: string
+  branch: string
+}
+
 export class BranchNamingController {
   private readonly requests = new Map<string, AbortController>()
+  private readonly busySessions = new Set<string>()
+  private readonly pending = new Map<string, Pending>()
+  private readonly idleAttempted = new Set<string>()
+  private readonly model = new Map<string, { providerID?: string; modelID?: string }>()
 
   constructor(private readonly deps: Deps) {}
 
+  /** Called for every outgoing user message. Defers naming until intent is clear:
+   *  the first message only arms, messages 2-4 may name, after that disarm. */
   prompt(input: Prompt): void {
-    const state = this.deps.state()
-    const session = state?.getSession(input.sessionID)
-    const worktree = session?.worktreeId ? state?.getWorktree(session.worktreeId) : undefined
+    const { state, worktree } = this.resolve(input.sessionID)
     if (!state || !worktree || worktree.autoNameSessionId !== input.sessionID) return
     if (!this.deps.settings().enabled) {
-      state.clearAutoName(worktree.id)
+      this.disarm(worktree.id)
       return
     }
     if (state.getSessions(worktree.id).length !== 1 || worktree.prNumber || worktree.prUrl) {
-      state.clearAutoName(worktree.id)
+      this.disarm(worktree.id)
       return
     }
+    this.model.set(worktree.id, { providerID: input.providerID, modelID: input.modelID })
+    this.idleAttempted.delete(worktree.id)
+    const count = state.incrementAutoNameCount(worktree.id)
+    if (count === undefined) return
+    if (count > MAX_PROMPTS) {
+      this.disarm(worktree.id)
+      return
+    }
+    if (count < 2) return
     if (this.requests.has(worktree.id)) return
+    this.dispatch(worktree.id, input)
+  }
 
-    const request = new AbortController()
-    this.requests.set(worktree.id, request)
-    void this.generate(worktree.id, input, request)
+  /** Mark a session busy so the rename is deferred to the next idle transition.
+   *  Only armed sessions are tracked to keep the set bounded. */
+  busy(sessionID: string): void {
+    const { worktree } = this.resolve(sessionID)
+    if (worktree?.autoNameSessionId !== sessionID) return
+    this.busySessions.add(sessionID)
+  }
+
+  /** Called when a session becomes idle. Triggers generation once when the
+   *  worktree already has changes (covering a single detailed first prompt),
+   *  and applies any rename that was held while the session was busy. */
+  idle(sessionID: string): void {
+    this.busySessions.delete(sessionID)
+    const { state, worktree } = this.resolve(sessionID)
+    if (state && worktree && worktree.autoNameSessionId === sessionID) {
+      const count = worktree.autoNamePromptCount ?? 0
+      if (count === 1 && !this.idleAttempted.has(worktree.id) && !this.requests.has(worktree.id)) {
+        this.idleAttempted.add(worktree.id)
+        void this.generateOnIdle(worktree.id, sessionID)
+      }
+    }
+    this.applyPending(sessionID)
   }
 
   dispose(): void {
     for (const request of this.requests.values()) request.abort()
     this.requests.clear()
+    this.pending.clear()
+  }
+
+  private resolve(sessionID: string) {
+    const state = this.deps.state()
+    const session = state?.getSession(sessionID)
+    const worktree = session?.worktreeId ? state?.getWorktree(session.worktreeId) : undefined
+    return { state, worktree }
+  }
+
+  /** Clear persisted arming plus the controller's in-memory bookkeeping. */
+  private disarm(id: string): void {
+    this.deps.state()?.clearAutoName(id)
+    this.forget(id)
+  }
+
+  private forget(id: string): void {
+    this.pending.delete(id)
+    this.model.delete(id)
+    this.idleAttempted.delete(id)
+  }
+
+  private dispatch(id: string, input: Prompt): void {
+    const request = new AbortController()
+    this.requests.set(id, request)
+    void this.generate(id, input, request)
+  }
+
+  private async generateOnIdle(id: string, sessionID: string): Promise<void> {
+    const state = this.deps.state()
+    const manager = this.deps.manager()
+    const worktree = state?.getWorktree(id)
+    if (!state || !manager || !worktree || worktree.autoNameSessionId !== sessionID) return
+    if (state.getSessions(id).length !== 1 || worktree.prNumber || worktree.prUrl) {
+      this.disarm(id)
+      return
+    }
+    const ref = this.model.get(id)
+    const has = await manager.hasWork(worktree.path, remoteRef(worktree)).catch(() => false)
+    if (!has) return
+    if (this.requests.has(id)) return
+    this.dispatch(id, { sessionID, text: "", providerID: ref?.providerID, modelID: ref?.modelID })
   }
 
   private async generate(id: string, input: Prompt, request: AbortController): Promise<void> {
@@ -83,7 +168,9 @@ export class BranchNamingController {
         { throwOnError: true, signal: request.signal },
       )
       if (!data.branch || request.signal.aborted) return
-      await this.rename(id, input.sessionID, data.branch)
+      // Keep the request slot occupied until the rename settles so a fast
+      // next prompt does not dispatch a redundant generation.
+      await this.queueRename(id, input.sessionID, data.branch)
     } catch (error) {
       if (request.signal.aborted) return
       this.deps.log(`Skipped automatic branch naming: ${error}`)
@@ -92,7 +179,24 @@ export class BranchNamingController {
     }
   }
 
-  private async rename(id: string, sessionID: string, generated: string): Promise<void> {
+  private async queueRename(id: string, sessionID: string, generated: string): Promise<void> {
+    if (this.busySessions.has(sessionID)) {
+      this.pending.set(id, { sessionID, branch: generated })
+      return
+    }
+    await this.applyRename(id, sessionID, generated)
+  }
+
+  private applyPending(sessionID: string): void {
+    const { worktree } = this.resolve(sessionID)
+    if (!worktree) return
+    const pending = this.pending.get(worktree.id)
+    if (!pending) return
+    this.pending.delete(worktree.id)
+    void this.applyRename(worktree.id, pending.sessionID, pending.branch)
+  }
+
+  private async applyRename(id: string, sessionID: string, generated: string): Promise<void> {
     const state = this.deps.state()
     const manager = this.deps.manager()
     const worktree = state?.getWorktree(id)
@@ -104,8 +208,15 @@ export class BranchNamingController {
     const branch = semanticBranchName(generated, cfg.prefix)
     if (!branch) return
     const current = worktree.branch
-    const renamed = await manager.renameBranch(worktree.path, current, branch)
+    // Called fire-and-forget: swallow rename failures into the log instead of
+    // an unhandled rejection, and stay armed so a later message can retry.
+    const renamed = await manager.renameBranch(worktree.path, current, branch).catch((error) => {
+      this.deps.log(`Skipped automatic branch naming: ${error}`)
+      return undefined
+    })
+    if (!renamed) return
     if (!state.renameOwnedBranch(id, current, renamed)) return
+    this.forget(id)
     this.deps.push()
     this.deps.log(`Automatically named branch from session ${sessionID}: ${renamed}`)
   }

--- a/packages/kilo-vscode/src/agent-manager/branch-naming.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-naming.ts
@@ -76,7 +76,7 @@ export class BranchNamingController {
       return
     }
     if (count < 2) return
-    if (this.requests.has(worktree.id)) return
+    if (this.requests.has(worktree.id) || this.pending.has(worktree.id)) return
     this.dispatch(worktree.id, input)
   }
 
@@ -123,7 +123,10 @@ export class BranchNamingController {
     this.forget(id)
   }
 
-  private forget(id: string): void {
+  /** Drop in-memory bookkeeping for a worktree whose arming ended without a
+   *  rename (worktree removed, session moved/deleted). Safe to call for any
+   *  id; no-ops when nothing is held. */
+  forget(id: string): void {
     this.pending.delete(id)
     this.model.delete(id)
     this.idleAttempted.delete(id)
@@ -140,6 +143,10 @@ export class BranchNamingController {
     const manager = this.deps.manager()
     const worktree = state?.getWorktree(id)
     if (!state || !manager || !worktree || worktree.autoNameSessionId !== sessionID) return
+    if (!this.deps.settings().enabled) {
+      this.disarm(id)
+      return
+    }
     if (state.getSessions(id).length !== 1 || worktree.prNumber || worktree.prUrl) {
       this.disarm(id)
       return
@@ -168,8 +175,10 @@ export class BranchNamingController {
         { throwOnError: true, signal: request.signal },
       )
       if (!data.branch || request.signal.aborted) return
-      // Keep the request slot occupied until the rename settles so a fast
-      // next prompt does not dispatch a redundant generation.
+      // Hold the name: if busy, stash it as pending (the request slot frees
+      // immediately, but prompt() refuses to dispatch while a rename is
+      // pending); otherwise apply it now, keeping the slot occupied until it
+      // settles so a fast next prompt does not dispatch a redundant generation.
       await this.queueRename(id, input.sessionID, data.branch)
     } catch (error) {
       if (request.signal.aborted) return

--- a/packages/kilo-vscode/src/agent-manager/branch-naming.ts
+++ b/packages/kilo-vscode/src/agent-manager/branch-naming.ts
@@ -124,9 +124,13 @@ export class BranchNamingController {
   }
 
   /** Drop in-memory bookkeeping for a worktree whose arming ended without a
-   *  rename (worktree removed, session moved/deleted). Safe to call for any
-   *  id; no-ops when nothing is held. */
+   *  rename (worktree removed, session moved/deleted). Also clears the armed
+   *  session from the busy set. Call before the worktree is removed from state
+   *  so the session is still resolvable. Safe to call for any id; no-ops when
+   *  nothing is held. */
   forget(id: string): void {
+    const worktree = this.deps.state()?.getWorktree(id)
+    if (worktree?.autoNameSessionId) this.busySessions.delete(worktree.autoNameSessionId)
     this.pending.delete(id)
     this.model.delete(id)
     this.idleAttempted.delete(id)

--- a/packages/kilo-vscode/tests/unit/branch-naming.test.ts
+++ b/packages/kilo-vscode/tests/unit/branch-naming.test.ts
@@ -14,6 +14,56 @@ async function settle() {
   await new Promise((resolve) => setTimeout(resolve, 20))
 }
 
+function makeNaming(
+  state: WorktreeStateManager,
+  deps: {
+    generate?: (input: {
+      directory: string
+      sessionID: string
+      prompt: string
+      providerID?: string
+      modelID?: string
+    }) => Promise<{ data: { branch: string | null } }>
+    rename?: (branch: string) => Promise<string>
+    hasWork?: () => Promise<boolean>
+  } = {},
+) {
+  const renamed: string[] = []
+  const prompts: string[] = []
+  const requests = { value: 0 }
+  const generate = deps.generate ?? (() => Promise.resolve({ data: { branch: null } }))
+  const naming = new BranchNamingController({
+    state: () => state,
+    manager: () => ({
+      renameBranch: async (_p: string, _c: string, branch: string) => {
+        renamed.push(branch)
+        return deps.rename ? await deps.rename(branch) : branch
+      },
+      hasWork: async () => (deps.hasWork ? await deps.hasWork() : false),
+    }),
+    client: async () => ({
+      branchName: {
+        generate: async (input) => {
+          requests.value += 1
+          prompts.push(input.prompt)
+          return generate(input)
+        },
+      },
+    }),
+    settings: () => ({ enabled: true, prefix: "" }),
+    push: () => {},
+    log: () => {},
+  })
+  return { naming, renamed, prompts, requests }
+}
+
+function armed(state: WorktreeStateManager, branch = "quiet-river") {
+  const wt = state.addWorktree({ branch, path: "/tmp/" + branch, parentBranch: "main", branchOwned: true })
+  state.addSession("session-1", wt.id)
+  state.armAutoName(wt.id, "session-1")
+  return wt
+}
+
 describe("BranchNamingController", () => {
   let root: string
   let state: WorktreeStateManager
@@ -29,62 +79,50 @@ describe("BranchNamingController", () => {
     fs.rmSync(root, { recursive: true, force: true })
   })
 
-  it("retries on a later message when the first attempt is not clear yet", async () => {
-    const wt = state.addWorktree({
-      branch: "quiet-river",
-      path: "/tmp/quiet-river",
-      parentBranch: "main",
-      branchOwned: true,
-    })
-    state.addSession("session-1", wt.id)
-    state.armAutoName(wt.id, "session-1")
-    const renamed: string[] = []
-    let requests = 0
-    const naming = new BranchNamingController({
-      state: () => state,
-      manager: () => ({
-        renameBranch: async (_path, _current, branch) => {
-          renamed.push(branch)
-          return branch
-        },
-      }),
-      client: async () => ({
-        branchName: {
-          generate: async () => {
-            requests += 1
-            return { data: { branch: requests === 1 ? null : "fix-final-task" } }
-          },
-        },
-      }),
-      settings: () => ({ enabled: true, prefix: "" }),
-      push: () => {},
-      log: () => {},
+  it("skips the first prompt and names on the second", async () => {
+    const wt = armed(state)
+    const { naming, renamed, prompts, requests } = makeNaming(state, {
+      generate: async () => ({ data: { branch: "fix-final-task" } }),
     })
 
     naming.prompt({ sessionID: "session-1", text: "hi" })
     await settle()
     expect(state.getWorktree(wt.id)?.autoNameSessionId).toBe("session-1")
+    expect(requests.value).toBe(0)
+
     naming.prompt({ sessionID: "session-1", text: "Fix the task" })
     await settle()
 
-    expect(requests).toBe(2)
+    expect(requests.value).toBe(1)
+    expect(prompts).toEqual(["Fix the task"])
     expect(renamed).toEqual(["fix-final-task"])
     expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
   })
 
-  it("renames once and applies the user prefix", async () => {
-    const wt = state.addWorktree({
-      branch: "quiet-river",
-      path: "/tmp/quiet-river",
-      parentBranch: "main",
-      branchOwned: true,
+  it("names on the first prompt once the worktree has work, via idle", async () => {
+    const wt = armed(state)
+    const { naming, renamed, requests } = makeNaming(state, {
+      generate: async () => ({ data: { branch: "fix-token-refresh-race" } }),
+      hasWork: async () => true,
     })
-    state.addSession("session-1", wt.id)
-    state.armAutoName(wt.id, "session-1")
+
+    naming.prompt({ sessionID: "session-1", text: "Fix the token refresh race" })
+    await settle()
+    expect(requests.value).toBe(0)
+    naming.idle("session-1")
+    await settle()
+
+    expect(requests.value).toBe(1)
+    expect(renamed).toEqual(["fix-token-refresh-race"])
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+  })
+
+  it("applies the user prefix", async () => {
+    const wt = armed(state)
     const prompts: string[] = []
     const naming = new BranchNamingController({
       state: () => state,
-      manager: () => ({ renameBranch: async (_path, _current, branch) => branch }),
+      manager: () => ({ renameBranch: async (_p, _c, branch) => branch, hasWork: async () => true }),
       client: async () => ({
         branchName: {
           generate: async (input) => {
@@ -99,9 +137,10 @@ describe("BranchNamingController", () => {
     })
 
     naming.prompt({ sessionID: "session-1", text: "Fix the token refresh race" })
+    naming.idle("session-1")
     await settle()
 
-    expect(prompts).toEqual(["Fix the token refresh race"])
+    expect(prompts).toEqual([""])
     expect(state.getWorktree(wt.id)).toMatchObject({
       branch: "marius/features/fix-token-refresh-race",
       autoNameSessionId: undefined,
@@ -119,14 +158,9 @@ describe("BranchNamingController", () => {
     let requests = 0
     const naming = new BranchNamingController({
       state: () => state,
-      manager: () => ({ renameBranch: async (_path, _current, branch) => branch }),
+      manager: () => ({ renameBranch: async (_p, _c, branch) => branch, hasWork: async () => true }),
       client: async () => ({
-        branchName: {
-          generate: async () => {
-            requests += 1
-            return { data: { branch: "replace-custom-name" } }
-          },
-        },
+        branchName: { generate: async () => ({ data: { branch: ((requests += 1), "replace-custom-name") } }) },
       }),
       settings: () => ({ enabled: true, prefix: "" }),
       push: () => {},
@@ -134,6 +168,7 @@ describe("BranchNamingController", () => {
     })
 
     naming.prompt({ sessionID: "session-1", text: "Implement auth" })
+    naming.idle("session-1")
     await settle()
 
     expect(requests).toBe(0)
@@ -141,24 +176,18 @@ describe("BranchNamingController", () => {
   })
 
   it("does not start another request while naming is pending", async () => {
-    const wt = state.addWorktree({
-      branch: "quiet-river",
-      path: "/tmp/quiet-river",
-      parentBranch: "main",
-      branchOwned: true,
-    })
-    state.addSession("session-1", wt.id)
-    state.armAutoName(wt.id, "session-1")
+    armed(state)
     const first = deferred<{ data: { branch: string | null } }>()
     const renamed: string[] = []
     let requests = 0
     const naming = new BranchNamingController({
       state: () => state,
       manager: () => ({
-        renameBranch: async (_path, _current, branch) => {
+        renameBranch: async (_p, _c, branch) => {
           renamed.push(branch)
           return branch
         },
+        hasWork: async () => false,
       }),
       client: async () => ({
         branchName: {
@@ -174,7 +203,6 @@ describe("BranchNamingController", () => {
     })
 
     naming.prompt({ sessionID: "session-1", text: "Explore some options" })
-    await Promise.resolve()
     naming.prompt({ sessionID: "session-1", text: "Fix the final task" })
     await settle()
     first.resolve({ data: { branch: "explore-options" } })
@@ -182,5 +210,131 @@ describe("BranchNamingController", () => {
 
     expect(requests).toBe(1)
     expect(renamed).toEqual(["explore-options"])
+  })
+
+  it("disarms after the maximum number of prompts without a rename", async () => {
+    const wt = armed(state)
+    const { naming, requests } = makeNaming(state, {
+      generate: async () => ({ data: { branch: null } }),
+    })
+
+    for (let i = 0; i < 6; i++) naming.prompt({ sessionID: "session-1", text: `vague ${i}` })
+    await settle()
+
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+    expect(requests.value).toBeLessThanOrEqual(4)
+  })
+
+  it("holds the rename while busy and applies it on idle", async () => {
+    const wt = armed(state)
+    const { naming, renamed } = makeNaming(state, {
+      generate: async () => ({ data: { branch: "fix-thing" } }),
+    })
+
+    naming.busy("session-1")
+    naming.prompt({ sessionID: "session-1", text: "first" })
+    naming.prompt({ sessionID: "session-1", text: "fix the thing" })
+    await settle()
+    expect(renamed).toEqual([])
+    expect(state.getWorktree(wt.id)?.branch).toBe("quiet-river")
+
+    naming.idle("session-1")
+    await settle()
+    expect(renamed).toEqual(["fix-thing"])
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+  })
+
+  it("logs a failed rename and stays armed for a retry", async () => {
+    const wt = armed(state)
+    const logs: string[] = []
+    const naming = new BranchNamingController({
+      state: () => state,
+      manager: () => ({
+        renameBranch: async () => {
+          throw new Error("Branch already has an upstream")
+        },
+        hasWork: async () => false,
+      }),
+      client: async () => ({
+        branchName: { generate: async () => ({ data: { branch: "fix-thing" } }) },
+      }),
+      settings: () => ({ enabled: true, prefix: "" }),
+      push: () => {},
+      log: (msg) => logs.push(msg),
+    })
+
+    naming.prompt({ sessionID: "session-1", text: "first" })
+    naming.prompt({ sessionID: "session-1", text: "fix the thing" })
+    await settle()
+
+    expect(logs.some((msg) => msg.includes("Branch already has an upstream"))).toBe(true)
+    expect(state.getWorktree(wt.id)).toMatchObject({
+      branch: "quiet-river",
+      autoNameSessionId: "session-1",
+    })
+  })
+
+  it("does not generate on idle before any prompt", async () => {
+    armed(state)
+    const { naming, requests } = makeNaming(state, { hasWork: async () => true })
+
+    naming.idle("session-1")
+    await settle()
+
+    expect(requests.value).toBe(0)
+  })
+
+  it("generates on prompts two to four and disarms on the fifth", async () => {
+    const wt = armed(state)
+    const { naming, requests } = makeNaming(state, {
+      generate: async () => ({ data: { branch: null } }),
+    })
+
+    const counts: number[] = []
+    for (let i = 1; i <= 5; i++) {
+      naming.prompt({ sessionID: "session-1", text: `message ${i}` })
+      await settle()
+      counts.push(requests.value)
+    }
+
+    expect(counts).toEqual([0, 1, 2, 3, 3])
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+  })
+
+  it("holds a rename that resolves while busy and applies it on idle", async () => {
+    const wt = armed(state)
+    const response = deferred<{ data: { branch: string | null } }>()
+    const { naming, renamed } = makeNaming(state, { generate: () => response.promise })
+
+    naming.prompt({ sessionID: "session-1", text: "first" })
+    naming.prompt({ sessionID: "session-1", text: "fix the thing" })
+    naming.busy("session-1")
+    response.resolve({ data: { branch: "fix-thing" } })
+    await settle()
+    expect(renamed).toEqual([])
+    expect(state.getWorktree(wt.id)?.branch).toBe("quiet-river")
+
+    naming.idle("session-1")
+    await settle()
+    expect(renamed).toEqual(["fix-thing"])
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+  })
+
+  it("disarms when the setting is disabled", async () => {
+    const wt = armed(state)
+    const naming = new BranchNamingController({
+      state: () => state,
+      manager: () => ({ renameBranch: async (_p, _c, branch) => branch, hasWork: async () => true }),
+      client: async () => ({ branchName: { generate: async () => ({ data: { branch: "fix-thing" } }) } }),
+      settings: () => ({ enabled: false, prefix: "" }),
+      push: () => {},
+      log: () => {},
+    })
+
+    naming.prompt({ sessionID: "session-1", text: "Fix the thing" })
+    await settle()
+
+    expect(state.getWorktree(wt.id)?.autoNameSessionId).toBeUndefined()
+    expect(state.getWorktree(wt.id)?.branch).toBe("quiet-river")
   })
 })

--- a/packages/opencode/src/kilocode/branch-name.ts
+++ b/packages/opencode/src/kilocode/branch-name.ts
@@ -18,7 +18,7 @@ Return exactly one line:
 - null when there is not yet a clear, stable workstream
 
 Return null for greetings, acknowledgements, capability questions, casual conversation, vague requests, unresolved brainstorming, or messages that only select an option without enough preceding context.
-Return null for read-only status checks or verification questions (for example "is X fixed?", "check whether ..."), unless later messages show the user acting on the result.
+Return null when the messages only ask a question or check a status and do not describe work to perform (for example "is X fixed?", "check whether ...").
 A concrete implementation, investigation, planning, documentation, or research task is a valid workstream.
 Name the durable goal or outcome, not a tentative implementation detail. Prefer an action and object, such as fix-token-refresh-race or research-branch-naming.
 If the user asks for a specific branch name, prefer that name.

--- a/packages/opencode/src/kilocode/branch-name.ts
+++ b/packages/opencode/src/kilocode/branch-name.ts
@@ -18,6 +18,7 @@ Return exactly one line:
 - null when there is not yet a clear, stable workstream
 
 Return null for greetings, acknowledgements, capability questions, casual conversation, vague requests, unresolved brainstorming, or messages that only select an option without enough preceding context.
+Return null for read-only status checks or verification questions (for example "is X fixed?", "check whether ..."), unless later messages show the user acting on the result.
 A concrete implementation, investigation, planning, documentation, or research task is a valid workstream.
 Name the durable goal or outcome, not a tentative implementation detail. Prefer an action and object, such as fix-token-refresh-race or research-branch-naming.
 If the user asks for a specific branch name, prefer that name.


### PR DESCRIPTION
## Problem

Agent Manager auto branch naming (#11741) renamed the placeholder branch on the first user message, so a read-only question like "check if issue #11903 was fixed?" immediately locked the branch to `investigate-issue-11903`. Renaming is one-shot, so if the session then pivoted to actually fixing the issue, the branch name could not recover. Two related defects: a question-only session that never edits files still claimed a semantic name, and while the model returned `null` the controller re-fired an LLM call on every subsequent message forever.

## Before vs after

Three concrete scenarios show why the first-message trigger was wrong and what this changes:

**1. Read-only question (the reported regression)**

New worktree gets a placeholder like `ambitious-keyboard`. First prompt:

> can you check if issue #11903 is fixed? use subagents to investigate

- **Before:** branch renamed to `investigate-issue-11903` immediately, on the first message. If the investigation concludes "not fixed, implement the fix", the branch is stuck with the premature investigation name forever (one-shot rename).
- **After:** the first message never triggers a rename. The agent only reads files, so the idle trigger finds no work either. The branch keeps `ambitious-keyboard`. When the user later sends "now fix it" and the agent edits files, the branch is named from the full conversation context.

**2. Single detailed implementation prompt**

New worktree, placeholder `quiet-river`. First prompt:

> fix the typo in the README title

The agent edits the README and finishes.

- **Before:** renamed to `fix-readme-title` at send time, before the agent even started working.
- **After:** the branch stays `quiet-river` through the entire turn. Once the agent finishes and the session goes idle with a dirty worktree, the rename lands as `fix-readme-title`. A single detailed prompt that produces edits still gets named, just not preemptively mid-turn.

**3. Greeting, then question, then real work**

New worktree, placeholder `misty-mountain`:

- Prompt 1: "hi" — **Before:** dispatches an LLM call; **After:** skipped (first message only arms).
- Prompt 2: "what does this repo do?" — **Before:** dispatches again; **After:** dispatches (it is the 2nd message), but the model returns `null` (vague/capability question). Branch stays `misty-mountain`.
- Prompt 3: "now add a health-check endpoint to the server" — dispatches, returns `add-health-check-endpoint`, and the agent edits files. The rename applies on idle after the work completes.

After four vague messages with no rename, the worktree disarms permanently — no further LLM rename attempts on subsequent messages. This also fixes the old behavior where `null` responses re-fired an LLM call on every message forever.

## What changed

Branch naming is now deferred until there is evidence of a durable workstream, and the rename itself only runs while the session is idle.

- **Send trigger (prompts 2-4 only).** The first user message no longer dispatches generation; it only arms and increments a persisted `autoNamePromptCount`. Prompts 2-4 may name the branch. After four prompts without a successful rename the worktree disarms permanently, which also fixes the unbounded-retry behavior where `null` responses re-fired an LLM call on every message.
- **Idle trigger (first prompt with work).** When the armed session goes idle and the worktree already has work (dirty files or commits ahead of base, checked via a new `WorktreeManager.hasWork` under the git lock), generation fires once per prompt. This keeps #11741's intent that a single detailed first prompt which produces edits still gets named, without naming on message 1.
- **Renames run only while idle.** The provider routes `session.status` SSE events into `naming.busy`/`naming.idle`. Names generated while the agent is busy are held in a `pending` map and applied on the next idle transition with all post-generation guards re-checked, removing mid-turn name-capture races. `generate` awaits the rename so the request slot stays occupied until it settles, preventing a fast follow-up prompt from dispatching a redundant generation mid-rename.
- **CLI prompt tightening.** The branch-name LLM prompt now returns `null` for read-only status/verification questions ("is X fixed?", "check whether..."), as a second layer behind the structural gates targeting the observed `investigate-issue-11903` case.

## Why this shape

The first message is the least informed moment to name a branch, and a semantic name only matters when the branch will carry changes. Deferring to either a second message (persistent intent) or to idle-with-work (actual edits) ties the name to real signal instead of guessing from a single prompt's wording, while preserving all of #11741's one-shot protections (explicit names, imported branches, upstream/PR, single session, `branchOwned` only, HEAD unchanged).

## Notes

- The only shared upstream file touched is `packages/opencode/src/kilocode/branch-name.ts` (kilocode-owned path, no markers needed); all extension-side changes are in `packages/kilo-vscode/`.
- `WorktreeStateManager` adds the persisted `autoNamePromptCount` field; existing disarm paths (manual rename, add/move session) clear it alongside `autoNameSessionId`.
- Tests cover: first-prompt skip, idle+work naming, prefix application, explicit-name protection, in-flight dedup, rename-failure logging + retry, idle-before-prompt no-op, sequential prompts 2-4 with count-5 disarm, realistic prompt→busy→resolve→idle ordering, and disabled-setting disarm.
