### PR TITLE
feat(vscode): render read-tool images inline in chat view

### DIFF
--- a/.changeset/inline-read-images.md
+++ b/.changeset/inline-read-images.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Render images inline in the chat view when the agent reads an image file. Images appear below the read tool card and can be clicked to open a full-size preview.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -412,6 +412,35 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   margin-bottom: 0px;
 }
 
+[data-slot="tool-read-images"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 8px;
+  max-width: min(100%, 64ch);
+}
+
+[data-slot="tool-read-image"] {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: var(--radius-sm, 6px);
+  overflow: hidden;
+  border: 1px solid var(--border-weak-base);
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+
+  &:hover {
+    border-color: var(--border-strong-base);
+  }
+}
+
+[data-slot="tool-read-image-img"] {
+  display: block;
+  max-width: 100%;
+  max-height: 200px;
+  object-fit: contain;
+}
+
 [data-component="todos"] {
   [data-slot="message-part-todo-hidden"] {
     padding: 2px 0 2px 28px;

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -995,6 +995,7 @@ export interface ToolProps {
   callID?: string
   output?: string
   status?: string
+  attachments?: FilePart[]
   hideDetails?: boolean
   defaultOpen?: boolean
   forceOpen?: boolean
@@ -1243,6 +1244,8 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               // @ts-expect-error
               output={part.state.output}
               status={part.state.status}
+              // @ts-expect-error
+              attachments={part.state.attachments}
               hideDetails={props.hideDetails}
               defaultOpen={props.defaultOpen}
               animate
@@ -1746,6 +1749,7 @@ ToolRegistry.register({
   render(props) {
     const data = useData()
     const i18n = useI18n()
+    const dialog = useDialog()
     const args: string[] = []
     if (props.input.offset) args.push("offset=" + props.input.offset)
     if (props.input.limit) args.push("limit=" + props.input.limit)
@@ -1755,6 +1759,10 @@ ToolRegistry.register({
       return value.filter((p): p is string => typeof p === "string")
     })
     const pending = createMemo(() => busy(props.status))
+    const images = createMemo(() =>
+      (props.attachments ?? []).filter((f) => f.mime.startsWith("image/") && f.url),
+    )
+    const preview = (url: string, alt?: string) => dialog.show(() => <ImagePreview src={url} alt={alt} />)
     return (
       <>
         <BasicTool
@@ -1783,6 +1791,23 @@ ToolRegistry.register({
             />
           )}
         </For>
+        <Show when={images().length > 0}>
+          <div data-slot="tool-read-images">
+            <For each={images()}>
+              {(file) => (
+                <div data-slot="tool-read-image" onClick={() => preview(file.url, file.filename)}>
+                  <img
+                    data-slot="tool-read-image-img"
+                    src={file.url}
+                    alt={file.filename ?? i18n.t("ui.message.attachment.alt")}
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
       </>
     )
   },


### PR DESCRIPTION
## Problem

When the agent reads an image file via the `read` tool, the image bytes never appear in the chat view. The user only sees a text line (`Read <filename>`) with no visual confirmation of what was read, even though the agent itself receives the image as vision input. CLI is out of scope and much more difficult.

<img width="841" height="306" alt="file-500d919f0c1f692608bb963c55b873b7" src="https://github.com/user-attachments/assets/07fa878f-1ef2-44fe-8f6a-f56fb62a2070" />
<img width="1236" height="750" alt="file-ea144fb7fb3f09725092ec8308e86568" src="https://github.com/user-attachments/assets/784c316e-6e53-4040-b5bc-a98745d5be4d" />
<img width="610" height="694" alt="file-3f26cb8ac890083c36f9160d9c6b7cf9" src="https://github.com/user-attachments/assets/10cf4856-e3dd-4aa4-b1ec-703a4e6bfcfe" />


## Why this happens

The data pipeline already exists end-to-end but stops short of rendering:

- The `read` tool (`packages/opencode/src/tool/read.ts:327-333`) base64-encodes image files and returns them as `FilePart` attachments with a `data:` URL.
- The processor persists them onto `ToolStateCompleted.attachments`, they flow over SSE (`message.part.updated`), land in the webview part store (`context/session.tsx:1635`), and survive session reload (they are not touched by compaction or `stripPartMetadata`).
- The `PART_MAPPING["tool"]` renderer passes `input`/`metadata`/`output`/`status` into each tool component but **not** `part.state.attachments`, so the `read` renderer never sees the image data. The webview CSP already allows `img-src ... data: https:`, and user-attached images already render with `<img src={file.url}>` at `message-part.tsx:836`.

So the only missing piece is a renderer.

## What this change does

Three additions to `packages/kilo-ui/src/components/message-part.tsx` (Kilo-owned, no upstream markers):

1. Add `attachments?: FilePart[]` to `ToolProps`.
2. Pass `part.state.attachments` through the `Dynamic` component in `PART_MAPPING["tool"]`.
3. In the `read` tool renderer, filter image attachments (`mime.startsWith("image/")` with a `url`) and render them inline as `<img>` thumbnails with `loading="lazy"` and `decoding="async"`, clickable to open the existing `ImagePreview` dialog (the same pattern already shipping for user-attached images and image diffs).

Plus matching CSS in `message-part.css` for the `tool-read-images` slots (200px max thumbnail, rounded border, hover highlight, `object-fit: contain`).

No backend, schema, SDK, or extension-host changes. The `FilePart` schema (`mime` + base64 `url`) is already a first-class `Part` type and already carries images for both user-attached and tool-read paths.

## Scope and limits

- Applies to the `read` tool only. `webfetch` also emits image attachments but is left for a follow-up if desired.
- Images render for the current and reloaded session. Compaction strips images from the model context window (existing behavior) but leaves them in the persisted `PartTable.data`, so the webview still shows them after compaction.
- SVG is correctly excluded: `SUPPORTED_IMAGE_MIMES` in the read tool is `jpeg/png/gif/webp` only, so no SVG data URL ever reaches the renderer. Even if one did, `<img>`-loaded SVGs are sandboxed by the browser (scripts do not execute).
- The backend already bounds payload size via `image.normalize()` (Photon WASM, 2000x2000 / ~5MB cap) before the data URL reaches the client, so each inline image is a bounded decode identical to the existing user-attachment and image-diff rendering paths.
- Cross-platform: pure webview HTML/CSS/JSX, no native APIs. Works on Windows, Mac, and Linux.