### PR TITLE
feat(jetbrains): add repo CLI dev mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version || inpu
 permissions:
   id-token: write
   contents: write
+  issues: write # kilocode_change - label automated JetBrains CLI pin bump PRs
   packages: write
+  pull-requests: write # kilocode_change - create automated JetBrains CLI pin bump PRs
 
 jobs:
   version:

--- a/.kilo/skills/release-jetbrains/SKILL.md
+++ b/.kilo/skills/release-jetbrains/SKILL.md
@@ -40,6 +40,14 @@ Show the resolved `version`, `kind`, and default `fromTagDefault` to the user.
 
 Before dispatching prepare, verify the JetBrains plugin is pinned to the intended Kilo Core release. The plugin downloads the CLI version from `packages/kilo-jetbrains/package.json`, not from the JetBrains plugin version.
 
+Verify repo CLI dev mode is disabled on `main` before creating the immutable tag:
+
+```bash
+git show origin/main:packages/kilo-jetbrains/gradle.properties | grep '^kilo.cli.pinned=' || true
+```
+
+If `kilo.cli.pinned` is present and is not `true`, stop and ask the user to reset it to `true` on `main` before dispatching prepare. `kilo.cli.pinned=false` generates from and bundles the local repo CLI, so it is dev-only and non-releasable.
+
 Read the pinned CLI version:
 
 ```bash
@@ -67,7 +75,7 @@ kilo-windows-x64.zip
 
 If the pin is stale or the release assets are missing, stop and ask the user to update `packages/kilo-jetbrains/package.json` on `main` before dispatching prepare. The prepare workflow tags `origin/main`, so the pin must already be reviewed and merged before the release tag is created.
 
-Show the resolved JetBrains plugin version, release kind, default `fromTagDefault`, pinned CLI version, and CLI release asset status to the user, then ask for confirmation before continuing.
+Show the resolved JetBrains plugin version, release kind, default `fromTagDefault`, `kilo.cli.pinned` status, pinned CLI version, and CLI release asset status to the user, then ask for confirmation before continuing.
 
 ## Prepare Workflow
 

--- a/.kilo/skills/release-jetbrains/SKILL.md
+++ b/.kilo/skills/release-jetbrains/SKILL.md
@@ -38,44 +38,67 @@ Show the resolved `version`, `kind`, and default `fromTagDefault` to the user.
 
 ## CLI Pin Verification
 
-Before dispatching prepare, verify the JetBrains plugin is pinned to the intended Kilo Core release. The plugin downloads the CLI version from `packages/kilo-jetbrains/package.json`, not from the JetBrains plugin version.
+Before dispatching prepare, verify the JetBrains plugin is pinned to the intended Kilo Core release. The plugin downloads the CLI version from `packages/kilo-jetbrains/package.json`, not from the JetBrains plugin version. Prepare tags `origin/main`, so the authoritative pin is the value on `origin/main`, not a local edit.
 
-Verify repo CLI dev mode is disabled on `main` before creating the immutable tag:
-
-```bash
-git show origin/main:packages/kilo-jetbrains/gradle.properties | grep '^kilo.cli.pinned=' || true
-```
-
-If `kilo.cli.pinned` is present and is not `true`, stop and ask the user to reset it to `true` on `main` before dispatching prepare. `kilo.cli.pinned=false` generates from and bundles the local repo CLI, so it is dev-only and non-releasable.
-
-Read the pinned CLI version:
+Run the pin preflight:
 
 ```bash
-bun -e 'const p=require("./packages/kilo-jetbrains/package.json"); console.log(p.version)'
+bun .kilo/skills/release-jetbrains/script/check-pin.ts
 ```
 
-Verify the matching GitHub Release exists and includes every runtime asset the backend may download:
+The script prints:
+
+| Field | Meaning |
+|---|---|
+| `pinMain` | CLI version that `origin/main` will lock into the release tag. |
+| `pinLocal` | CLI version in the current worktree, useful for catching stale local checkouts. |
+| `latestCli` | Latest stable `v*` Kilo CLI GitHub release. |
+| `prevJetbrainsCli` | CLI pin used by the latest `jetbrains/v*` release tag, for reviewing the jump. |
+| `pinnedMain` / `pinnedLocal` | Whether `kilo.cli.pinned=true`; `false` means repo CLI dev mode. |
+| `assetsOk` / `missingAssets` | Whether the pinned CLI release has every runtime asset. |
+| `drift` | `up-to-date`, `behind`, `worktree-behind-main`, `repo-mode-on-main`, `repo-mode-local`, or `assets-missing`. |
+
+Interpretation:
+
+| Drift | Action |
+|---|---|
+| `up-to-date` | Continue after user confirmation. |
+| `behind` | Stop and show `pinMain`, `latestCli`, and `prevJetbrainsCli`; ask whether to cancel, bump + test, or proceed anyway. |
+| `worktree-behind-main` | Explain that prepare tags `origin/main`; refresh the worktree or rely on `pinMain` in the confirmation. |
+| `repo-mode-on-main` | Stop. `kilo.cli.pinned=false` is dev-only and must be reset to `true` on `main` before release. |
+| `repo-mode-local` | Stop or reset local `kilo.cli.pinned=true`; release checks should run from a releasable local state. |
+| `assets-missing` | Stop. The pinned CLI release is incomplete and would fail runtime download. |
+
+Show the resolved JetBrains plugin version, release kind, default `fromTagDefault`, `pinMain`, `latestCli`, `prevJetbrainsCli`, and `assetsOk` to the user, then ask for confirmation before continuing. If the user wants a different CLI pin, use the bump workflow below and do not dispatch prepare until the bump is merged to `main`.
+
+## Bump the CLI Pin
+
+Use this only when the user wants to test or release with a different CLI than `origin/main` currently pins. The helper refuses versions whose GitHub release or runtime assets are missing.
+
+Local test edit only:
 
 ```bash
-cli_version="7.4.1"
-gh release view "v${cli_version}" --repo Kilo-Org/kilocode --json assets \
-  --jq '.assets[].name' | sort
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest
+# or
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --version 7.4.1
 ```
 
-Expected assets:
+Then test from `packages/kilo-jetbrains/`:
 
-```text
-kilo-darwin-arm64.zip
-kilo-darwin-x64.zip
-kilo-linux-arm64.tar.gz
-kilo-linux-x64.tar.gz
-kilo-windows-arm64.zip
-kilo-windows-x64.zip
+```bash
+./gradlew typecheck
+./gradlew test
 ```
 
-If the pin is stale or the release assets are missing, stop and ask the user to update `packages/kilo-jetbrains/package.json` on `main` before dispatching prepare. The prepare workflow tags `origin/main`, so the pin must already be reviewed and merged before the release tag is created.
+If the user confirms the tested pin should be released, open or update a pin bump PR to `main`:
 
-Show the resolved JetBrains plugin version, release kind, default `fromTagDefault`, `kilo.cli.pinned` status, pinned CLI version, and CLI release asset status to the user, then ask for confirmation before continuing.
+```bash
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest --pr
+# or
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --version 7.4.1 --pr
+```
+
+After that PR merges to `main`, re-run `resolve-version.ts`, re-run `check-pin.ts`, confirm `drift=up-to-date`, then dispatch prepare. Do not dispatch prepare from a local-only pin edit; the prepare workflow tags `origin/main`.
 
 ## Prepare Workflow
 
@@ -208,6 +231,7 @@ Report the Marketplace channel and GitHub Release URL. RC versions publish to th
 
 - If prepare created the tag but failed before creating a PR, rerun prepare for the same version. The existing workflow reuses the tag if it points to the same commit.
 - If a tag points to an unexpected SHA, stop and inspect manually. Do not move or delete release tags casually.
+- If prepare tagged an unintended CLI pin, do not move the tag. Land the intended pin on `main`, resolve the next JetBrains version, and create a new release tag.
 - If release PR checks fail from an apparent flake, use `gh run rerun <run-id> --failed`, then `gh run watch <run-id> --exit-status` before publishing.
 - If publish fails after merge, rerun the failed workflow only if Marketplace did not already accept the version.
 - If Marketplace succeeds but GitHub Release upload fails, manually create or edit the GitHub Release for `jetbrains/v<version>` using the reviewed changelog.

--- a/.kilo/skills/release-jetbrains/script/check-pin.ts
+++ b/.kilo/skills/release-jetbrains/script/check-pin.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+import semver from "semver"
+import { parseArgs } from "util"
+
+const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY ?? "Kilo-Org/kilocode"
+const asset = [
+  "kilo-darwin-arm64.zip",
+  "kilo-darwin-x64.zip",
+  "kilo-linux-arm64.tar.gz",
+  "kilo-linux-x64.tar.gz",
+  "kilo-windows-arm64.zip",
+  "kilo-windows-x64.zip",
+]
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    help: { type: "boolean", short: "h", default: false },
+  },
+})
+
+if (values.help) {
+  console.log(`
+Usage: bun .kilo/skills/release-jetbrains/script/check-pin.ts
+
+Checks the CLI pin that a JetBrains release would lock. Prepare tags origin/main,
+so this reads packages/kilo-jetbrains/package.json from origin/main and compares
+it with the latest published Kilo CLI release plus the local worktree pin.
+
+Exit codes:
+  0  Pin is release-ready.
+  2  Pin drift, repo CLI mode, or missing CLI assets require maintainer review.
+`)
+  process.exit(0)
+}
+
+await $`git fetch origin main --tags`.quiet()
+
+const pinMain = JSON.parse(await $`git show origin/main:packages/kilo-jetbrains/package.json`.text()).version as string
+const pinLocal = (await Bun.file("packages/kilo-jetbrains/package.json").json()).version as string
+const propsMain = await $`git show origin/main:packages/kilo-jetbrains/gradle.properties`.text()
+const propsLocal = await Bun.file("packages/kilo-jetbrains/gradle.properties").text()
+const pinnedMain = pinned(propsMain)
+const pinnedLocal = pinned(propsLocal)
+const latestCli = await latest()
+const prevJetbrainsCli = await previous()
+const missingAssets = await missing(pinMain)
+const assetsOk = missingAssets.length === 0
+const drift = (() => {
+  if (!pinnedMain) return "repo-mode-on-main"
+  if (!pinnedLocal) return "repo-mode-local"
+  if (pinLocal !== pinMain) return "worktree-behind-main"
+  if (!assetsOk) return "assets-missing"
+  if (latestCli && semver.lt(pinMain, latestCli)) return "behind"
+  return "up-to-date"
+})()
+
+console.log(JSON.stringify({
+  pinMain,
+  pinLocal,
+  latestCli,
+  prevJetbrainsCli,
+  pinnedMain,
+  pinnedLocal,
+  assetsOk,
+  missingAssets,
+  drift,
+}, null, 2))
+
+if (drift !== "up-to-date") process.exit(2)
+
+async function latest() {
+  const list = (await $`gh release list --repo ${repo} --limit 100 --json tagName,isDraft,isPrerelease`.json()) as {
+    tagName: string
+    isDraft: boolean
+    isPrerelease: boolean
+  }[]
+  return list
+    .filter((item) => /^v\d+\.\d+\.\d+$/.test(item.tagName) && !item.isDraft && !item.isPrerelease)
+    .map((item) => item.tagName.slice(1))
+    .sort(semver.rcompare)[0] ?? null
+}
+
+async function previous() {
+  const text = await $`git tag --list ${"jetbrains/v*"}`.text()
+  const tag = text
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((tag) => ({ tag, version: tag.replace(/^jetbrains\/v/, "") }))
+    .filter((item) => semver.valid(item.version))
+    .sort((a, b) => semver.rcompare(a.version, b.version))[0]?.tag
+  if (!tag) return null
+  const res = await $`git show ${tag}:packages/kilo-jetbrains/package.json`.nothrow().text()
+  if (!res.trim()) return null
+  return JSON.parse(res).version as string
+}
+
+async function missing(version: string) {
+  const res = await $`gh release view ${`v${version}`} --repo ${repo} --json assets --jq ${".assets[].name"}`.quiet().nothrow()
+  if (res.exitCode !== 0) return asset
+  const names = res.stdout.toString().split(/\r?\n/).map((item) => item.trim()).filter(Boolean)
+  return asset.filter((item) => !names.includes(item))
+}
+
+function pinned(text: string) {
+  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
+  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
+  return value == null || value === "true"
+}

--- a/.kilo/skills/release-jetbrains/script/check-pin.ts
+++ b/.kilo/skills/release-jetbrains/script/check-pin.ts
@@ -3,16 +3,9 @@
 import { $ } from "bun"
 import semver from "semver"
 import { parseArgs } from "util"
+import { latest, missing } from "./pin-common"
 
 const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY ?? "Kilo-Org/kilocode"
-const asset = [
-  "kilo-darwin-arm64.zip",
-  "kilo-darwin-x64.zip",
-  "kilo-linux-arm64.tar.gz",
-  "kilo-linux-x64.tar.gz",
-  "kilo-windows-arm64.zip",
-  "kilo-windows-x64.zip",
-]
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -44,9 +37,9 @@ const propsMain = await $`git show origin/main:packages/kilo-jetbrains/gradle.pr
 const propsLocal = await Bun.file("packages/kilo-jetbrains/gradle.properties").text()
 const pinnedMain = pinned(propsMain)
 const pinnedLocal = pinned(propsLocal)
-const latestCli = await latest()
+const latestCli = await latest(repo)
 const prevJetbrainsCli = await previous()
-const missingAssets = await missing(pinMain)
+const missingAssets = await missing(repo, pinMain)
 const assetsOk = missingAssets.length === 0
 const drift = (() => {
   if (!pinnedMain) return "repo-mode-on-main"
@@ -71,18 +64,6 @@ console.log(JSON.stringify({
 
 if (drift !== "up-to-date") process.exit(2)
 
-async function latest() {
-  const list = (await $`gh release list --repo ${repo} --limit 100 --json tagName,isDraft,isPrerelease`.json()) as {
-    tagName: string
-    isDraft: boolean
-    isPrerelease: boolean
-  }[]
-  return list
-    .filter((item) => /^v\d+\.\d+\.\d+$/.test(item.tagName) && !item.isDraft && !item.isPrerelease)
-    .map((item) => item.tagName.slice(1))
-    .sort(semver.rcompare)[0] ?? null
-}
-
 async function previous() {
   const text = await $`git tag --list ${"jetbrains/v*"}`.text()
   const tag = text
@@ -98,15 +79,11 @@ async function previous() {
   return JSON.parse(res).version as string
 }
 
-async function missing(version: string) {
-  const res = await $`gh release view ${`v${version}`} --repo ${repo} --json assets --jq ${".assets[].name"}`.quiet().nothrow()
-  if (res.exitCode !== 0) return asset
-  const names = res.stdout.toString().split(/\r?\n/).map((item) => item.trim()).filter(Boolean)
-  return asset.filter((item) => !names.includes(item))
-}
-
 function pinned(text: string) {
-  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
-  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
+  const value = text.split(/\r?\n/).flatMap((line) => {
+    const [key, value] = line.split("=", 2)
+    if (key.trim() !== "kilo.cli.pinned") return []
+    return [value?.trim().toLowerCase()]
+  })[0]
   return value == null || value === "true"
 }

--- a/.kilo/skills/release-jetbrains/script/pin-common.ts
+++ b/.kilo/skills/release-jetbrains/script/pin-common.ts
@@ -1,0 +1,30 @@
+import { $ } from "bun"
+import semver from "semver"
+
+export const assets = [
+  "kilo-darwin-arm64.zip",
+  "kilo-darwin-x64.zip",
+  "kilo-linux-arm64.tar.gz",
+  "kilo-linux-x64.tar.gz",
+  "kilo-windows-arm64.zip",
+  "kilo-windows-x64.zip",
+]
+
+export async function latest(repo: string) {
+  const list = (await $`gh release list --repo ${repo} --limit 100 --json tagName,isDraft,isPrerelease`.json()) as {
+    tagName: string
+    isDraft: boolean
+    isPrerelease: boolean
+  }[]
+  return list
+    .filter((item) => /^v\d+\.\d+\.\d+$/.test(item.tagName) && !item.isDraft && !item.isPrerelease)
+    .map((item) => item.tagName.slice(1))
+    .sort(semver.rcompare)[0] ?? null
+}
+
+export async function missing(repo: string, version: string) {
+  const res = await $`gh release view ${`v${version}`} --repo ${repo} --json assets --jq ${".assets[].name"}`.quiet().nothrow()
+  if (res.exitCode !== 0) return assets
+  const names = res.stdout.toString().split(/\r?\n/).map((item) => item.trim()).filter(Boolean)
+  return assets.filter((item) => !names.includes(item))
+}

--- a/.kilo/skills/release-jetbrains/script/set-pin.ts
+++ b/.kilo/skills/release-jetbrains/script/set-pin.ts
@@ -6,6 +6,7 @@ import { parseArgs } from "util"
 
 const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY ?? "Kilo-Org/kilocode"
 const file = "packages/kilo-jetbrains/package.json"
+const label = "jetbrains-cli-pin-bump"
 const asset = [
   "kilo-darwin-arm64.zip",
   "kilo-darwin-x64.zip",
@@ -101,10 +102,12 @@ async function pr(version: string) {
   const view = await $`gh pr view ${branch} --repo ${repo} --json url --jq .url`.quiet().nothrow()
   if (view.exitCode === 0 && view.stdout.toString().trim()) {
     await $`gh pr edit ${branch} --repo ${repo} --title ${title} --body ${desc}`
+    await tag(branch)
     console.log(view.stdout.toString().trim())
     return
   }
   const url = await $`gh pr create --repo ${repo} --base main --head ${branch} --title ${title} --body ${desc}`.text()
+  await tag(branch)
   console.log(url.trim())
 }
 
@@ -137,4 +140,12 @@ async function ensure(branch: string, sha: string) {
     return
   }
   await $`gh api --method POST ${`repos/${repo}/git/refs`} -f ref=${`refs/heads/${branch}`} -f sha=${sha}`.quiet()
+}
+
+async function tag(branch: string) {
+  await $`gh label create ${label} --repo ${repo} --color 1D76DB --description ${"JetBrains pinned CLI version bump"}`.quiet().nothrow()
+  const result = await $`gh pr edit ${branch} --repo ${repo} --add-label ${label}`.quiet().nothrow()
+  if (result.exitCode !== 0) {
+    console.warn(`Warning: failed to add ${label} label to ${branch}`)
+  }
 }

--- a/.kilo/skills/release-jetbrains/script/set-pin.ts
+++ b/.kilo/skills/release-jetbrains/script/set-pin.ts
@@ -3,18 +3,11 @@
 import { $ } from "bun"
 import semver from "semver"
 import { parseArgs } from "util"
+import { latest, missing } from "./pin-common"
 
 const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY ?? "Kilo-Org/kilocode"
 const file = "packages/kilo-jetbrains/package.json"
 const label = "jetbrains-cli-pin-bump"
-const asset = [
-  "kilo-darwin-arm64.zip",
-  "kilo-darwin-x64.zip",
-  "kilo-linux-arm64.tar.gz",
-  "kilo-linux-x64.tar.gz",
-  "kilo-windows-arm64.zip",
-  "kilo-windows-x64.zip",
-]
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -43,12 +36,12 @@ Examples:
 }
 
 if (values.latest && values.version) throw new Error("Pass either --latest or --version, not both")
-const version = values.latest ? await latest() : values.version?.replace(/^v/, "")
+const version = values.latest ? await latest(repo) : values.version?.replace(/^v/, "")
 if (!version || !semver.valid(version) || semver.prerelease(version)) {
   throw new Error("Pass a stable CLI version with --version x.y.z or use --latest")
 }
 
-const miss = await missing(version)
+const miss = await missing(repo, version)
 if (miss.length > 0) {
   throw new Error(`CLI release v${version} is missing required assets: ${miss.join(", ")}`)
 }
@@ -109,27 +102,6 @@ async function pr(version: string) {
   const url = await $`gh pr create --repo ${repo} --base main --head ${branch} --title ${title} --body ${desc}`.text()
   await tag(branch)
   console.log(url.trim())
-}
-
-async function latest() {
-  const list = (await $`gh release list --repo ${repo} --limit 100 --json tagName,isDraft,isPrerelease`.json()) as {
-    tagName: string
-    isDraft: boolean
-    isPrerelease: boolean
-  }[]
-  const version = list
-    .filter((item) => /^v\d+\.\d+\.\d+$/.test(item.tagName) && !item.isDraft && !item.isPrerelease)
-    .map((item) => item.tagName.slice(1))
-    .sort(semver.rcompare)[0]
-  if (!version) throw new Error(`No stable CLI release found in ${repo}`)
-  return version
-}
-
-async function missing(version: string) {
-  const res = await $`gh release view ${`v${version}`} --repo ${repo} --json assets --jq ${".assets[].name"}`.quiet().nothrow()
-  if (res.exitCode !== 0) return asset
-  const names = res.stdout.toString().split(/\r?\n/).map((item) => item.trim()).filter(Boolean)
-  return asset.filter((item) => !names.includes(item))
 }
 
 async function ensure(branch: string, sha: string) {

--- a/.kilo/skills/release-jetbrains/script/set-pin.ts
+++ b/.kilo/skills/release-jetbrains/script/set-pin.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+import semver from "semver"
+import { parseArgs } from "util"
+
+const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY ?? "Kilo-Org/kilocode"
+const file = "packages/kilo-jetbrains/package.json"
+const asset = [
+  "kilo-darwin-arm64.zip",
+  "kilo-darwin-x64.zip",
+  "kilo-linux-arm64.tar.gz",
+  "kilo-linux-x64.tar.gz",
+  "kilo-windows-arm64.zip",
+  "kilo-windows-x64.zip",
+]
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    version: { type: "string" },
+    latest: { type: "boolean", default: false },
+    pr: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h", default: false },
+  },
+})
+
+if (values.help) {
+  console.log(`
+Usage: bun .kilo/skills/release-jetbrains/script/set-pin.ts (--latest | --version <x.y.z>) [--pr]
+
+Without --pr, rewrites ${file} in the local worktree so you can test a CLI pin.
+With --pr, opens or updates a PR against main using the GitHub API; prepare tags
+origin/main, so the pin bump must merge there before a JetBrains release starts.
+
+Examples:
+  bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest
+  bun .kilo/skills/release-jetbrains/script/set-pin.ts --version 7.4.1
+  bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest --pr
+`)
+  process.exit(0)
+}
+
+if (values.latest && values.version) throw new Error("Pass either --latest or --version, not both")
+const version = values.latest ? await latest() : values.version?.replace(/^v/, "")
+if (!version || !semver.valid(version) || semver.prerelease(version)) {
+  throw new Error("Pass a stable CLI version with --version x.y.z or use --latest")
+}
+
+const miss = await missing(version)
+if (miss.length > 0) {
+  throw new Error(`CLI release v${version} is missing required assets: ${miss.join(", ")}`)
+}
+
+if (values.pr) {
+  await pr(version)
+  process.exit(0)
+}
+
+const pkg = await Bun.file(file).json()
+const previous = pkg.version as string
+pkg.version = version
+await Bun.write(file, `${JSON.stringify(pkg, null, 2)}\n`)
+if (previous === version) {
+  console.log(`${file} already pins CLI v${version}`)
+} else {
+  console.log(`Pinned JetBrains CLI ${previous} -> ${version} in ${file}`)
+}
+console.log("Test locally with: cd packages/kilo-jetbrains && ./gradlew typecheck && ./gradlew test")
+console.log("When satisfied, run this script again with --pr so the bump lands on main before prepare tags it.")
+
+async function pr(version: string) {
+  await $`git fetch origin main`.quiet()
+  const branch = `chore/jetbrains-cli-pin-v${version}`
+  const main = (await $`git rev-parse origin/main`.text()).trim()
+  const text = await $`git show origin/main:${file}`.text()
+  const pkg = JSON.parse(text)
+  const previous = pkg.version as string
+  if (previous === version) {
+    console.log(`origin/main already pins CLI v${version}; no PR needed.`)
+    return
+  }
+  pkg.version = version
+  const body = `${JSON.stringify(pkg, null, 2)}\n`
+  await ensure(branch, main)
+  const current = (await $`gh api ${`repos/${repo}/contents/${file}?ref=${branch}`}`.json()) as { sha: string }
+  await $`gh api --method PUT ${`repos/${repo}/contents/${file}`} -f message=${`chore(jetbrains): bump CLI pin to v${version}`} -f content=${Buffer.from(body).toString("base64")} -f branch=${branch} -f sha=${current.sha}`.quiet()
+
+  const title = `chore(jetbrains): bump CLI pin to v${version}`
+  const desc = [
+    `Bumps the JetBrains CLI pin from v${previous} to v${version}.`,
+    "",
+    "Prepare tags origin/main, so this PR must merge before dispatching a JetBrains release that should lock this CLI.",
+    "",
+    "After merging, re-run:",
+    "",
+    "```bash",
+    "bun .kilo/skills/release-jetbrains/script/check-pin.ts",
+    "```",
+  ].join("\n")
+  const view = await $`gh pr view ${branch} --repo ${repo} --json url --jq .url`.quiet().nothrow()
+  if (view.exitCode === 0 && view.stdout.toString().trim()) {
+    await $`gh pr edit ${branch} --repo ${repo} --title ${title} --body ${desc}`
+    console.log(view.stdout.toString().trim())
+    return
+  }
+  const url = await $`gh pr create --repo ${repo} --base main --head ${branch} --title ${title} --body ${desc}`.text()
+  console.log(url.trim())
+}
+
+async function latest() {
+  const list = (await $`gh release list --repo ${repo} --limit 100 --json tagName,isDraft,isPrerelease`.json()) as {
+    tagName: string
+    isDraft: boolean
+    isPrerelease: boolean
+  }[]
+  const version = list
+    .filter((item) => /^v\d+\.\d+\.\d+$/.test(item.tagName) && !item.isDraft && !item.isPrerelease)
+    .map((item) => item.tagName.slice(1))
+    .sort(semver.rcompare)[0]
+  if (!version) throw new Error(`No stable CLI release found in ${repo}`)
+  return version
+}
+
+async function missing(version: string) {
+  const res = await $`gh release view ${`v${version}`} --repo ${repo} --json assets --jq ${".assets[].name"}`.quiet().nothrow()
+  if (res.exitCode !== 0) return asset
+  const names = res.stdout.toString().split(/\r?\n/).map((item) => item.trim()).filter(Boolean)
+  return asset.filter((item) => !names.includes(item))
+}
+
+async function ensure(branch: string, sha: string) {
+  const ref = `repos/${repo}/git/refs/heads/${branch}`
+  const exists = await $`gh api ${ref}`.nothrow().quiet()
+  if (exists.exitCode === 0) {
+    await $`gh api --method PATCH ${ref} -f sha=${sha} -F force=true`.quiet()
+    return
+  }
+  await $`gh api --method POST ${`repos/${repo}/git/refs`} -f ref=${`refs/heads/${branch}`} -f sha=${sha}`.quiet()
+}

--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -15,6 +15,7 @@
 - `plugin.xml` `<content>` entries ↔ module XML descriptors (`kilo.jetbrains.{shared,frontend,backend}.xml`)
 - Service classes ↔ `<applicationService>`/`<projectService>` entries in the corresponding module XML
 - `packages/kilo-jetbrains/package.json` version ↔ GitHub CLI release tag consumed by the backend downloader
+- `packages/kilo-jetbrains/gradle.properties` `kilo.cli.pinned` ↔ Gradle and release-script gates
 
 ## IntelliJ Platform Source Lookup
 
@@ -154,8 +155,10 @@ For blocking I/O in coroutines, move the dispatcher switch inside the callee usi
 ## CLI Integration
 
 - CLI process spawning, download, extraction, and lifecycle belong in `backend`.
-- The plugin does not bundle CLI binaries. At connect time the backend downloads the GitHub Release asset for the version pinned in `packages/kilo-jetbrains/package.json`; `backend` resources include `kilo.properties` with `cli.version` for split-mode RPC and runtime use.
-- The generated API client is produced from the pinned release binary by running `kilo generate` during the Gradle OpenAPI generation task.
+- By default, the plugin does not bundle CLI binaries. At connect time the backend downloads the GitHub Release asset for the version pinned in `packages/kilo-jetbrains/package.json`; `backend` resources include `kilo.properties` with `cli.version` and `cli.pinned` for split-mode RPC and runtime use.
+- `kilo.cli.pinned=false` in `gradle.properties` is dev-only repo CLI mode: OpenAPI generation runs `bun run --conditions=browser ./src/index.ts generate` from `packages/opencode/`, and runtime extracts a staged local CLI resource instead of downloading.
+- Repo CLI mode requires a local CLI build. Run `./gradlew :backend:buildRepoCli` from `packages/kilo-jetbrains/` or `bun run script/build.ts --single --skip-install` from `packages/opencode/`, then let `:backend:stageRepoCli` bundle the full `dist/@kilocode/cli-<os>-<arch>/bin/` directory.
+- Production builds must keep `kilo.cli.pinned=true`; Gradle release mode, release scripts, and `script/build-version.sh` reject repo CLI mode.
 - For OS and environment checks, prefer IntelliJ Platform classes over raw JVM APIs such as `System.getProperty(...)` or `System.getenv(...)`.
 - Detect architecture with `com.intellij.util.system.CpuArch.CURRENT`, not `System.getProperty("os.arch")`.
 - Detect OS with `com.intellij.openapi.util.SystemInfo.isMac` / `isLinux` / `isWindows`.
@@ -191,7 +194,8 @@ For blocking I/O in coroutines, move the dispatcher switch inside the callee usi
 
 - **Marketplace version build**: Use `script/build-version.sh <version>` from `packages/kilo-jetbrains/` to clean, build, sign, and verify the JetBrains Marketplace plugin ZIP. Pass `--skip-verification` only when explicitly needed.
 - **Test version build**: If the user asks for a JetBrains test build, still require a version and use `script/build-version.sh <version> --skip-signing --skip-verification` from `packages/kilo-jetbrains/` so no signing secrets are needed. Add `--skip-clean` only when the user wants a faster incremental test build.
-- **Typecheck**: `bun run typecheck` or `./gradlew typecheck` from `packages/kilo-jetbrains/` — compiles all Kotlin sources including the generated API client. A cold build downloads the pinned CLI release via `generateOpenApiSpec` and needs network access; Gradle-cached incremental runs skip the download. It does not bundle per-platform CLI binaries.
+- **Typecheck**: `bun run typecheck` or `./gradlew typecheck` from `packages/kilo-jetbrains/` — compiles all Kotlin sources including the generated API client. A cold pinned build downloads the pinned CLI release via `generateOpenApiSpec` and needs network access; Gradle-cached incremental runs skip the download. Repo CLI mode (`-Pkilo.cli.pinned=false`) generates the spec from local source and bundles the staged local CLI binary.
+- **Build local repo CLI for JetBrains dev**: `./gradlew :backend:buildRepoCli` from `packages/kilo-jetbrains/` builds `packages/opencode/dist/@kilocode/cli-<os>-<arch>/bin/`. `stageRepoCli` intentionally does not depend on this task; missing binaries fail with instructions instead of silently starting a slow CLI build.
 - **Full build**: `bun run build` from `packages/kilo-jetbrains/` (runs Gradle `buildPlugin`).
 - **Gradle only**: `./gradlew buildPlugin` from `packages/kilo-jetbrains/`.
 - **Java checks**: Do not run `java -version` as a routine preflight. Gradle commands already fail clearly when Java is missing or incompatible; check Java only when diagnosing that failure mode.
@@ -202,7 +206,7 @@ For blocking I/O in coroutines, move the dispatcher switch inside the callee usi
 
 ### CLI/SDK Change Awareness
 
-- JetBrains runtime behavior depends on the downloaded CLI release pinned by `packages/kilo-jetbrains/package.json`; local `packages/opencode/` changes are not used unless published and pinned.
+- JetBrains runtime behavior normally depends on the downloaded CLI release pinned by `packages/kilo-jetbrains/package.json`; local `packages/opencode/` changes are used only with `kilo.cli.pinned=false` repo CLI mode.
 - If there are relevant server/API changes outside `packages/kilo-jetbrains/`, warn the user that JetBrains may need a newly published/pinned CLI release and regenerated SDK artifacts.
 
 ## UI Guidelines

--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -188,6 +188,8 @@ The JetBrains plugin has two independent CLI controls. Use the commands below di
 
 `set-pin.ts` refuses versions whose CLI release or runtime assets do not exist, so it cannot create a pin that would 404 during runtime download.
 
+Stable CLI releases also attempt this PR automatically after publishing and label it `jetbrains-cli-pin-bump`. The CLI release workflow logs the PR URL when creation succeeds and logs a warning without failing the release if PR creation fails.
+
 For the full release process (resolve version, pin verification, prepare, changelog, publish), load the `release-jetbrains` skill: `.kilo/skills/release-jetbrains/SKILL.md`.
 
 ### Server Protocol

--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -16,6 +16,7 @@
 - Service classes ↔ `<applicationService>`/`<projectService>` entries in the corresponding module XML
 - `packages/kilo-jetbrains/package.json` version ↔ GitHub CLI release tag consumed by the backend downloader
 - `packages/kilo-jetbrains/gradle.properties` `kilo.cli.pinned` ↔ Gradle and release-script gates
+- `.kilo/skills/release-jetbrains/script/check-pin.ts` / `set-pin.ts` ↔ release skill and CLI pin documentation
 
 ## IntelliJ Platform Source Lookup
 
@@ -156,15 +157,38 @@ For blocking I/O in coroutines, move the dispatcher switch inside the callee usi
 
 - CLI process spawning, download, extraction, and lifecycle belong in `backend`.
 - By default, the plugin does not bundle CLI binaries. At connect time the backend downloads the GitHub Release asset for the version pinned in `packages/kilo-jetbrains/package.json`; `backend` resources include `kilo.properties` with `cli.version` and `cli.pinned` for split-mode RPC and runtime use.
-- `kilo.cli.pinned=false` in `gradle.properties` is dev-only repo CLI mode: OpenAPI generation runs `bun run --conditions=browser ./src/index.ts generate` from `packages/opencode/`, and runtime extracts a staged local CLI resource instead of downloading.
-- Repo CLI mode requires a local CLI build. Run `./gradlew :backend:buildRepoCli` from `packages/kilo-jetbrains/` or `bun run script/build.ts --single --skip-install` from `packages/opencode/`, then let `:backend:stageRepoCli` bundle the full `dist/@kilocode/cli-<os>-<arch>/bin/` directory.
-- Production builds must keep `kilo.cli.pinned=true`; Gradle release mode, release scripts, and `script/build-version.sh` reject repo CLI mode.
+- For release questions, use the `release-jetbrains` skill and reference `.kilo/skills/release-jetbrains/SKILL.md`; it verifies the CLI pin before creating immutable `jetbrains/v*` tags.
 - For OS and environment checks, prefer IntelliJ Platform classes over raw JVM APIs such as `System.getProperty(...)` or `System.getenv(...)`.
 - Detect architecture with `com.intellij.util.system.CpuArch.CURRENT`, not `System.getProperty("os.arch")`.
 - Detect OS with `com.intellij.openapi.util.SystemInfo.isMac` / `isLinux` / `isWindows`.
 - Read environment variables with `com.intellij.util.EnvironmentUtil.getValue(...)` or `getEnvironmentMap()` when platform-aware environment handling matters.
 - Resolve IDE paths with `com.intellij.openapi.application.PathManager` rather than inferring paths from process working directories.
 - For packaging/build plumbing, see `script/build.ts` and `backend/build.gradle.kts`.
+
+### CLI Pinning, Unpinning, and Bumping
+
+The JetBrains plugin has two independent CLI controls. Use the commands below directly when asked to change either one; do not hand-edit versions by guesswork.
+
+**Pin mode** (`kilo.cli.pinned` in `packages/kilo-jetbrains/gradle.properties`) controls release CLI vs local repo CLI.
+
+| Ask | Do |
+|---|---|
+| Unpin / use local repo CLI | Set `kilo.cli.pinned=false`, then run `./gradlew :backend:buildRepoCli` from `packages/kilo-jetbrains/`. `:backend:stageRepoCli` bundles `packages/opencode/dist/@kilocode/cli-<os>-<arch>/bin/`; runtime extracts it instead of downloading. |
+| Re-pin / use release CLI | Set `kilo.cli.pinned=true`. This is the default and the only releasable state. |
+
+`kilo.cli.pinned=false` is dev-only: OpenAPI generation runs from local `packages/opencode/` source and the local binary is bundled. Production Gradle builds, `script/build-version.sh`, and the release scripts hard-fail on `false`, so restore `true` before releasing.
+
+**Pinned CLI version** (`packages/kilo-jetbrains/package.json` `version`) controls which GitHub CLI release the plugin downloads and generates the client from. The JetBrains release locks the value already merged to `origin/main`.
+
+| Ask | Do |
+|---|---|
+| Check whether the CLI pin is current | `bun .kilo/skills/release-jetbrains/script/check-pin.ts` |
+| Bump the pin to `<version>` / latest and test locally | `bun .kilo/skills/release-jetbrains/script/set-pin.ts --version <x.y.z>` or `bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest`, then run `./gradlew typecheck && ./gradlew test` from `packages/kilo-jetbrains/`. |
+| Land a tested pin bump for release | `bun .kilo/skills/release-jetbrains/script/set-pin.ts --version <x.y.z> --pr` or `bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest --pr`; merge the PR to `main`, then re-run `check-pin.ts` before dispatching prepare. |
+
+`set-pin.ts` refuses versions whose CLI release or runtime assets do not exist, so it cannot create a pin that would 404 during runtime download.
+
+For the full release process (resolve version, pin verification, prepare, changelog, publish), load the `release-jetbrains` skill: `.kilo/skills/release-jetbrains/SKILL.md`.
 
 ### Server Protocol
 

--- a/packages/kilo-jetbrains/RELEASING.md
+++ b/packages/kilo-jetbrains/RELEASING.md
@@ -14,6 +14,40 @@ JetBrains plugin builds and runtime downloads use the Kilo Core version pinned i
 
 The skill lives at `.kilo/skills/release-jetbrains/SKILL.md`. It does not move or recreate release tags, and merge permission is only required if the user explicitly asks the skill to merge the release PR automatically.
 
+## CLI Pin Review
+
+The JetBrains plugin has two independent versions:
+
+| Field | Meaning |
+|---|---|
+| `packages/kilo-jetbrains/package.json` `version` | The pinned Kilo CLI release used for OpenAPI generation and runtime downloads. |
+| `packages/kilo-jetbrains/gradle.properties` `kilo.jetbrains.version` | The JetBrains Marketplace plugin version. |
+
+The prepare workflow tags `origin/main`, so the CLI pin that matters is the one already merged to `main`. Before creating a release tag, run:
+
+```bash
+bun .kilo/skills/release-jetbrains/script/check-pin.ts
+```
+
+The script reports the CLI that `origin/main` will lock, the latest published stable CLI release, the CLI shipped by the latest `jetbrains/v*` tag, whether `kilo.cli.pinned=true`, and whether all runtime assets exist. Stop before tagging if the pin is behind the latest CLI and you want to test the newer CLI first.
+
+To test a different CLI pin locally:
+
+```bash
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest
+cd packages/kilo-jetbrains
+./gradlew typecheck
+./gradlew test
+```
+
+To land the tested pin on `main` before releasing:
+
+```bash
+bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest --pr
+```
+
+Merge the generated pin PR first, then re-run `check-pin.ts` and dispatch prepare. Do not dispatch prepare from a local-only pin edit.
+
 ## Create Release Tag And PR
 
 1. Open the GitHub Actions workflow:

--- a/packages/kilo-jetbrains/RELEASING.md
+++ b/packages/kilo-jetbrains/RELEASING.md
@@ -48,6 +48,8 @@ bun .kilo/skills/release-jetbrains/script/set-pin.ts --latest --pr
 
 Merge the generated pin PR first, then re-run `check-pin.ts` and dispatch prepare. Do not dispatch prepare from a local-only pin edit.
 
+Stable CLI releases also try to open this pin bump PR automatically after publishing. The PR is labeled `jetbrains-cli-pin-bump`. Release publishing does not fail if creating the PR fails; inspect the publish log for either the PR URL or the warning with manual follow-up instructions.
+
 ## Create Release Tag And PR
 
 1. Open the GitHub Actions workflow:

--- a/packages/kilo-jetbrains/RELEASING.md
+++ b/packages/kilo-jetbrains/RELEASING.md
@@ -10,6 +10,8 @@ Maintainers can use the Kilo `release-jetbrains` skill to drive this process fro
 
 JetBrains plugin builds and runtime downloads use the Kilo Core version pinned in `packages/kilo-jetbrains/package.json`, so verify that pin points at a published `v<version>` release before creating the release tag.
 
+`kilo.cli.pinned=false` in `packages/kilo-jetbrains/gradle.properties` is local development mode only. It generates the client from `packages/opencode/` and bundles a locally built CLI into the plugin; production Gradle builds and release scripts fail until the property is restored to `true`.
+
 The skill lives at `.kilo/skills/release-jetbrains/SKILL.md`. It does not move or recreate release tags, and merge permission is only required if the user explicitly asks the skill to merge the release PR automatically.
 
 ## Create Release Tag And PR

--- a/packages/kilo-jetbrains/backend/build.gradle.kts
+++ b/packages/kilo-jetbrains/backend/build.gradle.kts
@@ -1,4 +1,6 @@
 import normalization.NormalizeOpenApiSpecTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.WriteProperties
 
 plugins {
@@ -17,6 +19,10 @@ val generatedApi = layout.buildDirectory.dir("generated/openapi/src/main/kotlin"
 val rawSpec = layout.buildDirectory.file("generated/openapi-spec/openapi.raw.json")
 val generatedSpec = layout.buildDirectory.file("generated/openapi-spec/openapi.json")
 val generatedProps = layout.buildDirectory.dir("generated/kilo-props")
+val generatedCli = layout.buildDirectory.dir("generated/kilo-cli-res")
+val pinned = providers.gradleProperty("kilo.cli.pinned").map { it.trim().toBoolean() }.orElse(true)
+val repoCli = pinned.map { !it }
+val repoRootDir = rootProject.layout.projectDirectory.dir("../opencode")
 
 val pinnedCliVersion = providers.fileContents(rootProject.layout.projectDirectory.file("package.json")).asText.map { text ->
     Regex("\"version\"\\s*:\\s*\"([^\"]+)\"").find(text)?.groupValues?.get(1)
@@ -26,6 +32,7 @@ val pinnedCliVersion = providers.fileContents(rootProject.layout.projectDirector
 sourceSets {
     main {
         resources.srcDir(generatedProps)
+        if (repoCli.get()) resources.srcDir(generatedCli)
         kotlin.srcDir(generatedApi)
     }
 }
@@ -35,17 +42,50 @@ val writeKiloProperties by tasks.registering(WriteProperties::class) {
     val out = generatedProps.map { it.file("kilo.properties") }
     destinationFile.set(out)
     property("cli.version", pinnedCliVersion)
+    property("cli.pinned", pinned.map { it.toString() })
 }
 
 val generateOpenApiSpec by tasks.registering(GenerateOpenApiSpecTask::class) {
     description = "Generate CLI OpenAPI spec into the build directory"
     cliVersion.set(pinnedCliVersion)
+    repo.set(repoCli)
+    repoRoot.set(repoRootDir)
     token.set(
         providers.environmentVariable("GH_TOKEN")
             .orElse(providers.environmentVariable("GITHUB_TOKEN"))
     )
     cacheDir.set(layout.buildDirectory.dir("cli-cache"))
     spec.set(rawSpec)
+}
+
+val buildRepoCli by tasks.registering(Exec::class) {
+    description = "Build the local repo CLI for the current platform"
+    workingDir = repoRootDir.asFile
+    commandLine("bun", "run", "script/build.ts", "--single", "--skip-install")
+}
+
+fun platform(): String {
+    val os = System.getProperty("os.name").lowercase()
+    val name = when {
+        os.contains("mac") || os.contains("darwin") -> "darwin"
+        os.contains("linux") -> "linux"
+        os.contains("windows") -> "windows"
+        else -> throw GradleException("Unsupported OS: ${System.getProperty("os.name")}")
+    }
+    val arch = when (System.getProperty("os.arch").lowercase()) {
+        "aarch64", "arm64" -> "arm64"
+        "x86_64", "amd64" -> "x64"
+        else -> throw GradleException("Unsupported architecture: ${System.getProperty("os.arch")}")
+    }
+    return "$name-$arch"
+}
+
+val stageRepoCli by tasks.registering(StageRepoCliTask::class) {
+    description = "Stage the local repo CLI into backend resources"
+    val bin = repoRootDir.dir("dist/@kilocode/cli-${platform()}/bin")
+    this.bin.set(bin)
+    archive.set(generatedCli.map { it.file("kilo-cli.zip") })
+    outputs.upToDateWhen { false }
 }
 
 val normalizeOpenApiSpec by tasks.registering(NormalizeOpenApiSpecTask::class) {
@@ -102,11 +142,13 @@ val fixGeneratedApi by tasks.registering(FixGeneratedApiTask::class) {
 
 tasks.named("compileKotlin") {
     dependsOn(fixGeneratedApi, writeKiloProperties)
+    if (repoCli.get()) dependsOn(stageRepoCli)
     inputs.dir(generatedApi)
 }
 
 tasks.named("processResources") {
     dependsOn(writeKiloProperties)
+    if (repoCli.get()) dependsOn(stageRepoCli)
 }
 
 tasks.named("compileTestKotlin") {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
@@ -87,6 +87,11 @@ class KiloBackendCliManager(
     private suspend fun resolveCli(onProgress: (CliDownload) -> Unit): File {
         val force = forceExtract
         forceExtract = false
+        if (!KiloProps.pinned()) {
+            if (force) log.info("Force re-extracting local repo CLI ${KiloProps.cliVersion()}")
+            onProgress(CliDownload(100, KiloProps.cliVersion(), KiloCliPlatform.current()))
+            return KiloRepoCli.extract(force)
+        }
         if (force) log.info("Force re-downloading CLI ${KiloProps.cliVersion()}")
         return KiloCliDownloader(log = log).resolve(KiloProps.cliVersion(), force, onProgress)
     }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
@@ -89,8 +89,9 @@ class KiloBackendCliManager(
         forceExtract = false
         if (!KiloProps.pinned()) {
             if (force) log.info("Force re-extracting local repo CLI ${KiloProps.cliVersion()}")
+            val cli = KiloRepoCli.extract(force)
             onProgress(CliDownload(100, KiloProps.cliVersion(), KiloCliPlatform.current()))
-            return KiloRepoCli.extract(force)
+            return cli
         }
         if (force) log.info("Force re-downloading CLI ${KiloProps.cliVersion()}")
         return KiloCliDownloader(log = log).resolve(KiloProps.cliVersion(), force, onProgress)

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloProps.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloProps.kt
@@ -13,4 +13,8 @@ object KiloProps {
 
     fun cliVersion(): String = props.getProperty("cli.version")
         ?: throw IllegalStateException("cli.version missing from kilo.properties")
+
+    fun pinned(): Boolean = pinned(props)
+
+    internal fun pinned(props: Properties): Boolean = props.getProperty("cli.pinned")?.toBoolean() ?: true
 }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloRepoCli.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloRepoCli.kt
@@ -2,13 +2,15 @@ package ai.kilocode.backend.cli
 
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.util.SystemInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.zip.ZipInputStream
 
 object KiloRepoCli {
-    fun extract(force: Boolean): File = extract(
+    suspend fun extract(force: Boolean): File = extract(
         force = force,
         root = File(PathManager.getSystemPath(), "kilo/repo-cli"),
         source = {
@@ -17,12 +19,12 @@ object KiloRepoCli {
         },
     )
 
-    internal fun extract(force: Boolean, root: File, source: () -> InputStream): File {
+    internal suspend fun extract(force: Boolean, root: File, source: () -> InputStream): File = withContext(Dispatchers.IO) {
         val exe = File(root, "bin/${KiloCliPlatform.exe()}")
         val done = File(root, ".complete")
         if (!force && done.isFile && exe.isFile) {
             if (!SystemInfo.isWindows) exe.setExecutable(true)
-            return exe
+            return@withContext exe
         }
 
         if (root.exists() && !root.deleteRecursively()) {
@@ -45,7 +47,7 @@ object KiloRepoCli {
         if (!exe.isFile) throw IllegalStateException("Local repo CLI archive did not contain bin/${KiloCliPlatform.exe()}")
         if (!SystemInfo.isWindows) exe.setExecutable(true)
         done.writeText("ok\n")
-        return exe
+        return@withContext exe
     }
 
     private fun write(dir: File, name: String, directory: Boolean, copy: (OutputStream) -> Unit) {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloRepoCli.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloRepoCli.kt
@@ -1,0 +1,68 @@
+package ai.kilocode.backend.cli
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.util.SystemInfo
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.zip.ZipInputStream
+
+object KiloRepoCli {
+    fun extract(force: Boolean): File = extract(
+        force = force,
+        root = File(PathManager.getSystemPath(), "kilo/repo-cli"),
+        source = {
+            KiloRepoCli::class.java.classLoader.getResourceAsStream("kilo-cli.zip")
+                ?: throw IllegalStateException("kilo-cli.zip resource not found; rebuild with kilo.cli.pinned=false")
+        },
+    )
+
+    internal fun extract(force: Boolean, root: File, source: () -> InputStream): File {
+        val exe = File(root, "bin/${KiloCliPlatform.exe()}")
+        val done = File(root, ".complete")
+        if (!force && done.isFile && exe.isFile) {
+            if (!SystemInfo.isWindows) exe.setExecutable(true)
+            return exe
+        }
+
+        if (root.exists() && !root.deleteRecursively()) {
+            throw IllegalStateException("Failed to delete local repo CLI under ${root.absolutePath}")
+        }
+        if (!root.isDirectory && !root.mkdirs()) {
+            throw IllegalStateException("Failed to create local repo CLI directory ${root.absolutePath}")
+        }
+
+        source().use { input ->
+            ZipInputStream(input.buffered()).use { zip ->
+                while (true) {
+                    val entry = zip.nextEntry ?: break
+                    write(root, entry.name, entry.isDirectory) { out -> zip.copyTo(out) }
+                    zip.closeEntry()
+                }
+            }
+        }
+
+        if (!exe.isFile) throw IllegalStateException("Local repo CLI archive did not contain bin/${KiloCliPlatform.exe()}")
+        if (!SystemInfo.isWindows) exe.setExecutable(true)
+        done.writeText("ok\n")
+        return exe
+    }
+
+    private fun write(dir: File, name: String, directory: Boolean, copy: (OutputStream) -> Unit) {
+        val path = if (name.startsWith("bin/")) name else "bin/$name"
+        val target = File(dir, path).canonicalFile
+        val base = dir.canonicalFile
+        if (target != base && !target.path.startsWith(base.path + File.separator)) {
+            throw IllegalStateException("Archive entry escapes target directory: $name")
+        }
+        if (directory) {
+            target.mkdirs()
+            return
+        }
+        target.parentFile.mkdirs()
+        target.outputStream().use(copy)
+        if (!SystemInfo.isWindows && (target.name == "kilo" || target.name == "bwrap")) {
+            target.setExecutable(true)
+        }
+    }
+}

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloRepoCliTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloRepoCliTest.kt
@@ -1,5 +1,6 @@
 package ai.kilocode.backend.cli
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -18,7 +19,7 @@ class KiloRepoCliTest {
     lateinit var dir: File
 
     @Test
-    fun `extracts cached repo cli and force re-extracts`() {
+    fun `extracts cached repo cli and force re-extracts`() = runBlocking {
         val first = archive("#!/bin/old\n")
         val next = archive("#!/bin/new\n")
         val cli = KiloRepoCli.extract(false, dir) { ByteArrayInputStream(first) }
@@ -38,7 +39,7 @@ class KiloRepoCliTest {
     }
 
     @Test
-    fun `rejects archive entries that escape root`() {
+    fun `rejects archive entries that escape root`() = runBlocking {
         val ex = assertFailsWith<IllegalStateException> {
             KiloRepoCli.extract(false, dir) { ByteArrayInputStream(archive(entry = "../../../bad")) }
         }

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloRepoCliTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloRepoCliTest.kt
@@ -1,0 +1,68 @@
+package ai.kilocode.backend.cli
+
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.Properties
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class KiloRepoCliTest {
+    @TempDir
+    lateinit var dir: File
+
+    @Test
+    fun `extracts cached repo cli and force re-extracts`() {
+        val first = archive("#!/bin/old\n")
+        val next = archive("#!/bin/new\n")
+        val cli = KiloRepoCli.extract(false, dir) { ByteArrayInputStream(first) }
+
+        assertTrue(cli.isFile)
+        assertEquals("#!/bin/old\n", cli.readText())
+        assertTrue(File(cli.parentFile, "kilo-sandbox-mutation-worker.js").isFile)
+        assertTrue(File(dir, ".complete").isFile)
+
+        val cached = KiloRepoCli.extract(false, dir) { ByteArrayInputStream(next) }
+        assertEquals(cli.absolutePath, cached.absolutePath)
+        assertEquals("#!/bin/old\n", cached.readText())
+
+        val forced = KiloRepoCli.extract(true, dir) { ByteArrayInputStream(next) }
+        assertEquals(cli.absolutePath, forced.absolutePath)
+        assertEquals("#!/bin/new\n", forced.readText())
+    }
+
+    @Test
+    fun `rejects archive entries that escape root`() {
+        val ex = assertFailsWith<IllegalStateException> {
+            KiloRepoCli.extract(false, dir) { ByteArrayInputStream(archive(entry = "../../../bad")) }
+        }
+
+        assertContains(ex.message.orEmpty(), "escapes target directory")
+    }
+
+    @Test
+    fun `pinned defaults true unless explicitly false`() {
+        assertEquals(true, KiloProps.pinned(Properties()))
+        assertEquals(true, KiloProps.pinned(Properties().apply { setProperty("cli.pinned", "true") }))
+        assertEquals(false, KiloProps.pinned(Properties().apply { setProperty("cli.pinned", "false") }))
+    }
+
+    private fun archive(script: String = "#!/bin/sh\n", entry: String = "bin/${KiloCliPlatform.exe()}"): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            zip.putNextEntry(ZipEntry(entry))
+            zip.write(script.toByteArray())
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("bin/kilo-sandbox-mutation-worker.js"))
+            zip.write("worker".toByteArray())
+            zip.closeEntry()
+        }
+        return out.toByteArray()
+    }
+}

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
@@ -37,6 +37,12 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
     @get:Input
     abstract val cliVersion: Property<String>
 
+    @get:Input
+    abstract val repo: Property<Boolean>
+
+    @get:Internal
+    abstract val repoRoot: DirectoryProperty
+
     @get:Internal
     abstract val token: Property<String>
 
@@ -49,20 +55,51 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
     @get:Inject
     abstract val exec: ExecOperations
 
+    init {
+        repo.convention(false)
+        outputs.upToDateWhen { !repo.getOrElse(false) }
+    }
+
     @TaskAction
     fun run() {
+        if (repo.getOrElse(false)) {
+            generateFromRepo()
+            return
+        }
         val kilo = resolve()
+        generate(kilo.absolutePath)
+    }
+
+    private fun generateFromRepo() {
+        val root = repoRoot.asFile.get()
         val out = ByteArrayOutputStream()
         val err = ByteArrayOutputStream()
         val result = exec.exec {
-            commandLine(kilo.absolutePath, "generate")
+            workingDir = root
+            commandLine("bun", "run", "--conditions=browser", "./src/index.ts", "generate")
             standardOutput = out
             errorOutput = err
             isIgnoreExitValue = true
         }
-        if (result.exitValue != 0) {
+        writeSpec(result.exitValue, out, err)
+    }
+
+    private fun generate(kilo: String) {
+        val out = ByteArrayOutputStream()
+        val err = ByteArrayOutputStream()
+        val result = exec.exec {
+            commandLine(kilo, "generate")
+            standardOutput = out
+            errorOutput = err
+            isIgnoreExitValue = true
+        }
+        writeSpec(result.exitValue, out, err)
+    }
+
+    private fun writeSpec(code: Int, out: ByteArrayOutputStream, err: ByteArrayOutputStream) {
+        if (code != 0) {
             throw GradleException(
-                "kilo generate failed with exit code ${result.exitValue}.\n" +
+                "kilo generate failed with exit code $code.\n" +
                     err.toString(Charsets.UTF_8).take(2000)
             )
         }

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/StageRepoCliTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/StageRepoCliTask.kt
@@ -1,0 +1,45 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+abstract class StageRepoCliTask : DefaultTask() {
+    @get:Internal
+    abstract val bin: DirectoryProperty
+
+    @get:OutputFile
+    abstract val archive: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val dir = bin.asFile.get()
+        val exe = File(dir, exe())
+        if (!exe.isFile) {
+            throw GradleException(
+                "Repo CLI binary not found at ${exe.absolutePath}. Run ./gradlew :backend:buildRepoCli " +
+                    "(or bun run script/build.ts --single --skip-install in packages/opencode) first."
+            )
+        }
+
+        val out = archive.get().asFile
+        out.parentFile.mkdirs()
+        ZipOutputStream(out.outputStream().buffered()).use { zip ->
+            dir.walkTopDown()
+                .filter { it.isFile }
+                .forEach { file ->
+                    val name = "bin/${file.relativeTo(dir).invariantSeparatorsPath}"
+                    zip.putNextEntry(ZipEntry(name))
+                    file.inputStream().use { it.copyTo(zip) }
+                    zip.closeEntry()
+                }
+        }
+    }
+
+    private fun exe() = if (System.getProperty("os.name").lowercase().contains("windows")) "kilo.exe" else "kilo"
+}

--- a/packages/kilo-jetbrains/build.gradle.kts
+++ b/packages/kilo-jetbrains/build.gradle.kts
@@ -82,12 +82,17 @@ fun gitTag(): String? {
 }
 
 val release = providers.gradleProperty("production").map { it.toBoolean() }.orElse(false).get()
+val pinned = providers.gradleProperty("kilo.cli.pinned").map { it.trim().toBoolean() }.orElse(true).get()
 val override = providers.gradleProperty("kilo.version").orNull?.trim()?.takeIf { it.isNotEmpty() }
 val prop = providers.gradleProperty("kilo.jetbrains.version").orNull?.trim()?.takeIf { it.isNotEmpty() }
 val tag = gitTag()?.removePrefix("jetbrains/v")
 val ver = override?.let(::checked) ?: prop?.let(::checked) ?: if (release) checked(
     tag ?: error("Missing JetBrains plugin version. Publish builds must set kilo.jetbrains.version or run from a jetbrains/v<version> tag."),
 ) else checked(tag ?: "0.0.0-dev")
+
+if (release && !pinned) error(
+    "kilo.cli.pinned=false is a dev-only mode and cannot be released. Set kilo.cli.pinned=true before a production/publish build."
+)
 
 val channel = providers.gradleProperty("kilo.channel").map { it.trim() }.orElse("default")
 val splitPort = providers.gradleProperty("kilo.splitModeServerPort").map(::port).orElse(0)

--- a/packages/kilo-jetbrains/gradle.properties
+++ b/packages/kilo-jetbrains/gradle.properties
@@ -1,5 +1,9 @@
 kotlin.stdlib.default.dependency=false
 kilo.jetbrains.version=7.0.2
+# When true (default) the JetBrains plugin uses the pinned CLI release from package.json.
+# Set to false ONLY for local dev: generate the client from local source + bundle the local binary.
+# false is NOT releasable -- production builds fail unless this is true.
+kilo.cli.pinned=true
 org.gradle.configuration-cache=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m

--- a/packages/kilo-jetbrains/script/build-version.sh
+++ b/packages/kilo-jetbrains/script/build-version.sh
@@ -86,7 +86,7 @@ if [[ ! -d "$plugin" ]]; then
   exit 1
 fi
 
-if grep -q '^kilo\.cli\.pinned=false[[:space:]]*$' "$plugin/gradle.properties"; then
+if grep -Eq '^[[:space:]]*kilo\.cli\.pinned[[:space:]]*=[[:space:]]*false[[:space:]]*$' "$plugin/gradle.properties"; then
   echo "kilo.cli.pinned=false is a dev-only mode and cannot be released. Set kilo.cli.pinned=true before building a version." >&2
   exit 1
 fi

--- a/packages/kilo-jetbrains/script/build-version.sh
+++ b/packages/kilo-jetbrains/script/build-version.sh
@@ -86,6 +86,11 @@ if [[ ! -d "$plugin" ]]; then
   exit 1
 fi
 
+if grep -q '^kilo\.cli\.pinned=false[[:space:]]*$' "$plugin/gradle.properties"; then
+  echo "kilo.cli.pinned=false is a dev-only mode and cannot be released. Set kilo.cli.pinned=true before building a version." >&2
+  exit 1
+fi
+
 if [[ "$sign" == "1" ]]; then
   for file in "$chain" "$key" "$pass"; do
     if [[ ! -s "$file" ]]; then

--- a/script/jetbrains-release-pr.ts
+++ b/script/jetbrains-release-pr.ts
@@ -42,6 +42,9 @@ if (kind === "stable" && !/^\d+\.\d+\.\d+$/.test(ver)) throw new Error("Stable v
 if (!semver.valid(ver)) throw new Error(`Invalid semver: ${ver}`)
 
 await $`git fetch origin main --tags`
+if (!(await pinned())) {
+  throw new Error("packages/kilo-jetbrains/gradle.properties has kilo.cli.pinned=false; JetBrains releases require kilo.cli.pinned=true")
+}
 
 const tag = `jetbrains/v${ver}`
 const branch = `jetbrains/release/v${ver}`
@@ -212,6 +215,13 @@ async function writeprops(ver: string) {
     ? current.replace(/^kilo\.jetbrains\.version=.*$/m, line)
     : `${current.trim()}\n${line}\n`
   await Bun.write(props, next.endsWith("\n") ? next : `${next}\n`)
+}
+
+async function pinned() {
+  const text = await Bun.file(props).text()
+  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
+  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
+  return value !== "false"
 }
 
 async function writelog(ver: string, entry: string) {

--- a/script/jetbrains-release-pr.ts
+++ b/script/jetbrains-release-pr.ts
@@ -164,7 +164,7 @@ async function release(from: string, tag: string, sha: string) {
 }
 
 async function label(name: string, color: string, desc: string) {
-  const labels = (await $`gh label list --repo ${repo} --json name --limit 1000`.json()) as { name: string }[]
+  const labels: { name: string }[] = await $`gh label list --repo ${repo} --json name --limit 1000`.json()
   if (labels.some((item) => item.name === name)) return
   await $`gh label create ${name} --repo ${repo} --color ${color} --description ${desc}`
 }
@@ -219,9 +219,12 @@ async function writeprops(ver: string) {
 
 async function pinned() {
   const text = await Bun.file(props).text()
-  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
-  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
-  return value !== "false"
+  const value = text.split(/\r?\n/).flatMap((line) => {
+    const [key, raw] = line.split("=", 2)
+    if (key.trim() !== "kilo.cli.pinned") return []
+    return [raw?.trim().toLowerCase()]
+  })[0]
+  return value == null || value === "true"
 }
 
 async function writelog(ver: string, entry: string) {

--- a/script/jetbrains-release-validate.ts
+++ b/script/jetbrains-release-validate.ts
@@ -39,8 +39,8 @@ type Pull = {
   state: string
 }
 
-const data =
-  (await $`gh pr view ${pr} --repo ${repo} --json body,headRefName,isCrossRepository,labels,mergedAt,mergeCommit,state`.json()) as Pull
+const data: Pull =
+  await $`gh pr view ${pr} --repo ${repo} --json body,headRefName,isCrossRepository,labels,mergedAt,mergeCommit,state`.json()
 const labels = new Set(data.labels.map((item) => item.name))
 if (!labels.has("jetbrains-release")) throw new Error("PR is missing jetbrains-release label")
 if (data.isCrossRepository) throw new Error("JetBrains release PR must come from this repository")
@@ -123,7 +123,10 @@ async function props() {
 
 async function pinned() {
   const text = await Bun.file("packages/kilo-jetbrains/gradle.properties").text()
-  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
-  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
-  return value !== "false"
+  const value = text.split(/\r?\n/).flatMap((line) => {
+    const [key, raw] = line.split("=", 2)
+    if (key.trim() !== "kilo.cli.pinned") return []
+    return [raw?.trim().toLowerCase()]
+  })[0]
+  return value == null || value === "true"
 }

--- a/script/jetbrains-release-validate.ts
+++ b/script/jetbrains-release-validate.ts
@@ -73,6 +73,9 @@ if (sha !== commit) throw new Error(`${tag} points at ${sha}, expected ${commit}
 const prop = await props()
 if (prop !== ver)
   throw new Error(`packages/kilo-jetbrains/gradle.properties kilo.jetbrains.version is ${prop}, expected ${ver}`)
+if (!(await pinned())) {
+  throw new Error("packages/kilo-jetbrains/gradle.properties has kilo.cli.pinned=false; JetBrains releases require kilo.cli.pinned=true")
+}
 
 const changelog = await Bun.file("packages/kilo-jetbrains/CHANGELOG.md").text()
 if (!changelog.includes(`## [${ver}]`)) throw new Error(`CHANGELOG.md is missing section for ${ver}`)
@@ -116,4 +119,11 @@ async function props() {
   const value = line?.split("=", 2)[1]?.trim()
   if (!value) throw new Error("packages/kilo-jetbrains/gradle.properties is missing kilo.jetbrains.version")
   return value
+}
+
+async function pinned() {
+  const text = await Bun.file("packages/kilo-jetbrains/gradle.properties").text()
+  const line = text.split(/\r?\n/).find((item) => item.startsWith("kilo.cli.pinned="))
+  const value = line?.split("=", 2)[1]?.trim().toLowerCase()
+  return value !== "false"
 }

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -6,6 +6,11 @@ import { fileURLToPath } from "url"
 
 console.log("=== publishing ===\n")
 
+// kilocode_change start - keep JetBrains CLI pin reviewable outside CLI release commits
+const jetbrainsPkg = fileURLToPath(new URL("../packages/kilo-jetbrains/package.json", import.meta.url))
+const jetbrainsPin = await Bun.file(jetbrainsPkg).text()
+// kilocode_change end
+
 // kilocode_change start - consume changesets on the publish runner so changelog
 // changes are included in the release commit. Previously this ran in the
 // version job on a separate runner whose workspace was discarded.
@@ -42,6 +47,13 @@ const pkgjsons = await Array.fromAsync(
 ).then((arr) => arr.filter((x) => !x.includes("node_modules") && !x.includes("dist")))
 
 for (const file of pkgjsons) {
+  // kilocode_change start - create a follow-up PR for JetBrains CLI pin bumps
+  if (file === jetbrainsPkg) {
+    console.log("preserved JetBrains CLI pin:", file)
+    await Bun.file(file).write(jetbrainsPin)
+    continue
+  }
+  // kilocode_change end
   let pkg = await Bun.file(file).text()
   pkg = pkg.replaceAll(/"version": "[^"]+"/g, `"version": "${Script.version}"`)
   console.log("updated:", file)
@@ -122,3 +134,34 @@ await import(`../packages/kilo-vscode/script/publish.ts`)
 
 const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
+
+// kilocode_change start - non-blocking JetBrains CLI pin bump PR after stable CLI release
+await createJetbrainsPinPr()
+// kilocode_change end
+
+// kilocode_change start
+async function createJetbrainsPinPr() {
+  console.log("\n=== jetbrains cli pin bump pr ===\n")
+  if (!Script.release) {
+    console.log("Skipping JetBrains CLI pin bump PR: not a release build")
+    return
+  }
+  if (Script.preview) {
+    console.log(`Skipping JetBrains CLI pin bump PR for pre-release v${Script.version}`)
+    return
+  }
+  const result = await $`bun .kilo/skills/release-jetbrains/script/set-pin.ts --version ${Script.version} --pr`.nothrow()
+  const out = result.stdout.toString().trim()
+  const err = result.stderr.toString().trim()
+  if (result.exitCode === 0) {
+    if (out) console.log(out)
+    const url = out.match(/https:\/\/github\.com\/\S+\/pull\/\d+/)?.[0]
+    if (url) console.log(`::notice title=JetBrains CLI pin bump PR::${url}`)
+    return
+  }
+  console.warn("JetBrains CLI pin bump PR creation failed; release will continue.")
+  if (out) console.warn(out)
+  if (err) console.warn(err)
+  console.warn("::warning title=JetBrains CLI pin bump PR failed::Release completed, but the JetBrains CLI pin bump PR was not created. Check the logs above and create it manually if needed.")
+}
+// kilocode_change end


### PR DESCRIPTION
## Summary
- Add a dev-only JetBrains `kilo.cli.pinned=false` repo CLI mode that generates the OpenAPI client from local repo source and stages the locally built CLI into backend resources.
- Keep the default pinned release flow unchanged for normal JetBrains builds and runtime downloads.
- Add release checks and helper scripts to inspect, bump, test, and land JetBrains CLI pin changes deliberately.
- Add CLI release follow-up automation that opens a labeled JetBrains CLI pin bump PR after stable CLI releases.

## Why
JetBrains releases need to move independently from the CLI while still benefiting from the monorepo. A pinned CLI version lets us cut JetBrains-specific releases from a known, published CLI without accidentally taking unreleased or untested CLI/runtime changes. An unpinned repo mode lets us test cross-system work locally when the JetBrains plugin, generated SDK, and CLI/server need to evolve together.

This gives maintainers explicit options instead of one implicit coupling:
- Pin to a released CLI when preparing a JetBrains-only release.
- Unpin locally when developing or validating changes that span JetBrains and the CLI.
- Keep production/release workflows deterministic by rejecting repo CLI mode in release builds.

## Scenarios
### JetBrains-Specific Release
Use the pinned default (`kilo.cli.pinned=true`) when releasing only JetBrains changes, such as IDE UI, split-mode integration, lifecycle fixes, or Marketplace packaging updates. The plugin downloads the published CLI version from `packages/kilo-jetbrains/package.json`, and release checks verify that the pinned CLI release/assets exist before tagging.

Ask the agent:

```text
Release next JetBrains RC.
```

### Cross-System Feature Work
Use repo CLI mode (`kilo.cli.pinned=false`) for local development when a feature needs coordinated changes across the JetBrains plugin and the CLI/server API. In this mode OpenAPI generation runs from local `packages/opencode/`, and the local CLI build is bundled into backend resources for runtime testing.

Ask the agent:

```text
Test JetBrains with local repo CLI.
```

### OpenCode Merge Validation
Use repo CLI mode to validate upstream/OpenCode merge work that may affect generated API types, server routes, process behavior, or bundled CLI assets before a CLI release exists. This makes it possible to test the JetBrains plugin against the merged repo state without publishing a temporary CLI.

Ask the agent:

```text
Validate JetBrains against this OpenCode merge.
```

### Returning To Release Mode
Before publishing or preparing a JetBrains release, restore `kilo.cli.pinned=true`. Gradle production builds, release scripts, and the JetBrains release skill reject repo CLI mode so local test binaries cannot be shipped accidentally.

Ask the agent:

```text
Re-pin JetBrains for release.
```

## CLI Release Follow-Up
Stable CLI releases now leave the JetBrains CLI pin as a reviewed follow-up instead of silently changing it in the CLI release commit. After the CLI publish flow completes, it attempts to open or update a PR that bumps `packages/kilo-jetbrains/package.json` to the newly released CLI version.

That follow-up PR:
- Is labeled `jetbrains-cli-pin-bump`.
- Logs its URL in the CLI release workflow when creation succeeds.
- Logs a warning and does not fail the main CLI release if PR creation fails.
- Gives maintainers a review/test point before the JetBrains release skill locks the new CLI pin into an immutable `jetbrains/v*` tag.

## Notes
- Repo mode intentionally fails when the local CLI binary is missing and points developers at `:backend:buildRepoCli` instead of auto-building.
- The staged runtime bundle includes the full local CLI `bin/` directory so tree-sitter assets, console files, sandbox workers, and Linux `bwrap` stay available.

## Release Analysis
- Reviewed the stable CLI pin-bump PR timing, repo CLI dev mode, and existing pinned JetBrains release flow. Assets are published before the follow-up PR runs, release gates block repo mode, and the default pinned path remains unchanged.


