### PR TITLE
fix(cli): resolve curl upgrade version from npm dist-tag instead of GitHub releases/latest

### DIFF
--- a/.changeset/fix-upgrade-curl-version.md
+++ b/.changeset/fix-upgrade-curl-version.md
@@ -1,0 +1,7 @@
+---
+" @kilocode/cli": patch
+---
+
+Fix `kilo upgrade` for curl installs resolving the wrong latest version
+
+The upgrade command's version resolution for curl-detected installations used GitHub's `/releases/latest` endpoint, which now returns JetBrains plugin releases (e.g. `jetbrains/v7.0.4`) instead of the latest CLI release. This caused `kilo upgrade` to fail for curl installs. Version resolution now uses the npm `latest` dist-tag, matching the install script fix.

--- a/.changeset/fix-upgrade-curl-version.md
+++ b/.changeset/fix-upgrade-curl-version.md
@@ -1,5 +1,5 @@
 ---
-" @kilocode/cli": patch
+"@kilocode/cli": patch
 ---
 
 Fix `kilo upgrade` for curl installs resolving the wrong latest version

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -308,11 +308,17 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProce
           return data.version
         }
 
+        // kilocode_change start - curl/unknown fallback: resolve from the npm dist-tag
+        // instead of GitHub /releases/latest, which is polluted by non-CLI (e.g. JetBrains)
+        // releases and returns a tag like "jetbrains/v7.0.4" that breaks version resolution.
         const response = yield* httpOk.execute(
-          HttpClientRequest.get(KiloRelease.api).pipe(HttpClientRequest.acceptJson), // kilocode_change
+          HttpClientRequest.get(
+            `${yield* NpmConfig.registry(process.cwd())}/${KiloNpm.path}/${InstallationChannel}`,
+          ).pipe(HttpClientRequest.acceptJson),
         )
-        const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
-        return data.tag_name.replace(/^v/, "")
+        const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
+        return data.version
+        // kilocode_change end
       }, Effect.orDie),
       upgrade: Effect.fn("Installation.upgrade")(function* (m: Method, target: string) {
         let upgradeResult: { code: number; stdout: string; stderr: string } | undefined

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -308,13 +308,15 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProce
           return data.version
         }
 
-        // kilocode_change start - curl/unknown fallback: resolve from the npm dist-tag
-        // instead of GitHub /releases/latest, which is polluted by non-CLI (e.g. JetBrains)
-        // releases and returns a tag like "jetbrains/v7.0.4" that breaks version resolution.
+        // kilocode_change start - curl/unknown fallback: resolve from the public npm
+        // dist-tag instead of GitHub /releases/latest, which is polluted by non-CLI
+        // (e.g. JetBrains) releases and returns a tag like "jetbrains/v7.0.4" that
+        // breaks version resolution. Use the public registry directly: a curl-
+        // installed binary is not tied to any project's npm config.
         const response = yield* httpOk.execute(
-          HttpClientRequest.get(
-            `${yield* NpmConfig.registry(process.cwd())}/${KiloNpm.path}/${InstallationChannel}`,
-          ).pipe(HttpClientRequest.acceptJson),
+          HttpClientRequest.get(`https://registry.npmjs.org/${KiloNpm.path}/${InstallationChannel}`).pipe(
+            HttpClientRequest.acceptJson,
+          ),
         )
         const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
         return data.version

--- a/packages/opencode/src/kilocode/installation/index.ts
+++ b/packages/opencode/src/kilocode/installation/index.ts
@@ -21,6 +21,5 @@ export const Scoop = {
 }
 
 export const Release = {
-  api: "https://api.github.com/repos/Kilo-Org/kilocode/releases/latest",
   install: "https://kilo.ai/cli/install",
 }

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -58,16 +58,23 @@ function testLayer(
 
 describe("installation", () => {
   describe("latest", () => {
-    testEffect(testLayer(() => jsonResponse({ tag_name: "v1.2.3" }))).effect(
-      "reads release version from GitHub releases",
-      () =>
-        Effect.gen(function* () {
-          const result = yield* Installation.use.latest("unknown")
-          expect(result).toBe("1.2.3")
-        }),
+    // kilocode_change start - curl/unknown fallback now resolves from the public npm
+    // registry instead of GitHub /releases/latest (which is polluted by JetBrains releases)
+    const curlCalls: string[] = []
+    testEffect(
+      testLayer((request) => {
+        curlCalls.push(request.url)
+        return jsonResponse({ version: "1.2.3" })
+      }),
+    ).effect("reads release version from GitHub releases", () =>
+      Effect.gen(function* () {
+        const result = yield* Installation.use.latest("unknown")
+        expect(result).toBe("1.2.3")
+        expect(curlCalls).toContain("https://registry.npmjs.org/@kilocode%2fcli/local")
+      }),
     )
 
-    testEffect(testLayer(() => jsonResponse({ tag_name: "v4.0.0-beta.1" }))).effect(
+    testEffect(testLayer(() => jsonResponse({ version: "4.0.0-beta.1" }))).effect(
       "strips v prefix from GitHub release tag",
       () =>
         Effect.gen(function* () {
@@ -75,6 +82,7 @@ describe("installation", () => {
           expect(result).toBe("4.0.0-beta.1")
         }),
     )
+    // kilocode_change end
 
     const npmCalls: string[] = []
     testEffect(

--- a/packages/opencode/test/kilocode/installation/upgrade.test.ts
+++ b/packages/opencode/test/kilocode/installation/upgrade.test.ts
@@ -59,14 +59,14 @@ describe("Kilo installation upgrade", () => {
       () => "",
       (request) => {
         release.push(request.url)
-        return json({ tag_name: "v8.8.8" })
+        return json({ version: "8.8.8" })
       },
     ),
-  ).effect("reads fallback versions from Kilo GitHub releases", () =>
+  ).effect("reads fallback versions from the Kilo npm registry", () =>
     Effect.gen(function* () {
       const result = yield* Installation.Service.use((svc) => svc.latest("unknown"))
       expect(result).toBe("8.8.8")
-      expect(release).toContain("https://api.github.com/repos/Kilo-Org/kilocode/releases/latest")
+      expect(release).toContain(`https://registry.npmjs.org/@kilocode%2fcli/${InstallationChannel}`)
     }),
   )
 


### PR DESCRIPTION
## Problem

`kilo upgrade` for curl-detected installs (`~/.kilo/bin/kilo`) resolved the latest version from GitHub's `/releases/latest` endpoint. That endpoint now returns JetBrains plugin releases (e.g. `jetbrains/v7.0.4`) instead of the latest CLI release, because JetBrains releases are published more recently than CLI releases. The old code stripped the leading `v` from `tag_name`, leaving `jetbrains/v7.0.4` — not a valid semver — which then broke the upgrade flow. This is the same root cause as issue #12125 (fixed for the install script in #12148), but in a separate code path: `Installation.latest()` in `src/installation/index.ts`.

Reported in Discord: `kilo upgrade` and `curl https://kilo.ai/cli/install` both broken, with `kilo --version` and `kilocode --version` diverging (stale curl-installed binary vs up-to-date npm-installed one).

## Fix

The curl/unknown fallback in `Installation.latest()` now fetches the npm `latest` dist-tag (`${registry}/@kilocode%2fcli/${InstallationChannel}`) instead of GitHub `/releases/latest`. This naturally excludes JetBrains releases and CLI prerelease channels (RC lives on the `rc` dist-tag) without requiring `jq` or pagination. The npm branch already used this approach for npm/yarn/bun/pnpm installs — the curl fallback now uses the same source for consistency.

`upgradeCurl` needed no change: it passes `VERSION: target` to the install script (already fixed in #12148), which constructs the versioned GitHub asset URL from it.

## Verification

- `Installation.latest("curl")` with `KILO_CHANNEL=latest` resolves `7.4.5` from the live npm registry
- npm `latest` dist-tag: `7.4.5`; npm `rc` dist-tag: `7.4.2` (prerelease correctly excluded)
- GitHub `/releases/latest`: still returns `jetbrains/v7.0.4` (broken)
- Unit tests: 13 pass, 0 fail (`test/kilocode/installation/upgrade.test.ts`)
- Typecheck: no errors in changed files