### PR TITLE
feat(sandbox): widen writable-paths settings input and add coverage

### DIFF
--- a/.changeset/sandbox-writable-paths-input-width.md
+++ b/.changeset/sandbox-writable-paths-input-width.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Widen the Additional Writable Paths input in the Sandboxing settings so longer filesystem paths are easier to read while typing.

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SandboxingTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SandboxingTab.tsx
@@ -64,63 +64,67 @@ const SandboxingTab: Component = () => {
         </Switch>
       </SettingsRow>
 
-      <SettingsRow
-        title={language.t("settings.sandboxing.writablePaths.title")}
-        description={language.t("settings.sandboxing.writablePaths.description")}
-        descriptionId={writablePathsDescription}
-        last
-      >
-        <div style={{ width: "100%" }}>
-          <div
-            style={{
-              display: "flex",
-              gap: "8px",
-              "align-items": "center",
-              padding: "8px 0",
-              "border-bottom": writablePaths().length > 0 ? "1px solid var(--border-weak-base)" : "none",
-            }}
-          >
-            <div style={{ flex: 1 }}>
-              <TextField
-                value={newPath()}
-                placeholder="/tmp"
-                onChange={(val) => setNewPath(val)}
-                onKeyDown={(e: KeyboardEvent) => {
-                  if (e.key === "Enter") addPath()
-                }}
-                hideLabel
-                label={language.t("settings.sandboxing.writablePaths.title")}
-              />
+      {/* wide-input widens the input column so long filesystem paths are readable */}
+      <div data-variant="wide-input">
+        <SettingsRow
+          title={language.t("settings.sandboxing.writablePaths.title")}
+          description={language.t("settings.sandboxing.writablePaths.description")}
+          descriptionId={writablePathsDescription}
+          last
+        >
+          <div style={{ width: "100%" }}>
+            <div
+              style={{
+                display: "flex",
+                gap: "8px",
+                "align-items": "center",
+                padding: "8px 0",
+                "border-bottom": writablePaths().length > 0 ? "1px solid var(--border-weak-base)" : "none",
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <TextField
+                  value={newPath()}
+                  placeholder="/tmp"
+                  onChange={(val) => setNewPath(val)}
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === "Enter") addPath()
+                  }}
+                  hideLabel
+                  label={language.t("settings.sandboxing.writablePaths.title")}
+                />
+              </div>
+              <Button variant="secondary" onClick={addPath}>
+                {language.t("common.add")}
+              </Button>
             </div>
-            <Button variant="secondary" onClick={addPath}>
-              {language.t("common.add")}
-            </Button>
-          </div>
-          <For each={writablePaths()}>
-            {(path, index) => (
-              <div
-                style={{
-                  display: "flex",
-                  "align-items": "center",
-                  "justify-content": "space-between",
-                  padding: "6px 0",
-                  "border-bottom": index() < writablePaths().length - 1 ? "1px solid var(--border-weak-base)" : "none",
-                }}
-              >
-                <span
+            <For each={writablePaths()}>
+              {(path, index) => (
+                <div
                   style={{
-                    "font-family": "var(--vscode-editor-font-family, monospace)",
-                    "font-size": "var(--kilo-font-size-12)",
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    padding: "6px 0",
+                    "border-bottom":
+                      index() < writablePaths().length - 1 ? "1px solid var(--border-weak-base)" : "none",
                   }}
                 >
-                  {path}
-                </span>
-                <IconButton size="small" variant="ghost" icon="close" onClick={() => removePath(index())} />
-              </div>
-            )}
-          </For>
-        </div>
-      </SettingsRow>
+                  <span
+                    style={{
+                      "font-family": "var(--vscode-editor-font-family, monospace)",
+                      "font-size": "var(--kilo-font-size-12)",
+                    }}
+                  >
+                    {path}
+                  </span>
+                  <IconButton size="small" variant="ghost" icon="close" onClick={() => removePath(index())} />
+                </div>
+              )}
+            </For>
+          </div>
+        </SettingsRow>
+      </div>
     </Card>
   )
 }

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -242,6 +242,41 @@ describe("kilocode indexing config", () => {
   })
 })
 
+describe("kilocode sandbox writable paths config", () => {
+  test("honors sandbox_writable_paths from global config only, ignoring project config", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir({ git: true })
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = globalTmp.path
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await writeConfig(globalTmp.path, {
+        $schema: "https://app.kilo.ai/config.json",
+        experimental: { sandbox_writable_paths: ["/tmp/global"] },
+      })
+      // A project kilo.json must not widen the sandbox: its writable paths are dropped at merge time.
+      await writeConfig(tmp.path, {
+        experimental: { sandbox_writable_paths: ["/tmp/project"] },
+      })
+
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await load()
+          expect(config.experimental?.sandbox_writable_paths).toEqual(["/tmp/global"])
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+})
+
 describe("custom provider model config", () => {
   test("persists and removes reasoning across a global config reload", async () => {
     await using globalTmp = await tmpdir()

--- a/packages/opencode/test/kilocode/sandbox/policy.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/policy.test.ts
@@ -234,4 +234,34 @@ describe("sandbox policy", () => {
     expect(roots(ctx)).not.toContain(dirs.approved)
     expect(Exit.isFailure(result)).toBe(true)
   })
+
+  test("makes configured extra writable paths writable while unlisted paths stay denied", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.a, dirs.a, dirs)
+    const policy = profile(ctx, "deny", [dirs.approved])
+    const result = await Effect.runPromise(
+      Effect.all({
+        extra: runSandbox(policy, assertWrite(path.join(dirs.approved, "allowed.txt")).pipe(Effect.exit)),
+        other: runSandbox(policy, assertWrite(path.join(dirs.b, "denied.txt")).pipe(Effect.exit)),
+      }),
+    )
+
+    expect(policy.filesystem.allowWrite.map((rule) => rule.path)).toContain(dirs.approved)
+    expect(roots(ctx)).not.toContain(dirs.approved)
+    expect(Exit.isSuccess(result.extra)).toBe(true)
+    expect(Exit.isFailure(result.other)).toBe(true)
+  })
+
+  test("keeps .git denied inside a configured extra writable path", async () => {
+    await using tmp = await fixture()
+    const dirs = tmp.extra
+    const ctx = context(dirs.a, dirs.a, dirs)
+    const policy = profile(ctx, "deny", [dirs.approved])
+    const result = await Effect.runPromise(
+      runSandbox(policy, assertWrite(path.join(dirs.approved, ".git", "config")).pipe(Effect.exit)),
+    )
+
+    expect(Exit.isFailure(result)).toBe(true)
+  })
 })


### PR DESCRIPTION
Follow-up to #11995, which added the `sandbox_writable_paths` option and its Sandboxing settings UI.

The Additional Writable Paths input inherited the default settings-row input column, which is capped at 160px. Filesystem paths are long, so the field truncated most of what the user typed and made the list of configured paths hard to scan. This widens that single row using the existing `wide-input` variant, giving the input roughly the full control column while leaving the network toggle row unchanged.

It also backfills automated coverage for behavior that previously had none:

- Real `sandbox-exec` enforcement in `policy.test.ts`: a configured extra path becomes writable, an unlisted sibling stays denied, and `.git` inside an extra writable path is still denied.
- A config-scope test in `config.test.ts` confirming `sandbox_writable_paths` is honored from global config only and dropped from a project `kilo.json`, so a repository cannot widen its own sandbox.


<img width="930" height="284" alt="image" src="https://github.com/user-attachments/assets/6f0e82e8-a055-47d5-a335-660d7f229b8e" />
