### PR TITLE
feat: add /reload action to reboot the instance from disk

### DIFF
--- a/.changeset/reload-instance.md
+++ b/.changeset/reload-instance.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+---
+
+Add a reload action that reboots the per-directory instance, picking up config, skills, agents, commands, and MCP prompts changed on disk. Sessions and history are preserved. Surfaces: `/reload` in the CLI palette and editor chat, a reload button in the task header and settings panel, the `Kilo Code: Reload Config and Skills` command, and a `POST /instance/reload` HTTP endpoint. The endpoint returns 409 while a session is actively running.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -117,6 +117,7 @@ For detailed help on every command and subcommand, see the [CLI Command Referenc
 | `/status` | - | View status |
 | `/themes` | - | Switch theme |
 | `/help` | - | Show help |
+| `/reload` | - | Reload config, skills, agents, and commands from disk |
 | `/editor` | - | Open external editor |
 | `/exit` | `/quit`, `/q` | Exit the app |
 

--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -232,7 +232,7 @@ Skills are discovered when a session starts. The CLI scans all configured skill 
 - In the **CLI**: Skills are loaded when you start a new session or run `kilo run`
 - In the **VS Code extension**: Skills are loaded when the extension connects to the CLI server
 
-Skills are re-scanned at the start of each new session. To pick up newly added or modified skills, start a new session.
+Skills are re-scanned at the start of each new session. To pick up newly added or modified skills without starting a new session, use `/reload`.
 
 {% /tab %}
 {% tab label="CLI" %}
@@ -242,7 +242,7 @@ Skills are discovered when a session starts. The CLI scans all configured skill 
 - In the **CLI**: Skills are loaded when you start a new session or run `kilo run`
 - In the **VS Code extension**: Skills are loaded when the extension connects to the CLI server
 
-Skills are re-scanned at the start of each new session. To pick up newly added or modified skills, start a new session.
+Skills are re-scanned at the start of each new session. To pick up newly added or modified skills without starting a new session, use `/reload`.
 
 {% /tab %}
 {% /tabs %}
@@ -430,7 +430,7 @@ The new platform does not have a marketplace UI yet. You can find and share skil
 
 1. **Verify frontmatter**: Ensure `name` and `description` are present in the YAML frontmatter. The `name` does not need to match the directory name but should be unique across all loaded skills.
 
-2. **Start a new session**: Skills are scanned at session start. Begin a new session to pick up changes.
+2. **Reload or start a new session**: Use `/reload` to pick up changes without losing your current session, or start a new session.
 
 3. **Check file location**: Ensure `SKILL.md` is directly inside the skill directory (e.g., `.kilo/skills/my-skill/SKILL.md`), not nested further.
 
@@ -441,7 +441,7 @@ The new platform does not have a marketplace UI yet. You can find and share skil
 
 1. **Verify frontmatter**: Ensure `name` and `description` are present in the YAML frontmatter. The `name` does not need to match the directory name but should be unique across all loaded skills.
 
-2. **Start a new session**: Skills are scanned at session start. Begin a new session to pick up changes.
+2. **Reload or start a new session**: Use `/reload` to pick up changes without losing your current session, or start a new session.
 
 3. **Check file location**: Ensure `SKILL.md` is directly inside the skill directory (e.g., `.kilo/skills/my-skill/SKILL.md`), not nested further.
 

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/sandboxing-panel-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/sandboxing-panel-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a817c2b87e1d7b28a7c28deaa8fd8d1e9c51aa2daabda1a2de4a0db0a33fcc17
-size 27768
+oid sha256:ea36a9604fbc773d2312289f46205221e607a927b0d302b1d9a5e6bdc1d80308
+size 28888

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/settings-panel-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/settings-panel-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4dbd3be2cdf72a789c17076afa73ddeb2eacbe201ace8d8a2657eb95b23a413
-size 53851
+oid sha256:1ee158333ea6c4478f6c167eac878bdc5969fce47ba9f68a1e731fd9035e9e49
+size 52312

--- a/packages/kilo-ui/src/components/icon.tsx
+++ b/packages/kilo-ui/src/components/icon.tsx
@@ -42,6 +42,10 @@ const icons: Record<string, { path: string; viewBox: string }> = {
     viewBox: "0 0 16 16",
     path: `<path d="M14 4.27051C14.5999 4.62053 15 5.26009 15 6V11C15 13.21 13.21 15 11 15H6C5.26009 15 4.62053 14.5999 4.27051 14H11C12.65 14 14 12.65 14 11V4.27051Z" fill="currentColor"/><path d="M9.5 7C9.776 7 10 7.224 10 7.5C10 7.776 9.776 8 9.5 8H5.5C5.224 8 5 7.776 5 7.5C5 7.224 5.224 7 5.5 7H9.5Z" fill="currentColor"/><path fill-rule="evenodd" clip-rule="evenodd" d="M11 2C12.103 2 13 2.897 13 4V11C13 12.103 12.103 13 11 13H4C2.897 13 2 12.103 2 11V4C2 2.897 2.897 2 4 2H11ZM4 3C3.449 3 3 3.449 3 4V11C3 11.552 3.449 12 4 12H11C11.551 12 12 11.552 12 11V4C12 3.449 11.551 3 11 3H4Z" fill="currentColor"/>`,
   },
+  reload: {
+    viewBox: "0 0 24 24",
+    path: `<path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><path d="M21 3v5h-5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 21v-5h5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>`,
+  },
 }
 
 type Name = keyof typeof icons

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -422,6 +422,11 @@
         "command": "kilo-code.new.takeHeapSnapshot",
         "title": "Take Heap Snapshot",
         "category": "Kilo Code"
+      },
+      {
+        "command": "kilo-code.new.reload",
+        "title": "Reload Config and Skills",
+        "category": "Kilo Code"
       }
     ],
     "submenus": [

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1075,6 +1075,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             console.error("[Kilo New] KiloProvider: ❌ Retry connection failed:", e),
           )
           break
+        case "reload":
+          this.handleReload().catch((e) => console.error("[Kilo New] KiloProvider: Reload failed:", e))
+          break
         case "openSubAgentViewer":
           vscode.commands.executeCommand("kilo-code.new.openSubAgentViewer", message.sessionID, message.title)
           break
@@ -3606,6 +3609,36 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.fetchAndSendIndexingStatus(),
       this.fetchAndSendNotifications(),
     ])
+  }
+
+  /** Reload config, skills, agents, and commands from disk by rebooting the instance. */
+  private async handleReload(): Promise<void> {
+    if (!this.client) {
+      console.warn("[Kilo New] handleReload: no client connection")
+      return
+    }
+    const dir = this.getWorkspaceDirectory(this.currentSession?.id)
+    try {
+      await this.client.instance.reload({ directory: dir }, { throwOnError: true })
+    } catch (err: any) {
+      const status = err?.response?.status
+      if (status === 409) {
+        vscode.window.showWarningMessage(
+          "Cannot reload while a session is running. Wait for it to finish or abort it first.",
+        )
+      } else {
+        console.error("[Kilo New] handleReload: reload endpoint failed:", err)
+        vscode.window.showErrorMessage("Reload failed. See extension logs for details.")
+      }
+      return
+    }
+    this.clearCommandsCache()
+    await this.reloadAfterAuthChange()
+  }
+
+  /** Public reload entry point for VS Code commands. */
+  async reload(): Promise<void> {
+    return this.handleReload()
   }
 
   private mapSyncEventToWebviewMessage(event: LegacySyncEvent) {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3620,8 +3620,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const dir = this.getWorkspaceDirectory(this.currentSession?.id)
     try {
       await this.client.instance.reload({ directory: dir }, { throwOnError: true })
-    } catch (err: any) {
-      const status = err?.response?.status
+    } catch (err) {
+      const status =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined
       if (status === 409) {
         vscode.window.showWarningMessage(
           "Cannot reload while a session is running. Wait for it to finish or abort it first.",
@@ -3633,7 +3636,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       return
     }
     this.clearCommandsCache()
-    await this.reloadAfterAuthChange()
+    if (!sameDirectory(dir, this.getWorkspaceDirectory())) {
+      await this.reloadAfterAuthChange()
+    }
   }
 
   /** Public reload entry point for VS Code commands. */

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -530,6 +530,12 @@ export function activate(context: vscode.ExtensionContext) {
 
   registerHeapSnapshot(context, connectionService)
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand("kilo-code.new.reload", () => {
+      provider.reload().catch((e) => console.error("[Kilo New] reload command failed:", e))
+    }),
+  )
+
   // Register code actions (editor context menus, terminal context menus, keyboard shortcuts)
   registerCodeActions(context, provider, agentManagerProvider)
   registerTerminalActions(context, provider, agentManagerProvider)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -214,7 +214,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
             </Tooltip>
             <Tooltip value={language.t("common.reload")} placement="bottom">
               <IconButton
-                icon="reset"
+                icon="reload"
                 size="small"
                 variant="ghost"
                 onClick={() => vscode.postMessage({ type: "reload" })}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -212,6 +212,15 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                 aria-label={language.t("command.session.compact")}
               />
             </Tooltip>
+            <Tooltip value={language.t("common.reload")} placement="bottom">
+              <IconButton
+                icon="reset"
+                size="small"
+                variant="ghost"
+                onClick={() => vscode.postMessage({ type: "reload" })}
+                aria-label={language.t("common.reload")}
+              />
+            </Tooltip>
           </Show>
           <Show when={hasMessages()}>
             <button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -212,15 +212,6 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                 aria-label={language.t("command.session.compact")}
               />
             </Tooltip>
-            <Tooltip value={language.t("common.reload")} placement="bottom">
-              <IconButton
-                icon="reload"
-                size="small"
-                variant="ghost"
-                onClick={() => vscode.postMessage({ type: "reload" })}
-                aria-label={language.t("common.reload")}
-              />
-            </Tooltip>
           </Show>
           <Show when={hasMessages()}>
             <button

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -143,6 +143,14 @@ const Settings: Component<SettingsProps> = (props) => {
         <Button variant="secondary" size="small" icon="edit" onClick={() => open("global")}>
           {language.t("settings.openGlobalConfig")}
         </Button>
+        <Button
+          variant="secondary"
+          size="small"
+          icon="reset"
+          onClick={() => vscode.postMessage({ type: "reload" })}
+        >
+          {language.t("common.reload")}
+        </Button>
       </div>
 
       {/* Settings tabs */}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -144,7 +144,7 @@ const Settings: Component<SettingsProps> = (props) => {
         <Button variant="secondary" size="small" icon="edit" onClick={() => open("global")}>
           {language.t("settings.openGlobalConfig")}
         </Button>
-        <Tooltip value={language.t("common.reload")} placement="bottom">
+        <Tooltip value={language.t("common.reloadDescription")} placement="bottom">
           <Button variant="secondary" size="small" onClick={() => vscode.postMessage({ type: "reload" })}>
             <Icon name="reload" size="small" />
             {language.t("common.reload")}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -2,6 +2,7 @@ import { Component, createSignal, createEffect, createMemo, on, Show } from "sol
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Tabs } from "@kilocode/kilo-ui/tabs"
 import { Button } from "@kilocode/kilo-ui/button"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { showToast } from "@kilocode/kilo-ui/toast"
 import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
@@ -143,14 +144,12 @@ const Settings: Component<SettingsProps> = (props) => {
         <Button variant="secondary" size="small" icon="edit" onClick={() => open("global")}>
           {language.t("settings.openGlobalConfig")}
         </Button>
-        <Button
-          variant="secondary"
-          size="small"
-          icon="reset"
-          onClick={() => vscode.postMessage({ type: "reload" })}
-        >
-          {language.t("common.reload")}
-        </Button>
+        <Tooltip value={language.t("common.reload")} placement="bottom">
+          <Button variant="secondary" size="small" onClick={() => vscode.postMessage({ type: "reload" })}>
+            <Icon name="reload" size="small" />
+            {language.t("common.reload")}
+          </Button>
+        </Tooltip>
       </div>
 
       {/* Settings tabs */}

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -158,6 +158,14 @@ export function useSlashCommand(
       action: sandbox.action,
       enabled: sandbox.enabled,
     },
+    {
+      name: "reload",
+      description: "Reload config, skills, agents, and commands from disk",
+      hints: ["refresh"],
+      action: () => {
+        vscode.postMessage({ type: "reload" })
+      },
+    },
   ]
 
   const excluded = () => {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1183,6 +1183,7 @@ export const dict = {
 
   "common.retry": "إعادة المحاولة",
   "common.refresh": "تحديث",
+  "common.reload": "إعادة التحميل",
 
   "profile.title": "الملف الشخصي",
   "profile.notLoggedIn": "لم يتم تسجيل الدخول",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1184,6 +1184,7 @@ export const dict = {
   "common.retry": "إعادة المحاولة",
   "common.refresh": "تحديث",
   "common.reload": "إعادة التحميل",
+  "common.reloadDescription": "إعادة تحميل التكوين والمهارات والوكلاء والأوامر من القرص",
 
   "profile.title": "الملف الشخصي",
   "profile.notLoggedIn": "لم يتم تسجيل الدخول",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1205,6 +1205,7 @@ export const dict = {
   "common.retry": "Tentar novamente",
   "common.refresh": "Atualizar",
   "common.reload": "Recarregar",
+  "common.reloadDescription": "Recarregar configuração, habilidades, agentes e comandos do disco",
 
   "profile.title": "Perfil",
   "profile.notLoggedIn": "Não conectado",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1204,6 +1204,7 @@ export const dict = {
 
   "common.retry": "Tentar novamente",
   "common.refresh": "Atualizar",
+  "common.reload": "Recarregar",
 
   "profile.title": "Perfil",
   "profile.notLoggedIn": "Não conectado",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1245,6 +1245,7 @@ export const dict = {
 
   "common.retry": "Pokušaj ponovo",
   "common.refresh": "Osvježi",
+  "common.reload": "Učitaj ponovo",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Niste prijavljeni",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1246,6 +1246,7 @@ export const dict = {
   "common.retry": "Pokušaj ponovo",
   "common.refresh": "Osvježi",
   "common.reload": "Učitaj ponovo",
+  "common.reloadDescription": "Učitaj ponovo konfiguraciju, vještine, agente i naredbe s diska",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Niste prijavljeni",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1239,6 +1239,7 @@ export const dict = {
   "common.retry": "Prøv igen",
   "common.refresh": "Opdatér",
   "common.reload": "Genindlæs",
+  "common.reloadDescription": "Genindlæs konfiguration, færdigheder, agenter og kommandoer fra disken",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Ikke logget ind",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1238,6 +1238,7 @@ export const dict = {
 
   "common.retry": "Prøv igen",
   "common.refresh": "Opdatér",
+  "common.reload": "Genindlæs",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Ikke logget ind",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1260,6 +1260,7 @@ export const dict = {
   "common.retry": "Erneut versuchen",
   "common.refresh": "Aktualisieren",
   "common.reload": "Neu laden",
+  "common.reloadDescription": "Konfiguration, Skills, Agents und Befehle vom Datenträger neu laden",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Nicht angemeldet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1259,6 +1259,7 @@ export const dict = {
 
   "common.retry": "Erneut versuchen",
   "common.refresh": "Aktualisieren",
+  "common.reload": "Neu laden",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Nicht angemeldet",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1156,6 +1156,7 @@ export const dict = {
 
   "common.retry": "Retry",
   "common.refresh": "Refresh",
+  "common.reload": "Reload",
 
   "profile.title": "Profile",
   "profile.notLoggedIn": "Not logged in",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1157,6 +1157,7 @@ export const dict = {
   "common.retry": "Retry",
   "common.refresh": "Refresh",
   "common.reload": "Reload",
+  "common.reloadDescription": "Reload config, skills, agents, and commands from disk",
 
   "profile.title": "Profile",
   "profile.notLoggedIn": "Not logged in",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1252,6 +1252,7 @@ export const dict = {
 
   "common.retry": "Reintentar",
   "common.refresh": "Actualizar",
+  "common.reload": "Recargar",
 
   "profile.title": "Perfil",
   "profile.notLoggedIn": "No conectado",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1253,6 +1253,7 @@ export const dict = {
   "common.retry": "Reintentar",
   "common.refresh": "Actualizar",
   "common.reload": "Recargar",
+  "common.reloadDescription": "Recargar configuración, habilidades, agentes y comandos desde el disco",
 
   "profile.title": "Perfil",
   "profile.notLoggedIn": "No conectado",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1263,7 +1263,8 @@ export const dict = {
   "common.retry": "Réessayer",
   "common.refresh": "Actualiser",
   "common.reload": "Recharger",
-  "common.reloadDescription": "Recharger la configuration, les compétences, les agents et les commandes depuis le disque",
+  "common.reloadDescription":
+    "Recharger la configuration, les compétences, les agents et les commandes depuis le disque",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Non connecté",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1263,6 +1263,7 @@ export const dict = {
   "common.retry": "Réessayer",
   "common.refresh": "Actualiser",
   "common.reload": "Recharger",
+  "common.reloadDescription": "Recharger la configuration, les compétences, les agents et les commandes depuis le disque",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Non connecté",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1262,6 +1262,7 @@ export const dict = {
 
   "common.retry": "Réessayer",
   "common.refresh": "Actualiser",
+  "common.reload": "Recharger",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Non connecté",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1007,6 +1007,7 @@ export const dict = {
   "common.retry": "Riprova",
   "common.refresh": "Aggiorna",
   "common.reload": "Ricarica",
+  "common.reloadDescription": "Ricarica configurazione, competenze, agenti e comandi dal disco",
   "profile.title": "Profilo",
   "profile.notLoggedIn": "Accesso non effettuato",
   "profile.action.login": "Accedi con Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1006,6 +1006,7 @@ export const dict = {
   "deviceAuth.error.detailsTitle": "Dettagli errore accesso",
   "common.retry": "Riprova",
   "common.refresh": "Aggiorna",
+  "common.reload": "Ricarica",
   "profile.title": "Profilo",
   "profile.notLoggedIn": "Accesso non effettuato",
   "profile.action.login": "Accedi con Kilo Code",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1234,6 +1234,7 @@ export const dict = {
   "common.retry": "再試行",
   "common.refresh": "更新",
   "common.reload": "再読み込み",
+  "common.reloadDescription": "ディスクから設定、スキル、エージェント、コマンドを再読み込みします",
 
   "profile.title": "プロフィール",
   "profile.notLoggedIn": "ログインしていません",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1233,6 +1233,7 @@ export const dict = {
 
   "common.retry": "再試行",
   "common.refresh": "更新",
+  "common.reload": "再読み込み",
 
   "profile.title": "プロフィール",
   "profile.notLoggedIn": "ログインしていません",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1191,6 +1191,7 @@ export const dict = {
   "common.retry": "재시도",
   "common.refresh": "새로고침",
   "common.reload": "새로고침",
+  "common.reloadDescription": "디스크에서 구성, 스킬, 에이전트 및 명령을 새로고침합니다",
 
   "profile.title": "프로필",
   "profile.notLoggedIn": "로그인하지 않음",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1190,6 +1190,7 @@ export const dict = {
 
   "common.retry": "재시도",
   "common.refresh": "새로고침",
+  "common.reload": "새로고침",
 
   "profile.title": "프로필",
   "profile.notLoggedIn": "로그인하지 않음",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1198,6 +1198,7 @@ export const dict = {
 
   "common.retry": "Opnieuw proberen",
   "common.refresh": "Vernieuwen",
+  "common.reload": "Herladen",
 
   "profile.title": "Profiel",
   "profile.notLoggedIn": "Niet ingelogd",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1199,6 +1199,7 @@ export const dict = {
   "common.retry": "Opnieuw proberen",
   "common.refresh": "Vernieuwen",
   "common.reload": "Herladen",
+  "common.reloadDescription": "Herlaad configuratie, vaardigheden, agents en opdrachten vanaf schijf",
 
   "profile.title": "Profiel",
   "profile.notLoggedIn": "Niet ingelogd",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1203,6 +1203,7 @@ export const dict = {
   "common.retry": "Prøv igjen",
   "common.refresh": "Oppdater",
   "common.reload": "Last inn på nytt",
+  "common.reloadDescription": "Last inn konfigurasjon, ferdigheter, agenter og kommandoer fra disk på nytt",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Ikke pålogget",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1202,6 +1202,7 @@ export const dict = {
 
   "common.retry": "Prøv igjen",
   "common.refresh": "Oppdater",
+  "common.reload": "Last inn på nytt",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Ikke pålogget",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1202,6 +1202,7 @@ export const dict = {
   "common.retry": "Ponów",
   "common.refresh": "Odśwież",
   "common.reload": "Przeładuj",
+  "common.reloadDescription": "Przeładuj konfigurację, umiejętności, agentów i polecenia z dysku",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Nie zalogowano",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1201,6 +1201,7 @@ export const dict = {
 
   "common.retry": "Ponów",
   "common.refresh": "Odśwież",
+  "common.reload": "Przeładuj",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Nie zalogowano",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1244,6 +1244,7 @@ export const dict = {
 
   "common.retry": "Повторить",
   "common.refresh": "Обновить",
+  "common.reload": "Перезагрузить",
 
   "profile.title": "Профиль",
   "profile.notLoggedIn": "Не авторизован",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1245,6 +1245,7 @@ export const dict = {
   "common.retry": "Повторить",
   "common.refresh": "Обновить",
   "common.reload": "Перезагрузить",
+  "common.reloadDescription": "Перезагрузить конфигурацию, навыки, агентов и команды с диска",
 
   "profile.title": "Профиль",
   "profile.notLoggedIn": "Не авторизован",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1227,6 +1227,7 @@ export const dict = {
   "common.retry": "ลองอีกครั้ง",
   "common.refresh": "รีเฟรช",
   "common.reload": "โหลดใหม่",
+  "common.reloadDescription": "โหลดการตั้งค่า ทักษะ เอเจนต์ และคำสั่งจากดิสก์ใหม่",
 
   "profile.title": "โปรไฟล์",
   "profile.notLoggedIn": "ยังไม่ได้เข้าสู่ระบบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1226,6 +1226,7 @@ export const dict = {
 
   "common.retry": "ลองอีกครั้ง",
   "common.refresh": "รีเฟรช",
+  "common.reload": "โหลดใหม่",
 
   "profile.title": "โปรไฟล์",
   "profile.notLoggedIn": "ยังไม่ได้เข้าสู่ระบบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1195,6 +1195,7 @@ export const dict = {
 
   "common.retry": "Tekrar Dene",
   "common.refresh": "Yenile",
+  "common.reload": "Yeniden yükle",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Giriş yapılmadı",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1196,6 +1196,7 @@ export const dict = {
   "common.retry": "Tekrar Dene",
   "common.refresh": "Yenile",
   "common.reload": "Yeniden yükle",
+  "common.reloadDescription": "Diskten yapılandırma, yetenekler, ajanlar ve komutları yeniden yükle",
 
   "profile.title": "Profil",
   "profile.notLoggedIn": "Giriş yapılmadı",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1193,6 +1193,7 @@ export const dict = {
 
   "common.retry": "Спробувати ще раз",
   "common.refresh": "Оновити",
+  "common.reload": "Перезавантажити",
 
   "profile.title": "Профіль",
   "profile.notLoggedIn": "Не увійшов",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1194,6 +1194,7 @@ export const dict = {
   "common.retry": "Спробувати ще раз",
   "common.refresh": "Оновити",
   "common.reload": "Перезавантажити",
+  "common.reloadDescription": "Перезавантажити конфігурацію, навички, агентів та команди з диска",
 
   "profile.title": "Профіль",
   "profile.notLoggedIn": "Не увійшов",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1206,6 +1206,7 @@ export const dict = {
 
   "common.retry": "重试",
   "common.refresh": "刷新",
+  "common.reload": "重新加载",
 
   "profile.title": "个人资料",
   "profile.notLoggedIn": "未登录",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1207,6 +1207,7 @@ export const dict = {
   "common.retry": "重试",
   "common.refresh": "刷新",
   "common.reload": "重新加载",
+  "common.reloadDescription": "重新加载磁盘上的配置、技能、智能体和命令",
 
   "profile.title": "个人资料",
   "profile.notLoggedIn": "未登录",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1171,6 +1171,7 @@ export const dict = {
   "common.retry": "重試",
   "common.refresh": "重新整理",
   "common.reload": "重新載入",
+  "common.reloadDescription": "重新載入磁碟上的設定、技能、智慧代理和命令",
 
   "profile.title": "個人資料",
   "profile.notLoggedIn": "尚未登入",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1170,6 +1170,7 @@ export const dict = {
 
   "common.retry": "重試",
   "common.refresh": "重新整理",
+  "common.reload": "重新載入",
 
   "profile.title": "個人資料",
   "profile.notLoggedIn": "尚未登入",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -924,6 +924,10 @@ export interface RetryConnectionRequest {
   type: "retryConnection"
 }
 
+export interface ReloadRequest {
+  type: "reload"
+}
+
 // Open a sub-agent session in a read-only editor panel
 export interface OpenSubAgentViewerRequest {
   type: "openSubAgentViewer"
@@ -1333,6 +1337,7 @@ export type WebviewMessage =
   | DiffViewerSetBaseBranchRequest
   | DiffVirtualSetMarkdownRenderRequest
   | RetryConnectionRequest
+  | ReloadRequest
   | OpenSubAgentViewerRequest
   | PreviewImageRequest
   | SaveImageRequest

--- a/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
@@ -15,6 +15,7 @@ import KiloSidebarPr from "@/kilocode/plugins/sidebar-pr"
 import KiloSidebarUsage from "@/kilocode/plugins/sidebar-usage"
 import KiloSandbox from "@/kilocode/plugins/sandbox"
 import KiloRemote from "@/kilocode/plugins/remote"
+import KiloReload from "@/kilocode/plugins/reload"
 // kilocode_change end
 import SidebarContext from "../feature-plugins/sidebar/context"
 import SidebarMcp from "../feature-plugins/sidebar/mcp"
@@ -54,6 +55,7 @@ export function internalTuiPlugins(flags: Pick<RuntimeFlags.Info, "experimentalE
     KiloSidebarUsage, // kilocode_change
     KiloSandbox, // kilocode_change
     KiloRemote, // kilocode_change
+    KiloReload, // kilocode_change
     HomeFooter,
     HomeTips,
     SidebarContext,

--- a/packages/opencode/src/kilocode/plugins/reload.tsx
+++ b/packages/opencode/src/kilocode/plugins/reload.tsx
@@ -1,0 +1,30 @@
+import type { TuiPlugin, TuiPluginModule } from "@kilocode/plugin/tui"
+
+const id = "internal:reload"
+
+const tui: TuiPlugin = async (api) => {
+  api.keymap.registerLayer({
+    commands: [
+      {
+        namespace: "palette",
+        name: "app.reload",
+        title: "Reload",
+        desc: "Reload config, skills, agents, and commands from disk",
+        category: "System",
+        slashName: "reload",
+        async run() {
+          try {
+            await api.client.instance.reload({}, { throwOnError: true })
+            api.ui.toast({ message: "Reloaded", variant: "success" })
+          } catch (err) {
+            api.ui.toast({ message: String(err), variant: "error", duration: 5000 })
+          }
+        },
+      },
+    ],
+  })
+}
+
+const plugin: TuiPluginModule & { id: string } = { id, tui }
+
+export default plugin

--- a/packages/opencode/src/kilocode/plugins/reload.tsx
+++ b/packages/opencode/src/kilocode/plugins/reload.tsx
@@ -3,6 +3,7 @@ import type { TuiPlugin, TuiPluginModule } from "@kilocode/plugin/tui"
 const id = "internal:reload"
 
 const tui: TuiPlugin = async (api) => {
+  let pending = false
   api.keymap.registerLayer({
     commands: [
       {
@@ -13,11 +14,15 @@ const tui: TuiPlugin = async (api) => {
         category: "System",
         slashName: "reload",
         async run() {
+          if (pending) return
+          pending = true
           try {
             await api.client.instance.reload({}, { throwOnError: true })
             api.ui.toast({ message: "Reloaded", variant: "success" })
           } catch (err) {
             api.ui.toast({ message: String(err), variant: "error", duration: 5000 })
+          } finally {
+            pending = false
           }
         },
       },

--- a/packages/opencode/src/kilocode/server/httpapi/groups/instance-reload.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/instance-reload.ts
@@ -1,0 +1,49 @@
+import { Authorization } from "@/server/routes/instance/httpapi/middleware/authorization"
+import { InstanceContextMiddleware } from "@/server/routes/instance/httpapi/middleware/instance-context"
+import {
+  WorkspaceRoutingMiddleware,
+  WorkspaceRoutingQuery,
+} from "@/server/routes/instance/httpapi/middleware/workspace-routing"
+import { described } from "@/server/routes/instance/httpapi/groups/metadata"
+import { ConflictError } from "@/server/routes/instance/httpapi/errors"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+
+export const ReloadPaths = {
+  reload: "/instance/reload",
+} as const
+
+export const InstanceReloadApi = HttpApi.make("instance-reload")
+  .add(
+    HttpApiGroup.make("instance-reload")
+      .add(
+        HttpApiEndpoint.post("reload", ReloadPaths.reload, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Instance reloaded"),
+          error: ConflictError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "instance.reload",
+            summary: "Reload instance",
+            description:
+              "Atomically dispose and reboot the current Kilo instance, reloading config, skills, agents, commands, and MCP prompts from disk. Returns 409 if a session is actively running.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "instance-reload",
+          description: "Kilo instance reload route.",
+        }),
+      )
+      .middleware(InstanceContextMiddleware)
+      .middleware(WorkspaceRoutingMiddleware)
+      .middleware(Authorization),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "kilo HttpApi",
+      version: "0.0.1",
+      description: "Kilo HttpApi surface.",
+    }),
+  )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/instance-reload.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/instance-reload.ts
@@ -1,15 +1,15 @@
 import * as InstanceState from "@/effect/instance-state"
+import { InstanceStore } from "@/project/instance-store"
 import { SessionStatus } from "@/session/status"
 import { ConflictError } from "@/server/routes/instance/httpapi/errors"
-import { markInstanceForReload } from "@/server/routes/instance/httpapi/lifecycle"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import type { SessionID } from "@/session/schema"
 
-export function hasBusySession(statuses: Map<SessionID, SessionStatus.Info>): boolean {
+export function hasActiveSession(statuses: Map<SessionID, SessionStatus.Info>): boolean {
   for (const info of statuses.values()) {
-    if (info.type === "busy") return true
+    if (info.type !== "idle") return true
   }
   return false
 }
@@ -17,17 +17,18 @@ export function hasBusySession(statuses: Map<SessionID, SessionStatus.Info>): bo
 export const instanceReloadHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance-reload", (handlers) =>
   Effect.gen(function* () {
     const status = yield* SessionStatus.Service
+    const store = yield* InstanceStore.Service
 
     const reload = Effect.fn("InstanceReloadHttpApi.reload")(function* () {
       const ctx = yield* InstanceState.context
-      if (hasBusySession(yield* status.list())) {
+      if (hasActiveSession(yield* status.list())) {
         return yield* Effect.fail(
           new ConflictError({
             message: "Cannot reload while a session is running. Wait for it to finish or abort it first.",
           }),
         )
       }
-      yield* markInstanceForReload(ctx, {
+      yield* store.reload({
         directory: ctx.directory,
         worktree: ctx.worktree,
         project: ctx.project,

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/instance-reload.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/instance-reload.ts
@@ -1,0 +1,40 @@
+import * as InstanceState from "@/effect/instance-state"
+import { SessionStatus } from "@/session/status"
+import { ConflictError } from "@/server/routes/instance/httpapi/errors"
+import { markInstanceForReload } from "@/server/routes/instance/httpapi/lifecycle"
+import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
+import { Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import type { SessionID } from "@/session/schema"
+
+export function hasBusySession(statuses: Map<SessionID, SessionStatus.Info>): boolean {
+  for (const info of statuses.values()) {
+    if (info.type === "busy") return true
+  }
+  return false
+}
+
+export const instanceReloadHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance-reload", (handlers) =>
+  Effect.gen(function* () {
+    const status = yield* SessionStatus.Service
+
+    const reload = Effect.fn("InstanceReloadHttpApi.reload")(function* () {
+      const ctx = yield* InstanceState.context
+      if (hasBusySession(yield* status.list())) {
+        return yield* Effect.fail(
+          new ConflictError({
+            message: "Cannot reload while a session is running. Wait for it to finish or abort it first.",
+          }),
+        )
+      }
+      yield* markInstanceForReload(ctx, {
+        directory: ctx.directory,
+        worktree: ctx.worktree,
+        project: ctx.project,
+      })
+      return true
+    })
+
+    return handlers.handle("reload", reload)
+  }),
+)

--- a/packages/opencode/src/kilocode/server/httpapi/server.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/server.ts
@@ -15,6 +15,7 @@ import { commitMessageHandlers } from "./handlers/commit-message"
 import { configConsoleHandlers } from "./handlers/config-console"
 import { enhancePromptHandlers } from "./handlers/enhance-prompt"
 import { indexingHandlers } from "./handlers/indexing"
+import { instanceReloadHandlers } from "./handlers/instance-reload"
 import { interactiveTerminalHandlers } from "./handlers/interactive-terminal"
 import { kiloGatewayHandlers } from "./handlers/kilo-gateway"
 import { kilocodeHandlers } from "./handlers/kilocode"
@@ -35,6 +36,7 @@ export const provide = Layer.provide([
   configConsoleHandlers,
   enhancePromptHandlers,
   indexingHandlers,
+  instanceReloadHandlers,
   interactiveTerminalHandlers,
   kiloGatewayHandlers,
   kilocodeHandlers,

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -28,6 +28,7 @@ import { BackgroundProcessApi } from "@/kilocode/server/httpapi/groups/backgroun
 import { ConfigConsoleApi } from "@/kilocode/server/httpapi/groups/config-console"
 import { EnhancePromptApi } from "@/kilocode/server/httpapi/groups/enhance-prompt"
 import { IndexingApi } from "@/kilocode/server/httpapi/groups/indexing"
+import { InstanceReloadApi } from "@/kilocode/server/httpapi/groups/instance-reload"
 import { InteractiveTerminalApi } from "@/kilocode/server/httpapi/groups/interactive-terminal"
 import { KiloGatewayApi } from "@/kilocode/server/httpapi/groups/kilo-gateway"
 import { KilocodeApi } from "@/kilocode/server/httpapi/groups/kilocode"
@@ -76,6 +77,7 @@ export const InstanceHttpApi = HttpApi.make("opencode-instance")
   .addHttpApi(ConfigConsoleApi)
   .addHttpApi(EnhancePromptApi)
   .addHttpApi(IndexingApi)
+  .addHttpApi(InstanceReloadApi)
   .addHttpApi(InteractiveTerminalApi)
   .addHttpApi(KiloGatewayApi)
   .addHttpApi(KilocodeApi)

--- a/packages/opencode/test/kilocode/instance-reload.test.ts
+++ b/packages/opencode/test/kilocode/instance-reload.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test"
+import { hasBusySession } from "@/kilocode/server/httpapi/handlers/instance-reload"
+import type { SessionStatus } from "@/session/status"
+import { SessionID } from "@/session/schema"
+
+const entries = (items: [string, SessionStatus.Info][]) =>
+  items.map(([k, v]) => [k as SessionID, v] as [SessionID, SessionStatus.Info])
+
+describe("instance-reload hasBusySession", () => {
+  it("returns false for an empty map", () => {
+    expect(hasBusySession(new Map(entries([])))).toBe(false)
+  })
+
+  it("returns false when all sessions are idle", () => {
+    expect(
+      hasBusySession(
+        new Map(
+          entries([
+            ["s1", { type: "idle" }],
+            ["s2", { type: "idle" }],
+          ]),
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it("returns true when any session is busy", () => {
+    expect(
+      hasBusySession(
+        new Map(
+          entries([
+            ["s1", { type: "idle" }],
+            ["s2", { type: "busy" }],
+          ]),
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it("returns true when the only session is busy", () => {
+    expect(hasBusySession(new Map(entries([["s1", { type: "busy" }]])))).toBe(true)
+  })
+})

--- a/packages/opencode/test/kilocode/instance-reload.test.ts
+++ b/packages/opencode/test/kilocode/instance-reload.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "bun:test"
-import { hasBusySession } from "@/kilocode/server/httpapi/handlers/instance-reload"
+import { hasActiveSession } from "@/kilocode/server/httpapi/handlers/instance-reload"
 import type { SessionStatus } from "@/session/status"
 import { SessionID } from "@/session/schema"
 
 const entries = (items: [string, SessionStatus.Info][]) =>
   items.map(([k, v]) => [k as SessionID, v] as [SessionID, SessionStatus.Info])
 
-describe("instance-reload hasBusySession", () => {
+describe("instance-reload hasActiveSession", () => {
   it("returns false for an empty map", () => {
-    expect(hasBusySession(new Map(entries([])))).toBe(false)
+    expect(hasActiveSession(new Map(entries([])))).toBe(false)
   })
 
   it("returns false when all sessions are idle", () => {
     expect(
-      hasBusySession(
+      hasActiveSession(
         new Map(
           entries([
             ["s1", { type: "idle" }],
@@ -24,9 +24,9 @@ describe("instance-reload hasBusySession", () => {
     ).toBe(false)
   })
 
-  it("returns true when any session is busy", () => {
+  it("returns true when a session is busy", () => {
     expect(
-      hasBusySession(
+      hasActiveSession(
         new Map(
           entries([
             ["s1", { type: "idle" }],
@@ -37,7 +37,29 @@ describe("instance-reload hasBusySession", () => {
     ).toBe(true)
   })
 
-  it("returns true when the only session is busy", () => {
-    expect(hasBusySession(new Map(entries([["s1", { type: "busy" }]])))).toBe(true)
+  it("returns true when a session is retrying", () => {
+    expect(
+      hasActiveSession(
+        new Map(
+          entries([
+            ["s1", { type: "idle" }],
+            ["s2", { type: "retry", attempt: 1, message: "retrying", next: 0 }],
+          ]),
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it("returns true when a session is offline", () => {
+    expect(
+      hasActiveSession(
+        new Map(
+          entries([
+            ["s1", { type: "idle" }],
+            ["s2", { type: "offline", requestID: "q1" as never, message: "waiting" }],
+          ]),
+        ),
+      ),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -682,4 +682,14 @@ export const kiloScenarios: Scenario[] = [
     .post("/telemetry/setEnabled", "telemetry.setEnabled")
     .at((ctx) => ({ path: "/telemetry/setEnabled", headers: ctx.headers(), body: { enabled: true } }))
     .json(200, (body) => check(body === true, "telemetry enabled update should return true")),
+  http.protected
+    .post("/instance/reload", "instance.reload")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "Reload" }))
+    .at((ctx) => ({
+      path: `/instance/reload?directory=${encodeURIComponent(directory(ctx))}`,
+      headers: ctx.headers(),
+      body: {},
+    }))
+    .json(200, (body) => check(body === true, "instance reload should return true")),
 ]

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -134,6 +134,8 @@ import type {
   IndexingWarningsResponses,
   InstanceDisposeErrors,
   InstanceDisposeResponses,
+  InstanceReloadErrors,
+  InstanceReloadResponses,
   InteractiveTerminalCloseErrors,
   InteractiveTerminalCloseResponses,
   InteractiveTerminalGetErrors,
@@ -2253,6 +2255,36 @@ export class Instance extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<InstanceDisposeResponses, InstanceDisposeErrors, ThrowOnError>({
       url: "/instance/dispose",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reload instance
+   *
+   * Atomically dispose and reboot the current Kilo instance, reloading config, skills, agents, commands, and MCP prompts from disk. Returns 409 if a session is actively running.
+   */
+  public reload<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<InstanceReloadResponses, InstanceReloadErrors, ThrowOnError>({
+      url: "/instance/reload",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2571,6 +2571,12 @@ export type KiloEmbeddingModelCatalog = {
   }
 }
 
+export type ConflictError = {
+  _tag: "ConflictError"
+  message: string
+  resource?: string
+}
+
 export type InteractiveTerminalSnapshot = {
   info: InteractiveTerminalInfo
   output: string
@@ -10587,6 +10593,38 @@ export type IndexingModelsResponses = {
 }
 
 export type IndexingModelsResponse = IndexingModelsResponses[keyof IndexingModelsResponses]
+
+export type InstanceReloadData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/instance/reload"
+}
+
+export type InstanceReloadErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * ConflictError
+   */
+  409: ConflictError
+}
+
+export type InstanceReloadError = InstanceReloadErrors[keyof InstanceReloadErrors]
+
+export type InstanceReloadResponses = {
+  /**
+   * Instance reloaded
+   */
+  200: boolean
+}
+
+export type InstanceReloadResponse = InstanceReloadResponses[keyof InstanceReloadResponses]
 
 export type InteractiveTerminalListData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -13085,6 +13085,71 @@
         ]
       }
     },
+    "/instance/reload": {
+      "post": {
+        "tags": ["instance-reload"],
+        "operationId": "instance.reload",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Instance reloaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "Instance reloaded"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "ConflictError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConflictError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Atomically dispose and reboot the current Kilo instance, reloading config, skills, agents, commands, and MCP prompts from disk. Returns 409 if a session is actively running.",
+        "summary": "Reload instance",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.instance.reload({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/interactive-terminal": {
       "get": {
         "tags": ["interactive-terminal"],
@@ -27801,6 +27866,23 @@
         "required": ["defaultModel", "models", "aliases"],
         "additionalProperties": false
       },
+      "ConflictError": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["ConflictError"]
+          },
+          "message": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "message"],
+        "additionalProperties": false
+      },
       "InteractiveTerminalSnapshot": {
         "type": "object",
         "properties": {
@@ -36966,6 +37048,10 @@
     {
       "name": "indexing",
       "description": "Kilo indexing routes."
+    },
+    {
+      "name": "instance-reload",
+      "description": "Kilo instance reload route."
     },
     {
       "name": "interactive-terminal",


### PR DESCRIPTION
## What

Adds a reload action that reboots the per-directory instance, picking up `kilo.json`, skills, agents, markdown commands, and MCP prompts that changed on disk — without restarting the server process. Sessions and their history are preserved; only the per-directory instance caches are torn down and rebuilt. This mirrors the `pi` `/reload` behavior: settings apply, history stays.

## Why

Editing config, adding a skill, or dropping a new `command/*.md` file in an already-running workspace had no way to take effect short of restarting `kilo serve` (which kills every session across every directory) or saving a dirty draft through the settings panel (which only covers fields the panel owns, and is racy on the post-response dispose path). External edits to the raw JSON, or new skill/command files, were invisible until a full restart.

`InstanceStore.reload` already existed as the atomic pre-response rebuild path used by `project.git.init`, but nothing surfaced it as a user action. This wires that path up to every client.

<img width="687" height="251" alt="image" src="https://github.com/user-attachments/assets/518a64d4-cc55-4439-8793-c541c8dd7e32" />

<img width="531" height="153" alt="file-eb43d7a7854f45cda336fc3f478a461a" src="https://github.com/user-attachments/assets/99f75515-4901-4cc2-8977-1e21a13cc937" />
<img width="857" height="304" alt="file-ac93d69d448d95634db4f001b1addc51" src="https://github.com/user-attachments/assets/d7596a2c-bde7-433c-983b-6a5dd0b787e7" />



## How

**Server** — new `POST /instance/reload` endpoint (Kilo-owned `httpapi` path) wraps the existing `markInstanceForReload` / `InstanceStore.reload` path. The rebuild completes before the 200 response, so clients can refetch immediately with no race (unlike the lazy post-response `instance.dispose` path). A busy-session guard returns 409 `ConflictError` via `SessionStatus.list()` when a session is actively streaming. The endpoint emits the existing `server.instance.disposed` SSE event, which the TUI and extension already subscribe to for auto-refetch.

No `Command.refresh()` was needed: although `Command.defaultLayer` is server-scoped, the Command service's `InstanceState` registers a per-directory disposer that `InstanceStore.reload` fires, invalidating the cached registry. The next `command.list()` / `skill.all()` / `config.get()` rebuilds from disk.

**CLI** — `/reload` palette command (new `kilocode/plugins/reload.tsx`) calls the endpoint. The TUI already bootstraps on `server.instance.disposed`, so no extra refetch wiring is required.

**Extension** — four surfaces, all posting `{ type: "reload" }` to the same `KiloProvider` handler, which clears the command cache and reuses `reloadAfterAuthChange()` to re-fetch config, providers, agents, skills, commands, indexing, and notifications:
- `/reload` slash command in the chat input
- a reload button in the task header (next to compact)
- a reload button in the settings panel header (next to Open Local/Global Config)
- a `Kilo Code: Reload Config and Skills` command palette entry

The handler resolves the **current session's directory** when reloading, so an Agent Manager worktree session reloads its own worktree instance rather than the workspace root.

**SDK** — regenerated so `client.instance.reload({ directory })` is available to external integrations (JetBrains plugin, CI scripts).

## Scope and conflict footprint

Only three shared upstream files are touched, all inside existing `kilocode_change` blocks (no new markers in shared code): `internal.ts` (plugin registration), `api.ts` (endpoint wiring), and `kilocode/server/httpapi/server.ts` (handler provision). All new code lives in `kilocode/` paths or `packages/kilo-vscode/`.

## Verification

Tested end-to-end against the local dev backend and the isolated VS Code self-test instance:

- API: endpoint registered in OpenAPI; reload returns 200; picks up a new command file, a new skill, and a config change (proving cache invalidation across Command/Skill/Config `InstanceState` entries); returns 409 while a session is busy then 200 once idle; atomic (fresh immediately after 200); emits `server.instance.disposed` SSE.
- Session preservation: session list, message IDs, and tool output content are byte-identical before/after reload; the session continues accepting new work afterward.
- Per-directory scoping: reloading directory A applied A's config while directory B's instance stayed untouched.
- Extension: `/reload` slash, command palette, settings Reload button, and TaskHeader Reload button each reloaded the backend end-to-end and surfaced a new command file in the slash menu; zero console errors.
- CLI: the plugin module loads, registers `palette`/`app.reload` with the correct metadata, and its `run()` invokes `client.instance.reload`.

---

Closes #11960 — editing a skill file mid-session didn't take effect until a full server restart. The `/reload` action rebuilds the per-directory instance caches from disk, so edited skills are picked up without losing session history.
