### PR TITLE
fix(cli): resolve Bedrock SSO credentials

### DIFF
--- a/.changeset/fix-bedrock-sso.md
+++ b/.changeset/fix-bedrock-sso.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Resolve AWS Bedrock credentials from SSO profiles in packaged CLI builds.

--- a/bun.lock
+++ b/bun.lock
@@ -500,7 +500,6 @@
         "@secretlint/secretlint-rule-preset-recommend": "10.2.2",
         "@silvia-odwyer/photon-node": "0.3.4",
         "@solid-primitives/event-bus": "1.1.2",
-        "@solid-primitives/scheduled": "1.5.2",
         "@types/ws": "8.18.1",
         "@zip.js/zip.js": "2.7.62",
         "ai": "catalog:",
@@ -1974,8 +1973,6 @@
     "@solid-primitives/resize-observer": ["@solid-primitives/resize-observer@2.1.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.5", "@solid-primitives/rootless": "^1.5.3", "@solid-primitives/static-store": "^0.1.3", "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw=="],
 
     "@solid-primitives/rootless": ["@solid-primitives/rootless@1.5.2", "", { "dependencies": { "@solid-primitives/utils": "^6.3.2" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-9HULb0QAzL2r47CCad0M+NKFtQ+LrGGNHZfteX/ThdGvKIg2o2GYhBooZubTCd/RTu2l2+Nw4s+dEfiDGvdrrQ=="],
-
-    "@solid-primitives/scheduled": ["@solid-primitives/scheduled@1.5.2", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-/j2igE0xyNaHhj6kMfcUQn5rAVSTLbAX+CDEBm25hSNBmNiHLu2lM7Usj2kJJ5j36D67bE8wR1hBNA8hjtvsQA=="],
 
     "@solid-primitives/static-store": ["@solid-primitives/static-store@0.1.3", "", { "dependencies": { "@solid-primitives/utils": "^6.4.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -129,7 +129,6 @@
     "@secretlint/secretlint-rule-preset-recommend": "10.2.2",
     "@silvia-odwyer/photon-node": "0.3.4",
     "@solid-primitives/event-bus": "1.1.2",
-    "@solid-primitives/scheduled": "1.5.2",
     "@types/ws": "8.18.1",
     "@zip.js/zip.js": "2.7.62",
     "ai": "catalog:",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -292,7 +292,7 @@ for (const item of targets) {
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
   await Bun.build({
-    conditions: ["bun", "node"], // kilocode_change - load Node credential providers in packaged builds
+    conditions: ["bun", "node"], // kilocode_change - port anomalyco/opencode#30873; current form from #31566
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
     // kilocode_change start - skip sourcemaps for release builds (each .js.map adds ~50 MB per target → ~600 MB total)

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -292,7 +292,7 @@ for (const item of targets) {
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
 
   await Bun.build({
-    conditions: ["browser"],
+    conditions: ["bun", "node"], // kilocode_change - load Node credential providers in packaged builds
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
     // kilocode_change start - skip sourcemaps for release builds (each .js.map adds ~50 MB per target → ~600 MB total)

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/session/preview-pane.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/session/preview-pane.tsx
@@ -76,7 +76,7 @@ export function prefetchPreviews(sdk: Sdk, sync: Sync, sessionIDs: readonly stri
 export function createLeadingTrailingSignal<T>(initial: T, ms: number): [Accessor<T>, (v: T) => void, (v: T) => void] {
   const [get, set] = createSignal(initial)
   const setNow = (v: T) => set(() => v)
-  // kilocode_change start - preserve scheduling when Solid resolves its Node export
+  // kilocode_change start - Kilo preview equivalent of anomalyco/opencode#31748
   let timer: ReturnType<typeof setTimeout> | undefined
   let queued = false
   let value = initial

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/session/preview-pane.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/session/preview-pane.tsx
@@ -1,7 +1,6 @@
-import { createResource, Show, createMemo, createSignal, onMount, type Accessor, type JSX } from "solid-js"
+import { createResource, Show, createMemo, createSignal, onCleanup, onMount, type Accessor, type JSX } from "solid-js" // kilocode_change
 import { TextAttributes, type RGBA } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { debounce, leadingAndTrailing } from "@solid-primitives/scheduled"
 import type { Message, Part, Session as SdkSession, SnapshotFileDiff } from "@kilocode/sdk/v2"
 import { useTheme } from "@tui/context/theme"
 import { useSDK } from "@tui/context/sdk"
@@ -77,7 +76,26 @@ export function prefetchPreviews(sdk: Sdk, sync: Sync, sessionIDs: readonly stri
 export function createLeadingTrailingSignal<T>(initial: T, ms: number): [Accessor<T>, (v: T) => void, (v: T) => void] {
   const [get, set] = createSignal(initial)
   const setNow = (v: T) => set(() => v)
-  const schedule = leadingAndTrailing(debounce, setNow, ms)
+  // kilocode_change start - preserve scheduling when Solid resolves its Node export
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let queued = false
+  let value = initial
+  const schedule = (next: T) => {
+    value = next
+    if (!timer) setNow(next)
+    else queued = true
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = undefined
+      if (!queued) return
+      queued = false
+      setNow(value)
+    }, ms)
+  }
+  onCleanup(() => {
+    if (timer) clearTimeout(timer)
+  })
+  // kilocode_change end
   return [get, setNow, schedule]
 }
 

--- a/packages/opencode/src/cli/cmd/tui/util/signal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/signal.ts
@@ -1,10 +1,22 @@
 import { createEffect, createSignal, on, onCleanup, type Accessor } from "solid-js"
-import { debounce, type Scheduled } from "@solid-primitives/scheduled"
 
-export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, Scheduled<[value: T]>] {
+// kilocode_change start - Solid's Node export disables browser-only scheduling primitives
+export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, (value: T) => void] {
   const [get, set] = createSignal(value)
-  return [get, debounce((v: T) => set(() => v), ms)]
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const debounced = (next: T) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = undefined
+      set(() => next)
+    }, ms)
+  }
+  onCleanup(() => {
+    if (timer) clearTimeout(timer)
+  })
+  return [get, debounced]
 }
+// kilocode_change end
 
 export function createFadeIn(show: Accessor<boolean>, enabled: Accessor<boolean>) {
   const [alpha, setAlpha] = createSignal(show() ? 1 : 0)

--- a/packages/opencode/src/cli/cmd/tui/util/signal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/signal.ts
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, on, onCleanup, type Accessor } from "solid-js"
 
-// kilocode_change start - Solid's Node export disables browser-only scheduling primitives
+// kilocode_change start - port anomalyco/opencode#31748 for Node build conditions
 export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, (value: T) => void] {
   const [get, set] = createSignal(value)
   let timer: ReturnType<typeof setTimeout> | undefined

--- a/packages/opencode/test/kilocode/tui/signal.test.ts
+++ b/packages/opencode/test/kilocode/tui/signal.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createLeadingTrailingSignal } from "@tui/feature-plugins/session/preview-pane"
+import { createDebouncedSignal } from "@tui/util/signal"
+
+describe("TUI scheduling", () => {
+  test("debounces signal updates", async () => {
+    await createRoot(async (dispose) => {
+      const [value, schedule] = createDebouncedSignal("initial", 10)
+
+      schedule("first")
+      schedule("last")
+      expect(value()).toBe("initial")
+
+      await Bun.sleep(30)
+      expect(value()).toBe("last")
+      dispose()
+    })
+  })
+
+  test("updates on the leading and trailing edges", async () => {
+    await createRoot(async (dispose) => {
+      const [value, , schedule] = createLeadingTrailingSignal("initial", 10)
+
+      schedule("leading")
+      expect(value()).toBe("leading")
+
+      schedule("middle")
+      schedule("trailing")
+      expect(value()).toBe("leading")
+
+      await Bun.sleep(30)
+      expect(value()).toBe("trailing")
+
+      schedule("next")
+      expect(value()).toBe("next")
+      dispose()
+    })
+  })
+})


### PR DESCRIPTION
## What changed

Build the packaged CLI with Bun and Node export conditions so AWS Bedrock can load the real Node credential chain instead of browser-only Symbol stubs. Replace the Solid scheduling primitives that become no-ops under Node conditions with timer-based implementations, preserving TUI session search and preview behavior.

## Why

Kilo 7.4.0 changed minification in the VS Code extension bundle, but Bedrock credentials are resolved by the separately packaged CLI. The CLI still selected browser AWS/Smithy exports, causing SSO profiles to fail with errors such as `KC is not a function` where `KC` was a `Symbol`.

## Upstream fixes

This is a targeted backport of the same approach OpenCode adopted upstream:

- [anomalyco/opencode#30873](https://github.com/anomalyco/opencode/pull/30873) / [`1e216e12dc`](https://github.com/anomalyco/opencode/commit/1e216e12dccdf4831e63a16c4aaee96117f213f7) switched packaged builds from browser to Node conditions, fixing AWS/Smithy credential and event-stream resolution.
- [anomalyco/opencode#31748](https://github.com/anomalyco/opencode/pull/31748) / [`c51a1588c7`](https://github.com/anomalyco/opencode/commit/c51a1588c7c5829323f7158f8005881328d8c610) replaced Solid's browser-only scheduling primitive after Node conditions made it resolve to a server-side no-op.
- [`a0409e64d8`](https://github.com/anomalyco/opencode/commit/a0409e64d8faaa8b89a9f6fbb31f18c3af0e5dd9) later established the current upstream `conditions: ["bun", "node"]` form used here.

A straight cherry-pick is not suitable because Kilo has diverged from the relevant upstream tree: the TUI still lives under `packages/opencode/src/cli/cmd/tui`, while current upstream moved it into `packages/tui`, and Kilo has an additional session-preview leading/trailing scheduler with no direct counterpart in the upstream fix. Cherry-picking only #30873 would fix Bedrock but regress TUI search and preview scheduling. This PR therefore applies the equivalent build-condition change and ports the timer-based compatibility fix to both Kilo call sites.