### PR TITLE
fix(vscode): show sandbox tooltip immediately on hover

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/components/shared/SandboxButton.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/SandboxButton.tsx
@@ -69,7 +69,12 @@ export const SandboxButtonBase: Component<SandboxButtonBaseProps> = (props) => {
         language.t(props.enabled ? "prompt.action.sandbox.enabled" : "prompt.action.sandbox.disabled"))
 
   return (
-    <Tooltip value={tooltip()} contentClass={unavailable() ? undefined : props.tooltipClass} placement="top">
+    <Tooltip
+      value={tooltip()}
+      contentClass={unavailable() ? undefined : props.tooltipClass}
+      placement="top"
+      openDelay={0}
+    >
       <Button
         variant="ghost"
         size="small"


### PR DESCRIPTION
The sandbox lock tooltip in the prompt input waited for Kobalte's default `openDelay` (700ms) before appearing on hover, which felt sluggish for a status control the user is actively inspecting.

`SandboxButtonBase` is the shared control used by both the chat `PromptInput` and the Agent Manager `NewWorktreeDialog`, so setting `openDelay={0}` on its `Tooltip` makes the sandbox status appear instantly on hover across all prompt inputs. The close behavior (`closeDelay={0}`, already set in the shared `Tooltip`) is unchanged.