### PR TITLE
test(cli): stabilize process-heavy integration tests

### DIFF
--- a/packages/opencode/test/kilocode/background-process.test.ts
+++ b/packages/opencode/test/kilocode/background-process.test.ts
@@ -383,21 +383,24 @@ setInterval(() => console.log("tick"), 100)
           command,
           cwd: test.directory,
           lifetime: "persistent",
-          ready: { pattern: "ready", timeout: 5_000 },
+          ready: { pattern: "ready", timeout: 15_000 },
         }),
       )
 
-      const otherID = SessionID.descending()
-      const visible = yield* Effect.promise(() => BackgroundProcess.list({ sessionID: otherID }))
-      expect(visible.map((item) => item.id)).toContain(info.id)
-      yield* Effect.promise(() => BackgroundProcess.shutdown())
-      const adopted = yield* Effect.promise(() => BackgroundProcess.get(info.id))
-      expect(adopted?.pid).toBe(info.pid)
-      expect(adopted?.lifetime).toBe("persistent")
-      expect(adopted?.output).toContain("ready")
-
-      yield* Effect.promise(() => BackgroundProcess.stop(info.id))
-      yield* Effect.promise(() => BackgroundProcess.stopSession(sessionID))
+      try {
+        expect(info.status).toBe("ready")
+        const otherID = SessionID.descending()
+        const visible = yield* Effect.promise(() => BackgroundProcess.list({ sessionID: otherID }))
+        expect(visible.map((item) => item.id)).toContain(info.id)
+        yield* Effect.promise(() => BackgroundProcess.shutdown())
+        const adopted = yield* Effect.promise(() => BackgroundProcess.get(info.id))
+        expect(adopted?.pid).toBe(info.pid)
+        expect(adopted?.lifetime).toBe("persistent")
+        expect(adopted?.output).toContain("ready")
+      } finally {
+        yield* Effect.promise(() => BackgroundProcess.stop(info.id))
+        yield* Effect.promise(() => BackgroundProcess.stopSession(sessionID))
+      }
     }),
   )
 
@@ -421,7 +424,7 @@ setInterval(() => {}, 1_000)
             command,
             cwd: first.path,
             lifetime: "persistent",
-            ready: { pattern: "ready", timeout: 5_000 },
+            ready: { pattern: "ready", timeout: 15_000 },
           }),
       })
 
@@ -463,7 +466,7 @@ setInterval(() => {}, 1_000)
             command,
             cwd: tmp.path,
             lifetime: "persistent",
-            ready: { pattern: "ready", timeout: 5_000 },
+            ready: { pattern: "ready", timeout: 15_000 },
           }),
       })
 
@@ -566,7 +569,7 @@ setInterval(() => {}, 1_000)
           command,
           cwd: test.directory,
           lifetime: "persistent",
-          ready: { pattern: "ready", timeout: 5_000 },
+          ready: { pattern: "ready", timeout: 15_000 },
         }),
       )
       const files = artifacts(test.directory, info.id)
@@ -603,20 +606,32 @@ setInterval(() => {}, 1_000)
     }),
   )
 
-  it.instance("keeps persistent descendants manageable after the leader exits", () =>
-    Effect.gen(function* () {
-      if (!["linux", "darwin", "win32"].includes(process.platform)) return
-      const test = yield* TestInstance
-      const sessionID = SessionID.descending()
-      const child = path.join(test.directory, "descendant.mjs")
-      yield* Effect.promise(() => Bun.write(child, "setInterval(() => {}, 1_000)\n"))
-      // Bun kills its detached children when their parent exits on Windows (oven-sh/bun#31603).
-      const exec = process.platform === "win32" ? "node" : process.execPath
-      const command = yield* Effect.promise(() =>
-        script(
-          test.directory,
-          "leader.cjs",
-          `const { spawn } = require("child_process")
+  it.instance(
+    "keeps persistent descendants manageable after the leader exits",
+    () =>
+      Effect.gen(function* () {
+        if (!["linux", "darwin", "win32"].includes(process.platform)) return
+        const test = yield* TestInstance
+        const sessionID = SessionID.descending()
+        const child = path.join(test.directory, "descendant.mjs")
+        const ready = path.join(test.directory, "descendant-ready")
+        yield* Effect.promise(() =>
+          Bun.write(
+            child,
+            `import { writeFileSync } from "fs"
+writeFileSync(${JSON.stringify(ready)}, "ready")
+setInterval(() => {}, 1_000)
+`,
+          ),
+        )
+        // Use Node so child process-group inheritance is consistent across Bun versions.
+        const exec = "node"
+        const command = yield* Effect.promise(() =>
+          script(
+            test.directory,
+            "leader.cjs",
+            `const { spawn } = require("child_process")
+const { existsSync } = require("fs")
 console.log("leader:" + process.pid)
 const child = spawn(process.execPath, [${JSON.stringify(child)}], {
   stdio: "ignore",
@@ -624,55 +639,61 @@ const child = spawn(process.execPath, [${JSON.stringify(child)}], {
   windowsHide: true,
 })
 child.unref()
-console.log("child:" + child.pid)
+const timer = setInterval(() => {
+  if (!existsSync(${JSON.stringify(ready)})) return
+  clearInterval(timer)
+  console.log("child:" + child.pid)
+}, 10)
 if (process.platform === "win32") setTimeout(() => {}, 5_000)
 `,
-          exec,
-        ),
-      )
-      const info = yield* Effect.promise(() =>
-        BackgroundProcess.start({
-          sessionID,
-          command,
-          cwd: test.directory,
-          lifetime: "persistent",
-          ready: { pattern: "child:", timeout: 5_000 },
-        }),
-      )
-      const leader = Number(info.output.match(/leader:(\d+)/)?.[1])
-      const pid = Number(info.output.match(/child:(\d+)/)?.[1])
-      const runner = info.pid
-      try {
-        expect(leader).toBeGreaterThan(0)
-        expect(pid).toBeGreaterThan(0)
-        yield* Effect.promise(() => until(() => !alive(leader), "persistent command leader did not exit", 10_000))
-        if (process.platform === "win32") {
-          // Assert after the runner's one-second ancestry grace window has elapsed.
-          yield* Effect.promise(() => Bun.sleep(2_000))
-          expect(alive(runner)).toBe(true)
-        }
-        if (process.platform !== "win32") {
-          yield* Effect.promise(() => until(() => !alive(runner), "persistent runner did not exit"))
-        }
-        const current = yield* Effect.promise(() => BackgroundProcess.get(info.id))
-        expect(current?.status === "running" || current?.status === "ready").toBe(true)
-        expect(alive(pid)).toBe(true)
-        yield* Effect.promise(() => BackgroundProcess.stop(info.id))
-        yield* Effect.promise(() => until(() => !alive(pid), "persistent descendant was not terminated"))
-      } finally {
-        yield* Effect.promise(async () => {
-          await Promise.allSettled([BackgroundProcess.stop(info.id)])
-          for (const item of [pid, runner]) {
-            if (!item || !alive(item)) continue
-            try {
-              process.kill(item, "SIGKILL")
-            } catch (err) {
-              if (alive(item)) throw err
-            }
+            exec,
+          ),
+        )
+        const info = yield* Effect.promise(() =>
+          BackgroundProcess.start({
+            sessionID,
+            command,
+            cwd: test.directory,
+            lifetime: "persistent",
+            ready: { pattern: "child:", timeout: 15_000 },
+          }),
+        )
+        const leader = Number(info.output.match(/leader:(\d+)/)?.[1])
+        const pid = Number(info.output.match(/child:(\d+)/)?.[1])
+        const runner = info.pid
+        try {
+          expect(info.status).toBe("ready")
+          expect(leader).toBeGreaterThan(0)
+          expect(pid).toBeGreaterThan(0)
+          yield* Effect.promise(() => until(() => !alive(leader), "persistent command leader did not exit", 10_000))
+          if (process.platform === "win32") {
+            // Assert after the runner's one-second ancestry grace window has elapsed.
+            yield* Effect.promise(() => Bun.sleep(2_000))
+            expect(alive(runner)).toBe(true)
           }
-        })
-      }
-    }),
+          if (process.platform !== "win32") {
+            yield* Effect.promise(() => until(() => !alive(runner), "persistent runner did not exit"))
+          }
+          const current = yield* Effect.promise(() => BackgroundProcess.get(info.id))
+          if (!current) throw new Error("Persistent process disappeared while its descendant was running")
+          expect(["running", "ready"]).toContain(current.status)
+          expect(alive(pid)).toBe(true)
+          yield* Effect.promise(() => BackgroundProcess.stop(info.id))
+          yield* Effect.promise(() => until(() => !alive(pid), "persistent descendant was not terminated"))
+        } finally {
+          yield* Effect.promise(async () => {
+            await Promise.allSettled([BackgroundProcess.stop(info.id)])
+            for (const item of [pid, runner]) {
+              if (!item || !alive(item)) continue
+              try {
+                process.kill(item, "SIGKILL")
+              } catch (err) {
+                if (alive(item)) throw err
+              }
+            }
+          })
+        }
+      }),
     30_000,
   )
 

--- a/packages/opencode/test/kilocode/daemon.test.ts
+++ b/packages/opencode/test/kilocode/daemon.test.ts
@@ -45,7 +45,7 @@ function opts(root: string): Daemon.Options {
     cors: [],
     command: [process.execPath, "--conditions=browser", path.join(process.cwd(), "src/index.ts")],
     env: dirs(root),
-    timeout: 20_000,
+    timeout: 30_000,
   }
 }
 
@@ -184,7 +184,7 @@ describe("daemon manager", () => {
     } finally {
       process.chdir(cwd)
     }
-  }, 20_000)
+  }, 45_000)
 
   test("starts, reuses, authenticates, and stops a daemon", async () => {
     await using tmp = await tmpdir()
@@ -225,7 +225,7 @@ describe("daemon manager", () => {
       headers: { authorization: `Basic ${again.state!.token}` },
     })
     expect(restarted.status).toBe(200)
-  }, 20_000)
+  }, 60_000)
 
   test("does not let a foreground owner stop a replacement daemon", async () => {
     await using tmp = await tmpdir()
@@ -244,7 +244,7 @@ describe("daemon manager", () => {
     expect(current.running).toBe(true)
     expect(current.state?.pid).toBe(second.state?.pid)
     expect(current.state?.pid).not.toBe(state.pid)
-  }, 30_000)
+  }, 60_000)
 
   test.skipIf(process.platform === "win32")(
     "records foreground interrupts while startup is pending",
@@ -292,7 +292,7 @@ describe("daemon manager", () => {
         await Daemon.stop()
       }
     },
-    25_000,
+    45_000,
   )
 
   test("supports console stop as a daemon stop alias", async () => {
@@ -301,7 +301,7 @@ describe("daemon manager", () => {
     await Daemon.start(input)
     const proc = cli(["console", "stop"], input.env)
     const [code, stdout, stderr] = await Promise.all([
-      deadline(proc.exited, 20_000),
+      deadline(proc.exited, 30_000),
       new Response(proc.stdout).text(),
       new Response(proc.stderr).text(),
     ])
@@ -310,7 +310,7 @@ describe("daemon manager", () => {
     expect(stdout).toContain("kilo daemon stopped")
     expect(stderr).not.toContain("Could not open browser automatically")
     expect((await Daemon.status()).running).toBe(false)
-  }, 30_000)
+  }, 45_000)
 
   test.skipIf(process.platform === "win32")(
     "stops a foreground daemon on SIGINT",
@@ -329,7 +329,7 @@ describe("daemon manager", () => {
               throw new Error("Foreground daemon exited before becoming ready")
             }),
           ]),
-          20_000,
+          30_000,
         )
         const state = await Daemon.status()
         expect(state.running).toBe(true)
@@ -346,7 +346,7 @@ describe("daemon manager", () => {
         await Daemon.stop()
       }
     },
-    35_000,
+    45_000,
   )
 
   test("daemon client does not start a daemon while attaching", async () => {
@@ -368,7 +368,7 @@ describe("daemon manager", () => {
 
     expect(daemon).toBeUndefined()
     expect((await Daemon.status()).state?.pid).toBe(started.state?.pid)
-  }, 20_000)
+  }, 45_000)
 
   test("daemon client returns authenticated attach settings", async () => {
     await using tmp = await tmpdir()
@@ -378,5 +378,5 @@ describe("daemon manager", () => {
 
     expect(daemon?.url).toBe(started.state?.url)
     expect(daemon?.headers.Authorization).toBe(`Basic ${daemon?.state.token}`)
-  }, 20_000)
+  }, 45_000)
 })

--- a/packages/opencode/test/kilocode/snapshot-freeze-repro.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-freeze-repro.test.ts
@@ -67,47 +67,56 @@ test("pathological diffFull workload finishes quickly and does not block abort",
           const after = yield* snapshot.track()
           expect(after).toBeTruthy()
 
+          const app = Server.Default().app
+          const headers = { "x-kilo-directory": tmp.path }
+          const warm = yield* Effect.promise(() =>
+            Promise.resolve(app.request(`/session/${session.id}/abort`, { method: "POST", headers })),
+          )
+          expect(warm.status).toBe(200)
+
           // Kick off a diffFull that exercises the freeze path.
           const diff = yield* snapshot.diffFull(before!, after!).pipe(Effect.forkChild({ startImmediately: true }))
 
           // Concurrently keep a tick counter running. If the event loop blocks we
           // will see this count fall behind wall-clock elapsed.
-          let ticks = 0
+          const ticks = { count: 0 }
           const start = Date.now()
           const timer = setInterval(() => {
-            ticks++
+            ticks.count++
           }, 25)
 
-          // Fire an abort request against the Hono app in the middle of the diff.
-          const app = Server.Default().app
-          const abortStart = Date.now()
-          const res = yield* Effect.promise(() =>
-            Promise.resolve(app.request(`/session/${session.id}/abort`, { method: "POST" })),
-          )
-          const abortLatency = Date.now() - abortStart
-          expect(res.status).toBe(200)
-          // The abort endpoint must respond well under a second even under load.
-          expect(abortLatency).toBeLessThan(2000)
+          try {
+            // Fire an abort request against the warmed Hono route in the middle of the diff.
+            const abortStart = Date.now()
+            const res = yield* Effect.promise(() =>
+              Promise.resolve(app.request(`/session/${session.id}/abort`, { method: "POST", headers })),
+            )
+            const abortLatency = Date.now() - abortStart
+            expect(res.status).toBe(200)
+            // The abort endpoint must respond well under a second even under load.
+            expect(abortLatency).toBeLessThan(2000)
 
-          const diffs = yield* Fiber.join(diff)
-          clearInterval(timer)
-          const total = Date.now() - start
+            const diffs = yield* Fiber.join(diff)
+            const total = Date.now() - start
 
-          // The freeze workload must finish in bounded time. Five seconds is
-          // generous even for a slow CI box; without the fix this hangs.
-          expect(total).toBeLessThan(5000)
-          // And we must have ticked at least a few times during the work, proving
-          // the event loop stayed responsive (ESC would actually arrive).
-          expect(ticks).toBeGreaterThan(0)
+            // The freeze workload must finish in bounded time. Five seconds is
+            // generous even for a slow CI box; without the fix this hangs.
+            expect(total).toBeLessThan(5000)
+            // And we must have ticked at least a few times during the work, proving
+            // the event loop stayed responsive (ESC would actually arrive).
+            expect(ticks.count).toBeGreaterThan(0)
 
-          // With git-based diff the patch is a real unified diff, not empty.
-          const hit = diffs.find((d) => d.file === "fat.json")
-          expect(hit).toBeDefined()
-          expect(hit!.patch).toMatch(/^diff --git /m)
-          expect(hit!.patch).toContain("-v1_line_0")
-          expect(hit!.patch).toContain("+v2_line_0")
-          expect(hit!.additions).toBeGreaterThan(0)
-          expect(hit!.deletions).toBeGreaterThan(0)
+            // With git-based diff the patch is a real unified diff, not empty.
+            const hit = diffs.find((d) => d.file === "fat.json")
+            expect(hit).toBeDefined()
+            expect(hit!.patch).toMatch(/^diff --git /m)
+            expect(hit!.patch).toContain("-v1_line_0")
+            expect(hit!.patch).toContain("+v2_line_0")
+            expect(hit!.additions).toBeGreaterThan(0)
+            expect(hit!.deletions).toBeGreaterThan(0)
+          } finally {
+            clearInterval(timer)
+          }
         }),
       ),
   })


### PR DESCRIPTION
macOS unit jobs run several process-heavy CLI test files concurrently. The affected tests coupled assertions to cold-start timing rather than observable readiness, so normal runner contention could produce failures unrelated to the behavior under test.

The persistent background-process tests allowed only five seconds for a second CLI process to initialize. When that deadline elapsed, `BackgroundProcess.start` correctly returned a running process, but the tests immediately parsed output that had not arrived yet. Persistent test launches now have a 15-second readiness window, assert the ready state explicitly, and clean up in `finally` blocks. The descendant fixture also waits for a marker written by the descendant itself and uses Node for consistent process-group inheritance across Bun versions.

The daemon fixture used the same 20-second deadline for daemon startup and for the enclosing test. Under contention, Bun could time out the test while the daemon startup promise was reaching its own timeout, leaving a later unhandled rejection. Daemon startup now has a 30-second budget, while enclosing lifecycle tests have separate 45- or 60-second deadlines based on how many daemon launches they perform.

The snapshot responsiveness test included the first Hono project-route initialization in its two-second abort latency measurement and omitted the project directory header, so it initialized the workspace checkout instead of the temporary test repository. It now warms the exact abort route with `x-kilo-directory` before starting the timer and always clears its interval. The latency assertion therefore measures event-loop responsiveness during `diffFull`, which is the regression the test is intended to catch.

These changes only harden test synchronization and deadlines. Production runtime behavior is unchanged.