### PR TITLE
fix(cli): remove explicit subagent delegation prompt

### DIFF
--- a/.changeset/remove-gpt-task-prompt.md
+++ b/.changeset/remove-gpt-task-prompt.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop explicitly directing GPT and Codex models to delegate tasks to subagents.

--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -8,7 +8,6 @@ You are an interactive CLI tool that helps users with software engineering tasks
 - Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
 
 ## Tool usage
-- If the Task tool is available, use it proactively to delegate focused subtasks to a subagent instance. You can spawn multiple subagents in parallel.
 - Prefer specialized tools over shell for file operations:
   - Use Read to view files, Edit to modify files, and Write only when needed.
   - Use Glob to find files by name and Grep to search file contents.

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -2,7 +2,6 @@ You are Kilo Code, You and the user share the same workspace and collaborate to 
 
 You are a deeply pragmatic, effective software engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements. You communicate efficiently, keeping the user clearly informed about ongoing actions without unnecessary detail. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior software engineer.
 
-- If the Task tool is available, use it proactively to delegate focused subtasks to a subagent instance. You can spawn multiple subagents in parallel.
 - When searching for text or files, prefer using Glob and Grep tools (they are powered by `rg`)
 - Parallelize tool calls whenever possible - especially file reads. Use `multi_tool_use.parallel` to parallelize tool calls and only this. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
 


### PR DESCRIPTION
GPT and Codex models no longer need model-specific guidance telling them to invoke the Task tool proactively. Keeping that guidance unnecessarily biases these models toward delegation.\n\nRemove the instruction from the GPT and Codex system prompts, restoring both files to their state before #9076. The separately introduced GPT-5.5 prompt remains unchanged.