### PR TITLE
fix(indexing): respect nested ignore files during codebase indexing

### DIFF
--- a/.changeset/nested-ignore-indexing.md
+++ b/.changeset/nested-ignore-indexing.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-indexing": patch
+"kilo-code": patch
+---
+
+Respect nested `.gitignore` and `.kilocodeignore` files during codebase indexing.

--- a/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
+++ b/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
@@ -3,7 +3,6 @@ import { stat, readFile } from "fs/promises"
 import { createHash } from "crypto"
 import path from "path"
 import { v5 as uuidv5 } from "uuid"
-import type { Ignore } from "ignore"
 import { Emitter, type Disposable } from "../runtime"
 import {
   QDRANT_CODE_BLOCK_NAMESPACE,
@@ -33,6 +32,7 @@ import { FileIgnore } from "../../file/ignore"
 import { Log } from "../../util/log"
 import type { WorktreeOverlay } from "../worktree-overlay"
 import { sanitizeErrorMessage } from "../shared/validation-helpers"
+import type { IgnoreMatcher } from "../shared/load-ignore"
 
 const log = Log.create({ service: "file-watcher" })
 
@@ -43,7 +43,7 @@ const log = Log.create({ service: "file-watcher" })
  * so the watcher works outside VS Code (CLI, tests, headless).
  */
 export class FileWatcher implements IFileWatcher {
-  private ignoreInstance?: Ignore
+  private ignoreInstance?: IgnoreMatcher
   private watcher?: ChokidarFSWatcher
   private accumulatedEvents: Map<string, { path: string; type: "create" | "change" | "delete" }> = new Map()
   private batchProcessDebounceTimer?: NodeJS.Timeout
@@ -70,7 +70,7 @@ export class FileWatcher implements IFileWatcher {
     private readonly cacheManager: CacheManager,
     private embedder?: IEmbedder,
     private vectorStore?: IVectorStore,
-    ignoreInstance?: Ignore,
+    ignoreInstance?: IgnoreMatcher,
     batchSegmentThreshold?: number,
     maxBatchRetries?: number,
     private readonly onTelemetry?: IndexingTelemetryReporter,

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -1,4 +1,3 @@
-import type { Ignore } from "ignore"
 import { stat, readFile } from "fs/promises"
 import path from "path"
 import { glob } from "glob"
@@ -28,6 +27,7 @@ import { FileIgnore } from "../../file/ignore"
 import { Log } from "../../util/log"
 import { sanitizeErrorMessage } from "../shared/validation-helpers"
 import type { IndexingTelemetryMeta, IndexingTelemetryMode, IndexingTelemetryReporter } from "../interfaces/telemetry"
+import type { IgnoreMatcher } from "../shared/load-ignore"
 
 const log = Log.create({ service: "indexing-scanner" })
 
@@ -41,7 +41,7 @@ export class DirectoryScanner implements IDirectoryScanner {
     private readonly vectorStore: IVectorStore,
     private readonly codeParser: ICodeParser,
     private readonly cacheManager: CacheManager,
-    private readonly ignoreInstance: Ignore,
+    private readonly ignoreInstance: IgnoreMatcher,
     batchSegmentThreshold?: number,
     maxBatchRetries?: number,
     private readonly onTelemetry?: IndexingTelemetryReporter,

--- a/packages/kilo-indexing/src/indexing/service-factory.ts
+++ b/packages/kilo-indexing/src/indexing/service-factory.ts
@@ -1,4 +1,3 @@
-import type { Ignore } from "ignore"
 import path from "path"
 
 import { getDefaultModelId } from "./model-registry"
@@ -28,6 +27,7 @@ import {
   REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
 } from "./constants"
 import { Log } from "../util/log"
+import type { IgnoreMatcher } from "./shared/load-ignore"
 
 const log = Log.create({ service: "indexing-factory" })
 
@@ -208,7 +208,7 @@ export class CodeIndexServiceFactory {
     embedder: IEmbedder,
     vectorStore: IVectorStore,
     parser: ICodeParser,
-    ignoreInstance: Ignore,
+    ignoreInstance: IgnoreMatcher,
   ): DirectoryScanner {
     const config = this.configManager.getConfig()
     const meta = this.getTelemetryMeta()
@@ -229,7 +229,7 @@ export class CodeIndexServiceFactory {
     embedder: IEmbedder,
     vectorStore: IVectorStore,
     cacheManager: CacheManager,
-    ignoreInstance: Ignore,
+    ignoreInstance: IgnoreMatcher,
   ): IFileWatcher {
     const config = this.configManager.getConfig()
     const meta = this.getTelemetryMeta()
@@ -248,7 +248,7 @@ export class CodeIndexServiceFactory {
 
   public createServices(
     cacheManager: CacheManager,
-    ignoreInstance: Ignore,
+    ignoreInstance: IgnoreMatcher,
   ): {
     embedder: IEmbedder
     vectorStore: IVectorStore

--- a/packages/kilo-indexing/src/indexing/shared/load-ignore.ts
+++ b/packages/kilo-indexing/src/indexing/shared/load-ignore.ts
@@ -1,8 +1,21 @@
 import fs from "fs/promises"
+import { glob } from "glob"
 import ignore, { type Ignore } from "ignore"
 import path from "path"
+import { FileIgnore } from "../../file/ignore"
 
 const files = [".gitignore", ".kilocodeignore"] as const
+const order = new Map(files.map((name, index) => [name, index]))
+
+type Entry = {
+  dir: string
+  name: string
+  txt: string | undefined
+}
+
+export interface IgnoreMatcher {
+  ignores(filePath: string): boolean
+}
 
 function notFound(err: unknown): boolean {
   if (!err || typeof err !== "object") {
@@ -11,8 +24,30 @@ function notFound(err: unknown): boolean {
   return "code" in err && err.code === "ENOENT"
 }
 
-async function read(root: string, name: string): Promise<string | undefined> {
-  return fs.readFile(path.join(root, name), "utf8").catch((err) => {
+function toPosix(value: string): string {
+  return value.replaceAll("\\", "/")
+}
+
+function depth(dir: string): number {
+  if (!dir) {
+    return 0
+  }
+  return dir.split("/").length
+}
+
+function relative(root: string, filePath: string): string | undefined {
+  const rel = toPosix(path.relative(root, filePath))
+  if (!rel || rel === ".") {
+    return
+  }
+  if (rel === ".." || rel.startsWith("../") || path.isAbsolute(rel)) {
+    return
+  }
+  return rel
+}
+
+async function read(filePath: string): Promise<string | undefined> {
+  return fs.readFile(filePath, "utf8").catch((err) => {
     if (notFound(err)) {
       return undefined
     }
@@ -20,18 +55,127 @@ async function read(root: string, name: string): Promise<string | undefined> {
   })
 }
 
-export async function loadIgnore(root: string): Promise<Ignore> {
-  const ig = ignore()
+function escape(dir: string): string {
+  return dir
+    .split("/")
+    .map((part) => part.replace(/[\\[\]*?!#]/g, "\\$&"))
+    .join("/")
+}
 
-  for (const name of files) {
-    const txt = await read(root, name)
-    if (!txt?.trim()) {
+function discovery(): string[] {
+  const result = new Set(FileIgnore.PATTERNS)
+  for (const pattern of FileIgnore.PATTERNS) {
+    if (pattern.includes("/") || [...pattern].some((char) => "*!?[]{}()".includes(char))) {
+      continue
+    }
+    result.add(`${pattern}/**`)
+    result.add(`**/${pattern}/**`)
+  }
+  return [...result]
+}
+
+function rules(dir: string, txt: string): string[] {
+  const result = []
+  for (const line of txt.split(/\r?\n/)) {
+    if (!line.trim() || line.startsWith("#")) {
       continue
     }
 
-    ig.add(txt)
-    ig.add(name)
-  }
+    const negated = line.startsWith("!")
+    const raw = negated ? line.slice(1) : line
+    const anchored = raw.startsWith("/")
+    const body = anchored ? raw.slice(1) : raw
+    if (!body) {
+      continue
+    }
 
-  return ig
+    const root = escape(dir)
+    const match = body.endsWith("/") ? body.slice(0, -1) : body
+    const scoped = anchored || match.includes("/") ? `${root}/${body}` : `${root}/**/${body}`
+    result.push(negated ? `!${scoped}` : scoped)
+  }
+  return result
+}
+
+class WorkspaceIgnore implements IgnoreMatcher {
+  constructor(private readonly matcher: Ignore) {}
+
+  ignores(filePath: string): boolean {
+    const rel = toPosix(path.normalize(filePath))
+    if (!rel || rel === "." || rel === ".." || rel.startsWith("../") || path.isAbsolute(rel)) {
+      return false
+    }
+
+    return this.matcher.ignores(rel)
+  }
+}
+
+export async function loadIgnore(root: string): Promise<IgnoreMatcher> {
+  const paths = await glob("**/{.gitignore,.kilocodeignore}", {
+    cwd: root,
+    absolute: true,
+    nodir: true,
+    dot: true,
+    ignore: discovery(),
+    maxDepth: Infinity,
+  })
+
+  const entries = await Promise.all(
+    paths.map(async (filePath) => {
+      const rel = relative(root, filePath)
+      if (!rel) {
+        return
+      }
+      if (FileIgnore.match(rel)) {
+        return
+      }
+
+      const dir = toPosix(path.dirname(rel))
+      const name = path.basename(rel)
+      if (!order.has(name as (typeof files)[number])) {
+        return
+      }
+
+      const txt = await read(filePath)
+
+      return {
+        dir: dir === "." ? "" : dir,
+        name,
+        txt,
+      }
+    }),
+  )
+
+  const sorted = entries
+    .filter((entry): entry is Entry => Boolean(entry))
+    .sort((left, right) => {
+      const level = depth(left.dir) - depth(right.dir)
+      if (level !== 0) {
+        return level
+      }
+      const dir = left.dir.localeCompare(right.dir)
+      if (dir !== 0) {
+        return dir
+      }
+      return order.get(left.name as (typeof files)[number])! - order.get(right.name as (typeof files)[number])!
+    })
+
+  const matcher = ignore()
+  for (const entry of sorted) {
+    if (!entry.dir) {
+      if (entry.txt?.trim()) {
+        matcher.add(entry.txt)
+      }
+      matcher.add(entry.name)
+      continue
+    }
+
+    if (entry.txt?.trim()) {
+      matcher.add(rules(entry.dir, entry.txt))
+    }
+    matcher.add(`${entry.dir}/${entry.name}`)
+  }
+  matcher.add([".gitignore", ".kilocodeignore", "**/.gitignore", "**/.kilocodeignore"])
+
+  return new WorkspaceIgnore(matcher)
 }

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { mkdtemp, mkdir, writeFile } from "fs/promises"
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { createHash } from "crypto"
@@ -316,5 +316,30 @@ describe("FileWatcher", () => {
 
     expect(result.status).toBe("skipped")
     expect(result.reason).toBe("File is ignored by .gitignore or .kilocodeignore")
+  })
+
+  test("processFile skips files matched by nested .gitignore during incremental updates", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-test-"))
+    try {
+      const cacheDir = path.join(root, ".cache")
+      const dir = path.join(root, "pkg")
+      const file = path.join(dir, "secret.ts")
+
+      await mkdir(cacheDir, { recursive: true })
+      await mkdir(dir, { recursive: true })
+      await writeFile(path.join(dir, ".gitignore"), "secret.ts\n")
+      await writeFile(file, "export const secret = 1\n")
+
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+
+      const watcher = new FileWatcher(root, cache, createEmbedder(), undefined, await loadIgnore(root))
+      const result = await watcher.processFile(file)
+
+      expect(result.status).toBe("skipped")
+      expect(result.reason).toBe("File is ignored by .gitignore or .kilocodeignore")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto"
-import { mkdtemp } from "fs/promises"
+import { mkdir, mkdtemp, rm } from "fs/promises"
 import ignore from "ignore"
 import { tmpdir } from "os"
 import { join } from "path"
@@ -307,6 +307,34 @@ describe("DirectoryScanner", () => {
     expect(result.stats.processed).toBe(1)
     expect(cache.getHash(blocked)).toBeUndefined()
     expect(cache.getHash(open)).toBeDefined()
+  })
+
+  test("skips files matched by nested .kilocodeignore during full scans", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    try {
+      const dir = join(root, "pkg")
+      const blocked = join(dir, "blocked.ts")
+      const open = join(dir, "open.ts")
+
+      await mkdir(dir, { recursive: true })
+      await Bun.write(join(dir, ".kilocodeignore"), "blocked.ts\n")
+      await Bun.write(blocked, "export const blocked = 1\n")
+      await Bun.write(open, "export const open = 1\n")
+
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+
+      const scan = new DirectoryScanner(new Emb(), new Store(), new Parser(), cache, await loadIgnore(root), 1, 1)
+      const result = await scan.scanDirectory(root)
+
+      expect(result.stats.processed).toBe(1)
+      expect(cache.getHash(blocked)).toBeUndefined()
+      expect(cache.getHash(open)).toBeDefined()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
   })
 
   test("emits retry telemetry for transient batch failures", async () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/shared/load-ignore.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/shared/load-ignore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm, writeFile } from "fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { loadIgnore } from "../../../../src/indexing/shared/load-ignore"
@@ -38,6 +38,121 @@ describe("loadIgnore", () => {
     expect(ig.ignores("src/app.ts")).toBe(false)
   })
 
+  test("loads nested .kilocodeignore relative to its directory", async () => {
+    await mkdir(path.join(root, "pkg", "sub"), { recursive: true })
+    await writeFile(path.join(root, "pkg", ".kilocodeignore"), "secret.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/secret.ts")).toBe(true)
+    expect(ig.ignores("pkg/sub/secret.ts")).toBe(true)
+    expect(ig.ignores("secret.ts")).toBe(false)
+    expect(ig.ignores("pkg/open.ts")).toBe(false)
+  })
+
+  test("anchors nested patterns that start with slash to the ignore file directory", async () => {
+    await mkdir(path.join(root, "pkg", "sub"), { recursive: true })
+    await writeFile(path.join(root, "pkg", ".gitignore"), "/secret.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/secret.ts")).toBe(true)
+    expect(ig.ignores("pkg/sub/secret.ts")).toBe(false)
+  })
+
+  test("matches nested bare directory patterns at any depth", async () => {
+    await mkdir(path.join(root, "pkg", "sub"), { recursive: true })
+    await writeFile(path.join(root, "pkg", ".gitignore"), "dist/\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/dist/file.ts")).toBe(true)
+    expect(ig.ignores("pkg/sub/dist/file.ts")).toBe(true)
+  })
+
+  test("lets child ignore files override parent rules with negation", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "*.ts\n")
+    await writeFile(path.join(root, "pkg", ".gitignore"), "!keep.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("root.ts")).toBe(true)
+    expect(ig.ignores("pkg/drop.ts")).toBe(true)
+    expect(ig.ignores("pkg/keep.ts")).toBe(false)
+  })
+
+  test("keeps files ignored when a parent directory is ignored", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "pkg/\n")
+    await writeFile(path.join(root, "pkg", ".gitignore"), "!keep.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/keep.ts")).toBe(true)
+  })
+
+  test("allows descendants when a parent directory is re-included", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "pkg/\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!pkg/\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/file.ts")).toBe(false)
+  })
+
+  test("keeps explicit file ignores when a parent directory is re-included", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "*.ts\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!pkg/\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/file.ts")).toBe(true)
+  })
+
+  test("keeps explicit file ignores when a re-included parent also had explicit file rules", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "pkg/\npkg/*.ts\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!pkg/\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/file.ts")).toBe(true)
+  })
+
+  test("keeps descendants ignored when only a child directory is re-included", async () => {
+    await mkdir(path.join(root, "pkg", "sub"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "pkg/\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!pkg/sub/\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/sub/file.ts")).toBe(true)
+  })
+
+  test("allows child negation after a parent directory is re-included", async () => {
+    await mkdir(path.join(root, "pkg"), { recursive: true })
+    await writeFile(path.join(root, ".gitignore"), "pkg/\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!pkg/\n")
+    await writeFile(path.join(root, "pkg", ".gitignore"), "!keep.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg/keep.ts")).toBe(false)
+  })
+
+  test("applies .kilocodeignore after .gitignore in the same directory", async () => {
+    await writeFile(path.join(root, ".gitignore"), "*.ts\n")
+    await writeFile(path.join(root, ".kilocodeignore"), "!keep.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("drop.ts")).toBe(true)
+    expect(ig.ignores("keep.ts")).toBe(false)
+  })
+
   test("ignores the ignore files themselves", async () => {
     await writeFile(path.join(root, ".gitignore"), "dist/\n")
     await writeFile(path.join(root, ".kilocodeignore"), "secret/\n")
@@ -46,5 +161,39 @@ describe("loadIgnore", () => {
 
     expect(ig.ignores(".gitignore")).toBe(true)
     expect(ig.ignores(".kilocodeignore")).toBe(true)
+  })
+
+  test("keeps ignore files ignored after negation rules", async () => {
+    await writeFile(path.join(root, ".kilocodeignore"), "!.gitignore\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores(".gitignore")).toBe(true)
+  })
+
+  test("ignores ignore file names even when absent during loading", async () => {
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores(".gitignore")).toBe(true)
+    expect(ig.ignores("pkg/.kilocodeignore")).toBe(true)
+  })
+
+  test("does not load ignore files from hardcoded ignored folders", async () => {
+    await mkdir(path.join(root, "dist"), { recursive: true })
+    await writeFile(path.join(root, "dist", ".gitignore"), "*.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("dist/file.ts")).toBe(false)
+  })
+
+  test("escapes nested ignore file directory names in generated patterns", async () => {
+    await mkdir(path.join(root, "pkg[1]"), { recursive: true })
+    await writeFile(path.join(root, "pkg[1]", ".gitignore"), "secret.ts\n")
+
+    const ig = await loadIgnore(root)
+
+    expect(ig.ignores("pkg[1]/secret.ts")).toBe(true)
+    expect(ig.ignores("pkg1/secret.ts")).toBe(false)
   })
 })


### PR DESCRIPTION
## Issue

Fixes #12031

## Context

Ensure nested .gitignore and .kilocodeignore files are respected during codebase indexing.

## Implementation

- Added recursive .gitignore / .kilocodeignore loading with nested-rule scoping.
- Updated indexing code to use the new rule matching via `IgnoreMatcher`.
- Added unit tests for new ignore matching functionality.
- All changes are scoped within the indexing package to avoid OpenCode conflicts.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Create a `.kilocodeignore` file within a subdirectory of a project which ignores one or more files or directories
- Open Kilo
- Verify that the ignored files/directories are not indexed

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord