### PR TITLE
fix(vscode): correct cache token indicator

### DIFF
--- a/.changeset/fix-cache-token-arrow.md
+++ b/.changeset/fix-cache-token-arrow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Correct the token usage summary's cache-read indicator and group cached input with other input tokens.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
@@ -50,16 +50,16 @@ export const TaskUsage: Component<TaskUsageProps> = (props) => {
           {number(props.tokens.input)}
         </span>
       </Show>
+      <Show when={props.tokens.cached > 0}>
+        <span class="task-header-tokens-value">
+          <Icon name="arrow-up" size="small" />
+          cache {number(props.tokens.cached)}
+        </span>
+      </Show>
       <Show when={props.tokens.output > 0}>
         <span class="task-header-tokens-value">
           <Icon name="arrow-down-to-line" size="small" />
           {number(props.tokens.output)}
-        </span>
-      </Show>
-      <Show when={props.tokens.cached > 0}>
-        <span class="task-header-tokens-value">
-          <Icon name="arrow-down-to-line" size="small" />
-          cache {number(props.tokens.cached)}
         </span>
       </Show>
     </>


### PR DESCRIPTION
## Issue

No linked issue. This is a small visual correctness fix for the session token usage summary.

## Context

Cached tokens are cache-read prompt tokens, so they belong to the input side of token usage. The summary previously showed them with the output/down-arrow icon and placed them after output, which made the token flow misleading.

## Implementation

The compact token summary now renders cache reads with the input/up-arrow icon and orders the values as fresh input, cached input, then generated output. A patch changeset is included because this corrects user-visible token usage information.

## Screenshots / Video

| before | after |
|---|---|
| <img width="456" height="192" alt="Screenshot From 2026-07-13 16-04-47" src="https://github.com/user-attachments/assets/5c44c709-890a-4455-9583-cc1210b82ae1" /> | <img width="456" height="192" alt="Screenshot From 2026-07-13 16-04-16" src="https://github.com/user-attachments/assets/6c209a2a-7da5-482a-a2ff-61b24147e9ad" /> |

## How to Test

### Manual/local verification

- Ran `bun run typecheck` from `packages/kilo-vscode/`.
- Built the VS Code extension and manually confirmed the updated token summary in VS Code.

### Reviewer test steps

1. Open a session that has both prompt-cache reads and generated output.
2. Expand the task usage summary.
3. Confirm the compact summary orders values as fresh input, cached input, then output.
4. Confirm both fresh input and `cache` use up-arrow icons, while output uses the down-arrow icon.

### Blocked checks and substitute verification

- No checks were blocked.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.