### PR TITLE
docs(kilo-docs): exclude Google AI Studio API keys page from link checker

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -52,6 +52,8 @@ exclude = [
   '^https?://api\.apertis\.ai/v1/?$',
   # Redirects to authenticated Google Cloud console
   '^https?://console\.cloud\.google\.com',
+  # Google AI Studio API keys page redirects to Google sign-in
+  '^https?://aistudio\.google\.com/api-keys/?$',
   # Linear intermittently returns 503 to CI link checks.
   '^https?://linear\.app/?$',
   # Consistently times out in CI


### PR DESCRIPTION
The link check CI started failing after `packages/kilo-docs/pages/ai-providers/gemini.md` added a link to `https://aistudio.google.com/api-keys`:

```
### Errors in pages/ai-providers/gemini.md

* [302] <https://aistudio.google.com/api-keys> | Rejected status code: 302 Found
```

The URL itself is correct. It is the canonical Google AI Studio API keys page, and Google's own Gemini API key documentation ([ai.google.dev/gemini-api/docs/api-key](https://ai.google.dev/gemini-api/docs/api-key), updated 2026-07-06) links to this exact URL. The check fails only because the page redirects unauthenticated requests to Google account sign-in (302), which lychee cannot follow.

This adds `aistudio.google.com/api-keys` to the lychee `exclude` list, matching the existing treatment of `console.cloud.google.com` ("Redirects to authenticated Google Cloud console").