### PR TITLE
feat(autocomplete): support configured BYOK completion models

### DIFF
--- a/.changeset/mtplx-autocomplete.md
+++ b/.changeset/mtplx-autocomplete.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+"@kilocode/kilo-gateway": minor
+---
+
+Support cache-aware Qwen3.5 9B inline autocomplete through a custom MTPLX provider.

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -11,10 +11,11 @@ Kilo Code's autocomplete feature provides intelligent code suggestions and compl
 
 The extension uses **Fill-in-the-Middle (FIM)** completion routed through the **Kilo Gateway**. It analyzes the code before and after your cursor to generate contextually accurate inline suggestions.
 
-You can choose between two FIM models:
+You can choose between these completion models:
 
 - **Codestral** (`mistralai/codestral-2508`) by Mistral AI — the default, billed through your Kilo account.
 - **Mercury Edit 2** (`inception/mercury-edit-2`) by Inception — temporarily available via **BYOK** (Bring Your Own Key) only; Kilo Gateway support is coming soon.
+- **Qwen3.5 9B** (`Qwen3.5-9B-MTPLX`) through a local MTPLX server — runs on your own Apple Silicon Mac and does not use Kilo credits.
 
 ## Triggering Options
 
@@ -36,10 +37,36 @@ Autocomplete requests are routed through the **Kilo Gateway**. You can pick the 
 
 - **Codestral** (`mistralai/codestral-2508`) — the default. Billed through your Kilo account, or free when you add your own Mistral Codestral key via BYOK. See [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup).
 - **Mercury Edit 2** (`inception/mercury-edit-2`) — a fast diffusion-based FIM model by Inception. Temporarily requires an **Inception BYOK key** until Kilo Gateway support lands. Add one from the [BYOK page](https://app.kilo.ai/byok) in the Kilo platform. See [Bring Your Own Key (BYOK)](/docs/getting-started/byok) for setup details.
+- **Qwen3.5 9B (MTPLX)** (`Qwen3.5-9B-MTPLX`) — a local, cache-aware completion model served by MTPLX.
 
 {% callout type="note" %}
 Mercury Edit 2 is only available through BYOK for now — Kilo Gateway support is coming soon. If you select Mercury Edit 2 without a valid Inception BYOK key configured, autocomplete requests will fail — switch back to Codestral or add an Inception key to continue.
 {% /callout %}
+
+### Local MTPLX setup
+
+Start MTPLX with the `Qwen3.5-9B-MTPLX` model on port `8001`, then add this provider to `~/.config/kilo/kilo.jsonc`:
+
+```json
+{
+  "provider": {
+    "mtplx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "MTPLX",
+      "options": {
+        "baseURL": "http://127.0.0.1:8001/v1"
+      },
+      "models": {
+        "Qwen3.5-9B-MTPLX": {
+          "name": "Qwen3.5 9B (MTPLX)"
+        }
+      }
+    }
+  }
+}
+```
+
+In VS Code settings, set **Autocomplete provider** to **MTPLX** and **Autocomplete model** to **Qwen3.5 9B (MTPLX)**. Loopback MTPLX servers do not require an API key. For a remote server, configure the provider API key and use an HTTPS `baseURL`.
 
 ## Status Bar
 

--- a/packages/kilo-gateway/src/autocomplete.ts
+++ b/packages/kilo-gateway/src/autocomplete.ts
@@ -1,4 +1,4 @@
-export type AutocompleteProviderID = "kilo" | "mistral" | "inception"
+export type AutocompleteProviderID = "kilo" | "mistral" | "inception" | "mtplx"
 export type DirectAutocompleteProviderID = Exclude<AutocompleteProviderID, "kilo">
 
 interface AutocompleteModelBase {
@@ -18,6 +18,8 @@ interface AutocompleteModelBase {
   readonly directProvider?: DirectAutocompleteProviderID
   /** Request temperature. */
   readonly temperature: number
+  /** Maximum number of completion tokens requested from the provider. */
+  readonly maxTokens?: number
 }
 
 export type AutocompleteModelDef = AutocompleteModelBase &
@@ -102,6 +104,17 @@ const models: AutocompleteModelDef[] = [
     temperature: 0,
     kind: "edit",
     fimModelID: "inception/mercury-edit-2",
+  },
+  {
+    id: "mtplx/Qwen3.5-9B-MTPLX",
+    modelID: "Qwen3.5-9B-MTPLX",
+    label: "Qwen3.5 9B (MTPLX)",
+    providerID: "mtplx",
+    provider: "MTPLX",
+    requestModel: "Qwen3.5-9B-MTPLX",
+    directProvider: "mtplx",
+    temperature: 0,
+    maxTokens: 64,
   },
 ]
 

--- a/packages/kilo-gateway/src/edit.ts
+++ b/packages/kilo-gateway/src/edit.ts
@@ -8,6 +8,7 @@ import { getAutocompleteModel, type DirectAutocompleteProviderID } from "./autoc
 export const DIRECT_EDIT_ENV: Record<DirectAutocompleteProviderID, string[]> = {
   mistral: ["MISTRAL_API_KEY"],
   inception: ["INCEPTION_API_KEY"],
+  mtplx: [],
 }
 
 export type EditTarget =

--- a/packages/kilo-gateway/src/fim.ts
+++ b/packages/kilo-gateway/src/fim.ts
@@ -6,15 +6,58 @@ export { requestMistralFim } from "./mistral-fim-endpoint.js"
 export const DIRECT_FIM_ENV: Record<DirectAutocompleteProviderID, string[]> = {
   mistral: ["MISTRAL_API_KEY"],
   inception: ["INCEPTION_API_KEY"],
+  mtplx: ["MTPLX_API_KEY"],
 }
 
 export type FimTarget =
   | { provider: "kilo"; model: string; url: string }
   | { provider: "inception"; model: string; url: string }
   | { provider: "mistral"; model: string }
+  | { provider: "mtplx"; model: string }
 
 const KILO_FIM_URL = KILO_API_BASE + "/api/fim/completions"
 const INCEPTION_FIM_URL = "https://api.inceptionlabs.ai/v1/fim/completions"
+export const MTPLX_DEFAULT_BASE_URL = "http://127.0.0.1:8001/v1"
+
+const MTPLX_SYSTEM_PROMPT =
+  "You are an inline code-completion engine. Return only code inserted at the cursor. Never repeat any suffix text. No markdown or explanation."
+
+export function mtplxChatUrl(baseURL = MTPLX_DEFAULT_BASE_URL) {
+  return `${baseURL.replace(/\/+$/, "")}/chat/completions`
+}
+
+export function isLoopbackMtplxUrl(baseURL: string) {
+  if (!URL.canParse(baseURL)) return false
+  const hostname = new URL(baseURL).hostname
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1"
+}
+
+export function buildMtplxRequest(input: {
+  model: string
+  prefix: string
+  suffix: string
+  maxTokens: number
+  temperature: number
+}) {
+  const stop = input.suffix.trimEnd().slice(0, 64)
+  return {
+    model: input.model,
+    messages: [
+      { role: "system", content: MTPLX_SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: `SUFFIX AFTER CURSOR:\n${input.suffix}\n\nPREFIX BEFORE CURSOR:\n${input.prefix}\n\nINSERT AT CURSOR:`,
+      },
+    ],
+    max_tokens: Math.min(input.maxTokens, 64),
+    temperature: input.temperature,
+    stream: true,
+    stream_options: { include_usage: true },
+    enable_thinking: false,
+    chat_template_kwargs: { enable_thinking: false },
+    ...(stop ? { stop: [stop] } : {}),
+  }
+}
 
 function kiloTarget(model?: string): FimTarget {
   return { provider: "kilo", model: model ?? "mistralai/codestral-2501", url: KILO_FIM_URL }
@@ -29,6 +72,9 @@ export function resolveFimTarget(provider?: string, model?: string): FimTarget {
   }
   if (info.directProvider === "inception") {
     return { provider: "inception", model: info.requestModel, url: INCEPTION_FIM_URL }
+  }
+  if (info.directProvider === "mtplx") {
+    return { provider: "mtplx", model: info.requestModel }
   }
   return kiloTarget(model)
 }

--- a/packages/kilo-gateway/src/server/fim.ts
+++ b/packages/kilo-gateway/src/server/fim.ts
@@ -1,6 +1,14 @@
 import { HEADER_FEATURE } from "../api/constants.js"
 import type { DirectAutocompleteProviderID } from "../autocomplete.js"
-import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget, type FimTarget } from "../fim.js"
+import {
+  buildMtplxRequest,
+  DIRECT_FIM_ENV,
+  isLoopbackMtplxUrl,
+  mtplxChatUrl,
+  requestMistralFim,
+  resolveFimTarget,
+  type FimTarget,
+} from "../fim.js"
 import { buildKiloHeaders } from "../headers.js"
 import type { AuthStore } from "./handlers.js"
 
@@ -26,7 +34,7 @@ async function getProviderKey(Auth: Auth, provider: DirectAutocompleteProviderID
 
 async function fetchFim(
   target: FimTarget,
-  key: string,
+  key: string | undefined,
   input: {
     prefix: string
     suffix: string
@@ -34,6 +42,8 @@ async function fetchFim(
     temperature: number
     signal: AbortSignal
     organizationId?: string
+    sessionId?: string
+    mtplxBaseURL?: string
   },
 ): Promise<Response> {
   const run = async (url: string) => {
@@ -42,34 +52,48 @@ async function fetchFim(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${key}`,
+        ...(key ? { Authorization: `Bearer ${key}` } : {}),
         ...(target.provider === "kilo"
           ? buildKiloHeaders(undefined, { kilocodeOrganizationId: input.organizationId })
           : {}),
         ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
+        ...(target.provider === "mtplx" ? { "x-mtplx-client": "kilocode" } : {}),
+        ...(target.provider === "mtplx" && input.sessionId ? { "x-mtplx-session-id": input.sessionId } : {}),
       },
       signal: input.signal,
-      body: JSON.stringify({
-        model: target.model,
-        prompt: input.prefix,
-        suffix: input.suffix,
-        max_tokens: input.maxTokens,
-        temperature: input.temperature,
-        stream: true,
-      }),
+      body: JSON.stringify(
+        target.provider === "mtplx"
+          ? buildMtplxRequest({
+              model: target.model,
+              prefix: input.prefix,
+              suffix: input.suffix,
+              maxTokens: input.maxTokens,
+              temperature: input.temperature,
+            })
+          : {
+              model: target.model,
+              prompt: input.prefix,
+              suffix: input.suffix,
+              max_tokens: input.maxTokens,
+              temperature: input.temperature,
+              stream: true,
+            },
+      ),
     })
   }
 
   if (target.provider === "mistral") return requestMistralFim(run)
+  if (target.provider === "mtplx") return run(mtplxChatUrl(input.mtplxBaseURL))
   return run(target.url)
 }
 
 export function createFimHandler(Auth: Auth) {
   return async (c: any) => {
-    const { prefix, suffix, provider, model, maxTokens, temperature } = c.req.valid("json")
+    const { prefix, suffix, provider, model, maxTokens, temperature, sessionId } = c.req.valid("json")
     const target = resolveFimTarget(provider, model)
     const fimMaxTokens = maxTokens ?? 256
     const fimTemperature = temperature ?? 0.2
+    const mtplxBaseURL = target.provider === "mtplx" ? process.env.MTPLX_BASE_URL : undefined
     const proxy = target.provider === "kilo" ? await getProxyAuth(Auth) : undefined
     const token = target.provider === "kilo" ? proxy?.token : await getProviderKey(Auth, target.provider)
 
@@ -81,7 +105,7 @@ export function createFimHandler(Auth: Auth) {
       return c.json({ error: "No valid token found" }, 401)
     }
 
-    if (!token) {
+    if (!token && (target.provider !== "mtplx" || !isLoopbackMtplxUrl(mtplxChatUrl(mtplxBaseURL)))) {
       return c.json({ error: `Missing ${target.provider} provider API key` }, 401)
     }
 
@@ -95,6 +119,8 @@ export function createFimHandler(Auth: Auth) {
         temperature: fimTemperature,
         signal,
         organizationId: proxy?.organizationId,
+        sessionId,
+        mtplxBaseURL,
       })
 
       if (!response.ok) {

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -343,6 +343,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           model: z.string().optional(),
           maxTokens: z.number().optional(),
           temperature: z.number().optional(),
+          sessionId: z.string().optional(),
         }),
       ),
       createFimHandler(Auth),

--- a/packages/kilo-gateway/test/autocomplete.test.ts
+++ b/packages/kilo-gateway/test/autocomplete.test.ts
@@ -30,3 +30,17 @@ describe("Next Edit FIM models", () => {
     }
   })
 })
+
+describe("MTPLX autocomplete model", () => {
+  test("uses deterministic short completions for Qwen3.5 9B", () => {
+    const model = AUTOCOMPLETE_MODELS.find((candidate) => candidate.id === "mtplx/Qwen3.5-9B-MTPLX")
+
+    expect(model).toMatchObject({
+      providerID: "mtplx",
+      directProvider: "mtplx",
+      requestModel: "Qwen3.5-9B-MTPLX",
+      temperature: 0,
+      maxTokens: 64,
+    })
+  })
+})

--- a/packages/kilo-gateway/test/fim.test.ts
+++ b/packages/kilo-gateway/test/fim.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { resolveFimTarget } from "../src/fim"
+import { buildMtplxRequest, isLoopbackMtplxUrl, mtplxChatUrl, resolveFimTarget } from "../src/fim"
 
 describe("FIM target resolution", () => {
   test("keeps gateway autocomplete models on Kilo Gateway", () => {
@@ -25,6 +25,10 @@ describe("FIM target resolution", () => {
       model: "mercury-edit-2",
       url: "https://api.inceptionlabs.ai/v1/fim/completions",
     })
+    expect(resolveFimTarget("mtplx", "Qwen3.5-9B-MTPLX")).toEqual({
+      provider: "mtplx",
+      model: "Qwen3.5-9B-MTPLX",
+    })
   })
 
   test("preserves gateway model pass-through behavior", () => {
@@ -48,5 +52,32 @@ describe("FIM target resolution", () => {
       model: "custom/fim-model",
       url: "https://api.kilo.ai/api/fim/completions",
     })
+  })
+})
+
+describe("MTPLX chat transport", () => {
+  test("places the stable suffix before the changing prefix and disables thinking", () => {
+    const request = buildMtplxRequest({
+      model: "Qwen3.5-9B-MTPLX",
+      prefix: "function add(a, b) { return ",
+      suffix: "; }\n",
+      maxTokens: 256,
+      temperature: 0,
+    })
+
+    expect(request.max_tokens).toBe(64)
+    expect(request.enable_thinking).toBe(false)
+    expect(request.chat_template_kwargs).toEqual({ enable_thinking: false })
+    expect(request.stop).toEqual(["; }"])
+    expect(request.messages[1]?.content).toBe(
+      "SUFFIX AFTER CURSOR:\n; }\n\n\nPREFIX BEFORE CURSOR:\nfunction add(a, b) { return \n\nINSERT AT CURSOR:",
+    )
+  })
+
+  test("builds the chat endpoint and recognizes only loopback URLs as local", () => {
+    expect(mtplxChatUrl()).toBe("http://127.0.0.1:8001/v1/chat/completions")
+    expect(mtplxChatUrl("https://bifrost.example/v1/")).toBe("https://bifrost.example/v1/chat/completions")
+    expect(isLoopbackMtplxUrl("http://localhost:8001/v1/chat/completions")).toBe(true)
+    expect(isLoopbackMtplxUrl("https://bifrost.example/v1/chat/completions")).toBe(false)
   })
 })

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -949,7 +949,8 @@
             "inception/mercury-next-edit",
             "codestral-2508",
             "mercury-edit-2",
-            "mercury-next-edit"
+            "mercury-next-edit",
+            "Qwen3.5-9B-MTPLX"
           ],
           "enumDescriptions": [
             "Codestral via Kilo Gateway",
@@ -957,7 +958,8 @@
             "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
             "Codestral via your connected Mistral provider API key",
             "Mercury Edit 2 (FIM) via your connected Inception provider API key",
-            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key"
+            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key",
+            "Qwen3.5 9B through your connected MTPLX custom provider"
           ],
           "description": "Model to use for inline autocomplete suggestions. If unset, the recommended default is used."
         },
@@ -966,12 +968,14 @@
           "enum": [
             "kilo",
             "mistral",
-            "inception"
+            "inception",
+            "mtplx"
           ],
           "enumDescriptions": [
             "Use autocomplete models through Kilo Gateway",
             "Use autocomplete models through your connected Mistral provider API key",
-            "Use autocomplete models through your connected Inception provider API key"
+            "Use autocomplete models through your connected Inception provider API key",
+            "Use Qwen3.5 autocomplete through your connected MTPLX custom provider"
           ],
           "description": "Provider to use for inline autocomplete suggestions. If unset, Kilo Gateway is used."
         },

--- a/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
@@ -107,9 +107,17 @@ export class ChatTextAreaAutocomplete {
     let response = ""
 
     try {
-      await generateFim(this.connection, entry.id, prefix, suffix, (chunk) => {
-        response += chunk
-      })
+      await generateFim(
+        this.connection,
+        entry.id,
+        prefix,
+        suffix,
+        (chunk) => {
+          response += chunk
+        },
+        undefined,
+        `${vscode.env.machineId}\0${this.dir || "chat-textarea"}`,
+      )
 
       const latencyMs = Date.now() - startTime
 

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode"
 import {
   AutocompleteInput,
   AutocompleteContextProvider,
@@ -9,6 +10,7 @@ import { getProcessedSnippets } from "./getProcessedSnippets"
 import { getTemplateForModel } from "../continuedev/core/autocomplete/templating/AutocompleteTemplate"
 import { generateFim } from "../fim"
 import type { KiloConnectionService } from "../../cli-backend"
+import { getAutocompleteModelById } from "../../../shared/autocomplete-models"
 
 export type { FimAutocompletePrompt, FimCompletionResult }
 
@@ -33,9 +35,10 @@ export class FimPromptBuilder {
     const prunedSuffix = helper.prunedSuffix
 
     const template = getTemplateForModel(modelName)
+    const mtplx = getAutocompleteModelById(modelName).providerID === "mtplx"
 
     let formattedPrefix = prunedPrefixRaw
-    if (template.compilePrefixSuffix && prunedSuffix) {
+    if (!mtplx && template.compilePrefixSuffix && prunedSuffix) {
       const [compiledPrefix] = template.compilePrefixSuffix(
         prunedPrefixRaw,
         prunedSuffix,
@@ -69,7 +72,15 @@ export class FimPromptBuilder {
     const onChunk = (text: string) => {
       response += text
     }
-    const usageInfo = await generateFim(connection, modelId, formattedPrefix, prunedSuffix, onChunk, signal)
+    const usageInfo = await generateFim(
+      connection,
+      modelId,
+      formattedPrefix,
+      prunedSuffix,
+      onChunk,
+      signal,
+      `${vscode.env.machineId}\0${autocompleteInput.filepath}`,
+    )
 
     const fillInAtCursorSuggestion = processSuggestion(response)
 

--- a/packages/kilo-vscode/src/services/autocomplete/fim.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/fim.ts
@@ -1,8 +1,14 @@
 import { ResponseMetaData } from "./types"
 import type { KiloConnectionService } from "../cli-backend"
 import { getAutocompleteModelById } from "../../shared/autocomplete-models"
+import { createHash } from "node:crypto"
 
 const FIM_MAX_TOKENS = 256
+
+export function getFimSessionId(modelId: string, scope?: string) {
+  if (!scope) return undefined
+  return createHash("sha256").update(modelId).update("\0").update(scope).digest("hex")
+}
 
 /**
  * Generate a FIM (Fill-in-the-Middle) completion via the CLI backend.
@@ -17,6 +23,7 @@ export async function generateFim(
   suffix: string,
   onChunk: (text: string) => void,
   signal?: AbortSignal,
+  scope?: string,
 ): Promise<ResponseMetaData> {
   const client = await connectionService.getClientAsync()
   const info = getAutocompleteModelById(modelId)
@@ -37,8 +44,9 @@ export async function generateFim(
       suffix,
       provider: info.providerID,
       model: info.modelID,
-      maxTokens: FIM_MAX_TOKENS,
+      maxTokens: info.maxTokens ?? FIM_MAX_TOKENS,
       temperature: info.temperature,
+      sessionId: info.providerID === "mtplx" ? getFimSessionId(info.id, scope) : undefined,
     },
     {
       signal,

--- a/packages/kilo-vscode/tests/unit/autocomplete-fim-session.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-fim-session.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { getFimSessionId } from "../../src/services/autocomplete/fim"
+
+describe("autocomplete FIM sessions", () => {
+  it("creates a stable opaque session per model and file", () => {
+    const first = getFimSessionId("mtplx/Qwen3.5-9B-MTPLX", "/workspace/src/index.ts")
+    const again = getFimSessionId("mtplx/Qwen3.5-9B-MTPLX", "/workspace/src/index.ts")
+    const other = getFimSessionId("mtplx/Qwen3.5-9B-MTPLX", "/workspace/src/other.ts")
+
+    expect(first).toBe(again)
+    expect(first).toHaveLength(64)
+    expect(first).not.toContain("workspace")
+    expect(other).not.toBe(first)
+  })
+
+  it("omits a session when no stable scope is available", () => {
+    expect(getFimSessionId("mtplx/Qwen3.5-9B-MTPLX")).toBeUndefined()
+  })
+})

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
@@ -161,6 +161,7 @@ export const FimBody = Schema.Struct({
   model: Schema.optional(Schema.String),
   maxTokens: Schema.optional(Schema.Finite),
   temperature: Schema.optional(Schema.Finite),
+  sessionId: Schema.optional(Schema.String),
 })
 
 // Next Edit (NES) — non-streaming. Clients send structured editor context; the

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -22,7 +22,14 @@ import {
   fetchOrganizationModes,
   fetchProfile,
 } from "@kilocode/kilo-gateway"
-import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget } from "@kilocode/kilo-gateway/fim"
+import {
+  buildMtplxRequest,
+  DIRECT_FIM_ENV,
+  isLoopbackMtplxUrl,
+  mtplxChatUrl,
+  requestMistralFim,
+  resolveFimTarget,
+} from "@kilocode/kilo-gateway/fim"
 import { DIRECT_EDIT_ENV, extractFencedBody, resolveEditTarget } from "@kilocode/kilo-gateway/edit"
 import { buildMercuryEditPrompt } from "@kilocode/kilo-gateway/edit-prompt"
 import { buildKiloHeaders } from "@kilocode/kilo-gateway"
@@ -34,6 +41,7 @@ import * as Log from "@opencode-ai/core/util/log"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { KilocodeConfig } from "@/kilocode/config/config"
 import { Auth } from "@/auth"
+import { Config } from "@/config/config"
 import { EffectBridge } from "@/effect/bridge"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Identifier } from "@/id/id"
@@ -63,6 +71,7 @@ function logError(route: string, err: unknown) {
 export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo", (handlers) =>
   Effect.gen(function* () {
     const auth = yield* Auth.Service
+    const config = yield* Config.Service
     const store = yield* InstanceStore.Service
     const cache = yield* ModelCache.Service
     const events = yield* EventV2Bridge.Service
@@ -113,6 +122,12 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const fim = Effect.fn("KiloGatewayHttpApi.fim")(function* (ctx: { payload: typeof FimBody.Type }) {
       const target = resolveFimTarget(ctx.payload.provider, ctx.payload.model)
+      const cfg = target.provider === "mtplx" ? yield* config.get() : undefined
+      const opts = cfg?.provider?.mtplx?.options
+      const baseURL =
+        target.provider === "mtplx" && typeof opts?.baseURL === "string" ? opts.baseURL : process.env.MTPLX_BASE_URL
+      const headers = target.provider === "mtplx" && opts?.headers ? opts.headers : {}
+      const mtplxURL = mtplxChatUrl(baseURL)
       const info = target.provider === "kilo" ? yield* proxyAuth() : undefined
       const token = yield* Effect.gen(function* () {
         if (target.provider === "kilo") return info?.token
@@ -122,7 +137,9 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       })
 
       if (target.provider === "kilo" && !info?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      if (!token && (target.provider !== "mtplx" || !isLoopbackMtplxUrl(mtplxURL))) {
+        return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      }
 
       const request = yield* HttpServerRequest.HttpServerRequest
       const signal =
@@ -136,25 +153,41 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
             return fetch(url, {
               method: "POST",
               headers: {
+                ...headers,
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
                 ...(target.provider === "kilo"
                   ? buildKiloHeaders(undefined, { kilocodeOrganizationId: info?.organizationId })
                   : {}),
                 ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
+                ...(target.provider === "mtplx" ? { "x-mtplx-client": "kilocode" } : {}),
+                ...(target.provider === "mtplx" && ctx.payload.sessionId
+                  ? { "x-mtplx-session-id": ctx.payload.sessionId }
+                  : {}),
               },
               signal,
-              body: JSON.stringify({
-                model: target.model,
-                prompt: ctx.payload.prefix,
-                suffix: ctx.payload.suffix,
-                max_tokens: ctx.payload.maxTokens ?? 256,
-                temperature: ctx.payload.temperature ?? 0.2,
-                stream: true,
-              }),
+              body: JSON.stringify(
+                target.provider === "mtplx"
+                  ? buildMtplxRequest({
+                      model: target.model,
+                      prefix: ctx.payload.prefix,
+                      suffix: ctx.payload.suffix,
+                      maxTokens: ctx.payload.maxTokens ?? 64,
+                      temperature: ctx.payload.temperature ?? 0,
+                    })
+                  : {
+                      model: target.model,
+                      prompt: ctx.payload.prefix,
+                      suffix: ctx.payload.suffix,
+                      max_tokens: ctx.payload.maxTokens ?? 256,
+                      temperature: ctx.payload.temperature ?? 0.2,
+                      stream: true,
+                    },
+              ),
             })
           }
           if (target.provider === "mistral") return requestMistralFim(run)
+          if (target.provider === "mtplx") return run(mtplxURL)
           return run(target.url)
         } catch (err) {
           if (err instanceof DOMException && err.name === "TimeoutError")

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi"
 import { Auth } from "../../../src/auth"
+import { Config } from "../../../src/config/config"
 import { KiloGatewayApi, KiloGatewayPaths } from "../../../src/kilocode/server/httpapi/groups/kilo-gateway"
 import { kiloGatewayHandlers } from "../../../src/kilocode/server/httpapi/handlers/kilo-gateway"
 import { InstanceStore } from "../../../src/project/instance-store"
@@ -22,6 +23,24 @@ import { testEffect } from "../../lib/effect"
 const TestHttpApi = HttpApi.make("opencode-instance").addHttpApi(KiloGatewayApi)
 const auth = Layer.mock(Auth.Service)({
   get: () => Effect.succeed(new Auth.Api({ type: "api", key: "test-token" })),
+})
+const config = Layer.mock(Config.Service)({
+  get: () =>
+    Effect.succeed({
+      provider: {
+        mtplx: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "MTPLX",
+          options: {
+            baseURL: "https://mtplx.test/v1",
+            headers: { "x-test-header": "configured" },
+          },
+          models: {
+            "Qwen3.5-9B-MTPLX": { name: "Qwen3.5 9B (MTPLX)" },
+          },
+        },
+      },
+    } as Config.Info),
 })
 const store = Layer.mock(InstanceStore.Service)({})
 const cache = Layer.mock(ModelCache.Service)({})
@@ -49,6 +68,7 @@ const layer = HttpRouter.serve(
       passthroughInstanceContext,
       testWorkspaceRouting,
       auth,
+      config,
       store,
       cache,
       session,
@@ -59,14 +79,14 @@ const layer = HttpRouter.serve(
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 const it = testEffect(layer)
 
-function stub(run: () => Response | Promise<Response>) {
+function stub(run: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>) {
   // These tests run sequentially; scope the process-global override and delegate in-process server traffic.
   const original = globalThis.fetch
   const fetch: typeof globalThis.fetch = Object.assign(
     async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
       if (url.startsWith("http://127.0.0.1:")) return original(input, init)
-      return run()
+      return run(input, init)
     },
     { preconnect: original.preconnect },
   )
@@ -94,6 +114,42 @@ describe("Kilo gateway HttpApi statuses", () => {
 
       expect(response.status).toBe(200)
       expect(yield* response.json).toEqual({ authenticated: true, type: "api" })
+    }),
+  )
+
+  it.live("routes MTPLX autocomplete through chat completions with a stable session", () =>
+    Effect.gen(function* () {
+      let upstream: Request | undefined
+      yield* stub((input, init) => {
+        upstream = new Request(input, init)
+        return new Response('data: {"choices":[]}\n\n', {
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      })
+
+      const response = yield* post(KiloGatewayPaths.fim, {
+        prefix: "function add(a, b) { return ",
+        suffix: "; }\n",
+        provider: "mtplx",
+        model: "Qwen3.5-9B-MTPLX",
+        maxTokens: 64,
+        temperature: 0,
+        sessionId: "stable-file-session",
+      })
+
+      expect(response.status).toBe(200)
+      expect(upstream).toBeDefined()
+      expect(upstream?.url).toBe("https://mtplx.test/v1/chat/completions")
+      expect(upstream?.headers.get("authorization")).toBe("Bearer test-token")
+      expect(upstream?.headers.get("x-mtplx-client")).toBe("kilocode")
+      expect(upstream?.headers.get("x-mtplx-session-id")).toBe("stable-file-session")
+      expect(upstream?.headers.get("x-test-header")).toBe("configured")
+      const body = yield* Effect.promise(() => upstream!.json() as Promise<Record<string, unknown>>)
+      expect(body.model).toBe("Qwen3.5-9B-MTPLX")
+      expect(body.max_tokens).toBe(64)
+      expect(body.enable_thinking).toBe(false)
+      expect(body).not.toHaveProperty("prompt")
+      expect(body).not.toHaveProperty("suffix")
     }),
   )
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -7091,6 +7091,7 @@ export class Kilo extends HeyApiClient {
       model?: string
       maxTokens?: number
       temperature?: number
+      sessionId?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7107,6 +7108,7 @@ export class Kilo extends HeyApiClient {
             { in: "body", key: "model" },
             { in: "body", key: "maxTokens" },
             { in: "body", key: "temperature" },
+            { in: "body", key: "sessionId" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -11776,6 +11776,7 @@ export type KiloFimData = {
     model?: string
     maxTokens?: number
     temperature?: number
+    sessionId?: string
   }
   path?: never
   query?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -13555,6 +13555,9 @@
                   },
                   "temperature": {
                     "type": "number"
+                  },
+                  "sessionId": {
+                    "type": "string"
                   }
                 },
                 "required": ["prefix", "suffix"],


### PR DESCRIPTION
## Issue

Related to #4498.

## Context

Draft: add inline autocomplete using configured BYOK completion models.

The selected endpoint and model must support fill-in-the-middle code completion; ordinary chat models are not expected to produce useful inline insertions. Local validation has covered standard OpenAI-compatible completion endpoints, including:

- `mlx-community/Qwen2.5-Coder-1.5B-4bit` served through OMLX
- `mlx-community/Qwen2.5-Coder-3B-4bit` served through OMLX
- `Qwen3-Coder-30B-A3B` through a local llama.cpp endpoint

The same configuration pattern applies to FIM-capable models exposed through other OpenAI-compatible servers such as LM Studio or Ollama.

## Implementation

Work in progress.

## Screenshots / Video

N/A: no new visual component is planned.

## How to Test

Verification details will be added before this draft is marked ready.

## Checklist

- [x] Issue linked above, or exception explained
- [ ] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [ ] I personally reviewed the final diff and can explain the changes, including any AI-assisted work.
