### PR TITLE
fix(ci): authenticate JetBrains metadata requests

### DIFF
--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts
         working-directory: packages/kilo-jetbrains
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Publish JetBrains unit reports
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Setup Node
         if: matrix.settings.run
         id: setup-node
-        # kilocode_change
         continue-on-error: ${{ runner.os == 'Windows' }}
         uses: actions/setup-node@v6 # kilocode_change
         with:
@@ -156,9 +155,6 @@ jobs:
 
       - name: Upload unit artifacts
         if: always() && matrix.settings.run
-        # kilocode_change start
-        continue-on-error: ${{ runner.os == 'Windows' }}
-        # kilocode_change end
         uses: actions/upload-artifact@v7 # kilocode_change
         with:
           name: unit-${{ matrix.settings.os }}-${{ matrix.settings.index }}-${{ github.run_attempt }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,9 @@ jobs:
 
       - name: Upload unit artifacts
         if: always() && matrix.settings.run
+        # kilocode_change start
         continue-on-error: ${{ runner.os == 'Windows' }}
+        # kilocode_change end
         uses: actions/upload-artifact@v7 # kilocode_change
         with:
           name: unit-${{ matrix.settings.os }}-${{ matrix.settings.index }}-${{ github.run_attempt }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
 
       - name: Upload unit artifacts
         if: always() && matrix.settings.run
+        continue-on-error: ${{ runner.os == 'Windows' }}
         uses: actions/upload-artifact@v7 # kilocode_change
         with:
           name: unit-${{ matrix.settings.os }}-${{ matrix.settings.index }}-${{ github.run_attempt }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Setup Node
         if: matrix.settings.run
         id: setup-node
-        continue-on-error: ${{ runner.os == 'Windows' }} # kilocode_change
+        # kilocode_change
+        continue-on-error: ${{ runner.os == 'Windows' }}
         uses: actions/setup-node@v6 # kilocode_change
         with:
           node-version: "24"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node
         if: matrix.settings.run
         id: setup-node
-        continue-on-error: ${{ runner.os == 'Windows' }}
+        continue-on-error: ${{ runner.os == 'Windows' }} # kilocode_change
         uses: actions/setup-node@v6 # kilocode_change
         with:
           node-version: "24"


### PR DESCRIPTION
JetBrains CI generates the OpenAPI client from the pinned CLI release before compiling and running tests. The Gradle task already reads `GH_TOKEN` or `GITHUB_TOKEN`, but GitHub Actions does not expose `${{ github.token }}` as either environment variable automatically. Cold runs therefore query GitHub release metadata anonymously and can exhaust the 60-request-per-hour unauthenticated limit.

This change maps the workflow's ephemeral `${{ github.token }}` to the existing `GH_TOKEN` input for the JetBrains test process. The reusable workflow grants only `contents: read`, `checks: write`, and `pull-requests: read`; the token is not persisted and test behavior is unchanged.

The original Windows runner disconnect was separately confirmed as a Blacksmith control-plane failure: the same shard passed unchanged on rerun and on the post-merge `main` workflow. No repository workaround for that infrastructure event is included in this PR.