### PR TITLE
fix(memory): drop filename allowlist from diff durability check

### DIFF
--- a/packages/kilo-memory/src/capture/diff.ts
+++ b/packages/kilo-memory/src/capture/diff.ts
@@ -5,20 +5,29 @@ export type CaptureDiff = {
   deletions: number
 }
 
-const durable =
-  /(^|\/)(AGENTS\.md|README(?:\.[^/]*)?|docs?\/.+|package\.json|bun\.lock|pnpm-lock\.yaml|package-lock\.json|turbo\.json|tsconfig[^/]*\.json|vite\.config|eslint|biome|prettier|kilo\.json|\.kilo\/.+|[^/]*(test|spec|config|command|agent|workflow)[^/]*\.(ts|tsx|js|json|md|yml|yaml))$/i
-const generated =
+// Build/generated output: machine-produced files that are never a user edit.
+const generatedDenyList =
   /(^|\/)(dist|build|out|coverage|node_modules|\.next|target|vendor|generated|gen|__snapshots__)(\/|$)|(^|\/)[^/]*\.(min|gen)\.[^/]+$|\.map$/i
 
-export function hasDurableDiff(diffs: Pick<CaptureDiff, "file" | "additions" | "deletions">[]) {
+/** Any non-generated file change. Presence-based: numstat only lists changed files, and binary
+ * edits report 0/0, so churn must not be required. */
+export function hasUserEdit(diffs: Pick<CaptureDiff, "file">[]) {
   return diffs.some((item) => {
     const file = item.file ?? ""
     if (!file) return false
-    // Generated output wins over the durable allowlist: a copied dist/package.json or a vendored doc
-    // is build output, not a user edit.
-    if (generated.test(file)) return false
-    if (durable.test(file)) return true
-    // Fall back to churn size so any language counts, not just files matching the pattern above.
+    return !generatedDenyList.test(file)
+  })
+}
+
+/** A change big enough to consolidate immediately instead of waiting for the interval throttle.
+ * Churn-only, so every language/ecosystem is treated the same; build output is excluded. Text edits
+ * (human or agent) always carry real +/- counts — only binary files are 0/0, so a binary edit is
+ * never substantial here, but still counts as work via hasUserEdit. */
+export function hasSubstantialDiff(diffs: Pick<CaptureDiff, "file" | "additions" | "deletions">[]) {
+  return diffs.some((item) => {
+    const file = item.file ?? ""
+    if (!file) return false
+    if (generatedDenyList.test(file)) return false
     return item.additions + item.deletions >= 20
   })
 }

--- a/packages/kilo-memory/src/capture/diff.ts
+++ b/packages/kilo-memory/src/capture/diff.ts
@@ -6,7 +6,7 @@ export type CaptureDiff = {
 }
 
 // Build/generated output: machine-produced files that are never a user edit.
-const generatedDenyList =
+const generated =
   /(^|\/)(dist|build|out|coverage|node_modules|\.next|target|vendor|generated|gen|__snapshots__)(\/|$)|(^|\/)[^/]*\.(min|gen)\.[^/]+$|\.map$/i
 
 /** Any non-generated file change. Presence-based: numstat only lists changed files, and binary
@@ -15,7 +15,7 @@ export function hasUserEdit(diffs: Pick<CaptureDiff, "file">[]) {
   return diffs.some((item) => {
     const file = item.file ?? ""
     if (!file) return false
-    return !generatedDenyList.test(file)
+    return !generated.test(file)
   })
 }
 
@@ -27,7 +27,7 @@ export function hasSubstantialDiff(diffs: Pick<CaptureDiff, "file" | "additions"
   return diffs.some((item) => {
     const file = item.file ?? ""
     if (!file) return false
-    if (generatedDenyList.test(file)) return false
+    if (generated.test(file)) return false
     return item.additions + item.deletions >= 20
   })
 }

--- a/packages/kilo-memory/src/capture/plan.ts
+++ b/packages/kilo-memory/src/capture/plan.ts
@@ -13,7 +13,8 @@ export function capturePlan(input: {
   reason?: CaptureReason
   summary: string
   echo: boolean
-  durable: boolean
+  substantial: boolean
+  edited: boolean
   priorTime: number
   now: number
   minIntervalMs: number
@@ -27,19 +28,19 @@ export function capturePlan(input: {
   const session = base && !input.echo
   // Typed capture trusts the prompt as the content filter and remains bounded by the interval throttle.
   const typedSession = base
-  const trivial = Boolean(input.summary) && !input.durable && input.summary.length < 80
+  const trivial = Boolean(input.summary) && !input.edited && input.summary.length < 80
   const digestDue =
     session &&
     !trivial &&
     (!input.priorTime ||
       !Number.isFinite(input.priorTime) ||
       input.now - input.priorTime >= input.minIntervalMs ||
-      input.durable)
+      input.substantial)
   const interval = Boolean(
     !input.bypassInterval &&
       input.lastTypedConsolidationAt &&
       input.now - input.lastTypedConsolidationAt < input.minIntervalMs &&
-      !input.durable,
+      !input.substantial,
   )
   const typed = typedCapture({ reason: input.reason, interval })
   const typedCall = input.autoConsolidate && typed.call && typedSession

--- a/packages/kilo-memory/src/effect/capture.ts
+++ b/packages/kilo-memory/src/effect/capture.ts
@@ -10,7 +10,8 @@ import {
   evidence,
   fallbackDigest,
   guardReason,
-  hasDurableDiff,
+  hasSubstantialDiff,
+  hasUserEdit,
   mergeOps,
   notice,
   parseDigest,
@@ -149,11 +150,12 @@ export namespace MemoryCapture {
     const summary = summarize({ user, assistant, max: state.limits.maxSessionLineChars })
     const diffs = view.diffs
     const changed = summarizeDiffs(diffs)
-    const durable = hasDurableDiff(diffs)
+    const substantial = hasSubstantialDiff(diffs)
+    const edited = hasUserEdit(diffs)
     const completed = !input.reason || input.reason === "completed"
     // Echo = short lookup answered from memory with no file changes. Long recall-assisted answers
     // (research, investigations) carry new content and must still be digested.
-    const echo = !durable && assistant.length < 1200 && view.recalledMemory
+    const echo = !edited && assistant.length < 1200 && view.recalledMemory
     // Echo gates the digest only. Typed capture is bounded by the interval throttle, and the typed
     // prompt is the language-agnostic content filter for lookup/correction turns.
     const sourced = provenance({ assistant }) && !editsInstructionDocs(diffs)
@@ -168,7 +170,8 @@ export namespace MemoryCapture {
       reason: input.reason,
       summary,
       echo,
-      durable,
+      substantial,
+      edited,
       priorTime,
       now,
       minIntervalMs: state.capture.minIntervalMs,

--- a/packages/kilo-memory/test/capture.test.ts
+++ b/packages/kilo-memory/test/capture.test.ts
@@ -5,7 +5,8 @@ import {
   duplicateOps,
   fallbackDigest,
   guardReason,
-  hasDurableDiff,
+  hasSubstantialDiff,
+  hasUserEdit,
   mergeOps,
   notice,
   parseJson,
@@ -303,7 +304,8 @@ describe("memory capture parsing", () => {
     const base = {
       summary: "User: continue implementing digest robustness Result: updated capture and storage behavior",
       echo: false,
-      durable: false,
+      substantial: false,
+      edited: false,
       priorTime: 0,
       now: 1_000,
       minIntervalMs: 500,
@@ -332,13 +334,13 @@ describe("memory capture parsing", () => {
         expected: { session: false, digestDue: false, typedCall: true, typedWork: true, skipReason: undefined },
       },
       {
-        name: "expected work: recall-assisted durable answer is modeled as non-echo by caller",
-        input: { ...base, durable: true },
+        name: "expected work: recall-assisted substantial answer is modeled as non-echo by caller",
+        input: { ...base, substantial: true },
         expected: { session: true, digestDue: true, typedCall: true, skipReason: undefined },
       },
       {
         name: "expected skip: interrupted turn still schedules a non-LLM fallback digest",
-        input: { ...base, reason: "interrupted" as const, durable: true },
+        input: { ...base, reason: "interrupted" as const, substantial: true },
         expected: {
           completed: false,
           session: false,
@@ -375,6 +377,16 @@ describe("memory capture parsing", () => {
         input: { ...base, summary: "User: test Result: ok", lastTypedConsolidationAt: 900 },
         expected: { digestDue: false, typedCall: false, fallbackDigest: false, skipReason: "trivial" },
       },
+      {
+        name: "expected skip: short edited turn is interval-gated instead of trivial",
+        input: { ...base, summary: "User: test Result: ok", edited: true, priorTime: 900, lastTypedConsolidationAt: 900 },
+        expected: { digestDue: false, typedCall: false, fallbackDigest: false, skipReason: "interval" },
+      },
+      {
+        name: "expected skip: short unedited turn is trivial",
+        input: { ...base, summary: "User: test Result: ok", edited: false, lastTypedConsolidationAt: 900 },
+        expected: { digestDue: false, typedCall: false, fallbackDigest: false, skipReason: "trivial" },
+      },
     ]
 
     for (const item of cases) {
@@ -388,22 +400,26 @@ describe("memory capture parsing", () => {
       { file: "README.md", status: "modified", additions: 1, deletions: 0 },
     ]
 
-    expect(hasDurableDiff(diffs)).toBe(true)
-    expect(hasDurableDiff([{ file: "docs/setup.md", additions: 1, deletions: 0 }])).toBe(true)
-    expect(hasDurableDiff([{ file: ".kilo/rules.md", additions: 1, deletions: 0 }])).toBe(true)
-    expect(hasDurableDiff([{ file: "src/plain.ts", additions: 1, deletions: 0 }])).toBe(false)
-    // P1.5: a substantial edit is durable regardless of language — no JS/TS extension allowlist.
-    expect(hasDurableDiff([{ file: "src/service.py", additions: 20, deletions: 0 }])).toBe(true)
-    // Generated output never counts, even with heavy churn or a durable-looking basename...
-    expect(hasDurableDiff([{ file: "dist/service.py", additions: 200, deletions: 0 }])).toBe(false)
-    expect(hasDurableDiff([{ file: "src/generated/client.ts", additions: 200, deletions: 0 }])).toBe(false)
-    expect(hasDurableDiff([{ file: "sdk/src/gen/types.gen.ts", additions: 200, deletions: 0 }])).toBe(false)
-    expect(hasDurableDiff([{ file: "dist/package.json", additions: 1, deletions: 0 }])).toBe(false)
-    expect(hasDurableDiff([{ file: "vendor/docs/readme.md", additions: 30, deletions: 0 }])).toBe(false)
-    // ...while the durable allowlist still wins over churn size elsewhere (lockfiles are a real dep-change signal).
-    expect(hasDurableDiff([{ file: "packages/app/package.json", additions: 1, deletions: 0 }])).toBe(true)
-    expect(hasDurableDiff([{ file: "internal/server/main.go", additions: 12, deletions: 10 }])).toBe(true)
-    expect(hasDurableDiff([{ file: "src/lib.rs", additions: 5, deletions: 5 }])).toBe(false)
+    // Identical churn yields the identical verdict across every kind of path, so no ecosystem
+    // (manifest, doc, config, or source language) is treated specially.
+    for (const file of ["src/app.ts", "src/app.py", "src/app.go", "src/app.rb", "package.json", "docs/x.md", "config.yaml"]) {
+      expect(hasSubstantialDiff([{ file, additions: 1, deletions: 0 }]), `${file} small`).toBe(false)
+      expect(hasSubstantialDiff([{ file, additions: 20, deletions: 0 }]), `${file} large`).toBe(true)
+    }
+    // A split edit still counts by total churn.
+    expect(hasSubstantialDiff([{ file: "internal/server/main", additions: 12, deletions: 10 }])).toBe(true)
+    // Build output never counts, even with heavy churn.
+    expect(hasSubstantialDiff([{ file: "dist/bundle.js", additions: 200, deletions: 0 }])).toBe(false)
+    expect(hasSubstantialDiff([{ file: "src/generated/client.ts", additions: 200, deletions: 0 }])).toBe(false)
+    expect(hasSubstantialDiff([{ file: "sdk/src/gen/types.gen.ts", additions: 200, deletions: 0 }])).toBe(false)
+    // Binary edits report 0/0 churn, so they are never substantial (but still count as work below).
+    expect(hasSubstantialDiff([{ file: "assets/logo.png", additions: 0, deletions: 0 }])).toBe(false)
+    // hasUserEdit: any non-generated file changed counts as work, in any language; presence, not churn.
+    expect(hasUserEdit([])).toBe(false)
+    expect(hasUserEdit([{ additions: 1, deletions: 0 }])).toBe(false)
+    expect(hasUserEdit([{ file: "src/app.ts", additions: 1, deletions: 0 }])).toBe(true)
+    expect(hasUserEdit([{ file: "dist/bundle.js", additions: 300, deletions: 0 }])).toBe(false)
+    expect(hasUserEdit([{ file: "assets/logo.png", additions: 0, deletions: 0 }])).toBe(true)
     expect(summarizeDiffs(diffs)).toContain("modified README.md +1 -0")
     expect(fallbackDigest({ prior: "Earlier state.", summary: "New state.", max: 80 })).toContain("Latest: New state.")
     expect(parseDigest({ topic: "", summary: "User: x Result: y." }, "", 120).topic).not.toBe("User")

--- a/packages/kilo-memory/test/effect-capture.test.ts
+++ b/packages/kilo-memory/test/effect-capture.test.ts
@@ -312,6 +312,40 @@ describe("MemoryCapture (fake ports)", () => {
     }
   })
 
+  test("small file edit with recalled memory still records digest (edit defeats echo, any file type)", async () => {
+    const t = await tmp()
+    try {
+      await KiloMemory.enable({ root: t.root })
+      await KiloMemory.configure({ root: t.root, settings: { autoConsolidate: true } })
+
+      let runs = 0
+      const result = await run({
+        root: t.root,
+        session: session(
+          view({
+            assistant: "Fixed the parser.",
+            recalledMemory: true,
+            diffs: [{ file: "src/parser", additions: 4, deletions: 0 }],
+          }),
+        ),
+        model: model({
+          digest: '{"topic":"parser","summary":"Fixed the parser in src/parser."}',
+          typed: '{"operations":[],"skipped":[]}',
+          onRun: (system) => {
+            if (system === digestPrompt) runs++
+          },
+        }),
+      })
+
+      expect(result).toMatchObject({ skipped: false })
+      expect(runs).toBe(1)
+      const saved = await MemoryFiles.readSession(t.root, { sessionID: "ses_effect", max: 480 })
+      expect(saved?.summary).toContain("Fixed the parser")
+    } finally {
+      await t.done()
+    }
+  })
+
   test("interrupted close records a non-LLM fallback digest tagged with the reason", async () => {
     const t = await tmp()
     try {


### PR DESCRIPTION
## Issue

No linked issue. Follow-up to review feedback on #11921 (https://github.com/Kilo-Org/kilocode/pull/11921#discussion_r3535036529): the durability heuristic was flagged as hardcoded and JS-biased.

## Context

`hasDurableDiff` decided when a turn's file changes are worth an LLM consolidation call, using a hardcoded filename allowlist with an English word list (`test|spec|config|command|agent|workflow` plus JS extensions). Small edits outside the listed patterns, a 5 line .py fix for example, could be dropped as echo or trivial and never captured.

## Implementation

The old check mixed two signals in one bit: did the turn do real work, and should it skip the consolidation throttle. This splits them:

- `hasUserEdit`: any non-generated file change. Gates echo and trivial classification. Presence based, since git numstat only lists changed files and binary edits report 0/0 churn, so requiring churn would misclassify asset replacements.
- `hasSubstantialDiff`: 20+ lines of churn in any language. Decides the interval throttle bypass only.

The filename allowlist is gone entirely. Generated output (dist/, build/, .map, etc) is still excluded from both.

Behavior changes:

- A completed small fix in any language with a short summary is now digested at interval cadence instead of dropped as trivial.
- A small edit plus recalled memory plus a short answer is no longer misclassified as a recall echo.
- Binary asset changes count as work.
- Small edits to previously allowlisted files (package.json, docs/, .kilo/) no longer bypass the throttle. A miss here costs latency, not a dropped turn.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- `bun test` in packages/kilo-memory: 152 pass, 0 fail (agent executed)
- `bunx tsc --noEmit` in packages/kilo-memory: clean (agent executed)
- Full monorepo typecheck ran via the pre-push hook, including JetBrains: clean (agent executed)
- Verified memory feature continues to work normally in the CLI

### Reviewer test steps

1. `bun test packages/kilo-memory`
2. See the new `hasUserEdit` / `hasSubstantialDiff` cases in test/capture.test.ts and the .py echo regression test in test/effect-capture.test.ts

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes: none added, internal capture heuristic in the opt-in memory feature, no CLI surface change
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
