### PR TITLE
Fix remote CLI session control from mobile

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -73,6 +73,7 @@ function normalizePrompt(input: RemotePromptInput): SessionPrompt.PromptInput {
   return {
     ...input,
     model: normalizeModel(input.model),
+    tools: { ...input.tools, interactive_terminal: false },
   }
 }
 
@@ -97,6 +98,11 @@ export namespace RemoteSender {
       readonly reject: (requestID: QuestionID) => Promise<void>
     }
     prompt?: (input: SessionPrompt.PromptInput) => Promise<unknown>
+    cancel?: (sessionID: SessionID) => Promise<void>
+    session?: {
+      readonly get: (sessionID: SessionID) => Promise<Session.Info>
+      readonly children: (sessionID: SessionID) => Promise<Session.Info[]>
+    }
     catalog?: {
       readonly get: (sessionID: SessionID) => Promise<Session.Info>
       readonly messages: (sessionID: SessionID) => Promise<MessageV2.WithParts[]>
@@ -144,6 +150,12 @@ export namespace RemoteSender {
         const { AppRuntime } = await import("@/effect/app-runtime")
         return AppRuntime.runPromise(SessionPrompt.Service.use((svc) => svc.prompt(input)))
       })
+    const cancel =
+      options.cancel ??
+      (async (sessionID: SessionID) => {
+        const { AppRuntime } = await import("@/effect/app-runtime")
+        return AppRuntime.runPromise(SessionPrompt.Service.use((svc) => svc.cancel(sessionID)))
+      })
     const catalog = options.catalog ?? {
       get: async (sessionID: SessionID) => {
         const { AppRuntime } = await import("@/effect/app-runtime")
@@ -168,6 +180,16 @@ export namespace RemoteSender {
         return AppRuntime.runPromise(Provider.Service.use((svc) => svc.defaultModel()))
       },
     }
+    const session = options.session ?? {
+      get: async (sessionID: SessionID) => {
+        const { AppRuntime } = await import("@/effect/app-runtime")
+        return AppRuntime.runPromise(Session.Service.use((svc) => svc.get(sessionID)))
+      },
+      children: async (sessionID: SessionID) => {
+        const { AppRuntime } = await import("@/effect/app-runtime")
+        return AppRuntime.runPromise(Session.Service.use((svc) => svc.children(sessionID)))
+      },
+    }
 
     const sub =
       options.subscribe ??
@@ -180,10 +202,7 @@ export namespace RemoteSender {
       })
 
     async function directoryFor(sid: string): Promise<string> {
-      const { AppRuntime } = await import("@/effect/app-runtime")
-      const info = await AppRuntime.runPromise(
-        Session.Service.use((svc) => svc.get(SessionID.make(sid)).pipe(Effect.orElseSucceed(() => undefined))),
-      )
+      const info = await session.get(SessionID.make(sid)).catch(() => undefined)
       return info?.directory ?? options.directory
     }
 
@@ -218,6 +237,7 @@ export namespace RemoteSender {
     // sees state that was asked before it connected — analogous to the Cloud
     // Agent's `connected` event carrying pending question/permission fields.
     async function replay(sessionId: string) {
+      const root = rootOf(sessionId)
       const [suggestions, questions, permissions] = await Promise.all([
         Suggestion.list(),
         question.list(),
@@ -228,6 +248,7 @@ export namespace RemoteSender {
         options.conn.send({
           type: "event",
           sessionId,
+          ...(root ? { parentSessionId: root } : {}),
           event: "suggestion.shown",
           data: suggestion,
         })
@@ -237,6 +258,7 @@ export namespace RemoteSender {
         options.conn.send({
           type: "event",
           sessionId,
+          ...(root ? { parentSessionId: root } : {}),
           event: "question.asked",
           data: q,
         })
@@ -246,6 +268,7 @@ export namespace RemoteSender {
         options.conn.send({
           type: "event",
           sessionId,
+          ...(root ? { parentSessionId: root } : {}),
           event: "permission.asked",
           data: p,
         })
@@ -266,10 +289,7 @@ export namespace RemoteSender {
     }
 
     async function discoverChildren(parentId: string) {
-      const { AppRuntime } = await import("@/effect/app-runtime")
-      const childSessions = await AppRuntime.runPromise(
-        Session.Service.use((svc) => svc.children(SessionID.make(parentId))),
-      )
+      const childSessions = await session.children(SessionID.make(parentId))
       for (const child of childSessions) {
         children.set(child.id, parentId)
         const root = rootOf(child.id) ?? parentId
@@ -413,6 +433,19 @@ export namespace RemoteSender {
         dispatchLongRunning(msg, directoryFor(input.data.sessionID), async () => {
           await prompt(input.data as SessionPrompt.PromptInput)
         })
+        return
+      }
+      if (msg.command === "interrupt") {
+        const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()
+        if (Option.isNone(session)) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid interrupt command",
+          })
+          return
+        }
+        dispatchQuick(msg, directoryFor(session.value), () => cancel(session.value))
         return
       }
       if (msg.command === "question_reply") {

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -421,7 +421,8 @@ export namespace RemoteSender {
           })
           return
         }
-        const input = SessionPrompt.PromptInput.zod.safeParse(normalizePrompt(parsed.data as RemotePromptInput))
+        const normalized = normalizePrompt(parsed.data as RemotePromptInput)
+        const input = SessionPrompt.PromptInput.zod.safeParse(normalized)
         if (!input.success) {
           options.conn.send({
             type: "response",
@@ -430,8 +431,9 @@ export namespace RemoteSender {
           })
           return
         }
-        dispatchLongRunning(msg, directoryFor(input.data.sessionID), async () => {
-          await prompt(input.data as SessionPrompt.PromptInput)
+        const promptInput = { ...input.data, ephemeralTools: normalized.ephemeralTools } as SessionPrompt.PromptInput
+        dispatchLongRunning(msg, directoryFor(promptInput.sessionID), async () => {
+          await prompt(promptInput)
         })
         return
       }

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -73,8 +73,7 @@ function normalizePrompt(input: RemotePromptInput): SessionPrompt.PromptInput {
   return {
     ...input,
     model: normalizeModel(input.model),
-    tools: { ...input.tools, interactive_terminal: false },
-    persistToolPermissions: false,
+    ephemeralTools: { interactive_terminal: false },
   }
 }
 

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -74,6 +74,7 @@ function normalizePrompt(input: RemotePromptInput): SessionPrompt.PromptInput {
     ...input,
     model: normalizeModel(input.model),
     tools: { ...input.tools, interactive_terminal: false },
+    persistToolPermissions: false,
   }
 }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -783,7 +783,7 @@ export const layer = Layer.effect(
         role: "user",
         sessionID: input.sessionID,
         time: { created: Date.now() },
-        tools: { ...input.tools, ...input.ephemeralTools },
+        tools: { ...input.tools, ...input.ephemeralTools }, // kilocode_change - apply non-persistent remote tool restrictions
         agent: ag.name,
         model: {
           providerID: model.providerID,
@@ -2096,9 +2096,11 @@ export const PromptInput = Schema.Struct({
     description:
       "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
   }),
+  // kilocode_change start - per-message tool restrictions that do not update session permissions
   ephemeralTools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
     description: "@internal Tool toggles applied to this message without updating session permissions.",
   }),
+  // kilocode_change end
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1310,7 +1310,7 @@ export const layer = Layer.effect(
         for (const [t, enabled] of Object.entries(input.tools ?? {})) {
           permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
         }
-        if (permissions.length > 0) {
+        if (permissions.length > 0 && input.persistToolPermissions !== false) {
           // kilocode_change start - preserve inherited task restrictions while refreshing prompt tool toggles
           const merged = KiloSessionPrompt.mergeToolPermissions({
             existing: session.permission ?? [],
@@ -2095,6 +2095,9 @@ export const PromptInput = Schema.Struct({
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
     description:
       "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
+  }),
+  persistToolPermissions: Schema.optional(Schema.Boolean).annotate({
+    description: "@internal Persist deprecated tool toggles to the session. Defaults to true.",
   }),
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -783,7 +783,7 @@ export const layer = Layer.effect(
         role: "user",
         sessionID: input.sessionID,
         time: { created: Date.now() },
-        tools: input.tools,
+        tools: { ...input.tools, ...input.ephemeralTools },
         agent: ag.name,
         model: {
           providerID: model.providerID,
@@ -1310,7 +1310,7 @@ export const layer = Layer.effect(
         for (const [t, enabled] of Object.entries(input.tools ?? {})) {
           permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
         }
-        if (permissions.length > 0 && input.persistToolPermissions !== false) {
+        if (permissions.length > 0) {
           // kilocode_change start - preserve inherited task restrictions while refreshing prompt tool toggles
           const merged = KiloSessionPrompt.mergeToolPermissions({
             existing: session.permission ?? [],
@@ -2096,8 +2096,8 @@ export const PromptInput = Schema.Struct({
     description:
       "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
   }),
-  persistToolPermissions: Schema.optional(Schema.Boolean).annotate({
-    description: "@internal Persist deprecated tool toggles to the session. Defaults to true.",
+  ephemeralTools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
+    description: "@internal Tool toggles applied to this message without updating session permissions.",
   }),
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2096,14 +2096,11 @@ export const PromptInput = Schema.Struct({
     description:
       "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
   }),
-  // kilocode_change start - per-message tool restrictions that do not update session permissions
-  ephemeralTools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
-    description: "@internal Tool toggles applied to this message without updating session permissions.",
-  }),
-  // kilocode_change end
+  // kilocode_change start - keep internal ephemeral tool controls out of the public prompt schema
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),
+  // kilocode_change end
   // kilocode_change start - managed product slow-snapshot policy
   snapshotInitialization: Schema.optional(Schema.Literal("wait")).annotate({
     description: "Wait silently if snapshot initialization is slow instead of asking the user.",
@@ -2134,6 +2131,7 @@ type PartInputUnion =
 export type PromptInput = Omit<Schema.Schema.Type<typeof PromptInput>, "parts" | "editorContext"> & {
   parts: PartInputUnion[]
   editorContext?: MessageV2.EditorContext
+  ephemeralTools?: Record<string, boolean>
 }
 // kilocode_change end
 

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -279,7 +279,7 @@ describe("RemoteSender", () => {
     await provideStarted
   })
 
-  test("send_message disables interactive_terminal for remote prompts", async () => {
+  test("send_message disables interactive_terminal without persisting the restriction", async () => {
     const { conn } = fakeConn()
     const calls: SessionPrompt.PromptInput[] = []
     const sender = RemoteSender.create({
@@ -304,6 +304,7 @@ describe("RemoteSender", () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(calls[0]?.tools).toEqual({ bash: true, interactive_terminal: false })
+    expect(calls[0]?.persistToolPermissions).toBe(false)
   })
 
   test("interrupt waits for session cancellation before responding", async () => {
@@ -793,6 +794,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("anthropic/claude-sonnet-4-20250514") },
+        persistToolPermissions: false,
         tools: { interactive_terminal: false },
       },
     ])
@@ -828,6 +830,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("gpt-5-mini") },
+        persistToolPermissions: false,
         tools: { interactive_terminal: false },
       },
     ])
@@ -868,6 +871,7 @@ describe("RemoteSender", () => {
           providerID: ProviderV2.ID.make("custom:edge"),
           modelID: ModelV2.ID.make("deployment/model-v1"),
         },
+        persistToolPermissions: false,
         tools: { interactive_terminal: false },
         variant: "precise",
       },
@@ -964,6 +968,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("kilo/gpt-5-mini") },
+        persistToolPermissions: false,
         tools: { interactive_terminal: false },
       },
     ])

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -279,7 +279,7 @@ describe("RemoteSender", () => {
     await provideStarted
   })
 
-  test("send_message disables interactive_terminal without persisting the restriction", async () => {
+  test("send_message keeps client toggles persistent and terminal restriction ephemeral", async () => {
     const { conn } = fakeConn()
     const calls: SessionPrompt.PromptInput[] = []
     const sender = RemoteSender.create({
@@ -303,8 +303,8 @@ describe("RemoteSender", () => {
     })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(calls[0]?.tools).toEqual({ bash: true, interactive_terminal: false })
-    expect(calls[0]?.persistToolPermissions).toBe(false)
+    expect(calls[0]?.tools).toEqual({ bash: true })
+    expect(calls[0]?.ephemeralTools).toEqual({ interactive_terminal: false })
   })
 
   test("interrupt waits for session cancellation before responding", async () => {
@@ -794,8 +794,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("anthropic/claude-sonnet-4-20250514") },
-        persistToolPermissions: false,
-        tools: { interactive_terminal: false },
+        ephemeralTools: { interactive_terminal: false },
       },
     ])
   })
@@ -830,8 +829,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("gpt-5-mini") },
-        persistToolPermissions: false,
-        tools: { interactive_terminal: false },
+        ephemeralTools: { interactive_terminal: false },
       },
     ])
   })
@@ -871,8 +869,7 @@ describe("RemoteSender", () => {
           providerID: ProviderV2.ID.make("custom:edge"),
           modelID: ModelV2.ID.make("deployment/model-v1"),
         },
-        persistToolPermissions: false,
-        tools: { interactive_terminal: false },
+        ephemeralTools: { interactive_terminal: false },
         variant: "precise",
       },
     ])
@@ -968,8 +965,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("kilo/gpt-5-mini") },
-        persistToolPermissions: false,
-        tools: { interactive_terminal: false },
+        ephemeralTools: { interactive_terminal: false },
       },
     ])
   })

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -13,6 +13,7 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionID } from "../../../src/session/schema"
+import { Session } from "../../../src/session/session"
 import { Suggestion } from "../../../src/kilocode/suggestion" // kilocode_change
 
 function fakeConn() {
@@ -276,6 +277,68 @@ describe("RemoteSender", () => {
 
     // provide was still called
     await provideStarted
+  })
+
+  test("send_message disables interactive_terminal for remote prompts", async () => {
+    const { conn } = fakeConn()
+    const calls: SessionPrompt.PromptInput[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async (input: any) => input.fn(),
+      prompt: prompts(calls),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_remote_tools",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hi" }],
+        tools: { bash: true },
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(calls[0]?.tools).toEqual({ bash: true, interactive_terminal: false })
+  })
+
+  test("interrupt waits for session cancellation before responding", async () => {
+    const { conn, sent } = fakeConn()
+    let finishCancel: () => void
+    const cancelled: string[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async (input: any) => input.fn(),
+      cancel: async (sessionID) => {
+        cancelled.push(sessionID)
+        await new Promise<void>((resolve) => {
+          finishCancel = resolve
+        })
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_interrupt",
+      command: "interrupt",
+      sessionId: "ses_x",
+      data: {},
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(cancelled).toEqual(["ses_x"])
+    expect(sent).toEqual([])
+
+    finishCancel!()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(sent).toEqual([{ type: "response", id: "req_interrupt", result: {} }])
   })
 
   test("send_message with invalid data sends error response immediately", () => {
@@ -730,6 +793,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("anthropic/claude-sonnet-4-20250514") },
+        tools: { interactive_terminal: false },
       },
     ])
   })
@@ -764,6 +828,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("gpt-5-mini") },
+        tools: { interactive_terminal: false },
       },
     ])
   })
@@ -803,6 +868,7 @@ describe("RemoteSender", () => {
           providerID: ProviderV2.ID.make("custom:edge"),
           modelID: ModelV2.ID.make("deployment/model-v1"),
         },
+        tools: { interactive_terminal: false },
         variant: "precise",
       },
     ])
@@ -898,6 +964,7 @@ describe("RemoteSender", () => {
         sessionID: SessionID.make("ses_x"),
         parts: [{ type: "text", text: "hello" }],
         model: { providerID: ProviderV2.ID.make("kilo"), modelID: ModelV2.ID.make("kilo/gpt-5-mini") },
+        tools: { interactive_terminal: false },
       },
     ])
   })
@@ -1506,6 +1573,59 @@ describe("RemoteSender", () => {
         sessionID: "ses_target",
         permission: "file.write",
         patterns: ["src/**"],
+        metadata: {},
+        always: [],
+      },
+    })
+  })
+
+  test("child permission replay includes the subscribed root session", async () => {
+    const { conn, sent } = fakeConn()
+    const child = {
+      id: SessionID.make("ses_child"),
+      parentID: SessionID.make("ses_root"),
+      directory: "/workspace/child",
+    } as Session.Info
+    spyOn(Suggestion, "list").mockResolvedValue([])
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/workspace/root",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async (input: any) => input.fn(),
+      session: {
+        get: async (sessionID) =>
+          sessionID === child.id
+            ? child
+            : ({ id: sessionID, directory: "/workspace/root" } as Session.Info),
+        children: async (sessionID) => (sessionID === SessionID.make("ses_root") ? [child] : []),
+      },
+      question: questions(),
+      permission: permissions([
+        {
+          id: "permission_child",
+          sessionID: "ses_child",
+          permission: "external_directory",
+          patterns: ["/workspace/child/**"],
+          metadata: {},
+          always: [],
+        } as any,
+      ]),
+    })
+
+    sender.handle({ type: "subscribe", sessionId: "ses_root" })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent).toContainEqual({
+      type: "event",
+      sessionId: "ses_child",
+      parentSessionId: "ses_root",
+      event: "permission.asked",
+      data: {
+        id: "permission_child",
+        sessionID: "ses_child",
+        permission: "external_directory",
+        patterns: ["/workspace/child/**"],
         metadata: {},
         always: [],
       },


### PR DESCRIPTION
## Summary
- bubble replayed child permission, question, and suggestion events to the subscribed root session
- disable `interactive_terminal` for prompts initiated over the remote protocol
- implement remote `interrupt` with the same awaited session cancellation path as CLI Esc

## Validation
- `bun test test/kilocode/sessions/remote-sender.test.ts` (49 passed)
- `bun run typecheck`
- full pre-push typecheck, including JetBrains Gradle build
- `bun run lint` (0 errors; existing repository warnings)
- launched the branch CLI against local Next.js and session-ingest services in tmux
