### PR TITLE
feat(vscode): jump transcript to message on timeline bar click

### DIFF
--- a/.changeset/timeline-bar-jump-to-message.md
+++ b/.changeset/timeline-bar-jump-to-message.md
@@ -2,4 +2,4 @@
 "kilo-code": minor
 ---
 
-Click or press Enter on a bar in the task timeline to jump the transcript to that message.
+Click or press Enter/Space on a bar in the task timeline to jump the transcript to that message.

--- a/.changeset/timeline-bar-jump-to-message.md
+++ b/.changeset/timeline-bar-jump-to-message.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Click or press Enter on a bar in the task timeline to jump the transcript to that message.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -157,6 +157,29 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const lookup = createMemo(() => new Map(partition().direct.map((row) => [row.key, row])))
   const keys = createMemo(() => partition().virtual.map((row) => row.key))
   const fingerprint = createMemo(() => rowFingerprint(keys()))
+
+  // Clicking a bar in the task timeline scrolls the transcript to that message.
+  // Jumps land instantly (no smooth animation): while pinned at the bottom, a
+  // smooth scroll's initial frames sit within createAutoScroll's near-bottom
+  // threshold, which resumes auto-follow mid-animation and snaps back down.
+  const onScrollToMessage = (e: Event) => {
+    const id = (e as CustomEvent<{ id: string }>).detail?.id
+    if (!id) return
+    const row = rows().find((r) => r.type === "assistant" && r.message.id === id)
+    if (!row) return
+    autoScroll.pause()
+    const index = keys().indexOf(row.key)
+    if (index >= 0) {
+      virtualizer()?.scrollToIndex(index, { align: "start" })
+      return
+    }
+    const el = scrollEl()
+    const target = el?.querySelector<HTMLElement>(`[data-row-key="${CSS.escape(row.key)}"]`)
+    target?.scrollIntoView({ block: "start" })
+  }
+  window.addEventListener("scrollToMessage", onScrollToMessage)
+  onCleanup(() => window.removeEventListener("scrollToMessage", onScrollToMessage))
+
   const measurement = createMemo(() => {
     const id = session.currentSessionID()
     const token = layout()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -163,9 +163,12 @@ export const MessageList: Component<MessageListProps> = (props) => {
   // smooth scroll's initial frames sit within createAutoScroll's near-bottom
   // threshold, which resumes auto-follow mid-animation and snaps back down.
   const onScrollToMessage = (e: Event) => {
-    const id = (e as CustomEvent<{ id: string }>).detail?.id
-    if (!id) return
-    const row = rows().find((r) => r.type === "assistant" && r.message.id === id)
+    const detail = (e as CustomEvent<{ id: string; partId?: string }>).detail
+    if (!detail?.id) return
+    const matches = rows().filter((r) => r.type === "assistant" && r.message.id === detail.id)
+    // Long messages split into multiple rows (chunks); land on the chunk that
+    // actually contains the clicked part, not just the message's first chunk.
+    const row = matches.find((r) => r.type === "assistant" && r.parts.some((p) => p.id === detail.partId)) ?? matches[0]
     if (!row) return
     autoScroll.pause()
     const index = keys().indexOf(row.key)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -17,6 +17,7 @@ export interface TimelineBar {
   width: number
   height: number
   idx: number
+  msgId: string
 }
 
 function collect(messages: Message[], parts: Record<string, Part[]>): TimelineBar[] {
@@ -39,6 +40,7 @@ function collect(messages: Message[], parts: Record<string, Part[]>): TimelineBa
     width: sz[i]!.width,
     height: sz[i]!.height,
     idx: i,
+    msgId: item.msg.id,
   }))
 }
 
@@ -46,6 +48,7 @@ export const TaskTimeline: Component = () => {
   const session = useSession()
   let ref: HTMLDivElement | undefined
   let dragging = false
+  let dragMoved = false
   let startX = 0
   let startScroll = 0
   const [hover, setHover] = createSignal(-1)
@@ -135,11 +138,19 @@ export const TaskTimeline: Component = () => {
     hideTip()
     if (!ref) return
     dragging = true
+    dragMoved = false
     startX = e.clientX
     startScroll = ref.scrollLeft
     ref.setPointerCapture(e.pointerId)
     ref.style.cursor = "grabbing"
     ref.style.userSelect = "none"
+  }
+
+  const jumpToMessage = (idx: number) => {
+    const bar = bars()[idx]
+    if (!bar) return
+    setActive(idx)
+    window.dispatchEvent(new CustomEvent("scrollToMessage", { detail: { id: bar.msgId } }))
   }
 
   const onPointerMove = (e: PointerEvent) => {
@@ -150,15 +161,18 @@ export const TaskTimeline: Component = () => {
       if (idx < 0) return hideTip()
       return showTip(idx)
     }
+    if (Math.abs(e.clientX - startX) > 3) dragMoved = true
     ref.scrollLeft = startScroll - (e.clientX - startX)
   }
 
   const onPointerUp = (e: PointerEvent) => {
     if (!ref) return
+    const wasDragging = dragging
     dragging = false
     if (ref.hasPointerCapture(e.pointerId)) ref.releasePointerCapture(e.pointerId)
     ref.style.cursor = "grab"
     ref.style.userSelect = ""
+    if (wasDragging && !dragMoved) jumpToMessage(pointerIndex(e))
   }
 
   const onWheel = (e: WheelEvent) => {
@@ -169,6 +183,11 @@ export const TaskTimeline: Component = () => {
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      jumpToMessage(selected())
+      return
+    }
     if (!ref || !["ArrowLeft", "ArrowRight", "Home", "End"].includes(e.key)) return
     e.preventDefault()
     const idx = navigate(selected(), bars().length, e.key)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskTimeline.tsx
@@ -18,6 +18,7 @@ export interface TimelineBar {
   height: number
   idx: number
   msgId: string
+  partId: string
 }
 
 function collect(messages: Message[], parts: Record<string, Part[]>): TimelineBar[] {
@@ -41,6 +42,7 @@ function collect(messages: Message[], parts: Record<string, Part[]>): TimelineBa
     height: sz[i]!.height,
     idx: i,
     msgId: item.msg.id,
+    partId: item.part.id,
   }))
 }
 
@@ -150,7 +152,7 @@ export const TaskTimeline: Component = () => {
     const bar = bars()[idx]
     if (!bar) return
     setActive(idx)
-    window.dispatchEvent(new CustomEvent("scrollToMessage", { detail: { id: bar.msgId } }))
+    window.dispatchEvent(new CustomEvent("scrollToMessage", { detail: { id: bar.msgId, partId: bar.partId } }))
   }
 
   const onPointerMove = (e: PointerEvent) => {


### PR DESCRIPTION
<!-- ## Issue

Fixes #
<!-- No tracked issue exists for this; opening directly as a small UX improvement. -->

## Context

The task timeline (the small bar-chart histogram shown under the chat header, next to the token/cost stats) previously only supported hover tooltips, drag-to-scroll, and keyboard arrow navigation. There was no way to jump the transcript to the message a given bar represents.

## Implementation

- `TaskTimeline.tsx`: each `TimelineBar` now retains the source message's `msgId` (previously discarded in `collect()`). A click (pointer-up without a preceding drag) or `Enter`/`Space` on the focused bar calls `jumpToMessage`, which dispatches a `window` `CustomEvent("scrollToMessage", { detail: { id } })` — mirroring the existing `resumeAutoScroll` cross-component event convention already used between `TaskHeader`/`TaskTimeline` and `MessageList` (they share no direct props or context signal for this).
- `MessageList.tsx`: listens for `scrollToMessage`, resolves the message to its `TranscriptRow` key, and scrolls to it — via `virtualizer()?.scrollToIndex()` when the row is in the virtualized region, or `element.scrollIntoView()` (found via the existing `data-row-key` attribute) when the row is in the non-virtualized "direct" tail.
- The jump is **instant**, not smoothly animated. While pinned at the very bottom, a smooth scroll's first animation frames sit within `createAutoScroll`'s near-bottom threshold, which resumes auto-follow mid-animation and snaps the view back down before the jump completes. An instant scroll has no such transient frame, so it isn't cancelled.

## Screenshots / Video

| before | after |
|---|---|
| https://github.com/user-attachments/assets/c349ce22-b042-4b97-8a48-cea4eb7af4c1 | https://github.com/user-attachments/assets/e1016abe-3b7d-464e-9184-3a98f0e38143 |

## How to Test

### Manual/local verification

- Ran `bun run typecheck`, `bun run lint`, and `bun run format` in `packages/kilo-vscode` — all pass (agent-executed).
- Manually verified in the running extension (human-executed): clicked bars at various points in the timeline and confirmed the transcript scrolls to the corresponding message, including while pinned at the very bottom of the conversation (previously the jump would silently snap back to the bottom due to the auto-scroll race described above).
- Verified keyboard activation (`Enter`/`Space` after arrow-key selecting a bar) also jumps to the message.
- Verified drag-to-scroll on the timeline still works and is not misinterpreted as a click.

### Reviewer test steps

1. Open a session with enough messages that the task timeline shows multiple bars and the transcript is scrollable.
2. Scroll the chat transcript to the bottom.
3. Click any bar in the task timeline (or focus it and press Enter/Space).
4. Confirm the transcript scrolls to the message that bar represents, without snapping back to the bottom.
5. Repeat after manually scrolling the transcript up first, and confirm the same behavior.

### Blocked checks and substitute verification

-

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

<!-- ## Get in Touch -->