### PR TITLE
fix(codex): hide gpt-5.5-pro for Codex OAuth users

### DIFF
--- a/.changeset/hide-gpt-5-5-pro.md
+++ b/.changeset/hide-gpt-5-5-pro.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Hide gpt-5.5-pro from the model picker when using ChatGPT OAuth login, since Codex rejects it with HTTP 400.

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -15,6 +15,9 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+const DISALLOWED_MODELS = new Set([
+  "gpt-5.5-pro",
+])
 const ALLOWED_MODELS = new Set([
   "gpt-5.5",
   "gpt-5.2",
@@ -394,6 +397,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
           Object.entries(provider.models)
             .filter(([, model]) => {
               if (ALLOWED_MODELS.has(model.api.id)) return true
+              if (DISALLOWED_MODELS.has(model.api.id)) return false
               const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
               return match ? parseFloat(match[1]) > 5.4 : false
             })

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -15,9 +15,6 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
-const DISALLOWED_MODELS = new Set([
-  "gpt-5.5-pro",
-])
 const ALLOWED_MODELS = new Set([
   "gpt-5.5",
   "gpt-5.2",
@@ -32,6 +29,11 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.2-codex",
   // kilocode_change end
 ])
+// kilocode_change start
+const DISALLOWED_MODELS = new Set([
+  "gpt-5.5-pro",
+])
+// kilocode_change end
 
 interface PkceCodes {
   verifier: string
@@ -397,7 +399,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
           Object.entries(provider.models)
             .filter(([, model]) => {
               if (ALLOWED_MODELS.has(model.api.id)) return true
-              if (DISALLOWED_MODELS.has(model.api.id)) return false
+              if (DISALLOWED_MODELS.has(model.api.id)) return false // kilocode_change
               const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
               return match ? parseFloat(match[1]) > 5.4 : false
             })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -122,6 +122,7 @@ describe("plugin.codex", () => {
     })
   })
 
+  // kilocode_change start
   describe("models filter", () => {
     test("filters out disallowed models for oauth users", async () => {
       const hooks = await CodexAuthPlugin({} as never)
@@ -181,6 +182,7 @@ describe("plugin.codex", () => {
       expect(provider).toHaveProperty(["other-model"])
     })
   })
+  // kilocode_change end
 
   test("installs websocket transport only when experimental websockets are enabled", async () => {
     const disabled = await CodexAuthPlugin({} as never)

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -122,6 +122,66 @@ describe("plugin.codex", () => {
     })
   })
 
+  describe("models filter", () => {
+    test("filters out disallowed models for oauth users", async () => {
+      const hooks = await CodexAuthPlugin({} as never)
+      const provider = await hooks.provider!.models!({
+        id: "openai",
+        baseURL: "",
+        apiKey: "",
+        models: {
+          "gpt-5.5-pro": {
+            id: "gpt-5.5-pro",
+            api: { id: "gpt-5.5-pro" },
+          } as never,
+          "gpt-5.5": {
+            id: "gpt-5.5",
+            api: { id: "gpt-5.5" },
+          } as never,
+          "gpt-5.4-mini": {
+            id: "gpt-5.4-mini",
+            api: { id: "gpt-5.4-mini" },
+          } as never,
+          "gpt-5.1-codex": {
+            id: "gpt-5.1-codex",
+            api: { id: "gpt-5.1-codex" },
+          } as never,
+          "other-model": {
+            id: "other-model",
+            api: { id: "other-model" },
+          } as never,
+        },
+      } as never, { auth: { type: "oauth" } } as never)
+      expect(provider).not.toHaveProperty(["gpt-5.5-pro"])
+      expect(provider).toHaveProperty(["gpt-5.5"])
+      expect(provider).toHaveProperty(["gpt-5.4-mini"])
+      expect(provider).toHaveProperty(["gpt-5.1-codex"])
+      expect(provider).not.toHaveProperty(["other-model"])
+    })
+
+    test("passes through all models when not using oauth", async () => {
+      const hooks = await CodexAuthPlugin({} as never)
+      const models = {
+        "gpt-5.5-pro": {
+          id: "gpt-5.5-pro",
+          api: { id: "gpt-5.5-pro" },
+        } as never,
+        "other-model": {
+          id: "other-model",
+          api: { id: "other-model" },
+        } as never,
+      }
+      const provider = await hooks.provider!.models!({
+        id: "openai",
+        baseURL: "",
+        apiKey: "",
+        models,
+      } as never, { auth: { type: "api", key: "sk-test" } } as never)
+      expect(provider).toHaveProperty(["gpt-5.5-pro"])
+      expect(provider).toHaveProperty(["other-model"])
+    })
+  })
+
   test("installs websocket transport only when experimental websockets are enabled", async () => {
     const disabled = await CodexAuthPlugin({} as never)
     const enabled = await CodexAuthPlugin({} as never, { experimentalWebSockets: true })


### PR DESCRIPTION
## Issue

Fixes #12038 

## Context

When authenticated with OpenAI using Codex OAuth (ChatGPT Plus/Pro), Kilo displayed gpt-5.5-pro in the model picker even though the model is not supported by the Codex OAuth backend. Selecting it resulted in a 400 Bad Request response from the server

## Implementation

Added a DISALLOWED_MODELS set to the Codex OAuth plugin and excluded gpt-5.5-pro during model filtering for OAuth authentication.

The existing fallback logic for supported GPT models remains unchanged, so only the unsupported model is filtered out while API key authentication continues to expose all available models.

Also added regression tests covering:

- gpt-5.5-pro is hidden for OAuth users.
- Supported Codex/GPT models remain available for OAuth users.
- Non-OAuth (API key) authentication is unaffected.

## Screenshots / Video

n/a (small change)

## How to Test

### Manual/local verification

- Built the extension locally.
- Signed in using OpenAI Codex OAuth.
- Verified gpt-5.5-pro no longer appears in the model picker.
- Verified supported GPT/Codex models are still available.
- Verified API key authentication continues to expose gpt-5.5-pro.

### Reviewer test steps

- Sign in using OpenAI → ChatGPT (Codex OAuth).
- Open the model picker.
- Verify gpt-5.5-pro is not listed.
- Switch to an OpenAI API key.
- Verify gpt-5.5-pro is available.

### Blocked checks and substitute verification

No additional blockers encountered.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [ ] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@travix26
