### PR TITLE
fix: restore GPT-5.6 reasoning summaries

### DIFF
--- a/.changeset/tidy-gpt-reasoning.md
+++ b/.changeset/tidy-gpt-reasoning.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-ui": patch
+---
+
+Show detailed GPT-5.6 reasoning summaries and avoid expandable blank panels when a provider returns only a summary title.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/title-only-reasoning-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/title-only-reasoning-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43ea789b53b0bd402231f30970e9f8f1648ac1d0bcd971102ed4769bd002d9e6
+size 6764

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -553,6 +553,14 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
     &:hover {
       background-color: var(--surface-inset-base-hover, var(--vscode-list-hoverBackground));
     }
+
+    &[data-static] {
+      cursor: default;
+    }
+
+    &[data-static]:hover {
+      background-color: var(--surface-inset-base);
+    }
   }
 
   [data-slot="reasoning-header"] {
@@ -667,6 +675,10 @@ html[data-theme="kilo-vscode"] [data-component="reasoning-part"] {
     &:hover {
       background-color: var(--vscode-list-hoverBackground, var(--surface-raised-base-hover));
     }
+
+    &[data-static]:hover {
+      background-color: transparent;
+    }
   }
 
   [data-slot="collapsible-arrow"] {
@@ -698,7 +710,7 @@ html[data-theme="kilo-vscode"] [data-component="reasoning-part"] {
     color: var(--text-weak);
   }
 
-  [data-slot="collapsible-trigger"]:hover {
+  [data-slot="collapsible-trigger"]:not([data-static]):hover {
     [data-slot="reasoning-label"],
     [data-slot="reasoning-title"] {
       color: var(--vscode-list-hoverForeground, var(--vscode-foreground, var(--text-strong)));

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1481,6 +1481,14 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
   const display = createThrottledValue(text)
   const view = createMemo(() => reasoningHeading(display()))
 
+  const Header = () => (
+    <div data-slot="reasoning-header">
+      <Icon name="brain" size="small" />
+      <span data-slot="reasoning-label">{i18n.t("ui.reasoning.label" as never)}</span>
+      <Show when={view().title}>{(title) => <span data-slot="reasoning-title">{title()}</span>}</Show>
+    </div>
+  )
+
   // time.end is set by the processor on reasoning-end.
   // v1 parts lack time entirely → treat as historical.
   const done = () => {
@@ -1549,29 +1557,34 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
   })
 
   return (
-    <Show when={display()}>
+    <Show when={view().title || view().body}>
       <div
         data-component="reasoning-part"
         data-streaming={!done() ? "" : undefined}
         data-auto-collapse={props.reasoningAutoCollapse ? "" : undefined}
       >
-        <Collapsible open={open()} onOpenChange={track} class="tool-collapsible">
-          <Collapsible.Trigger>
-            <div data-slot="reasoning-header">
-              <Icon name="brain" size="small" />
-              <span data-slot="reasoning-label">{i18n.t("ui.reasoning.label" as never)}</span>
-              <Show when={view().title}>{(title) => <span data-slot="reasoning-title">{title()}</span>}</Show>
+        <Show
+          when={view().body}
+          fallback={
+            <div data-slot="collapsible-trigger" data-static="">
+              <Header />
             </div>
-            <Collapsible.Arrow />
-          </Collapsible.Trigger>
-          <Collapsible.Content>
-            <div data-slot="reasoning-details">
-              <div data-slot="reasoning-content" ref={ref} onScroll={onScroll} onWheel={onWheel}>
-                <Markdown text={view().body} cacheKey={id} streaming={!done()} />
+          }
+        >
+          <Collapsible open={open()} onOpenChange={track} class="tool-collapsible">
+            <Collapsible.Trigger>
+              <Header />
+              <Collapsible.Arrow />
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <div data-slot="reasoning-details">
+                <div data-slot="reasoning-content" ref={ref} onScroll={onScroll} onWheel={onWheel}>
+                  <Markdown text={view().body} cacheKey={id} streaming={!done()} />
+                </div>
               </div>
-            </div>
-          </Collapsible.Content>
-        </Collapsible>
+            </Collapsible.Content>
+          </Collapsible>
+        </Show>
       </div>
     </Show>
   )

--- a/packages/kilo-ui/src/components/reasoning-heading.test.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.test.ts
@@ -48,4 +48,29 @@ describe("reasoning heading", () => {
       body: "",
     })
   })
+
+  test("treats an OpenAI placeholder comment as an empty body", () => {
+    expect(reasoningHeading("**Assessing search behavior**\n\n<!-- -->")).toEqual({
+      title: "Assessing search behavior",
+      body: "",
+    })
+  })
+
+  test("preserves visible body text around HTML comments", () => {
+    expect(reasoningHeading("**Assessing search behavior**\n\n<!-- status -->\nContinue checking results.")).toEqual({
+      title: "Assessing search behavior",
+      body: "<!-- status -->\nContinue checking results.",
+    })
+  })
+
+  test("treats an interrupted HTML comment as an empty body", () => {
+    expect(reasoningHeading("**Assessing search behavior**\n\n<!--")).toEqual({
+      title: "Assessing search behavior",
+      body: "",
+    })
+  })
+
+  test("treats a titleless placeholder comment as empty", () => {
+    expect(reasoningHeading("<!-- -->")).toEqual({ body: "" })
+  })
 })

--- a/packages/kilo-ui/src/components/reasoning-heading.test.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.test.ts
@@ -70,6 +70,13 @@ describe("reasoning heading", () => {
     })
   })
 
+  test("preserves reasoning after an interrupted HTML comment", () => {
+    expect(reasoningHeading("**Assessing search behavior**\n\n<!--\nActually reconsider the alternate endpoint.")).toEqual({
+      title: "Assessing search behavior",
+      body: "Actually reconsider the alternate endpoint.",
+    })
+  })
+
   test("treats a titleless placeholder comment as empty", () => {
     expect(reasoningHeading("<!-- -->")).toEqual({ body: "" })
   })

--- a/packages/kilo-ui/src/components/reasoning-heading.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.ts
@@ -13,6 +13,10 @@ function clean(value: string) {
     .trim()
 }
 
+function visible(value: string) {
+  return value.replace(/<!--[\s\S]*?(?:-->|$)/g, "").trim() ? value : ""
+}
+
 function pick(src: string, expr: RegExp, group = 1): ReasoningHeading | undefined {
   const found = src.match(expr)
   const raw = found?.[group]
@@ -21,9 +25,10 @@ function pick(src: string, expr: RegExp, group = 1): ReasoningHeading | undefine
   const title = clean(raw)
   if (!title) return
 
+  const body = src.slice(found[0].length).trimStart()
   return {
     title,
-    body: src.slice(found[0].length).trimStart(),
+    body: visible(body),
   }
 }
 
@@ -34,7 +39,7 @@ export function reasoningHeading(text: string): ReasoningHeading {
     pick(src, /^#{1,6}[ \t]+([^\n]+?)(?:[ \t]+#+[ \t]*)?(?:\n|$)/) ??
     pick(src, /^([^\n]+)\n(?:=+|-+)[ \t]*(?:\n|$)/) ??
     pick(src, /^(\*\*|__)([^\n]+?)\1[ \t]*(?:\n|$)/, 2) ?? {
-      body: src,
+      body: visible(src),
     }
   )
 }

--- a/packages/kilo-ui/src/components/reasoning-heading.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.ts
@@ -14,7 +14,11 @@ function clean(value: string) {
 }
 
 function visible(value: string) {
-  return value.replace(/<!--[\s\S]*?(?:-->|$)/g, "").trim() ? value : ""
+  const closed = value.replace(/<!--[\s\S]*?-->/g, "")
+  const start = closed.indexOf("<!--")
+  if (start === -1) return closed.trim() ? value : ""
+  const body = `${closed.slice(0, start)}${closed.slice(start + 4)}`
+  return body.trim() ? body.trimStart() : ""
 }
 
 function pick(src: string, expr: RegExp, group = 1): ReasoningHeading | undefined {

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import type { AssistantMessage as SDKAssistantMessage, TextPart, ToolPart } from "@kilocode/sdk/v2"
+import type { AssistantMessage as SDKAssistantMessage, ReasoningPart, TextPart, ToolPart } from "@kilocode/sdk/v2"
 import { StoryProviders, defaultMockData, mockSessionValue } from "./StoryProviders"
 import { AssistantMessage } from "../components/chat/AssistantMessage"
 import { VscodeSessionTurn } from "../components/chat/VscodeSessionTurn"
@@ -43,6 +43,15 @@ const baseAssistantMessage: SDKAssistantMessage = {
   path: { cwd: "/project", root: "/project" },
   cost: 0.0023,
   tokens: { total: 512, input: 256, output: 256, reasoning: 0, cache: { read: 0, write: 0 } },
+}
+
+const titleOnlyReasoning: ReasoningPart = {
+  id: "part-reasoning-title-only",
+  sessionID: SESSION_ID,
+  messageID: ASST_MSG_ID,
+  type: "reasoning",
+  text: "**Assessing search behavior**\n\n<!-- -->",
+  time: { start: now - 7000, end: now - 6500 },
 }
 
 // ---------------------------------------------------------------------------
@@ -638,6 +647,18 @@ export const ToolCards: Story = {
   name: "Tool Cards",
   render: () => {
     const data = dataWith([readCompleted, globCompleted, grepCompleted, lsCompleted])
+    return (
+      <StoryProviders data={data} sessionID={SESSION_ID}>
+        <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+export const TitleOnlyReasoning: Story = {
+  name: "Reasoning - title only",
+  render: () => {
+    const data = dataWith([titleOnlyReasoning, textPart])
     return (
       <StoryProviders data={data} sessionID={SESSION_ID}>
         <AssistantMessage message={baseAssistantMessage} />

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -131,7 +131,7 @@ const OpenAIResponsesCoreFields = {
   reasoning: Schema.optional(
     Schema.Struct({
       effort: Schema.optional(OpenAIOptions.OpenAIReasoningEffort),
-      summary: Schema.optional(Schema.Literal("auto")),
+      summary: Schema.optional(OpenAIOptions.OpenAIReasoningSummary), // kilocode_change
     }),
   ),
   text: Schema.optional(

--- a/packages/llm/src/protocols/utils/openai-options.ts
+++ b/packages/llm/src/protocols/utils/openai-options.ts
@@ -7,6 +7,11 @@ export const OpenAIReasoningEfforts = ReasoningEfforts.filter(
 )
 export type OpenAIReasoningEffort = (typeof OpenAIReasoningEfforts)[number]
 
+// kilocode_change start - support every reasoning summary mode in the OpenAI Responses API
+export const OpenAIReasoningSummaries = ["auto", "concise", "detailed"] as const
+export type OpenAIReasoningSummary = (typeof OpenAIReasoningSummaries)[number]
+// kilocode_change end
+
 // Mirrors OpenAI's `ResponseIncludable` union from the official SDK. Keep this
 // in lockstep with `openai-node/src/resources/responses/responses.ts`.
 export const OpenAIResponseIncludables = [
@@ -23,10 +28,12 @@ export type OpenAIResponseIncludable = (typeof OpenAIResponseIncludables)[number
 
 const REASONING_EFFORTS = new Set<string>(ReasoningEfforts)
 const OPENAI_REASONING_EFFORTS = new Set<string>(OpenAIReasoningEfforts)
+const REASONING_SUMMARIES = new Set<string>(OpenAIReasoningSummaries) // kilocode_change
 const TEXT_VERBOSITY = new Set<string>(["low", "medium", "high"])
 const INCLUDABLES = new Set<string>(OpenAIResponseIncludables)
 
 export const OpenAIReasoningEffort = Schema.Literals(OpenAIReasoningEfforts)
+export const OpenAIReasoningSummary = Schema.Literals(OpenAIReasoningSummaries) // kilocode_change
 export const OpenAITextVerbosity = TextVerbosity
 export const OpenAIResponseIncludable = Schema.Literals(OpenAIResponseIncludables)
 
@@ -51,8 +58,12 @@ export const reasoningEffort = (request: LLMRequest): ReasoningEffort | undefine
   return isAnyReasoningEffort(value) ? value : undefined
 }
 
-export const reasoningSummary = (request: LLMRequest): "auto" | undefined =>
-  options(request)?.reasoningSummary === "auto" ? "auto" : undefined
+// kilocode_change start - preserve every reasoning summary mode supported by OpenAI Responses
+export const reasoningSummary = (request: LLMRequest): OpenAIReasoningSummary | undefined => {
+  const value = options(request)?.reasoningSummary
+  return typeof value === "string" && REASONING_SUMMARIES.has(value) ? (value as OpenAIReasoningSummary) : undefined
+}
+// kilocode_change end
 
 // Resolve the OpenAI Responses `include` field. Filters out unknown
 // includable values defensively so a typo in upstream config drops the

--- a/packages/llm/src/providers/openai-options.ts
+++ b/packages/llm/src/providers/openai-options.ts
@@ -9,7 +9,7 @@ export interface OpenAIOptionsInput {
   readonly store?: boolean
   readonly promptCacheKey?: string
   readonly reasoningEffort?: ReasoningEffort
-  readonly reasoningSummary?: "auto"
+  readonly reasoningSummary?: "auto" | "concise" | "detailed" // kilocode_change
   // OpenAI Responses `include` wire field. Mirrors the official SDK's
   // `ResponseIncludable[]` union exactly so AI SDK callers and direct
   // native-SDK callers share one shape and no translation is required.

--- a/packages/llm/test/kilocode/openai-reasoning-summary.test.ts
+++ b/packages/llm/test/kilocode/openai-reasoning-summary.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { LLM } from "../../src"
+import * as OpenAI from "../../src/providers/openai"
+import * as OpenAIResponses from "../../src/protocols/openai-responses"
+import { LLMClient } from "../../src/route"
+import { it } from "../lib/effect"
+
+for (const summary of ["auto", "concise", "detailed"] as const) {
+  it.effect(`serializes the ${summary} OpenAI reasoning summary mode`, () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.request({
+          model: OpenAI.configure({ baseURL: "https://api.openai.test/v1/", apiKey: "test" }).model("gpt-5.6"),
+          prompt: "think",
+          providerOptions: { openai: { reasoningEffort: "high", reasoningSummary: summary } },
+        }),
+      )
+
+      expect(prepared.body.reasoning).toEqual({ effort: "high", summary })
+    }),
+  )
+}

--- a/packages/opencode/src/kilocode/provider/reasoning-summary.ts
+++ b/packages/opencode/src/kilocode/provider/reasoning-summary.ts
@@ -5,5 +5,6 @@ const VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
 export function reasoningSummary(model: Provider.Model) {
   if (model.api.npm !== "@ai-sdk/openai") return "auto"
   const version = Number(VERSION_RE.exec(model.api.id)?.[1]) || undefined
+  // GPT-5.6 auto summaries can contain only a title, so request the detailed summary explicitly.
   return version === 6 ? "detailed" : "auto"
 }

--- a/packages/opencode/src/kilocode/provider/reasoning-summary.ts
+++ b/packages/opencode/src/kilocode/provider/reasoning-summary.ts
@@ -1,0 +1,9 @@
+import type { Provider } from "@/provider/provider"
+
+const VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
+
+export function reasoningSummary(model: Provider.Model) {
+  if (model.api.npm !== "@ai-sdk/openai") return "auto"
+  const version = Number(VERSION_RE.exec(model.api.id)?.[1]) || undefined
+  return version === 6 ? "detailed" : "auto"
+}

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -6,6 +6,7 @@ import type * as ModelsDev from "@opencode-ai/core/models-dev"
 import { iife } from "@/util/iife"
 import { kiloProviderOptions } from "@/kilocode/provider-options"
 import { isLing } from "@/kilocode/model-match" // kilocode_change
+import { reasoningSummary } from "@/kilocode/provider/reasoning-summary" // kilocode_change
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -900,7 +901,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           effort,
           {
             reasoningEffort: effort,
-            reasoningSummary: "auto",
+            reasoningSummary: reasoningSummary(model), // kilocode_change
             include: INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
@@ -1257,7 +1258,7 @@ export function options(input: {
         input.model.api.npm === "@openrouter/ai-sdk-provider" || // kilocode_change
         input.model.api.npm === "@kilocode/kilo-gateway" // kilocode_change
       ) {
-        result["reasoningSummary"] = "auto"
+        result["reasoningSummary"] = reasoningSummary(input.model) // kilocode_change
         if (input.model.api.npm === "@ai-sdk/openai") {
           result["include"] = INCLUDE_ENCRYPTED_REASONING
         }

--- a/packages/opencode/test/kilocode/provider/gpt-5.6-summary.test.ts
+++ b/packages/opencode/test/kilocode/provider/gpt-5.6-summary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../../src/provider/transform"
+import type { Provider } from "../../../src/provider/provider"
+
+function model(api = "gpt-5.6-sol-fast", npm = "@ai-sdk/openai") {
+  return {
+    id: api,
+    providerID: "openai",
+    api: { id: api, npm, url: "https://api.openai.com/v1" },
+    name: api,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 5, output: 30, cache: { read: 0.5, write: 6.25 } },
+    limit: { context: 1_050_000, output: 128_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-07-09",
+  } as Provider.Model
+}
+
+describe("GPT-5.6 reasoning summaries", () => {
+  test("requests detailed summaries by default from direct OpenAI", () => {
+    const result = ProviderTransform.options({ model: model(), sessionID: "test-session" })
+    expect(result.reasoningSummary).toBe("detailed")
+  })
+
+  test("requests detailed summaries for every direct OpenAI reasoning variant", () => {
+    const result = ProviderTransform.variants(model())
+    expect(Object.values(result).every((variant) => variant.reasoningSummary === "detailed")).toBe(true)
+  })
+
+  test("keeps auto summaries for older and non-OpenAI GPT models", () => {
+    expect(ProviderTransform.options({ model: model("gpt-5.5"), sessionID: "test-session" }).reasoningSummary).toBe(
+      "auto",
+    )
+    expect(
+      ProviderTransform.options({
+        model: model("openai/gpt-5.6-sol", "@kilocode/kilo-gateway"),
+        sessionID: "test-session",
+      }).reasoningSummary,
+    ).toBe("auto")
+  })
+})


### PR DESCRIPTION
Direct OpenAI GPT-5.6 responses can resolve `reasoning.summary: auto` to title-only Markdown followed by an invisible comment marker. That leaves no useful summary body, while the renderer interprets the marker as expandable content and displays a blank panel.

Request detailed summaries for direct OpenAI GPT-5.6 defaults and reasoning variants, and preserve all supported summary modes through the native OpenAI Responses path. Keep the provider override scoped to direct OpenAI so older models and routed providers retain their existing behavior.

Treat title-only reasoning as a static, non-interactive header and suppress entirely invisible placeholder parts. Detailed and concise summaries with visible content remain expandable.