### PR TITLE
fix(cli): resolve latest CLI release when GitHub latest points to non-CLI tag

### DIFF
--- a/.changeset/fix-install-jetbrains-tag.md
+++ b/.changeset/fix-install-jetbrains-tag.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix install script failing when the latest GitHub release is not a CLI release.

--- a/.changeset/fix-install-jetbrains-tag.md
+++ b/.changeset/fix-install-jetbrains-tag.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix install script failing when the latest GitHub release is not a CLI release.
+Install the latest stable CLI release when newer non-CLI or prerelease releases exist.

--- a/install
+++ b/install
@@ -183,8 +183,8 @@ else
     fi
 
     if [ -z "$requested_version" ]; then
-        url="https://github.com/Kilo-Org/kilocode/releases/latest/download/$filename"
-        specific_version=$(curl -s https://api.github.com/repos/Kilo-Org/kilocode/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+        specific_version=$(curl -s "https://api.github.com/repos/Kilo-Org/kilocode/releases?per_page=30" | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1) # kilocode_change
+        url="https://github.com/Kilo-Org/kilocode/releases/download/v${specific_version}/$filename" # kilocode_change
 
         if [[ $? -ne 0 || -z "$specific_version" ]]; then
             echo -e "${RED}Failed to fetch version information${NC}"

--- a/install
+++ b/install
@@ -183,13 +183,17 @@ else
     fi
 
     if [ -z "$requested_version" ]; then
-        specific_version=$(curl -s "https://api.github.com/repos/Kilo-Org/kilocode/releases?per_page=30" | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1) # kilocode_change
-        url="https://github.com/Kilo-Org/kilocode/releases/download/v${specific_version}/$filename" # kilocode_change
-
-        if [[ $? -ne 0 || -z "$specific_version" ]]; then
+        # The npm latest tag tracks stable CLI releases independently of other GitHub release types.
+        if ! specific_version=$(curl -fsSL "https://registry.npmjs.org/-/package/%40kilocode%2Fcli/dist-tags" |
+            sed -n 's/.*"latest"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'); then
             echo -e "${RED}Failed to fetch version information${NC}"
             exit 1
         fi
+        if [[ ! "$specific_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo -e "${RED}Failed to fetch version information${NC}"
+            exit 1
+        fi
+        url="https://github.com/Kilo-Org/kilocode/releases/download/v${specific_version}/$filename"
     else
         # Strip leading 'v' if present
         requested_version="${requested_version#v}"


### PR DESCRIPTION
GitHub’s repository-wide latest release can point to a JetBrains release, which leaves the CLI installer without a matching version or binary asset.

Resolve unversioned installs through the `@kilocode/cli` npm `latest` dist-tag, which tracks the stable CLI channel independently from prerelease channels and other product releases. Use that version in the explicit GitHub asset URL so the displayed version and downloaded archive always match.

Closes #12125