### PR TITLE
feat(jetbrains): intellij_read PSI code intelligence tool

### DIFF
--- a/.changeset/jetbrains-ide-code-intel.md
+++ b/.changeset/jetbrains-ide-code-intel.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": minor
 ---
 
-Support an experimental JetBrains-backed IDE code intelligence tool for definitions, references, implementations, symbols, and type hierarchy.
+Support an experimental `intellij_read` tool for JetBrains-backed definitions, references, implementations, symbols, and type hierarchy.

--- a/.changeset/jetbrains-ide-code-intel.md
+++ b/.changeset/jetbrains-ide-code-intel.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support an experimental JetBrains-backed IDE code intelligence tool for definitions, references, implementations, symbols, and type hierarchy.

--- a/.changeset/jetbrains-ide-code-intel.md
+++ b/.changeset/jetbrains-ide-code-intel.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": minor
 ---
 
-Support an experimental `intellij_read` tool for JetBrains-backed definitions, references, implementations, symbols, and type hierarchy.
+Support an experimental `intellij_read` tool for JetBrains-backed definitions, references, implementations, symbols, and type hierarchy. When IntelliJ is still indexing or the project has not been imported yet, the tool reports that code intelligence is unavailable and tells the agent to fall back to text-based search instead of trusting an empty result.

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendAppService.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendAppService.kt
@@ -131,6 +131,7 @@ class KiloBackendAppService private constructor(
 
     val sessions = KiloBackendSessionManager(cs, log)
     val chat = KiloBackendChatManager(cs, log)
+    val ideLsp = KiloBackendIdeLspManager(cs, log)
     val models = KiloBackendModelStateManager(log)
     val workspaces = KiloBackendWorkspaceManager(cs, sessions, log)
     @Volatile var profile: KiloProfile200Response? = null
@@ -420,6 +421,7 @@ class KiloBackendAppService private constructor(
                     models.start(connection.apiClient!!, connection.port)
                     sessions.start(connection.api!!, connection.apiClient!!, connection.port, connection.events)
                     chat.start(connection.apiClient!!, connection.port, connection.events)
+                    ideLsp.start(connection.apiClient!!, connection.port, connection.events)
                     workspaces.start(connection.api!!, connection.apiClient!!, connection.port, connection.events)
                     startWatchingGlobalSseEvents()
                     setTelemetry(true)
@@ -818,6 +820,7 @@ class KiloBackendAppService private constructor(
     private fun stopRuntime() {
         workspaces.stop()
         models.stop()
+        ideLsp.stop()
         chat.stop()
         sessions.stop()
     }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendIdeLspManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/app/KiloBackendIdeLspManager.kt
@@ -1,0 +1,136 @@
+package ai.kilocode.backend.app
+
+import ai.kilocode.backend.cli.IdeLspRequestInfo
+import ai.kilocode.backend.cli.IdeLspResultInfo
+import ai.kilocode.backend.cli.KiloCliDataParser
+import ai.kilocode.backend.ideintel.CodeIntelFailure
+import ai.kilocode.backend.ideintel.KiloPsiCodeIntel
+import ai.kilocode.log.KiloLog
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+
+class KiloBackendIdeLspManager(
+    private val cs: CoroutineScope,
+    private val log: KiloLog,
+) {
+    private val active = ConcurrentHashMap<String, Job>()
+    private val dirs = ConcurrentHashMap.newKeySet<String>()
+    private var client: OkHttpClient? = null
+    private var base: String? = null
+    private var watcher: Job? = null
+
+    fun start(http: OkHttpClient, port: Int, sse: SharedFlow<SseEvent>) {
+        stop()
+        client = http
+        base = "http://127.0.0.1:$port"
+        dirs.forEach { dir -> cs.launch { drain(dir) } }
+        watcher = cs.launch {
+            sse.collect { event ->
+                when (event.type) {
+                    "kilocode.ideLsp.requested" -> {
+                        val dir = KiloCliDataParser.extractDirectory(event.data) ?: return@collect
+                        dirs.add(dir)
+                        drain(dir)
+                    }
+                    "kilocode.ideLsp.cancelled" -> {
+                        val id = KiloCliDataParser.parseIdeLspRequestId(event.data) ?: return@collect
+                        active.remove(id)?.cancel()
+                    }
+                }
+            }
+        }
+    }
+
+    fun stop() {
+        watcher?.cancel()
+        watcher = null
+        active.values.forEach { it.cancel() }
+        active.clear()
+        client = null
+        base = null
+    }
+
+    private suspend fun drain(dir: String) {
+        val requests = runCatching { list(dir) }.getOrElse { err ->
+            log.warn("IDE code intelligence request list failed for $dir: ${err.message}", err)
+            return
+        }
+        for (request in requests) {
+            active.computeIfAbsent(request.id) {
+                cs.launch(Dispatchers.Default) {
+                    try {
+                        handle(dir, request)
+                    } finally {
+                        active.remove(request.id)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun list(dir: String): List<IdeLspRequestInfo> = withContext(Dispatchers.IO) {
+        val http = client ?: return@withContext emptyList()
+        val url = "${base ?: return@withContext emptyList()}/kilocode/ide-lsp?directory=${encode(dir)}"
+        val request = Request.Builder().url(url).get().build()
+        http.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw IllegalStateException("HTTP ${response.code}: $body")
+            KiloCliDataParser.parseIdeLspRequests(body)
+        }
+    }
+
+    private suspend fun handle(dir: String, request: IdeLspRequestInfo) {
+        try {
+            val result = KiloPsiCodeIntel.handle(dir, request)
+            reply(dir, request.id, result)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: CodeIntelFailure) {
+            reject(dir, request.id, e.code, e.message)
+        } catch (e: Exception) {
+            log.warn("IDE code intelligence request failed for ${request.operation}: ${e.message}", e)
+            reject(dir, request.id, "not_found", e.message ?: "IDE code intelligence request failed")
+        }
+    }
+
+    private suspend fun reply(dir: String, id: String, result: IdeLspResultInfo) = post(
+        path = "/kilocode/ide-lsp/$id/reply?directory=${encode(dir)}",
+        body = KiloCliDataParser.buildIdeLspReplyJson(result),
+    )
+
+    private suspend fun reject(dir: String, id: String, code: String, message: String) = post(
+        path = "/kilocode/ide-lsp/$id/reject?directory=${encode(dir)}",
+        body = KiloCliDataParser.buildIdeLspRejectJson(code, message),
+    )
+
+    private suspend fun post(path: String, body: String) = withContext(Dispatchers.IO) {
+        val http = client ?: return@withContext
+        val url = "${base ?: return@withContext}$path"
+        val request = Request.Builder()
+            .url(url)
+            .post(body.toRequestBody(JSON))
+            .build()
+        http.newCall(request).execute().use { response ->
+            val text = response.body?.string().orEmpty()
+            if (!response.isSuccessful) throw IllegalStateException("HTTP ${response.code}: $text")
+        }
+    }
+
+    private fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    companion object {
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
@@ -111,7 +111,8 @@ data class IdeLspEntryInfo(
 
 data class IdeLspResultInfo(
     val operation: String,
-    val indexing: Boolean = false,
+    val status: String = "ready",
+    val reason: String? = null,
     val entries: List<IdeLspEntryInfo> = emptyList(),
     val supertypes: List<IdeLspEntryInfo>? = null,
     val subtypes: List<IdeLspEntryInfo>? = null,
@@ -186,7 +187,8 @@ object KiloCliDataParser {
             "\"operation\":${escape(result.operation)}",
             "\"entries\":${buildIdeLspEntriesJson(result.entries)}",
         )
-        if (result.indexing) fields += "\"indexing\":true"
+        if (result.status != "ready") fields += "\"status\":${escape(result.status)}"
+        result.reason?.let { fields += "\"reason\":${escape(it)}" }
         result.supertypes?.let { fields += "\"supertypes\":${buildIdeLspEntriesJson(it)}" }
         result.subtypes?.let { fields += "\"subtypes\":${buildIdeLspEntriesJson(it)}" }
         return "{${fields.joinToString(",")}}"

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
@@ -90,6 +90,33 @@ import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import java.util.concurrent.ConcurrentHashMap
 
+data class IdeLspRequestInfo(
+    val id: String,
+    val sessionID: String,
+    val operation: String,
+    val filePath: String,
+    val line: Int?,
+    val character: Int?,
+    val query: String?,
+)
+
+data class IdeLspEntryInfo(
+    val name: String? = null,
+    val kind: String? = null,
+    val filePath: String,
+    val startLine: Int,
+    val endLine: Int,
+    val preview: String? = null,
+)
+
+data class IdeLspResultInfo(
+    val operation: String,
+    val indexing: Boolean = false,
+    val entries: List<IdeLspEntryInfo> = emptyList(),
+    val supertypes: List<IdeLspEntryInfo>? = null,
+    val subtypes: List<IdeLspEntryInfo>? = null,
+)
+
 /**
  * Stateless parser that centralizes all CLI server response parsing.
  *
@@ -121,6 +148,62 @@ object KiloCliDataParser {
      */
     fun extractEventType(data: String): String =
         TYPE_REGEX.find(data)?.groupValues?.get(1) ?: "unknown"
+
+    fun extractDirectory(data: String): String? =
+        tryParseObject(data)?.str("directory")
+
+    fun parseIdeLspRequestId(data: String): String? {
+        val obj = tryParseObject(data) ?: return null
+        val payload = obj["payload"]?.jsonObject ?: obj
+        val props = payload["properties"]?.jsonObject ?: payload
+        return props.str("requestID") ?: props.str("id")
+    }
+
+    fun parseIdeLspRequests(raw: String): List<IdeLspRequestInfo> {
+        val arr = tryParseArray(raw) ?: return emptyList()
+        return arr.mapNotNull { elem ->
+            val obj = runCatching { elem.jsonObject }.getOrNull() ?: return@mapNotNull null
+            IdeLspRequestInfo(
+                id = obj.str("id") ?: return@mapNotNull null,
+                sessionID = obj.str("sessionID") ?: "",
+                operation = obj.str("operation") ?: return@mapNotNull null,
+                filePath = obj.str("filePath") ?: return@mapNotNull null,
+                line = obj.long("line")?.safeInt(),
+                character = obj.long("character")?.safeInt(),
+                query = obj.str("query"),
+            )
+        }
+    }
+
+    fun buildIdeLspReplyJson(result: IdeLspResultInfo): String =
+        """{"result":${buildIdeLspResultJson(result)}}"""
+
+    fun buildIdeLspRejectJson(code: String, message: String): String =
+        """{"error":{"code":${escape(code)},"message":${escape(message)}}}"""
+
+    private fun buildIdeLspResultJson(result: IdeLspResultInfo): String {
+        val fields = mutableListOf(
+            "\"operation\":${escape(result.operation)}",
+            "\"entries\":${buildIdeLspEntriesJson(result.entries)}",
+        )
+        if (result.indexing) fields += "\"indexing\":true"
+        result.supertypes?.let { fields += "\"supertypes\":${buildIdeLspEntriesJson(it)}" }
+        result.subtypes?.let { fields += "\"subtypes\":${buildIdeLspEntriesJson(it)}" }
+        return "{${fields.joinToString(",")}}"
+    }
+
+    private fun buildIdeLspEntriesJson(entries: List<IdeLspEntryInfo>): String =
+        entries.joinToString(prefix = "[", postfix = "]") { entry ->
+            val fields = mutableListOf(
+                "\"filePath\":${escape(entry.filePath)}",
+                "\"startLine\":${entry.startLine}",
+                "\"endLine\":${entry.endLine}",
+            )
+            entry.name?.let { fields += "\"name\":${escape(it)}" }
+            entry.kind?.let { fields += "\"kind\":${escape(it)}" }
+            entry.preview?.let { fields += "\"preview\":${escape(it)}" }
+            "{${fields.joinToString(",")}}"
+        }
 
     /**
      * Parse an SSE chat event into a [ChatEventDto].

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/ideintel/KiloPsiCodeIntel.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/ideintel/KiloPsiCodeIntel.kt
@@ -1,0 +1,176 @@
+package ai.kilocode.backend.ideintel
+
+import ai.kilocode.backend.cli.IdeLspEntryInfo
+import ai.kilocode.backend.cli.IdeLspRequestInfo
+import ai.kilocode.backend.cli.IdeLspResultInfo
+import ai.kilocode.log.KiloLog
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.DefinitionsScopedSearch
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.PsiTreeUtil
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+
+object KiloPsiCodeIntel {
+    private val LOG = KiloLog.create(KiloPsiCodeIntel::class.java)
+
+    suspend fun handle(directory: String, request: IdeLspRequestInfo): IdeLspResultInfo {
+        val base = path(directory) ?: throw CodeIntelFailure("invalid_path", "Invalid workspace path")
+        val file = path(request.filePath) ?: throw CodeIntelFailure("invalid_path", "Invalid file path")
+        if (!file.startsWith(base)) throw CodeIntelFailure("invalid_path", "File is outside the workspace")
+        val project = project(file) ?: project(base) ?: throw CodeIntelFailure("not_found", "No IntelliJ project is available")
+        if (DumbService.getInstance(project).isDumb) return IdeLspResultInfo(request.operation, indexing = true)
+        return try {
+            readAction { execute(project, base, file, request) }
+        } catch (e: IndexNotReadyException) {
+            IdeLspResultInfo(request.operation, indexing = true)
+        } catch (e: LinkageError) {
+            LOG.warn("IDE code intelligence API unavailable for ${request.operation}", e)
+            IdeLspResultInfo(request.operation)
+        }
+    }
+
+    private fun execute(project: Project, base: Path, file: Path, request: IdeLspRequestInfo): IdeLspResultInfo =
+        when (request.operation) {
+            "goToDefinition" -> IdeLspResultInfo(request.operation, entries = definition(project, file, request))
+            "findReferences" -> IdeLspResultInfo(request.operation, entries = references(project, file, request))
+            "goToImplementation" -> IdeLspResultInfo(request.operation, entries = implementations(project, file, request))
+            "workspaceSymbol" -> IdeLspResultInfo(request.operation, entries = workspaceSymbols(project, base, request.query.orEmpty()))
+            "documentSymbol" -> IdeLspResultInfo(request.operation, entries = documentSymbols(project, file))
+            "typeHierarchy" -> hierarchy(project, file, request)
+            else -> throw CodeIntelFailure("unsupported", "Unsupported IDE code intelligence operation: ${request.operation}")
+        }
+
+    private fun definition(project: Project, file: Path, request: IdeLspRequestInfo): List<IdeLspEntryInfo> {
+        val element = element(project, file, request) ?: return emptyList()
+        val resolved = referenceTarget(element) ?: named(element) ?: return emptyList()
+        return listOfNotNull(entry(resolved))
+    }
+
+    private fun references(project: Project, file: Path, request: IdeLspRequestInfo): List<IdeLspEntryInfo> {
+        val element = element(project, file, request) ?: return emptyList()
+        val target = referenceTarget(element) ?: named(element) ?: return emptyList()
+        val scope = GlobalSearchScope.projectScope(project)
+        return ReferencesSearch.search(target, scope).findAll().asSequence()
+            .mapNotNull { entry(it.element) }
+            .distinctBy { listOf(it.filePath, it.startLine, it.endLine, it.name, it.kind) }
+            .take(500)
+            .toList()
+    }
+
+    private fun implementations(project: Project, file: Path, request: IdeLspRequestInfo): List<IdeLspEntryInfo> {
+        val element = element(project, file, request) ?: return emptyList()
+        val target = referenceTarget(element) ?: named(element) ?: element
+        val scope = GlobalSearchScope.projectScope(project)
+        return DefinitionsScopedSearch.search(target, scope, false).findAll().asSequence()
+            .mapNotNull { entry(it) }
+            .distinctBy { listOf(it.filePath, it.startLine, it.endLine, it.name, it.kind) }
+            .take(500)
+            .toList()
+    }
+
+    private fun workspaceSymbols(project: Project, base: Path, query: String): List<IdeLspEntryInfo> {
+        val text = query.trim()
+        if (text.isBlank()) return emptyList()
+        val index = ProjectFileIndex.getInstance(project)
+        val result = mutableListOf<IdeLspEntryInfo>()
+        index.iterateContent { file ->
+            if (result.size >= 500) return@iterateContent false
+            if (file.isDirectory || path(file.path)?.startsWith(base) != true) return@iterateContent true
+            val psi = PsiManager.getInstance(project).findFile(file) ?: return@iterateContent true
+            PsiTreeUtil.findChildrenOfType(psi, PsiNamedElement::class.java)
+                .asSequence()
+                .filter { it.name?.contains(text, ignoreCase = true) == true }
+                .mapNotNull { entry(it) }
+                .forEach { entry ->
+                    if (result.size < 500) result.add(entry)
+                }
+            result.size < 500
+        }
+        return result.distinctBy { listOf(it.filePath, it.startLine, it.endLine, it.name, it.kind) }
+    }
+
+    private fun documentSymbols(project: Project, file: Path): List<IdeLspEntryInfo> {
+        val psi = psi(project, file) ?: return emptyList()
+        return PsiTreeUtil.findChildrenOfType(psi, PsiNamedElement::class.java).asSequence()
+            .mapNotNull { entry(it) }
+            .distinctBy { listOf(it.filePath, it.startLine, it.endLine, it.name, it.kind) }
+            .take(500)
+            .toList()
+    }
+
+    private fun hierarchy(project: Project, file: Path, request: IdeLspRequestInfo): IdeLspResultInfo {
+        val element = element(project, file, request) ?: return IdeLspResultInfo(request.operation, supertypes = emptyList(), subtypes = emptyList())
+        return IdeLspResultInfo(request.operation, entries = listOfNotNull(entry(element)), supertypes = emptyList(), subtypes = emptyList())
+    }
+
+    private fun element(project: Project, file: Path, request: IdeLspRequestInfo): PsiElement? {
+        val psi = psi(project, file) ?: return null
+        val vf = psi.virtualFile ?: return null
+        val doc = FileDocumentManager.getInstance().getDocument(vf) ?: return null
+        val line = ((request.line ?: 1) - 1).coerceIn(0, (doc.lineCount - 1).coerceAtLeast(0))
+        val start = doc.getLineStartOffset(line)
+        val end = doc.getLineEndOffset(line)
+        val column = ((request.character ?: 1) - 1).coerceAtLeast(0)
+        val offset = (start + column).coerceIn(start, end)
+        return psi.findElementAt(offset) ?: psi.findElementAt((offset - 1).coerceAtLeast(0))
+    }
+
+    private fun psi(project: Project, file: Path) =
+        LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString())
+            ?.let { PsiManager.getInstance(project).findFile(it) }
+
+    private fun referenceTarget(element: PsiElement): PsiElement? {
+        val chain = generateSequence(element) { it.parent }.take(8)
+        return chain.firstNotNullOfOrNull { item -> item.reference?.resolve() }
+    }
+
+    private fun named(element: PsiElement): PsiNamedElement? =
+        element as? PsiNamedElement ?: PsiTreeUtil.getParentOfType(element, PsiNamedElement::class.java, false)
+
+    private fun entry(element: PsiElement): IdeLspEntryInfo? {
+        val item = element.navigationElement ?: element
+        val file = item.containingFile?.virtualFile ?: return null
+        val doc = FileDocumentManager.getInstance().getDocument(file) ?: return null
+        val range = item.textRange ?: return null
+        val start = doc.getLineNumber(range.startOffset.coerceIn(0, doc.textLength)) + 1
+        val offset = range.endOffset.coerceIn(range.startOffset, doc.textLength)
+        val end = doc.getLineNumber(offset) + 1
+        val text = item.text?.lineSequence()?.take(5)?.joinToString("\n")?.take(2_000)
+        return IdeLspEntryInfo(
+            name = (item as? PsiNamedElement)?.name,
+            kind = item::class.java.simpleName,
+            filePath = file.path,
+            startLine = start,
+            endLine = end,
+            preview = text,
+        )
+    }
+
+    private fun project(path: Path): Project? {
+        val projects = ProjectManager.getInstance().openProjects.filter { !it.isDefault }
+        return projects.sortedByDescending { it.basePath?.length ?: 0 }.firstOrNull { item ->
+            val base = item.basePath?.let(::path) ?: return@firstOrNull false
+            path.startsWith(base)
+        } ?: projects.firstOrNull()
+    }
+
+    private fun path(value: String): Path? = try {
+        Path.of(value).normalize()
+    } catch (_: InvalidPathException) {
+        null
+    }
+}
+
+class CodeIntelFailure(val code: String, override val message: String) : RuntimeException(message)

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/ideintel/KiloPsiCodeIntel.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/ideintel/KiloPsiCodeIntel.kt
@@ -29,20 +29,40 @@ object KiloPsiCodeIntel {
         val base = path(directory) ?: throw CodeIntelFailure("invalid_path", "Invalid workspace path")
         val file = path(request.filePath) ?: throw CodeIntelFailure("invalid_path", "Invalid file path")
         if (!file.startsWith(base)) throw CodeIntelFailure("invalid_path", "File is outside the workspace")
-        val project = project(file) ?: project(base) ?: throw CodeIntelFailure("not_found", "No IntelliJ project is available")
-        if (DumbService.getInstance(project).isDumb) return IdeLspResultInfo(request.operation, indexing = true)
+        val project = project(file) ?: project(base)
+            ?: return unavailable(request.operation, "no IntelliJ project is open for this workspace")
+        if (DumbService.getInstance(project).isDumb) return indexing(request.operation)
         return try {
             readAction { execute(project, base, file, request) }
         } catch (e: IndexNotReadyException) {
-            IdeLspResultInfo(request.operation, indexing = true)
+            indexing(request.operation)
         } catch (e: LinkageError) {
             LOG.warn("IDE code intelligence API unavailable for ${request.operation}", e)
-            IdeLspResultInfo(request.operation)
+            unavailable(request.operation, "code intelligence is not supported for this file's language")
         }
     }
 
-    private fun execute(project: Project, base: Path, file: Path, request: IdeLspRequestInfo): IdeLspResultInfo =
-        when (request.operation) {
+    private fun indexing(op: String) = IdeLspResultInfo(op, status = "indexing")
+
+    private fun unavailable(op: String, reason: String) = IdeLspResultInfo(op, status = "unavailable", reason = reason)
+
+    /** True for operations that resolve a specific file position; workspaceSymbol searches globally. */
+    private fun needsFile(op: String) = op != "workspaceSymbol"
+
+    private fun execute(project: Project, base: Path, file: Path, request: IdeLspRequestInfo): IdeLspResultInfo {
+        // Guard against false negatives: when the file is not part of the imported project model (e.g. the
+        // project is only opened as a directory tree and has not been imported), PSI resolve/search return
+        // empty results that must not be reported as authoritative "no results".
+        if (needsFile(request.operation)) {
+            val vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString())
+                ?: return unavailable(request.operation, "the file is not available in the IDE")
+            if (!ProjectFileIndex.getInstance(project).isInProject(vf))
+                return unavailable(
+                    request.operation,
+                    "the file is not part of the imported project model; the project may not be imported yet",
+                )
+        }
+        return when (request.operation) {
             "goToDefinition" -> IdeLspResultInfo(request.operation, entries = definition(project, file, request))
             "findReferences" -> IdeLspResultInfo(request.operation, entries = references(project, file, request))
             "goToImplementation" -> IdeLspResultInfo(request.operation, entries = implementations(project, file, request))
@@ -51,6 +71,7 @@ object KiloPsiCodeIntel {
             "typeHierarchy" -> hierarchy(project, file, request)
             else -> throw CodeIntelFailure("unsupported", "Unsupported IDE code intelligence operation: ${request.operation}")
         }
+    }
 
     private fun definition(project: Project, file: Path, request: IdeLspRequestInfo): List<IdeLspEntryInfo> {
         val element = element(project, file, request) ?: return emptyList()

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
@@ -117,6 +117,24 @@ class KiloCliDataParserTest {
             )
         }
 
+        @Test
+        fun `ide lsp reply builders - omit status when ready and emit status with reason otherwise`() {
+            assertEquals(
+                """{"result":{"operation":"goToDefinition","entries":[]}}""",
+                KiloCliDataParser.buildIdeLspReplyJson(IdeLspResultInfo(operation = "goToDefinition")),
+            )
+            assertEquals(
+                """{"result":{"operation":"goToDefinition","entries":[],"status":"indexing"}}""",
+                KiloCliDataParser.buildIdeLspReplyJson(IdeLspResultInfo(operation = "goToDefinition", status = "indexing")),
+            )
+            assertEquals(
+                """{"result":{"operation":"findReferences","entries":[],"status":"unavailable","reason":"project not imported"}}""",
+                KiloCliDataParser.buildIdeLspReplyJson(
+                    IdeLspResultInfo(operation = "findReferences", status = "unavailable", reason = "project not imported"),
+                ),
+            )
+        }
+
         // ---- parseChatEvent — GlobalEvent wrapper ----
 
         @Test

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDataParserTest.kt
@@ -70,6 +70,53 @@ class KiloCliDataParserTest {
             assertEquals("unknown", KiloCliDataParser.extractEventType(""))
         }
 
+        @Test
+        fun `ide lsp event helpers - parse directory and cancel id`() {
+            val data = """{
+                "directory": "/repo",
+                "payload": {
+                    "type": "kilocode.ideLsp.cancelled",
+                    "properties": { "requestID": "ilr_1", "reason": "cancelled" }
+                }
+            }"""
+
+            assertEquals("/repo", KiloCliDataParser.extractDirectory(data))
+            assertEquals("ilr_1", KiloCliDataParser.parseIdeLspRequestId(data))
+        }
+
+        @Test
+        fun `ide lsp requests - parse list response`() {
+            val result = KiloCliDataParser.parseIdeLspRequests(
+                """[{"id":"ilr_1","sessionID":"ses_1","operation":"goToDefinition","filePath":"/repo/A.kt","line":4,"character":2}]"""
+            )
+
+            assertEquals(1, result.size)
+            assertEquals("ilr_1", result[0].id)
+            assertEquals("goToDefinition", result[0].operation)
+            assertEquals("/repo/A.kt", result[0].filePath)
+            assertEquals(4, result[0].line)
+            assertEquals(2, result[0].character)
+        }
+
+        @Test
+        fun `ide lsp reply builders - emit CLI payload shapes`() {
+            val result = IdeLspResultInfo(
+                operation = "typeHierarchy",
+                entries = listOf(IdeLspEntryInfo(name = "A", kind = "PsiClass", filePath = "/repo/A.kt", startLine = 1, endLine = 3)),
+                supertypes = emptyList(),
+                subtypes = emptyList(),
+            )
+
+            assertEquals(
+                """{"result":{"operation":"typeHierarchy","entries":[{"filePath":"/repo/A.kt","startLine":1,"endLine":3,"name":"A","kind":"PsiClass"}],"supertypes":[],"subtypes":[]}}""",
+                KiloCliDataParser.buildIdeLspReplyJson(result),
+            )
+            assertEquals(
+                """{"error":{"code":"invalid_path","message":"outside workspace"}}""",
+                KiloCliDataParser.buildIdeLspRejectJson("invalid_path", "outside workspace"),
+            )
+        }
+
         // ---- parseChatEvent — GlobalEvent wrapper ----
 
         @Test

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -404,6 +404,9 @@ export const Info = Schema.Struct({
       native_notebook_tools: Schema.optional(Schema.Boolean).annotate({
         description: "Enable native tools for reading, editing, and executing VS Code notebooks",
       }),
+      ide_code_intelligence: Schema.optional(Schema.Boolean).annotate({
+        description: "Enable IntelliJ PSI-backed code-intelligence tool (JetBrains only)",
+      }),
       speech_to_text_model: Schema.optional(Schema.String).annotate({
         description: "Speech-to-text transcription model ID to use for voice input",
       }),

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -60,6 +60,7 @@ import { DataMigration } from "@/data-migration"
 import { BackgroundJob } from "@/background/job"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { IdeLsp } from "@/kilocode/ide-lsp/service" // kilocode_change
 import { Notebook } from "@/kilocode/notebook/service" // kilocode_change
 
 const CoreLayer = Layer.mergeAll(
@@ -87,6 +88,7 @@ const CoreLayer = Layer.mergeAll(
 
 const SessionLayer = Layer.mergeAll(
   Question.defaultLayer,
+  IdeLsp.defaultLayer, // kilocode_change
   Notebook.defaultLayer, // kilocode_change
   Permission.defaultLayer,
   Todo.defaultLayer,

--- a/packages/opencode/src/kilocode/ide-lsp/protocol.ts
+++ b/packages/opencode/src/kilocode/ide-lsp/protocol.ts
@@ -1,0 +1,78 @@
+import { BusEvent } from "@/bus/bus-event"
+import { SessionID } from "@/session/schema"
+import { NonNegativeInt } from "@opencode-ai/core/schema"
+import { Schema } from "effect"
+
+export const RequestID = Schema.String.pipe(Schema.brand("IdeLspRequestID")).annotate({
+  identifier: "IdeLspRequestID",
+})
+export type RequestID = Schema.Schema.Type<typeof RequestID>
+
+export const Operation = Schema.Literals([
+  "goToDefinition",
+  "findReferences",
+  "goToImplementation",
+  "workspaceSymbol",
+  "documentSymbol",
+  "typeHierarchy",
+])
+export type Operation = Schema.Schema.Type<typeof Operation>
+
+export const Request = Schema.Struct({
+  id: RequestID,
+  sessionID: SessionID,
+  operation: Operation,
+  filePath: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(4096)),
+  line: Schema.optional(NonNegativeInt),
+  character: Schema.optional(NonNegativeInt),
+  query: Schema.optional(Schema.String.check(Schema.isMaxLength(1000))),
+}).annotate({ identifier: "IdeLspRequest" })
+export type Request = Schema.Schema.Type<typeof Request>
+
+export const Entry = Schema.Struct({
+  name: Schema.optional(Schema.String.check(Schema.isMaxLength(500))),
+  kind: Schema.optional(Schema.String.check(Schema.isMaxLength(100))),
+  filePath: Schema.String,
+  startLine: NonNegativeInt,
+  endLine: NonNegativeInt,
+  preview: Schema.optional(Schema.String.check(Schema.isMaxLength(2000))),
+}).annotate({ identifier: "IdeLspEntry" })
+export type Entry = Schema.Schema.Type<typeof Entry>
+
+export const Result = Schema.Struct({
+  operation: Operation,
+  indexing: Schema.optional(Schema.Boolean),
+  entries: Schema.Array(Entry).check(Schema.isMaxLength(500)),
+  supertypes: Schema.optional(Schema.Array(Entry).check(Schema.isMaxLength(500))),
+  subtypes: Schema.optional(Schema.Array(Entry).check(Schema.isMaxLength(500))),
+}).annotate({ identifier: "IdeLspResult" })
+export type Result = Schema.Schema.Type<typeof Result>
+
+export const ErrorCode = Schema.Literals([
+  "cancelled",
+  "disconnected",
+  "timeout",
+  "indexing",
+  "invalid_path",
+  "not_found",
+  "unsupported",
+])
+export type ErrorCode = Schema.Schema.Type<typeof ErrorCode>
+
+export const Failure = Schema.Struct({
+  code: ErrorCode,
+  message: Schema.String.check(Schema.isMinLength(1), Schema.isMaxLength(10_000)),
+}).annotate({ identifier: "IdeLspFailure" })
+export type Failure = Schema.Schema.Type<typeof Failure>
+
+export const Event = {
+  Requested: BusEvent.define("kilocode.ideLsp.requested", Request),
+  Cancelled: BusEvent.define(
+    "kilocode.ideLsp.cancelled",
+    Schema.Struct({
+      requestID: RequestID,
+      sessionID: SessionID,
+      reason: Schema.Literals(["cancelled", "disposed", "timeout"]),
+    }),
+  ),
+}

--- a/packages/opencode/src/kilocode/ide-lsp/protocol.ts
+++ b/packages/opencode/src/kilocode/ide-lsp/protocol.ts
@@ -39,9 +39,13 @@ export const Entry = Schema.Struct({
 }).annotate({ identifier: "IdeLspEntry" })
 export type Entry = Schema.Schema.Type<typeof Entry>
 
+export const Status = Schema.Literals(["ready", "indexing", "unavailable"])
+export type Status = Schema.Schema.Type<typeof Status>
+
 export const Result = Schema.Struct({
   operation: Operation,
-  indexing: Schema.optional(Schema.Boolean),
+  status: Schema.optional(Status),
+  reason: Schema.optional(Schema.String.check(Schema.isMaxLength(500))),
   entries: Schema.Array(Entry).check(Schema.isMaxLength(500)),
   supertypes: Schema.optional(Schema.Array(Entry).check(Schema.isMaxLength(500))),
   subtypes: Schema.optional(Schema.Array(Entry).check(Schema.isMaxLength(500))),

--- a/packages/opencode/src/kilocode/ide-lsp/service.ts
+++ b/packages/opencode/src/kilocode/ide-lsp/service.ts
@@ -1,0 +1,149 @@
+import { Bus } from "@/bus"
+import { InstanceState } from "@/effect/instance-state"
+import { Identifier } from "@/id/id"
+import { Deferred, Duration, Effect, Layer, Schema, Context } from "effect"
+import * as Log from "@opencode-ai/core/util/log"
+import { ErrorCode, Event, type Failure, type Request, RequestID, type Result } from "./protocol"
+
+const log = Log.create({ service: "ide-lsp-host" })
+type WithoutID<T> = T extends unknown ? Omit<T, "id"> : never
+export type Input = WithoutID<Request>
+
+export class HostError extends Schema.TaggedErrorClass<HostError>()("IdeLspHostError", {
+  code: ErrorCode,
+  detail: Schema.String,
+}) {
+  override get message() {
+    return this.detail
+  }
+}
+
+export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("IdeLsp.NotFoundError", {
+  requestID: RequestID,
+}) {}
+
+export class InvalidReplyError extends Schema.TaggedErrorClass<InvalidReplyError>()("IdeLsp.InvalidReplyError", {
+  requestID: RequestID,
+}) {}
+
+interface Entry {
+  info: Request
+  deferred: Deferred.Deferred<Result, HostError>
+}
+interface State {
+  pending: Map<RequestID, Entry>
+}
+
+function matches(request: Request, result: Result) {
+  return request.operation === result.operation
+}
+
+export interface Interface {
+  readonly request: (input: Input) => Effect.Effect<Result, HostError>
+  readonly list: () => Effect.Effect<ReadonlyArray<Request>>
+  readonly reply: (input: {
+    requestID: RequestID
+    result: Result
+  }) => Effect.Effect<void, NotFoundError | InvalidReplyError>
+  readonly reject: (input: { requestID: RequestID; error: Failure }) => Effect.Effect<void, NotFoundError>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@kilocode/IdeLsp") {}
+
+export function layer(timeout: Duration.Input = "2 minutes") {
+  return Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const state = yield* InstanceState.make<State>(
+        Effect.fn("IdeLsp.state")(function* () {
+          const state = { pending: new Map<RequestID, Entry>() }
+          yield* Effect.addFinalizer(() =>
+            Effect.gen(function* () {
+              for (const entry of state.pending.values()) {
+                yield* bus.publish(Event.Cancelled, {
+                  requestID: entry.info.id,
+                  sessionID: entry.info.sessionID,
+                  reason: "disposed",
+                })
+                yield* Deferred.fail(
+                  entry.deferred,
+                  new HostError({ code: "disconnected", detail: "The IDE code intelligence host disconnected" }),
+                )
+              }
+              state.pending.clear()
+            }),
+          )
+          return state
+        }),
+      )
+
+      const cancel = Effect.fn("IdeLsp.cancel")(function* (id: RequestID, reason: "cancelled" | "timeout") {
+        const pending = (yield* InstanceState.get(state)).pending
+        const entry = pending.get(id)
+        if (!entry) return
+        pending.delete(id)
+        yield* bus.publish(Event.Cancelled, { requestID: id, sessionID: entry.info.sessionID, reason })
+        yield* Deferred.fail(
+          entry.deferred,
+          new HostError({
+            code: reason,
+            detail:
+              reason === "timeout"
+                ? "The IDE code intelligence host request timed out"
+                : "The IDE code intelligence host request was cancelled",
+          }),
+        )
+      })
+
+      const request: Interface["request"] = Effect.fn("IdeLsp.request")(function* (input) {
+        const pending = (yield* InstanceState.get(state)).pending
+        const id = RequestID.make(Identifier.create("ilr", "ascending"))
+        const deferred = yield* Deferred.make<Result, HostError>()
+        const info = { ...input, id } as Request
+        pending.set(id, { info, deferred })
+        return yield* Effect.gen(function* () {
+          yield* bus.publish(Event.Requested, info)
+          return yield* Deferred.await(deferred).pipe(
+            Effect.timeoutOrElse({
+              duration: timeout,
+              orElse: () => cancel(id, "timeout").pipe(Effect.andThen(Deferred.await(deferred))),
+            }),
+          )
+        }).pipe(Effect.ensuring(cancel(id, "cancelled")))
+      })
+
+      const list: Interface["list"] = Effect.fn("IdeLsp.list")(function* () {
+        return Array.from((yield* InstanceState.get(state)).pending.values(), (entry) => entry.info)
+      })
+
+      const reply: Interface["reply"] = Effect.fn("IdeLsp.reply")(function* (input) {
+        const pending = (yield* InstanceState.get(state)).pending
+        const entry = pending.get(input.requestID)
+        if (!entry) {
+          log.warn("reply for unknown request", { requestID: input.requestID })
+          return yield* new NotFoundError({ requestID: input.requestID })
+        }
+        if (!matches(entry.info, input.result)) return yield* new InvalidReplyError({ requestID: input.requestID })
+        pending.delete(input.requestID)
+        yield* Deferred.succeed(entry.deferred, input.result)
+      })
+
+      const reject: Interface["reject"] = Effect.fn("IdeLsp.reject")(function* (input) {
+        const pending = (yield* InstanceState.get(state)).pending
+        const entry = pending.get(input.requestID)
+        if (!entry) {
+          log.warn("rejection for unknown request", { requestID: input.requestID })
+          return yield* new NotFoundError({ requestID: input.requestID })
+        }
+        pending.delete(input.requestID)
+        yield* Deferred.fail(entry.deferred, new HostError({ code: input.error.code, detail: input.error.message }))
+      })
+
+      return Service.of({ request, list, reply, reject })
+    }),
+  )
+}
+
+export const defaultLayer = layer().pipe(Layer.provide(Bus.layer))
+export * as IdeLsp from "./service"

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -16,6 +16,12 @@ import {
   RequestID as NotebookRequestID,
   Result as NotebookResult,
 } from "@/kilocode/notebook/protocol"
+import {
+  Failure as IdeLspFailure,
+  Request as IdeLspRequest,
+  RequestID as IdeLspRequestID,
+  Result as IdeLspResult,
+} from "@/kilocode/ide-lsp/protocol"
 import { ModelUsage } from "@/kilocode/session/model-usage"
 import { SessionID } from "@/session/schema"
 
@@ -35,6 +41,8 @@ export const AgentRequirementQuery = Schema.Struct({
 })
 export const NotebookReplyPayload = Schema.Struct({ result: NotebookResult })
 export const NotebookRejectPayload = Schema.Struct({ error: NotebookFailure })
+export const IdeLspReplyPayload = Schema.Struct({ result: IdeLspResult })
+export const IdeLspRejectPayload = Schema.Struct({ error: IdeLspFailure })
 
 export const KilocodePaths = {
   heapSnapshot: `${root}/heap/snapshot`,
@@ -44,6 +52,9 @@ export const KilocodePaths = {
   notebookList: `${root}/notebook`,
   notebookReply: `${root}/notebook/:requestID/reply`,
   notebookReject: `${root}/notebook/:requestID/reject`,
+  ideLspList: `${root}/ide-lsp`,
+  ideLspReply: `${root}/ide-lsp/:requestID/reply`,
+  ideLspReject: `${root}/ide-lsp/:requestID/reject`,
   sessionModelUsage: `/session/:sessionID/model-usage`,
 } as const
 
@@ -105,6 +116,42 @@ export const KilocodeApi = HttpApi.make("kilocode")
             identifier: "kilocode.notebook.list",
             summary: "List pending notebook requests",
             description: "List pending native notebook requests for the routed workspace.",
+          }),
+        ),
+        HttpApiEndpoint.get("ideLspList", KilocodePaths.ideLspList, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(IdeLspRequest), "Pending IDE code intelligence requests"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.ideLsp.list",
+            summary: "List pending IDE code intelligence requests",
+            description: "List pending IDE code intelligence requests for the routed workspace.",
+          }),
+        ),
+        HttpApiEndpoint.post("ideLspReply", KilocodePaths.ideLspReply, {
+          params: { requestID: IdeLspRequestID },
+          query: WorkspaceRoutingQuery,
+          payload: IdeLspReplyPayload,
+          success: described(Schema.Boolean, "IDE code intelligence reply accepted"),
+          error: [HttpApiError.BadRequest, HttpApiError.NotFound],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.ideLsp.reply",
+            summary: "Reply to an IDE code intelligence request",
+            description: "Complete a pending IDE code intelligence request with a structured result.",
+          }),
+        ),
+        HttpApiEndpoint.post("ideLspReject", KilocodePaths.ideLspReject, {
+          params: { requestID: IdeLspRequestID },
+          query: WorkspaceRoutingQuery,
+          payload: IdeLspRejectPayload,
+          success: described(Schema.Boolean, "IDE code intelligence rejection accepted"),
+          error: HttpApiError.NotFound,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.ideLsp.reject",
+            summary: "Reject an IDE code intelligence request",
+            description: "Complete a pending IDE code intelligence request with a structured host error.",
           }),
         ),
         HttpApiEndpoint.post("notebookReply", KilocodePaths.notebookReply, {

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -6,6 +6,8 @@ import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
 import { HeapSnapshot } from "@/kilocode/cli/heap-snapshot"
+import type { RequestID as IdeLspRequestID } from "@/kilocode/ide-lsp/protocol"
+import { IdeLsp } from "@/kilocode/ide-lsp/service"
 import type { RequestID as NotebookRequestID } from "@/kilocode/notebook/protocol"
 import { Notebook } from "@/kilocode/notebook/service"
 import { ModelUsage } from "@/kilocode/session/model-usage"
@@ -13,7 +15,14 @@ import { InstanceStore } from "@/project/instance-store"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Skill } from "@/skill"
 import type { SessionID } from "@/session/schema"
-import { NotebookRejectPayload, NotebookReplyPayload, RemoveAgentPayload, RemoveSkillPayload } from "../groups/kilocode"
+import {
+  IdeLspRejectPayload,
+  IdeLspReplyPayload,
+  NotebookRejectPayload,
+  NotebookReplyPayload,
+  RemoveAgentPayload,
+  RemoveSkillPayload,
+} from "../groups/kilocode"
 
 export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode", (handlers) =>
   Effect.gen(function* () {
@@ -21,6 +30,7 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
     const skills = yield* Skill.Service
     const config = yield* Config.Service
     const store = yield* InstanceStore.Service
+    const ide = yield* IdeLsp.Service
     const notebook = yield* Notebook.Service
 
     const heapSnapshot = Effect.fn("KilocodeHttpApi.heapSnapshot")(function* () {
@@ -69,6 +79,31 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       return yield* notebook.list()
     })
 
+    const ideLspList = Effect.fn("KilocodeHttpApi.ideLspList")(function* () {
+      return yield* ide.list()
+    })
+
+    const ideLspReply = Effect.fn("KilocodeHttpApi.ideLspReply")(function* (ctx: {
+      params: { requestID: IdeLspRequestID }
+      payload: typeof IdeLspReplyPayload.Type
+    }) {
+      yield* ide.reply({ requestID: ctx.params.requestID, result: ctx.payload.result }).pipe(
+        Effect.catchTag("IdeLsp.NotFoundError", () => Effect.fail(new HttpApiError.NotFound({}))),
+        Effect.catchTag("IdeLsp.InvalidReplyError", () => Effect.fail(new HttpApiError.BadRequest({}))),
+      )
+      return true
+    })
+
+    const ideLspReject = Effect.fn("KilocodeHttpApi.ideLspReject")(function* (ctx: {
+      params: { requestID: IdeLspRequestID }
+      payload: typeof IdeLspRejectPayload.Type
+    }) {
+      yield* ide
+        .reject({ requestID: ctx.params.requestID, error: ctx.payload.error })
+        .pipe(Effect.catchTag("IdeLsp.NotFoundError", () => Effect.fail(new HttpApiError.NotFound({}))))
+      return true
+    })
+
     const notebookReply = Effect.fn("KilocodeHttpApi.notebookReply")(function* (ctx: {
       params: { requestID: NotebookRequestID }
       payload: typeof NotebookReplyPayload.Type
@@ -104,6 +139,9 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       .handle("removeSkill", removeSkill)
       .handle("removeAgent", removeAgent)
       .handle("notebookList", notebookList)
+      .handle("ideLspList", ideLspList)
+      .handle("ideLspReply", ideLspReply)
+      .handle("ideLspReject", ideLspReject)
       .handle("notebookReply", notebookReply)
       .handle("notebookReject", notebookReject)
       .handle("sessionModelUsage", sessionModelUsage)

--- a/packages/opencode/src/kilocode/tool/ide-lsp.ts
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.ts
@@ -1,0 +1,100 @@
+import { InstanceState } from "@/effect/instance-state"
+import { IdeLsp, HostError } from "@/kilocode/ide-lsp/service"
+import { Operation, type Entry, type Result } from "@/kilocode/ide-lsp/protocol"
+import * as Tool from "@/tool/tool"
+import { Effect, Schema } from "effect"
+import path from "path"
+import DESCRIPTION from "./ide-lsp.txt"
+
+const Line = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1))
+const Params = Schema.Struct({
+  operation: Operation.annotate({ description: "The code-intelligence operation" }),
+  filePath: Schema.String.annotate({ description: "Absolute or workspace-relative file path" }),
+  line: Schema.optional(Line).annotate({ description: "1-based line (not needed for workspaceSymbol)" }),
+  character: Schema.optional(Line).annotate({ description: "1-based column (not needed for workspaceSymbol)" }),
+  query: Schema.optional(Schema.String).annotate({ description: "Symbol query for workspaceSymbol" }),
+})
+
+function abort(signal: AbortSignal) {
+  return Effect.callback<never, HostError>((resume) => {
+    const err = () => new HostError({ code: "cancelled", detail: "The IDE code intelligence tool call was cancelled" })
+    if (signal.aborted) return resume(Effect.fail(err()))
+    const handler = () => resume(Effect.fail(err()))
+    signal.addEventListener("abort", handler, { once: true })
+    return Effect.sync(() => signal.removeEventListener("abort", handler))
+  })
+}
+
+function run(effect: Effect.Effect<Result, HostError>, signal: AbortSignal) {
+  return effect.pipe(Effect.raceFirst(abort(signal)), Effect.orDie)
+}
+
+function label(entry: Entry) {
+  return [entry.kind, entry.name].filter(Boolean).join(" ")
+}
+
+function format(entry: Entry, index?: number) {
+  const prefix = index === undefined ? "-" : `${index}.`
+  const title = label(entry)
+  const head = `${prefix} ${entry.filePath}:${entry.startLine}-${entry.endLine}${title ? `  ${title}` : ""}`
+  return entry.preview ? `${head}\n${entry.preview}` : head
+}
+
+function section(title: string, entries: readonly Entry[]) {
+  if (entries.length === 0) return `${title}: no results`
+  return [`${title}:`, ...entries.map((entry, index) => format(entry, index + 1))].join("\n")
+}
+
+function render(result: Result) {
+  if (result.indexing) return "The IDE is still indexing. Retry shortly or fall back to grep/glob/read for text search."
+  if (result.operation === "typeHierarchy") {
+    return [
+      section("Supertypes", result.supertypes ?? []),
+      section("Subtypes", result.subtypes ?? []),
+      result.entries.length ? section("Element", result.entries) : undefined,
+    ]
+      .filter(Boolean)
+      .join("\n\n")
+  }
+  if (result.entries.length === 0) return `No results found for ${result.operation}`
+  return result.entries.map((entry, index) => format(entry, index + 1)).join("\n")
+}
+
+export const IdeCodeIntelTool = Tool.define<
+  typeof Params,
+  { operation: string },
+  IdeLsp.Service,
+  "ide_code_intel"
+>(
+  "ide_code_intel",
+  Effect.gen(function* () {
+    const ide = yield* IdeLsp.Service
+    return {
+      description: DESCRIPTION,
+      parameters: Params,
+      execute: (params, ctx) =>
+        Effect.gen(function* () {
+          const dir = yield* InstanceState.directory
+          const file = path.isAbsolute(params.filePath) ? params.filePath : path.join(dir, params.filePath)
+          const result = yield* run(
+            ide.request({
+              operation: params.operation,
+              sessionID: ctx.sessionID,
+              filePath: file,
+              line: params.line,
+              character: params.character,
+              query: params.query,
+            }),
+            ctx.abort,
+          )
+          if (result.operation !== params.operation)
+            return yield* Effect.die(new Error("IDE code intelligence host returned the wrong result type"))
+          return {
+            title: `ide_code_intel: ${params.operation}`,
+            output: render(result),
+            metadata: { operation: params.operation },
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/kilocode/tool/ide-lsp.ts
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.ts
@@ -46,7 +46,10 @@ function section(title: string, entries: readonly Entry[]) {
 }
 
 function render(result: Result) {
-  if (result.indexing) return "The IDE is still indexing. Retry shortly or fall back to grep/glob/read for text search."
+  if (result.status === "indexing")
+    return "IntelliJ is still indexing, so code intelligence is not ready. Do NOT treat this as a definitive result: retry shortly, or use grep/glob/read (and the lsp tool if available) for text-based search instead."
+  if (result.status === "unavailable")
+    return `IntelliJ code intelligence is unavailable${result.reason ? ` (${result.reason})` : ""}. Do NOT treat an empty result as authoritative: fall back to grep/glob/read (and the lsp tool if available) for this workspace.`
   if (result.operation === "typeHierarchy") {
     return [
       section("Supertypes", result.supertypes ?? []),
@@ -62,7 +65,7 @@ function render(result: Result) {
 
 export const IntellijReadTool = Tool.define<
   typeof Params,
-  { operation: string },
+  { operation: string; status: string },
   IdeLsp.Service,
   "intellij_read"
 >(
@@ -92,7 +95,7 @@ export const IntellijReadTool = Tool.define<
           return {
             title: `intellij_read: ${params.operation}`,
             output: render(result),
-            metadata: { operation: params.operation },
+            metadata: { operation: params.operation, status: result.status ?? "ready" },
           }
         }),
     }

--- a/packages/opencode/src/kilocode/tool/ide-lsp.ts
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.ts
@@ -60,13 +60,13 @@ function render(result: Result) {
   return result.entries.map((entry, index) => format(entry, index + 1)).join("\n")
 }
 
-export const IdeCodeIntelTool = Tool.define<
+export const IntellijReadTool = Tool.define<
   typeof Params,
   { operation: string },
   IdeLsp.Service,
-  "ide_code_intel"
+  "intellij_read"
 >(
-  "ide_code_intel",
+  "intellij_read",
   Effect.gen(function* () {
     const ide = yield* IdeLsp.Service
     return {
@@ -90,7 +90,7 @@ export const IdeCodeIntelTool = Tool.define<
           if (result.operation !== params.operation)
             return yield* Effect.die(new Error("IDE code intelligence host returned the wrong result type"))
           return {
-            title: `ide_code_intel: ${params.operation}`,
+            title: `intellij_read: ${params.operation}`,
             output: render(result),
             metadata: { operation: params.operation },
           }

--- a/packages/opencode/src/kilocode/tool/ide-lsp.txt
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.txt
@@ -12,4 +12,4 @@ Supported operations:
 
 Positions are 1-based line and character numbers, matching what users see in editors. filePath may be absolute or relative to the workspace.
 
-If the result says the IDE is indexing, retry shortly if the task depends on typed symbol data, or fall back to grep/glob/read for text-based investigation.
+If the result says IntelliJ is indexing or that code intelligence is unavailable (for example the project has not been imported yet and only its directory tree is loaded), do NOT treat an empty or missing result as authoritative. Retry shortly if the task depends on typed symbol data, or fall back to grep/glob/read (and the lsp tool if available) for text-based investigation.

--- a/packages/opencode/src/kilocode/tool/ide-lsp.txt
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.txt
@@ -1,4 +1,4 @@
-IDE-backed code intelligence tool for structural navigation when running in the JetBrains plugin.
+IntelliJ-backed read-only code intelligence tool for structural navigation when running in the JetBrains plugin.
 
 Use this tool for precise symbol and type-aware operations powered by the already-indexed IntelliJ PSI model. It is best for JVM and other JetBrains-supported languages when you need accurate definitions, references, implementations, symbols, or direct class/type hierarchy.
 

--- a/packages/opencode/src/kilocode/tool/ide-lsp.txt
+++ b/packages/opencode/src/kilocode/tool/ide-lsp.txt
@@ -1,0 +1,15 @@
+IDE-backed code intelligence tool for structural navigation when running in the JetBrains plugin.
+
+Use this tool for precise symbol and type-aware operations powered by the already-indexed IntelliJ PSI model. It is best for JVM and other JetBrains-supported languages when you need accurate definitions, references, implementations, symbols, or direct class/type hierarchy.
+
+Supported operations:
+- goToDefinition: find where the symbol at filePath:line:character is defined.
+- findReferences: find references to the symbol at filePath:line:character.
+- goToImplementation: find implementations of the symbol at filePath:line:character.
+- workspaceSymbol: search indexed workspace symbols by query. line and character are not required.
+- documentSymbol: list symbols in filePath. line and character are not required.
+- typeHierarchy: find direct supertypes and subtypes for the type at filePath:line:character.
+
+Positions are 1-based line and character numbers, matching what users see in editors. filePath may be absolute or relative to the workspace.
+
+If the result says the IDE is indexing, retry shortly if the task depends on typed symbol data, or fall back to grep/glob/read for text-based investigation.

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -5,6 +5,7 @@ import { AgentManagerModelsTool } from "./agent-manager-models"
 import { AgentManagerTool } from "./agent-manager"
 import { BackgroundProcessTool } from "./background-process"
 import { GenerateImageTool } from "./generate-image"
+import { IdeCodeIntelTool } from "./ide-lsp"
 import { InteractiveTerminalTool } from "./interactive-terminal"
 import { NotebookEditTool, NotebookExecuteTool, NotebookReadTool } from "./notebook-host"
 import { MemoryRecallTool } from "./memory-recall"
@@ -13,6 +14,7 @@ import * as Tool from "../../tool/tool"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Effect } from "effect"
 import { Notebook } from "@/kilocode/notebook/service"
+import { IdeLsp } from "@/kilocode/ide-lsp/service"
 import * as Log from "@opencode-ai/core/util/log"
 import type { Config } from "@/config/config"
 import { Agent } from "@/agent/agent"
@@ -52,7 +54,7 @@ export namespace KiloToolRegistry {
 
   /** Resolve Kilo-specific tool Infos outside any InstanceState, so their Truncate/Agent deps are
    * satisfied at the outer registry scope instead of leaking into InstanceState's Effect. */
-  export function infos(notebook?: Notebook.Interface) {
+  export function infos(notebook?: Notebook.Interface, ideLsp?: IdeLsp.Interface) {
     return Effect.gen(function* () {
       const codebase = yield* CodebaseSearchTool
       const recall = yield* RecallTool
@@ -63,13 +65,17 @@ export namespace KiloToolRegistry {
       const process = yield* BackgroundProcessTool
       const image = yield* GenerateImageTool
       const terminal = yield* InteractiveTerminalTool
-      if (!notebook) return { codebase, recall, managerModels, memory, save, manager, process, image, terminal }
-      const tools = yield* Effect.all({
-        notebookRead: NotebookReadTool,
-        notebookEdit: NotebookEditTool,
-        notebookExecute: NotebookExecuteTool,
-      }).pipe(Effect.provideService(Notebook.Service, notebook))
-      return { codebase, recall, managerModels, memory, save, manager, process, image, terminal, ...tools }
+      const notebooks = notebook
+        ? yield* Effect.all({
+            notebookRead: NotebookReadTool,
+            notebookEdit: NotebookEditTool,
+            notebookExecute: NotebookExecuteTool,
+          }).pipe(Effect.provideService(Notebook.Service, notebook))
+        : {}
+      const ide = ideLsp
+        ? yield* Effect.all({ ideCodeIntel: IdeCodeIntelTool }).pipe(Effect.provideService(IdeLsp.Service, ideLsp))
+        : {}
+      return { codebase, recall, managerModels, memory, save, manager, process, image, terminal, ...notebooks, ...ide }
     })
   }
 
@@ -89,6 +95,7 @@ export namespace KiloToolRegistry {
       notebookRead?: Tool.Info
       notebookEdit?: Tool.Info
       notebookExecute?: Tool.Info
+      ideCodeIntel?: Tool.Info
     },
     deps: Deps,
     loaders: Loaders = {},
@@ -113,8 +120,9 @@ export namespace KiloToolRegistry {
               notebookExecute: Tool.init(tools.notebookExecute),
             })
           : {}
+      const ide = tools.ideCodeIntel ? { ideCodeIntel: yield* Tool.init(tools.ideCodeIntel) } : {}
       const semantic = yield* semanticTool(deps, loaders)
-      return { ...base, terminal, ...notebooks, semantic }
+      return { ...base, terminal, ...notebooks, ...ide, semantic }
     })
   }
 
@@ -177,8 +185,16 @@ export namespace KiloToolRegistry {
       notebookRead?: Tool.Def
       notebookEdit?: Tool.Def
       notebookExecute?: Tool.Def
+      ideCodeIntel?: Tool.Def
     },
-    cfg: { experimental?: { codebase_search?: boolean; image_generation?: boolean; native_notebook_tools?: boolean } },
+    cfg: {
+      experimental?: {
+        codebase_search?: boolean
+        image_generation?: boolean
+        native_notebook_tools?: boolean
+        ide_code_intelligence?: boolean
+      }
+    },
   ): Tool.Def[] {
     return [
       ...(cfg.experimental?.codebase_search === true ? [tools.codebase] : []),
@@ -197,6 +213,11 @@ export namespace KiloToolRegistry {
       tools.notebookEdit &&
       tools.notebookExecute
         ? [tools.notebookRead, tools.notebookEdit, tools.notebookExecute]
+        : []),
+      ...(Flag.KILO_CLIENT === "jetbrains" &&
+      cfg.experimental?.ide_code_intelligence === true &&
+      tools.ideCodeIntel
+        ? [tools.ideCodeIntel]
         : []),
     ]
   }
@@ -249,11 +270,14 @@ export namespace KiloToolRegistry {
     })
   })
 
-  export function describe(tools: Tool.Def[], extra: { semantic?: Tool.Def }): Tool.Def[] {
-    if (!extra.semantic) return tools
+  export function describe(tools: Tool.Def[], extra: { semantic?: Tool.Def; ideCodeIntel?: Tool.Def }): Tool.Def[] {
+    if (!extra.semantic && !extra.ideCodeIntel) return tools
     return tools.map((tool) => {
       if (tool.id !== "glob" && tool.id !== "grep") return tool
-      return { ...tool, description: `${tool.description}\n${hint}` }
+      const intel = extra.ideCodeIntel
+        ? "- When you need precise symbol navigation, references, implementations, document/workspace symbols, or class/type hierarchy in JetBrains, use the `ide_code_intel` tool"
+        : undefined
+      return { ...tool, description: [tool.description, extra.semantic ? hint : undefined, intel].filter(Boolean).join("\n") }
     })
   }
 }

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -5,7 +5,7 @@ import { AgentManagerModelsTool } from "./agent-manager-models"
 import { AgentManagerTool } from "./agent-manager"
 import { BackgroundProcessTool } from "./background-process"
 import { GenerateImageTool } from "./generate-image"
-import { IdeCodeIntelTool } from "./ide-lsp"
+import { IntellijReadTool } from "./ide-lsp"
 import { InteractiveTerminalTool } from "./interactive-terminal"
 import { NotebookEditTool, NotebookExecuteTool, NotebookReadTool } from "./notebook-host"
 import { MemoryRecallTool } from "./memory-recall"
@@ -73,7 +73,7 @@ export namespace KiloToolRegistry {
           }).pipe(Effect.provideService(Notebook.Service, notebook))
         : {}
       const ide = ideLsp
-        ? yield* Effect.all({ ideCodeIntel: IdeCodeIntelTool }).pipe(Effect.provideService(IdeLsp.Service, ideLsp))
+        ? yield* Effect.all({ intellijRead: IntellijReadTool }).pipe(Effect.provideService(IdeLsp.Service, ideLsp))
         : {}
       return { codebase, recall, managerModels, memory, save, manager, process, image, terminal, ...notebooks, ...ide }
     })
@@ -95,7 +95,7 @@ export namespace KiloToolRegistry {
       notebookRead?: Tool.Info
       notebookEdit?: Tool.Info
       notebookExecute?: Tool.Info
-      ideCodeIntel?: Tool.Info
+      intellijRead?: Tool.Info
     },
     deps: Deps,
     loaders: Loaders = {},
@@ -120,7 +120,7 @@ export namespace KiloToolRegistry {
               notebookExecute: Tool.init(tools.notebookExecute),
             })
           : {}
-      const ide = tools.ideCodeIntel ? { ideCodeIntel: yield* Tool.init(tools.ideCodeIntel) } : {}
+      const ide = tools.intellijRead ? { intellijRead: yield* Tool.init(tools.intellijRead) } : {}
       const semantic = yield* semanticTool(deps, loaders)
       return { ...base, terminal, ...notebooks, ...ide, semantic }
     })
@@ -185,7 +185,7 @@ export namespace KiloToolRegistry {
       notebookRead?: Tool.Def
       notebookEdit?: Tool.Def
       notebookExecute?: Tool.Def
-      ideCodeIntel?: Tool.Def
+      intellijRead?: Tool.Def
     },
     cfg: {
       experimental?: {
@@ -216,8 +216,8 @@ export namespace KiloToolRegistry {
         : []),
       ...(Flag.KILO_CLIENT === "jetbrains" &&
       cfg.experimental?.ide_code_intelligence === true &&
-      tools.ideCodeIntel
-        ? [tools.ideCodeIntel]
+      tools.intellijRead
+        ? [tools.intellijRead]
         : []),
     ]
   }
@@ -270,12 +270,12 @@ export namespace KiloToolRegistry {
     })
   })
 
-  export function describe(tools: Tool.Def[], extra: { semantic?: Tool.Def; ideCodeIntel?: Tool.Def }): Tool.Def[] {
-    if (!extra.semantic && !extra.ideCodeIntel) return tools
+  export function describe(tools: Tool.Def[], extra: { semantic?: Tool.Def; intellijRead?: Tool.Def }): Tool.Def[] {
+    if (!extra.semantic && !extra.intellijRead) return tools
     return tools.map((tool) => {
       if (tool.id !== "glob" && tool.id !== "grep") return tool
-      const intel = extra.ideCodeIntel
-        ? "- When you need precise symbol navigation, references, implementations, document/workspace symbols, or class/type hierarchy in JetBrains, use the `ide_code_intel` tool"
+      const intel = extra.intellijRead
+        ? "- When you need precise symbol navigation, references, implementations, document/workspace symbols, or class/type hierarchy in JetBrains, use the `intellij_read` tool"
         : undefined
       return { ...tool, description: [tool.description, extra.semantic ? hint : undefined, intel].filter(Boolean).join("\n") }
     })

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -37,6 +37,7 @@ import { Provider } from "@/provider/provider"
 import { Pty } from "@/pty"
 import { PtyTicket } from "@/pty/ticket"
 import { Question } from "@/question"
+import { IdeLsp } from "@/kilocode/ide-lsp/service" // kilocode_change
 import { Notebook } from "@/kilocode/notebook/service" // kilocode_change
 import { Session } from "@/session/session"
 import { SessionCompaction } from "@/session/compaction"
@@ -228,6 +229,7 @@ export function createRoutes(
       Pty.defaultLayer,
       PtyTicket.defaultLayer,
       Question.defaultLayer,
+      IdeLsp.defaultLayer, // kilocode_change
       Notebook.defaultLayer, // kilocode_change
       Ripgrep.defaultLayer,
       RuntimeFlags.defaultLayer,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,6 +27,7 @@ import { Provider } from "@/provider/provider"
 import { ProviderID, type ModelID } from "../provider/schema"
 import { WebSearchTool } from "./websearch"
 import { KiloToolRegistry } from "../kilocode/tool/registry" // kilocode_change
+import { IdeLsp } from "@/kilocode/ide-lsp/service" // kilocode_change
 import { Notebook } from "@/kilocode/notebook/service" // kilocode_change
 import { RepoCloneTool } from "./repo_clone"
 import { RepoOverviewTool } from "./repo_overview"
@@ -162,7 +163,8 @@ export const layer: Layer.Layer<
     // kilocode_change start
     const suggesttool = yield* SuggestTool
     const notebook = Option.getOrUndefined(yield* Effect.serviceOption(Notebook.Service))
-    const kiloToolInfos = yield* KiloToolRegistry.infos(notebook).pipe(Effect.provide(MemoryService.layer))
+    const ideLsp = Option.getOrUndefined(yield* Effect.serviceOption(IdeLsp.Service))
+    const kiloToolInfos = yield* KiloToolRegistry.infos(notebook, ideLsp).pipe(Effect.provide(MemoryService.layer))
     // kilocode_change end
 
     const state = yield* InstanceState.make<State>(
@@ -460,6 +462,7 @@ export const defaultLayer = Layer.suspend(
       // kilocode_change start - provide Kilo-owned registry dependencies
       .pipe(
         Layer.provide(Command.defaultLayer),
+        Layer.provide(IdeLsp.defaultLayer),
         Layer.provide(Notebook.defaultLayer),
         Layer.provide(RuntimeFlags.defaultLayer),
         Layer.provide(SessionStatus.defaultLayer),

--- a/packages/opencode/test/kilocode/ide-lsp/service.test.ts
+++ b/packages/opencode/test/kilocode/ide-lsp/service.test.ts
@@ -1,0 +1,151 @@
+import { expect } from "bun:test"
+import { Bus } from "@/bus"
+import { GlobalBus, type GlobalEvent } from "@/bus/global"
+import { disposeInstance } from "@/effect/instance-registry"
+import { Event, Request } from "@/kilocode/ide-lsp/protocol"
+import { HostError, IdeLsp } from "@/kilocode/ide-lsp/service"
+import { SessionID } from "@/session/schema"
+import { Effect, Fiber, Layer, Queue } from "effect"
+import { TestInstance } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+const it = testEffect(IdeLsp.layer("20 millis").pipe(Layer.provideMerge(Bus.layer)))
+const sessionID = SessionID.make("ses_ide_lsp_test")
+
+function request(ide: IdeLsp.Interface) {
+  return ide.request({
+    operation: "goToDefinition",
+    sessionID,
+    filePath: "/workspace/src/main.kt",
+    line: 10,
+    character: 5,
+  })
+}
+
+it.instance(
+  "publishes, lists, and completes a correlated request",
+  () =>
+    Effect.gen(function* () {
+      const ide = yield* IdeLsp.Service
+      const bus = yield* Bus.Service
+      const instance = yield* TestInstance
+      const events = yield* Queue.unbounded<{ properties: Request }>()
+      const global = yield* Queue.unbounded<GlobalEvent>()
+      const off = yield* bus.subscribeCallback(Event.Requested, (event) => Queue.offerUnsafe(events, event))
+      const handler = (event: GlobalEvent) => {
+        if (event.payload?.type === Event.Requested.type) Queue.offerUnsafe(global, event)
+      }
+      GlobalBus.on("event", handler)
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          off()
+          GlobalBus.off("event", handler)
+        }),
+      )
+
+      const fiber = yield* request(ide).pipe(Effect.forkChild)
+      const event = yield* Queue.take(events).pipe(Effect.timeout("2 seconds"))
+      expect(event.properties.sessionID).toBe(sessionID)
+      expect(event.properties.operation).toBe("goToDefinition")
+      expect(event.properties.filePath).toBe("/workspace/src/main.kt")
+      expect((yield* Queue.take(global).pipe(Effect.timeout("2 seconds"))).directory).toBe(instance.directory)
+      expect(yield* ide.list()).toEqual([event.properties])
+
+      yield* ide.reply({
+        requestID: event.properties.id,
+        result: {
+          operation: "goToDefinition",
+          entries: [{ filePath: "/workspace/src/main.kt", startLine: 1, endLine: 3, name: "Main", kind: "class" }],
+        },
+      })
+      expect(yield* Fiber.join(fiber)).toEqual({
+        operation: "goToDefinition",
+        entries: [{ filePath: "/workspace/src/main.kt", startLine: 1, endLine: 3, name: "Main", kind: "class" }],
+      })
+      expect(yield* ide.list()).toEqual([])
+
+      const late = yield* ide
+        .reply({
+          requestID: event.properties.id,
+          result: { operation: "goToDefinition", entries: [] },
+        })
+        .pipe(Effect.flip)
+      expect(late._tag).toBe("IdeLsp.NotFoundError")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "propagates structured host rejection and removes pending state",
+  () =>
+    Effect.gen(function* () {
+      const ide = yield* IdeLsp.Service
+      const fiber = yield* request(ide).pipe(Effect.forkChild)
+      const pending = yield* ide.list().pipe(Effect.repeat({ until: (items) => items.length === 1 }))
+      yield* ide.reject({
+        requestID: pending[0].id,
+        error: { code: "indexing", message: "IDE indexes are not ready" },
+      })
+      const err = yield* Fiber.join(fiber).pipe(Effect.flip)
+      expect(err).toBeInstanceOf(HostError)
+      expect(err.code).toBe("indexing")
+      expect(err.message).toContain("indexes")
+      expect(yield* ide.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "cancels interrupted requests and rejects mismatched replies",
+  () =>
+    Effect.gen(function* () {
+      const ide = yield* IdeLsp.Service
+      const bus = yield* Bus.Service
+      const cancelled = yield* Queue.unbounded<string>()
+      const off = yield* bus.subscribeCallback(Event.Cancelled, (event) =>
+        Queue.offerUnsafe(cancelled, event.properties.reason),
+      )
+      yield* Effect.addFinalizer(() => Effect.sync(off))
+
+      const fiber = yield* request(ide).pipe(Effect.forkChild)
+      const pending = yield* ide.list().pipe(Effect.repeat({ until: (items) => items.length === 1 }))
+      const mismatch = yield* ide
+        .reply({
+          requestID: pending[0].id,
+          result: { operation: "findReferences", entries: [] },
+        })
+        .pipe(Effect.flip)
+      expect(mismatch._tag).toBe("IdeLsp.InvalidReplyError")
+      yield* Fiber.interrupt(fiber)
+      expect(yield* Queue.take(cancelled).pipe(Effect.timeout("2 seconds"))).toBe("cancelled")
+      expect(yield* ide.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "times out pending requests",
+  () =>
+    Effect.gen(function* () {
+      const ide = yield* IdeLsp.Service
+      const err = yield* request(ide).pipe(Effect.flip)
+      expect(err.code).toBe("timeout")
+      expect(yield* ide.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "fails pending requests when the instance is disposed",
+  () =>
+    Effect.gen(function* () {
+      const ide = yield* IdeLsp.Service
+      const instance = yield* TestInstance
+      const fiber = yield* request(ide).pipe(Effect.forkChild)
+      yield* ide.list().pipe(Effect.repeat({ until: (items) => items.length === 1 }))
+      yield* Effect.promise(() => disposeInstance(instance.directory))
+      const err = yield* Fiber.join(fiber).pipe(Effect.flip)
+      expect(err.code).toBe("disconnected")
+    }),
+  { git: true },
+)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -126,6 +126,9 @@ import type {
   GlobalHealthResponses,
   GlobalUpgradeErrors,
   GlobalUpgradeResponses,
+  IdeLspFailure,
+  IdeLspRequestId,
+  IdeLspResult,
   IndexingModelsErrors,
   IndexingModelsResponses,
   IndexingStatusErrors,
@@ -166,6 +169,12 @@ import type {
   KilocodeAgentRequirementsResponses,
   KilocodeHeapSnapshotErrors,
   KilocodeHeapSnapshotResponses,
+  KilocodeIdeLspListErrors,
+  KilocodeIdeLspListResponses,
+  KilocodeIdeLspRejectErrors,
+  KilocodeIdeLspRejectResponses,
+  KilocodeIdeLspReplyErrors,
+  KilocodeIdeLspReplyResponses,
   KilocodeNotebookListErrors,
   KilocodeNotebookListResponses,
   KilocodeNotebookRejectErrors,
@@ -7451,6 +7460,122 @@ export class Notebook extends HeyApiClient {
   }
 }
 
+export class IdeLsp extends HeyApiClient {
+  /**
+   * List pending IDE code intelligence requests
+   *
+   * List pending IDE code intelligence requests for the routed workspace.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<KilocodeIdeLspListResponses, KilocodeIdeLspListErrors, ThrowOnError>({
+      url: "/kilocode/ide-lsp",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reply to an IDE code intelligence request
+   *
+   * Complete a pending IDE code intelligence request with a structured result.
+   */
+  public reply<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: IdeLspRequestId
+      directory?: string
+      workspace?: string
+      result?: IdeLspResult
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "result" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<KilocodeIdeLspReplyResponses, KilocodeIdeLspReplyErrors, ThrowOnError>(
+      {
+        url: "/kilocode/ide-lsp/{requestID}/reply",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
+  }
+
+  /**
+   * Reject an IDE code intelligence request
+   *
+   * Complete a pending IDE code intelligence request with a structured host error.
+   */
+  public reject<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: IdeLspRequestId
+      directory?: string
+      workspace?: string
+      error?: IdeLspFailure
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "error" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeIdeLspRejectResponses,
+      KilocodeIdeLspRejectErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/ide-lsp/{requestID}/reject",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class SessionImport extends HeyApiClient {
   /**
    * Insert project for session import
@@ -7994,6 +8119,11 @@ export class Kilocode extends HeyApiClient {
   private _notebook?: Notebook
   get notebook(): Notebook {
     return (this._notebook ??= new Notebook({ client: this.client }))
+  }
+
+  private _ideLsp?: IdeLsp
+  get ideLsp(): IdeLsp {
+    return (this._ideLsp ??= new IdeLsp({ client: this.client }))
   }
 
   private _sessionImport?: SessionImport

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -14,6 +14,8 @@ export type Event =
   | EventTuiSessionSelect
   | EventSandboxStatusChanged
   | EventKilocodeAgentManagerStart
+  | EventKilocodeIdeLspRequested
+  | EventKilocodeIdeLspCancelled
   | EventKilocodeNotebookRequested
   | EventKilocodeNotebookCancelled
   | EventIndexingStatus
@@ -198,6 +200,24 @@ export type EventTuiSessionSelect = {
      */
     sessionID: string
   }
+}
+
+export type IdeLspRequestId = string
+
+export type IdeLspRequest = {
+  id: IdeLspRequestId
+  sessionID: string
+  operation:
+    | "goToDefinition"
+    | "findReferences"
+    | "goToImplementation"
+    | "workspaceSymbol"
+    | "documentSymbol"
+    | "typeHierarchy"
+  filePath: string
+  line?: number
+  character?: number
+  query?: string
 }
 
 export type NotebookRequestId = string
@@ -1047,6 +1067,8 @@ export type GlobalEvent = {
     | EventTuiSessionSelect
     | EventSandboxStatusChanged
     | EventKilocodeAgentManagerStart
+    | EventKilocodeIdeLspRequested
+    | EventKilocodeIdeLspCancelled
     | EventKilocodeNotebookRequested
     | EventKilocodeNotebookCancelled
     | EventIndexingStatus
@@ -1706,6 +1728,7 @@ export type Config = {
     image_generation_model?: string
     agent_requirements?: boolean
     native_notebook_tools?: boolean
+    ide_code_intelligence?: boolean
     speech_to_text_model?: string
     openTelemetry?: boolean
     primary_tools?: Array<string>
@@ -2648,6 +2671,34 @@ export type AgentRequirementResult = {
   }
 }
 
+export type IdeLspEntry = {
+  name?: string
+  kind?: string
+  filePath: string
+  startLine: number
+  endLine: number
+  preview?: string
+}
+
+export type IdeLspResult = {
+  operation:
+    | "goToDefinition"
+    | "findReferences"
+    | "goToImplementation"
+    | "workspaceSymbol"
+    | "documentSymbol"
+    | "typeHierarchy"
+  indexing?: boolean
+  entries: Array<IdeLspEntry>
+  supertypes?: Array<IdeLspEntry>
+  subtypes?: Array<IdeLspEntry>
+}
+
+export type IdeLspFailure = {
+  code: "cancelled" | "disconnected" | "timeout" | "indexing" | "invalid_path" | "not_found" | "unsupported"
+  message: string
+}
+
 export type NotebookOutput = {
   mime: string
   text?: string
@@ -3444,6 +3495,22 @@ export type EventKilocodeAgentManagerStart = {
       }
       variant?: string
     }>
+  }
+}
+
+export type EventKilocodeIdeLspRequested = {
+  id: string
+  type: "kilocode.ideLsp.requested"
+  properties: IdeLspRequest
+}
+
+export type EventKilocodeIdeLspCancelled = {
+  id: string
+  type: "kilocode.ideLsp.cancelled"
+  properties: {
+    requestID: IdeLspRequestId
+    sessionID: string
+    reason: "cancelled" | "disposed" | "timeout"
   }
 }
 
@@ -11567,6 +11634,106 @@ export type KilocodeNotebookListResponses = {
 }
 
 export type KilocodeNotebookListResponse = KilocodeNotebookListResponses[keyof KilocodeNotebookListResponses]
+
+export type KilocodeIdeLspListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/ide-lsp"
+}
+
+export type KilocodeIdeLspListErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type KilocodeIdeLspListError = KilocodeIdeLspListErrors[keyof KilocodeIdeLspListErrors]
+
+export type KilocodeIdeLspListResponses = {
+  /**
+   * Pending IDE code intelligence requests
+   */
+  200: Array<IdeLspRequest>
+}
+
+export type KilocodeIdeLspListResponse = KilocodeIdeLspListResponses[keyof KilocodeIdeLspListResponses]
+
+export type KilocodeIdeLspReplyData = {
+  body?: {
+    result: IdeLspResult
+  }
+  path: {
+    requestID: IdeLspRequestId
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/ide-lsp/{requestID}/reply"
+}
+
+export type KilocodeIdeLspReplyErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KilocodeIdeLspReplyError = KilocodeIdeLspReplyErrors[keyof KilocodeIdeLspReplyErrors]
+
+export type KilocodeIdeLspReplyResponses = {
+  /**
+   * IDE code intelligence reply accepted
+   */
+  200: boolean
+}
+
+export type KilocodeIdeLspReplyResponse = KilocodeIdeLspReplyResponses[keyof KilocodeIdeLspReplyResponses]
+
+export type KilocodeIdeLspRejectData = {
+  body?: {
+    error: IdeLspFailure
+  }
+  path: {
+    requestID: IdeLspRequestId
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/ide-lsp/{requestID}/reject"
+}
+
+export type KilocodeIdeLspRejectErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KilocodeIdeLspRejectError = KilocodeIdeLspRejectErrors[keyof KilocodeIdeLspRejectErrors]
+
+export type KilocodeIdeLspRejectResponses = {
+  /**
+   * IDE code intelligence rejection accepted
+   */
+  200: boolean
+}
+
+export type KilocodeIdeLspRejectResponse = KilocodeIdeLspRejectResponses[keyof KilocodeIdeLspRejectResponses]
 
 export type KilocodeNotebookReplyData = {
   body?: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2688,7 +2688,8 @@ export type IdeLspResult = {
     | "workspaceSymbol"
     | "documentSymbol"
     | "typeHierarchy"
-  indexing?: boolean
+  status?: "ready" | "indexing" | "unavailable"
+  reason?: string
   entries: Array<IdeLspEntry>
   supertypes?: Array<IdeLspEntry>
   subtypes?: Array<IdeLspEntry>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14387,16 +14387,6 @@
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/effect_HttpApiError_Unauthorized"
-                }
-              }
-            }
           }
         },
         "description": "List image-capable models from the Kilo Gateway OpenRouter passthrough",
@@ -14404,7 +14394,7 @@
         "x-codeSamples": [
           {
             "lang": "js",
-            "source": "import { createKiloClient } from \"@kilocode/sdk\n\nconst client = createKiloClient()\nawait client.kilo.models.images({\n  ...\n})"
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilo.models.images({\n  ...\n})"
           }
         ]
       }
@@ -15565,6 +15555,249 @@
           {
             "lang": "js",
             "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.notebook.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/ide-lsp": {
+      "get": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.ideLsp.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pending IDE code intelligence requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IdeLspRequest"
+                  },
+                  "description": "Pending IDE code intelligence requests"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "List pending IDE code intelligence requests for the routed workspace.",
+        "summary": "List pending IDE code intelligence requests",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.ideLsp.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/ide-lsp/{requestID}/reply": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.ideLsp.reply",
+        "parameters": [
+          {
+            "name": "requestID",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/IdeLspRequestID"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "IDE code intelligence reply accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "IDE code intelligence reply accepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Complete a pending IDE code intelligence request with a structured result.",
+        "summary": "Reply to an IDE code intelligence request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "result": {
+                    "$ref": "#/components/schemas/IdeLspResult"
+                  }
+                },
+                "required": ["result"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.ideLsp.reply({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/ide-lsp/{requestID}/reject": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.ideLsp.reject",
+        "parameters": [
+          {
+            "name": "requestID",
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/IdeLspRequestID"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "IDE code intelligence rejection accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "IDE code intelligence rejection accepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Complete a pending IDE code intelligence request with a structured host error.",
+        "summary": "Reject an IDE code intelligence request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "error": {
+                    "$ref": "#/components/schemas/IdeLspFailure"
+                  }
+                },
+                "required": ["error"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.ideLsp.reject({\n  ...\n})"
           }
         ]
       }
@@ -20213,6 +20446,12 @@
             "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
           },
           {
+            "$ref": "#/components/schemas/EventKilocodeIdeLspRequested"
+          },
+          {
+            "$ref": "#/components/schemas/EventKilocodeIdeLspCancelled"
+          },
+          {
             "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
           },
           {
@@ -20814,6 +21053,51 @@
           }
         },
         "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "IdeLspRequestID": {
+        "type": "string"
+      },
+      "IdeLspRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/IdeLspRequestID"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "goToDefinition",
+              "findReferences",
+              "goToImplementation",
+              "workspaceSymbol",
+              "documentSymbol",
+              "typeHierarchy"
+            ]
+          },
+          "filePath": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "character": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "query": {
+            "type": "string",
+            "maxLength": 1000
+          }
+        },
+        "required": ["id", "sessionID", "operation", "filePath"],
         "additionalProperties": false
       },
       "NotebookRequestID": {
@@ -23396,6 +23680,12 @@
                 "$ref": "#/components/schemas/EventKilocodeAgent_managerStart"
               },
               {
+                "$ref": "#/components/schemas/EventKilocodeIdeLspRequested"
+              },
+              {
+                "$ref": "#/components/schemas/EventKilocodeIdeLspCancelled"
+              },
+              {
                 "$ref": "#/components/schemas/EventKilocodeNotebookRequested"
               },
               {
@@ -25272,6 +25562,9 @@
                 "type": "boolean"
               },
               "native_notebook_tools": {
+                "type": "boolean"
+              },
+              "ide_code_intelligence": {
                 "type": "boolean"
               },
               "speech_to_text_model": {
@@ -28189,6 +28482,94 @@
         "required": ["agent", "directory", "enabled", "state", "skills", "mcps", "vscode_extensions"],
         "additionalProperties": false
       },
+      "IdeLspEntry": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 500
+          },
+          "kind": {
+            "type": "string",
+            "maxLength": 100
+          },
+          "filePath": {
+            "type": "string"
+          },
+          "startLine": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "endLine": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "preview": {
+            "type": "string",
+            "maxLength": 2000
+          }
+        },
+        "required": ["filePath", "startLine", "endLine"],
+        "additionalProperties": false
+      },
+      "IdeLspResult": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "type": "string",
+            "enum": [
+              "goToDefinition",
+              "findReferences",
+              "goToImplementation",
+              "workspaceSymbol",
+              "documentSymbol",
+              "typeHierarchy"
+            ]
+          },
+          "indexing": {
+            "type": "boolean"
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IdeLspEntry"
+            },
+            "maxItems": 500
+          },
+          "supertypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IdeLspEntry"
+            },
+            "maxItems": 500
+          },
+          "subtypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IdeLspEntry"
+            },
+            "maxItems": 500
+          }
+        },
+        "required": ["operation", "entries"],
+        "additionalProperties": false
+      },
+      "IdeLspFailure": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": ["cancelled", "disconnected", "timeout", "indexing", "invalid_path", "not_found", "unsupported"]
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000
+          }
+        },
+        "required": ["code", "message"],
+        "additionalProperties": false
+      },
       "NotebookOutput": {
         "type": "object",
         "properties": {
@@ -30849,6 +31230,55 @@
               }
             },
             "required": ["requestID", "sessionID", "mode", "tasks"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeIdeLspRequested": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.ideLsp.requested"]
+          },
+          "properties": {
+            "$ref": "#/components/schemas/IdeLspRequest"
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventKilocodeIdeLspCancelled": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["kilocode.ideLsp.cancelled"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "$ref": "#/components/schemas/IdeLspRequestID"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "reason": {
+                "type": "string",
+                "enum": ["cancelled", "disposed", "timeout"]
+              }
+            },
+            "required": ["requestID", "sessionID", "reason"],
             "additionalProperties": false
           }
         },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -28526,8 +28526,13 @@
               "typeHierarchy"
             ]
           },
-          "indexing": {
-            "type": "boolean"
+          "status": {
+            "type": "string",
+            "enum": ["ready", "indexing", "unavailable"]
+          },
+          "reason": {
+            "type": "string",
+            "maxLength": 500
           },
           "entries": {
             "type": "array",


### PR DESCRIPTION
## What

Adds an experimental, JetBrains-only `intellij_read` tool that lets the agent use IntelliJ's already-indexed PSI model for precise, type-aware navigation: `goToDefinition`, `findReferences`, `goToImplementation`, `workspaceSymbol`, `documentSymbol`, and `typeHierarchy`.

The tool is gated behind both `KILO_CLIENT === "jetbrains"` and the `experimental.ide_code_intelligence` config flag.

## How it works

The CLI does no analysis itself. `intellij_read` publishes a request on the bus and awaits a reply; the JetBrains backend drains pending requests over HTTP (`/kilocode/ide-lsp`), runs PSI queries inside a read action, and posts a structured reply/reject. This mirrors the existing notebook-host pattern.

## Readiness & fallback (avoiding false negatives)

Code intelligence returns empty when IntelliJ isn't ready, which the agent would otherwise trust as an authoritative "no results". To prevent that, results now carry a `status` (`ready` | `indexing` | `unavailable`) plus a human-readable `reason`:

- **Indexing** — `DumbService.isDumb` / `IndexNotReadyException` report `indexing`.
- **Project not imported** — for file-based operations the backend checks `ProjectFileIndex.isInProject(file)`; if the file isn't part of the imported model, it returns `unavailable` instead of an empty result. This is a language-agnostic signal (no JVM-biased source-root/SDK heuristics).
- **No open project / unsupported language** — also mapped to `unavailable`.

When the status is not `ready`, the tool tells the agent not to trust the empty result and to fall back to `grep`/`glob`/`read` (and the `lsp` tool if enabled).

## Notes for reviewers

- JetBrains runtime uses the CLI release pinned in `packages/kilo-jetbrains/package.json`; these CLI/SDK changes require a newly published/pinned CLI release before the JetBrains plugin picks them up.
- `workspaceSymbol` is intentionally left ungated (it genuinely searches indexed content; gating risked false "unavailable").

## Testing

- CLI: `bun run typecheck`, `bun test ./test/kilocode/ide-lsp/service.test.ts` (5 pass)
- JetBrains: `./gradlew :backend:test --tests KiloCliDataParserTest` (green; backend main sources compile)
- SDK regenerated via `./script/generate.ts`