### PR TITLE
fix: reserve buffer space when calculating input limits for models wi…

### DIFF
--- a/.changeset/fix-compaction-overflow.md
+++ b/.changeset/fix-compaction-overflow.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent compaction failures and ContextOverflowErrors during long chat sessions on models without hardcoded input limits.

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -13,9 +13,17 @@ export function usable(input: { cfg: Config.Info; model: Provider.Model; outputT
   const reserved =
     input.cfg.compaction?.reserved ??
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+  // kilocode_change start
+  // Properly deduct the reserved buffer even when limit.input is unset.
+  // Models lacking a hardcoded input limit (like OpenRouter or Ollama) dynamically calculate
+  // their usable space based on the max context window minus output tokens. If we don't 
+  // subtract the reserved buffer here, the system will use 100% of the context window for 
+  // conversation history, leaving zero headroom for the compaction summarization prompt, 
+  // which causes a ContextOverflowError when compaction is attempted.
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax) - reserved)
+  // kilocode_change end
 }
 
 export function isOverflow(input: {


### PR DESCRIPTION
## Issue

Fixes #12137

## Context

When using models that lack a hardcoded `limit.input` field (such as OpenRouter models, Ollama models, or the "Hy3" model mentioned in the issue), the compaction sequence fails with a `ContextOverflowError: Conversation history too large to compact - exceeds model context limit`. 

This occurs because the `usable()` space budget was failing to subtract the `reserved` token buffer in the dynamic calculation fallback. As a result, the conversation history was allowed to fill 100% of the model's context window. When the system then attempted to trigger compaction by appending the summarization prompt, it immediately exceeded the model's hard context limit and crashed.

## Implementation

Updated the `usable()` token calculation in `packages/opencode/src/session/overflow.ts` to explicitly deduct the `reserved` compaction buffer in the dynamic calculation branch. 

This ensures that the conversation budget consistently leaves ~20,000 tokens of headroom for the compaction agent to operate safely, regardless of whether the model has a predefined `limit.input` or relies on dynamic max-context math.

## Screenshots / Video

N/A - backend logic change.

## How to Test

### Manual/local verification

- Tested locally with a large `dummy-context.txt` payload using an Ollama model (no hardcoded limits). Verified that compaction triggers safely and successfully summarizes the conversation history without throwing `ContextOverflowError`.
- Verified the `usable()` unit tests pass and correctly apply the reserved buffer.

### Reviewer test steps

1. Start KiloCode connected to any local model via Ollama or a free OpenRouter model (ensuring it uses dynamic input limits).
2. Attach a massive block of text to fill the context window (e.g. ~50k-100k tokens).
3. Confirm that the AI successfully compacts the conversation history instead of throwing a `ContextOverflowError`.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
