### PR TITLE
fix(jetbrains): stop orphaned CLI on Windows (app-close deadlock + kill-on-close job)

### DIFF
--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
@@ -53,6 +53,8 @@ class KiloBackendCliManager(
     private var process: Process? = null
     @Volatile
     private var closing: Process? = null
+    @Volatile
+    private var job: KiloProcessJob? = null
     private val lock = Any()
     private var closed = false
     private var hook: Thread? = null
@@ -103,14 +105,16 @@ class KiloBackendCliManager(
     }
 
     override fun exited(proc: Process) {
-        val ok = synchronized(lock) {
-            if (process != proc) return@synchronized false
+        val orphan = synchronized(lock) {
+            if (process != proc) return
             process = null
+            val current = job
+            job = null
             uninstall()
             stderr = null
-            true
+            current
         }
-        if (!ok) return
+        orphan?.close()
         log.info("CLI process exited (pid=${proc.pid()}, exitCode=${runCatching { proc.exitValue() }.getOrNull()})")
     }
 
@@ -158,14 +162,19 @@ class KiloBackendCliManager(
                 throw e
             }
             log.info("CLI process started (pid=${proc.pid()})")
+            // Windows-only, best-effort: bind the CLI tree to the IDE via a kill-on-close job so it
+            // can never be orphaned. Null on other platforms / when unavailable — see KiloProcessJob.
+            val jobHandle = KiloProcessJob.assign(proc.pid(), log)
             val reject = synchronized(lock) {
                 if (closed) return@synchronized true
                 process = proc
+                job = jobHandle
                 install(proc)
                 false
             }
             if (reject) {
                 log.info("CLI process started after disposal; killing process tree (pid=${proc.pid()})")
+                jobHandle?.close()
                 cleanup(proc, "disposed startup cleanup")
                 return@withContext CliServer.State.Error("CLI startup cancelled because service is disposed")
             }
@@ -224,20 +233,35 @@ class KiloBackendCliManager(
     }
 
     /**
-     * Fast teardown for IDE app close: send SIGTERM so the CLI can flush state, then return without
-     * waiting. The JVM shutdown hook stays installed and escalates to SIGKILL when the JVM exits, so
-     * we neither block the shutdown thread (often the EDT) nor risk orphaning the tree.
+     * Fast teardown for IDE app close.
+     *
+     * Kill BEFORE touching the CLI's streams. On Windows, closing stderr/stdout while the reader
+     * threads are still blocked in a native read hangs indefinitely — which deadlocked IDE shutdown
+     * and left both the CLI and the IDE process alive (so the job's kill-on-close never fired, and a
+     * manual kill was needed to unblock the next launch). Closing the job triggers kill-on-close so
+     * the OS terminates the tree; [Process.destroy] is the no-job fallback. Both make the pending
+     * reads return EOF, so [close] cannot block. We do not wait, so the shutdown thread (often the
+     * EDT) is never blocked.
      */
     override fun closeForShutdown() {
-        val proc = synchronized(lock) {
+        log.info("App close — closeForShutdown() entered")
+        val state = synchronized(lock) {
             closed = true
-            process
-        } ?: return
+            val proc = process
+            val held = job
+            job = null
+            proc to held
+        }
+        val proc = state.first
+        val orphanJob = state.second
+        if (proc == null) {
+            orphanJob?.close()
+            log.info("App close — no live CLI process to stop (job present=${orphanJob != null})")
+            return
+        }
         closing = proc
-        close(proc)
-        descendants(proc).forEach { it.destroy() }
-        proc.destroy()
-        log.info("App close — SIGTERM sent to CLI tree (pid=${proc.pid()}); shutdown hook will confirm exit")
+        // Ordering is enforced (and regression-tested) in shutdownTree: kill first, close streams last.
+        shutdownTree(proc, jobKill = orphanJob != null, log = log, killJob = { orphanJob?.close() })
     }
 
     private fun take(): Process? = synchronized(lock) {
@@ -246,11 +270,18 @@ class KiloBackendCliManager(
         proc
     }
 
+    private fun clearJob(): KiloProcessJob? = synchronized(lock) {
+        val current = job
+        job = null
+        current
+    }
+
     private fun cleanup(proc: Process, source: String) {
         closing = proc
         try {
             uninstall()
-            close(proc)
+            clearJob()?.close()
+            closeStreams(proc, log)
             kill(proc, source)
             val thread = stderr
             stderr = null
@@ -293,12 +324,6 @@ class KiloBackendCliManager(
     private fun kill(proc: Process, source: String, wait: Boolean = true) {
         log.info("$source — killing CLI process tree (pid ${proc.pid()})")
         killCliProcessTree(proc, log, wait = wait, timeoutSeconds = KILL_TIMEOUT_SECONDS)
-    }
-
-    private fun close(proc: Process) {
-        runCatching { proc.errorStream.close() }.onFailure { log.info("CLI stderr stream close skipped: ${it.message}") }
-        runCatching { proc.inputStream.close() }.onFailure { log.info("CLI stdout stream close skipped: ${it.message}") }
-        runCatching { proc.outputStream.close() }.onFailure { log.info("CLI stdin stream close skipped: ${it.message}") }
     }
 
     private fun generatePassword(): String {
@@ -394,6 +419,35 @@ private fun confirmKilled(proc: Process, kids: List<ProcessHandle>, log: KiloLog
 
 private fun descendants(proc: Process): List<ProcessHandle> =
     proc.toHandle().descendants().toList().asReversed()
+
+/**
+ * App-close teardown, in the order that matters on Windows: terminate the tree FIRST — close the
+ * kill-on-close job ([killJob]), destroy descendants, destroy the parent — and only THEN close the
+ * CLI's streams. Closing a process stream while a reader thread is blocked reading it hangs on
+ * Windows until the process exits, so killing first makes those reads return EOF. Reversing this
+ * order deadlocked IDE shutdown; the order is locked by KiloBackendCliShutdownTest. Never waits, so
+ * the shutdown thread (often the EDT) is not blocked.
+ */
+internal fun shutdownTree(
+    proc: Process,
+    jobKill: Boolean,
+    log: KiloLog,
+    killJob: () -> Unit,
+    descendants: (Process) -> List<ProcessHandle> = ::descendants,
+) {
+    killJob()
+    descendants(proc).forEach { it.destroy() }
+    proc.destroy()
+    log.info("App close — CLI tree kill issued (pid=${proc.pid()}, jobKill=$jobKill); closing streams")
+    closeStreams(proc, log)
+    log.info("App close — CLI teardown complete (pid=${proc.pid()})")
+}
+
+internal fun closeStreams(proc: Process, log: KiloLog) {
+    runCatching { proc.errorStream.close() }.onFailure { log.info("CLI stderr stream close skipped: ${it.message}") }
+    runCatching { proc.inputStream.close() }.onFailure { log.info("CLI stdout stream close skipped: ${it.message}") }
+    runCatching { proc.outputStream.close() }.onFailure { log.info("CLI stdin stream close skipped: ${it.message}") }
+}
 
 internal fun startupDiagnostics(cli: File, env: Map<String, String>, log: KiloLog): String {
     val home = System.getProperty("user.home").orEmpty()

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloProcessJob.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloProcessJob.kt
@@ -1,0 +1,173 @@
+package ai.kilocode.backend.cli
+
+import ai.kilocode.log.KiloLog
+import com.intellij.jna.JnaLoader
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.system.CpuArch
+import com.sun.jna.Memory
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.win32.StdCallLibrary
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Ties the CLI process tree to the IDE process via a Windows Job Object configured with
+ * `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+ *
+ * The job handle is held open inside the IDE process. When the IDE goes away for any reason —
+ * clean exit, `Runtime.halt()` on restart, a crash, or an external force-kill — its handle table
+ * is torn down, the last job handle closes, and Windows terminates every process in the job. This
+ * is OS-enforced and needs no cooperation from the CLI or a JVM shutdown hook, so the CLI can never
+ * be orphaned. That matters on Windows specifically: an orphaned child inherits IDE handles and
+ * wedges the next IDE launch until it is killed by hand.
+ *
+ * Windows-only and strictly best-effort: [assign] returns null on other platforms, when JNA is not
+ * available, or if any native call fails, and callers fall back to their existing process-tree kill.
+ * So this can only ever improve teardown, never regress it.
+ *
+ * We map the three Job Object functions directly against `kernel32` because the JNA build bundled
+ * with the IDE does not expose them. This relies only on the stable core JNA runtime and the
+ * kernel32 ABI, so it is unaffected by JNA version changes across IDE releases.
+ *
+ * JNA is deliberately NOT bundled with the plugin (unlike other third-party deps): it loads a
+ * single native `jnidispatch` library per process, so a second copy would collide with the
+ * platform's. Like `kotlinx.coroutines`, it must come from the IDE's own classloader — here via
+ * `lib/util-8.jar`, which already backs platform APIs such as `WinProcessManager` and `NioFiles`.
+ *
+ * Known limitations:
+ * - Persistent background processes: kill-on-close terminates every CLI descendant, including a
+ *   `background_process` started with `persistent=true`. Letting those outlive the CLI on Windows
+ *   needs a coordinated CLI change (spawn with `CREATE_BREAKAWAY_FROM_JOB` plus a job that sets
+ *   `JOB_OBJECT_LIMIT_BREAKAWAY_OK`) and is out of scope for this plugin-only fix.
+ * - Start-to-assignment race: [assign] runs after `ProcessBuilder.start()`, leaving a sub-millisecond
+ *   window before the process joins the job. Closing it would require creating the process suspended
+ *   (abandoning `ProcessBuilder`); the window is negligible next to the previously-always-orphaned CLI.
+ */
+internal class KiloProcessJob private constructor(
+    private val lib: Kernel32Job,
+    private val handle: Pointer,
+    private val pid: Long,
+    private val log: KiloLog,
+) {
+    private val closed = AtomicBoolean(false)
+
+    /**
+     * Close the job handle. When this is the last open handle, kill-on-close terminates the whole
+     * CLI process tree immediately. Idempotent, and safe to call after the tree has already exited.
+     */
+    fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        log.info("Closing CLI kill-on-close job handle (pid=$pid) — OS terminates the CLI tree")
+        val ok = runCatching { lib.CloseHandle(handle) }
+            .onFailure { log.warn("CloseHandle on CLI job object threw (pid=$pid)", it) }
+            .getOrDefault(false)
+        if (!ok) log.warn("CloseHandle on CLI job object returned false (pid=$pid, err=${Native.getLastError()})")
+    }
+
+    companion object {
+        // kernel32 / winnt.h constants
+        private const val JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+        private const val JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+        private const val PROCESS_TERMINATE = 0x0001
+        private const val PROCESS_SET_QUOTA = 0x0100
+        // sizeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION) and offsetof(BasicLimitInformation.LimitFlags)
+        // on 64-bit Windows. We only ever write LimitFlags, so a raw buffer avoids modelling the
+        // full nested struct and any field-alignment mistakes.
+        private const val EXTENDED_LIMIT_SIZE = 144L
+        private const val LIMIT_FLAGS_OFFSET = 16L
+
+        private val lib: Kernel32Job? by lazy {
+            runCatching { Native.load("kernel32", Kernel32Job::class.java) }
+                .getOrElse { KiloLog.create(KiloProcessJob::class.java).warn("Native.load(kernel32) failed", it); null }
+        }
+
+        /**
+         * Assign the process tree rooted at [pid] to a kill-on-close job. Returns null (and logs the
+         * reason) when not applicable or on any failure, so the caller keeps its existing teardown.
+         */
+        fun assign(pid: Long, log: KiloLog): KiloProcessJob? {
+            if (!SystemInfo.isWindows) return null
+            // Check JnaLoader.isLoaded() BEFORE any com.sun.jna.Native access. isLoaded() initializes
+            // JNA behind its own failure boundary and returns false if jnidispatch is unavailable, so
+            // a linkage error can never escape this best-effort path and orphan the just-started CLI.
+            if (!JnaLoader.isLoaded()) {
+                log.warn("CLI kill-on-close job skipped: JNA not loaded (pid=$pid, arch=${CpuArch.CURRENT})")
+                return null
+            }
+            return runCatching { setup(pid, log) }
+                .getOrElse { log.warn("CLI kill-on-close job failed to initialize (pid=$pid)", it); null }
+        }
+
+        // All com.sun.jna.Native access lives here, behind assign()'s isLoaded() guard and runCatching.
+        private fun setup(pid: Long, log: KiloLog): KiloProcessJob? {
+            log.info("Setting up CLI kill-on-close job (pid=$pid, arch=${CpuArch.CURRENT}, pointerSize=${Native.POINTER_SIZE})")
+            if (Native.POINTER_SIZE != 8) {
+                log.warn("CLI kill-on-close job skipped: unsupported pointer size ${Native.POINTER_SIZE} (pid=$pid)")
+                return null
+            }
+            val k = lib ?: run {
+                log.warn("CLI kill-on-close job skipped: kernel32 mapping unavailable (pid=$pid)")
+                return null
+            }
+            return create(k, pid, log)
+        }
+
+        private fun create(k: Kernel32Job, pid: Long, log: KiloLog): KiloProcessJob? {
+            val job = k.CreateJobObjectW(null, null)
+            if (job == null || job == Pointer.NULL) {
+                log.warn("CreateJobObject failed (pid=$pid, err=${Native.getLastError()})")
+                return null
+            }
+            // Own the job handle until assignment succeeds; any early return or exception below closes
+            // it in the finally so repeated CLI restarts cannot accumulate native handles.
+            var owned = false
+            try {
+                val info = Memory(EXTENDED_LIMIT_SIZE)
+                info.clear()
+                info.setInt(LIMIT_FLAGS_OFFSET, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
+                if (!k.SetInformationJobObject(job, JOB_OBJECT_EXTENDED_LIMIT_INFORMATION, info, EXTENDED_LIMIT_SIZE.toInt())) {
+                    log.warn("SetInformationJobObject failed (pid=$pid, err=${Native.getLastError()})")
+                    return null
+                }
+                val proc = k.OpenProcess(PROCESS_TERMINATE or PROCESS_SET_QUOTA, false, pid.toInt())
+                if (proc == null || proc == Pointer.NULL) {
+                    log.warn("OpenProcess failed (pid=$pid, err=${Native.getLastError()})")
+                    return null
+                }
+                try {
+                    val assigned = k.AssignProcessToJobObject(job, proc)
+                    if (!assigned) {
+                        log.warn("AssignProcessToJobObject failed (pid=$pid, err=${Native.getLastError()})")
+                        return null
+                    }
+                } finally {
+                    closeHandle(k, proc, "process", pid, log)
+                }
+                owned = true
+                log.info("CLI assigned to kill-on-close job object (pid=$pid, job=$job)")
+                return KiloProcessJob(k, job, pid, log)
+            } finally {
+                if (!owned) closeHandle(k, job, "job (rollback)", pid, log)
+            }
+        }
+
+        private fun closeHandle(k: Kernel32Job, handle: Pointer, label: String, pid: Long, log: KiloLog) {
+            val ok = runCatching { k.CloseHandle(handle) }
+                .onFailure { log.warn("CloseHandle($label) threw (pid=$pid)", it) }
+                .getOrDefault(false)
+            if (!ok) log.info("CloseHandle($label) returned false (pid=$pid, err=${Native.getLastError()})")
+        }
+    }
+}
+
+/**
+ * Minimal direct mapping of the `kernel32` Job Object functions absent from the IDE's bundled JNA.
+ * Handles are plain [Pointer]s and BOOL maps to [Boolean]; all functions have stable ABIs.
+ */
+internal interface Kernel32Job : StdCallLibrary {
+    fun CreateJobObjectW(attributes: Pointer?, name: Pointer?): Pointer?
+    fun SetInformationJobObject(job: Pointer, infoClass: Int, info: Pointer, length: Int): Boolean
+    fun AssignProcessToJobObject(job: Pointer, process: Pointer): Boolean
+    fun OpenProcess(access: Int, inheritHandle: Boolean, pid: Int): Pointer?
+    fun CloseHandle(handle: Pointer): Boolean
+}

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloBackendCliShutdownTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloBackendCliShutdownTest.kt
@@ -1,0 +1,129 @@
+package ai.kilocode.backend.cli
+
+import ai.kilocode.backend.testing.TestLog
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the app-close teardown ordering so a future edit cannot reintroduce the Windows deadlock:
+ * closing a CLI stream while its reader thread is blocked reading it hangs until the process dies,
+ * so the process tree MUST be killed before any stream is closed.
+ */
+class KiloBackendCliShutdownTest {
+
+    @Test
+    fun `shutdownTree kills the tree before closing streams`() {
+        val events = mutableListOf<String>()
+        val proc = RecordingProcess(events)
+
+        shutdownTree(
+            proc = proc,
+            jobKill = true,
+            log = TestLog(),
+            killJob = { events += "job" },
+            descendants = { emptyList() },
+        )
+
+        // Both kill steps (job close + destroy) must precede every stream close.
+        val lastKill = maxOf(events.indexOf("job"), events.indexOf("destroy"))
+        val firstClose = events.indexOfFirst { it.startsWith("close-") }
+        assertTrue(lastKill >= 0, "kill steps ran: $events")
+        assertTrue(firstClose >= 0, "streams were closed: $events")
+        assertTrue(lastKill < firstClose, "process must be killed before its streams are closed; got $events")
+        assertEquals(listOf("job", "destroy", "close-stderr", "close-stdout", "close-stdin"), events)
+    }
+
+    @Test
+    fun `shutdownTree destroys descendants before the parent and before streams`() {
+        val events = mutableListOf<String>()
+        val proc = RecordingProcess(events)
+        val child = RecordingHandle("child", events)
+
+        shutdownTree(
+            proc = proc,
+            jobKill = false,
+            log = TestLog(),
+            killJob = {},
+            descendants = { listOf(child) },
+        )
+
+        assertEquals(listOf("destroy-child", "destroy", "close-stderr", "close-stdout", "close-stdin"), events)
+    }
+
+    @Test
+    fun `closeStreams closes every stream even when one throws`() {
+        val events = mutableListOf<String>()
+        val proc = RecordingProcess(events, failStderrClose = true)
+
+        closeStreams(proc, TestLog())
+
+        // stderr close throws, but stdout and stdin must still be closed.
+        assertEquals(listOf("close-stderr", "close-stdout", "close-stdin"), events)
+    }
+}
+
+private class RecordingProcess(
+    private val events: MutableList<String>,
+    failStderrClose: Boolean = false,
+) : Process() {
+    private val err = RecordingInput("close-stderr", events, fail = failStderrClose)
+    private val out = RecordingInput("close-stdout", events, fail = false)
+    private val inp = RecordingOutput("close-stdin", events)
+
+    override fun getErrorStream(): InputStream = err
+    override fun getInputStream(): InputStream = out
+    override fun getOutputStream(): OutputStream = inp
+    override fun waitFor(): Int = 0
+    override fun exitValue(): Int = 0
+    override fun isAlive(): Boolean = false
+    override fun pid(): Long = 4321L
+    override fun destroy() {
+        events += "destroy"
+    }
+}
+
+private class RecordingHandle(
+    private val label: String,
+    private val events: MutableList<String>,
+) : ProcessHandle {
+    override fun pid(): Long = label.hashCode().toLong()
+    override fun info(): ProcessHandle.Info = throw UnsupportedOperationException()
+    override fun parent(): java.util.Optional<ProcessHandle> = java.util.Optional.empty()
+    override fun children(): java.util.stream.Stream<ProcessHandle> = java.util.stream.Stream.empty()
+    override fun descendants(): java.util.stream.Stream<ProcessHandle> = java.util.stream.Stream.empty()
+    override fun onExit(): java.util.concurrent.CompletableFuture<ProcessHandle> = java.util.concurrent.CompletableFuture.completedFuture(this)
+    override fun supportsNormalTermination(): Boolean = true
+    override fun isAlive(): Boolean = false
+    override fun compareTo(other: ProcessHandle): Int = pid().compareTo(other.pid())
+    override fun destroyForcibly(): Boolean = true
+    override fun destroy(): Boolean {
+        events += "destroy-$label"
+        return true
+    }
+}
+
+private class RecordingInput(
+    private val label: String,
+    private val events: MutableList<String>,
+    private val fail: Boolean,
+) : InputStream() {
+    override fun read(): Int = -1
+    override fun close() {
+        events += label
+        if (fail) throw IOException("boom")
+    }
+}
+
+private class RecordingOutput(
+    private val label: String,
+    private val events: MutableList<String>,
+) : OutputStream() {
+    override fun write(b: Int) = Unit
+    override fun close() {
+        events += label
+    }
+}

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloProcessJobTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloProcessJobTest.kt
@@ -1,0 +1,42 @@
+package ai.kilocode.backend.cli
+
+import ai.kilocode.backend.testing.TestLog
+import com.intellij.openapi.util.SystemInfo
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KiloProcessJobTest {
+
+    /**
+     * The kill-on-close job is Windows-only. Everywhere else (including CI) [KiloProcessJob.assign]
+     * must be an inert no-op that never touches native code — callers rely on that to fall back to
+     * their existing process-tree kill.
+     */
+    @Test
+    fun `assign is a no-op on non-Windows platforms`() {
+        if (SystemInfo.isWindows) return
+        assertNull(KiloProcessJob.assign(4321L, TestLog()))
+    }
+
+    /**
+     * Windows-only end-to-end check of the native path: assigns a disposable child (never the test
+     * JVM) to a kill-on-close job and asserts closing the job terminates it. Exercises the struct
+     * layout, JNA signatures, assignment, and handle cleanup on the one platform where they run.
+     */
+    @Test
+    fun `closing the job terminates a disposable child on Windows`() {
+        if (!SystemInfo.isWindows) return
+        val child = ProcessBuilder("cmd.exe", "/c", "ping -n 30 127.0.0.1 >NUL").start()
+        try {
+            val job = assertNotNull(KiloProcessJob.assign(child.pid(), TestLog()), "job assigned on Windows")
+            assertTrue(child.isAlive, "child still running before job close")
+            job.close()
+            assertTrue(child.waitFor(15, TimeUnit.SECONDS), "child exits after kill-on-close")
+        } finally {
+            child.destroyForcibly()
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On Windows, the `kilo serve` process the plugin spawns could **outlive PhpStorm/IntelliJ** — a lingering ~365 MB Bun process in Task Manager — and, worse, **block the next IDE launch** until it was killed by hand.

## Root cause (confirmed on Windows 11 / PhpStorm 2026.1.4)

Two independent problems, both fixed here:

1. **App-close deadlock (the decisive bug).** `closeForShutdown()` closed the CLI's stderr/stdout **before** killing the process. On Windows, closing a process stream while its reader thread is blocked in a native read **hangs until the process dies** — but the kill came *after* the close. So IDE shutdown blocked mid-teardown: the JVM stayed alive → the CLI stayed alive → its stderr never hit EOF → the close never returned. That is exactly why manually killing the CLI "unblocked" the restart (it let the blocked read return so shutdown could finish). Field logs showed `closeForShutdown()` entering and then producing no further output.

2. **No OS-enforced backstop.** The previous teardown relied on a JVM shutdown hook (which JetBrains can skip via `Runtime.halt()`) and the CLI-side PID watchdog (unreliable on Windows due to PID reuse). A surviving child also inherits IDE handles (`ProcessBuilder` spawns with `bInheritHandles=TRUE`), which is what wedges relaunch.

## Fix

- **Reorder app-close teardown to kill first, then close streams.** Extracted into `shutdownTree`: close the kill-on-close job, destroy descendants, destroy the parent, and only then close the streams. The kill makes the pending reads return EOF, so `close()` can't block. This removes the deadlock. The ordering is locked by a regression test.
- **Bind the CLI tree to the IDE with a Windows Job Object** (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`), in the new `KiloProcessJob`. Closing the job handle on teardown terminates the tree immediately, and if the IDE dies for any reason — clean exit, `halt()`, crash, or force-kill — the OS kills the job. This is the OS-enforced backstop and it releases the inherited handles promptly, so relaunch is no longer blocked.
- The three Job Object functions are mapped directly against `kernel32` (the IDE's bundled JNA doesn't expose them) using only the **stable core JNA runtime already on the platform classpath** (`lib/util-8.jar`) plus the stable kernel32 ABI, so it is unaffected by JNA version bumps across IDE releases.
- **Diagnostics** on the setup and app-close paths (arch/pointer size/JNA state, Win32 error codes on any native failure, and entry/checkpoint lines) so future field reports are traceable.

Verified on the reporter's machine: app close now runs to completion —
`closeForShutdown() entered` → `Closing CLI kill-on-close job handle` → `CLI tree kill issued (jobKill=true)` → `CLI teardown complete` — no orphaned process remains, and relaunch is not blocked.

## Robustness / review hardening

- **JNA initialized safely.** `assign()` checks `JnaLoader.isLoaded()` (which initializes JNA behind its own failure boundary) *before* any `com.sun.jna.Native` access, and all native work runs inside `runCatching`, so a linkage error can never escape and orphan the just-started CLI.
- **No native handle leaks.** `create()` uses try/finally ownership — the job handle is released unless assignment succeeds and ownership transfers to the returned `KiloProcessJob`; the process handle is released in its own `finally`; `CloseHandle` results are checked/logged.
- **Best-effort / never-worse.** `KiloProcessJob.assign` returns `null` on non-Windows, without JNA, on non-64-bit, or on any native failure, and callers keep the existing process-tree kill. Non-Windows behavior is unchanged.
- **JNA is intentionally not bundled.** Like `kotlinx.coroutines`, it must come from the platform — a second copy would collide on the single `jnidispatch` native library.
- **No CLI changes** — confined to the (Kilo-owned) JetBrains backend module.

## Tests

- `KiloBackendCliShutdownTest` locks the teardown order: the tree is killed (job close + destroy) **before** any stream is closed, descendants before the parent, and `closeStreams` closes every stream even if one throws.
- `KiloProcessJobTest`: off-Windows no-op contract, plus a **Windows-gated** integration test that spawns a disposable child (never the test JVM), assigns its PID, closes the job, and asserts the child exits — covering struct layout, JNA signatures, assignment, and handle cleanup.
- `./gradlew typecheck` and `./gradlew :backend:test` pass.

## Known limitations (documented in `KiloProcessJob`)

- **Persistent background processes:** kill-on-close also terminates `persistent=true` CLI descendants on Windows. Letting them outlive the CLI needs a coordinated CLI change (`CREATE_BREAKAWAY_FROM_JOB` + a job with `JOB_OBJECT_LIMIT_BREAKAWAY_OK`) and is out of scope for this plugin-only fix.
- **Start-to-assignment race:** `assign()` runs immediately after `ProcessBuilder.start()`, leaving a sub-millisecond window before the process joins the job. Closing it fully would require creating the process suspended (abandoning `ProcessBuilder`); the window is negligible next to the previously-always-orphaned behavior.