### PR TITLE
fix(vscode): restore fresh prompt history recall

### DIFF
--- a/.changeset/restore-vscode-prompt-history.md
+++ b/.changeset/restore-vscode-prompt-history.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore the newest prompt to keyboard history when starting a new chat.

--- a/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
@@ -21,6 +21,23 @@ describe("PromptInput connection guard", () => {
     expect(send).toBeGreaterThan(guard)
     expect(clear).toBeGreaterThan(send)
   })
+
+  it("records a dispatched prompt before returning for a changed draft scope", () => {
+    // Regression source: fbe5f4cb in PR #11442 made fresh sends set draftSessionID synchronously,
+    // changing draftKey from :new to :pending:<uuid>. The changed key must block UI cleanup,
+    // but it must not skip recording the already-dispatched prompt in keyboard history.
+    const start = src.indexOf("const key = draftKey()")
+    const command = src.indexOf("session.sendCommand(", start)
+    const message = src.indexOf("session.sendMessage(", command)
+    const append = src.indexOf("history.append(draft)", message)
+    const guard = src.indexOf("if (draftKey() !== key) return", message)
+
+    expect(start).toBeGreaterThan(-1)
+    expect(command).toBeGreaterThan(start)
+    expect(message).toBeGreaterThan(command)
+    expect(append).toBeGreaterThan(message)
+    expect(guard).toBeGreaterThan(append)
+  })
 })
 
 describe("PromptInput sandbox toggle", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1079,9 +1079,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     reviewDrafts.delete(key)
     imageDrafts.delete(key)
     scrolls.delete(key)
+    history.append(draft)
     if (draftKey() !== key) return
 
-    history.append(draft)
     history.reset()
     setText("")
     clearReviewComments()


### PR DESCRIPTION
Fixes #11945

## What changed

Restore the newest prompt to keyboard history when it is the first message in a new chat.

## Root cause

This regressed in [`fbe5f4cb`](https://github.com/Kilo-Org/kilocode/commit/fbe5f4cbfcfb1628dff21015c03dd66ed66e902f) from #11442. During the first send, `session.sendMessage()` synchronously changes the draft key from `:new` to `:pending:<uuid>`. `PromptInput` checked that key before appending the sent draft to history, so the guard returned early and skipped the append.

The fix moves only `history.append(draft)` before that changed-key guard. Dispatch still happens first, and the guard continues to protect the later UI cleanup/reset from stale state.

## Validation

- Focused prompt-history suites: 38 passed, 0 failed.
- Extension typecheck, lint, Prettier check, and knip passed.
- Repository pre-push typecheck passed, including the JetBrains package.

## Local limitations

The full VS Code unit suite reproducibly had 39 failures in this Windows environment outside the touched tests (symlink, POSIX-path, and shell-environment assumptions); no clean-main baseline was run, so they are not claimed as pre-existing. A local development extension launch was also not completed because the Windows CLI build path was unavailable, so manual ArrowUp verification is not claimed.
