### PR TITLE
fix(agent-manager): accept Windows workspace path casing

### DIFF
--- a/.changeset/windows-local-agent-sessions.md
+++ b/.changeset/windows-local-agent-sessions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start Agent Manager local sessions on Windows when workspace drive-letter casing differs.

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -4,6 +4,7 @@ import type { CreateWorktreeResult } from "./WorktreeManager"
 import type { WorktreeStateManager } from "./WorktreeStateManager"
 import type { PanelContext } from "./host"
 import { PLATFORM, SNAPSHOT_INITIALIZATION } from "./constants"
+import { sameDirectory } from "../kilo-provider-utils"
 
 const LABEL_MAX = 28
 const PREFIX = new Set(["feat", "fix", "chore", "bug", "issue", "task", "branch"])
@@ -121,8 +122,9 @@ async function local(deps: ToolDeps, client: KiloClient, task: ToolTask, directo
   if (!root || !state) return false
 
   const dir = clean(directory) ?? root
-  const wt = dir === root ? undefined : state.findWorktreeByPath(dir)
-  if (dir !== root && !wt) {
+  const match = sameDirectory(dir, root)
+  const wt = match ? undefined : state.findWorktreeByPath(dir)
+  if (!match && !wt) {
     deps.log("Agent Manager tool local request ignored unknown directory", dir)
     deps.post({
       type: "error",

--- a/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-tool-start.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it, mock } from "bun:test"
+import { afterEach, describe, expect, it, mock } from "bun:test"
 import { parseToolRequest, startFromTool, type ToolDeps, type ToolRequest } from "../../src/agent-manager/tool-start"
 import type { CreateWorktreeResult } from "../../src/agent-manager/WorktreeManager"
 import type { Session } from "@kilocode/sdk/v2/client"
+
+const platform = Object.getOwnPropertyDescriptor(process, "platform")
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, "platform", { value, configurable: true })
+}
+
+afterEach(() => {
+  if (platform) Object.defineProperty(process, "platform", platform)
+})
 
 function session(id: string): Session {
   return { id, title: id, createdAt: "", updatedAt: "" } as Session
@@ -132,6 +142,43 @@ describe("agent manager tool start", () => {
       }),
       { throwOnError: true },
     )
+  })
+
+  it("starts local sessions when Windows drive-letter casing differs", async () => {
+    setPlatform("win32")
+    const client = {
+      session: {
+        create: mock(async () => ({ data: session("s-local") })),
+        promptAsync: mock(async () => ({})),
+      },
+    }
+    const state = {
+      addSession: mock(() => {}),
+      findWorktreeByPath: mock(() => undefined),
+    }
+    const c = deps({
+      getClient: () => client as never,
+      getRoot: () => "c:\\Users\\dev\\repo",
+      getState: () => state as never,
+    })
+
+    await startFromTool(c, {
+      requestID: "am-windows-dir",
+      mode: "local",
+      directory: "C:\\Users\\dev\\repo",
+      tasks: [{ prompt: "Do work" }],
+    })
+
+    expect(client.session.create).toHaveBeenCalledWith(expect.objectContaining({ directory: "c:\\Users\\dev\\repo" }), {
+      throwOnError: true,
+    })
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: "c:\\Users\\dev\\repo" }),
+      { throwOnError: true },
+    )
+    expect(state.addSession).toHaveBeenCalledWith("s-local", null)
+    expect(state.findWorktreeByPath).not.toHaveBeenCalled()
+    expect(c.error).not.toHaveBeenCalled()
   })
 
   it("starts worktree sessions through existing hooks", async () => {


### PR DESCRIPTION
Agent Manager local tool requests can receive a canonical Windows directory from the CLI while VS Code reports the same workspace root with different drive-letter casing. Strict string equality then treats the workspace as an unknown directory and prevents session creation.

Use platform-aware directory equivalence for root classification while preserving case-sensitive behavior on POSIX and existing validation for actual worktree directories.

Fixes #12138