### PR TITLE
feat(mcp): directory config

### DIFF
--- a/.changeset/mcp-directory-config.md
+++ b/.changeset/mcp-directory-config.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": minor
+---
+
+Support `.kilocode/mcp/` directory-based MCP server config, loaded in priority
+order over the legacy `.kilocode/mcp.json` file. Also supports home-level
+globals via `~/.kilocode/mcp/` and `~/.kilo/mcp/`.

--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -174,18 +174,23 @@ export namespace McpMigrator {
       serversByName.set(name, server)
     }
 
-    // Convert each server
+    // Convert each server. Errors for individual servers are caught so that
+    // one malformed entry does not discard all otherwise valid MCP servers.
     for (const [name, server] of serversByName) {
-      // Warn about alwaysAllow permissions that cannot be migrated
-      if (server.alwaysAllow && server.alwaysAllow.length > 0) {
-        warnings.push(
-          `MCP server '${name}' has alwaysAllow permissions that cannot be migrated: ${server.alwaysAllow.join(", ")}`,
-        )
-      }
+      try {
+        if (server.alwaysAllow && server.alwaysAllow.length > 0) {
+          warnings.push(
+            `MCP server '${name}' has alwaysAllow permissions that cannot be migrated: ${server.alwaysAllow.join(", ")}`,
+          )
+        }
 
-      const converted = convertServer(name, server)
-      if (converted) {
-        mcp[name] = converted
+        const converted = convertServer(name, server)
+        if (converted) {
+          mcp[name] = converted
+        }
+      } catch (err) {
+        log.warn("failed to migrate MCP server, skipping", { name, error: err })
+        skipped.push({ name, reason: `conversion error: ${err}` })
       }
     }
 

--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises"
 import * as path from "path"
+import os from "os"
 import { Config } from "../config/config"
 import { ConfigMCP } from "../config/mcp"
 import * as Log from "@opencode-ai/core/util/log"
@@ -8,6 +9,7 @@ import { KilocodePaths } from "./paths"
 
 export namespace McpMigrator {
   const log = Log.create({ service: "kilocode.mcp-migrator" })
+  const home = () => process.env.KILO_TEST_HOME || process.env.HOME || process.env.USERPROFILE || os.homedir()
 
   // Remote transport types used by the Kilocode extension
   const REMOTE_TYPES = new Set(["streamable-http", "sse"])
@@ -51,6 +53,32 @@ export namespace McpMigrator {
     }
   }
 
+  export async function readMcpDirectory(
+    mcpDir: string,
+  ): Promise<Array<{ name: string; server: KilocodeMcpServer }>> {
+    if (!(await Filesystem.isDir(mcpDir))) return []
+
+    const servers: Array<{ name: string; server: KilocodeMcpServer }> = []
+    try {
+      const entries = await fs.readdir(mcpDir)
+      for (const entry of entries) {
+        if (!entry.endsWith(".json")) continue
+        const name = entry.slice(0, -5)
+        const filepath = path.join(mcpDir, entry)
+        try {
+          const content = await fs.readFile(filepath, "utf-8")
+          const server = JSON.parse(content) as KilocodeMcpServer
+          servers.push({ name, server })
+        } catch (err) {
+          log.warn("failed to parse MCP server file, skipping", { filepath, error: err })
+        }
+      }
+    } catch (err) {
+      log.warn("failed to read MCP directory", { dir: mcpDir, error: err })
+    }
+    return servers
+  }
+
   export function convertServer(name: string, server: KilocodeMcpServer): ConfigMCP.Info | null {
     if (isRemote(server)) {
       if (!server.url) {
@@ -85,6 +113,19 @@ export namespace McpMigrator {
     return config
   }
 
+  async function loadMcpFromDir(dirPath: string, allServers: Array<{ name: string; server: KilocodeMcpServer }>) {
+    const filepath = path.join(dirPath, "mcp.json")
+    const settings = await readMcpSettings(filepath)
+    if (settings?.mcpServers) {
+      for (const [name, server] of Object.entries(settings.mcpServers)) {
+        allServers.push({ name, server })
+      }
+    }
+    const mcpDir = path.join(dirPath, "mcp")
+    const dirServers = await readMcpDirectory(mcpDir)
+    allServers.push(...dirServers)
+  }
+
   export async function migrate(options?: {
     projectDir?: string
     skipGlobalPaths?: boolean
@@ -106,19 +147,21 @@ export namespace McpMigrator {
       }
     }
 
-    // 2. Project-level MCP settings (if projectDir provided)
-    // Check .kilo/mcp.json and .kilocode/mcp.json for project-level settings
-    // (not "mcp_settings.json" which is only used for global settings)
-    // .kilocode is loaded first (lower precedence), .kilo second (higher precedence)
+    // 2. Global home-level configs (~/.kilocode and ~/.kilo)
+    // File loaded first, then directory (directory overrides file)
+    // .kilocode first (lower precedence), .kilo second (higher precedence)
+    if (!options?.skipGlobalPaths) {
+      for (const dir of [".kilocode", ".kilo"]) {
+        await loadMcpFromDir(path.join(home(), dir), allServers)
+      }
+    }
+
+    // 3. Project-level MCP settings (if projectDir provided)
+    // .kilocode first (lower precedence), .kilo second (higher precedence)
+    // Directory overrides file
     if (options?.projectDir) {
       for (const dir of [".kilocode", ".kilo"]) {
-        const projectSettingsPath = path.join(options.projectDir, dir, "mcp.json")
-        const projectSettings = await readMcpSettings(projectSettingsPath)
-        if (projectSettings?.mcpServers) {
-          for (const [name, server] of Object.entries(projectSettings.mcpServers)) {
-            allServers.push({ name, server }) // Later entries win in deduplication
-          }
-        }
+        await loadMcpFromDir(path.join(options.projectDir, dir), allServers)
       }
     }
 

--- a/packages/opencode/src/kilocode/mcp-migrator.ts
+++ b/packages/opencode/src/kilocode/mcp-migrator.ts
@@ -67,7 +67,12 @@ export namespace McpMigrator {
         const filepath = path.join(mcpDir, entry)
         try {
           const content = await fs.readFile(filepath, "utf-8")
-          const server = JSON.parse(content) as KilocodeMcpServer
+          const parsed = JSON.parse(content)
+          if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+            log.warn("MCP server entry must be a JSON object, skipping", { filepath })
+            continue
+          }
+          const server = parsed as KilocodeMcpServer
           servers.push({ name, server })
         } catch (err) {
           log.warn("failed to parse MCP server file, skipping", { filepath, error: err })
@@ -150,10 +155,8 @@ export namespace McpMigrator {
     // 2. Global home-level configs (~/.kilocode and ~/.kilo)
     // File loaded first, then directory (directory overrides file)
     // .kilocode first (lower precedence), .kilo second (higher precedence)
-    if (!options?.skipGlobalPaths) {
-      for (const dir of [".kilocode", ".kilo"]) {
-        await loadMcpFromDir(path.join(home(), dir), allServers)
-      }
+    for (const dir of [".kilocode", ".kilo"]) {
+      await loadMcpFromDir(path.join(home(), dir), allServers)
     }
 
     // 3. Project-level MCP settings (if projectDir provided)

--- a/packages/opencode/test/kilocode/mcp-migrator.test.ts
+++ b/packages/opencode/test/kilocode/mcp-migrator.test.ts
@@ -1,7 +1,8 @@
-import { test, expect, describe } from "bun:test"
+import { test, expect, describe, afterEach } from "bun:test"
 import { McpMigrator } from "../../src/kilocode/mcp-migrator"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
+import fs from "fs/promises"
 
 describe("McpMigrator", () => {
   describe("convertServer", () => {
@@ -730,6 +731,468 @@ describe("McpMigrator", () => {
           url: "http://localhost:4322/mcp",
           enabled: false,
         })
+      })
+    })
+  })
+
+  describe("readMcpDirectory", () => {
+    test("returns empty array for non-existent directory", async () => {
+      const result = await McpMigrator.readMcpDirectory("/non/existent/path/mcp")
+      expect(result).toEqual([])
+    })
+
+    test("returns empty array for path that is a file, not a directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.writeFile(path.join(dir, "mcp"), "not a dir")
+        },
+      })
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+      expect(result).toEqual([])
+    })
+
+    test("reads single server from directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "github.json"),
+            JSON.stringify({
+              command: "npx",
+              args: ["-y", "@modelcontextprotocol/server-github"],
+              env: { GITHUB_TOKEN: "token123" },
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe("github")
+      expect(result[0].server.command).toBe("npx")
+      expect(result[0].server.args).toEqual(["-y", "@modelcontextprotocol/server-github"])
+    })
+
+    test("reads multiple servers from directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "github.json"),
+            JSON.stringify({ command: "npx", args: ["-y", "server-github"] }),
+          )
+          await fs.writeFile(
+            path.join(mcpDir, "postgres.json"),
+            JSON.stringify({ command: "docker", args: ["run", "mcp/postgres"] }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name).sort()
+      expect(names).toEqual(["github", "postgres"])
+    })
+
+    test("skips non-JSON files in directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(path.join(mcpDir, "github.json"), JSON.stringify({ command: "npx" }))
+          await fs.writeFile(path.join(mcpDir, "notes.txt"), "this is not json")
+          await fs.writeFile(path.join(mcpDir, "readme.md"), "# readme")
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe("github")
+    })
+
+    test("skips malformed JSON files with log and continues", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(path.join(mcpDir, "good.json"), JSON.stringify({ command: "valid-cmd" }))
+          await fs.writeFile(path.join(mcpDir, "bad.json"), "{ invalid json !!!")
+          await fs.writeFile(path.join(mcpDir, "also-good.json"), JSON.stringify({ command: "another-cmd" }))
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name).sort()
+      expect(names).toEqual(["also-good", "good"])
+    })
+
+    test("uses filename without .json as server name", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "my-custom-server.json"),
+            JSON.stringify({ command: "custom-cmd" }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe("my-custom-server")
+    })
+  })
+
+  describe("directory-based MCP loading (migrate)", () => {
+    test("loads servers from .kilocode/mcp/ directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilocode", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "github.json"),
+            JSON.stringify({
+              command: "npx",
+              args: ["-y", "@modelcontextprotocol/server-github"],
+              env: { GITHUB_TOKEN: "token123" },
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("github")
+      expect(result.mcp.github).toEqual({
+        type: "local",
+        command: ["npx", "-y", "@modelcontextprotocol/server-github"],
+        environment: { GITHUB_TOKEN: "token123" },
+      })
+    })
+
+    test("loads servers from .kilo/mcp/ directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilo", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "database.json"),
+            JSON.stringify({
+              command: "docker",
+              args: ["run", "-i", "--rm", "mcp/postgres"],
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("database")
+      expect(result.mcp.database).toEqual({
+        type: "local",
+        command: ["docker", "run", "-i", "--rm", "mcp/postgres"],
+      })
+    })
+
+    test("directory file overrides .kilocode/mcp.json for same server name", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode", "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp.json"),
+            JSON.stringify({
+              mcpServers: {
+                github: {
+                  command: "npx",
+                  args: ["-y", "@modelcontextprotocol/server-github"],
+                  env: { GITHUB_TOKEN: "old-token" },
+                },
+              },
+            }),
+          )
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp", "github.json"),
+            JSON.stringify({
+              command: "npx",
+              args: ["-y", "@modelcontextprotocol/server-github"],
+              env: { GITHUB_TOKEN: "new-token" },
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp.github).toEqual({
+        type: "local",
+        command: ["npx", "-y", "@modelcontextprotocol/server-github"],
+        environment: { GITHUB_TOKEN: "new-token" },
+      })
+    })
+
+    test(".kilo/mcp/ directory overrides .kilocode/mcp/ directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode", "mcp"), { recursive: true })
+          await fs.mkdir(path.join(dir, ".kilo", "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp", "myserver.json"),
+            JSON.stringify({ command: "old-cmd", args: ["old"] }),
+          )
+          await fs.writeFile(
+            path.join(dir, ".kilo", "mcp", "myserver.json"),
+            JSON.stringify({ command: "new-cmd", args: ["new"] }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp.myserver).toEqual({
+        type: "local",
+        command: ["new-cmd", "new"],
+      })
+    })
+
+    test("malformed JSON in directory file is skipped, others still load", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilocode", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(path.join(mcpDir, "good.json"), JSON.stringify({ command: "valid-cmd" }))
+          await fs.writeFile(path.join(mcpDir, "bad.json"), "{ corrupt }")
+          await fs.writeFile(path.join(mcpDir, "also-good.json"), JSON.stringify({ command: "another-cmd" }))
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("good")
+      expect(result.mcp).toHaveProperty("also-good")
+      expect(Object.keys(result.mcp)).toHaveLength(2)
+    })
+
+    test("loads servers from directory only (no mcp.json file)", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilocode", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "filesystem.json"),
+            JSON.stringify({
+              command: "npx",
+              args: ["-y", "@modelcontextprotocol/server-filesystem", "/home"],
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("filesystem")
+      expect(Object.keys(result.mcp)).toHaveLength(1)
+    })
+
+    test("loads multiple servers from directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilocode", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "github.json"),
+            JSON.stringify({ command: "npx", args: ["-y", "server-github"] }),
+          )
+          await fs.writeFile(
+            path.join(mcpDir, "postgres.json"),
+            JSON.stringify({ command: "docker", args: ["run", "mcp/postgres"] }),
+          )
+          await fs.writeFile(
+            path.join(mcpDir, "filesystem.json"),
+            JSON.stringify({ command: "npx", args: ["-y", "server-filesystem"] }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(Object.keys(result.mcp)).toHaveLength(3)
+    })
+
+    test("empty mcp/ directory does not affect loading", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode", "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp.json"),
+            JSON.stringify({
+              mcpServers: {
+                server1: { command: "cmd1" },
+              },
+            }),
+          )
+        },
+      })
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.path,
+        skipGlobalPaths: true,
+      })
+
+      expect(result.mcp).toHaveProperty("server1")
+      expect(Object.keys(result.mcp)).toHaveLength(1)
+    })
+  })
+
+  describe("home-level global MCP config", () => {
+    const ORIGINAL_HOME = process.env.KILO_TEST_HOME
+
+    afterEach(() => {
+      if (ORIGINAL_HOME === undefined) {
+        delete process.env.KILO_TEST_HOME
+      } else {
+        process.env.KILO_TEST_HOME = ORIGINAL_HOME
+      }
+    })
+
+    test("loads servers from ~/.kilocode/mcp/ directory", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, ".kilocode", "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(
+            path.join(mcpDir, "global-server.json"),
+            JSON.stringify({ command: "global-cmd" }),
+          )
+        },
+      })
+      process.env.KILO_TEST_HOME = tmp.path
+
+      const result = await McpMigrator.migrate({
+        projectDir: undefined,
+        skipGlobalPaths: false,
+      })
+
+      expect(result.mcp).toHaveProperty("global-server")
+      expect(result.mcp["global-server"]).toEqual({
+        type: "local",
+        command: ["global-cmd"],
+      })
+    })
+
+    test("loads servers from ~/.kilocode/mcp.json global file", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode"), { recursive: true })
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp.json"),
+            JSON.stringify({
+              mcpServers: {
+                "global-file-server": { command: "global-file-cmd" },
+              },
+            }),
+          )
+        },
+      })
+      process.env.KILO_TEST_HOME = tmp.path
+
+      const result = await McpMigrator.migrate({
+        projectDir: undefined,
+        skipGlobalPaths: false,
+      })
+
+      expect(result.mcp).toHaveProperty("global-file-server")
+    })
+
+    test("global directory overrides global file for same server", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const kiloDir = path.join(dir, ".kilocode")
+          await fs.mkdir(path.join(kiloDir, "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(kiloDir, "mcp.json"),
+            JSON.stringify({
+              mcpServers: {
+                myserver: { command: "file-cmd" },
+              },
+            }),
+          )
+          await fs.writeFile(
+            path.join(kiloDir, "mcp", "myserver.json"),
+            JSON.stringify({ command: "dir-cmd" }),
+          )
+        },
+      })
+      process.env.KILO_TEST_HOME = tmp.path
+
+      const result = await McpMigrator.migrate({
+        projectDir: undefined,
+        skipGlobalPaths: false,
+      })
+
+      expect(result.mcp.myserver).toEqual({
+        type: "local",
+        command: ["dir-cmd"],
+      })
+    })
+
+    test("project config overrides global config", async () => {
+      const projectDirName = "project"
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".kilocode", "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(dir, ".kilocode", "mcp", "server.json"),
+            JSON.stringify({ command: "global-cmd" }),
+          )
+          const pDir = path.join(dir, projectDirName)
+          await fs.mkdir(path.join(pDir, ".kilocode", "mcp"), { recursive: true })
+          await fs.writeFile(
+            path.join(pDir, ".kilocode", "mcp", "server.json"),
+            JSON.stringify({ command: "project-cmd" }),
+          )
+          return pDir
+        },
+      })
+      process.env.KILO_TEST_HOME = tmp.path
+
+      const result = await McpMigrator.migrate({
+        projectDir: tmp.extra,
+        skipGlobalPaths: false,
+      })
+
+      expect(result.mcp.server).toEqual({
+        type: "local",
+        command: ["project-cmd"],
       })
     })
   })

--- a/packages/opencode/test/kilocode/mcp-migrator.test.ts
+++ b/packages/opencode/test/kilocode/mcp-migrator.test.ts
@@ -1,10 +1,27 @@
-import { test, expect, describe, afterEach } from "bun:test"
+import { test, expect, describe, afterEach, beforeAll, afterAll } from "bun:test"
 import { McpMigrator } from "../../src/kilocode/mcp-migrator"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
 
 describe("McpMigrator", () => {
+  const ORIGINAL_TEST_HOME = process.env.KILO_TEST_HOME
+  let cleanHome: string
+
+  beforeAll(async () => {
+    const tmp = await tmpdir()
+    cleanHome = tmp.path
+    process.env.KILO_TEST_HOME = cleanHome
+  })
+
+  afterAll(async () => {
+    if (ORIGINAL_TEST_HOME === undefined) {
+      delete process.env.KILO_TEST_HOME
+    } else {
+      process.env.KILO_TEST_HOME = ORIGINAL_TEST_HOME
+    }
+    await fs.rm(cleanHome, { recursive: true, force: true })
+  })
   describe("convertServer", () => {
     test("converts local server with command and args", () => {
       const server: McpMigrator.KilocodeMcpServer = {
@@ -822,6 +839,42 @@ describe("McpMigrator", () => {
           await fs.mkdir(mcpDir, { recursive: true })
           await fs.writeFile(path.join(mcpDir, "good.json"), JSON.stringify({ command: "valid-cmd" }))
           await fs.writeFile(path.join(mcpDir, "bad.json"), "{ invalid json !!!")
+          await fs.writeFile(path.join(mcpDir, "also-good.json"), JSON.stringify({ command: "another-cmd" }))
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name).sort()
+      expect(names).toEqual(["also-good", "good"])
+    })
+
+    test("skips valid JSON that is not an object (null)", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(path.join(mcpDir, "good.json"), JSON.stringify({ command: "valid-cmd" }))
+          await fs.writeFile(path.join(mcpDir, "null.json"), "null")
+          await fs.writeFile(path.join(mcpDir, "also-good.json"), JSON.stringify({ command: "another-cmd" }))
+        },
+      })
+
+      const result = await McpMigrator.readMcpDirectory(path.join(tmp.path, "mcp"))
+
+      expect(result).toHaveLength(2)
+      const names = result.map((r) => r.name).sort()
+      expect(names).toEqual(["also-good", "good"])
+    })
+
+    test("skips valid JSON that is not an object (array)", async () => {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const mcpDir = path.join(dir, "mcp")
+          await fs.mkdir(mcpDir, { recursive: true })
+          await fs.writeFile(path.join(mcpDir, "good.json"), JSON.stringify({ command: "valid-cmd" }))
+          await fs.writeFile(path.join(mcpDir, "array.json"), JSON.stringify([1, 2, 3]))
           await fs.writeFile(path.join(mcpDir, "also-good.json"), JSON.stringify({ command: "another-cmd" }))
         },
       })


### PR DESCRIPTION
## Issue

Implements feature discussed in [kilocode#3579 (comment)](https://github.com/Kilo-Org/kilocode/discussions/3579#discussioncomment-17601002)

## Context

Add support for `.kilocode/mcp/` directory-based MCP server configuration. Each `.json` file inside `mcp/` defines one MCP server (filename without `.json` extension becomes the server name). This allows users to drop individual MCP server configs as separate files rather than editing a single `mcp.json`. Also adds home-level global MCP config from `~/.kilocode/` and `~/.kilo/` for consistency with other migrators (rules, workflows, etc.).

## Implementation

- New `readMcpDirectory()` reads individual `.json` files from an `mcp/` subdirectory, skipping non-JSON files and gracefully handling parse errors
- New `loadMcpFromDir()` helper loads both `mcp.json` (file) and `mcp/` (directory) from a given base directory — directory entries override file entries for the same server name via deduplication
- Refactored `migrate()` to load home-level global configs (`~/.kilocode/` and `~/.kilo/`) alongside the existing VS Code global storage and project-level configs
- Precedence: `.kilocode` < `.kilo` < project-level `.kilocode` < project-level `.kilo`

## Screenshots / Video

N/A (config-only change, no UI)

## How to Test

### Manual/local verification

- All 50 MCP migrator tests pass: `bun test ./test/kilocode/mcp-migrator.test.ts`
- Typecheck passes: `bun run typecheck`
- Create `.kilocode/mcp/` directory in a project with a `.json` file and verify the MCP server loads

### Reviewer test steps

1. Checkout branch, run `bun test ./test/kilocode/mcp-migrator.test.ts` — all 50 tests should pass
2. Verify `.changeset/mcp-directory-config.md` exists and is correct
3. Review `packages/opencode/src/kilocode/mcp-migrator.ts` for correctness of the loading order

### Blocked checks and substitute verification

- Full `bun test` suite was run; several pre-existing failures are unrelated to these changes (effect library compatibility, missing node in PATH, timeout-sensitive tests)

## Checklist

- [x] Issue linked above (discussion reference)
- [x] Tests/verification described
- [x] Screenshots/video N/A
- [x] Changeset added (commit `79ad350c614f3b7497595bb2d117d6f0cc95854d`)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
