### PR TITLE
Add MiniMax M3 model fixture

### DIFF
--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -21532,6 +21532,30 @@
           "cache_write": 0
         }
       },
+      "MiniMax-M3": {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-08",
+        "last_updated": "2026-07-08",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cache_read": 0
+        }
+      },
       "MiniMax-M2.1": {
         "id": "MiniMax-M2.1",
         "name": "MiniMax-M2.1",
@@ -32023,6 +32047,30 @@
           "output": 0,
           "cache_read": 0,
           "cache_write": 0
+        }
+      },
+      "MiniMax-M3": {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-08",
+        "last_updated": "2026-07-08",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cache_read": 0
         }
       },
       "MiniMax-M2.1": {
@@ -98821,6 +98869,30 @@
           "cache_write": 0.375
         }
       },
+      "MiniMax-M3": {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-08",
+        "last_updated": "2026-07-08",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.4,
+          "cache_read": 0.12
+        }
+      },
       "MiniMax-M2.1": {
         "id": "MiniMax-M2.1",
         "name": "MiniMax-M2.1",
@@ -116427,6 +116499,30 @@
           "output": 2.4,
           "cache_read": 0.06,
           "cache_write": 0.375
+        }
+      },
+      "MiniMax-M3": {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-07-08",
+        "last_updated": "2026-07-08",
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.4,
+          "cache_read": 0.12
         }
       },
       "MiniMax-M2.1": {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 to the existing MiniMax and MiniMax CN catalog fixture entries.
- Include the target context window and pricing metadata in the paid MiniMax provider fixtures, with zero-cost coding-plan fixture entries matching existing coding-plan conventions.

## Test plan
- `git add -A -N && if git diff HEAD | grep -E "$SECRET_RE"; then echo secret_scan_failed; exit 1; fi`
- `python3 -m json.tool packages/opencode/test/tool/fixtures/models-api.json >/dev/null`
- `node -e "JSON.parse(require(\"fs\").readFileSync(\"packages/opencode/test/tool/fixtures/models-api.json\",\"utf8\")); console.log(\"json ok\")"`
- `git diff --check`

Note: `bun test packages/opencode/test/kilocode/provider-model-refresh.test.ts packages/opencode/test/kilocode/provider-model-metadata.test.ts` could not run because `bun` is not installed in this worker environment.

Generated with Claude Code (https://claude.com/claude-code)
