### PR TITLE
fix(vscode): support agent manager prompt bidi

### DIFF
--- a/.changeset/fix-agent-manager-prompt-bidi.md
+++ b/.changeset/fix-agent-manager-prompt-bidi.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Support bidirectional text in the Agent Manager new worktree prompt.

--- a/packages/kilo-vscode/tests/unit/prompt-input-bidirectional.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-bidirectional.test.ts
@@ -6,6 +6,8 @@ const path = join(__dirname, "..", "..", "webview-ui", "src", "components", "cha
 const src = readFileSync(path, "utf8")
 const cssPath = join(__dirname, "..", "..", "webview-ui", "src", "styles", "prompt-input.css")
 const css = readFileSync(cssPath, "utf8")
+const dialogPath = join(__dirname, "..", "..", "webview-ui", "agent-manager", "NewWorktreeDialog.tsx")
+const dialog = readFileSync(dialogPath, "utf8")
 
 describe("PromptInput bidirectional text support", () => {
   it("lets the textarea and visible overlay resolve text direction automatically", () => {
@@ -16,6 +18,12 @@ describe("PromptInput bidirectional text support", () => {
     expect(overlay).toContain('dir="auto"')
     expect(overlayCss).toContain("unicode-bidi: plaintext")
     expect(input).toContain('class="prompt-input"')
+    expect(input).toContain('dir="auto"')
+  })
+
+  it("lets the Agent Manager worktree prompt resolve bidirectional text automatically", () => {
+    const input = dialog.match(/<textarea[\s\S]*?class="prompt-input am-prompt-input"[\s\S]*?\n\s*\/>/)?.[0]
+
     expect(input).toContain('dir="auto"')
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -468,6 +468,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                     }}
                     onPaste={(e) => imageAttach.handlePaste(e)}
                     rows={3}
+                    dir="auto"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Issue

No linked issue.

## Context

The main chat prompt already supports bidirectional text input. This aligns the Agent Manager “New Worktree” prompt modal with that behavior so mixed left-to-right and right-to-left content is handled consistently across prompt surfaces.

## Implementation

Adds `dir="auto"` to the Agent Manager new worktree prompt textarea. The modal uses a native textarea without the chat prompt’s highlight overlay, so no extra overlay bidi styling is needed.

The existing prompt bidirectional unit coverage was extended to guard this modal prompt as well.

## Screenshots / Video

| before | after |
|---|---|
| <img width="1016" height="544" alt="before" src="https://github.com/user-attachments/assets/70fdc6f6-9de8-4465-9260-55794dcaf946" /> | <img width="1016" height="544" alt="after" src="https://github.com/user-attachments/assets/cf901eb1-f28e-4fd0-8a33-3d96ad3e0e17" /> |

## How to Test

### Manual/local verification

- Manually built the extension and tested the Agent Manager “New Worktree” prompt modal with mixed direction content.
- `bun test tests/unit/prompt-input-bidirectional.test.ts`
- `bun eslint webview-ui/agent-manager/NewWorktreeDialog.tsx tests/unit/prompt-input-bidirectional.test.ts`
- `bun run check-types:webview`

### Reviewer test steps

1. Open Agent Manager.
2. Click “Configure New Worktree”.
3. Enter mixed left-to-right and right-to-left text in the prompt field.
4. Confirm the prompt direction resolves naturally based on the content, matching the main chat prompt behavior.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
