### PR TITLE
fix(cli): skip thinkingLevel for Gemma models on Google provider

### DIFF
--- a/.changeset/fix-gemma-thinking-level.md
+++ b/.changeset/fix-gemma-thinking-level.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Gemma 4 models failing with "thinkingLevel not supported" when using Google AI Studio.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1014,6 +1014,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
     case "@ai-sdk/google":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
+      if (id.includes("gemma")) return {} // kilocode_change
       if (id.includes("2.5")) {
         return {
           high: {


### PR DESCRIPTION
Gemma 4 models (gemma-4-31b-it, gemma-4-26b-a4b-it) don't support the
`thinkingLevel` parameter. When models.dev metadata reports reasoning
capability for these Google models, the `variants` function falls through
to the default branch that generates `thinkingConfig` entries with
`thinkingLevel: "low"` / `thinkingLevel: "high"`.

The Google AI Studio API rejects these with a 400 INVALID_ARGUMENT error:
`"Thinking level is not supported for this model."`

The fix adds an early `return {}` for model IDs containing `"gemma"`,
before the existing `"2.5"` check. This follows the same pattern used
for grok (line 728) and deepseek (line 699) models that don't support
provider-native thinking controls.

Closes #12063