### PR TITLE
fix(vscode): focus prompt after closing sidebar tab

### DIFF
--- a/.changeset/focus-sidebar-prompt.md
+++ b/.changeset/focus-sidebar-prompt.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Focus the sidebar prompt after closing an active session tab.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
@@ -6,7 +6,7 @@ import { useLocalTabs } from "../../context/local-tabs"
 import { useSession } from "../../context/session"
 import { isPendingTab } from "../../utils/local-tabs"
 import { useTabScroll } from "../../utils/tab-scroll"
-import { focusPrompt, focusSelectedTab, focusTabElement, handleTabKey } from "../../utils/tab-navigation"
+import { focusPrompt, focusTabElement, handleTabKey } from "../../utils/tab-navigation"
 import { setTabWidths } from "../../utils/tab-widths"
 import { useVSCode } from "../../context/vscode"
 import { SessionTab } from "./SessionTab"
@@ -62,7 +62,6 @@ export const SessionTabStrip: Component = () => {
   const close = (id: string) => {
     freeze()
     tabs.close(id)
-    focusSelectedTab(document, focusPrompt)
     requestAnimationFrame(release)
   }
   const closeOthers = (id: string) => {


### PR DESCRIPTION
When an active sidebar session tab is closed, its tab-strip handler schedules focus on the newly selected tab after the new session's prompt has already been focused. This leaves keyboard focus in the tab strip instead of the chat composer. Stop restoring tab focus for the regular close action so the normal session-switch flow retains focus in the active prompt. The separate close-other-tabs behavior continues to restore tab focus intentionally.