### PR TITLE
fix(cli): surface OpenAI Responses API failures

### DIFF
--- a/.changeset/surface-openai-response-errors.md
+++ b/.changeset/surface-openai-response-errors.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show detailed OpenAI Responses API failure messages instead of a generic provider error.

--- a/bun.lock
+++ b/bun.lock
@@ -250,7 +250,7 @@
     },
     "packages/kilo-jetbrains": {
       "name": "@kilocode/kilo-jetbrains",
-      "version": "7.4.5",
+      "version": "7.4.4",
     },
     "packages/kilo-memory": {
       "name": "@kilocode/kilo-memory",

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@ai-sdk/google-vertex": "4.0.128",
         "@ai-sdk/groq": "3.0.31",
         "@ai-sdk/mistral": "3.0.27",
-        "@ai-sdk/openai": "3.0.53",
+        "@ai-sdk/openai": "3.0.82",
         "@ai-sdk/openai-compatible": "2.0.48",
         "@ai-sdk/perplexity": "3.0.26",
         "@ai-sdk/provider": "3.0.8",
@@ -177,7 +177,7 @@
         "@ai-sdk/alibaba": "1.0.17",
         "@ai-sdk/anthropic": "3.0.71",
         "@ai-sdk/mistral": "3.0.27",
-        "@ai-sdk/openai": "3.0.53",
+        "@ai-sdk/openai": "3.0.82",
         "@ai-sdk/openai-compatible": "2.0.48",
         "@clack/prompts": "1.0.0-alpha.1",
         "@kilocode/plugin": "workspace:*",
@@ -250,7 +250,7 @@
     },
     "packages/kilo-jetbrains": {
       "name": "@kilocode/kilo-jetbrains",
-      "version": "7.4.4",
+      "version": "7.4.5",
     },
     "packages/kilo-memory": {
       "name": "@kilocode/kilo-memory",
@@ -457,7 +457,7 @@
         "@ai-sdk/google-vertex": "4.0.112",
         "@ai-sdk/groq": "3.0.31",
         "@ai-sdk/mistral": "3.0.27",
-        "@ai-sdk/openai": "3.0.53",
+        "@ai-sdk/openai": "3.0.82",
         "@ai-sdk/openai-compatible": "2.0.48",
         "@ai-sdk/perplexity": "3.0.26",
         "@ai-sdk/provider": "3.0.8",
@@ -858,7 +858,7 @@
 
     "@ai-sdk/mistral": ["@ai-sdk/mistral@3.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZXe7nZQgliDdjz5ufH5RKpHWxbN72AzmzzKGbF/z+0K9GN5tUCnftrQRvTRFHA5jAzTapcm2BEevmGLVbMkW+A=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.82", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.37" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Gn1YliuNMneXoBmuLX1kH/e5SR/VnU9FXLvJ8WyiV61Noo+wPdE4nuzxRGt3lfV6rla1wyCb1syV4jU0A310ew=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.48", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q=="],
 
@@ -4428,6 +4428,10 @@
 
     "@ai-sdk/mistral/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.13", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VG4tpVXCuzm21U9xjg05BCMZnjZOazC72+MxBkLAa7hCKsnqNt542GYWUUqwmHSczJwgbSXN8UvaNgSerUaKdw=="],
+
     "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
@@ -4645,6 +4649,8 @@
     "@vscode/vsce/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
     "ai-gateway-provider/@ai-sdk/google": ["@ai-sdk/google@3.0.64", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA=="],
+
+    "ai-gateway-provider/@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
 
     "ava/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "@ai-sdk/google-vertex": "4.0.128",
     "@ai-sdk/groq": "3.0.31",
     "@ai-sdk/mistral": "3.0.27",
-    "@ai-sdk/openai": "3.0.53",
+    "@ai-sdk/openai": "3.0.82",
     "@ai-sdk/openai-compatible": "2.0.48",
     "@ai-sdk/perplexity": "3.0.26",
     "@ai-sdk/provider": "3.0.8",

--- a/packages/kilo-gateway/package.json
+++ b/packages/kilo-gateway/package.json
@@ -35,7 +35,7 @@
     "@kilocode/plugin": "workspace:*",
     "@ai-sdk/alibaba": "1.0.17",
     "@ai-sdk/anthropic": "3.0.71",
-    "@ai-sdk/openai": "3.0.53",
+    "@ai-sdk/openai": "3.0.82",
     "@ai-sdk/openai-compatible": "2.0.48",
     "@ai-sdk/mistral": "3.0.27",
     "@openrouter/ai-sdk-provider": "2.9.0",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -86,7 +86,7 @@
     "@ai-sdk/google-vertex": "4.0.112",
     "@ai-sdk/groq": "3.0.31",
     "@ai-sdk/mistral": "3.0.27",
-    "@ai-sdk/openai": "3.0.53",
+    "@ai-sdk/openai": "3.0.82",
     "@ai-sdk/openai-compatible": "2.0.48",
     "@ai-sdk/perplexity": "3.0.26",
     "@ai-sdk/provider": "3.0.8",

--- a/packages/opencode/src/kilocode/provider/error.ts
+++ b/packages/opencode/src/kilocode/provider/error.ts
@@ -10,7 +10,9 @@ export function responseFailed(input: unknown) {
   if (typeof message !== "string" || !message.trim()) return
   const code = input.response.error.code
   return {
-    code: typeof code === "string" ? code : undefined,
+    type: "api_error" as const,
     message,
+    isRetryable: code === "server_error" || code === "server_is_overloaded",
+    responseBody: JSON.stringify(input),
   }
 }

--- a/packages/opencode/src/kilocode/provider/error.ts
+++ b/packages/opencode/src/kilocode/provider/error.ts
@@ -1,0 +1,16 @@
+import { isRecord } from "@/util/record"
+
+export function responseFailed(input: unknown) {
+  if (!isRecord(input)) return
+  if (input.type !== "response.failed") return
+  if (!isRecord(input.response)) return
+  if (!isRecord(input.response.error)) return
+
+  const message = input.response.error.message
+  if (typeof message !== "string" || !message.trim()) return
+  const code = input.response.error.code
+  return {
+    code: typeof code === "string" ? code : undefined,
+    message,
+  }
+}

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -1,6 +1,7 @@
 import { APICallError } from "ai"
 import { STATUS_CODES } from "http"
 import { iife } from "@/util/iife"
+import { responseFailed } from "@/kilocode/provider/error" // kilocode_change
 import type { ProviderID } from "./schema"
 
 export class HeaderTimeoutError extends Error {
@@ -142,6 +143,15 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (!body) return
 
   const responseBody = JSON.stringify(body)
+  const failed = responseFailed(body) // kilocode_change
+  if (failed) {
+    return {
+      type: "api_error",
+      message: failed.message,
+      isRetryable: failed.code === "server_error" || failed.code === "server_is_overloaded",
+      responseBody,
+    }
+  }
   if (body.type !== "error") return
 
   switch (body?.error?.code) {

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -143,15 +143,7 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (!body) return
 
   const responseBody = JSON.stringify(body)
-  const failed = responseFailed(body) // kilocode_change
-  if (failed) {
-    return {
-      type: "api_error",
-      message: failed.message,
-      isRetryable: failed.code === "server_error" || failed.code === "server_is_overloaded",
-      responseBody,
-    }
-  }
+  if (body.type === "response.failed") return responseFailed(body) // kilocode_change
   if (body.type !== "error") return
 
   switch (body?.error?.code) {

--- a/packages/opencode/test/kilocode/provider/error.test.ts
+++ b/packages/opencode/test/kilocode/provider/error.test.ts
@@ -1,8 +1,54 @@
 import { describe, expect, test } from "bun:test"
+import { createOpenAI } from "@ai-sdk/openai"
+import { streamText } from "ai"
 import { MessageV2 } from "@/session/message-v2"
 import { ProviderID } from "@/provider/schema"
 
 describe("provider stream errors", () => {
+  test("receives response.failed details from the OpenAI provider", async () => {
+    const body = {
+      type: "response.failed",
+      sequence_number: 1,
+      response: {
+        error: {
+          code: "cyber_policy",
+          message: "This content was flagged for possible cybersecurity risk.",
+        },
+        incomplete_details: null,
+        usage: null,
+        service_tier: null,
+      },
+    }
+    const fetch = Object.assign(
+      async () =>
+        new Response(`data: ${JSON.stringify(body)}\n\ndata: [DONE]\n\n`, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+      { preconnect() {} },
+    )
+    const openai = createOpenAI({
+      apiKey: "test",
+      fetch,
+    })
+    const stream = streamText({
+      model: openai.responses("gpt-5"),
+      prompt: "hello",
+      maxRetries: 0,
+      onError() {},
+    })
+    const error = await (async () => {
+      for await (const part of stream.fullStream) {
+        if (part.type === "error") return part.error
+      }
+    })()
+
+    expect(error).toBeDefined()
+    const result = MessageV2.fromError(error, { providerID: ProviderID.make("openai") })
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toBe(body.response.error.message)
+  })
+
   test("normalizes empty rate-limit messages", () => {
     const body = {
       type: "error",
@@ -40,6 +86,49 @@ describe("provider stream errors", () => {
     expect(MessageV2.APIError.isInstance(result)).toBe(true)
     if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
     expect(result.data.message).toBe(body.error.message)
+    expect(result.data.isRetryable).toBe(true)
+  })
+
+  test("surfaces Responses API response.failed messages", () => {
+    const body = {
+      type: "response.failed",
+      response: {
+        id: "resp_failed",
+        status: "failed",
+        error: {
+          code: "cyber_policy",
+          message:
+            "This content was flagged for possible cybersecurity risk. If this seems wrong, try rephrasing your request.",
+        },
+      },
+    }
+    const result = MessageV2.fromError(body, { providerID: ProviderID.make("openai") })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: body.response.error.message,
+        isRetryable: false,
+        responseBody: JSON.stringify(body),
+      },
+    })
+  })
+
+  test("marks Responses API server failures as retryable", () => {
+    const body = {
+      type: "response.failed",
+      response: {
+        error: {
+          code: "server_error",
+          message: "The provider failed while processing the response.",
+        },
+      },
+    }
+    const result = MessageV2.fromError(body, { providerID: ProviderID.make("openai") })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toBe(body.response.error.message)
     expect(result.data.isRetryable).toBe(true)
   })
 })


### PR DESCRIPTION
OpenAI Responses API failures currently degrade to a generic provider error because the installed AI SDK does not preserve `response.failed` details across every stream timing.

Update `@ai-sdk/openai` to the release that throws structured early-stream failures, and normalize nested `response.error` values that can still arrive after output has started. This preserves the provider message, full response body, and retryability for server failures while leaving policy failures non-retryable.

The Kilo-specific parser is isolated under `src/kilocode`, with only a minimal marked hook in shared OpenCode code.