### PR TITLE
fix(cli): resolve Bedrock empty response by using node build conditions

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -292,7 +292,7 @@ for (const item of targets) {
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
   await Bun.build({
-    conditions: ["browser"],
+    conditions: ["bun", "node"],
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
     // kilocode_change start - skip sourcemaps for release builds (each .js.map adds ~50 MB per target → ~600 MB total)


### PR DESCRIPTION
## Issue

No existing issue found for this bug (searched Kilo-Org/kilocode issues/PRs for "bedrock empty response" and related terms).

However, there is already a `.changeset/fix-bedrock-empty-output.md` in `main` describing this exact bug ("A smithy dependency version-skew made the Bedrock event-stream decoder silently fail under the browser build condition"). So this was already diagnosed, but I couldn't find any code fixing it.

I can file an issue if needed.

## Context

Every Bedrock Converse request through the CLI silently returns an empty response: no error, no toast, the session just goes idle with zero output text. Reproduces on every published `@kilocode/cli` release from `7.3.48` through `7.4.1` (latest at time of writing), regardless of AWS auth method (reproduced with both `AWS_BEARER_TOKEN_BEDROCK` and SSO), and independent of plugins (`--pure` still fails). `7.3.46` is the last good release.

## Implementation

Root cause: the release binary is compiled with `Bun.build({ conditions: ["browser"] })` (`packages/opencode/script/build.ts`). Under that condition, `@smithy/util-utf8`'s Node-path dependency chain (`@smithy/util-buffer-from` -> `@smithy/core/serde`, used by `packages/llm/src/protocols/bedrock-event-stream.ts` to build its `EventStreamCodec`) resolves to a dead binding after minification:

```
TypeError: X is not a function. (In 'X(...)', 'X' is a Symbol)
```

`EventStreamCodec.decode()` swallows that throw as a header-parsing failure rather than surfacing it, so every Converse response silently decodes to zero chunks instead of erroring.

`conditions: ["browser"]` was inherited from upstream OpenCode's OpenTUI integration (#2685) and was never Kilo-specific. Upstream hit this exact Bedrock bug and fixed it the same way in `anomalyco/opencode#30873` (merged 2026-06-05), changing to `conditions: ["node"]`. Their current `main` has since settled on `conditions: ["bun", "node"]`. Kilo's fork never picked up that fix and still carries the original browser condition.

Fix: match upstream's current build conditions (`conditions: ["bun", "node"]`) instead of patching the individual Bedrock decoder file. This is a one-line change to `packages/opencode/script/build.ts`, already validated by upstream across multiple Bedrock models.

An earlier, narrower version of this fix (patching only `bedrock-event-stream.ts` to stop depending on `@smithy/util-utf8`'s condition-sensitive resolution) was considered but not used here — it would have masked the underlying build misconfiguration rather than fixing it, and left every other package sensitive to the same `browser` condition unaddressed.

## Screenshots / Video

Screenshot of kilo CLI working in Neovim via OpenCode plugin, see version at the bottom right.
<img width="2168" height="1401" alt="Screenshot 2026-07-07 at 19 08 50" src="https://github.com/user-attachments/assets/ecf4ae61-f296-4649-ae9b-4a06964889b4" />


## How to Test

### Manual/local verification

- (agent-executed) Built the CLI from this branch with `bun run script/build.ts --single --skip-install` from `packages/opencode/`. Both existing smoke tests (`kilo --version`, `kilo --pure models anthropic`) pass.
- (agent-executed) Ran `kilo run "say hello" --pure -m amazon-bedrock/us.anthropic.claude-sonnet-5` with valid Bedrock credentials (`AWS_BEARER_TOKEN_BEDROCK`): before this fix, exits idle with no output and no error, after this fix, returns `Hello!`.
- (agent-executed) Ran a warpgrep-triggering prompt against the patched build to confirm switching off `conditions: ["browser"]` does not reintroduce the `@morphllm/morphsdk` ESM-splitter crash (`SyntaxError: Exported binding 'G9' needs to refer to a top-level declared variable`) that `conditions: ["browser"]` was separately worked around for in #10955/#10956. It completed cleanly, no splitter error.
- (agent-executed) Bisected the published `@kilocode/cli` npm releases: `7.3.46` (last good) vs `7.3.48` (first bad, `7.3.47` was never published) vs `7.4.1` (still bad). Which confirms this is a real regression window, not a pre-existing limitation.

### Reviewer test steps

1. Build the CLI with the release build flags: `bun run script/build.ts --single --skip-install` from `packages/opencode/`.
2. Run `./dist/*/bin/kilo run "say hello" --pure -m amazon-bedrock/<any-claude-model>` with valid Bedrock credentials.
3. Before this fix: exits with no text output and no error. After this fix: prints the model's response text.
4. Optionally, run a prompt that triggers the warpgrep tool (uses `@morphllm/morphsdk`) to confirm no regression on the ESM-splitter issue this build condition was also touching.

### Blocked checks and substitute verification

- No CI access to trigger the actual multi-platform release build matrix (windows-x64, alpine-x64/arm64, etc.) that `conditions: ["browser"]` and the morphsdk workaround originally targeted. Substitute verification was building and running the single-target `darwin-arm64` binary locally and exercising both the Bedrock path and a warpgrep-triggering prompt directly. Oh, and actually installing it on my system and using it.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (`.changeset/fix-bedrock-empty-output.md` already exists in `main` describing this bug, I left it as-is since its wording already matches this fix)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Denis Dupeyron ddupeyron@anaconda.com