### PR TITLE
feat: bump session ingest version to v2

### DIFF
--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -208,14 +208,14 @@ export namespace IngestQueue {
           const types = items.map((d) => d.type).join(",")
           options.log.info("ingest flush", {
             sessionId,
-            url: `${client.url}${share.ingestPath}?v=1`,
+            url: `${client.url}${share.ingestPath}?v=2`,
             items: items.length,
             types,
           })
         }
 
         const response = await client
-          .fetch(`${client.url}${share.ingestPath}?v=1`, {
+          .fetch(`${client.url}${share.ingestPath}?v=2`, {
             method: "POST",
             body: JSON.stringify({
               data: items,

--- a/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
@@ -373,7 +373,7 @@ describe("share ingest queue", () => {
     expect((statuses[0]!.data as { status: string }).status).toBe("idle")
   })
 
-  test("flush sends request with ?v=1 query parameter", async () => {
+  test("flush sends request with ?v=2 query parameter", async () => {
     const urls: string[] = []
     const sched = scheduler(() => clock.now)
 
@@ -397,6 +397,6 @@ describe("share ingest queue", () => {
     sched.run()
     await Bun.sleep(0)
     expect(urls.length).toBe(1)
-    expect(urls[0]).toBe("https://ingest.test/ingest?v=1")
+    expect(urls[0]).toBe("https://ingest.test/ingest?v=2")
   })
 })


### PR DESCRIPTION
## Summary

Bump the CLI session-ingest query parameter from `v=1` to `v=2` in both the request URL and its debug log, and update the existing URL assertion.

It does not change retries, transport, batching, payloads, or server routing, but does influence the server-side direct-ingest ramp in https://github.com/Kilo-Org/cloud/pull/4480 