### PR TITLE
test(cli): stabilize active-run prompt test

### DIFF
--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1522,7 +1522,7 @@ it.instance(
       expect(inputs).toHaveLength(2)
       expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
     }),
-  3_000,
+  10_000, // kilocode_change - loaded CI runners can exceed 3s for two prompt turns
 )
 
 it.instance(


### PR DESCRIPTION
The active-run prompt integration test waits for two LLM turns and persisted queue state, but its outer three-second deadline is shorter than the fixture's five-second persistence wait. Loaded macOS runners can exceed that deadline even when queue behavior is correct, reproducing the mismatch previously identified in #8992.

Raise only the enclosing budget to ten seconds. Signal-based synchronization and all behavioral assertions remain unchanged, so real ordering failures still fail while normal runner contention no longer does.