### PR TITLE
test(jetbrains): reduce unit test runtime

### DIFF
--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: true
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -42,13 +42,9 @@ jobs:
     needs: changes
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.jetbrains == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/kilo-org/build/jetbrains:24.04
     defaults:
       run:
         shell: bash
-    env:
-      GRADLE_USER_HOME: /home/runner/.gradle
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -58,11 +54,21 @@ jobs:
       - name: Mark workspace as git-safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
-          cache-overwrite-existing: true
 
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -47,6 +47,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      GRADLE_USER_HOME: /home/runner/.gradle
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -56,8 +56,11 @@ jobs:
       - name: Mark workspace as git-safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Install dependencies
-        run: bun install
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+          cache-overwrite-existing: true
 
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/app/KiloConnectionServiceTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/app/KiloConnectionServiceTest.kt
@@ -112,7 +112,6 @@ class KiloConnectionServiceTest {
         }
 
         ready.complete(Unit)
-        mock.awaitSseConnection()
         withTimeout(5_000) {
             svc.state.first { it is ConnectionState.Connected }
         }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/history/HistoryController.kt
@@ -8,6 +8,7 @@ import ai.kilocode.client.telemetry.Telemetry
 import ai.kilocode.rpc.dto.CloudSessionDto
 import ai.kilocode.rpc.dto.SessionDto
 import com.intellij.openapi.application.ApplicationManager
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -23,6 +24,7 @@ class HistoryController(
     private val deleted: (String) -> Unit = {},
     private val gitUrlProvider: () -> String? = { resolveGitRemoteUrl(workspace.directory) },
     private val telemetry: (String, Map<String, String>) -> Unit = { event, props -> Telemetry.send(event, props) },
+    private val io: CoroutineDispatcher = Dispatchers.IO,
 ) {
     companion object {
         const val CLOUD_LIMIT = 50
@@ -208,7 +210,7 @@ class HistoryController(
         if (resolved) return gitUrl
         return lock.withLock {
             if (resolved) return@withLock gitUrl
-            val url = withContext(Dispatchers.IO) {
+            val url = withContext(io) {
                 gitUrlProvider()
             }
             // Write gitUrl directly (volatile) so it is visible before EDT callbacks fire.

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/HistorySessionActionsTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/HistorySessionActionsTest.kt
@@ -14,6 +14,7 @@ import ai.kilocode.client.session.history.HistorySource
 import ai.kilocode.client.session.history.LocalHistoryItem
 import ai.kilocode.client.testing.FakeSessionRpcApi
 import ai.kilocode.client.testing.FakeWorkspaceRpcApi
+import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.rpc.dto.CloudSessionDto
 import ai.kilocode.rpc.dto.KiloWorkspaceStateDto
 import ai.kilocode.rpc.dto.KiloWorkspaceStatusDto
@@ -28,16 +29,13 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.ui.UIUtil
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 @Suppress("UnstableApiUsage")
 class HistorySessionActionsTest : BasePlatformTestCase() {
-    private lateinit var scope: CoroutineScope
+    private lateinit var coroutines: TestCoroutines
     private lateinit var rpc: FakeSessionRpcApi
     private lateinit var sessions: KiloSessionService
     private lateinit var workspace: Workspace
@@ -49,20 +47,20 @@ class HistorySessionActionsTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-        scope = CoroutineScope(SupervisorJob())
+        coroutines = TestCoroutines()
         rpc = FakeSessionRpcApi()
-        sessions = KiloSessionService(project, scope, rpc)
-        val workspaces = KiloWorkspaceService(scope, FakeWorkspaceRpcApi().also {
+        sessions = KiloSessionService(project, coroutines.scope, rpc)
+        val workspaces = KiloWorkspaceService(coroutines.scope, FakeWorkspaceRpcApi().also {
             it.state.value = KiloWorkspaceStateDto(status = KiloWorkspaceStatusDto.READY)
         })
         workspace = workspaces.workspace("/test")
-        controller = HistoryController(sessions, workspace, scope, deleted = { deleteCount++ })
+        controller = HistoryController(sessions, workspace, coroutines.scope, deleted = { deleteCount++ })
         manager = FakeManager()
     }
 
     override fun tearDown() {
         try {
-            scope.cancel()
+            coroutines.close(::pump)
         } finally {
             super.tearDown()
         }
@@ -123,7 +121,7 @@ class HistorySessionActionsTest : BasePlatformTestCase() {
 
     fun `test open action performs opens local item`() {
         val opened = mutableListOf<String>()
-        val ctrl = HistoryController(sessions, workspace, scope, open = { ref ->
+        val ctrl = HistoryController(sessions, workspace, coroutines.scope, open = { ref ->
             when (ref) {
                 is SessionRef.Local -> opened.add(ref.id)
                 is SessionRef.Cloud -> opened.add("cloud:${ref.id}")
@@ -141,7 +139,7 @@ class HistorySessionActionsTest : BasePlatformTestCase() {
 
     fun `test open action performs opens cloud item`() {
         val opened = mutableListOf<String>()
-        val ctrl = HistoryController(sessions, workspace, scope, open = { ref ->
+        val ctrl = HistoryController(sessions, workspace, coroutines.scope, open = { ref ->
             when (ref) {
                 is SessionRef.Local -> opened.add(ref.id)
                 is SessionRef.Cloud -> opened.add("cloud:${ref.id}")
@@ -474,11 +472,10 @@ class HistorySessionActionsTest : BasePlatformTestCase() {
         waitFor { deleteCount >= n }
     }
 
-    private fun flush() = runBlocking {
-        repeat(10) {
-            delay(100)
-            ApplicationManager.getApplication().invokeAndWait { UIUtil.dispatchAllInvocationEvents() }
-        }
+    private fun flush() = coroutines.drain(::pump)
+
+    private fun pump() {
+        ApplicationManager.getApplication().invokeAndWait { UIUtil.dispatchAllInvocationEvents() }
     }
 
     private fun waitFor(done: () -> Boolean) = runBlocking {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/SessionSidePanelManagerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/SessionSidePanelManagerTest.kt
@@ -18,6 +18,7 @@ import ai.kilocode.client.testing.FakeAppRpcApi
 import ai.kilocode.client.testing.FakeSessionRpcApi
 import ai.kilocode.client.testing.TestUiTimers
 import ai.kilocode.client.testing.FakeWorkspaceRpcApi
+import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.rpc.dto.ChatEventDto
 import ai.kilocode.rpc.dto.CloudSessionDto
 import ai.kilocode.rpc.dto.KiloAppStateDto
@@ -36,9 +37,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.registry.RegistryKeyDescriptor
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.swing.JLabel
 import javax.swing.JComponent
@@ -46,7 +44,7 @@ import javax.swing.JPanel
 
 @Suppress("UnstableApiUsage")
 class SessionSidePanelManagerTest : BasePlatformTestCase() {
-    private lateinit var scope: CoroutineScope
+    private lateinit var coroutines: TestCoroutines
     private lateinit var rpc: FakeSessionRpcApi
     private lateinit var workspaces: KiloWorkspaceService
     private lateinit var workspace: Workspace
@@ -61,13 +59,13 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
     override fun setUp() {
         super.setUp()
         timers = TestUiTimers()
-        scope = CoroutineScope(SupervisorJob())
+        coroutines = TestCoroutines()
         rpc = FakeSessionRpcApi()
-        sessions = KiloSessionService(project, scope, rpc)
-        app = KiloAppService(scope, FakeAppRpcApi().also {
+        sessions = KiloSessionService(project, coroutines.scope, rpc)
+        app = KiloAppService(coroutines.scope, FakeAppRpcApi().also {
             it.state.value = KiloAppStateDto(KiloAppStatusDto.READY)
         })
-        workspaces = KiloWorkspaceService(scope, FakeWorkspaceRpcApi().also {
+        workspaces = KiloWorkspaceService(coroutines.scope, FakeWorkspaceRpcApi().also {
             it.state.value = KiloWorkspaceStateDto(KiloWorkspaceStatusDto.READY)
         })
         workspace = workspaces.workspace("/test")
@@ -76,7 +74,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
     override fun tearDown() {
         try {
             managers.forEach { Disposer.dispose(it) }
-            scope.cancel()
+            coroutines.close(::pump)
         } finally {
             super.tearDown()
         }
@@ -287,7 +285,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         useLongInactiveDisposeTimeout()
         lateinit var history: HistoryPanel
         val manager = manager(history = { parent, _, _ ->
-            val controller = HistoryController(sessions, workspace, scope)
+            val controller = HistoryController(sessions, workspace, coroutines.scope, io = coroutines.dispatcher)
             controller.local.replace(listOf(LocalHistoryItem(session("ses_1", "/test", "Stored"))))
             HistoryPanel(parent, controller, manager = parent as SessionManager).also { history = it }
         })
@@ -319,7 +317,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         useLongInactiveDisposeTimeout()
         lateinit var history: HistoryPanel
         val manager = manager(history = { parent, _, _ ->
-            val controller = HistoryController(sessions, workspace, scope)
+            val controller = HistoryController(sessions, workspace, coroutines.scope, io = coroutines.dispatcher)
             controller.local.replace(listOf(LocalHistoryItem(session("ses_1", "/test", "Stored"))))
             HistoryPanel(parent, controller, manager = parent as SessionManager).also { history = it }
         })
@@ -690,7 +688,7 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
                     workspace,
                     sessions,
                     app,
-                    scope,
+                    coroutines.scope,
                     ref = ref,
                     manager = owner,
                     workspaces = workspaces,
@@ -765,12 +763,11 @@ class SessionSidePanelManagerTest : BasePlatformTestCase() {
         timers.advanceBy(10)
     }
 
-    private fun settle() = kotlinx.coroutines.runBlocking {
-        repeat(5) {
-            kotlinx.coroutines.delay(100)
-            com.intellij.openapi.application.ApplicationManager.getApplication().invokeAndWait {
-                com.intellij.util.ui.UIUtil.dispatchAllInvocationEvents()
-            }
+    private fun settle() = coroutines.drain(::pump)
+
+    private fun pump() {
+        com.intellij.openapi.application.ApplicationManager.getApplication().invokeAndWait {
+            com.intellij.util.ui.UIUtil.dispatchAllInvocationEvents()
         }
     }
 

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/history/HistoryControllerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/history/HistoryControllerTest.kt
@@ -9,6 +9,7 @@ import ai.kilocode.client.session.SessionActivityKind
 import ai.kilocode.client.session.SessionRef
 import ai.kilocode.client.testing.FakeSessionRpcApi
 import ai.kilocode.client.testing.FakeWorkspaceRpcApi
+import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.client.ui.UiStyle
 import ai.kilocode.client.ui.HoverIcon
 import ai.kilocode.client.ui.layout.Align
@@ -28,11 +29,9 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.UIUtil
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.awt.BorderLayout
 import java.awt.Cursor
 import java.awt.event.KeyEvent
@@ -49,7 +48,7 @@ import javax.swing.event.ListDataListener
 
 @Suppress("UnstableApiUsage")
 class HistoryControllerTest : BasePlatformTestCase() {
-    private lateinit var scope: CoroutineScope
+    private lateinit var coroutines: TestCoroutines
     private lateinit var parent: Disposable
     private lateinit var rpc: FakeSessionRpcApi
     private lateinit var sessions: KiloSessionService
@@ -57,11 +56,11 @@ class HistoryControllerTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-        scope = CoroutineScope(SupervisorJob())
+        coroutines = TestCoroutines()
         parent = Disposer.newDisposable("history")
         rpc = FakeSessionRpcApi()
-        sessions = KiloSessionService(project, scope, rpc)
-        val workspaces = KiloWorkspaceService(scope, FakeWorkspaceRpcApi().also {
+        sessions = KiloSessionService(project, coroutines.scope, rpc)
+        val workspaces = KiloWorkspaceService(coroutines.scope, FakeWorkspaceRpcApi().also {
             it.state.value = KiloWorkspaceStateDto(status = KiloWorkspaceStatusDto.READY)
         })
         workspace = workspaces.workspace("/test")
@@ -70,7 +69,7 @@ class HistoryControllerTest : BasePlatformTestCase() {
     override fun tearDown() {
         try {
             Disposer.dispose(parent)
-            scope.cancel()
+            coroutines.close(::pump)
         } finally {
             super.tearDown()
         }
@@ -787,7 +786,7 @@ class HistoryControllerTest : BasePlatformTestCase() {
     fun `test cloud git url resolves once across overlapping reloads`() {
         rpc.cloud += cloud("cloud_1", "Cloud One")
         val calls = AtomicInteger()
-        val controller = HistoryController(sessions, workspace, scope, gitUrlProvider = {
+        val controller = HistoryController(sessions, workspace, coroutines.scope, gitUrlProvider = {
             calls.incrementAndGet()
             Thread.sleep(100)
             "git@github.com:test/repo.git"
@@ -795,7 +794,7 @@ class HistoryControllerTest : BasePlatformTestCase() {
 
         controller.reloadCloud()
         controller.reloadCloud()
-        flush()
+        waitFor { rpc.cloudCalls.size == 2 }
 
         assertEquals(1, calls.get())
         assertEquals(2, rpc.cloudCalls.size)
@@ -876,29 +875,37 @@ class HistoryControllerTest : BasePlatformTestCase() {
         assertFalse(panel.repoOnlySelected())
     }
 
-    private fun controller() = HistoryController(sessions, workspace, scope)
+    private fun controller() = HistoryController(sessions, workspace, coroutines.scope, io = coroutines.dispatcher)
 
     private fun telemetryController(events: MutableList<Pair<String, Map<String, String>>>) = HistoryController(
         sessions,
         workspace,
-        scope,
+        coroutines.scope,
         telemetry = { event, props -> events.add(event to props) },
+        io = coroutines.dispatcher,
     )
 
     private fun controllerWithGit(url: String?) = HistoryController(
         sessions,
         workspace,
-        scope,
+        coroutines.scope,
         gitUrlProvider = { url },
+        io = coroutines.dispatcher,
     )
 
-    private fun controller(opened: MutableList<String>) = HistoryController(sessions, workspace, scope, open = { open ->
-        val id = when (open) {
-            is SessionRef.Local -> open.id
-            is SessionRef.Cloud -> "cloud:${open.id}"
-        }
-        opened.add(id)
-    })
+    private fun controller(opened: MutableList<String>) = HistoryController(
+        sessions,
+        workspace,
+        coroutines.scope,
+        open = { open ->
+            val id = when (open) {
+                is SessionRef.Local -> open.id
+                is SessionRef.Cloud -> "cloud:${open.id}"
+            }
+            opened.add(id)
+        },
+        io = coroutines.dispatcher,
+    )
 
     private class FakeManager : SessionManager {
         override fun newSession() {}
@@ -945,10 +952,18 @@ class HistoryControllerTest : BasePlatformTestCase() {
         return events
     }
 
-    private fun flush() = runBlocking {
-        repeat(5) {
-            delay(100)
-            ApplicationManager.getApplication().invokeAndWait { UIUtil.dispatchAllInvocationEvents() }
+    private fun flush() = coroutines.drain(::pump)
+
+    private fun pump() {
+        ApplicationManager.getApplication().invokeAndWait { UIUtil.dispatchAllInvocationEvents() }
+    }
+
+    private fun waitFor(done: () -> Boolean) = runBlocking {
+        withTimeout(5_000) {
+            while (!done()) {
+                delay(10)
+                pump()
+            }
         }
     }
 

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/UserProfileConfigurableTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/UserProfileConfigurableTest.kt
@@ -5,6 +5,7 @@ import ai.kilocode.client.settings.profile.ProfileUi
 import ai.kilocode.client.settings.profile.formatResetDate
 import ai.kilocode.client.settings.profile.formatShortBalance
 import ai.kilocode.client.testing.FakeAppRpcApi
+import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.rpc.dto.DeviceAuthDto
 import ai.kilocode.rpc.dto.KiloAppStateDto
 import ai.kilocode.rpc.dto.KiloAppStatusDto
@@ -20,9 +21,6 @@ import com.intellij.ui.SimpleColoredComponent
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.UIUtil
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.awt.Component
@@ -45,7 +43,7 @@ import javax.swing.event.ListDataListener
 @Suppress("UnstableApiUsage")
 class UserProfileConfigurableTest : BasePlatformTestCase() {
 
-    private lateinit var scope: CoroutineScope
+    private lateinit var coroutines: TestCoroutines
     private lateinit var rpc: FakeAppRpcApi
     private lateinit var app: KiloAppService
     private lateinit var panel: ProfileUi
@@ -53,15 +51,15 @@ class UserProfileConfigurableTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
-        scope = CoroutineScope(SupervisorJob())
+        coroutines = TestCoroutines()
         rpc = FakeAppRpcApi()
-        app = KiloAppService(scope, rpc)
+        app = KiloAppService(coroutines.scope, rpc)
         app._state.value = KiloAppStateDto(KiloAppStatusDto.READY)
         edt {
             panel = ProfileUi(
                 profile = null,
                 status = KiloAppStatusDto.READY,
-                cs = scope,
+                cs = coroutines.scope,
                 app = app,
                 browse = { urls.add(it) },
             )
@@ -70,7 +68,7 @@ class UserProfileConfigurableTest : BasePlatformTestCase() {
 
     override fun tearDown() {
         try {
-            scope.cancel()
+            coroutines.close(::pump)
         } finally {
             super.tearDown()
         }
@@ -1068,11 +1066,10 @@ class UserProfileConfigurableTest : BasePlatformTestCase() {
         return result as T
     }
 
-    private fun flush() = runBlocking {
-        repeat(5) {
-            delay(100)
-            edt { UIUtil.dispatchAllInvocationEvents() }
-        }
+    private fun flush() = coroutines.drain(::pump)
+
+    private fun pump() {
+        edt { UIUtil.dispatchAllInvocationEvents() }
     }
 
     private fun visible(comp: Component): Boolean =

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/agents/AgentsSettingsUiTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/agents/AgentsSettingsUiTest.kt
@@ -506,8 +506,8 @@ class AgentsSettingsUiTest : BasePlatformTestCase() {
     }
 
     private fun flushUntil(done: () -> Boolean) = runBlocking {
-        repeat(30) {
-            delay(100)
+        repeat(300) {
+            delay(10)
             edt { UIUtil.dispatchAllInvocationEvents(); true }
             if (done()) return@runBlocking
         }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/agents/McpSettingsUiTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/agents/McpSettingsUiTest.kt
@@ -438,8 +438,8 @@ class McpSettingsUiTest : BasePlatformTestCase() {
     }
 
     private fun flushUntil(done: () -> Boolean) = runBlocking {
-        repeat(30) {
-            delay(100)
+        repeat(300) {
+            delay(10)
             edt { UIUtil.dispatchAllInvocationEvents(); true }
             if (done()) return@runBlocking
         }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/models/ModelsSettingsUiTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/models/ModelsSettingsUiTest.kt
@@ -373,8 +373,8 @@ class ModelsSettingsUiTest : BasePlatformTestCase() {
     }
 
     private fun flushUntil(done: () -> Boolean) = runBlocking {
-        repeat(20) {
-            delay(100)
+        repeat(200) {
+            delay(10)
             edt { UIUtil.dispatchAllInvocationEvents() }
             if (done()) return@runBlocking
         }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/providers/ProvidersSettingsUiTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/providers/ProvidersSettingsUiTest.kt
@@ -967,8 +967,8 @@ class ProvidersSettingsUiTest : BasePlatformTestCase() {
     }
 
     private fun flushUntil(done: () -> Boolean) = runBlocking {
-        repeat(20) {
-            delay(100)
+        repeat(200) {
+            delay(10)
             edt { UIUtil.dispatchAllInvocationEvents() }
             if (done()) return@runBlocking
         }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/TestCoroutines.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/TestCoroutines.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 
 class TestCoroutines {
-    private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     private val job = SupervisorJob()
 
     val scope = CoroutineScope(job + dispatcher)

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -21,7 +21,7 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync } from 
 
 const root = join(import.meta.dir, "..")
 const gradlew = process.platform === "win32" ? "gradlew.bat" : "./gradlew"
-const args = ["clean", "test", "--continue", "--no-build-cache", "--stacktrace", "--console=plain"]
+const args = ["clean", "test", "--continue", "--stacktrace", "--console=plain"]
 const cmd = process.platform === "win32" ? ["cmd.exe", "/c", gradlew, ...args] : [gradlew, ...args]
 const fallback = 45 * 60 * 1000
 const parsed = Number(process.env.KILO_JETBRAINS_TEST_TIMEOUT_MS ?? fallback)

--- a/packages/kilo-jetbrains/script/test-ci.ts
+++ b/packages/kilo-jetbrains/script/test-ci.ts
@@ -3,7 +3,7 @@
 /**
  * CI test runner for the JetBrains plugin.
  *
- * Runs ./gradlew clean test --continue --no-build-cache --stacktrace --console=plain
+ * Runs ./gradlew clean test --continue --stacktrace --console=plain
  * so all modules run even when some fail,
  * then collects per-module JUnit XML results into .artifacts/unit/junit.xml
  * so mikepenz/action-junit-report can find them at the standard path.


### PR DESCRIPTION
The JetBrains pull-request check spends most of its time in two avoidable areas: frontend tests wait on fixed wall-clock sleeps even when their coroutine and EDT work is complete, and the CI job builds inside a container that cannot reuse the repository Gradle cache. The generated OpenAPI client also requires a clean build until its task outputs are modeled independently.

This change keeps the complete JetBrains test suite and improves the execution path without deleting coverage:

- Replace fixed 500 ms and 1 s flush/settle sleeps in history, side-panel, and profile tests with the existing controlled coroutine dispatcher, deterministic draining, and explicit EDT pumping. The tests now wait for queued work rather than sleeping for a worst-case duration.
- Inject the history controller IO dispatcher where tests need to control asynchronous work, while retaining Dispatchers.IO as the production default.
- Reduce bounded settings polling from 100 ms intervals to 10 ms intervals without changing the completion predicates or timeout bounds.
- Remove the connection test's race-prone wait on a mock-server latch and assert the observable Connected state after the readiness signal.
- Run JetBrains CI on the Blacksmith host with pinned Bun, Temurin 21, and setup-gradle, so Gradle can use the host dependency and transform cache. The workflow no longer runs a workspace-wide Bun install because the CI collector only uses Bun built-ins.
- Allow Gradle build-cache reuse by removing --no-build-cache while retaining clean to prevent stale generated OpenAPI classes.

The result preserves the existing JUnit artifact collection, --continue failure reporting, and full module coverage while making asynchronous tests deterministic and aligning CI with the cacheable host setup.