### PR TITLE
fix(cli): return a typed 422 for commit-message with no changes

### DIFF
--- a/.changeset/commit-message-no-changes-error.md
+++ b/.changeset/commit-message-no-changes-error.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show a clear "No changes found to generate a commit message for" error instead of a generic "Unexpected server error" when there is nothing to commit. The endpoint now returns a typed 422, and the extension surfaces the real message directly.

--- a/packages/kilo-vscode/src/services/commit-message/index.ts
+++ b/packages/kilo-vscode/src/services/commit-message/index.ts
@@ -119,7 +119,7 @@ export function registerCommitMessageService(
           }
           const msg = getErrorMessage(error)
           console.error("[Kilo New] Failed to generate commit message:", msg)
-          vscode.window.showErrorMessage(`Failed to generate commit message: ${msg}`)
+          vscode.window.showErrorMessage(msg || "Failed to generate commit message. Please try again.")
         })
     },
   )

--- a/packages/opencode/src/kilocode/commit-message/generate.ts
+++ b/packages/opencode/src/kilocode/commit-message/generate.ts
@@ -10,6 +10,13 @@ import { getGitContext } from "./git-context"
 
 const log = Log.create({ service: "commit-message" })
 
+export class NoChangesError extends Error {
+  constructor() {
+    super("No changes found to generate a commit message for")
+    this.name = "CommitMessageNoChanges"
+  }
+}
+
 export const CommitMessageRuntime = {
   context(repoPath: string, selectedFiles?: string[]) {
     return getGitContext(repoPath, selectedFiles)
@@ -146,7 +153,7 @@ const TIMEOUT_MS = 30_000
 export async function generateCommitMessage(request: CommitMessageRequest): Promise<CommitMessageResponse> {
   const ctx = await CommitMessageRuntime.context(request.path, request.selectedFiles)
   if (ctx.files.length === 0) {
-    throw new Error("No changes found to generate a commit message for")
+    throw new NoChangesError()
   }
 
   log.info("generating", {

--- a/packages/opencode/src/kilocode/commit-message/index.ts
+++ b/packages/opencode/src/kilocode/commit-message/index.ts
@@ -1,2 +1,2 @@
-export { generateCommitMessage } from "./generate"
+export { generateCommitMessage, NoChangesError } from "./generate"
 export type { CommitMessageRequest, CommitMessageResponse, GitContext, FileChange } from "./types"

--- a/packages/opencode/src/kilocode/server/httpapi/groups/commit-message.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/commit-message.ts
@@ -24,6 +24,13 @@ const CommitMessageResponse = Schema.Struct({
   message: Schema.String,
 })
 
+export class CommitMessageNoChangesError extends Schema.ErrorClass<CommitMessageNoChangesError>(
+  "CommitMessageNoChangesError",
+)(
+  { message: Schema.String },
+  { httpApiStatus: 422 },
+) {}
+
 export const CommitMessageApi = HttpApi.make("commit-message")
   .add(
     HttpApiGroup.make("commit-message")
@@ -32,7 +39,7 @@ export const CommitMessageApi = HttpApi.make("commit-message")
           query: WorkspaceRoutingQuery,
           payload: CommitMessagePayload,
           success: described(CommitMessageResponse, "Generated commit message"),
-          error: HttpApiError.BadRequest,
+          error: [HttpApiError.BadRequest, CommitMessageNoChangesError],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "commitMessage.generate",

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/commit-message.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/commit-message.ts
@@ -3,8 +3,8 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Config } from "@/config/config"
-import { generateCommitMessage } from "@/kilocode/commit-message"
-import { CommitMessagePayload } from "../groups/commit-message"
+import { generateCommitMessage, NoChangesError } from "@/kilocode/commit-message"
+import { CommitMessageNoChangesError, CommitMessagePayload } from "../groups/commit-message"
 
 export const commitMessageHandlers = HttpApiBuilder.group(InstanceHttpApi, "commit-message", (handlers) =>
   Effect.gen(function* () {
@@ -21,6 +21,13 @@ export const commitMessageHandlers = HttpApiBuilder.group(InstanceHttpApi, "comm
           selectedFiles: ctx.payload.selectedFiles ? [...ctx.payload.selectedFiles] : undefined,
           previousMessage: ctx.payload.previousMessage,
           prompt,
+        }),
+      ).pipe(
+        Effect.catchDefect((defect) => {
+          if (defect instanceof NoChangesError) {
+            return Effect.fail(new CommitMessageNoChangesError({ message: defect.message }))
+          }
+          return Effect.die(defect)
         }),
       )
       return { message: result.message }

--- a/packages/opencode/test/kilocode/commit-message/generate.test.ts
+++ b/packages/opencode/test/kilocode/commit-message/generate.test.ts
@@ -42,7 +42,7 @@ mock.module("@opencode-ai/core/util/log", () => ({
   }),
 }))
 
-import { CommitMessageRuntime, generateCommitMessage } from "../../../src/kilocode/commit-message/generate"
+import { CommitMessageRuntime, generateCommitMessage, NoChangesError } from "../../../src/kilocode/commit-message/generate"
 
 const context = spyOn(CommitMessageRuntime, "context").mockImplementation(async (repoPath, selectedFiles) => {
   captured = { path: repoPath, selected: selectedFiles }
@@ -133,11 +133,14 @@ describe("commit-message.generate", () => {
   })
 
   describe("error on no changes", () => {
-    test("throws when no git changes are found", async () => {
+    test("throws NoChangesError when no git changes are found", async () => {
       mockGitContext = { branch: "main", recentCommits: [], files: [] }
-      await expect(generateCommitMessage({ path: "/repo" })).rejects.toThrow(
-        "No changes found to generate a commit message for",
-      )
+      const err = await generateCommitMessage({ path: "/repo" }).catch((e) => e)
+      expect(err).toBeInstanceOf(NoChangesError)
+      if (err instanceof NoChangesError) {
+        expect(err.message).toBe("No changes found to generate a commit message for")
+        expect(err.name).toBe("CommitMessageNoChanges")
+      }
     })
   })
 

--- a/packages/opencode/test/kilocode/server/commit-message-no-changes.test.ts
+++ b/packages/opencode/test/kilocode/server/commit-message-no-changes.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Server } from "../../../src/server/server"
+import { resetDatabase } from "../../fixture/db"
+import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+describe("commit-message httpapi", () => {
+  test("returns 422 with the real message when there are no changes", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const res = await Server.Default().app.request("/commit-message", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-kilo-directory": tmp.path },
+      body: JSON.stringify({ path: tmp.path }),
+    })
+
+    expect(res.status).toBe(422)
+    expect(await res.json()).toEqual({ message: "No changes found to generate a commit message for" })
+  })
+})

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -466,6 +466,16 @@ export const kiloScenarios: Scenario[] = [
     .at((ctx) => ({ path: "/commit-message", headers: ctx.headers(), body: {} }))
     .status(400),
   http.protected
+    .post("/commit-message", "commitMessage.generate")
+    .at((ctx) => ({ path: "/commit-message", headers: ctx.headers(), body: { path: directory(ctx) } }))
+    .json(422, (body) => {
+      object(body)
+      check(
+        body.message === "No changes found to generate a commit message for",
+        "no changes should surface a real 422 message, not a masked 500",
+      )
+    }),
+  http.protected
     .post("/session/{sessionID}/branch-name", "branchName.generate")
     .at((ctx) => ({
       path: route("/session/{sessionID}/branch-name", { sessionID: "ses_httpapi_missing" }),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1693,6 +1693,7 @@ export type Config = {
     continue_loop_on_deny?: boolean
     sandbox?: boolean
     sandbox_restrict_network?: boolean
+    sandbox_writable_paths?: Array<string>
     mcp_timeout?: number
     policies?: Array<ConfigV2ExperimentalPolicy>
   }
@@ -2410,6 +2411,10 @@ export type BackgroundProcessLogs = {
   id: string
   sessionID: string
   output: string
+}
+
+export type CommitMessageNoChangesError = {
+  message: string
 }
 
 export type ConfigOverlayResponse = {
@@ -10101,6 +10106,10 @@ export type CommitMessageGenerateErrors = {
    * BadRequest | InvalidRequestError
    */
   400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * CommitMessageNoChangesError
+   */
+  422: CommitMessageNoChangesError
 }
 
 export type CommitMessageGenerateError = CommitMessageGenerateErrors[keyof CommitMessageGenerateErrors]


### PR DESCRIPTION
When generating a commit message with nothing to commit (nothing staged, or only lock files which are filtered out), the user saw a generic `Unexpected server error. Check server logs for details.` (HTTP 500) instead of a clear, actionable message.

## Why

`generate.ts` throws a plain `Error("No changes found to generate a commit message for")`. The HTTP handler wraps it via `EffectBridge.fromPromise`, but Effect maps unhandled promise rejections to Dies, so the plain error becomes an untyped defect. The error middleware treats untyped defects as 500 and masks the message, leaving the user with no idea why generation failed.

The correct pattern for this API surface is to declare an explicit `Schema.ErrorClass` on the endpoint and fail with that typed error so it surfaces as a real HTTP status with the actual message.

## What changed

- Declare `CommitMessageNoChangesError` (`Schema.ErrorClass`, `httpApiStatus: 422`, `{ message }`) on the commit-message endpoint error contract alongside the existing `HttpApiError.BadRequest`.
- Replace the plain `Error` in `generate.ts` with a recognizable `NoChangesError` domain class, so the handler can distinguish it from unexpected defects.
- In the handler, keep `EffectBridge.fromPromise` (preserves Kilo instance/workspace contexts across the callback) and add `Effect.catchDefect` to translate the `NoChangesError` defect into the typed `CommitMessageNoChangesError` failure (422). Unexpected defects are re-died so they still surface as masked 500s, which is correct for truly unexpected errors.
- The VS Code extension shows the real message directly instead of prepending a redundant `Failed to generate commit message:` prefix that doubled up the wording.
- Regenerated the SDK so `CommitMessageNoChangesError` and the 422 status are part of the typed client contract.

All changes are in Kilo-owned paths (`packages/opencode/src/kilocode/`, `packages/kilo-vscode/`); no shared upstream files were touched.