### PR TITLE
fix(vscode): gate sandbox controls on setting

### DIFF
--- a/.changeset/sandbox-controls-setting.md
+++ b/.changeset/sandbox-controls-setting.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show sandbox controls only after sandboxing is enabled in settings.

--- a/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
+++ b/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
@@ -18,7 +18,10 @@ describe("NewWorktreeDialog sandbox toggle", () => {
       'vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })',
     )
     expect(src).toContain("sandbox: sandboxVisible() ? sandboxOverride() : undefined")
-    expect(src).toContain("const sandboxVisible = () => features().sandboxControls")
+    expect(src).toContain("const { config, globalConfig, features } = useConfig()")
+    expect(src).toContain(
+      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true",
+    )
     expect(provider).toContain("await this.fetchAndSendSandboxDefault(message.contextDirectory, message.requestID)")
     expect(src).not.toContain("createSignal(config().sandbox?.enabled === true)")
     expect(src).not.toContain("visible as isSandboxVisible")

--- a/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
@@ -81,11 +81,11 @@ describe("PromptInput sandbox toggle", () => {
     expect(src).not.toContain("setSandboxTarget")
   })
 
-  it("keeps persisted sandbox state visible independently of the configured default", () => {
+  it("shows sandbox controls only when the global sandbox setting is enabled", () => {
     expect(src).toContain(
-      'const sandboxVisible = () => features().sandboxControls && !session.currentSessionID()?.startsWith("cloud:")',
+      'globalConfig().sandbox?.enabled === true &&\n    !session.currentSessionID()?.startsWith("cloud:")',
     )
-    expect(src).not.toContain("config().sandbox?.enabled === true")
+    expect(src).toContain("features().sandboxControls &&")
     expect(src).toContain("<Show when={sandboxVisible()}>")
     expect(src).toContain("{ action: toggleSandbox, enabled: () => sandboxVisible() && !sandboxDisabled() }")
     expect(src).toContain('if (!sandboxVisible()) hidden.add("sandbox")')

--- a/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
@@ -124,7 +124,9 @@ describe("Agent Manager sandbox startup", () => {
   })
 
   test("uses the persisted sandbox default for UI and only sends explicit overrides", () => {
-    expect(dialog).toContain("const sandboxVisible = () => features().sandboxControls")
+    expect(dialog).toContain(
+      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true",
+    )
     expect(dialog).toContain('vscode.postMessage({ type: "requestSandboxDefault", requestID: sandboxRequestID })')
     expect(dialog).toContain(
       'vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })',

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -72,7 +72,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const server = useServer()
   const session = useSession()
   const provider = useProvider()
-  const { config, features } = useConfig()
+  const { config, globalConfig, features } = useConfig()
   const metrics = tracker(vscode)
   const track = (button: string, properties?: Record<string, string | number | boolean | undefined>) =>
     metrics.track(button, "configure_worktree_dialog", properties)
@@ -110,7 +110,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const [sandboxReason, setSandboxReason] = createSignal<string | undefined>()
   const [sandboxRevision, setSandboxRevision] = createSignal(-1)
   const sandboxRequestID = crypto.randomUUID()
-  const sandboxVisible = () => features().sandboxControls
+  const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true
   const speech = useSpeechToText(vscode, server, { t })
   const canUseSpeech = () => canUseSpeechToText(config(), provider.authStates())
   const speechModel = () => selectedSpeechToTextModel(config())

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -174,7 +174,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const id = session.currentSessionID()
     return id?.startsWith("cloud:") ? undefined : id
   }
-  const sandboxVisible = () => features().sandboxControls && !session.currentSessionID()?.startsWith("cloud:")
+  const sandboxVisible = () =>
+    features().sandboxControls &&
+    globalConfig().sandbox?.enabled === true &&
+    !session.currentSessionID()?.startsWith("cloud:")
   const sandbox = () => {
     const id = sandboxID()
     return id ? sandboxes()[id] : undefined


### PR DESCRIPTION
Promoting sandbox configuration removed the experimental visibility gate, which left per-session sandbox controls visible to every user on a supported platform even when sandboxing was disabled globally. This made an inactive feature appear available before users opted in.

Require the stable global `sandbox.enabled` setting before showing the prompt lock, exposing the `/sandbox` action, or displaying the Agent Manager new-worktree control. The Sandboxing settings page remains visible on supported platforms so users can discover and enable the feature.