### PR TITLE
docs: add Lynkr provider guide

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -54,6 +54,7 @@ export const AiProvidersNav: NavSection[] = [
       { href: "/ai-providers/ollama", children: "Ollama" },
       { href: "/ai-providers/lmstudio", children: "LM Studio" },
       { href: "/ai-providers/atomic-chat", children: "Atomic Chat" },
+      { href: "/ai-providers/lynkr", children: "Lynkr" },
       {
         href: "/ai-providers/anaconda-desktop",
         children: "Anaconda Desktop",

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -37,6 +37,7 @@ Run models on your own hardware for privacy and offline use:
 - **[Anaconda Desktop](/docs/ai-providers/anaconda-desktop)** - Discover and connect to a local text-generation model server
 - **[Ollama](/docs/ai-providers/ollama)** - Easy local model management
 - **[LM Studio](/docs/ai-providers/lmstudio)** - Desktop app for local models
+- **[Lynkr](/docs/ai-providers/lynkr)** - Self-hosted gateway routing requests by complexity across local and cloud models
 - **[OpenAI Compatible](/docs/ai-providers/openai-compatible)** - Any OpenAI-compatible endpoint
 
 ### AI Gateways

--- a/packages/kilo-docs/pages/ai-providers/lynkr.md
+++ b/packages/kilo-docs/pages/ai-providers/lynkr.md
@@ -18,11 +18,15 @@ Kilo Code works with [Lynkr](https://github.com/Fast-Editor/Lynkr), a self-hoste
 
 ## Configuration in Kilo Code
 
-1. **Open Kilo Code Settings:** Click the gear icon in the Kilo Code panel.
-2. **Select Provider:** Choose "OpenAI Compatible" from the API Provider dropdown.
-3. **Enter Base URL:** `http://localhost:8081/v1`
-4. **Enter API Key:** Any non-empty value (provider authentication is handled inside Lynkr's own configuration).
-5. **Set Model ID:** Any placeholder value — Lynkr's tier routing selects the actual model per request.
+1. Open **Settings** (gear icon) and go to the **Providers** tab.
+2. Scroll to the bottom and click **Custom provider**.
+3. Fill in the custom provider dialog:
+   - **Provider ID** — a unique identifier, e.g. `lynkr`.
+   - **Display name** — e.g. `Lynkr`.
+   - **Provider API** — select **OpenAI Compatible**.
+   - **Base URL** — `http://localhost:8081/v1`
+   - **API key** — any non-empty value (provider authentication is handled inside Lynkr's own configuration).
+   - **Models** — add a placeholder model ID (e.g. `lynkr-auto`); Lynkr's tier routing selects the actual backend model per request.
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/lynkr.md
+++ b/packages/kilo-docs/pages/ai-providers/lynkr.md
@@ -26,7 +26,7 @@ Kilo Code works with [Lynkr](https://github.com/Fast-Editor/Lynkr), a self-hoste
    - **Provider API** — select **OpenAI Compatible**.
    - **Base URL** — `http://localhost:8081/v1`
    - **API key** — any non-empty value (provider authentication is handled inside Lynkr's own configuration).
-   - **Models** — add a placeholder model ID (e.g. `lynkr-auto`); Lynkr's tier routing selects the actual backend model per request.
+   - **Models** — add the model ID `lynkr-auto` (required). This is a virtual model name: Lynkr's tier routing selects the actual backend model per request.
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/lynkr.md
+++ b/packages/kilo-docs/pages/ai-providers/lynkr.md
@@ -26,7 +26,7 @@ Kilo Code works with [Lynkr](https://github.com/Fast-Editor/Lynkr), a self-hoste
    - **Provider API** — select **OpenAI Compatible**.
    - **Base URL** — `http://localhost:8081/v1`
    - **API key** — any non-empty value (provider authentication is handled inside Lynkr's own configuration).
-   - **Models** — add the model ID `lynkr-auto` (required). This is a virtual model name: Lynkr's tier routing selects the actual backend model per request.
+   - **Models** — once the Base URL is set, Kilo Code auto-detects Lynkr's models from its `/v1/models` endpoint. If adding manually, use model name **Lynkr Auto** with model ID `lynkr-auto` — a virtual model that Lynkr's tier routing resolves to the actual backend model per request.
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/lynkr.md
+++ b/packages/kilo-docs/pages/ai-providers/lynkr.md
@@ -1,0 +1,31 @@
+---
+title: "Using Lynkr with Kilo Code"
+description: "Route Kilo Code requests by complexity across local and cloud models with Lynkr, a self-hosted OpenAI-compatible gateway."
+sidebar_label: Lynkr
+---
+
+# Using Lynkr With Kilo Code
+
+Kilo Code works with [Lynkr](https://github.com/Fast-Editor/Lynkr), a self-hosted, Apache-2.0 LLM gateway with an OpenAI-compatible API. Lynkr routes each request by complexity: simple requests go to local models (Ollama, llama.cpp, LM Studio), complex ones to a cloud provider you configure (AWS Bedrock, Azure OpenAI, Databricks, OpenRouter, and others). It also strips unused tool schemas and compresses large JSON tool results, reducing token usage on agentic sessions.
+
+**Website:** [https://github.com/Fast-Editor/Lynkr](https://github.com/Fast-Editor/Lynkr)
+
+## Setting Up Lynkr
+
+1. **Install:** `npm install -g lynkr`
+2. **Configure:** Run `lynkr init` — an interactive wizard where you choose tier models (SIMPLE/MEDIUM/COMPLEX/REASONING) across 13 supported providers and enter credentials for the ones you use.
+3. **Start:** Run `lynkr start`. The gateway serves `http://localhost:8081`.
+
+## Configuration in Kilo Code
+
+1. **Open Kilo Code Settings:** Click the gear icon in the Kilo Code panel.
+2. **Select Provider:** Choose "OpenAI Compatible" from the API Provider dropdown.
+3. **Enter Base URL:** `http://localhost:8081/v1`
+4. **Enter API Key:** Any non-empty value (provider authentication is handled inside Lynkr's own configuration).
+5. **Set Model ID:** Any placeholder value — Lynkr's tier routing selects the actual model per request.
+
+## Tips and Notes
+
+- **Local-first routing:** With local tiers configured, most simple requests never leave your machine; only complex, tool-heavy requests reach a paid provider.
+- **Privacy:** Lynkr is fully self-hosted — requests go only to the providers you configured, with no third-party gateway in between.
+- **Tuning:** See [Lynkr's routing documentation](https://github.com/Fast-Editor/Lynkr/blob/main/documentation/routing.md) for tier configuration and complexity-threshold modes.


### PR DESCRIPTION
Adds a provider docs page for Lynkr, a self-hosted Apache-2.0 gateway usable with Kilo Code via the OpenAI Compatible provider, plus an entry in the ai-providers index.

Lynkr routes each request by complexity — simple requests to local models (Ollama/llama.cpp/LM Studio), complex ones to a configured cloud provider — and reduces token usage via tool-schema stripping and JSON tool-result compression. Repo: https://github.com/Fast-Editor/Lynkr

Page follows the structure of the existing provider pages (modeled on requesty.md). Happy to adjust to conventions.