### PR TITLE
fix(vscode): respect .gitignore in marketplace relevance scan to fix rg CPU spike

### DIFF
--- a/packages/kilo-vscode/src/services/marketplace/relevance.ts
+++ b/packages/kilo-vscode/src/services/marketplace/relevance.ts
@@ -2,6 +2,19 @@ import * as vscode from "vscode"
 import type { MarketplaceItem, MarketplaceRelevanceMetadata } from "./types"
 
 const EXCLUDE = "**/{node_modules,.git,dist,build,out,.kilo,.opencode,.kilocode}/**"
+// Build a regex from EXCLUDE so the same list drives both the glob pattern passed
+// to findFiles and the in-memory post-filter (see context().find below).
+// We extract the brace-group, escape dots only within each segment, and anchor on
+// path separators so "builds.ts" or "distribution/" are never falsely excluded.
+const EXCLUDE_REGEX = new RegExp(
+  "(^|/)(" +
+    EXCLUDE.replace(/^\*\*\/\{/, "")
+      .replace(/\}\/\*\*$/, "")
+      .split(",")
+      .map((s) => s.replaceAll(".", "\\."))
+      .join("|") +
+    ")(/|$)",
+)
 
 function strings(value: unknown): string[] {
   if (!Array.isArray(value)) return []
@@ -18,7 +31,9 @@ function context(): RelevanceHost {
     extensions: vscode.extensions.all.map((extension) => extension.id),
     find: async (root, pattern) => {
       const glob = new vscode.RelativePattern(root, `**/${pattern}`)
-      return (await vscode.workspace.findFiles(glob, EXCLUDE, 1)).length > 0
+      const matches = await vscode.workspace.findFiles(glob, undefined, 5)
+      const filtered = matches.filter((uri) => !EXCLUDE_REGEX.test(uri.fsPath.replaceAll("\\", "/")))
+      return filtered.length > 0
     },
   }
 }


### PR DESCRIPTION
## Problem

`detectMarketplaceRelevance` calls `vscode.workspace.findFiles(glob, EXCLUDE, 1)` with a custom exclude glob. Per VS Code API semantics, passing any non-null exclude value **completely bypasses `.gitignore` and `search.useIgnoreFiles`**, causing `rg` to run with `--no-ignore --no-ignore-global`. With 4–5 concurrent scans on startup this causes a significant CPU spike that makes the editor lag or stall.

Observed `rg` invocation before this fix:
```
rg --files --hidden --no-require-git -g **/*.directive.ts -g !**/.git ... --no-ignore --follow --no-config --no-ignore-global
```

## Root Cause

VS Code's `findFiles(include, exclude, maxResults)` uses **replace semantics** for the `exclude` parameter: passing any non-null value discards all system defaults including `.gitignore` integration. This is a known VS Code API footgun documented in the VS Code extension API reference.

## Fix

Pass `undefined` as the exclude argument so VS Code uses its native `.gitignore`-aware `rg` invocation (fast, near-zero CPU). Then post-filter the small result set in memory using a regex derived from the same `EXCLUDE` constant, so the excluded directory list remains a single source of truth.

The `EXCLUDE_REGEX` is built by parsing the brace-group in `EXCLUDE`, escaping dots per segment, and anchoring on path separators — avoiding false positives like `builds.ts` or `distribution/`.

## Testing

Verified `EXCLUDE_REGEX` correctly matches/excludes all expected paths including edge cases where filenames contain excluded directory names as substrings (`builds.ts`, `distribution/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)