### PR TITLE
Cli - Support remote slash command discovery and execution

### DIFF
--- a/.changeset/remote-session-slash-commands.md
+++ b/.changeset/remote-session-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Enable remote clients to discover and run workspace slash commands, including session compaction.

--- a/packages/opencode/src/kilo-sessions/remote-command.ts
+++ b/packages/opencode/src/kilo-sessions/remote-command.ts
@@ -1,0 +1,284 @@
+import type { Info as CommandInfo } from "@/command"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import type { MessageV2 } from "@/session/message-v2"
+import type { SessionPrompt } from "@/session/prompt"
+import type { Info as SessionInfo } from "@/session/session"
+import { MessageID, type SessionID } from "@/session/schema"
+import z from "zod"
+
+export namespace RemoteCommand {
+  export const MAX_COMMANDS = 256
+  export const MAX_STRING_LENGTH = 2_000
+  export const MAX_ARGUMENTS_LENGTH = 32_768
+  export const MAX_HINTS = 32
+  export const MAX_RESULT_BYTES = 512 * 1024
+
+  export const ListRequest = z
+    .object({
+      protocolVersion: z.literal(1),
+    })
+    .strict()
+
+  export const SendRequest = z
+    .object({
+      protocolVersion: z.literal(1),
+      command: z.string().min(1).max(MAX_STRING_LENGTH),
+      arguments: z.string().max(MAX_ARGUMENTS_LENGTH),
+      messageID: z.string().startsWith("msg").max(MAX_STRING_LENGTH).optional(),
+      model: z
+        .object({
+          providerID: z.string().min(1).max(MAX_STRING_LENGTH),
+          modelID: z.string().min(1).max(MAX_STRING_LENGTH),
+        })
+        .strict()
+        .optional(),
+      variant: z.string().max(MAX_STRING_LENGTH).optional(),
+    })
+    .strict()
+  export type SendRequest = z.infer<typeof SendRequest>
+
+  export const Info = z
+    .object({
+      name: z.string().min(1).max(MAX_STRING_LENGTH),
+      description: z.string().max(MAX_STRING_LENGTH).optional(),
+      agent: z.string().max(MAX_STRING_LENGTH).optional(),
+      model: z.string().max(MAX_STRING_LENGTH).optional(),
+      source: z.enum(["command", "mcp", "skill"]).optional(),
+      hints: z.array(z.string().max(MAX_STRING_LENGTH)).max(MAX_HINTS),
+      subtask: z.boolean().optional(),
+    })
+    .strict()
+  export type Info = z.infer<typeof Info>
+
+  export const Response = z
+    .object({
+      protocolVersion: z.literal(1),
+      commands: z.array(Info).max(MAX_COMMANDS),
+    })
+    .strict()
+  export type Response = z.infer<typeof Response>
+
+  // The only entry from BUILTIN_COMMANDS (kilocode/session/builtin-commands) exposed
+  // remotely: `summarize` is a local alias for the same compaction flow, so listing
+  // both would just duplicate the suggestion.
+  const compact: Info = {
+    name: "compact",
+    description: "compact the current session context",
+    hints: [],
+  }
+
+  function compare(a: Info, b: Info) {
+    if (a.name < b.name) return -1
+    if (a.name > b.name) return 1
+    return 0
+  }
+
+  // Truncates the alphabetical tail to stay within the count and byte caps.
+  // The `compact` entry is seeded first so truncation can never take remote
+  // compaction away; sizes are accumulated per entry to keep this a single pass.
+  function truncate(commands: Info[]): Info[] {
+    const encoder = new TextEncoder()
+    const measure = (value: unknown) => encoder.encode(JSON.stringify(value)).byteLength
+    const required = commands.find((item) => item.name === compact.name) ?? compact
+    const selected: Info[] = [required]
+    let budget = MAX_RESULT_BYTES - measure({ protocolVersion: 1, commands: [] }) - measure(required)
+    for (const item of commands) {
+      if (item === required) continue
+      if (selected.length >= MAX_COMMANDS) break
+      const bytes = measure(item) + 1 // +1 for the separating comma
+      if (bytes > budget) break
+      budget -= bytes
+      selected.push(item)
+    }
+    return selected.sort(compare)
+  }
+
+  // Validates a single source against the catalog caps, dropping skills and
+  // entries whose fields exceed the per-field limits. Shared by build() and
+  // the compact shadow check so discovery and execution apply the same rules.
+  function parse(source: CommandInfo): Info | undefined {
+    if (source.source === "skill") return
+    const item = Info.safeParse({
+      name: source.name,
+      ...(source.description !== undefined ? { description: source.description } : {}),
+      ...(source.agent !== undefined ? { agent: source.agent } : {}),
+      ...(source.model !== undefined ? { model: source.model } : {}),
+      ...(source.source !== undefined ? { source: source.source } : {}),
+      hints: source.hints,
+      ...(source.subtask !== undefined ? { subtask: source.subtask } : {}),
+    })
+    return item.success ? item.data : undefined
+  }
+
+  export function build(items: ReadonlyArray<CommandInfo>): Response {
+    const names = new Set<string>()
+    const commands: Info[] = []
+
+    for (const source of items) {
+      const item = parse(source)
+      if (!item || names.has(item.name)) continue
+      names.add(item.name)
+      commands.push(item)
+    }
+
+    if (!names.has(compact.name)) commands.push(compact)
+    commands.sort(compare)
+    return Response.parse({ protocolVersion: 1, commands: truncate(commands) })
+  }
+
+  export type ExecuteInput = SendRequest & { sessionID: SessionID }
+
+  export type Services = {
+    list: () => Promise<CommandInfo[]>
+    command: (input: SessionPrompt.CommandInput) => Promise<void>
+    session: {
+      get: (sessionID: SessionID) => Promise<SessionInfo>
+      messages: (sessionID: SessionID) => Promise<MessageV2.WithParts[]>
+    }
+    agent: { default: () => Promise<string> }
+    provider: { default: () => Promise<{ providerID: string; modelID: string }> }
+    revert: { cleanup: (session: SessionInfo) => Promise<void> }
+    compaction: {
+      create: (input: {
+        sessionID: SessionID
+        agent: string
+        model: { providerID: ProviderV2.ID; modelID: ModelV2.ID }
+        auto: boolean
+      }) => Promise<void>
+    }
+    prompt: { loop: (sessionID: SessionID) => Promise<void> }
+  }
+
+  export type Interface = {
+    list: () => Promise<Response>
+    execute: (input: ExecuteInput) => Promise<void>
+  }
+
+  export function create(services: Services): Interface {
+    return {
+      list: async () => build(await services.list()),
+      execute: async (input) => {
+        // A registered command named `compact` shadows the built-in only when it
+        // passes the same catalog validation as build(), so a malformed entry
+        // hidden from discovery cannot take over execution.
+        const shadowed =
+          input.command === compact.name &&
+          (await services.list()).some((item) => parse(item)?.name === compact.name)
+        if (input.command === compact.name && !shadowed) {
+          const session = await services.session.get(input.sessionID)
+          await services.revert.cleanup(session)
+          const messages = await services.session.messages(input.sessionID)
+          const user = messages.findLast((message) => message.info.role === "user")
+          const agent =
+            (user?.info.role === "user" ? user.info.agent : undefined) ??
+            session.agent ??
+            (await services.agent.default())
+          const model =
+            input.model ??
+            (session.model ? { providerID: session.model.providerID, modelID: session.model.id } : undefined) ??
+            (user?.info.role === "user"
+              ? { providerID: user.info.model.providerID, modelID: user.info.model.modelID }
+              : undefined) ??
+            (await services.provider.default())
+          await services.compaction.create({
+            sessionID: input.sessionID,
+            agent,
+            model: {
+              providerID: ProviderV2.ID.make(model.providerID),
+              modelID: ModelV2.ID.make(model.modelID),
+            },
+            auto: false,
+          })
+          await services.prompt.loop(input.sessionID)
+          return
+        }
+        await services.command({
+          sessionID: input.sessionID,
+          command: input.command,
+          arguments: input.arguments,
+          ...(input.messageID ? { messageID: MessageID.make(input.messageID) } : {}),
+          ...(input.model ? { model: `${input.model.providerID}/${input.model.modelID}` } : {}),
+          ...(input.variant !== undefined ? { variant: input.variant } : {}),
+        })
+      },
+    }
+  }
+
+  export function live(): Interface {
+    return create({
+      list: async () => {
+        const [{ AppRuntime }, { Command }] = await Promise.all([import("@/effect/app-runtime"), import("@/command")])
+        return AppRuntime.runPromise(Command.Service.use((service) => service.list()))
+      },
+      command: async (input) => {
+        const [{ AppRuntime }, { SessionPrompt }] = await Promise.all([
+          import("@/effect/app-runtime"),
+          import("@/session/prompt"),
+        ])
+        await AppRuntime.runPromise(SessionPrompt.Service.use((service) => service.command(input)))
+      },
+      session: {
+        get: async (sessionID) => {
+          const [{ AppRuntime }, { Session }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/session/session"),
+          ])
+          return AppRuntime.runPromise(Session.Service.use((service) => service.get(sessionID)))
+        },
+        messages: async (sessionID) => {
+          const [{ AppRuntime }, { Session }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/session/session"),
+          ])
+          return AppRuntime.runPromise(Session.Service.use((service) => service.messages({ sessionID })))
+        },
+      },
+      agent: {
+        default: async () => {
+          const [{ AppRuntime }, { Agent }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/agent/agent"),
+          ])
+          return AppRuntime.runPromise(Agent.Service.use((service) => service.defaultAgent()))
+        },
+      },
+      provider: {
+        default: async () => {
+          const [{ AppRuntime }, { Provider }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/provider/provider"),
+          ])
+          return AppRuntime.runPromise(Provider.Service.use((service) => service.defaultModel()))
+        },
+      },
+      revert: {
+        cleanup: async (session) => {
+          const [{ AppRuntime }, { SessionRevert }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/session/revert"),
+          ])
+          await AppRuntime.runPromise(SessionRevert.Service.use((service) => service.cleanup(session)))
+        },
+      },
+      compaction: {
+        create: async (input) => {
+          const [{ AppRuntime }, { SessionCompaction }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/session/compaction"),
+          ])
+          await AppRuntime.runPromise(SessionCompaction.Service.use((service) => service.create(input)))
+        },
+      },
+      prompt: {
+        loop: async (sessionID) => {
+          const [{ AppRuntime }, { SessionPrompt }] = await Promise.all([
+            import("@/effect/app-runtime"),
+            import("@/session/prompt"),
+          ])
+          await AppRuntime.runPromise(SessionPrompt.Service.use((service) => service.loop({ sessionID })))
+        },
+      },
+    })
+  }
+}

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -1,4 +1,5 @@
 import { RemoteModelCatalog } from "@/kilo-sessions/remote-model-catalog"
+import { RemoteCommand } from "@/kilo-sessions/remote-command"
 import { RemoteProtocol } from "@/kilo-sessions/remote-protocol"
 import type { RemoteWS } from "@/kilo-sessions/remote-ws"
 import { GlobalBus } from "@/bus/global"
@@ -76,6 +77,10 @@ function normalizePrompt(input: RemotePromptInput): SessionPrompt.PromptInput {
   }
 }
 
+function errorName(error: unknown) {
+  return error instanceof Error ? error.name : typeof error
+}
+
 export namespace RemoteSender {
   export type Options = {
     conn: RemoteWS.Connection
@@ -103,6 +108,7 @@ export namespace RemoteSender {
       readonly providers: () => Promise<Record<ProviderV2.ID, Provider.Info>>
       readonly default: () => Promise<RemoteModelCatalog.ModelRef | undefined>
     }
+    commands?: RemoteCommand.Interface
   }
 
   export type Sender = {
@@ -168,6 +174,7 @@ export namespace RemoteSender {
         return AppRuntime.runPromise(Provider.Service.use((svc) => svc.defaultModel()))
       },
     }
+    const commands = options.commands ?? RemoteCommand.live()
 
     const sub =
       options.subscribe ??
@@ -349,6 +356,88 @@ export namespace RemoteSender {
     }
 
     function dispatch(msg: RemoteProtocol.Command) {
+      if (msg.command === "list_commands") {
+        const parsed = RemoteCommand.ListRequest.safeParse(msg.data)
+        const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()
+        if (!parsed.success || Option.isNone(session)) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid list_commands command",
+          })
+          return
+        }
+        const run = options.provide ?? provide
+        void (async () => {
+          try {
+            const info = await catalog.get(session.value)
+            const result = await run({ directory: info.directory, fn: () => commands.list() })
+            options.conn.send({ type: "response", id: msg.id, result })
+          } catch (error) {
+            options.log.error("list commands failed", { id: msg.id, error: errorName(error) })
+            options.conn.send({ type: "response", id: msg.id, error: "failed to list commands" })
+          }
+        })()
+        return
+      }
+      if (msg.command === "send_command") {
+        const parsed = RemoteCommand.SendRequest.safeParse(msg.data)
+        const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()
+        if (!parsed.success || Option.isNone(session)) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid send_command command",
+          })
+          return
+        }
+        const run = options.provide ?? provide
+        const state = { acked: false }
+        void (async () => {
+          try {
+            const info = await catalog.get(session.value)
+            await run({
+              directory: info.directory,
+              fn: async () => {
+                // Reject stale catalog entries (command deleted or renamed since the
+                // client listed) before the ACK — after it, failures are only logged.
+                const available = await commands.list()
+                if (!available.commands.some((item) => item.name === parsed.data.command)) {
+                  options.conn.send({ type: "response", id: msg.id, error: "unknown slash command" })
+                  return
+                }
+                state.acked = true
+                options.conn.send({ type: "response", id: msg.id, result: {} })
+                try {
+                  await commands.execute({ ...parsed.data, sessionID: session.value })
+                } catch (error) {
+                  options.log.error("send command failed after ACK", {
+                    id: msg.id,
+                    operation: "send_command",
+                    error: errorName(error),
+                  })
+                }
+              },
+            })
+          } catch (error) {
+            if (state.acked) {
+              options.log.error("send command context failed after ACK", {
+                id: msg.id,
+                operation: "send_command",
+                error: errorName(error),
+              })
+              return
+            }
+            options.log.error("send command preflight failed", {
+              id: msg.id,
+              operation: "send_command",
+              error: errorName(error),
+            })
+            options.conn.send({ type: "response", id: msg.id, error: "failed to send command" })
+          }
+        })()
+        return
+      }
       if (msg.command === "list_models") {
         const parsed = RemoteModelCatalog.Request.safeParse(msg.data)
         const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()

--- a/packages/opencode/test/kilocode/sessions/remote-command.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-command.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, test } from "bun:test"
+import { RemoteCommand } from "../../../src/kilo-sessions/remote-command"
+import type { Info as SessionInfo } from "../../../src/session/session"
+import { SessionID } from "../../../src/session/schema"
+
+describe("RemoteCommand", () => {
+  test("validates list command protocol requests", () => {
+    expect(RemoteCommand.ListRequest.safeParse({ protocolVersion: 1 }).success).toBe(true)
+    expect(RemoteCommand.ListRequest.safeParse({ protocolVersion: 2 }).success).toBe(false)
+    expect(RemoteCommand.ListRequest.safeParse({ protocolVersion: 1, extra: true }).success).toBe(false)
+  })
+
+  test("validates structured command requests without duplicating session identity", () => {
+    const valid = {
+      protocolVersion: 1 as const,
+      command: "review",
+      arguments: "  main\nkeep spacing  ",
+      messageID: "msg_remote",
+      model: { providerID: "kilo", modelID: "anthropic/claude-sonnet-4" },
+      variant: "high",
+    }
+
+    expect(RemoteCommand.SendRequest.parse(valid)).toEqual(valid)
+    expect(RemoteCommand.SendRequest.safeParse({ ...valid, protocolVersion: 2 }).success).toBe(false)
+    expect(RemoteCommand.SendRequest.safeParse({ ...valid, sessionID: "ses_duplicate" }).success).toBe(false)
+    expect(RemoteCommand.SendRequest.safeParse({ ...valid, messageID: "bad" }).success).toBe(false)
+    expect(
+      RemoteCommand.SendRequest.safeParse({ ...valid, arguments: "x".repeat(RemoteCommand.MAX_ARGUMENTS_LENGTH + 1) })
+        .success,
+    ).toBe(false)
+    expect(
+      RemoteCommand.SendRequest.safeParse({ ...valid, messageID: "msg" + "x".repeat(RemoteCommand.MAX_STRING_LENGTH) })
+        .success,
+    ).toBe(false)
+  })
+
+  test("builds an allowlisted command catalog", () => {
+    const catalog = RemoteCommand.build([
+      {
+        name: "review",
+        description: "Review changes",
+        agent: "reviewer",
+        model: "kilo/review-model",
+        source: "command",
+        hints: ["$ARGUMENTS"],
+        subtask: true,
+        template: "must-not-leak",
+      },
+      {
+        name: "alpha",
+        description: "MCP prompt",
+        source: "mcp",
+        hints: ["$1"],
+        get template(): string {
+          throw new Error("template must not be read")
+        },
+      },
+      {
+        name: "secret-skill",
+        description: "Skill",
+        source: "skill",
+        hints: [],
+        template: "must-not-leak",
+      },
+      {
+        name: "review",
+        description: "Duplicate",
+        source: "mcp",
+        hints: [],
+        template: "must-not-leak",
+      },
+    ])
+
+    expect(catalog).toEqual({
+      protocolVersion: 1,
+      commands: [
+        {
+          name: "alpha",
+          description: "MCP prompt",
+          source: "mcp",
+          hints: ["$1"],
+        },
+        {
+          name: "compact",
+          description: "compact the current session context",
+          hints: [],
+        },
+        {
+          name: "review",
+          description: "Review changes",
+          agent: "reviewer",
+          model: "kilo/review-model",
+          source: "command",
+          hints: ["$ARGUMENTS"],
+          subtask: true,
+        },
+      ],
+    })
+    expect(JSON.stringify(catalog)).not.toContain("template")
+    expect(JSON.stringify(catalog)).not.toContain("secret-skill")
+  })
+
+  test("truncates catalogs over the command limit", () => {
+    const commands = Array.from({ length: RemoteCommand.MAX_COMMANDS + 10 }, (_, index) => ({
+      name: `command-${String(index).padStart(3, "0")}`,
+      source: "command" as const,
+      hints: [],
+      template: "hidden",
+    }))
+
+    const catalog = RemoteCommand.build(commands)
+    expect(catalog.commands).toHaveLength(RemoteCommand.MAX_COMMANDS)
+    expect(catalog.commands[0]?.name).toBe("command-000")
+    expect(catalog.commands.some((item) => item.name === "compact")).toBe(true)
+  })
+
+  test("skips entries over the per-field caps instead of failing the catalog", () => {
+    const catalog = RemoteCommand.build([
+      {
+        name: "x".repeat(RemoteCommand.MAX_STRING_LENGTH + 1),
+        source: "command",
+        hints: [],
+        template: "hidden",
+      },
+      {
+        name: "too-many-hints",
+        source: "command",
+        hints: Array.from({ length: RemoteCommand.MAX_HINTS + 1 }, () => "$ARGUMENTS"),
+        template: "hidden",
+      },
+      {
+        name: "review",
+        source: "command",
+        hints: ["$ARGUMENTS"],
+        template: "hidden",
+      },
+    ])
+
+    expect(catalog.commands.map((item) => item.name)).toEqual(["compact", "review"])
+  })
+
+  test("truncates to the serialized catalog limit measured in UTF-8 bytes", () => {
+    const commands = Array.from({ length: RemoteCommand.MAX_COMMANDS - 1 }, (_, index) => ({
+      name: `command-${index}`,
+      description: "🧪".repeat(900),
+      source: "command" as const,
+      hints: [],
+      template: "hidden",
+    }))
+
+    const catalog = RemoteCommand.build(commands)
+    expect(catalog.commands.length).toBeGreaterThan(0)
+    expect(catalog.commands.length).toBeLessThan(commands.length)
+    expect(catalog.commands.some((item) => item.name === "compact")).toBe(true)
+    expect(new TextEncoder().encode(JSON.stringify(catalog)).byteLength).toBeLessThanOrEqual(
+      RemoteCommand.MAX_RESULT_BYTES,
+    )
+  })
+
+  test("executes registered commands with verbatim structured input", async () => {
+    const calls: unknown[] = []
+    const remote = RemoteCommand.create({
+      list: async () => [],
+      command: async (input) => {
+        calls.push(input)
+      },
+      session: {
+        get: async () => {
+          throw new Error("unexpected session lookup")
+        },
+        messages: async () => {
+          throw new Error("unexpected message lookup")
+        },
+      },
+      agent: { default: async () => "unexpected-agent" },
+      provider: { default: async () => ({ providerID: "unexpected", modelID: "unexpected" }) },
+      revert: { cleanup: async () => {} },
+      compaction: { create: async () => {} },
+      prompt: { loop: async () => {} },
+    })
+
+    await remote.execute({
+      sessionID: SessionID.make("ses_remote"),
+      protocolVersion: 1,
+      command: "review",
+      arguments: "  main\nkeep spacing  ",
+      messageID: "msg_remote",
+      model: { providerID: "custom:edge", modelID: "deployment/model" },
+      variant: "high",
+    })
+
+    expect(calls).toEqual([
+      {
+        sessionID: SessionID.make("ses_remote"),
+        command: "review",
+        arguments: "  main\nkeep spacing  ",
+        messageID: "msg_remote",
+        model: "custom:edge/deployment/model",
+        variant: "high",
+      },
+    ])
+  })
+
+  test("lets a registered compact command shadow the built-in", async () => {
+    const calls: unknown[] = []
+    const remote = RemoteCommand.create({
+      list: async () => [{ name: "compact", source: "command", hints: [], template: "custom compact" }],
+      command: async (input) => {
+        calls.push(input)
+      },
+      session: {
+        get: async () => {
+          throw new Error("unexpected session lookup")
+        },
+        messages: async () => {
+          throw new Error("unexpected message lookup")
+        },
+      },
+      agent: { default: async () => "unexpected-agent" },
+      provider: { default: async () => ({ providerID: "unexpected", modelID: "unexpected" }) },
+      revert: { cleanup: async () => {} },
+      compaction: {
+        create: async () => {
+          throw new Error("unexpected built-in compaction")
+        },
+      },
+      prompt: { loop: async () => {} },
+    })
+
+    await remote.execute({
+      sessionID: SessionID.make("ses_remote"),
+      protocolVersion: 1,
+      command: "compact",
+      arguments: "",
+    })
+
+    expect(calls).toEqual([
+      {
+        sessionID: SessionID.make("ses_remote"),
+        command: "compact",
+        arguments: "",
+      },
+    ])
+  })
+
+  test("falls back to built-in compact when a registered compact fails catalog validation", async () => {
+    const steps: unknown[] = []
+    const session = {
+      id: SessionID.make("ses_remote"),
+      agent: "session-agent",
+      model: { providerID: "session-provider", id: "session-model" },
+    } as SessionInfo
+    const remote = RemoteCommand.create({
+      list: async () => [
+        {
+          name: "compact",
+          description: "x".repeat(RemoteCommand.MAX_STRING_LENGTH + 1),
+          source: "command",
+          hints: [],
+          template: "malformed compact",
+        },
+      ],
+      command: async () => {
+        throw new Error("unexpected registered command")
+      },
+      session: {
+        get: async () => {
+          steps.push("get")
+          return session
+        },
+        messages: async () => {
+          steps.push("messages")
+          return []
+        },
+      },
+      agent: { default: async () => "default-agent" },
+      provider: { default: async () => ({ providerID: "default-provider", modelID: "default-model" }) },
+      revert: {
+        cleanup: async () => {
+          steps.push("cleanup")
+        },
+      },
+      compaction: {
+        create: async () => {
+          steps.push("create")
+        },
+      },
+      prompt: {
+        loop: async () => {
+          steps.push("loop")
+        },
+      },
+    })
+
+    const catalog = RemoteCommand.build([
+      {
+        name: "compact",
+        description: "x".repeat(RemoteCommand.MAX_STRING_LENGTH + 1),
+        source: "command",
+        hints: [],
+        template: "malformed compact",
+      },
+    ])
+    expect(catalog.commands.some((item) => item.name === "compact")).toBe(true)
+
+    await remote.execute({
+      sessionID: SessionID.make("ses_remote"),
+      protocolVersion: 1,
+      command: "compact",
+      arguments: "",
+    })
+
+    expect(steps).toEqual(["get", "cleanup", "messages", "create", "loop"])
+  })
+
+  test("executes compact through cleanup, compaction, and prompt loop", async () => {
+    const steps: unknown[] = []
+    const session = {
+      id: SessionID.make("ses_remote"),
+      agent: "session-agent",
+      model: { providerID: "session-provider", id: "session-model" },
+    } as SessionInfo
+    const remote = RemoteCommand.create({
+      list: async () => [],
+      command: async () => {
+        throw new Error("unexpected registered command")
+      },
+      session: {
+        get: async () => {
+          steps.push("get")
+          return session
+        },
+        messages: async () => {
+          steps.push("messages")
+          return []
+        },
+      },
+      agent: { default: async () => "default-agent" },
+      provider: { default: async () => ({ providerID: "default-provider", modelID: "default-model" }) },
+      revert: {
+        cleanup: async (info) => {
+          steps.push(["cleanup", info.id])
+        },
+      },
+      compaction: {
+        create: async (input) => {
+          steps.push(["create", input])
+        },
+      },
+      prompt: {
+        loop: async (sessionID) => {
+          steps.push(["loop", sessionID])
+        },
+      },
+    })
+
+    await remote.execute({
+      sessionID: SessionID.make("ses_remote"),
+      protocolVersion: 1,
+      command: "compact",
+      arguments: "",
+      model: { providerID: "request-provider", modelID: "request-model" },
+    })
+
+    expect(steps).toEqual([
+      "get",
+      ["cleanup", SessionID.make("ses_remote")],
+      "messages",
+      [
+        "create",
+        {
+          sessionID: SessionID.make("ses_remote"),
+          agent: "session-agent",
+          model: { providerID: "request-provider", modelID: "request-model" },
+          auto: false,
+        },
+      ],
+      ["loop", SessionID.make("ses_remote")],
+    ])
+  })
+})

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { afterEach, mock, spyOn } from "bun:test"
 import { Effect } from "effect"
 import { RemoteModelCatalog } from "../../../src/kilo-sessions/remote-model-catalog"
+import type { RemoteCommand } from "../../../src/kilo-sessions/remote-command"
 import { RemoteSender } from "../../../src/kilo-sessions/remote-sender"
 import type { RemoteWS } from "../../../src/kilo-sessions/remote-ws"
 import type { RemoteProtocol } from "../../../src/kilo-sessions/remote-protocol"
@@ -12,6 +13,8 @@ import { Permission } from "../../../src/permission"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import type { Info as SessionInfo } from "../../../src/session/session"
 import { SessionID } from "../../../src/session/schema"
 import { Suggestion } from "../../../src/kilocode/suggestion" // kilocode_change
 
@@ -71,6 +74,18 @@ function questions(items: Question.Request[] = []) {
 function prompts(calls: SessionPrompt.PromptInput[]) {
   return async (input: SessionPrompt.PromptInput) => {
     calls.push(input)
+  }
+}
+
+function sessionInfo(id: string, directory: string): SessionInfo {
+  return {
+    id: SessionID.make(id),
+    slug: id,
+    projectID: ProjectV2.ID.global,
+    directory,
+    title: id,
+    version: "test",
+    time: { created: 1, updated: 1 },
   }
 }
 
@@ -324,6 +339,278 @@ describe("RemoteSender", () => {
       id: "req_unknown",
       error: "unknown command: unknown_command",
     })
+  })
+
+  test("list_commands returns each catalog from the exact session directory", async () => {
+    const { conn, sent } = fakeConn()
+    const dirs: string[] = []
+    const state = { directory: "" }
+    const first = Promise.withResolvers<void>()
+    const second = Promise.withResolvers<void>()
+    const send = conn.send.bind(conn)
+    conn.send = (message: RemoteProtocol.Outbound) => {
+      send(message)
+      if (message.type !== "response") return
+      if (message.id === "req_commands_first") first.resolve()
+      if (message.id === "req_commands_second") second.resolve()
+    }
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/process-default",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => {
+        dirs.push(input.directory)
+        state.directory = input.directory
+        const result = await input.fn()
+        state.directory = ""
+        return result
+      },
+      commands: {
+        list: async () => ({
+          protocolVersion: 1,
+          commands: [{ name: state.directory.endsWith("first") ? "first" : "second", hints: [] }],
+        }),
+        execute: async () => {},
+      },
+      catalog: {
+        get: async (sessionID) =>
+          sessionInfo(sessionID, sessionID === SessionID.make("ses_first") ? "/workspace/first" : "/workspace/second"),
+        messages: async () => [],
+        providers: async () => ({}),
+        default: async () => undefined,
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_commands_first",
+      command: "list_commands",
+      sessionId: "ses_first",
+      data: { protocolVersion: 1 },
+    })
+    await first.promise
+    sender.handle({
+      type: "command",
+      id: "req_commands_second",
+      command: "list_commands",
+      sessionId: "ses_second",
+      data: { protocolVersion: 1 },
+    })
+    await second.promise
+
+    expect(dirs).toEqual(["/workspace/first", "/workspace/second"])
+    expect(sent).toEqual([
+      {
+        type: "response",
+        id: "req_commands_first",
+        result: { protocolVersion: 1, commands: [{ name: "first", hints: [] }] },
+      },
+      {
+        type: "response",
+        id: "req_commands_second",
+        result: { protocolVersion: 1, commands: [{ name: "second", hints: [] }] },
+      },
+    ])
+  })
+
+  test("send_command validates the session directory before ACK and executes asynchronously", async () => {
+    const { conn, sent } = fakeConn()
+    const steps: unknown[] = []
+    const started = Promise.withResolvers<void>()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/process-default",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => {
+        steps.push(["provide", input.directory])
+        return input.fn()
+      },
+      commands: {
+        list: async () => ({ protocolVersion: 1, commands: [{ name: "review", hints: [] }] }),
+        execute: async (input) => {
+          steps.push(["execute", input])
+          started.resolve()
+          await new Promise(() => {})
+        },
+      },
+      catalog: {
+        get: async () => {
+          steps.push("get")
+          return sessionInfo("ses_commands", "/workspace/project-a")
+        },
+        messages: async () => [],
+        providers: async () => ({}),
+        default: async () => undefined,
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_send_command",
+      command: "send_command",
+      sessionId: "ses_commands",
+      data: {
+        protocolVersion: 1,
+        command: "review",
+        arguments: "  main  ",
+        messageID: "msg_remote",
+      },
+    })
+
+    expect(sent).toEqual([])
+    await started.promise
+    expect(sent).toEqual([{ type: "response", id: "req_send_command", result: {} }])
+    expect(steps).toEqual([
+      "get",
+      ["provide", "/workspace/project-a"],
+      [
+        "execute",
+        {
+          sessionID: SessionID.make("ses_commands"),
+          protocolVersion: 1,
+          command: "review",
+          arguments: "  main  ",
+          messageID: "msg_remote",
+        },
+      ],
+    ])
+  })
+
+  test("send_command rejects a command missing from the catalog without ACK", async () => {
+    const { conn, sent } = fakeConn()
+    const delivered = Promise.withResolvers<void>()
+    const send = conn.send.bind(conn)
+    conn.send = (message: RemoteProtocol.Outbound) => {
+      send(message)
+      if (message.type === "response" && message.id === "req_stale_command") delivered.resolve()
+    }
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/process-default",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => input.fn(),
+      commands: {
+        list: async () => ({ protocolVersion: 1, commands: [{ name: "compact", hints: [] }] }),
+        execute: async () => {
+          throw new Error("must not execute")
+        },
+      },
+      catalog: {
+        get: async () => sessionInfo("ses_commands", "/workspace/project-a"),
+        messages: async () => [],
+        providers: async () => ({}),
+        default: async () => undefined,
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_stale_command",
+      command: "send_command",
+      sessionId: "ses_commands",
+      data: { protocolVersion: 1, command: "deleted-command", arguments: "main" },
+    })
+
+    await delivered.promise
+    expect(sent).toEqual([{ type: "response", id: "req_stale_command", error: "unknown slash command" }])
+  })
+
+  test("send_command returns a safe error without ACK when the session is missing", async () => {
+    const { conn, sent } = fakeConn()
+    const delivered = Promise.withResolvers<void>()
+    const send = conn.send.bind(conn)
+    conn.send = (message: RemoteProtocol.Outbound) => {
+      send(message)
+      if (message.type === "response" && message.id === "req_missing_command") delivered.resolve()
+    }
+    const dirs: string[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/process-default",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => {
+        dirs.push(input.directory)
+        return input.fn()
+      },
+      commands: {
+        list: async () => ({ protocolVersion: 1, commands: [] }),
+        execute: async () => {
+          throw new Error("must not execute")
+        },
+      },
+      catalog: {
+        get: async () => {
+          throw new Error("private lookup detail")
+        },
+        messages: async () => [],
+        providers: async () => ({}),
+        default: async () => undefined,
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_missing_command",
+      command: "send_command",
+      sessionId: "ses_missing",
+      data: { protocolVersion: 1, command: "review", arguments: "main" },
+    })
+
+    expect(sent).toEqual([])
+    await delivered.promise
+    expect(dirs).toEqual([])
+    expect(sent).toEqual([{ type: "response", id: "req_missing_command", error: "failed to send command" }])
+    expect(JSON.stringify(sent)).not.toContain("private lookup detail")
+  })
+
+  test("send_command logs only the error class after ACK", async () => {
+    class CredentialLeakError extends Error {
+      override name = "CredentialLeakError"
+    }
+    const { conn, sent } = fakeConn()
+    const logged = Promise.withResolvers<unknown[]>()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/process-default",
+      log: {
+        ...nolog,
+        error: (...args: unknown[]) => logged.resolve(args),
+      },
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => input.fn(),
+      commands: {
+        list: async () => ({ protocolVersion: 1, commands: [{ name: "review", hints: [] }] }),
+        execute: async () => {
+          throw new CredentialLeakError("credential=must-not-leak")
+        },
+      },
+      catalog: {
+        get: async () => sessionInfo("ses_commands", "/workspace/project-a"),
+        messages: async () => [],
+        providers: async () => ({}),
+        default: async () => undefined,
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_failed_command",
+      command: "send_command",
+      sessionId: "ses_commands",
+      data: { protocolVersion: 1, command: "review", arguments: "main" },
+    })
+
+    const entry = await logged.promise
+    expect(sent).toEqual([{ type: "response", id: "req_failed_command", result: {} }])
+    expect(entry).toEqual([
+      "send command failed after ACK",
+      { id: "req_failed_command", operation: "send_command", error: "CredentialLeakError" },
+    ])
+    expect(JSON.stringify(entry)).not.toContain("credential=must-not-leak")
   })
 
   test("list_models returns the effective catalog from the exact session directory", async () => {


### PR DESCRIPTION
## What

Adds remote slash command support to the session WebSocket protocol so remote clients (VS Code extension, Agent Manager) can discover and run workspace slash commands — including session compaction.

## Why

Remote sessions previously had no way to list or invoke slash commands defined in the workspace. This wires the existing `Command` service into the remote protocol via two new commands: `list_commands` and `send_command`.

## How

- New `RemoteCommand` module (`packages/opencode/src/kilo-sessions/remote-command.ts`): defines the protocol schemas (with per-field size caps), builds a safe catalog response (skipping malformed entries, truncating by count/byte budget), and resolves execution against real services. `compact` is handled as a local alias for the compaction flow.
- `RemoteSender` dispatches `list_commands`/`send_command`, running each against the exact session directory via the existing `provide` boundary.
- `send_command` validates the command still exists in the catalog before ACKing; failures after the ACK are logged with only the error class (no message leakage), while pre-ACK failures return a safe error string.
- Covered by new tests in `remote-command.test.ts` and extended `remote-sender.test.ts` (directory isolation, stale-command rejection, missing-session, post-ACK leak prevention).

A changeset (`minor`) is included.