### PR TITLE
feat(vscode): toggle chat search from Command Palette, jump focus on close, and auto-expand matched blocks

### DIFF
--- a/.changeset/chat-search-toggle-and-jump.md
+++ b/.changeset/chat-search-toggle-and-jump.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Toggle chat search from the Command Palette, jump focus back to the chat input when it closes, and auto-expand the collapsed tool call or reasoning block containing the current search match.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -142,6 +142,10 @@ export interface MessagePartProps {
   message: MessageType
   hideDetails?: boolean
   defaultOpen?: boolean
+  /** True when this part contains the transcript search's current match —
+   * forces a collapsed tool/reasoning block open so the user can see the
+   * highlighted match without manually expanding it first. */
+  forceOpen?: boolean
   reasoningAutoCollapse?: boolean
   showAssistantCopyPartID?: string | null
   showTurnDiffSummary?: boolean
@@ -974,6 +978,7 @@ export function Part(props: MessagePartProps) {
         message={props.message}
         hideDetails={props.hideDetails}
         defaultOpen={props.defaultOpen}
+        forceOpen={props.forceOpen}
         reasoningAutoCollapse={props.reasoningAutoCollapse}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         showTurnDiffSummary={props.showTurnDiffSummary}
@@ -1198,6 +1203,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                     status={part.state.status}
                     hideDetails={props.hideDetails}
                     defaultOpen={props.defaultOpen}
+                    forceOpen={props.forceOpen}
                     animate
                     reveal={props.animate}
                   />
@@ -1265,6 +1271,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               attachments={part.state.attachments}
               hideDetails={props.hideDetails}
               defaultOpen={props.defaultOpen}
+              forceOpen={props.forceOpen}
               animate
               reveal={props.animate}
             />
@@ -1518,6 +1525,18 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
     else rememberReasoningState(userCollapsed, id)
     setOpen(value)
   }
+
+  // Reasoning has no built-in "force open" hook (unlike BasicTool's forceOpen
+  // ratchet) — mirror that one-way-open behavior here so jumping a chat
+  // search match to a collapsed reasoning block reveals it, the same as it
+  // does for tool calls. Recorded into userOpened/userCollapsed the same way
+  // a manual open would be, so it stays open across remounts/re-renders.
+  createEffect(() => {
+    if (!props.forceOpen || open()) return
+    if (props.reasoningAutoCollapse) rememberReasoningState(userOpened, id)
+    else userCollapsed.delete(id)
+    setOpen(true)
+  })
 
   createEffect(() => {
     if (!props.reasoningAutoCollapse) return
@@ -2587,6 +2606,15 @@ ToolRegistry.register({
       if (seeded) return
       seeded = true
       setExpanded(list.filter((f) => f.type !== "delete").map((f) => f.filePath))
+    })
+    // Deleted files start collapsed above; a chat search match could be
+    // inside one, and there's no per-file tracking of which file a match
+    // falls in, so force-opening this tool expands every file's accordion
+    // rather than guessing — better to over-reveal than leave the match
+    // hidden behind a still-collapsed file.
+    createEffect(() => {
+      if (!props.forceOpen) return
+      setExpanded(files().map((f) => f.filePath))
     })
     const subtitle = createMemo(() => {
       const count = files().length

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2311,7 +2311,12 @@ ToolRegistry.register({
           }
         >
           <Show when={mounted()}>
-            <BashHighlightedOutput cmd={cmd()} output={out()} outputPath={props.metadata.outputPath} active={open()} />
+            <BashHighlightedOutput
+              cmd={cmd()}
+              output={out()}
+              outputPath={props.metadata.outputPath}
+              active={open() || !!props.forceOpen}
+            />
           </Show>
         </BasicTool>
         <Show when={pruned()}>
@@ -2625,18 +2630,28 @@ ToolRegistry.register({
     })
     // Deleted files start collapsed above; a chat search match could be
     // inside one. `forceOpenFile` (from MessageList's per-chunk file
-    // attribution) names exactly which file's accordion to open — falling
-    // back to expanding every file only when forceOpen fires without a
-    // known file (defensive; MessageList always attributes apply_patch
-    // matches to a specific file today).
+    // attribution) names exactly which file's accordion to open. This is
+    // tracked separately from the user's own manual toggles: replacing it
+    // on every navigation (rather than appending to `expanded`, which never
+    // shrinks) closes the previously force-opened file again, so its Pierre
+    // diff instance unmounts instead of accumulating one per visited match.
+    const [searchOpenFile, setSearchOpenFile] = createSignal<string | undefined>()
     createEffect(() => {
       if (props.forceOpenFile) {
-        const path = props.forceOpenFile
-        setExpanded((prev) => (prev.includes(path) ? prev : [...prev, path]))
+        setSearchOpenFile(props.forceOpenFile)
         return
       }
+      // Defensive fallback for forceOpen without a known file (MessageList
+      // always attributes apply_patch matches to a specific file today):
+      // expand everything rather than nothing.
+      setSearchOpenFile(undefined)
       if (!props.forceOpen) return
       setExpanded(files().map((f) => f.filePath))
+    })
+    const allExpanded = createMemo(() => {
+      const search = searchOpenFile()
+      if (!search) return expanded()
+      return expanded().includes(search) ? expanded() : [...expanded(), search]
     })
     const subtitle = createMemo(() => {
       const count = files().length
@@ -2690,8 +2705,15 @@ ToolRegistry.register({
                   multiple
                   data-scope="apply-patch"
                   style={{ "--sticky-accordion-offset": "37px" }}
-                  value={expanded()}
-                  onChange={(value) => setExpanded(Array.isArray(value) ? value : value ? [value] : [])}
+                  value={allExpanded()}
+                  onChange={(value) => {
+                    const next = Array.isArray(value) ? value : value ? [value] : []
+                    // The user explicitly closed the search-forced file —
+                    // stop treating it as force-open so it doesn't reopen
+                    // itself out of `allExpanded()` on the next render.
+                    if (searchOpenFile() && !next.includes(searchOpenFile()!)) setSearchOpenFile(undefined)
+                    setExpanded(next.filter((path) => path !== searchOpenFile()))
+                  }}
                 >
                   <For each={files()}>
                     {(file) => {

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -146,6 +146,10 @@ export interface MessagePartProps {
    * forces a collapsed tool/reasoning block open so the user can see the
    * highlighted match without manually expanding it first. */
   forceOpen?: boolean
+  /** For a multi-file apply_patch part, the specific file path (matching
+   * that file's `filePath`) whose accordion contains the current match —
+   * lets that one nested item open instead of every file in the patch. */
+  forceOpenFile?: string
   reasoningAutoCollapse?: boolean
   showAssistantCopyPartID?: string | null
   showTurnDiffSummary?: boolean
@@ -979,6 +983,7 @@ export function Part(props: MessagePartProps) {
         hideDetails={props.hideDetails}
         defaultOpen={props.defaultOpen}
         forceOpen={props.forceOpen}
+        forceOpenFile={props.forceOpenFile}
         reasoningAutoCollapse={props.reasoningAutoCollapse}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         showTurnDiffSummary={props.showTurnDiffSummary}
@@ -1004,6 +1009,9 @@ export interface ToolProps {
   hideDetails?: boolean
   defaultOpen?: boolean
   forceOpen?: boolean
+  /** For a multi-file apply_patch part, the specific file path whose
+   * accordion contains the current transcript search match. */
+  forceOpenFile?: string
   locked?: boolean
   animate?: boolean
   reveal?: boolean
@@ -1272,6 +1280,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               hideDetails={props.hideDetails}
               defaultOpen={props.defaultOpen}
               forceOpen={props.forceOpen}
+              forceOpenFile={props.forceOpenFile}
               animate
               reveal={props.animate}
             />
@@ -2257,8 +2266,15 @@ ToolRegistry.register({
     const [open, setOpen] = createSignal(readToolOpen(key(), props.defaultOpen ?? true) ?? true)
     const [mounted, setMounted] = createSignal(open())
 
+    // BasicTool's `initialOpen()` forces its own open state to true whenever
+    // forceOpen is set, but that's an initial value, not a transition — if
+    // it's already mounted open (e.g. after a virtualized remount), there's
+    // no open/close change for `onOpenChange={setOpen}` below to fire, so
+    // this local `open`/`mounted` pair (seeded independently from
+    // readToolOpen) can stay stale and out of sync, leaving the accordion
+    // visibly expanded with no output mounted inside it.
     createEffect(() => {
-      if (open() || pending()) setMounted(true)
+      if (open() || pending() || props.forceOpen) setMounted(true)
     })
 
     // also apply processCarriageReturns for Windows CLI tools
@@ -2608,11 +2624,17 @@ ToolRegistry.register({
       setExpanded(list.filter((f) => f.type !== "delete").map((f) => f.filePath))
     })
     // Deleted files start collapsed above; a chat search match could be
-    // inside one, and there's no per-file tracking of which file a match
-    // falls in, so force-opening this tool expands every file's accordion
-    // rather than guessing — better to over-reveal than leave the match
-    // hidden behind a still-collapsed file.
+    // inside one. `forceOpenFile` (from MessageList's per-chunk file
+    // attribution) names exactly which file's accordion to open — falling
+    // back to expanding every file only when forceOpen fires without a
+    // known file (defensive; MessageList always attributes apply_patch
+    // matches to a specific file today).
     createEffect(() => {
+      if (props.forceOpenFile) {
+        const path = props.forceOpenFile
+        setExpanded((prev) => (prev.includes(path) ? prev : [...prev, path]))
+        return
+      }
       if (!props.forceOpen) return
       setExpanded(files().map((f) => f.filePath))
     })

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -409,6 +409,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.toggleChatSearch",
+        "title": "Toggle Chat Search",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.cycleAgentMode",
         "title": "Cycle Agent Mode",
         "category": "Kilo Code"

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1847,6 +1847,13 @@ export class AgentManagerProvider implements Disposable {
     return this.waitForPanel(panel, panel.waitForActive())
   }
 
+  /** Wait for the current panel's webview to be ready before posting to it. False if there is no panel or it closed while waiting. */
+  public waitForReady(): Promise<boolean> {
+    const panel = this.panel
+    if (!panel) return Promise.resolve(false)
+    return this.waitForPanelReady(panel)
+  }
+
   public async showMemory(): Promise<void> {
     const panel = this.panel
     const sid = this.activeSessionId

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -557,7 +557,7 @@ export function activate(context: vscode.ExtensionContext) {
   )
 
   // Register code actions (editor context menus, terminal context menus, keyboard shortcuts)
-  registerCodeActions(context, provider, agentManagerProvider)
+  registerCodeActions(context, provider, agentManagerProvider, activeTabProvider)
   registerTerminalActions(context, provider, agentManagerProvider)
 
   // Register CodeActionProvider (lightbulb quick fixes)

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -8,8 +8,9 @@ export function registerCodeActions(
   context: vscode.ExtensionContext,
   provider: KiloProvider,
   agentManager?: AgentManagerProvider,
+  activeTabProvider?: () => KiloProvider | undefined,
 ): void {
-  const target = () => (agentManager?.isActive() ? agentManager : provider)
+  const target = () => (agentManager?.isActive() ? agentManager : (activeTabProvider?.() ?? provider))
   const reveal = async () => {
     await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
     await provider.waitForReady()
@@ -81,6 +82,20 @@ export function registerCodeActions(
         await reveal()
       }
       view.postMessage({ type: "action", action: "focusInput" })
+    }),
+
+    // Command Palette only — no keybinding. A keybinding would need to
+    // route through VS Code's keybinding-to-focused-webview forwarding,
+    // which doesn't reliably reach a webview whose own input already has
+    // focus; invoking straight from the palette sidesteps that path
+    // entirely, the same way terminalAddToContext etc. do. Toggles: the
+    // webview closes the search bar itself if it's already open.
+    vscode.commands.registerCommand("kilo-code.new.toggleChatSearch", async () => {
+      const view = target()
+      if (view === provider) {
+        await reveal()
+      }
+      view.postMessage({ type: "action", action: "focusSearch" })
     }),
   )
 }

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -21,16 +21,22 @@ export function registerCodeActions(
   // does not queue — it silently drops the message if the webview hasn't
   // installed its listener yet. Wait for the selected target's own
   // readiness too before posting to it.
-  const revealTarget = async (view: KiloProvider | AgentManagerProvider) => {
+  //
+  // AgentManagerProvider.waitForReady() resolves `false` instead of hanging
+  // forever when the selected panel closes or is replaced while waiting.
+  // Propagate that so callers skip posting instead of delivering the
+  // message to whatever panel happens to be active by the time the wait
+  // settles.
+  const revealTarget = async (view: KiloProvider | AgentManagerProvider): Promise<boolean> => {
     if (view === provider) {
       await reveal()
-      return
+      return true
     }
     if (view === agentManager) {
-      await agentManager.waitForReady()
-      return
+      return agentManager.waitForReady()
     }
     await view.waitForReady()
+    return true
   }
 
   context.subscriptions.push(
@@ -87,13 +93,13 @@ export function registerCodeActions(
         selectedText: ctx.selectedText,
       })
       const view = target()
-      await revealTarget(view)
+      if (!(await revealTarget(view))) return
       view.postMessage({ type: "appendChatBoxMessage", text: prompt })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", async () => {
       const view = target()
-      await revealTarget(view)
+      if (!(await revealTarget(view))) return
       view.postMessage({ type: "action", action: "focusInput" })
     }),
 

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -111,7 +111,7 @@ export function registerCodeActions(
     // webview closes the search bar itself if it's already open.
     vscode.commands.registerCommand("kilo-code.new.toggleChatSearch", async () => {
       const view = target()
-      await revealTarget(view)
+      if (!(await revealTarget(view))) return
       view.postMessage({ type: "action", action: "focusSearch" })
     }),
   )

--- a/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
+++ b/packages/kilo-vscode/src/services/code-actions/register-code-actions.ts
@@ -15,6 +15,23 @@ export function registerCodeActions(
     await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
     await provider.waitForReady()
   }
+  // Only the sidebar `provider` branch used to await readiness before
+  // posting. An editor-tab webview or the Agent Manager panel can still be
+  // opening/restoring when one of these commands fires, and postMessage()
+  // does not queue — it silently drops the message if the webview hasn't
+  // installed its listener yet. Wait for the selected target's own
+  // readiness too before posting to it.
+  const revealTarget = async (view: KiloProvider | AgentManagerProvider) => {
+    if (view === provider) {
+      await reveal()
+      return
+    }
+    if (view === agentManager) {
+      await agentManager.waitForReady()
+      return
+    }
+    await view.waitForReady()
+  }
 
   context.subscriptions.push(
     vscode.commands.registerCommand("kilo-code.new.explainCode", async () => {
@@ -70,17 +87,13 @@ export function registerCodeActions(
         selectedText: ctx.selectedText,
       })
       const view = target()
-      if (view === provider) {
-        await reveal()
-      }
+      await revealTarget(view)
       view.postMessage({ type: "appendChatBoxMessage", text: prompt })
     }),
 
     vscode.commands.registerCommand("kilo-code.new.focusChatInput", async () => {
       const view = target()
-      if (view === provider) {
-        await reveal()
-      }
+      await revealTarget(view)
       view.postMessage({ type: "action", action: "focusInput" })
     }),
 
@@ -92,9 +105,7 @@ export function registerCodeActions(
     // webview closes the search bar itself if it's already open.
     vscode.commands.registerCommand("kilo-code.new.toggleChatSearch", async () => {
       const view = target()
-      if (view === provider) {
-        await reveal()
-      }
+      await revealTarget(view)
       view.postMessage({ type: "action", action: "focusSearch" })
     }),
   )

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -388,7 +388,7 @@ describe("Collapsed deferred tool details contract (source)", () => {
     const block =
       message.match(/ToolRegistry\.register\(\{\s*name:\s*"bash"[\s\S]*?(?=ToolRegistry\.register\(|$)/)?.[0] ?? ""
     expect(block).toContain("const [mounted, setMounted] = createSignal(open())")
-    expect(block).toMatch(/if \(open\(\) \|\| pending\(\)\) setMounted\(true\)/)
+    expect(block).toMatch(/if \(open\(\) \|\| pending\(\) \|\| props\.forceOpen\) setMounted\(true\)/)
     expect(block).toContain("hasDetails")
     expect(block).toMatch(/<Show when=\{mounted\(\)\}>[\s\S]*?<BashHighlightedOutput/)
   })

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -225,7 +225,10 @@ describe("Bash tool static terminal preview (source)", () => {
 
   it("BashHighlightedOutput highlights only while expanded", () => {
     expect(src).toContain("if (!props.active) return")
-    expect(block).toContain("active={open()}")
+    // Also active when forceOpen fires from a virtualized remount that
+    // starts already open — `open()` alone only reflects the toggle
+    // transition, not that initial-mount case.
+    expect(block).toContain("active={open() || !!props.forceOpen}")
   })
 
   it("BashHighlightedOutput keeps command and output in separate terminal containers", () => {

--- a/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
@@ -23,7 +23,7 @@ const original = {
   diagnostics: api.languages.getDiagnostics,
 }
 
-function setup(active = false) {
+function setup(active = false, agentReady = true) {
   const commands = new Map<string, Command>()
   const executed: unknown[][] = []
   const events: string[] = []
@@ -49,6 +49,7 @@ function setup(active = false) {
     waitForReady: async () => {
       events.push("wait")
       waits.push("agent")
+      return agentReady
     },
   }
 
@@ -116,5 +117,14 @@ describe("registerCodeActions", () => {
         text: "src/file.ts:3-5\n```\nconst value = 1\n```",
       },
     ])
+  })
+
+  it("does not post to the Agent Manager when its readiness wait is cancelled", async () => {
+    const state = setup(true, false)
+
+    await state.commands.get("kilo-code.new.addToContext")?.()
+
+    expect(state.events).toEqual(["wait"])
+    expect(state.posts).toEqual([])
   })
 })

--- a/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
@@ -127,4 +127,22 @@ describe("registerCodeActions", () => {
     expect(state.events).toEqual(["wait"])
     expect(state.posts).toEqual([])
   })
+
+  it("toggles chat search on the active Agent Manager once it is ready", async () => {
+    const state = setup(true)
+
+    await state.commands.get("kilo-code.new.toggleChatSearch")?.()
+
+    expect(state.events).toEqual(["wait", "post"])
+    expect(state.posts).toEqual([{ type: "action", action: "focusSearch" }])
+  })
+
+  it("does not toggle chat search when Agent Manager readiness is cancelled", async () => {
+    const state = setup(true, false)
+
+    await state.commands.get("kilo-code.new.toggleChatSearch")?.()
+
+    expect(state.events).toEqual(["wait"])
+    expect(state.posts).toEqual([])
+  })
 })

--- a/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/register-code-actions.test.ts
@@ -46,6 +46,10 @@ function setup(active = false) {
       events.push("post")
       posts.push(msg)
     },
+    waitForReady: async () => {
+      events.push("wait")
+      waits.push("agent")
+    },
   }
 
   api.commands.registerCommand = (command, callback) => {
@@ -103,9 +107,9 @@ describe("registerCodeActions", () => {
 
     await state.commands.get("kilo-code.new.addToContext")?.()
 
-    expect(state.events).toEqual(["post"])
+    expect(state.events).toEqual(["wait", "post"])
     expect(state.executed).toEqual([])
-    expect(state.waits).toEqual([])
+    expect(state.waits).toEqual(["agent"])
     expect(state.posts).toEqual([
       {
         type: "appendChatBoxMessage",

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -100,6 +100,7 @@ import {
   nextSelectionAfterDelete,
   adjacentHint,
   filterUnassignedSessions,
+  focusChatSearch,
   LOCAL,
 } from "./navigate"
 import {
@@ -1107,7 +1108,8 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "closeWorktree") closeSelectedWorktree()
       else if (msg.action === "showShortcuts") handleShowKeyboardShortcuts()
       else if (msg.action === "focusInput") window.dispatchEvent(new Event("focusPrompt"))
-      else if (msg.action === "focusSearch") window.dispatchEvent(new CustomEvent("focusTranscriptSearch"))
+      else if (msg.action === "focusSearch")
+        focusChatSearch({ history: setHistory, review: setReviewActive, terminal: () => terms.setActiveId(undefined) })
       else if (msg.action === "newTerminal") termHandlers.requestNew()
       else if (msg.action === "cycleAgentMode" && document.hasFocus()) cycleAgent(1)
       else if (msg.action === "cyclePreviousAgentMode" && document.hasFocus()) cycleAgent(-1)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1088,6 +1088,7 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "closeWorktree") closeSelectedWorktree()
       else if (msg.action === "showShortcuts") handleShowKeyboardShortcuts()
       else if (msg.action === "focusInput") window.dispatchEvent(new Event("focusPrompt"))
+      else if (msg.action === "focusSearch") window.dispatchEvent(new CustomEvent("focusTranscriptSearch"))
       else if (msg.action === "newTerminal") termHandlers.requestNew()
       else if (msg.action === "cycleAgentMode" && document.hasFocus()) cycleAgent(1)
       else if (msg.action === "cyclePreviousAgentMode" && document.hasFocus()) cycleAgent(-1)

--- a/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/navigate.ts
@@ -120,3 +120,15 @@ export function nextSelectionAfterDelete(deletedId: string, worktreeIds: string[
   // Prefer the item that was below (same index in the shortened list), else the one above
   return remaining[Math.min(idx, remaining.length - 1)]!
 }
+
+/**
+ * A "focus chat search" request only reaches TaskHeader while ChatView is
+ * the visible main surface — history, an active terminal tab, and the
+ * full-screen review each replace it. Reset to chat first, then dispatch.
+ */
+export function focusChatSearch(reset: { history(v: boolean): void; review(v: boolean): void; terminal(): void }) {
+  reset.history(false)
+  reset.review(false)
+  reset.terminal()
+  window.dispatchEvent(new CustomEvent("focusTranscriptSearch"))
+}

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -267,6 +267,10 @@ const AppContent: Component = () => {
       case "cyclePreviousAgentMode":
         if (document.hasFocus()) cycleAgent(-1)
         break
+      case "focusSearch":
+        setCurrentView("newTask")
+        window.dispatchEvent(new CustomEvent("focusTranscriptSearch"))
+        break
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -125,6 +125,10 @@ interface AssistantMessageProps {
   parts?: SDKPart[]
   showAssistantCopyPartID?: string | null
   feedback?: MessageFeedbackControls
+  /** id of the part containing the current chat-search match, if any — forces
+   * that part's collapsed tool/reasoning content open so the user can see
+   * the highlighted match without manually expanding it first. */
+  forceOpenPartID?: string
 }
 
 type ToolStateProps = {
@@ -136,7 +140,7 @@ type ToolStateProps = {
 
 type MemoryItem = MemoryMarkerMeta.Decoded
 
-function TodoToolCard(props: { part: ToolPart }) {
+function TodoToolCard(props: { part: ToolPart; forceOpen?: boolean }) {
   const render = ToolRegistry.render(props.part.tool)
   const state = () => props.part.state as ToolStateProps
   return (
@@ -152,6 +156,7 @@ function TodoToolCard(props: { part: ToolPart }) {
           output={state()?.output}
           status={state()?.status}
           defaultOpen
+          forceOpen={props.forceOpen}
           reveal={false}
         />
       )}
@@ -159,7 +164,7 @@ function TodoToolCard(props: { part: ToolPart }) {
   )
 }
 
-function BashToolCard(props: { part: ToolPart; defaultOpen: boolean }) {
+function BashToolCard(props: { part: ToolPart; defaultOpen: boolean; forceOpen?: boolean }) {
   const render = ToolRegistry.render(props.part.tool)
   const state = () => props.part.state as ToolStateProps
   return (
@@ -176,6 +181,7 @@ function BashToolCard(props: { part: ToolPart; defaultOpen: boolean }) {
           output={state()?.output}
           status={state()?.status}
           defaultOpen={props.defaultOpen}
+          forceOpen={props.forceOpen}
           animate
           reveal={state()?.status === "pending" || state()?.status === "running"}
         />
@@ -279,6 +285,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
             if (!planExitInfo(part)) return
             return part as unknown as ToolPart
           })
+          const forceOpen = createMemo(() => !!props.forceOpenPartID && part.id === props.forceOpenPartID)
 
           return (
             <Show
@@ -291,7 +298,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                 PART_MAPPING[part.type]
               }
             >
-              <div data-component="tool-part-wrapper" data-part-type={part.type}>
+              <div data-component="tool-part-wrapper" data-part-type={part.type} data-part-id={part.id}>
                 <Show
                   when={activeQuestion()}
                   fallback={
@@ -312,6 +319,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                       message={props.message as SDKMessage}
                                       showAssistantCopyPartID={props.showAssistantCopyPartID}
                                       defaultOpen={editOpen(part, edit())}
+                                      forceOpen={forceOpen()}
                                       reasoningAutoCollapse={display.reasoningAutoCollapse()}
                                       feedback={props.feedback}
                                       animate={
@@ -322,11 +330,17 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                     />
                                   }
                                 >
-                                  <TodoToolCard part={part as unknown as ToolPart} />
+                                  <TodoToolCard part={part as unknown as ToolPart} forceOpen={forceOpen()} />
                                 </Show>
                               }
                             >
-                              {(tool) => <BashToolCard part={tool() as unknown as ToolPart} defaultOpen={open()} />}
+                              {(tool) => (
+                                <BashToolCard
+                                  part={tool() as unknown as ToolPart}
+                                  defaultOpen={open()}
+                                  forceOpen={forceOpen()}
+                                />
+                              )}
                             </Show>
                           }
                         >

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -129,6 +129,9 @@ interface AssistantMessageProps {
    * that part's collapsed tool/reasoning content open so the user can see
    * the highlighted match without manually expanding it first. */
   forceOpenPartID?: string
+  /** For a multi-file apply_patch match, the specific file within that part —
+   * lets that one nested item open instead of every file in the patch. */
+  forceOpenFile?: string
 }
 
 type ToolStateProps = {
@@ -320,6 +323,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                       showAssistantCopyPartID={props.showAssistantCopyPartID}
                                       defaultOpen={editOpen(part, edit())}
                                       forceOpen={forceOpen()}
+                                      forceOpenFile={forceOpen() ? props.forceOpenFile : undefined}
                                       reasoningAutoCollapse={display.reasoningAutoCollapse()}
                                       feedback={props.feedback}
                                       animate={

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -56,6 +56,11 @@ import {
   stableMessageTurns,
   type MessageTurn,
 } from "../../context/session-queue"
+import { childID } from "../../context/session-utils"
+import { taskResult } from "./task-tool-state"
+import { tr } from "./question-dock-utils"
+import { useData } from "@kilocode/kilo-ui/context/data"
+import { getDirectory as getRawDirectory, getFilename } from "@opencode-ai/core/util/path"
 import {
   partitionRows,
   retainTurn,
@@ -98,6 +103,26 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const language = useLanguage()
   const provider = useProvider()
   const i18n = useI18n()
+  const data = useData()
+
+  // Mirrors message-part.tsx's own (unexported) relativizeProjectPath/
+  // getDirectory exactly, so the directory text indexed here matches what
+  // ToolMetaLine/ToolFileAccordion actually put on screen.
+  function relativizeProjectPath(path: string, directory?: string) {
+    if (!path) return ""
+    if (!directory) return path
+    if (directory === "/") return path
+    if (directory === "\\") return path
+    if (path === directory) return ""
+    const separator = directory.includes("\\") ? "\\" : "/"
+    const prefix = directory.endsWith(separator) ? directory : directory + separator
+    if (!path.startsWith(prefix)) return path
+    return path.slice(directory.length)
+  }
+
+  function getDirectory(path: string | undefined) {
+    return relativizeProjectPath(getRawDirectory(path), data.directory)
+  }
 
   const autoScroll = createAutoScroll({
     working: () => session.status() !== "idle",
@@ -169,7 +194,13 @@ export const MessageList: Component<MessageListProps> = (props) => {
     start: number
     end: number
     partId: string
+    /** For a multi-file apply_patch chunk, the file this range belongs to. */
+    file?: string
   }
+
+  /** A tool-text chunk, optionally attributed to a specific file within a
+   * multi-file tool part (currently only apply_patch's per-file chunks). */
+  type ToolChunk = string | { text: string; file: string }
 
   // Returns the row's full searchable text plus, for every chunk that came
   // from a specific part (tool call/reasoning/text/file), the character
@@ -190,11 +221,11 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const chunks: string[] = []
     const ranges: RowTextRange[] = []
     let pos = 0
-    const push = (text: string, partId: string) => {
+    const push = (text: string, partId: string, file?: string) => {
       if (!text) return
       if (chunks.length > 0) pos += 1 // account for the "\n" chunk joiner below
       chunks.push(text)
-      ranges.push({ start: pos, end: pos + text.length, partId })
+      ranges.push({ start: pos, end: pos + text.length, partId, file })
       pos += text.length
     }
     for (const part of row.parts) {
@@ -213,7 +244,10 @@ export const MessageList: Component<MessageListProps> = (props) => {
           // Stripping it here would search text that no longer matches the
           // literal characters on screen, the same class of mismatch this
           // rewrite fixes elsewhere.
-          for (const chunk of toolText(part)) push(chunk, part.id)
+          for (const chunk of toolText(part)) {
+            if (typeof chunk === "string") push(chunk, part.id)
+            else push(chunk.text, part.id, chunk.file)
+          }
           break
         case "file":
           if (part.filename) push(part.filename, part.id)
@@ -223,8 +257,8 @@ export const MessageList: Component<MessageListProps> = (props) => {
     return { text: chunks.join("\n"), ranges }
   }
 
-  function partIdAt(ranges: RowTextRange[], index: number): string | undefined {
-    return ranges.find((r) => index >= r.start && index < r.end)?.partId
+  function rangeAt(ranges: RowTextRange[], index: number): RowTextRange | undefined {
+    return ranges.find((r) => index >= r.start && index < r.end)
   }
 
   // Markdown link/image URLs are part of the raw source text but are never
@@ -318,17 +352,22 @@ export const MessageList: Component<MessageListProps> = (props) => {
   // exactly one file (message-part.tsx's `single()`) — for a multi-file
   // patch each file's name only appears once, in its own accordion header.
   const DIFF_TOOLS = new Set(["edit", "write"])
-  // todowrite/todoread's renderer resolves the shown list from a fallback
-  // chain (metadata.view.todos, else metadata.todos, else input.todos) —
+  // todowrite's renderer resolves the shown list from a fallback chain
+  // (metadata.view.todos, else metadata.todos, else input.todos) —
   // packages/opencode/src/tool/todo.ts sets metadata.todos to the exact
   // same array as input.todos, and metadata.view.todos to the exact same
   // content again whenever the view is in "full" mode (the common case,
   // see packages/opencode/src/kilocode/todo-view.ts). Recursively collecting
   // both input and metadata would count every todo's text 2-3x even though
   // shown() only ever renders it once.
-  const TODO_TOOLS = new Set(["todowrite", "todoread"])
+  // todoread is deliberately excluded: AssistantMessage.tsx's isRenderable()
+  // only shows a completed part from UPSTREAM_SUPPRESSED_TOOLS when
+  // ToolRegistry has a renderer for it, and only "todowrite" is registered —
+  // a completed todoread never reaches the DOM, so indexing it would count
+  // matches with nothing to highlight or navigate to.
+  const TODO_TOOLS = new Set(["todowrite"])
 
-  function toolText(part: Part & { type: "tool" }): string[] {
+  function toolText(part: Part & { type: "tool" }): ToolChunk[] {
     const state = part.state
     if (state.status === "error") return state.error ? [state.error] : []
     // task's trigger (title "{type} Agent" + input.description subtitle) and
@@ -343,7 +382,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
     if (CONTEXT_GROUP_TOOLS.has(part.tool)) return state.title ? [state.title] : []
     if (part.tool === "bash") return bashText(state)
     if (part.tool === "apply_patch") return applyPatchText(state)
-    if (DIFF_TOOLS.has(part.tool)) return editWriteText(state)
+    if (DIFF_TOOLS.has(part.tool)) return editWriteText(part.tool, state)
     if (TODO_TOOLS.has(part.tool)) return todoText(state)
     const chunks: string[] = []
     if (state.title) chunks.push(state.title)
@@ -353,19 +392,33 @@ export const MessageList: Component<MessageListProps> = (props) => {
     return chunks
   }
 
+  // transcript-search-highlight.ts's scanScope() walks the whole [data-part-
+  // id] subtree for this tool, which includes the ToolTriggerRow's title
+  // ("To-dos") and "completed/total" subtitle alongside each item's content
+  // — indexing only item content undercounts what's actually scanned there,
+  // shifting which range resolveSearchScopes/scanScope picks as "active".
   function todoText(state: Extract<ToolState, { status: "completed" }>): string[] {
     const metadata = state.metadata as { todos?: unknown; view?: unknown } | undefined
     const input = state.input as { todos?: unknown } | undefined
     const view = metadata?.view
     const viewTodos = isTodoView(view) ? view.todos : undefined
-    const todos =
-      viewTodos ??
+    // Matches the renderer's own `todos()` memo (used for the "N/M"
+    // subtitle): metadata.todos, else input.todos — never the (possibly
+    // view-truncated) compact list.
+    const full =
       (Array.isArray(metadata?.todos) ? metadata.todos : undefined) ??
       (Array.isArray(input?.todos) ? input.todos : undefined) ??
       []
-    return (todos as { content?: unknown }[])
-      .map((todo) => todo?.content)
-      .filter((content): content is string => typeof content === "string" && content.length > 0)
+    const shown = viewTodos ?? full
+    const chunks: string[] = [i18n.t("ui.tool.todos")]
+    if (full.length > 0) {
+      const completed = (full as { status?: unknown }[]).filter((t) => t?.status === "completed").length
+      chunks.push(`${completed}/${full.length}`)
+    }
+    for (const content of (shown as { content?: unknown }[]).map((todo) => todo?.content)) {
+      if (typeof content === "string" && content.length > 0) chunks.push(content)
+    }
+    return chunks
   }
 
   function isTodoView(value: unknown): value is { todos?: { content?: unknown }[] } {
@@ -385,6 +438,16 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const type = input?.subagent_type || part.tool
     const chunks = [i18n.t("ui.tool.agent", { type })]
     if (input?.description) chunks.push(input.description)
+    // TaskToolExpanded.tsx only shows the raw <task_result> body when there's
+    // no live child session to display instead (result() there resolves to
+    // undefined once a child session exists) — mirror that exactly so a
+    // completed task with no child session stays searchable, without
+    // indexing text that's actually replaced by the child tool list.
+    if (state.status === "completed") {
+      const child = childID({ type: "tool", tool: part.tool, state: { metadata: state.metadata } })
+      const result = taskResult(state.output, child)
+      if (result) chunks.push(result)
+    }
     return chunks
   }
 
@@ -395,10 +458,11 @@ export const MessageList: Component<MessageListProps> = (props) => {
   // text plus whichever answer was actually given (dismissed questions show
   // neither the options nor a real answer, just a static "dismissed"
   // label that isn't meaningful content to index).
+  type QuestionOption = { label?: string; description?: string; labelKey?: string; descriptionKey?: string }
+  type QuestionInfo = { question?: string; questionKey?: string; options?: QuestionOption[] }
+
   function questionText(state: ToolState): string[] {
-    const input = state.input as
-      | { questions?: { question?: string; options?: { label?: string; description?: string }[] }[] }
-      | undefined
+    const input = state.input as { questions?: QuestionInfo[] } | undefined
     const questions = input?.questions ?? []
     const done = state.status === "completed"
     const metadata = done ? (state.metadata as { answers?: unknown; dismissed?: unknown } | undefined) : undefined
@@ -406,11 +470,24 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const dismissed = metadata?.dismissed === true
     const chunks: string[] = []
     questions.forEach((q, i) => {
-      if (q.question) chunks.push(q.question)
+      // QuestionDock renders localized text via questionKey/labelKey/
+      // descriptionKey (see question-dock-utils.ts's tr()), with the raw
+      // wire strings kept only as untranslated fallbacks/reply values —
+      // index what's actually displayed, not the canonical fallback.
+      const questionLabel = tr(language.t, q.questionKey, q.question ?? "")
+      if (questionLabel) chunks.push(questionLabel)
       if (!done) {
+        // QuestionDock only ever mounts one page (store.tab) of a pending
+        // multi-question at a time and there's no external signal exposing
+        // which page that is — indexing every question's full option list
+        // produces matches for pages that aren't in the DOM. Limit to the
+        // first question, which is always the page mounted on first render.
+        if (i > 0) return
         for (const option of q.options ?? []) {
-          if (option.label) chunks.push(option.label)
-          if (option.description) chunks.push(option.description)
+          const label = tr(language.t, option.labelKey, option.label ?? "")
+          if (label) chunks.push(label)
+          const description = option.description ? tr(language.t, option.descriptionKey, option.description) : ""
+          if (description) chunks.push(description)
         }
         return
       }
@@ -422,25 +499,77 @@ export const MessageList: Component<MessageListProps> = (props) => {
     return chunks
   }
 
-  function editWriteText(state: Extract<ToolState, { status: "completed" }>): string[] {
-    const input = state.input as { filePath?: string } | undefined
-    const metadata = state.metadata as { filepath?: string; filediff?: { file?: string } } | undefined
-    const path = input?.filePath ?? metadata?.filediff?.file ?? metadata?.filepath
-    if (!path) return []
-    return [path, path]
+  type Diagnostic = { severity: number; range: { start: { line: number; character: number } }; message: string }
+
+  // Mirrors getDiagnostics()/DiagnosticsDisplay in message-part.tsx: up to 3
+  // severity-1 diagnostics for the file, each shown as an "Error" label, a
+  // "[line:char]" location, and the diagnostic message.
+  function editWriteDiagnostics(metadata: unknown, filePath: string | undefined): string[] {
+    const byFile = (metadata as { diagnostics?: Record<string, Diagnostic[]> } | undefined)?.diagnostics
+    if (!byFile || !filePath) return []
+    const diagnostics = (byFile[filePath] ?? []).filter((d) => d.severity === 1).slice(0, 3)
+    const chunks: string[] = []
+    for (const d of diagnostics) {
+      chunks.push(i18n.t("ui.messagePart.diagnostic.error"))
+      chunks.push(`[${d.range.start.line + 1}:${d.range.start.character + 1}]`)
+      if (d.message) chunks.push(d.message)
+    }
+    return chunks
   }
 
-  function applyPatchText(state: Extract<ToolState, { status: "completed" }>): string[] {
+  // edit/write show a file's path in two places with different layouts:
+  // the BasicTool trigger's ToolMetaLine (filename, then — only when the raw
+  // input path has a directory — the directory, bidi-isolated) and that
+  // file's own accordion header (directory-then-filename, same bidi
+  // wrapper). edit's accordion can source a different path than the
+  // trigger (metadata.filediff.file falls back to input.filePath); write
+  // uses input.filePath for both. Mirror both occurrences exactly rather
+  // than indexing the raw path string, which never appears in the DOM as a
+  // single contiguous run.
+  function editWriteText(tool: string, state: Extract<ToolState, { status: "completed" }>): string[] {
+    const input = state.input as { filePath?: string } | undefined
+    const metadata = state.metadata as
+      | { filepath?: string; filediff?: { file?: string }; diagnostics?: Record<string, Diagnostic[]> }
+      | undefined
+    const triggerPath = input?.filePath
+    const accordionPath = tool === "edit" ? (metadata?.filediff?.file ?? triggerPath) : triggerPath
+    const chunks: string[] = []
+    if (triggerPath) {
+      chunks.push(getFilename(triggerPath))
+      if (triggerPath.includes("/")) chunks.push(`\u2066${getDirectory(triggerPath)}\u2069`)
+    }
+    if (accordionPath) {
+      if (accordionPath.includes("/")) chunks.push(`\u2066${getDirectory(accordionPath)}\u2069`)
+      chunks.push(getFilename(accordionPath))
+    }
+    chunks.push(...editWriteDiagnostics(metadata, triggerPath))
+    return chunks
+  }
+
+  function applyPatchText(state: Extract<ToolState, { status: "completed" }>): ToolChunk[] {
     const files = ((state.metadata as { files?: { filePath?: string; relativePath?: string }[] } | undefined)?.files ??
       []) as { filePath?: string; relativePath?: string }[]
     // Only when there's exactly one file does the trigger also show a
-    // ToolMetaLine for it, on top of that file's own accordion header.
-    const perFile = files.length === 1 ? 2 : 1
-    const chunks: string[] = []
+    // ToolMetaLine for it (filename, then bidi-isolated directory), on top
+    // of that file's own accordion header (bidi-isolated directory, then
+    // filename) — for a multi-file patch each file's name only appears
+    // once, in its own accordion header. Multi-file chunks are tagged with
+    // the file's `filePath` (matching the accordion's item key) so a match
+    // can force just that one nested item open instead of every file.
+    const single = files.length === 1
+    const chunks: ToolChunk[] = []
     for (const file of files) {
       const path = file.relativePath ?? file.filePath
-      if (!path) continue
-      for (let i = 0; i < perFile; i += 1) chunks.push(path)
+      if (!path || !file.filePath) continue
+      const dir = path.includes("/") ? `\u2066${getDirectory(path)}\u2069` : undefined
+      if (single) {
+        chunks.push(getFilename(path))
+        if (dir) chunks.push(dir)
+        continue
+      }
+      const tag = (text: string): ToolChunk => ({ text, file: file.filePath! })
+      if (dir) chunks.push(tag(dir))
+      chunks.push(tag(getFilename(path)))
     }
     return chunks
   }
@@ -576,7 +705,8 @@ export const MessageList: Component<MessageListProps> = (props) => {
           hit = p.exec(text)
           continue
         }
-        result.push({ key: row.key, occurrence, partId: partIdAt(ranges, hit.index) })
+        const range = rangeAt(ranges, hit.index)
+        result.push({ key: row.key, occurrence, partId: range?.partId, partFile: range?.file })
         occurrence += 1
         hit = p.exec(text)
       }
@@ -1003,6 +1133,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                         onForkMessage={props.onForkMessage}
                         activeSearch={activeKey() === row.key}
                         activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
+                        activeSearchPartFile={activeKey() === row.key ? activeMatch()?.partFile : undefined}
                       />
                     )}
                   </Virtualizer>
@@ -1014,6 +1145,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                       onForkMessage={props.onForkMessage}
                       activeSearch={activeKey() === key}
                       activeSearchPartID={activeKey() === key ? activeMatch()?.partId : undefined}
+                      activeSearchPartFile={activeKey() === key ? activeMatch()?.partFile : undefined}
                     />
                   )}
                 </For>
@@ -1028,6 +1160,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                   row={row}
                   activeSearch={activeKey() === row.key}
                   activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
+                  activeSearchPartFile={activeKey() === row.key ? activeMatch()?.partFile : undefined}
                 />
               )}
             </For>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -29,6 +29,7 @@ import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
 import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { useProvider } from "../../context/provider"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { WelcomeEmptyState } from "./WelcomeEmptyState"
 import { TranscriptRowView } from "./TranscriptRow"
 import type { ErrorDisplayProps } from "./ErrorDisplay"
@@ -58,7 +59,7 @@ import {
 } from "../../context/session-queue"
 import { childID } from "../../context/session-utils"
 import { taskResult } from "./task-tool-state"
-import { tr } from "./question-dock-utils"
+import { activeQuestionTab, tr } from "./question-dock-utils"
 import { useData } from "@kilocode/kilo-ui/context/data"
 import { getDirectory as getRawDirectory, getFilename } from "@opencode-ai/core/util/path"
 import {
@@ -105,6 +106,11 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const provider = useProvider()
   const i18n = useI18n()
   const data = useData()
+  // Only present inside Agent Manager (see worktree-mode.tsx). Agent Manager
+  // never calls registerExpandedTaskTool(), so its "task" cards always fall
+  // back to kilo-ui's default hideDetails renderer, which never shows a
+  // task's result text — indexing it there would produce a phantom match.
+  const inAgentManager = !!useWorktreeMode()
 
   // Mirrors message-part.tsx's own (unexported) relativizeProjectPath/
   // getDirectory exactly, so the directory text indexed here matches what
@@ -378,7 +384,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
     // completion — so both need handling before the completed-only gate
     // below, or an in-progress task/question would index nothing at all.
     if (part.tool === "task") return taskText(part, state)
-    if (part.tool === "question") return questionText(state)
+    if (part.tool === "question") return questionText(part, state)
     if (state.status !== "completed") return "title" in state && state.title ? [state.title] : []
     if (CONTEXT_GROUP_TOOLS.has(part.tool)) return state.title ? [state.title] : []
     if (part.tool === "bash") return bashText(state)
@@ -443,11 +449,19 @@ export const MessageList: Component<MessageListProps> = (props) => {
     // no live child session to display instead (result() there resolves to
     // undefined once a child session exists) — mirror that exactly so a
     // completed task with no child session stays searchable, without
-    // indexing text that's actually replaced by the child tool list.
-    if (state.status === "completed") {
-      const child = childID({ type: "tool", tool: part.tool, state: { metadata: state.metadata } })
+    // indexing text that's actually replaced by the child tool list. Agent
+    // Manager never registers TaskToolExpanded at all (it always uses
+    // kilo-ui's default hideDetails task card, which never shows result
+    // text there), so skip this entirely in that surface.
+    if (state.status === "completed" && !inAgentManager) {
+      const child = childID({
+        type: "tool",
+        tool: part.tool,
+        metadata: part.metadata as { sessionId?: string } | undefined,
+        state: { metadata: state.metadata },
+      })
       const result = taskResult(state.output, child)
-      if (result) chunks.push(result)
+      if (result) chunks.push(stripMarkdownLinkUrls(result))
     }
     return chunks
   }
@@ -462,28 +476,40 @@ export const MessageList: Component<MessageListProps> = (props) => {
   type QuestionOption = { label?: string; description?: string; labelKey?: string; descriptionKey?: string }
   type QuestionInfo = { question?: string; questionKey?: string; options?: QuestionOption[] }
 
-  function questionText(state: ToolState): string[] {
+  // Correlates a "question" tool part to its live QuestionRequest the same
+  // way AssistantMessage.tsx's matchToolRequest does (by callID/messageID),
+  // so the pending branch below can read which page QuestionDock actually
+  // has mounted (question-dock-utils.ts's activeQuestionTab) instead of
+  // assuming it's always the first one.
+  function liveQuestionRequestId(part: Part & { type: "tool" }): string | undefined {
+    return session.questions().find((r) => r.tool?.callID === part.callID && r.tool?.messageID === part.messageID)?.id
+  }
+
+  function questionText(part: Part & { type: "tool" }, state: ToolState): string[] {
     const input = state.input as { questions?: QuestionInfo[] } | undefined
     const questions = input?.questions ?? []
     const done = state.status === "completed"
     const metadata = done ? (state.metadata as { answers?: unknown; dismissed?: unknown } | undefined) : undefined
     const answers = Array.isArray(metadata?.answers) ? (metadata!.answers as unknown[][]) : undefined
     const dismissed = metadata?.dismissed === true
+    const requestId = done ? undefined : liveQuestionRequestId(part)
+    const mountedTab = requestId ? activeQuestionTab(requestId) : 0
     const chunks: string[] = []
     questions.forEach((q, i) => {
-      // QuestionDock renders localized text via questionKey/labelKey/
-      // descriptionKey (see question-dock-utils.ts's tr()), with the raw
-      // wire strings kept only as untranslated fallbacks/reply values —
-      // index what's actually displayed, not the canonical fallback.
-      const questionLabel = tr(language.t, q.questionKey, q.question ?? "")
+      // The pending QuestionDock renders localized text via questionKey/
+      // labelKey/descriptionKey (see question-dock-utils.ts's tr()), with
+      // the raw wire strings kept only as untranslated fallbacks/reply
+      // values. Once completed, kilo-ui's question renderer instead shows
+      // the raw `q.question` directly (no questionKey lookup) — index
+      // whichever one that surface actually displays.
+      const questionLabel = done ? (q.question ?? "") : tr(language.t, q.questionKey, q.question ?? "")
       if (questionLabel) chunks.push(questionLabel)
       if (!done) {
         // QuestionDock only ever mounts one page (store.tab) of a pending
-        // multi-question at a time and there's no external signal exposing
-        // which page that is — indexing every question's full option list
-        // produces matches for pages that aren't in the DOM. Limit to the
-        // first question, which is always the page mounted on first render.
-        if (i > 0) return
+        // multi-question at a time — limit to the page it has published as
+        // mounted (question-dock-utils.ts), which stays correct as the user
+        // navigates instead of freezing on page 0.
+        if (i !== mountedTab) return
         for (const option of q.options ?? []) {
           const label = tr(language.t, option.labelKey, option.label ?? "")
           if (label) chunks.push(label)
@@ -551,12 +577,14 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const files = ((state.metadata as { files?: { filePath?: string; relativePath?: string }[] } | undefined)?.files ??
       []) as { filePath?: string; relativePath?: string }[]
     // Only when there's exactly one file does the trigger also show a
-    // ToolMetaLine for it (filename, then bidi-isolated directory), on top
-    // of that file's own accordion header (bidi-isolated directory, then
-    // filename) — for a multi-file patch each file's name only appears
-    // once, in its own accordion header. Multi-file chunks are tagged with
-    // the file's `filePath` (matching the accordion's item key) so a match
-    // can force just that one nested item open instead of every file.
+    // ToolMetaLine for it (filename, then bidi-isolated directory), ON TOP
+    // OF that file's own ToolFileAccordion header (bidi-isolated directory,
+    // then filename) — both are rendered simultaneously for a single-file
+    // patch, same as edit/write's two-location layout in editWriteText.
+    // For a multi-file patch each file's name only appears once, in its own
+    // accordion header. Multi-file chunks are tagged with the file's
+    // `filePath` (matching the accordion's item key) so a match can force
+    // just that one nested item open instead of every file.
     const single = files.length === 1
     const chunks: ToolChunk[] = []
     for (const file of files) {
@@ -566,6 +594,8 @@ export const MessageList: Component<MessageListProps> = (props) => {
       if (single) {
         chunks.push(getFilename(path))
         if (dir) chunks.push(dir)
+        if (dir) chunks.push(dir)
+        chunks.push(getFilename(path))
         continue
       }
       const tag = (text: string): ToolChunk => ({ text, file: file.filePath! })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -27,6 +27,7 @@ import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
 import { useLanguage } from "../../context/language"
+import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { useProvider } from "../../context/provider"
 import { WelcomeEmptyState } from "./WelcomeEmptyState"
 import { TranscriptRowView } from "./TranscriptRow"
@@ -96,6 +97,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const server = useServer()
   const language = useLanguage()
   const provider = useProvider()
+  const i18n = useI18n()
 
   const autoScroll = createAutoScroll({
     working: () => session.status() !== "idle",
@@ -163,9 +165,21 @@ export const MessageList: Component<MessageListProps> = (props) => {
 
   const search = useTranscriptSearch()
 
-  function rowText(row: TranscriptRow): string {
-    if (row.type === "error") return errorText(row.error)
-    if (row.type === "diff") return ""
+  interface RowTextRange {
+    start: number
+    end: number
+    partId: string
+  }
+
+  // Returns the row's full searchable text plus, for every chunk that came
+  // from a specific part (tool call/reasoning/text/file), the character
+  // range it occupies within that text. Lets a match's character index be
+  // attributed back to the part it came from, so navigation can force that
+  // exact collapsed tool/reasoning block open instead of just scrolling to
+  // the row.
+  function rowText(row: TranscriptRow): { text: string; ranges: RowTextRange[] } {
+    if (row.type === "error") return { text: errorText(row.error), ranges: [] }
+    if (row.type === "diff") return { text: "", ranges: [] }
     // User message text is rendered by UserMessageDisplay/HighlightedText
     // (message-part.tsx), which never parses markdown at all — [label](url)
     // always shows literally, brackets and all, unlike assistant text/
@@ -174,13 +188,22 @@ export const MessageList: Component<MessageListProps> = (props) => {
     // visible occurrences (the literal label and the literal URL) into one.
     const markdown = row.type !== "user"
     const chunks: string[] = []
+    const ranges: RowTextRange[] = []
+    let pos = 0
+    const push = (text: string, partId: string) => {
+      if (!text) return
+      if (chunks.length > 0) pos += 1 // account for the "\n" chunk joiner below
+      chunks.push(text)
+      ranges.push({ start: pos, end: pos + text.length, partId })
+      pos += text.length
+    }
     for (const part of row.parts) {
       switch (part.type) {
         case "text":
-          if (!part.synthetic) chunks.push(markdown ? stripMarkdownLinkUrls(part.text) : part.text)
+          if (!part.synthetic) push(markdown ? stripMarkdownLinkUrls(part.text) : part.text, part.id)
           break
         case "reasoning":
-          chunks.push(stripMarkdownLinkUrls(part.text))
+          push(stripMarkdownLinkUrls(part.text), part.id)
           break
         case "tool":
           // Bash output is rendered via escapeHtml + syntax highlighting
@@ -190,14 +213,18 @@ export const MessageList: Component<MessageListProps> = (props) => {
           // Stripping it here would search text that no longer matches the
           // literal characters on screen, the same class of mismatch this
           // rewrite fixes elsewhere.
-          chunks.push(...toolText(part))
+          for (const chunk of toolText(part)) push(chunk, part.id)
           break
         case "file":
-          if (part.filename) chunks.push(part.filename)
+          if (part.filename) push(part.filename, part.id)
           break
       }
     }
-    return chunks.join("\n")
+    return { text: chunks.join("\n"), ranges }
+  }
+
+  function partIdAt(ranges: RowTextRange[], index: number): string | undefined {
+    return ranges.find((r) => index >= r.start && index < r.end)?.partId
   }
 
   // Markdown link/image URLs are part of the raw source text but are never
@@ -273,18 +300,148 @@ export const MessageList: Component<MessageListProps> = (props) => {
   // the same class of bug this rewrite fixes for every other tool.
   const CONTEXT_GROUP_TOOLS = new Set(["read", "glob", "grep", "list"])
 
+  // edit/write/apply_patch render their actual diff content through
+  // @pierre/diffs inside a shadow-DOM <diffs-container> (packages/ui/src/
+  // pierre/file-runtime.ts's getViewerRoot()), which a light-DOM text scan
+  // can never reach — and diff-mode rendering is virtualized by default, so
+  // even piercing the shadow root wouldn't guarantee off-screen lines are
+  // mounted. state.input/state.metadata also duplicate the full before/
+  // after file content and the path itself several times over (a unified
+  // patch string with the path repeated in its `---`/`+++` headers, a
+  // separate raw `metadata.diff` copy, write's extra top-level
+  // `metadata.filepath`), none of which corresponds 1:1 with what's on
+  // screen. Rather than collect+dedupe those redundant fields, mirror the
+  // renderer's fixed, known layout directly: edit/write always show one
+  // file's path in exactly two places (the BasicTool trigger's
+  // ToolMetaLine and that file's own accordion header); apply_patch's
+  // trigger only adds a third, single-file ToolMetaLine when there's
+  // exactly one file (message-part.tsx's `single()`) — for a multi-file
+  // patch each file's name only appears once, in its own accordion header.
+  const DIFF_TOOLS = new Set(["edit", "write"])
+  // todowrite/todoread's renderer resolves the shown list from a fallback
+  // chain (metadata.view.todos, else metadata.todos, else input.todos) —
+  // packages/opencode/src/tool/todo.ts sets metadata.todos to the exact
+  // same array as input.todos, and metadata.view.todos to the exact same
+  // content again whenever the view is in "full" mode (the common case,
+  // see packages/opencode/src/kilocode/todo-view.ts). Recursively collecting
+  // both input and metadata would count every todo's text 2-3x even though
+  // shown() only ever renders it once.
+  const TODO_TOOLS = new Set(["todowrite", "todoread"])
+
   function toolText(part: Part & { type: "tool" }): string[] {
     const state = part.state
-    if (state.status === "running") return state.title ? [state.title] : []
     if (state.status === "error") return state.error ? [state.error] : []
-    if (state.status !== "completed") return []
+    // task's trigger (title "{type} Agent" + input.description subtitle) and
+    // question's dock (question text + full option list) render the same
+    // way whether the call is still pending/running or already completed —
+    // unlike every other tool, where only a bare title shows until
+    // completion — so both need handling before the completed-only gate
+    // below, or an in-progress task/question would index nothing at all.
+    if (part.tool === "task") return taskText(part, state)
+    if (part.tool === "question") return questionText(state)
+    if (state.status !== "completed") return "title" in state && state.title ? [state.title] : []
     if (CONTEXT_GROUP_TOOLS.has(part.tool)) return state.title ? [state.title] : []
     if (part.tool === "bash") return bashText(state)
+    if (part.tool === "apply_patch") return applyPatchText(state)
+    if (DIFF_TOOLS.has(part.tool)) return editWriteText(state)
+    if (TODO_TOOLS.has(part.tool)) return todoText(state)
     const chunks: string[] = []
     if (state.title) chunks.push(state.title)
     collectStrings(state.input, chunks)
     collectStrings(state.metadata, chunks)
     if (typeof state.output === "string" && state.output) chunks.push(mcpOutputText(state.output))
+    return chunks
+  }
+
+  function todoText(state: Extract<ToolState, { status: "completed" }>): string[] {
+    const metadata = state.metadata as { todos?: unknown; view?: unknown } | undefined
+    const input = state.input as { todos?: unknown } | undefined
+    const view = metadata?.view
+    const viewTodos = isTodoView(view) ? view.todos : undefined
+    const todos =
+      viewTodos ??
+      (Array.isArray(metadata?.todos) ? metadata.todos : undefined) ??
+      (Array.isArray(input?.todos) ? input.todos : undefined) ??
+      []
+    return (todos as { content?: unknown }[])
+      .map((todo) => todo?.content)
+      .filter((content): content is string => typeof content === "string" && content.length > 0)
+  }
+
+  function isTodoView(value: unknown): value is { todos?: { content?: unknown }[] } {
+    return !!value && typeof value === "object" && Array.isArray((value as { todos?: unknown }).todos)
+  }
+
+  // Matches TaskToolExpanded.tsx (the renderer this webview actually
+  // registers for "task", overriding kilo-ui's default) exactly: title is
+  // always `i18n.t("ui.tool.agent", { type })` regardless of status — the
+  // "capitalize" CSS class only changes how it *looks*, the DOM text node
+  // itself is the raw, lowercase subagent_type. The "(N)" child-tool-count
+  // suffix shown there is a live value from session.getSessionToolCount(),
+  // not stored on the part at all, so it can't be indexed from a snapshot —
+  // searching for that count isn't meaningful content anyway.
+  function taskText(part: Part & { type: "tool" }, state: ToolState): string[] {
+    const input = state.input as { subagent_type?: string; description?: string } | undefined
+    const type = input?.subagent_type || part.tool
+    const chunks = [i18n.t("ui.tool.agent", { type })]
+    if (input?.description) chunks.push(input.description)
+    return chunks
+  }
+
+  // QuestionDock renders very different content depending on whether the
+  // question is still awaiting an answer or already resolved: while
+  // pending/running it shows the full clickable option list (label +
+  // description per option); once completed it only shows the question
+  // text plus whichever answer was actually given (dismissed questions show
+  // neither the options nor a real answer, just a static "dismissed"
+  // label that isn't meaningful content to index).
+  function questionText(state: ToolState): string[] {
+    const input = state.input as
+      | { questions?: { question?: string; options?: { label?: string; description?: string }[] }[] }
+      | undefined
+    const questions = input?.questions ?? []
+    const done = state.status === "completed"
+    const metadata = done ? (state.metadata as { answers?: unknown; dismissed?: unknown } | undefined) : undefined
+    const answers = Array.isArray(metadata?.answers) ? (metadata!.answers as unknown[][]) : undefined
+    const dismissed = metadata?.dismissed === true
+    const chunks: string[] = []
+    questions.forEach((q, i) => {
+      if (q.question) chunks.push(q.question)
+      if (!done) {
+        for (const option of q.options ?? []) {
+          if (option.label) chunks.push(option.label)
+          if (option.description) chunks.push(option.description)
+        }
+        return
+      }
+      if (dismissed) return
+      for (const value of answers?.[i] ?? []) {
+        if (typeof value === "string" && value) chunks.push(value)
+      }
+    })
+    return chunks
+  }
+
+  function editWriteText(state: Extract<ToolState, { status: "completed" }>): string[] {
+    const input = state.input as { filePath?: string } | undefined
+    const metadata = state.metadata as { filepath?: string; filediff?: { file?: string } } | undefined
+    const path = input?.filePath ?? metadata?.filediff?.file ?? metadata?.filepath
+    if (!path) return []
+    return [path, path]
+  }
+
+  function applyPatchText(state: Extract<ToolState, { status: "completed" }>): string[] {
+    const files = ((state.metadata as { files?: { filePath?: string; relativePath?: string }[] } | undefined)?.files ??
+      []) as { filePath?: string; relativePath?: string }[]
+    // Only when there's exactly one file does the trigger also show a
+    // ToolMetaLine for it, on top of that file's own accordion header.
+    const perFile = files.length === 1 ? 2 : 1
+    const chunks: string[] = []
+    for (const file of files) {
+      const path = file.relativePath ?? file.filePath
+      if (!path) continue
+      for (let i = 0; i < perFile; i += 1) chunks.push(path)
+    }
     return chunks
   }
 
@@ -409,7 +566,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const list = rows()
     const result: SearchMatch[] = []
     for (const row of list) {
-      const text = rowText(row)
+      const { text, ranges } = rowText(row)
       p.lastIndex = 0
       let occurrence = 0
       let hit = p.exec(text)
@@ -419,7 +576,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
           hit = p.exec(text)
           continue
         }
-        result.push({ key: row.key, messageId: row.message.id, occurrence })
+        result.push({ key: row.key, occurrence, partId: partIdAt(ranges, hit.index) })
         occurrence += 1
         hit = p.exec(text)
       }
@@ -482,6 +639,26 @@ export const MessageList: Component<MessageListProps> = (props) => {
 
   const activeMatch = createMemo(() => matches()[search.index()])
 
+  // Maps a row's key to the part ids the data model could attribute matches
+  // to there. A row with NO entry here has zero data-level matches, so the
+  // highlighter must scan nothing in it at all — otherwise unindexed text (a
+  // static button label, a sibling part that didn't match) could get
+  // highlighted despite never being counted. An entry always exists for
+  // every row that has at least one match, even with an empty part-id set
+  // (a match that couldn't be attributed to a specific part, e.g. error/diff
+  // rows) — the highlighter treats "entry exists" as "this row has a real
+  // match" and falls back to scanning the whole row whenever the part-id
+  // lookup doesn't resolve to a mounted element.
+  const matchedPartsByRow = createMemo(() => {
+    const map = new Map<string, Set<string>>()
+    for (const match of matches()) {
+      const set = map.get(match.key) ?? new Set<string>()
+      if (match.partId) set.add(match.partId)
+      map.set(match.key, set)
+    }
+    return map
+  })
+
   // Highlights every rendered occurrence of the query (not just matching
   // rows) via the CSS Custom Highlight API, and returns the precise Range of
   // the current occurrence so navigation can judge whether it needs to
@@ -496,7 +673,12 @@ export const MessageList: Component<MessageListProps> = (props) => {
       return
     }
     const active = activeMatch()
-    const range = applyTranscriptHighlights(el, pattern(), active && { key: active.key, occurrence: active.occurrence })
+    const range = applyTranscriptHighlights(
+      el,
+      pattern(),
+      active && { key: active.key, occurrence: active.occurrence },
+      matchedPartsByRow(),
+    )
     if (!pendingCenter) return
     pendingCenter = false
     if (!range) return
@@ -820,6 +1002,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                         index={index()}
                         onForkMessage={props.onForkMessage}
                         activeSearch={activeKey() === row.key}
+                        activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
                       />
                     )}
                   </Virtualizer>
@@ -830,6 +1013,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                       row={lookup().get(key)!}
                       onForkMessage={props.onForkMessage}
                       activeSearch={activeKey() === key}
+                      activeSearchPartID={activeKey() === key ? activeMatch()?.partId : undefined}
                     />
                   )}
                 </For>
@@ -839,7 +1023,13 @@ export const MessageList: Component<MessageListProps> = (props) => {
               <RevertBanner />
             </Show>
             <For each={partition().queued}>
-              {(row) => <TranscriptRowView row={row} activeSearch={activeKey() === row.key} />}
+              {(row) => (
+                <TranscriptRowView
+                  row={row}
+                  activeSearch={activeKey() === row.key}
+                  activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
+                />
+              )}
             </For>
             <WorkingIndicator />
             <TurnOutcome />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -4,7 +4,7 @@
  * Uses kilo-ui's DockPrompt component for proper surface styling.
  */
 
-import { For, Show, createMemo, createEffect } from "solid-js"
+import { For, Show, createMemo, createEffect, onCleanup } from "solid-js"
 import type { Component } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@kilocode/kilo-ui/button"
@@ -13,9 +13,11 @@ import { useSession } from "../../context/session"
 import { useLanguage } from "../../context/language"
 import type { QuestionRequest } from "../../types/messages"
 import {
+  clearActiveQuestionTab,
   pickOutcome,
   resolveOptimisticQuestionAgent,
   resolveSelectedQuestionMode,
+  setActiveQuestionTab,
   toggleAnswer,
   tr,
 } from "./question-dock-utils"
@@ -51,6 +53,12 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
       }
     }
   })
+
+  // Chat search indexes only the mounted page's options, and there's no
+  // other signal exposing which page that is — publish it here so search
+  // stays in sync as the user navigates instead of always assuming page 0.
+  createEffect(() => setActiveQuestionTab(props.request.id, store.tab))
+  onCleanup(() => clearActiveQuestionTab(props.request.id))
 
   const question = createMemo(() => questions()[store.tab])
   const confirm = createMemo(() => !single() && store.tab === questions().length)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -111,28 +111,30 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   window.addEventListener("message", handler)
   onCleanup(() => window.removeEventListener("message", handler))
 
-  // "Kilo Code: Search Current Chat" (Command Palette) toggles the search
+  // "Kilo Code: Toggle Chat Search" (Command Palette) toggles the search
   // bar from here rather than TranscriptSearch.tsx itself: that component
   // only mounts once search.active() is already true (it's behind a
   // <Show>), so it can never be what turns search on in the first place —
   // and it also wouldn't exist anymore to react to a request to close it.
   // TaskHeader is mounted the whole time there's an active chat, so it's
   // the right place to react to the external toggle request.
-  const toggleSearch = () => search.setActive(!search.active())
+  const toggleSearch = () => (search.active() ? search.closeSearch() : search.setActive(true))
   window.addEventListener("focusTranscriptSearch", toggleSearch)
   onCleanup(() => window.removeEventListener("focusTranscriptSearch", toggleSearch))
 
-  // Whenever search closes — the header toggle button, the command palette
-  // toggle above, the search bar's own "X", or Escape — send focus back to
-  // the chat input rather than leaving it stranded on whatever control was
-  // just clicked/removed. `defer: true` skips the initial run so mounting
-  // with search already inactive doesn't steal focus from wherever it
-  // already was.
+  // Whenever search closes via an explicit user action — the header toggle
+  // button, the command palette toggle above, the search bar's own "X", or
+  // Escape — send focus back to the chat input rather than leaving it
+  // stranded on whatever control was just clicked/removed. Watches
+  // `closeSignal` rather than `active()` transitions so that MessageList
+  // silently resetting the widget on a session/tab change (which also
+  // flips `active()` false) can't trigger this same aggressive restore and
+  // steal focus back from the tab strip's own focus handling. `defer: true`
+  // skips the initial run so mounting doesn't immediately steal focus.
   createEffect(
     on(
-      () => search.active(),
-      (active) => {
-        if (active) return
+      () => search.closeSignal(),
+      () => {
         window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } }))
       },
       { defer: true },
@@ -266,7 +268,7 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
                 variant="ghost"
                 class="task-header-search-toggle"
                 data-active={search.active() ? "" : undefined}
-                onClick={() => search.setActive(!search.active())}
+                onClick={toggleSearch}
                 aria-label={language.t("chat.search.toggle")}
                 aria-pressed={search.active()}
               />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskHeader.tsx
@@ -8,7 +8,7 @@
  * session activity) and a context window progress bar.
  */
 
-import { Component, For, Show, createMemo, createSignal, createEffect, onMount, onCleanup } from "solid-js"
+import { Component, For, Show, createMemo, createSignal, createEffect, on, onMount, onCleanup } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Icon } from "@kilocode/kilo-ui/icon"
@@ -110,6 +110,34 @@ export const TaskHeader: Component<TaskHeaderProps> = (props) => {
   }
   window.addEventListener("message", handler)
   onCleanup(() => window.removeEventListener("message", handler))
+
+  // "Kilo Code: Search Current Chat" (Command Palette) toggles the search
+  // bar from here rather than TranscriptSearch.tsx itself: that component
+  // only mounts once search.active() is already true (it's behind a
+  // <Show>), so it can never be what turns search on in the first place —
+  // and it also wouldn't exist anymore to react to a request to close it.
+  // TaskHeader is mounted the whole time there's an active chat, so it's
+  // the right place to react to the external toggle request.
+  const toggleSearch = () => search.setActive(!search.active())
+  window.addEventListener("focusTranscriptSearch", toggleSearch)
+  onCleanup(() => window.removeEventListener("focusTranscriptSearch", toggleSearch))
+
+  // Whenever search closes — the header toggle button, the command palette
+  // toggle above, the search bar's own "X", or Escape — send focus back to
+  // the chat input rather than leaving it stranded on whatever control was
+  // just clicked/removed. `defer: true` skips the initial run so mounting
+  // with search already inactive doesn't steal focus from wherever it
+  // already was.
+  createEffect(
+    on(
+      () => search.active(),
+      (active) => {
+        if (active) return
+        window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } }))
+      },
+      { defer: true },
+    ),
+  )
 
   const toggle = () => {
     const next = !expanded()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -36,11 +36,17 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
     })
 
   const running = createMemo(() => taskRunning(props.status))
+  // BasicTool's forceOpen effect only fires onOpenChange on a false->true
+  // transition — a virtualized remount that starts with forceOpen already
+  // true never transitions, so this local signal must also seed itself from
+  // forceOpen directly, or the child list/result below stays hidden even
+  // though the accordion itself renders open.
   const [open, setOpen] = createSignal(
     initialOpen({
       tool: props.tool,
       partID: props.partID,
       defaultOpen: running(),
+      forceOpen: props.forceOpen,
     }),
   )
 
@@ -148,6 +154,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
         partID={props.partID}
         trigger={trigger()}
         defaultOpen={running()}
+        forceOpen={props.forceOpen}
         defer
         onOpenChange={setOpen}
       >

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -18,6 +18,9 @@ interface TranscriptRowViewProps {
   index?: number
   onForkMessage?: (sessionId: string, messageId: string) => void
   activeSearch?: boolean
+  /** id of the part (tool call/reasoning block) containing the current chat
+   * search match within this row, if any. */
+  activeSearchPartID?: string
 }
 
 export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
@@ -78,6 +81,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               message={row().message as unknown as SDKAssistantMessage}
               parts={row().parts as unknown as SDKPart[]}
               showAssistantCopyPartID={row().copy}
+              forceOpenPartID={props.activeSearchPartID}
               feedback={{
                 enabled: feedback.telemetryEnabled(),
                 rating: feedback.getRating(row().message.id),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -21,6 +21,8 @@ interface TranscriptRowViewProps {
   /** id of the part (tool call/reasoning block) containing the current chat
    * search match within this row, if any. */
   activeSearchPartID?: string
+  /** For a multi-file apply_patch match, the specific file within that part. */
+  activeSearchPartFile?: string
 }
 
 export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
@@ -82,6 +84,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               parts={row().parts as unknown as SDKPart[]}
               showAssistantCopyPartID={row().copy}
               forceOpenPartID={props.activeSearchPartID}
+              forceOpenFile={props.activeSearchPartFile}
               feedback={{
                 enabled: feedback.telemetryEnabled(),
                 rating: feedback.getRating(row().message.id),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptSearch.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptSearch.tsx
@@ -24,7 +24,7 @@ export const TranscriptSearch: Component = () => {
   }
 
   const close = () => {
-    search.setActive(false)
+    search.closeSearch()
     search.setQuery("")
     search.setCount(0)
     search.setIndex(0)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/question-dock-utils.ts
@@ -1,4 +1,31 @@
+import { createSignal } from "solid-js"
 import type { QuestionOption } from "../../types/messages"
+
+// Which page (question index) of a pending multi-question is currently
+// mounted in the DOM, keyed by request id. QuestionDock only ever mounts
+// `store.tab`, and nothing else observes which page that is — chat search
+// needs it to index exactly the visible page instead of guessing it's
+// always the first one (true only right after initial mount, not once the
+// user has navigated).
+const [activeQuestionTabs, setActiveQuestionTabs] = createSignal<Record<string, number>>({})
+
+export function setActiveQuestionTab(requestId: string, tab: number): void {
+  setActiveQuestionTabs((prev) => (prev[requestId] === tab ? prev : { ...prev, [requestId]: tab }))
+}
+
+export function clearActiveQuestionTab(requestId: string): void {
+  setActiveQuestionTabs((prev) => {
+    if (!(requestId in prev)) return prev
+    const next = { ...prev }
+    delete next[requestId]
+    return next
+  })
+}
+
+/** Returns the currently-mounted page for a request, defaulting to the first page. */
+export function activeQuestionTab(requestId: string): number {
+  return activeQuestionTabs()[requestId] ?? 0
+}
 
 /**
  * Translate a backend-provided i18n key, falling back to the canonical label when no key is

--- a/packages/kilo-vscode/webview-ui/src/components/chat/transcript-search-highlight.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/transcript-search-highlight.ts
@@ -90,11 +90,24 @@ export function scanScope(scope: HTMLElement, pattern: RegExp): Range[] {
  * actually found in the DOM, so a data/DOM count mismatch (e.g. content the
  * renderer collapses or reformats) still always highlights *something* in
  * the active row rather than silently highlighting nothing.
+ *
+ * `matchedParts` maps a row key to the part ids MessageList's data model
+ * could attribute a match to there. A row with **no entry** has zero
+ * data-level matches, so nothing in it is scanned at all — otherwise some
+ * unindexed text (a static button label, a different non-matching part in
+ * the same message) could get highlighted despite never being counted. A
+ * row *with* an entry (even one with an empty part-id set, e.g. an
+ * error/diff row with no per-part attribution) always has SOME genuine
+ * match, so scanning falls back to the whole row whenever the part-scoped
+ * DOM lookup doesn't resolve to anything mounted (a part id with no
+ * `[data-part-id]` marker at all — e.g. user messages — or not yet
+ * expanded) — that's a lookup failure, not a signal to scan nothing.
  */
 export function applyTranscriptHighlights(
   root: HTMLElement,
   pattern: RegExp | undefined,
   active: { key: string; occurrence: number } | undefined,
+  matchedParts?: Map<string, Set<string>>,
 ): Range | undefined {
   const api = highlightApi()
   if (!api) return undefined
@@ -107,7 +120,13 @@ export function applyTranscriptHighlights(
   const current: Range[] = []
   let currentRange: Range | undefined
   for (const scope of scopes) {
-    const ranges = scanScope(scope, pattern)
+    // Every search scope within a row contributes to ONE combined range
+    // list before the active-occurrence index is resolved — clamping it
+    // per search-scope instead would treat `active.occurrence` as local to
+    // whichever part happened to be scanned first, misattributing which
+    // occurrence is "current" for any row with more than one contributing
+    // part (e.g. a reasoning block followed by a tool call).
+    const ranges = resolveSearchScopes(scope, matchedParts).flatMap((searchScope) => scanScope(searchScope, pattern))
     if (ranges.length === 0) continue
     const isActiveRow = !!active && scope.dataset.rowKey === active.key
     const activeIdx = isActiveRow ? Math.min(active!.occurrence, ranges.length - 1) : -1
@@ -123,6 +142,28 @@ export function applyTranscriptHighlights(
   if (rest.length > 0) api.registry.set(MATCH_NAME, new api.ctor(...rest))
   if (current.length > 0) api.registry.set(ACTIVE_NAME, new api.ctor(...current))
   return currentRange
+}
+
+/**
+ * Decides which element(s) within a row to actually scan for text. A row
+ * with no entry in `matchedParts` has zero data-level matches, so it's
+ * skipped entirely. A row with an entry scans just its known parts' DOM
+ * subtrees when they're mounted, and falls back to the whole row whenever
+ * that lookup comes up empty — whether because a match couldn't be
+ * attributed to a specific part at all, or because the part it WAS
+ * attributed to has no `[data-part-id]` marker (or isn't mounted yet) — a
+ * row with a real match should never end up scanning nothing.
+ */
+function resolveSearchScopes(scope: HTMLElement, matchedParts: Map<string, Set<string>> | undefined): HTMLElement[] {
+  const rowKey = scope.dataset.rowKey
+  const partIds = rowKey ? matchedParts?.get(rowKey) : undefined
+  if (matchedParts && !partIds) return []
+  const partScopes = partIds
+    ? Array.from(partIds)
+        .map((id) => scope.querySelector<HTMLElement>(`[data-part-id="${CSS.escape(id)}"]`))
+        .filter((el): el is HTMLElement => !!el)
+    : []
+  return partScopes.length > 0 ? partScopes : [scope]
 }
 
 export function clearTranscriptHighlights(): void {

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-search.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-search.tsx
@@ -2,9 +2,12 @@ import { createContext, useContext, createSignal, type Accessor, type ParentComp
 
 export interface SearchMatch {
   key: string
-  messageId: string
   /** Index (0-based) of this occurrence among all matches within the same row. */
   occurrence: number
+  /** id of the part (tool call/reasoning block/text) this occurrence falls
+   * within, if it could be attributed to one — lets navigation force a
+   * collapsed part open instead of just scrolling to the row. */
+  partId?: string
 }
 
 interface TranscriptSearchContextValue {

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-search.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-search.tsx
@@ -8,6 +8,10 @@ export interface SearchMatch {
    * within, if it could be attributed to one — lets navigation force a
    * collapsed part open instead of just scrolling to the row. */
   partId?: string
+  /** For a multi-file apply_patch part, the specific file path this
+   * occurrence falls within — lets navigation open just that file's nested
+   * accordion instead of every file in the patch. */
+  partFile?: string
 }
 
 interface TranscriptSearchContextValue {
@@ -21,6 +25,16 @@ interface TranscriptSearchContextValue {
   setRegex: (value: boolean) => void
   active: Accessor<boolean>
   setActive: (value: boolean) => void
+  /** Bumped only when search closes via an explicit user action (the header
+   * toggle button, the Command Palette toggle, or the search bar's own "X"/
+   * Escape) — never when `setActive(false)` is called to silently reset the
+   * widget because the current session changed. TaskHeader watches this
+   * instead of `active()` transitions so a session/tab switch can't trigger
+   * the same aggressive focus-restore sequence as a real close. */
+  closeSignal: Accessor<number>
+  /** Closes search and bumps `closeSignal` — use this for explicit
+   * user-initiated closes; use `setActive(false)` for a silent reset. */
+  closeSearch: () => void
   index: Accessor<number>
   setIndex: (value: number) => void
   count: Accessor<number>
@@ -51,6 +65,11 @@ export const TranscriptSearchProvider: ParentComponent = (props) => {
   const [wholeWord, setWholeWord] = createSignal(false)
   const [regex, setRegex] = createSignal(false)
   const [active, setActive] = createSignal(false)
+  const [closeSignal, setCloseSignal] = createSignal(0)
+  const closeSearch = () => {
+    setActive(false)
+    setCloseSignal((n) => n + 1)
+  }
   const [index, setIndex] = createSignal(0)
   const [count, setCount] = createSignal(0)
   const [jump, setJump] = createSignal(0)
@@ -70,6 +89,8 @@ export const TranscriptSearchProvider: ParentComponent = (props) => {
         setRegex,
         active,
         setActive,
+        closeSignal,
+        closeSearch,
         index,
         setIndex,
         count,

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -49,6 +49,8 @@ export interface ToolPart extends BasePart {
   type: "tool"
   tool: string
   state: ToolState
+  metadata?: Record<string, unknown>
+  callID?: string
 }
 
 export interface ReasoningPart extends BasePart {


### PR DESCRIPTION
## Issue

Follow-up to #12083 

## Context

The in-chat search feature (`Search Current Chat` / `kilo-code.new.searchCurrentChat`) previously shipped via #12083 always opened (or refocused) the search bar and left it open until the user explicitly closed it, and jumping to a match inside a collapsed tool call or reasoning block never expanded that block, so the highlighted text stayed hidden. This PR follows up with three usability fixes: the Command Palette action now toggles the search bar open/closed, closing search returns focus to the chat input instead of leaving it stranded, and jumping to a match auto-expands the collapsed tool/reasoning block that contains it.

## Implementation

- Renamed the Command Palette command to `kilo-code.new.toggleChatSearch` ("Toggle Chat Search") and changed its handler to flip `search.active()` rather than only ever opening it (`TaskHeader.tsx`, `register-code-actions.ts`, `package.json`).
- Centralized a "focus chat input on close" effect in `TaskHeader.tsx` (`createEffect(on(() => search.active(), ...), { defer: true })`) that dispatches the existing `"focusPrompt"` window event whenever search transitions from active to inactive. This covers every close path (Command Palette toggle, header icon toggle, the search bar's own "X", and Escape) in one place, since `TranscriptSearch.tsx` itself only exists in the DOM while search is already active and can't react to its own removal.
- Added `forceOpen` support end-to-end so jumping to a match reveals it: `AssistantMessage.tsx` tags each part wrapper with `data-part-id` and computes `forceOpenPartID` for the row containing the current match; `MessagePartProps.forceOpen` threads through `Part()` into `ToolPartDisplay`'s two `<Dynamic>` calls (kilo-ui's `BasicTool` already has a one-way "force open" ratchet for regular tool calls); reasoning blocks had no such hook, so a new effect in `message-part.tsx` mirrors that one-way-open behavior for them; apply_patch's multi-file accordion has no per-file match tracking, so force-opening it expands every file rather than guessing which one contains the match.

## Screenshots / Video

N/A — no new visual states; existing search bar and tool/reasoning expand animations are unchanged.

## How to Test

### Manual/local verification

- Agent: ran `bun run typecheck`, `bun run lint`, `bun run knip`, `bun run format` from `packages/kilo-vscode/` — all pass with no diffs introduced by formatting.
- Agent: verified via `git diff` against `origin/main` that the stashed/rebased changes applied cleanly with no merge conflicts after fast-forwarding local `main` to the latest upstream sync.

### Reviewer test steps

1. Open a chat session with several turns, including at least one collapsed tool call and one collapsed reasoning block containing text you'll search for.
2. Run `Kilo Code: Toggle Chat Search` from the Command Palette — the search bar opens. Run it again — the search bar closes and focus moves to the chat input.
3. Reopen search, type a query that matches text inside a collapsed tool call or reasoning block, and press Enter/click next to jump to that match — the containing block should auto-expand to reveal the highlighted text.
4. Press Escape (or click the search bar's "X") to close search — confirm focus lands back in the chat input in both cases too.

### Blocked checks and substitute verification

- `bun run test:unit` / `bun run test` in `packages/kilo-vscode/` were not run in this session; substitute verification was the typecheck/lint/knip/format suite above plus the manual code review described in Implementation. A human should run the extension locally (`bun run extension`) and retrace the reviewer test steps above before merging.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
