### PR TITLE
feat(cli): improve model usage layout

### DIFF
--- a/.changeset/clear-model-usage.md
+++ b/.changeset/clear-model-usage.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Make session model usage easier to scan with collapsible summary rows and aligned steps and cost columns.

--- a/packages/opencode/src/kilocode/plugins/sidebar-usage.tsx
+++ b/packages/opencode/src/kilocode/plugins/sidebar-usage.tsx
@@ -1,7 +1,8 @@
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@kilocode/plugin/tui"
-import { createMemo, createResource, For, onCleanup, onMount, Show } from "solid-js"
+import { createMemo, createResource, createSignal, For, onCleanup, onMount, Show } from "solid-js"
 import { useLocal } from "@tui/context/local"
 import * as Model from "@tui/util/model"
+import { Locale } from "@/util/locale"
 import { RoutedModelMeta } from "@/kilocode/cli/cmd/tui/routes/session/routed-model-meta"
 import { fmtAttemptCost, fmtScore } from "@/kilocode/components/model-info-panel-utils"
 import {
@@ -18,6 +19,8 @@ import {
 const id = "internal:kilo-sidebar-usage"
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
+  const [modelsOpen, setModelsOpen] = createSignal(true)
+  const [expanded, setExpanded] = createSignal(new Set<string>())
   const theme = () => props.api.theme.current
   const local = useLocal()
   const [result, { refetch }] = createResource(
@@ -44,6 +47,13 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <text fg={theme().textMuted}>{props.value}</text>
     </box>
   )
+  const toggle = (key: string) =>
+    setExpanded((current) => {
+      const next = new Set(current)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
 
   onMount(() => {
     const refresh = () => void refetch()
@@ -109,43 +119,80 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <Show when={usage()}>
         {(data) => (
           <box>
-            <text fg={theme().text}>
-              <b>Models ({data().models.length})</b>
-            </text>
-            <Show when={data().models.length > 0} fallback={<text fg={theme().textMuted}>No model usage yet</text>}>
-              <box gap={1}>
-                <For each={groups()}>
-                  {(group) => (
-                    <box>
-                      <text fg={theme().text}>
-                        <b>{group.providerName}</b>
-                      </text>
-                      <box gap={1} paddingLeft={1}>
-                        <For each={group.models}>
-                          {(model) => (
-                            <box>
-                              <text fg={theme().text} wrapMode="char">
-                                <b>{RoutedModelMeta.label(providers(), model)}</b>
-                              </text>
-                              <text fg={theme().textMuted} wrapMode="word">
-                                Steps {formatCount(model.steps)} | Cost {formatCost(model.cost)}
-                              </text>
-                              <text fg={theme().textMuted} wrapMode="word">
-                                In {formatCount(model.tokens.input)} | Out {formatCount(model.tokens.output)} | Reason{" "}
-                                {formatCount(model.tokens.reasoning)}
-                              </text>
-                              <text fg={theme().textMuted} wrapMode="word">
-                                Cache R {formatCount(model.tokens.cache.read)} | W{" "}
-                                {formatCount(model.tokens.cache.write)} | Rate {formatRate(model.tokens)}
-                              </text>
+            <box flexDirection="row" gap={1} onMouseDown={() => setModelsOpen((open) => !open)}>
+              <text fg={theme().text}>{modelsOpen() ? "▼" : "▶"}</text>
+              <text fg={theme().text}>
+                <b>Models ({data().models.length})</b>
+              </text>
+            </box>
+            <Show when={modelsOpen()}>
+              <Show when={data().models.length > 0} fallback={<text fg={theme().textMuted}>No model usage yet</text>}>
+                <box gap={1}>
+                  <For each={groups()}>
+                    {(group) => (
+                      <box>
+                        <text fg={theme().text}>
+                          <b>{group.providerName}</b>
+                        </text>
+                        <box>
+                          <box flexDirection="row" gap={1}>
+                            <box width={1} flexShrink={0} />
+                            <text fg={theme().textMuted} flexGrow={1} minWidth={0} wrapMode="none">
+                              Model
+                            </text>
+                            <box width={5} flexShrink={0} justifyContent="flex-end">
+                              <text fg={theme().textMuted}>Steps</text>
                             </box>
-                          )}
-                        </For>
+                            <box width={9} flexShrink={0} justifyContent="flex-end">
+                              <text fg={theme().textMuted}>Cost</text>
+                            </box>
+                          </box>
+                          <For each={group.models}>
+                            {(model) => {
+                              const key = `${props.session_id}/${model.providerID}/${model.modelID}`
+                              return (
+                                <box>
+                                  <box flexDirection="row" gap={1} onMouseDown={() => toggle(key)}>
+                                    <text fg={theme().text} flexShrink={0}>
+                                      {expanded().has(key) ? "▼" : "▶"}
+                                    </text>
+                                    <box flexGrow={1} minWidth={0} overflow="hidden">
+                                      <text fg={theme().text} wrapMode="none">
+                                        <b>
+                                          {Locale.truncate(
+                                            RoutedModelMeta.label(providers(), model) ?? model.modelID,
+                                            19,
+                                          )}
+                                        </b>
+                                      </text>
+                                    </box>
+                                    <box width={5} flexShrink={0} justifyContent="flex-end">
+                                      <text fg={theme().textMuted}>{formatCount(model.steps)}</text>
+                                    </box>
+                                    <box width={9} flexShrink={0} justifyContent="flex-end">
+                                      <text fg={theme().textMuted}>{formatCost(model.cost)}</text>
+                                    </box>
+                                  </box>
+                                  <Show when={expanded().has(key)}>
+                                    <box paddingLeft={2}>
+                                      <Row label="Input" value={formatCount(model.tokens.input)} />
+                                      <Row label="Output" value={formatCount(model.tokens.output)} />
+                                      <Row label="Reasoning" value={formatCount(model.tokens.reasoning)} />
+                                      <Row label="Cache read" value={formatCount(model.tokens.cache.read)} />
+                                      <Row label="Cache write" value={formatCount(model.tokens.cache.write)} />
+                                      <Row label="Cache rate" value={formatRate(model.tokens)} />
+                                    </box>
+                                  </Show>
+                                </box>
+                              )
+                            }}
+                          </For>
+                        </box>
                       </box>
-                    </box>
-                  )}
-                </For>
-              </box>
+                    )}
+                  </For>
+                </box>
+              </Show>
             </Show>
           </box>
         )}

--- a/packages/opencode/src/kilocode/plugins/sidebar-usage.tsx
+++ b/packages/opencode/src/kilocode/plugins/sidebar-usage.tsx
@@ -127,10 +127,10 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
             </box>
             <Show when={modelsOpen()}>
               <Show when={data().models.length > 0} fallback={<text fg={theme().textMuted}>No model usage yet</text>}>
-                <box gap={1}>
+                <box gap={1} paddingTop={1}>
                   <For each={groups()}>
                     {(group) => (
-                      <box>
+                      <box gap={1}>
                         <text fg={theme().text}>
                           <b>{group.providerName}</b>
                         </text>


### PR DESCRIPTION
## Summary
Make session model usage easier to scan and selectively inspect in the CLI sidebar.

### Why this change is needed
Model statistics were presented as several wrapped lines with inline separators. In sessions using multiple models, costs and step counts were difficult to compare, and the section consumed substantial sidebar space even when users did not need it.

### How this is addressed
- Present each model as a compact row with aligned Model, Steps, and Cost columns.
- Let users collapse the entire Models section or expand individual models for token and cache details.
- Preserve provider grouping and truncate long model labels so numeric columns stay aligned.

### Before and after

Before:
```text
Models (4)
Kilo Gateway
  GPT-5.6 Sol (new)
  Steps 45 | Cost $3.549455
  In 214,037 | Out 11,155 | Reason 13,900
  Cache R 3,455,240 | W 0 | Rate 94.2%

  GPT-5.4
  Steps 78 | Cost $2.373468
  In 644,127 | Out 20,882 | Reason 0
  Cache R 1,799,680 | W 0 | Rate 73.6%
```

After:
```text
▼ Models (4)
Kilo Gateway
 Model             Steps      Cost
▶ GPT-5.6 Sol         45      $3.55
▶ GPT-5.4             78      $2.37
▶ GPT-5.6 Terra       50      $1.45
▶ GPT-5.6 Luna        42      $0.73
```

Expanded model:
```text
▼ GPT-5.6 Sol         45        $3.55
  Input                       214,037
  Output                       11,155
  Reasoning                    13,900
  Cache read                3,455,240
  Cache write                       0
  Cache rate                    94.2%
```

<img width="612" height="220" alt="CleanShot 2026-07-10 at 17 57 47@2x" src="https://github.com/user-attachments/assets/03ccf230-6b14-4da0-bf43-a01204029617" />


## Human Verification
The implementation received a focused local code review covering logic, type safety, security, resource management, data safety, and SolidJS/OpenTUI patterns. No actionable issues were found.

## Reviewer Notes

### Human Reviewer Flags
- Model details now favor compact comparison by default and require one click to inspect per-model token details.
- Collapse state is local to the current TUI component lifetime.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Reuses the existing `Locale.truncate` utility and established sidebar `▶`/`▼` disclosure pattern.
- Keeps implementation in a Kilo-owned path, avoiding changes to shared upstream OpenCode files.

</details>
