### PR TITLE
fix(vscode): preserve focus after closing inactive tab

### DIFF
--- a/.changeset/sidebar-tab-close-focus.md
+++ b/.changeset/sidebar-tab-close-focus.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep keyboard focus on the active sidebar tab after closing an inactive session tab.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
@@ -6,7 +6,7 @@ import { useLocalTabs } from "../../context/local-tabs"
 import { useSession } from "../../context/session"
 import { isPendingTab } from "../../utils/local-tabs"
 import { useTabScroll } from "../../utils/tab-scroll"
-import { focusPrompt, focusTabElement, handleTabKey } from "../../utils/tab-navigation"
+import { focusPrompt, focusSelectedTab, focusTabElement, handleTabKey } from "../../utils/tab-navigation"
 import { setTabWidths } from "../../utils/tab-widths"
 import { useVSCode } from "../../context/vscode"
 import { SessionTab } from "./SessionTab"
@@ -61,7 +61,9 @@ export const SessionTabStrip: Component = () => {
   const release = () => setTabWidths(false, document)
   const close = (id: string) => {
     freeze()
+    const active = tabs.active() === id
     tabs.close(id)
+    if (!active) focusSelectedTab(document, focusPrompt)
     requestAnimationFrame(release)
   }
   const closeOthers = (id: string) => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
@@ -35,7 +35,7 @@ export const SessionTabStrip: Component = () => {
     if (event.button !== 1) return
     event.preventDefault()
     event.stopPropagation()
-    close(id)
+    close(id, false)
   }
   const key = (id: string, event: KeyboardEvent) => {
     const root = event.currentTarget instanceof HTMLElement ? event.currentTarget.closest(".am-tab-list") : null
@@ -59,11 +59,11 @@ export const SessionTabStrip: Component = () => {
   const root = () => document.querySelector("[data-component=session-tabs] .am-tab-list")
   const freeze = () => setTabWidths(true, document)
   const release = () => setTabWidths(false, document)
-  const close = (id: string) => {
+  const close = (id: string, restore = true) => {
     freeze()
     const active = tabs.active() === id
     tabs.close(id)
-    if (!active) focusSelectedTab(document, focusPrompt)
+    if (!active && restore) focusSelectedTab(document, focusPrompt)
     requestAnimationFrame(release)
   }
   const closeOthers = (id: string) => {


### PR DESCRIPTION
Follow-up to #12176. Closing an inactive tab from its close button or context menu removes the focused control, so focus is restored to the selected tab. Middle-clicking prevents the browser from moving focus before closing the tab, so that path leaves the current focus unchanged and preserves typing in the prompt or another control.