### PR TITLE
feat(opencode): warn users about leftover opencode configuration

### DIFF
--- a/.changeset/warn-leftover-opencode-config.md
+++ b/.changeset/warn-leftover-opencode-config.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Warn on startup when a leftover opencode config directory is found. Kilo no longer falls back to opencode configuration, so the notice points you to move `.opencode` config into a `.kilo` directory (or the global kilo config dir).
+Show a dismissible notification when a leftover opencode config directory is found. Kilo no longer falls back to opencode configuration, so the notice points you to move `.opencode` config into a `.kilo` directory (or the global kilo config dir). Dismiss it once and it won't return unless the directory is still present.

--- a/.changeset/warn-leftover-opencode-config.md
+++ b/.changeset/warn-leftover-opencode-config.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Warn on startup when a leftover opencode config directory is found. Kilo no longer falls back to opencode configuration, so the notice points you to move `.opencode` config into a `.kilo` directory (or the global kilo config dir).

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -339,6 +339,10 @@ The Kilo CLI is a fork of [OpenCode](https://opencode.ai) and supports the same 
 
 Project-level configuration takes precedence over global settings.
 
+{% callout type="warning" %}
+**Migrating from opencode?** Kilo no longer falls back to opencode configuration stored in `.opencode` directories (such as `~/.config/opencode` or a project `./.opencode/`). To keep using it, move your global config into `~/.config/kilo/` and any project config into `./.kilo/`.
+{% /callout %}
+
 ### Key Configuration Options
 
 ```json

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -27,6 +27,12 @@ This is especially useful for complex configuration like custom model definition
 
 ## Managing Settings
 
+Kilo reads JSONC config from a **global** location (`~/.config/kilo/kilo.jsonc`) and from your **project** (`kilo.jsonc`, or `.kilo/kilo.jsonc`). All clients — CLI, VS Code, and JetBrains — read the same files.
+
+{% callout type="warning" %}
+**Migrating from opencode?** Kilo no longer falls back to opencode configuration stored in `.opencode` directories (such as `~/.config/opencode` or a project `./.opencode/`). To keep using it, move your global config into `~/.config/kilo/` and any project config into `./.kilo/`.
+{% /callout %}
+
 {% tabs %}
 {% tab label="VSCode" %}
 

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -128,8 +128,6 @@
   <!-- packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx -->
 - <https://kilo.ai/docs/automate/mcp/what-is-mcp>
   <!-- packages/kilo-vscode/webview-ui/src/components/marketplace/InstallModal.tsx -->
-- <https://kilo.ai/docs/code-with-ai/platforms/cli>
-  <!-- packages/opencode/src/kilocode/config/config.ts -->
 - <https://kilo.ai/docs/code-with-ai/platforms/vscode/whats-new>
   <!-- packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx -->
 - <https://kilo.ai/docs/customize/custom-subagents>
@@ -139,6 +137,8 @@
   <!-- packages/kilo-vscode/webview-ui/src/components/marketplace/MarketplaceListView.tsx -->
 - <https://kilo.ai/docs/customize/workflows>
   <!-- packages/opencode/src/config/config.ts -->
+- <https://kilo.ai/docs/getting-started/settings>
+  <!-- packages/opencode/src/kilocode/config/config.ts -->
 - <https://kilo.ai/gateway>
   <!-- packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-provider.tsx -->
 - <https://kilo.ai/kiloclaw>

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -128,6 +128,8 @@
   <!-- packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx -->
 - <https://kilo.ai/docs/automate/mcp/what-is-mcp>
   <!-- packages/kilo-vscode/webview-ui/src/components/marketplace/InstallModal.tsx -->
+- <https://kilo.ai/docs/code-with-ai/platforms/cli>
+  <!-- packages/opencode/src/kilocode/config/config.ts -->
 - <https://kilo.ai/docs/code-with-ai/platforms/vscode/whats-new>
   <!-- packages/kilo-vscode/webview-ui/src/components/migration/MigrationWizard.tsx -->
 - <https://kilo.ai/docs/customize/custom-subagents>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -887,6 +887,17 @@ export const layer = Layer.effect(
           // kilocode_change end
         }
 
+        // kilocode_change start - warn about leftover opencode config directories (no longer read)
+        warnings.push(
+          ...(yield* KilocodeConfig.detectOpencodeConfig({
+            fs,
+            directory: ctx.directory,
+            worktree: ctx.worktree,
+            scanProject: !Flag.KILO_DISABLE_PROJECT_CONFIG,
+          })),
+        )
+        // kilocode_change end
+
         result.agent = result.agent || {}
         result.mode = result.mode || {}
         result.plugin = result.plugin || []

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -887,17 +887,6 @@ export const layer = Layer.effect(
           // kilocode_change end
         }
 
-        // kilocode_change start - warn about leftover opencode config directories (no longer read)
-        warnings.push(
-          ...(yield* KilocodeConfig.detectOpencodeConfig({
-            fs,
-            directory: ctx.directory,
-            worktree: ctx.worktree,
-            scanProject: !Flag.KILO_DISABLE_PROJECT_CONFIG,
-          })),
-        )
-        // kilocode_change end
-
         result.agent = result.agent || {}
         result.mode = result.mode || {}
         result.plugin = result.plugin || []

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -436,4 +436,51 @@ export namespace KilocodeConfig {
   export function isConfigDir(dir: string, flagDir?: string): boolean {
     return dir.endsWith(".kilo") || dir.endsWith(".kilocode") || dir === flagDir
   }
+
+  // ── Opencode config migration notice ─────────────────────────────────
+
+  /** Docs page describing where Kilo reads configuration from. */
+  export const CONFIG_DOCS_URL = "https://kilo.ai/docs/code-with-ai/platforms/cli"
+
+  /**
+   * Detect leftover opencode config directories. Kilo used to fall back to
+   * opencode configuration but no longer reads `.opencode` directories, so
+   * surface a warning telling the user where to move it.
+   */
+  export const detectOpencodeConfig = Effect.fn("KilocodeConfig.detectOpencodeConfig")(function* (input: {
+    fs: AppFileSystem.Interface
+    directory: string
+    worktree?: string
+    scanProject: boolean
+  }) {
+    const found: string[] = []
+
+    // Global opencode config dir (sibling of the kilo global config dir, e.g. ~/.config/opencode).
+    const globalDir = path.join(path.dirname(Global.Path.config), "opencode")
+    if (existsSync(globalDir)) found.push(globalDir)
+
+    // Project `.opencode` directories, walked from the working directory up to the worktree root.
+    const project = input.scanProject
+      ? yield* input.fs
+          .up({ targets: [".opencode"], start: input.directory, stop: input.worktree })
+          .pipe(Effect.orElseSucceed(() => [] as string[]))
+      : []
+    for (const dir of project) {
+      if (existsSync(dir) && !found.includes(dir)) found.push(dir)
+    }
+
+    if (found.length === 0) return []
+    const suffix = found.length > 1 ? ` (and ${found.length - 1} more)` : ""
+    return [
+      {
+        path: found[0],
+        message:
+          `Kilo no longer falls back to opencode configuration. ` +
+          `Found opencode config at ${found[0]}${suffix}. ` +
+          `To use it in Kilo, move it into a .kilo directory (project) or ${Global.Path.config} (global). ` +
+          `See ${CONFIG_DOCS_URL}`,
+        detail: found.length > 1 ? `Locations: ${found.join(", ")}` : undefined,
+      },
+    ]
+  })
 }

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -442,17 +442,15 @@ export namespace KilocodeConfig {
   /** Docs page describing where Kilo reads configuration from. */
   export const CONFIG_DOCS_URL = "https://kilo.ai/docs/code-with-ai/platforms/cli"
 
+  /** Stable id for the synthetic "move your opencode config" notification (used for client-side dismissal). */
+  export const OPENCODE_NOTIFICATION_ID = "kilo.local.opencode-config-detected"
+
   /**
    * Detect leftover opencode config directories. Kilo used to fall back to
-   * opencode configuration but no longer reads `.opencode` directories, so
-   * surface a warning telling the user where to move it.
+   * opencode configuration but no longer reads `.opencode` directories.
+   * Returns the existing `.opencode` locations (global + project), highest first.
    */
-  export const detectOpencodeConfig = Effect.fn("KilocodeConfig.detectOpencodeConfig")(function* (input: {
-    fs: AppFileSystem.Interface
-    directory: string
-    worktree?: string
-    scanProject: boolean
-  }) {
+  export function detectOpencodeConfig(input: { directory: string; worktree?: string; scanProject: boolean }): string[] {
     const found: string[] = []
 
     // Global opencode config dir (sibling of the kilo global config dir, e.g. ~/.config/opencode).
@@ -460,27 +458,40 @@ export namespace KilocodeConfig {
     if (existsSync(globalDir)) found.push(globalDir)
 
     // Project `.opencode` directories, walked from the working directory up to the worktree root.
-    const project = input.scanProject
-      ? yield* input.fs
-          .up({ targets: [".opencode"], start: input.directory, stop: input.worktree })
-          .pipe(Effect.orElseSucceed(() => [] as string[]))
-      : []
-    for (const dir of project) {
-      if (existsSync(dir) && !found.includes(dir)) found.push(dir)
+    if (input.scanProject) {
+      let current = input.directory
+      while (true) {
+        const candidate = path.join(current, ".opencode")
+        if (existsSync(candidate) && !found.includes(candidate)) found.push(candidate)
+        if (input.worktree === current) break
+        const parent = path.dirname(current)
+        if (parent === current) break
+        current = parent
+      }
     }
 
-    if (found.length === 0) return []
+    return found
+  }
+
+  /**
+   * Build the synthetic notification shown when a leftover `.opencode` config
+   * directory is found. Returns undefined when nothing needs migrating.
+   * The shape matches the gateway `Notification` schema so it can be appended
+   * to the cloud notifications list and reuse each client's dismissal path.
+   */
+  export function opencodeConfigNotification(input: { directory: string; worktree?: string; scanProject: boolean }) {
+    const found = detectOpencodeConfig(input)
+    if (found.length === 0) return undefined
     const suffix = found.length > 1 ? ` (and ${found.length - 1} more)` : ""
-    return [
-      {
-        path: found[0],
-        message:
-          `Kilo no longer falls back to opencode configuration. ` +
-          `Found opencode config at ${found[0]}${suffix}. ` +
-          `To use it in Kilo, move it into a .kilo directory (project) or ${Global.Path.config} (global). ` +
-          `See ${CONFIG_DOCS_URL}`,
-        detail: found.length > 1 ? `Locations: ${found.join(", ")}` : undefined,
-      },
-    ]
-  })
+    return {
+      id: OPENCODE_NOTIFICATION_ID,
+      title: "Move your opencode configuration",
+      message:
+        `Kilo no longer falls back to opencode configuration. ` +
+        `Found opencode config at ${found[0]}${suffix}. ` +
+        `Move it into a .kilo directory (project) or ${Global.Path.config} (global).`,
+      action: { actionText: "Learn more", actionURL: CONFIG_DOCS_URL },
+      showIn: ["cli", "extension"],
+    }
+  }
 }

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -439,8 +439,8 @@ export namespace KilocodeConfig {
 
   // ── Opencode config migration notice ─────────────────────────────────
 
-  /** Docs page describing where Kilo reads configuration from. */
-  export const CONFIG_DOCS_URL = "https://kilo.ai/docs/code-with-ai/platforms/cli"
+  /** Client-neutral docs page describing where Kilo reads configuration from. */
+  export const CONFIG_DOCS_URL = "https://kilo.ai/docs/getting-started/settings"
 
   /** Stable id for the synthetic "move your opencode config" notification (used for client-side dismissal). */
   export const OPENCODE_NOTIFICATION_ID = "kilo.local.opencode-config-detected"

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -30,6 +30,8 @@ import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import * as Log from "@opencode-ai/core/util/log"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { KilocodeConfig } from "@/kilocode/config/config"
 import { Auth } from "@/auth"
 import { EffectBridge } from "@/effect/bridge"
 import { Bus } from "@/bus"
@@ -313,16 +315,25 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const notifications = Effect.fn("KiloGatewayHttpApi.notifications")(function* () {
+      // Locally-detected notice about leftover opencode config; appended so it reuses each client's dismissal path.
+      const notice = KilocodeConfig.opencodeConfigNotification({
+        directory: Instance.directory,
+        worktree: Instance.worktree,
+        scanProject: !Flag.KILO_DISABLE_PROJECT_CONFIG,
+      })
+      const append = <T>(list: T[]) => (notice ? [...list, notice] : list)
+
       const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
       const token = getToken(info)
-      if (!token) return []
+      if (!token) return append([])
 
-      return yield* Effect.promise(() =>
+      const cloud = yield* Effect.promise(() =>
         fetchKilocodeNotifications({
           kilocodeToken: token,
           kilocodeOrganizationId: getOrganizationId(info),
         }),
       )
+      return append(cloud)
     })
 
     const organization = Effect.fn("KiloGatewayHttpApi.organization")(function* (ctx) {

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -616,6 +616,95 @@ describe("linked worktree config", () => {
   })
 })
 
+describe("opencode config migration notice", () => {
+  const warnings = () =>
+    Effect.runPromise(Config.Service.use((svc) => svc.warnings()).pipe(Effect.scoped, Effect.provide(layer)))
+
+  test("warns when a project .opencode directory exists", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir({ git: true })
+    await Filesystem.write(path.join(tmp.path, ".opencode", "opencode.json"), JSON.stringify({ model: "test/legacy" }))
+
+    // Isolate the global config dir so a real ~/.config/opencode on the host cannot interfere.
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () => {
+          await load()
+          const list = await warnings()
+          const hit = list.find((w) => w.message.includes("opencode configuration"))
+          expect(hit).toBeDefined()
+          expect(hit!.path).toContain(".opencode")
+          expect(hit!.message).toContain(KilocodeConfig.CONFIG_DOCS_URL)
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+
+  test("warns when a global opencode config directory exists", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir({ git: true })
+    const opencodeDir = path.join(globalTmp.path, "opencode")
+    await Filesystem.write(path.join(opencodeDir, "opencode.json"), JSON.stringify({ model: "test/legacy" }))
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () => {
+          await load()
+          const list = await warnings()
+          const hit = list.find((w) => w.message.includes("opencode configuration"))
+          expect(hit).toBeDefined()
+          expect(hit!.path).toBe(opencodeDir)
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+
+  test("stays silent when no opencode config exists", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir({ git: true })
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
+    await clear()
+    await disposeAllInstances()
+
+    try {
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () => {
+          await load()
+          const list = await warnings()
+          expect(list.find((w) => w.message.includes("opencode configuration"))).toBeUndefined()
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+      await clear()
+      await disposeAllInstances()
+    }
+  })
+})
+
 describe("bash permission migration", () => {
   for (const action of ["allow", "ask", "deny"] as const) {
     test(`preserves string-form ${action} permission in jsonc`, async () => {

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -617,91 +617,73 @@ describe("linked worktree config", () => {
 })
 
 describe("opencode config migration notice", () => {
-  const warnings = () =>
-    Effect.runPromise(Config.Service.use((svc) => svc.warnings()).pipe(Effect.scoped, Effect.provide(layer)))
+  const withGlobalConfig = async <T>(dir: string, fn: () => Promise<T> | T): Promise<T> => {
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = dir
+    try {
+      return await fn()
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+    }
+  }
 
-  test("warns when a project .opencode directory exists", async () => {
+  test("detects a project .opencode directory", async () => {
     await using globalTmp = await tmpdir()
-    await using tmp = await tmpdir({ git: true })
+    await using tmp = await tmpdir()
     await Filesystem.write(path.join(tmp.path, ".opencode", "opencode.json"), JSON.stringify({ model: "test/legacy" }))
 
     // Isolate the global config dir so a real ~/.config/opencode on the host cannot interfere.
-    const prev = Global.Path.config
-    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
-    await clear()
-    await disposeAllInstances()
-
-    try {
-      await provideTestInstance({
-        directory: tmp.path,
-        fn: async () => {
-          await load()
-          const list = await warnings()
-          const hit = list.find((w) => w.message.includes("opencode configuration"))
-          expect(hit).toBeDefined()
-          expect(hit!.path).toContain(".opencode")
-          expect(hit!.message).toContain(KilocodeConfig.CONFIG_DOCS_URL)
-        },
-      })
-    } finally {
-      ;(Global.Path as { config: string }).config = prev
-      await clear()
-      await disposeAllInstances()
-    }
+    await withGlobalConfig(path.join(globalTmp.path, "kilo"), () => {
+      const found = KilocodeConfig.detectOpencodeConfig({ directory: tmp.path, scanProject: true })
+      expect(found).toEqual([path.join(tmp.path, ".opencode")])
+    })
   })
 
-  test("warns when a global opencode config directory exists", async () => {
+  test("detects a global opencode config directory", async () => {
     await using globalTmp = await tmpdir()
-    await using tmp = await tmpdir({ git: true })
+    await using tmp = await tmpdir()
     const opencodeDir = path.join(globalTmp.path, "opencode")
     await Filesystem.write(path.join(opencodeDir, "opencode.json"), JSON.stringify({ model: "test/legacy" }))
 
-    const prev = Global.Path.config
-    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
-    await clear()
-    await disposeAllInstances()
-
-    try {
-      await provideTestInstance({
-        directory: tmp.path,
-        fn: async () => {
-          await load()
-          const list = await warnings()
-          const hit = list.find((w) => w.message.includes("opencode configuration"))
-          expect(hit).toBeDefined()
-          expect(hit!.path).toBe(opencodeDir)
-        },
-      })
-    } finally {
-      ;(Global.Path as { config: string }).config = prev
-      await clear()
-      await disposeAllInstances()
-    }
+    await withGlobalConfig(path.join(globalTmp.path, "kilo"), () => {
+      const found = KilocodeConfig.detectOpencodeConfig({ directory: tmp.path, scanProject: true })
+      expect(found).toEqual([opencodeDir])
+    })
   })
 
-  test("stays silent when no opencode config exists", async () => {
+  test("skips the project scan when disabled", async () => {
     await using globalTmp = await tmpdir()
-    await using tmp = await tmpdir({ git: true })
+    await using tmp = await tmpdir()
+    await Filesystem.write(path.join(tmp.path, ".opencode", "opencode.json"), JSON.stringify({ model: "test/legacy" }))
 
-    const prev = Global.Path.config
-    ;(Global.Path as { config: string }).config = path.join(globalTmp.path, "kilo")
-    await clear()
-    await disposeAllInstances()
+    await withGlobalConfig(path.join(globalTmp.path, "kilo"), () => {
+      const found = KilocodeConfig.detectOpencodeConfig({ directory: tmp.path, scanProject: false })
+      expect(found).toEqual([])
+    })
+  })
 
-    try {
-      await provideTestInstance({
-        directory: tmp.path,
-        fn: async () => {
-          await load()
-          const list = await warnings()
-          expect(list.find((w) => w.message.includes("opencode configuration"))).toBeUndefined()
-        },
-      })
-    } finally {
-      ;(Global.Path as { config: string }).config = prev
-      await clear()
-      await disposeAllInstances()
-    }
+  test("builds a dismissible notification when opencode config exists", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir()
+    await Filesystem.write(path.join(tmp.path, ".opencode", "opencode.json"), JSON.stringify({ model: "test/legacy" }))
+
+    await withGlobalConfig(path.join(globalTmp.path, "kilo"), () => {
+      const notice = KilocodeConfig.opencodeConfigNotification({ directory: tmp.path, scanProject: true })
+      expect(notice?.id).toBe(KilocodeConfig.OPENCODE_NOTIFICATION_ID)
+      expect(notice?.message).toContain(path.join(tmp.path, ".opencode"))
+      expect(notice?.action?.actionURL).toBe(KilocodeConfig.CONFIG_DOCS_URL)
+      expect(notice?.showIn).toEqual(["cli", "extension"])
+    })
+  })
+
+  test("returns no notification when nothing needs migrating", async () => {
+    await using globalTmp = await tmpdir()
+    await using tmp = await tmpdir()
+
+    await withGlobalConfig(path.join(globalTmp.path, "kilo"), () => {
+      const notice = KilocodeConfig.opencodeConfigNotification({ directory: tmp.path, scanProject: true })
+      expect(notice).toBeUndefined()
+    })
   })
 })
 


### PR DESCRIPTION
## What

Shows a **dismissible notification** when a user still has a leftover **opencode config directory** on disk. Kilo used to fall back to opencode configuration but no longer reads `.opencode` directories, so this notice tells the user where to move it.

The notice is injected into the cloud notifications list served by `client.kilo.notifications()` (the single endpoint the TUI, VS Code extension, and JetBrains plugin all consume). Because it flows through the same list as cloud notifications, it reuses each client's existing per-`id` dismissal persistence — dismiss it once and it won't come back unless the `.opencode` directory is still present.

Detection (`KilocodeConfig.detectOpencodeConfig`) checks:
- The global opencode config dir (sibling of the kilo global config dir, e.g. `~/.config/opencode`)
- Project `.opencode/` directories walked up from the working directory to the worktree root

The synthetic notification uses a stable id (`kilo.local.opencode-config-detected`), `showIn: ["cli", "extension"]`, and an action linking to the CLI config docs.

## Why

The old opencode fallback for `.opencode` directories was removed, but users migrating from opencode had no signal their existing configuration was being ignored. An earlier revision surfaced this as a config warning (shown on every startup); this revision moves it to the notifications feed instead so it is **dismissible once** and non-nagging.

## Notes

- Detection + notification-building live in the Kilo-owned `kilocode/config/config.ts`; injection happens in the Kilo-owned gateway handler `kilocode/server/httpapi/handlers/kilo-gateway.ts`. No shared upstream files are modified.
- The notice is appended after the cloud fetch (and also returned when the user has a kilo auth record but no token), so it does not depend on cloud announcements being present.
- Client dismissal support: **TUI** (`news_read_ids`) and **VS Code** (`kilo.dismissedNotificationIds`) both persist dismissal by id. **JetBrains** currently renders the notifications list but has no client-side dismissal persistence for it, so the notice will reappear per session there until that path exists — a pre-existing limitation of the JetBrains notifications consumption, not specific to this change.
- Docs: a migration callout was added to the CLI config docs; the action button links there.
- Tests cover project/global detection, the disabled-project-scan case, and the built notification shape.

<img width="766" height="155" alt="CleanShot 2026-07-08 at 13 28 37" src="https://github.com/user-attachments/assets/86c9b735-9dae-434b-8a4a-e4c8fdf60782" />
