### PR TITLE
feat(autocomplete): support configured BYOK completion models

### DIFF
--- a/.changeset/configured-byok-autocomplete.md
+++ b/.changeset/configured-byok-autocomplete.md
@@ -1,0 +1,8 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+"@kilocode/kilo-gateway": minor
+"@kilocode/sdk": minor
+---
+
+Support inline autocomplete through configured OpenAI-compatible BYOK providers and FIM models.

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -45,10 +45,32 @@ Mercury Edit 2 is only available through BYOK for now — Kilo Gateway support i
 
 ### Local OpenAI-compatible setup
 
-Start a FIM-capable model in an OpenAI-compatible server, then add its normal provider configuration to `~/.config/kilo/kilo.jsonc`. For example, an LM Studio server commonly listens on port `1234`:
+Use these steps with LM Studio, llama.cpp, Ollama, OMLX, or another server that implements OpenAI-compatible text completions with a `suffix` field.
 
-```json
+1. Start the server and load a FIM-capable model. This example uses an LM Studio-compatible base URL at `http://127.0.0.1:1234/v1` and the model ID `qwen2.5-coder-1.5b`. Replace both values with those reported by your server.
+2. Verify the endpoint before configuring Kilo Code:
+
+```bash
+curl --no-buffer --silent --show-error \
+  http://127.0.0.1:1234/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "qwen2.5-coder-1.5b",
+    "prompt": "function add(a, b) {\n  return ",
+    "suffix": "\n}\n",
+    "max_tokens": 32,
+    "temperature": 0,
+    "stream": true
+  }'
+```
+
+The streamed `choices[0].text` values should contain an insertion such as `a + b` without repeating the prefix or suffix. If the server requires authentication, add `-H "Authorization: Bearer $API_KEY"`.
+
+3. Add the server as a normal provider in `~/.config/kilo/kilo.jsonc`:
+
+```jsonc
 {
+  "$schema": "https://app.kilo.ai/config.json",
   "provider": {
     "lmstudio": {
       "npm": "@ai-sdk/openai-compatible",
@@ -58,7 +80,11 @@ Start a FIM-capable model in an OpenAI-compatible server, then add its normal pr
       },
       "models": {
         "qwen2.5-coder-1.5b": {
-          "name": "Qwen2.5 Coder 1.5B"
+          "name": "Qwen2.5 Coder 1.5B",
+          "limit": {
+            "context": 32768,
+            "output": 256
+          }
         }
       }
     }
@@ -66,7 +92,12 @@ Start a FIM-capable model in an OpenAI-compatible server, then add its normal pr
 }
 ```
 
-The same configuration works with a llama.cpp server at a base URL such as `http://127.0.0.1:8080/v1`, Ollama at `http://127.0.0.1:11434/v1`, or another OpenAI-compatible endpoint. Select the provider and model under **Settings → Models → Autocomplete model**. Loopback servers do not require an API key. For a remote server, configure the provider API key and use an HTTPS `baseURL`.
+For a remote endpoint, add `"apiKey": "{env:MY_PROVIDER_API_KEY}"` under `options` and use an HTTPS `baseURL`. Keep credentials in the global config shown above; project-level configuration cannot resolve `{env:...}` references.
+
+4. Reload Kilo Code, open **Settings → Models → Autocomplete model**, and select **Qwen2.5 Coder 1.5B** under **LM Studio**.
+5. Open a source file, place the cursor after `return ` in the example above, and request a suggestion. Automatic suggestions appear as you type. To test manually, enable `kilo-code.new.autocomplete.enableSmartInlineTaskKeybinding` and press `Cmd+L` on macOS or `Ctrl+L` on Windows/Linux. Press `Tab` to accept the ghost text.
+
+The same configuration shape works with a llama.cpp server at a base URL such as `http://127.0.0.1:8080/v1`, Ollama at `http://127.0.0.1:11434/v1`, or another OpenAI-compatible endpoint. Endpoint support varies by server and version, so run the `curl` check with the actual base URL and model ID first. Loopback servers do not require an API key.
 
 {% callout type="warning" %}
 OpenAI compatibility alone is not enough: the endpoint must support text completions with the `suffix` field, and the selected model must be trained for FIM. Validate this with the server's `/v1/completions` endpoint before enabling automatic suggestions.

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -9,12 +9,13 @@ Kilo Code's autocomplete feature provides intelligent code suggestions and compl
 
 ## How Autocomplete Works
 
-The extension uses **Fill-in-the-Middle (FIM)** completion routed through the **Kilo Gateway**. It analyzes the code before and after your cursor to generate contextually accurate inline suggestions.
+The extension uses **Fill-in-the-Middle (FIM)** completion. It analyzes the code before and after your cursor to generate contextually accurate inline suggestions through Kilo Gateway or a configured BYOK provider.
 
-You can choose between two FIM models:
+You can choose between these completion models:
 
 - **Codestral** (`mistralai/codestral-2508`) by Mistral AI — the default, billed through your Kilo account.
 - **Mercury Edit 2** (`inception/mercury-edit-2`) by Inception — temporarily available via **BYOK** (Bring Your Own Key) only; Kilo Gateway support is coming soon.
+- A FIM-capable model exposed by a configured OpenAI-compatible provider, including local servers such as LM Studio, llama.cpp, Ollama, or OMLX.
 
 ## Triggering Options
 
@@ -32,13 +33,43 @@ This keybinding requires `kilo-code.new.autocomplete.enableSmartInlineTaskKeybin
 
 ## Provider and Model
 
-Autocomplete requests are routed through the **Kilo Gateway**. You can pick the FIM model under **Settings → Models → Autocomplete model**:
+You can pick the FIM model under **Settings → Models → Autocomplete model**:
 
 - **Codestral** (`mistralai/codestral-2508`) — the default. Billed through your Kilo account, or free when you add your own Mistral Codestral key via BYOK. See [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup).
 - **Mercury Edit 2** (`inception/mercury-edit-2`) — a fast diffusion-based FIM model by Inception. Temporarily requires an **Inception BYOK key** until Kilo Gateway support lands. Add one from the [BYOK page](https://app.kilo.ai/byok) in the Kilo platform. See [Bring Your Own Key (BYOK)](/docs/getting-started/byok) for setup details.
+- A model from any connected OpenAI-compatible provider. The server and model must implement `POST /v1/completions` with both `prompt` and `suffix`; chat-only models are not compatible.
 
 {% callout type="note" %}
 Mercury Edit 2 is only available through BYOK for now — Kilo Gateway support is coming soon. If you select Mercury Edit 2 without a valid Inception BYOK key configured, autocomplete requests will fail — switch back to Codestral or add an Inception key to continue.
+{% /callout %}
+
+### Local OpenAI-compatible setup
+
+Start a FIM-capable model in an OpenAI-compatible server, then add its normal provider configuration to `~/.config/kilo/kilo.jsonc`. For example, an LM Studio server commonly listens on port `1234`:
+
+```json
+{
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "qwen2.5-coder-1.5b": {
+          "name": "Qwen2.5 Coder 1.5B"
+        }
+      }
+    }
+  }
+}
+```
+
+The same configuration works with a llama.cpp server at a base URL such as `http://127.0.0.1:8080/v1`, Ollama at `http://127.0.0.1:11434/v1`, or another OpenAI-compatible endpoint. Select the provider and model under **Settings → Models → Autocomplete model**. Loopback servers do not require an API key. For a remote server, configure the provider API key and use an HTTPS `baseURL`.
+
+{% callout type="warning" %}
+OpenAI compatibility alone is not enough: the endpoint must support text completions with the `suffix` field, and the selected model must be trained for FIM. Validate this with the server's `/v1/completions` endpoint before enabling automatic suggestions.
 {% /callout %}
 
 ## Status Bar

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -45,42 +45,54 @@ Mercury Edit 2 is only available through BYOK for now — Kilo Gateway support i
 
 ### Local OpenAI-compatible setup
 
-Use these steps with LM Studio, llama.cpp, Ollama, OMLX, or another server that implements OpenAI-compatible text completions with a `suffix` field.
+Ollama documents the complete API contract that autocomplete needs: `/v1/completions`, streaming, and the `suffix` field. Its `qwen2.5-coder:1.5b-base` template also maps the prompt and suffix to the model's FIM tokens.
 
-1. Start the server and load a FIM-capable model. This example uses an LM Studio-compatible base URL at `http://127.0.0.1:1234/v1` and the model ID `qwen2.5-coder-1.5b`. Replace both values with those reported by your server.
-2. Verify the endpoint before configuring Kilo Code:
+1. Install [Ollama](https://ollama.com/download), pull the FIM base model, and start the server if it is not already running:
 
 ```bash
-curl --no-buffer --silent --show-error \
-  http://127.0.0.1:1234/v1/completions \
+ollama pull qwen2.5-coder:1.5b-base
+ollama serve
+```
+
+2. Confirm the exact model ID reported by the server:
+
+```bash
+curl --silent --show-error http://127.0.0.1:11434/v1/models
+```
+
+3. Verify non-streaming FIM before configuring Kilo Code:
+
+```bash
+curl --silent --show-error \
+  http://127.0.0.1:11434/v1/completions \
   -H 'Content-Type: application/json' \
   -d '{
-    "model": "qwen2.5-coder-1.5b",
+    "model": "qwen2.5-coder:1.5b-base",
     "prompt": "function add(a, b) {\n  return ",
     "suffix": "\n}\n",
     "max_tokens": 32,
     "temperature": 0,
-    "stream": true
+    "stream": false
   }'
 ```
 
-The streamed `choices[0].text` values should contain an insertion such as `a + b` without repeating the prefix or suffix. If the server requires authentication, add `-H "Authorization: Bearer $API_KEY"`.
+The `choices[0].text` value should contain an insertion such as `a + b` without repeating the prefix or suffix. Repeat the request with `"stream": true` to verify the streaming path Kilo Code uses.
 
-3. Add the server as a normal provider in `~/.config/kilo/kilo.jsonc`:
+4. Add Ollama as a normal provider in `~/.config/kilo/kilo.jsonc`:
 
 ```jsonc
 {
   "$schema": "https://app.kilo.ai/config.json",
   "provider": {
-    "lmstudio": {
+    "ollama": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "LM Studio",
+      "name": "Ollama",
       "options": {
-        "baseURL": "http://127.0.0.1:1234/v1"
+        "baseURL": "http://127.0.0.1:11434/v1"
       },
       "models": {
-        "qwen2.5-coder-1.5b": {
-          "name": "Qwen2.5 Coder 1.5B",
+        "qwen2.5-coder:1.5b-base": {
+          "name": "Qwen2.5 Coder 1.5B Base",
           "limit": {
             "context": 32768,
             "output": 256
@@ -92,12 +104,16 @@ The streamed `choices[0].text` values should contain an insertion such as `a + b
 }
 ```
 
-For a remote endpoint, add `"apiKey": "{env:MY_PROVIDER_API_KEY}"` under `options` and use an HTTPS `baseURL`. Keep credentials in the global config shown above; project-level configuration cannot resolve `{env:...}` references.
+5. Run **Developer: Reload Window** in VS Code. Open **Kilo Code Settings → Models → Autocomplete model**, then select **Qwen2.5 Coder 1.5B Base** under **Ollama**. The selector shows every connected-provider model; appearing in the list does not prove that a model supports FIM.
+6. Disable other inline-completion extensions such as GitHub Copilot for this test. Open a source file, place the cursor after `return ` in the example above, and request a suggestion. Automatic suggestions appear as you type. To test manually, enable `kilo-code.new.autocomplete.enableSmartInlineTaskKeybinding` and press `Cmd+L` on macOS or `Ctrl+L` on Windows/Linux. Press `Tab` to accept the ghost text.
 
-4. Reload Kilo Code, open **Settings → Models → Autocomplete model**, and select **Qwen2.5 Coder 1.5B** under **LM Studio**.
-5. Open a source file, place the cursor after `return ` in the example above, and request a suggestion. Automatic suggestions appear as you type. To test manually, enable `kilo-code.new.autocomplete.enableSmartInlineTaskKeybinding` and press `Cmd+L` on macOS or `Ctrl+L` on Windows/Linux. Press `Tab` to accept the ghost text.
+### Other local servers
 
-The same configuration shape works with a llama.cpp server at a base URL such as `http://127.0.0.1:8080/v1`, Ollama at `http://127.0.0.1:11434/v1`, or another OpenAI-compatible endpoint. Endpoint support varies by server and version, so run the `curl` check with the actual base URL and model ID first. Loopback servers do not require an API key.
+- **OMLX:** Use its OpenAI-compatible base URL and the exact ID from `/v1/models`; local validation covered `mlx-community/Qwen2.5-Coder-1.5B-4bit` and `mlx-community/Qwen2.5-Coder-3B-4bit`.
+- **LM Studio:** It exposes `/v1/completions`, but `suffix` support depends on the loaded model and server version. Copy the exact ID from `http://127.0.0.1:1234/v1/models` and run the FIM request above before adding the provider.
+- **llama.cpp:** Its documented code-infill API is `/infill` with `input_prefix` and `input_suffix`, which this OpenAI-compatible transport does not call directly. Use a version or adapter that maps `POST /v1/completions` with `prompt` and `suffix`, and verify it with the request above.
+
+Loopback servers do not require an API key. For a remote endpoint, use HTTPS and add `"apiKey": "{env:MY_PROVIDER_API_KEY}"` under `options`. The environment variable must be visible to the VS Code process. Alternatively, save the key through **Kilo Code Settings → Providers → Custom provider**. Keep credentials in global configuration; project-level configuration cannot resolve `{env:...}` references.
 
 {% callout type="warning" %}
 OpenAI compatibility alone is not enough: the endpoint must support text completions with the `suffix` field, and the selected model must be trained for FIM. Validate this with the server's `/v1/completions` endpoint before enabling automatic suggestions.

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -119,6 +119,11 @@ Loopback servers do not require an API key. For a remote endpoint, use HTTPS and
 OpenAI compatibility alone is not enough: the endpoint must support text completions with the `suffix` field, and the selected model must be trained for FIM. Validate this with the server's `/v1/completions` endpoint before enabling automatic suggestions.
 {% /callout %}
 
+### Models that do not work
+
+- **Qwen3-Coder-Next (instruct):** Hosted endpoints accept `POST /v1/completions` with `prompt` and `suffix` but ignore the suffix and route through the chat template, so responses are conversational prose instead of insertable code. The model only emits FIM content through chat completions with explicit `<|fim_prefix|>`/`<|fim_suffix|>`/`<|fim_middle|>` markers, and even then wraps it in Markdown code fences, which this transport does not send or strip. Common self-hosted servers do not bridge the gap either: vLLM rejects `suffix` and OMLX has no `suffix` field on `/v1/completions`. Only the separate Base checkpoint behind a server that maps `prompt`+`suffix` into Qwen FIM tokens (for example SGLang with `--completion-template qwen_coder`) fits this transport.
+- Chat-tuned models in general: if a model's `/v1/completions` output starts with prose like "Here's the corrected version", it is answering as a chat model and will not produce usable inline completions.
+
 ## Status Bar
 
 The extension displays an **autocomplete status indicator** in the VS Code status bar, including:

--- a/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/autocomplete/index.md
@@ -119,6 +119,12 @@ Loopback servers do not require an API key. For a remote endpoint, use HTTPS and
 OpenAI compatibility alone is not enough: the endpoint must support text completions with the `suffix` field, and the selected model must be trained for FIM. Validate this with the server's `/v1/completions` endpoint before enabling automatic suggestions.
 {% /callout %}
 
+### Measured local performance
+
+On an Apple M3 Pro with 36 GB of unified memory, `mlx-community/Qwen2.5-Coder-1.5B-4bit` served by OMLX produced a 283 ms cached time to first token (p50, 346 ms p90) and a 284 ms complete response (p50, 399 ms p90) on a realistic 3,968-token prompt. The server reused 3,840 prompt tokens, and all 15 measured edits were correct after Kilo Code's conservative identifier-boundary trimming.
+
+These measurements exclude editor debounce. Kilo Code's classic autocomplete provider starts at a 300 ms debounce and adapts down to a 150 ms floor, while the first request in a sequence can run immediately. Cold requests are substantially slower: the same 4K model/server path took about 2.3 seconds without a reusable prompt cache. Keep the model loaded and preserve a stable model-and-document session to get responsive ghost text.
+
 ### Models that do not work
 
 - **Qwen3-Coder-Next (instruct):** Hosted endpoints accept `POST /v1/completions` with `prompt` and `suffix` but ignore the suffix and route through the chat template, so responses are conversational prose instead of insertable code. The model only emits FIM content through chat completions with explicit `<|fim_prefix|>`/`<|fim_suffix|>`/`<|fim_middle|>` markers, and even then wraps it in Markdown code fences, which this transport does not send or strip. Common self-hosted servers do not bridge the gap either: vLLM rejects `suffix` and OMLX has no `suffix` field on `/v1/completions`. Only the separate Base checkpoint behind a server that maps `prompt`+`suffix` into Qwen FIM tokens (for example SGLang with `--completion-template qwen_coder`) fits this transport.

--- a/packages/kilo-gateway/src/autocomplete.ts
+++ b/packages/kilo-gateway/src/autocomplete.ts
@@ -1,5 +1,5 @@
-export type AutocompleteProviderID = "kilo" | "mistral" | "inception"
-export type DirectAutocompleteProviderID = Exclude<AutocompleteProviderID, "kilo">
+export type AutocompleteProviderID = string
+export type DirectAutocompleteProviderID = "mistral" | "inception"
 
 interface AutocompleteModelBase {
   /** Stable combined value for internal comparisons. */
@@ -18,6 +18,10 @@ interface AutocompleteModelBase {
   readonly directProvider?: DirectAutocompleteProviderID
   /** Request temperature. */
   readonly temperature: number
+  /** Maximum number of completion tokens requested from the provider. */
+  readonly maxTokens?: number
+  /** Uses the configured provider's OpenAI-compatible completions endpoint. */
+  readonly configuredProvider?: boolean
 }
 
 export type AutocompleteModelDef = AutocompleteModelBase &
@@ -136,6 +140,20 @@ export function getAutocompleteModel(provider?: string, model?: string): Autocom
   for (const m of models) {
     if (m.providerID === pid && m.modelID === mid) return m
   }
+  if (provider?.trim() && model?.trim()) {
+    return {
+      id: `${provider}/${model}`,
+      modelID: model,
+      label: model,
+      providerID: provider,
+      provider,
+      requestModel: model,
+      directProvider: undefined,
+      temperature: 0,
+      maxTokens: 64,
+      configuredProvider: provider !== "kilo",
+    }
+  }
   return DEFAULT_AUTOCOMPLETE_MODEL
 }
 
@@ -143,16 +161,17 @@ export function getAutocompleteModelById(id: string): AutocompleteModelDef {
   for (const m of models) {
     if (m.id === id) return m
   }
+  const separator = id.indexOf("/")
+  if (separator > 0 && separator < id.length - 1) {
+    return getAutocompleteModel(id.slice(0, separator), id.slice(separator + 1))
+  }
   return DEFAULT_AUTOCOMPLETE_MODEL
 }
 
 export function validAutocompleteProvider(value: unknown) {
-  if (typeof value !== "string") return false
-  return models.some((m) => m.providerID === value)
+  return typeof value === "string" && value.trim().length > 0
 }
 
 export function validAutocompleteModel(value: unknown) {
-  if (typeof value !== "string") return false
-  const resolved = aliases[value] ?? value
-  return models.some((m) => m.modelID === resolved)
+  return typeof value === "string" && value.trim().length > 0
 }

--- a/packages/kilo-gateway/src/fim.ts
+++ b/packages/kilo-gateway/src/fim.ts
@@ -12,9 +12,37 @@ export type FimTarget =
   | { provider: "kilo"; model: string; url: string }
   | { provider: "inception"; model: string; url: string }
   | { provider: "mistral"; model: string }
+  | { provider: "configured"; providerID: string; model: string }
 
 const KILO_FIM_URL = KILO_API_BASE + "/api/fim/completions"
 const INCEPTION_FIM_URL = "https://api.inceptionlabs.ai/v1/fim/completions"
+
+export function openAICompletionsUrl(baseURL: string) {
+  return `${baseURL.replace(/\/+$/, "")}/completions`
+}
+
+export function isLoopbackUrl(value: string) {
+  if (!URL.canParse(value)) return false
+  const hostname = new URL(value).hostname
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1"
+}
+
+export function buildOpenAICompletionsRequest(input: {
+  model: string
+  prefix: string
+  suffix: string
+  maxTokens: number
+  temperature: number
+}) {
+  return {
+    model: input.model,
+    prompt: input.prefix,
+    suffix: input.suffix,
+    max_tokens: input.maxTokens,
+    temperature: input.temperature,
+    stream: true,
+  }
+}
 
 function kiloTarget(model?: string): FimTarget {
   return { provider: "kilo", model: model ?? "mistralai/codestral-2501", url: KILO_FIM_URL }
@@ -30,5 +58,8 @@ export function resolveFimTarget(provider?: string, model?: string): FimTarget {
   if (info.directProvider === "inception") {
     return { provider: "inception", model: info.requestModel, url: INCEPTION_FIM_URL }
   }
-  return kiloTarget(model)
+  if (info.configuredProvider) {
+    return { provider: "configured", providerID: info.providerID, model: info.requestModel }
+  }
+  return { provider: "configured", providerID: provider, model: model ?? "" }
 }

--- a/packages/kilo-gateway/src/server/fim.ts
+++ b/packages/kilo-gateway/src/server/fim.ts
@@ -1,10 +1,30 @@
 import { HEADER_FEATURE } from "../api/constants.js"
 import type { DirectAutocompleteProviderID } from "../autocomplete.js"
-import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget, type FimTarget } from "../fim.js"
+import {
+  buildOpenAICompletionsRequest,
+  DIRECT_FIM_ENV,
+  isLoopbackUrl,
+  openAICompletionsUrl,
+  requestMistralFim,
+  resolveFimTarget,
+  type FimTarget,
+} from "../fim.js"
 import { buildKiloHeaders } from "../headers.js"
 import type { AuthStore } from "./handlers.js"
 
 type Auth = Pick<AuthStore, "get">
+
+export interface ConfiguredFimProvider {
+  baseURL: string
+  apiKey?: string
+  headers?: Record<string, string>
+  model?: string
+}
+
+export type ResolveConfiguredFimProvider = (
+  providerID: string,
+  modelID: string,
+) => ConfiguredFimProvider | undefined | Promise<ConfiguredFimProvider | undefined>
 
 const FIM_TIMEOUT_MS = 30_000
 
@@ -26,7 +46,7 @@ async function getProviderKey(Auth: Auth, provider: DirectAutocompleteProviderID
 
 async function fetchFim(
   target: FimTarget,
-  key: string,
+  key: string | undefined,
   input: {
     prefix: string
     suffix: string
@@ -34,44 +54,64 @@ async function fetchFim(
     temperature: number
     signal: AbortSignal
     organizationId?: string
+    sessionId?: string
+    configured?: ConfiguredFimProvider
   },
 ): Promise<Response> {
+  const model = input.configured?.model ?? target.model
   const run = async (url: string) => {
-    console.info(`[FIM] request provider=${target.provider} model=${target.model} url=${url}`)
+    console.info(`[FIM] request provider=${target.provider} model=${model} url=${url}`)
     return fetch(url, {
       method: "POST",
       headers: {
+        ...input.configured?.headers,
         "Content-Type": "application/json",
-        Authorization: `Bearer ${key}`,
+        ...(key ? { Authorization: `Bearer ${key}` } : {}),
         ...(target.provider === "kilo"
           ? buildKiloHeaders(undefined, { kilocodeOrganizationId: input.organizationId })
           : {}),
         ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
+        ...(target.provider === "configured" && input.sessionId
+          ? { "x-kilo-autocomplete-session-id": input.sessionId }
+          : {}),
       },
       signal: input.signal,
-      body: JSON.stringify({
-        model: target.model,
-        prompt: input.prefix,
-        suffix: input.suffix,
-        max_tokens: input.maxTokens,
-        temperature: input.temperature,
-        stream: true,
-      }),
+      body: JSON.stringify(
+        buildOpenAICompletionsRequest({
+          model,
+          prefix: input.prefix,
+          suffix: input.suffix,
+          maxTokens: input.maxTokens,
+          temperature: input.temperature,
+        }),
+      ),
     })
   }
 
   if (target.provider === "mistral") return requestMistralFim(run)
+  if (target.provider === "configured") return run(openAICompletionsUrl(input.configured!.baseURL))
   return run(target.url)
 }
 
-export function createFimHandler(Auth: Auth) {
+export function createFimHandler(Auth: Auth, resolveConfiguredProvider?: ResolveConfiguredFimProvider) {
   return async (c: any) => {
-    const { prefix, suffix, provider, model, maxTokens, temperature } = c.req.valid("json")
+    const { prefix, suffix, provider, model, maxTokens, temperature, sessionId } = c.req.valid("json")
     const target = resolveFimTarget(provider, model)
     const fimMaxTokens = maxTokens ?? 256
     const fimTemperature = temperature ?? 0.2
+    const configured =
+      target.provider === "configured" ? await resolveConfiguredProvider?.(target.providerID, target.model) : undefined
+    if (target.provider === "configured" && !configured) {
+      return c.json({ error: "Autocomplete provider or model is not configured" }, 400)
+    }
+
     const proxy = target.provider === "kilo" ? await getProxyAuth(Auth) : undefined
-    const token = target.provider === "kilo" ? proxy?.token : await getProviderKey(Auth, target.provider)
+    const token =
+      target.provider === "kilo"
+        ? proxy?.token
+        : target.provider === "configured"
+          ? configured?.apiKey
+          : await getProviderKey(Auth, target.provider)
 
     if (target.provider === "kilo" && !proxy?.auth) {
       return c.json({ error: "Not authenticated with Kilo Gateway" }, 401)
@@ -81,8 +121,9 @@ export function createFimHandler(Auth: Auth) {
       return c.json({ error: "No valid token found" }, 401)
     }
 
-    if (!token) {
-      return c.json({ error: `Missing ${target.provider} provider API key` }, 401)
+    if (!token && (target.provider !== "configured" || !isLoopbackUrl(configured!.baseURL))) {
+      const name = target.provider === "configured" ? target.providerID : target.provider
+      return c.json({ error: `Missing ${name} provider API key` }, 401)
     }
 
     const signal = AbortSignal.any([c.req.raw.signal, AbortSignal.timeout(FIM_TIMEOUT_MS)])
@@ -95,6 +136,8 @@ export function createFimHandler(Auth: Auth) {
         temperature: fimTemperature,
         signal,
         organizationId: proxy?.organizationId,
+        sessionId,
+        configured,
       })
 
       if (!response.ok) {

--- a/packages/kilo-gateway/src/server/routes.ts
+++ b/packages/kilo-gateway/src/server/routes.ts
@@ -19,6 +19,7 @@ import {
 } from "../cloud-sessions.js"
 import { createEditHandler } from "./edit.js"
 import { createFimHandler } from "./fim.js"
+import type { ResolveConfiguredFimProvider } from "./fim.js"
 import {
   GatewayError,
   UnauthorizedError,
@@ -50,6 +51,7 @@ interface KiloRoutesDeps extends ImportDeps {
   ModelCache: ModelCache
   z: Z
   Instances: { disposeAllInstances(): Promise<void> }
+  resolveConfiguredFimProvider?: ResolveConfiguredFimProvider
 }
 
 /**
@@ -95,6 +97,7 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
     Identifier,
     ModelCache,
     Instances,
+    resolveConfiguredFimProvider,
   } = deps
 
   const Organization = z.object({
@@ -348,9 +351,10 @@ export function createKiloRoutes(deps: KiloRoutesDeps) {
           model: z.string().optional(),
           maxTokens: z.number().optional(),
           temperature: z.number().optional(),
+          sessionId: z.string().optional(),
         }),
       ),
-      createFimHandler(Auth),
+      createFimHandler(Auth, resolveConfiguredFimProvider),
     )
     .post(
       "/edit",

--- a/packages/kilo-gateway/test/autocomplete.test.ts
+++ b/packages/kilo-gateway/test/autocomplete.test.ts
@@ -30,3 +30,21 @@ describe("Next Edit FIM models", () => {
     }
   })
 })
+
+describe("configured autocomplete models", () => {
+  test("preserves arbitrary configured provider and model IDs", async () => {
+    const { getAutocompleteModel } = await import("../src/autocomplete")
+    const model = getAutocompleteModel("lmstudio", "qwen2.5-coder-1.5b")
+
+    expect(model).toMatchObject({
+      id: "lmstudio/qwen2.5-coder-1.5b",
+      providerID: "lmstudio",
+      modelID: "qwen2.5-coder-1.5b",
+      requestModel: "qwen2.5-coder-1.5b",
+      configuredProvider: true,
+      temperature: 0,
+      maxTokens: 64,
+    })
+    expect(model.directProvider).toBeUndefined()
+  })
+})

--- a/packages/kilo-gateway/test/fim.test.ts
+++ b/packages/kilo-gateway/test/fim.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { resolveFimTarget } from "../src/fim"
+import { buildOpenAICompletionsRequest, isLoopbackUrl, openAICompletionsUrl, resolveFimTarget } from "../src/fim"
 
 describe("FIM target resolution", () => {
   test("keeps gateway autocomplete models on Kilo Gateway", () => {
@@ -8,14 +8,9 @@ describe("FIM target resolution", () => {
       model: "mistralai/codestral-2508",
       url: "https://api.kilo.ai/api/fim/completions",
     })
-    expect(resolveFimTarget("kilo", "inception/mercury-edit-2")).toEqual({
-      provider: "kilo",
-      model: "inception/mercury-edit-2",
-      url: "https://api.kilo.ai/api/fim/completions",
-    })
   })
 
-  test("routes explicit provider autocomplete models directly", () => {
+  test("routes built-in direct providers without configured-provider lookup", () => {
     expect(resolveFimTarget("mistral", "codestral-2508")).toEqual({
       provider: "mistral",
       model: "codestral-2508",
@@ -27,26 +22,55 @@ describe("FIM target resolution", () => {
     })
   })
 
-  test("preserves gateway model pass-through behavior", () => {
+  test("routes arbitrary explicit selections through their configured provider", () => {
+    expect(resolveFimTarget("llamacpp", "qwen2.5-coder-1.5b")).toEqual({
+      provider: "configured",
+      providerID: "llamacpp",
+      model: "qwen2.5-coder-1.5b",
+    })
+  })
+
+  test("fails closed when an explicit provider has no model", () => {
+    expect(resolveFimTarget("lmstudio")).toEqual({
+      provider: "configured",
+      providerID: "lmstudio",
+      model: "",
+    })
+  })
+
+  test("preserves the default gateway behavior when no provider is selected", () => {
     expect(resolveFimTarget()).toEqual({
       provider: "kilo",
       model: "mistralai/codestral-2501",
       url: "https://api.kilo.ai/api/fim/completions",
     })
-    expect(resolveFimTarget(undefined, "mistralai/codestral-2508")).toEqual({
-      provider: "kilo",
-      model: "mistralai/codestral-2508",
-      url: "https://api.kilo.ai/api/fim/completions",
+  })
+})
+
+describe("OpenAI-compatible FIM transport", () => {
+  test("uses the standard prompt and suffix completions fields", () => {
+    expect(
+      buildOpenAICompletionsRequest({
+        model: "qwen2.5-coder-1.5b",
+        prefix: "function add(a, b) { return ",
+        suffix: "; }\n",
+        maxTokens: 64,
+        temperature: 0,
+      }),
+    ).toEqual({
+      model: "qwen2.5-coder-1.5b",
+      prompt: "function add(a, b) { return ",
+      suffix: "; }\n",
+      max_tokens: 64,
+      temperature: 0,
+      stream: true,
     })
-    expect(resolveFimTarget(undefined, "inception/mercury-edit")).toEqual({
-      provider: "kilo",
-      model: "inception/mercury-edit",
-      url: "https://api.kilo.ai/api/fim/completions",
-    })
-    expect(resolveFimTarget("kilo", "custom/fim-model")).toEqual({
-      provider: "kilo",
-      model: "custom/fim-model",
-      url: "https://api.kilo.ai/api/fim/completions",
-    })
+  })
+
+  test("joins the completions endpoint and recognizes loopback servers", () => {
+    expect(openAICompletionsUrl("http://127.0.0.1:1234/v1/")).toBe("http://127.0.0.1:1234/v1/completions")
+    expect(openAICompletionsUrl("https://inference.example/v1")).toBe("https://inference.example/v1/completions")
+    expect(isLoopbackUrl("http://localhost:1234/v1/completions")).toBe(true)
+    expect(isLoopbackUrl("https://inference.example/v1/completions")).toBe(false)
   })
 })

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -957,37 +957,11 @@
         },
         "kilo-code.new.autocomplete.model": {
           "type": "string",
-          "enum": [
-            "mistralai/codestral-2508",
-            "inception/mercury-edit-2",
-            "inception/mercury-next-edit",
-            "codestral-2508",
-            "mercury-edit-2",
-            "mercury-next-edit"
-          ],
-          "enumDescriptions": [
-            "Codestral via Kilo Gateway",
-            "Mercury Edit 2 (FIM) via Kilo Gateway",
-            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via Kilo Gateway",
-            "Codestral via your connected Mistral provider API key",
-            "Mercury Edit 2 (FIM) via your connected Inception provider API key",
-            "Mercury Edit 2 (Next Edit), multi-line edit predictions with jump-to-edit UX, via your connected Inception provider API key"
-          ],
-          "description": "Model to use for inline autocomplete suggestions. If unset, the recommended default is used."
+          "description": "Model ID to use for inline autocomplete suggestions. Configured BYOK models must support OpenAI-compatible fill-in-the-middle completions. If unset, the recommended default is used."
         },
         "kilo-code.new.autocomplete.provider": {
           "type": "string",
-          "enum": [
-            "kilo",
-            "mistral",
-            "inception"
-          ],
-          "enumDescriptions": [
-            "Use autocomplete models through Kilo Gateway",
-            "Use autocomplete models through your connected Mistral provider API key",
-            "Use autocomplete models through your connected Inception provider API key"
-          ],
-          "description": "Provider to use for inline autocomplete suggestions. If unset, Kilo Gateway is used."
+          "description": "Configured provider ID to use for inline autocomplete suggestions. If unset, Kilo Gateway is used."
         },
         "kilo-code.new.autocomplete.enableAutoTrigger": {
           "type": "boolean",

--- a/packages/kilo-vscode/src/services/autocomplete/__tests__/settings.spec.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/__tests__/settings.spec.ts
@@ -76,11 +76,18 @@ describe("autocomplete settings", () => {
     expect(validAutocompleteSetting("model", undefined)).toBe(true)
   })
 
-  it("rejects unsupported autocomplete updates", async () => {
+  it("accepts arbitrary connected provider and model IDs", async () => {
     const { validAutocompleteSetting } = await import("../settings")
 
-    expect(validAutocompleteSetting("model", "other/model")).toBe(false)
-    expect(validAutocompleteSetting("provider", "openrouter")).toBe(false)
+    expect(validAutocompleteSetting("model", "qwen2.5-coder-1.5b")).toBe(true)
+    expect(validAutocompleteSetting("provider", "lmstudio")).toBe(true)
+  })
+
+  it("rejects blank provider and model IDs", async () => {
+    const { validAutocompleteSetting } = await import("../settings")
+
+    expect(validAutocompleteSetting("model", "  ")).toBe(false)
+    expect(validAutocompleteSetting("provider", "")).toBe(false)
   })
 
   it("rejects non-boolean toggle updates", async () => {

--- a/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
@@ -107,9 +107,17 @@ export class ChatTextAreaAutocomplete {
     let response = ""
 
     try {
-      await generateFim(this.connection, entry.id, prefix, suffix, (chunk) => {
-        response += chunk
-      })
+      await generateFim(
+        this.connection,
+        entry.id,
+        prefix,
+        suffix,
+        (chunk) => {
+          response += chunk
+        },
+        undefined,
+        `${vscode.env.machineId}\0${this.dir || "chat-textarea"}`,
+      )
 
       const latencyMs = Date.now() - startTime
 

--- a/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/classic-auto-complete/FillInTheMiddle.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode"
 import {
   AutocompleteInput,
   AutocompleteContextProvider,
@@ -9,6 +10,7 @@ import { getProcessedSnippets } from "./getProcessedSnippets"
 import { getTemplateForModel } from "../continuedev/core/autocomplete/templating/AutocompleteTemplate"
 import { generateFim } from "../fim"
 import type { KiloConnectionService } from "../../cli-backend"
+import { getAutocompleteModelById } from "../../../shared/autocomplete-models"
 
 export type { FimAutocompletePrompt, FimCompletionResult }
 
@@ -33,9 +35,10 @@ export class FimPromptBuilder {
     const prunedSuffix = helper.prunedSuffix
 
     const template = getTemplateForModel(modelName)
+    const configuredProvider = getAutocompleteModelById(modelName).configuredProvider === true
 
     let formattedPrefix = prunedPrefixRaw
-    if (template.compilePrefixSuffix && prunedSuffix) {
+    if (!configuredProvider && template.compilePrefixSuffix && prunedSuffix) {
       const [compiledPrefix] = template.compilePrefixSuffix(
         prunedPrefixRaw,
         prunedSuffix,
@@ -69,7 +72,15 @@ export class FimPromptBuilder {
     const onChunk = (text: string) => {
       response += text
     }
-    const usageInfo = await generateFim(connection, modelId, formattedPrefix, prunedSuffix, onChunk, signal)
+    const usageInfo = await generateFim(
+      connection,
+      modelId,
+      formattedPrefix,
+      prunedSuffix,
+      onChunk,
+      signal,
+      `${vscode.env.machineId}\0${autocompleteInput.filepath}`,
+    )
 
     const fillInAtCursorSuggestion = processSuggestion(response)
 

--- a/packages/kilo-vscode/src/services/autocomplete/fim.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/fim.ts
@@ -1,8 +1,14 @@
 import { ResponseMetaData } from "./types"
 import type { KiloConnectionService } from "../cli-backend"
 import { getAutocompleteModelById } from "../../shared/autocomplete-models"
+import { createHash } from "node:crypto"
 
 const FIM_MAX_TOKENS = 256
+
+export function getFimSessionId(modelId: string, scope?: string) {
+  if (!scope) return undefined
+  return createHash("sha256").update(modelId).update("\0").update(scope).digest("hex")
+}
 
 /**
  * Generate a FIM (Fill-in-the-Middle) completion via the CLI backend.
@@ -17,6 +23,7 @@ export async function generateFim(
   suffix: string,
   onChunk: (text: string) => void,
   signal?: AbortSignal,
+  scope?: string,
 ): Promise<ResponseMetaData> {
   const client = await connectionService.getClientAsync()
   const info = getAutocompleteModelById(modelId)
@@ -37,8 +44,9 @@ export async function generateFim(
       suffix,
       provider: info.providerID,
       model: info.modelID,
-      maxTokens: FIM_MAX_TOKENS,
+      maxTokens: info.maxTokens ?? FIM_MAX_TOKENS,
       temperature: info.temperature,
+      sessionId: info.configuredProvider ? getFimSessionId(info.id, scope) : undefined,
     },
     {
       signal,

--- a/packages/kilo-vscode/tests/unit/autocomplete-custom-model-warning.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-custom-model-warning.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Guards the custom-model autocomplete warning.
+ *
+ * Curated autocomplete models are known to support FIM. A model from a
+ * configured (BYOK) provider is unverified: a chat-only model returns prose
+ * or fenced markdown instead of insertable code. When such a model is
+ * selected, the Models settings tab must show a visible warning card
+ * (requested in Kilo-Org/kilocode#4498).
+ */
+
+import { describe, it, expect } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+import { isCustomAutocompleteSelection } from "../../webview-ui/src/components/settings/autocomplete-model-selector"
+import { dict as en } from "../../webview-ui/src/i18n/en"
+import { dict as ar } from "../../webview-ui/src/i18n/ar"
+import { dict as br } from "../../webview-ui/src/i18n/br"
+import { dict as bs } from "../../webview-ui/src/i18n/bs"
+import { dict as da } from "../../webview-ui/src/i18n/da"
+import { dict as de } from "../../webview-ui/src/i18n/de"
+import { dict as es } from "../../webview-ui/src/i18n/es"
+import { dict as fr } from "../../webview-ui/src/i18n/fr"
+import { dict as it_ } from "../../webview-ui/src/i18n/it"
+import { dict as ja } from "../../webview-ui/src/i18n/ja"
+import { dict as ko } from "../../webview-ui/src/i18n/ko"
+import { dict as nl } from "../../webview-ui/src/i18n/nl"
+import { dict as no } from "../../webview-ui/src/i18n/no"
+import { dict as pl } from "../../webview-ui/src/i18n/pl"
+import { dict as ru } from "../../webview-ui/src/i18n/ru"
+import { dict as th } from "../../webview-ui/src/i18n/th"
+import { dict as tr } from "../../webview-ui/src/i18n/tr"
+import { dict as uk } from "../../webview-ui/src/i18n/uk"
+import { dict as zh } from "../../webview-ui/src/i18n/zh"
+import { dict as zht } from "../../webview-ui/src/i18n/zht"
+
+const TITLE_KEY = "settings.autocomplete.model.customWarning.title"
+const DESCRIPTION_KEY = "settings.autocomplete.model.customWarning.description"
+
+const locales: Record<string, Record<string, string>> = {
+  en,
+  ar,
+  br,
+  bs,
+  da,
+  de,
+  es,
+  fr,
+  it: it_,
+  ja,
+  ko,
+  nl,
+  no,
+  pl,
+  ru,
+  th,
+  tr,
+  uk,
+  zh,
+  zht,
+}
+
+describe("custom autocomplete model detection", () => {
+  it("does not flag curated Kilo Gateway models", () => {
+    expect(isCustomAutocompleteSelection("kilo", "mistralai/codestral-2508")).toBe(false)
+    expect(isCustomAutocompleteSelection("kilo", "inception/mercury-next-edit")).toBe(false)
+  })
+
+  it("does not flag curated direct BYOK models", () => {
+    expect(isCustomAutocompleteSelection("mistral", "codestral-2508")).toBe(false)
+    expect(isCustomAutocompleteSelection("inception", "mercury-edit-2")).toBe(false)
+  })
+
+  it("does not flag the unset (server default) state", () => {
+    expect(isCustomAutocompleteSelection(undefined, undefined)).toBe(false)
+    expect(isCustomAutocompleteSelection("lmstudio", undefined)).toBe(false)
+    expect(isCustomAutocompleteSelection(undefined, "qwen2.5-coder-1.5b")).toBe(false)
+  })
+
+  it("flags configured-provider models as custom", () => {
+    expect(isCustomAutocompleteSelection("lmstudio", "qwen2.5-coder-1.5b")).toBe(true)
+    expect(isCustomAutocompleteSelection("ollama", "qwen2.5-coder:1.5b-base")).toBe(true)
+  })
+})
+
+describe("custom autocomplete model warning copy", () => {
+  it("states the FIM requirement and the chat symptom in English", () => {
+    expect(en[TITLE_KEY]).toBe("Unverified autocomplete model")
+    expect(en[DESCRIPTION_KEY]).toBe(
+      "Kilo Code has not tested this model for autocomplete. It must support fill-in-the-middle (FIM) through its provider's completions endpoint. If suggestions appear as prose or fenced Markdown, the model is responding as chat. Switch to a FIM-capable model.",
+    )
+  })
+
+  it("exists in every locale and keeps the FIM technical token", () => {
+    for (const [locale, dict] of Object.entries(locales)) {
+      expect(dict[TITLE_KEY], `locale ${locale} is missing ${TITLE_KEY}`).toBeTruthy()
+      expect(dict[DESCRIPTION_KEY], `locale ${locale} is missing ${DESCRIPTION_KEY}`).toBeTruthy()
+      expect(dict[DESCRIPTION_KEY], `locale ${locale} dropped the FIM token from ${DESCRIPTION_KEY}`).toContain("FIM")
+    }
+  })
+})
+
+describe("custom autocomplete model warning rendering", () => {
+  const modelsTab = fs.readFileSync(
+    path.resolve(import.meta.dir, "../../webview-ui/src/components/settings/ModelsTab.tsx"),
+    "utf8",
+  )
+
+  it("renders a warning card gated on the custom-model check", () => {
+    expect(modelsTab).toContain("isCustomAutocompleteSelection")
+    expect(modelsTab).toContain('data-slot="autocomplete-custom-model-warning"')
+    expect(modelsTab).toMatch(/<Card\s+variant="warning"\s+role="alert"/)
+    expect(modelsTab).toContain('language.t("settings.autocomplete.model.customWarning.title")')
+    expect(modelsTab).toContain('language.t("settings.autocomplete.model.customWarning.description")')
+  })
+
+  it("announces the warning to assistive technology", () => {
+    expect(modelsTab).toMatch(/role="alert"[^>]*data-slot="autocomplete-custom-model-warning"/)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/autocomplete-fim-hint.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-fim-hint.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Guards the FIM-only autocomplete model hint.
+ *
+ * The autocomplete model description must warn users that only
+ * fill-in-the-middle (FIM) models work for inline completions, because
+ * chat-only models return conversational prose or fenced markdown instead
+ * of raw insertable code. The hint renders visibly in the Models settings
+ * row and also feeds the model selector's aria-describedby.
+ */
+
+import { describe, it, expect } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+import { dict as en } from "../../webview-ui/src/i18n/en"
+import { dict as ar } from "../../webview-ui/src/i18n/ar"
+import { dict as br } from "../../webview-ui/src/i18n/br"
+import { dict as bs } from "../../webview-ui/src/i18n/bs"
+import { dict as da } from "../../webview-ui/src/i18n/da"
+import { dict as de } from "../../webview-ui/src/i18n/de"
+import { dict as es } from "../../webview-ui/src/i18n/es"
+import { dict as fr } from "../../webview-ui/src/i18n/fr"
+import { dict as it_ } from "../../webview-ui/src/i18n/it"
+import { dict as ja } from "../../webview-ui/src/i18n/ja"
+import { dict as ko } from "../../webview-ui/src/i18n/ko"
+import { dict as nl } from "../../webview-ui/src/i18n/nl"
+import { dict as no } from "../../webview-ui/src/i18n/no"
+import { dict as pl } from "../../webview-ui/src/i18n/pl"
+import { dict as ru } from "../../webview-ui/src/i18n/ru"
+import { dict as th } from "../../webview-ui/src/i18n/th"
+import { dict as tr } from "../../webview-ui/src/i18n/tr"
+import { dict as uk } from "../../webview-ui/src/i18n/uk"
+import { dict as zh } from "../../webview-ui/src/i18n/zh"
+import { dict as zht } from "../../webview-ui/src/i18n/zht"
+
+const KEY = "settings.autocomplete.model.description"
+
+const locales: Record<string, Record<string, string>> = {
+  en,
+  ar,
+  br,
+  bs,
+  da,
+  de,
+  es,
+  fr,
+  it: it_,
+  ja,
+  ko,
+  nl,
+  no,
+  pl,
+  ru,
+  th,
+  tr,
+  uk,
+  zh,
+  zht,
+}
+
+describe("autocomplete FIM-only model hint", () => {
+  it("states the FIM requirement and the chat-only limitation in English", () => {
+    expect(en[KEY]).toBe("Select a fill-in-the-middle (FIM) model. Chat-only models are not supported.")
+  })
+
+  it("keeps the FIM technical token in every locale", () => {
+    for (const [locale, dict] of Object.entries(locales)) {
+      expect(dict[KEY], `locale ${locale} is missing ${KEY}`).toBeTruthy()
+      expect(dict[KEY], `locale ${locale} dropped the FIM token from ${KEY}`).toContain("FIM")
+    }
+  })
+
+  it("renders the hint visibly and assistively in the Models settings row", () => {
+    const modelsTab = fs.readFileSync(
+      path.resolve(import.meta.dir, "../../webview-ui/src/components/settings/ModelsTab.tsx"),
+      "utf8",
+    )
+    const uses = modelsTab.match(/language\.t\("settings\.autocomplete\.model\.description"\)/g) ?? []
+    // Once for the visible SettingsRow subtitle, once for the selector's assistive description.
+    expect(uses.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("wires the selector description into aria-describedby", () => {
+    const modelSelector = fs.readFileSync(
+      path.resolve(import.meta.dir, "../../webview-ui/src/components/shared/ModelSelector.tsx"),
+      "utf8",
+    )
+    expect(modelSelector).toContain("model-selector-assistive")
+    expect(modelSelector).toContain("aria-describedby")
+    expect(modelSelector).toMatch(/props\.description \? descriptionID : undefined/)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/autocomplete-fim-session.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-fim-session.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { getFimSessionId } from "../../src/services/autocomplete/fim"
+
+describe("autocomplete FIM sessions", () => {
+  it("creates a stable opaque session per model and file", () => {
+    const first = getFimSessionId("lmstudio/qwen2.5-coder-1.5b", "/workspace/src/index.ts")
+    const again = getFimSessionId("lmstudio/qwen2.5-coder-1.5b", "/workspace/src/index.ts")
+    const other = getFimSessionId("lmstudio/qwen2.5-coder-1.5b", "/workspace/src/other.ts")
+
+    expect(first).toBe(again)
+    expect(first).toHaveLength(64)
+    expect(first).not.toContain("workspace")
+    expect(other).not.toBe(first)
+  })
+
+  it("omits a session when no stable scope is available", () => {
+    expect(getFimSessionId("lmstudio/qwen2.5-coder-1.5b")).toBeUndefined()
+  })
+})

--- a/packages/kilo-vscode/tests/unit/autocomplete-model-selector.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-model-selector.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, it } from "vitest"
-import { AUTOCOMPLETE_SELECTOR_MODELS } from "../../webview-ui/src/components/settings/autocomplete-model-selector"
-import { AUTOCOMPLETE_MODELS } from "../../src/shared/autocomplete-models"
+import { getAutocompleteSelection } from "../../webview-ui/src/components/settings/autocomplete-model-selector"
 
 describe("autocomplete model selector", () => {
-  it("shows autocomplete models grouped by their configured provider", () => {
-    expect(AUTOCOMPLETE_SELECTOR_MODELS).toEqual(
-      AUTOCOMPLETE_MODELS.map((m) => ({
-        id: m.modelID,
-        name: m.label,
-        providerID: m.providerID,
-        providerName: m.provider,
-      })),
-    )
+  it("preserves a model from the normal connected-provider list", () => {
+    expect(getAutocompleteSelection("lmstudio", "qwen2.5-coder-1.5b")).toEqual({
+      providerID: "lmstudio",
+      modelID: "qwen2.5-coder-1.5b",
+    })
+  })
+
+  it("renders the clear state when neither setting is configured", () => {
+    expect(getAutocompleteSelection()).toBeNull()
   })
 })

--- a/packages/kilo-vscode/tests/unit/autocomplete-models-sync.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-models-sync.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect } from "bun:test"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { AUTOCOMPLETE_MODELS } from "../../src/shared/autocomplete-models"
 
-describe("autocomplete model enum ↔ AUTOCOMPLETE_MODELS sync", () => {
+describe("autocomplete provider and model settings", () => {
   const pkg = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf8"))
-  const prop = pkg.contributes.configuration.properties["kilo-code.new.autocomplete.model"]
+  const props = pkg.contributes.configuration.properties
+  const model = props["kilo-code.new.autocomplete.model"]
+  const provider = props["kilo-code.new.autocomplete.provider"]
 
-  it("package.json enum matches AUTOCOMPLETE_MODELS model IDs", () => {
-    const ids = AUTOCOMPLETE_MODELS.map((m) => m.modelID)
-    expect(prop.enum).toEqual(ids)
+  it("accepts IDs from the normal configured-provider registry", () => {
+    expect(provider.type).toBe("string")
+    expect(model.type).toBe("string")
+    expect(provider.enum).toBeUndefined()
+    expect(model.enum).toBeUndefined()
   })
 
-  it("package.json enumDescriptions has one entry per model", () => {
-    expect(prop.enumDescriptions).toHaveLength(AUTOCOMPLETE_MODELS.length)
+  it("documents the FIM compatibility requirement", () => {
+    expect(model.description).toContain("fill-in-the-middle")
   })
 
-  it("package.json does not declare a default (VS Code strips user overrides that equal the schema default)", () => {
-    expect(prop.default).toBeUndefined()
+  it("does not declare defaults that would strip matching user overrides", () => {
+    expect(provider.default).toBeUndefined()
+    expect(model.default).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/tests/unit/autocomplete-settings-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/autocomplete-settings-message.test.ts
@@ -69,14 +69,14 @@ describe("validAutocompleteSetting", () => {
     expect(validAutocompleteSetting("model", undefined)).toBe(true)
   })
 
-  it("accepts known providers and models", () => {
-    expect(validAutocompleteSetting("provider", "inception")).toBe(true)
-    expect(validAutocompleteSetting("model", "mercury-edit-2")).toBe(true)
+  it("accepts arbitrary configured providers and models", () => {
+    expect(validAutocompleteSetting("provider", "lmstudio")).toBe(true)
+    expect(validAutocompleteSetting("model", "qwen2.5-coder-1.5b")).toBe(true)
   })
 
-  it("rejects unknown providers and models", () => {
-    expect(validAutocompleteSetting("provider", "openrouter")).toBe(false)
-    expect(validAutocompleteSetting("model", "gpt-5")).toBe(false)
+  it("rejects blank providers and models", () => {
+    expect(validAutocompleteSetting("provider", "")).toBe(false)
+    expect(validAutocompleteSetting("model", "  ")).toBe(false)
   })
 
   it("rejects non-boolean toggle updates", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -1,5 +1,5 @@
 import { Component, For, Show, createMemo } from "solid-js"
-import { Card } from "@kilocode/kilo-ui/card"
+import { Card, CardDescription, CardTitle } from "@kilocode/kilo-ui/card"
 import { Select } from "@kilocode/kilo-ui/select"
 import { Switch } from "@kilocode/kilo-ui/switch"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
@@ -14,7 +14,7 @@ import SettingsRow from "./SettingsRow"
 import { DEFAULT_SPEECH_TO_TEXT_MODEL } from "../../../../src/speech-to-text/models"
 import { hasSpeechToTextAccess, selectedSpeechToTextModel } from "../speech-to-text/availability"
 import { SPEECH_TO_TEXT_MODEL_OPTIONS } from "../speech-to-text/model-selector"
-import { getAutocompleteSelection } from "./autocomplete-model-selector"
+import { getAutocompleteSelection, isCustomAutocompleteSelection } from "./autocomplete-model-selector"
 
 const ModelsTab: Component = () => {
   const { config, settings, updateConfig, updateSetting } = useConfig()
@@ -30,6 +30,9 @@ const ModelsTab: Component = () => {
     const v = settings()["autocomplete.model"]
     return typeof v === "string" ? v : undefined
   }
+  const autocompleteIsCustom = createMemo(() =>
+    isCustomAutocompleteSelection(autocompleteProvider(), autocompleteModel()),
+  )
 
   function handleModelSelect(configKey: "model" | "small_model") {
     return (providerID: string, modelID: string) => {
@@ -175,6 +178,17 @@ const ModelsTab: Component = () => {
             description={language.t("settings.autocomplete.model.description")}
           />
         </SettingsRow>
+        <Show when={autocompleteIsCustom()}>
+          <Card
+            variant="warning"
+            role="alert"
+            data-slot="autocomplete-custom-model-warning"
+            style={{ "margin-bottom": "8px" }}
+          >
+            <CardTitle variant="warning">{language.t("settings.autocomplete.model.customWarning.title")}</CardTitle>
+            <CardDescription>{language.t("settings.autocomplete.model.customWarning.description")}</CardDescription>
+          </Card>
+        </Show>
         <SettingsRow
           title={language.t("settings.models.speechToTextModel.title")}
           description={

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -14,7 +14,7 @@ import SettingsRow from "./SettingsRow"
 import { DEFAULT_SPEECH_TO_TEXT_MODEL } from "../../../../src/speech-to-text/models"
 import { hasSpeechToTextAccess, selectedSpeechToTextModel } from "../speech-to-text/availability"
 import { SPEECH_TO_TEXT_MODEL_OPTIONS } from "../speech-to-text/model-selector"
-import { AUTOCOMPLETE_SELECTOR_MODELS, getAutocompleteSelection } from "./autocomplete-model-selector"
+import { getAutocompleteSelection } from "./autocomplete-model-selector"
 
 const ModelsTab: Component = () => {
   const { config, settings, updateConfig, updateSetting } = useConfig()
@@ -168,7 +168,6 @@ const ModelsTab: Component = () => {
             value={getAutocompleteSelection(autocompleteProvider(), autocompleteModel())}
             onSelect={handleAutocompleteModelSelect}
             placement="bottom-start"
-            models={AUTOCOMPLETE_SELECTOR_MODELS}
             favorites={false}
             allowClear
             clearLabel={language.t("settings.providers.notSet")}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/autocomplete-model-selector.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/autocomplete-model-selector.ts
@@ -10,3 +10,13 @@ export function getAutocompleteSelection(provider?: string, modelID?: string) {
   const model = getAutocompleteModel(provider, modelID)
   return { providerID: model.providerID, modelID: model.modelID }
 }
+
+/**
+ * True when the selection resolves to a configured-provider (BYOK) model
+ * rather than a curated entry. Curated models are known to support FIM;
+ * custom models are unverified, so the settings UI shows a warning.
+ */
+export function isCustomAutocompleteSelection(provider?: string, modelID?: string) {
+  if (!provider || !modelID) return false
+  return getAutocompleteModel(provider, modelID).configuredProvider === true
+}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/autocomplete-model-selector.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/autocomplete-model-selector.ts
@@ -1,21 +1,12 @@
-import { AUTOCOMPLETE_MODELS, getAutocompleteModel } from "../../../../src/shared/autocomplete-models"
-import type { EnrichedModel } from "../../context/provider"
+import { getAutocompleteModel } from "../../../../src/shared/autocomplete-models"
 
 /**
- * Resolve the (provider, model) pair to the dropdown's value. Returns
- * `null` when neither is set so the selector renders the "Not set" (clear)
- * state via `allowClear`. The runtime resolves unset values to
- * `DEFAULT_AUTOCOMPLETE_MODEL` separately.
+ * Resolve the stored provider/model pair to the dropdown value. The selector
+ * itself uses the normal connected-provider model list, just like the other
+ * model settings on this page.
  */
 export function getAutocompleteSelection(provider?: string, modelID?: string) {
   if (!provider && !modelID) return null
   const model = getAutocompleteModel(provider, modelID)
   return { providerID: model.providerID, modelID: model.modelID }
 }
-
-export const AUTOCOMPLETE_SELECTOR_MODELS: EnrichedModel[] = AUTOCOMPLETE_MODELS.map((m) => ({
-  id: m.modelID,
-  name: m.label,
-  providerID: m.providerID,
-  providerName: m.provider,
-}))

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1230,7 +1230,8 @@ export const dict = {
   "settings.display.title": "العرض",
   "settings.autocomplete.title": "الإكمال التلقائي",
   "settings.autocomplete.model.title": "نموذج الإكمال التلقائي",
-  "settings.autocomplete.model.description": "حدد النموذج المستخدم لإكمال الكود المضمن (inline completions)",
+  "settings.autocomplete.model.description":
+    "حدد نموذج إكمال منتصف النص (FIM). النماذج المخصصة للدردشة فقط غير مدعومة.",
   "settings.notifications.title": "الإشعارات",
   "settings.context.title": "السياق",
   "settings.indexing.title": "الفهرسة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1232,6 +1232,9 @@ export const dict = {
   "settings.autocomplete.model.title": "نموذج الإكمال التلقائي",
   "settings.autocomplete.model.description":
     "حدد نموذج إكمال منتصف النص (FIM). النماذج المخصصة للدردشة فقط غير مدعومة.",
+  "settings.autocomplete.model.customWarning.title": "نموذج إكمال تلقائي غير مُتحقق منه",
+  "settings.autocomplete.model.customWarning.description":
+    "لم يختبر Kilo Code هذا النموذج للإكمال التلقائي. يجب أن يدعم النموذج إكمال منتصف النص (FIM) عبر نقطة نهاية completions لدى المزود. إذا ظهرت الاقتراحات كنص نثري أو Markdown داخل أسوار تعليمات برمجية، فالنموذج يرد كنموذج دردشة. بدّل إلى نموذج يدعم FIM.",
   "settings.notifications.title": "الإشعارات",
   "settings.context.title": "السياق",
   "settings.indexing.title": "الفهرسة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1253,7 +1253,8 @@ export const dict = {
   "settings.display.title": "Exibição",
   "settings.autocomplete.title": "Autocompletar",
   "settings.autocomplete.model.title": "Modelo de autocompletar",
-  "settings.autocomplete.model.description": "Selecione o modelo usado para preenchimento de código inline",
+  "settings.autocomplete.model.description":
+    "Selecione um modelo de preenchimento no meio (FIM). Modelos apenas de chat não são suportados.",
   "settings.notifications.title": "Notificações",
   "settings.context.title": "Contexto",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1255,6 +1255,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Modelo de autocompletar",
   "settings.autocomplete.model.description":
     "Selecione um modelo de preenchimento no meio (FIM). Modelos apenas de chat não são suportados.",
+  "settings.autocomplete.model.customWarning.title": "Modelo de autocompletar não verificado",
+  "settings.autocomplete.model.customWarning.description":
+    "O Kilo Code não testou este modelo para autocompletar. Ele precisa suportar preenchimento no meio (FIM) pelo endpoint de completions do provedor. Se as sugestões aparecerem como prosa ou Markdown cercado, o modelo está respondendo como chat. Troque para um modelo com suporte a FIM.",
   "settings.notifications.title": "Notificações",
   "settings.context.title": "Contexto",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1300,6 +1300,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Model za automatsko dovršavanje",
   "settings.autocomplete.model.description":
     "Odaberite model za popunjavanje u sredini (FIM). Modeli samo za chat nisu podržani.",
+  "settings.autocomplete.model.customWarning.title": "Neprovjereni model za automatsko dovršavanje",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code nije testirao ovaj model za automatsko dovršavanje. Model mora podržavati popunjavanje u sredini (FIM) putem completions endpointa providera. Ako se prijedlozi prikazuju kao proza ili Markdown u ogradama koda, model odgovara kao chat. Prebacite se na model koji podržava FIM.",
   "settings.notifications.title": "Obavještenja",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1298,7 +1298,8 @@ export const dict = {
   "settings.display.title": "Prikaz",
   "settings.autocomplete.title": "Automatsko dovršavanje",
   "settings.autocomplete.model.title": "Model za automatsko dovršavanje",
-  "settings.autocomplete.model.description": "Odaberite model koji se koristi za inline dovršavanje koda",
+  "settings.autocomplete.model.description":
+    "Odaberite model za popunjavanje u sredini (FIM). Modeli samo za chat nisu podržani.",
   "settings.notifications.title": "Obavještenja",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1291,7 +1291,8 @@ export const dict = {
   "settings.display.title": "Visning",
   "settings.autocomplete.title": "Autofuldførelse",
   "settings.autocomplete.model.title": "Autocomplete-model",
-  "settings.autocomplete.model.description": "Vælg den model, der bruges til inline kodefuldførelse",
+  "settings.autocomplete.model.description":
+    "Vælg en fill-in-the-middle-model (FIM). Modeller kun til chat understøttes ikke.",
   "settings.notifications.title": "Notifikationer",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1293,6 +1293,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Autocomplete-model",
   "settings.autocomplete.model.description":
     "Vælg en fill-in-the-middle-model (FIM). Modeller kun til chat understøttes ikke.",
+  "settings.autocomplete.model.customWarning.title": "Ikke-verificeret autocomplete-model",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code har ikke testet denne model til autofuldførelse. Den skal understøtte fill-in-the-middle (FIM) via udbyderens completions-endpoint. Hvis forslag vises som prosa eller indhegnet Markdown, svarer modellen som chat. Skift til en model, der understøtter FIM.",
   "settings.notifications.title": "Notifikationer",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1314,6 +1314,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Autocomplete-Modell",
   "settings.autocomplete.model.description":
     "Wählen Sie ein Fill-in-the-Middle-Modell (FIM). Reine Chat-Modelle werden nicht unterstützt.",
+  "settings.autocomplete.model.customWarning.title": "Nicht verifiziertes Autocomplete-Modell",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code hat dieses Modell nicht für die Autovervollständigung getestet. Es muss Fill-in-the-Middle (FIM) über den Completions-Endpunkt des Anbieters unterstützen. Erscheinen Vorschläge als Fließtext oder eingezäuntes Markdown, antwortet das Modell als Chat. Wechseln Sie zu einem FIM-fähigen Modell.",
   "settings.notifications.title": "Benachrichtigungen",
   "settings.context.title": "Kontext",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1312,7 +1312,8 @@ export const dict = {
   "settings.display.title": "Anzeige",
   "settings.autocomplete.title": "Autovervollständigung",
   "settings.autocomplete.model.title": "Autocomplete-Modell",
-  "settings.autocomplete.model.description": "Wählen Sie das Modell für Inline-Code-Vervollständigungen",
+  "settings.autocomplete.model.description":
+    "Wählen Sie ein Fill-in-the-Middle-Modell (FIM). Reine Chat-Modelle werden nicht unterstützt.",
   "settings.notifications.title": "Benachrichtigungen",
   "settings.context.title": "Kontext",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1393,6 +1393,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Autocomplete model",
   "settings.autocomplete.model.description":
     "Select a fill-in-the-middle (FIM) model. Chat-only models are not supported.",
+  "settings.autocomplete.model.customWarning.title": "Unverified autocomplete model",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code has not tested this model for autocomplete. It must support fill-in-the-middle (FIM) through its provider's completions endpoint. If suggestions appear as prose or fenced Markdown, the model is responding as chat. Switch to a FIM-capable model.",
   "settings.autocomplete.autoTrigger.title": "Enable automatic inline completions",
   "settings.autocomplete.autoTrigger.description": "Automatically show inline completion suggestions as you type",
   "settings.autocomplete.smartKeybinding.title": "Enable smart inline task keybinding",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1391,7 +1391,8 @@ export const dict = {
   "common.choose": "Choose…",
 
   "settings.autocomplete.model.title": "Autocomplete model",
-  "settings.autocomplete.model.description": "Select the model used for inline code completions",
+  "settings.autocomplete.model.description":
+    "Select a fill-in-the-middle (FIM) model. Chat-only models are not supported.",
   "settings.autocomplete.autoTrigger.title": "Enable automatic inline completions",
   "settings.autocomplete.autoTrigger.description": "Automatically show inline completion suggestions as you type",
   "settings.autocomplete.smartKeybinding.title": "Enable smart inline task keybinding",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1307,6 +1307,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Modelo de autocompletado",
   "settings.autocomplete.model.description":
     "Selecciona un modelo de relleno intermedio (FIM). Los modelos solo de chat no son compatibles.",
+  "settings.autocomplete.model.customWarning.title": "Modelo de autocompletado no verificado",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code no ha probado este modelo para autocompletado. Debe admitir relleno intermedio (FIM) a través del endpoint de completions del proveedor. Si las sugerencias aparecen como prosa o Markdown con vallas de código, el modelo está respondiendo como chat. Cambia a un modelo compatible con FIM.",
   "settings.notifications.title": "Notificaciones",
   "settings.context.title": "Contexto",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1305,7 +1305,8 @@ export const dict = {
   "settings.display.title": "Pantalla",
   "settings.autocomplete.title": "Autocompletado",
   "settings.autocomplete.model.title": "Modelo de autocompletado",
-  "settings.autocomplete.model.description": "Selecciona el modelo utilizado para el autocompletado de código en línea",
+  "settings.autocomplete.model.description":
+    "Selecciona un modelo de relleno intermedio (FIM). Los modelos solo de chat no son compatibles.",
   "settings.notifications.title": "Notificaciones",
   "settings.context.title": "Contexto",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1316,7 +1316,8 @@ export const dict = {
   "settings.display.title": "Affichage",
   "settings.autocomplete.title": "Autocomplétion",
   "settings.autocomplete.model.title": "Modèle d'autocomplétion",
-  "settings.autocomplete.model.description": "Sélectionnez le modèle utilisé pour les complétions de code en ligne",
+  "settings.autocomplete.model.description":
+    "Sélectionnez un modèle fill-in-the-middle (FIM). Les modèles de chat uniquement ne sont pas pris en charge.",
   "settings.notifications.title": "Notifications",
   "settings.context.title": "Contexte",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1318,6 +1318,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Modèle d'autocomplétion",
   "settings.autocomplete.model.description":
     "Sélectionnez un modèle fill-in-the-middle (FIM). Les modèles de chat uniquement ne sont pas pris en charge.",
+  "settings.autocomplete.model.customWarning.title": "Modèle d'autocomplétion non vérifié",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code n'a pas testé ce modèle pour l'autocomplétion. Il doit prendre en charge le fill-in-the-middle (FIM) via l'endpoint completions du fournisseur. Si les suggestions apparaissent comme de la prose ou du Markdown clôturé, le modèle répond comme un chat. Passez à un modèle compatible FIM.",
   "settings.notifications.title": "Notifications",
   "settings.context.title": "Contexte",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1204,7 +1204,8 @@ export const dict = {
   "common.add": "Aggiungi",
   "common.choose": "Scegli...",
   "settings.autocomplete.model.title": "Modello autocompletamento",
-  "settings.autocomplete.model.description": "Seleziona il modello usato per i completamenti inline del codice",
+  "settings.autocomplete.model.description":
+    "Seleziona un modello fill-in-the-middle (FIM). I modelli solo chat non sono supportati.",
   "settings.autocomplete.autoTrigger.title": "Abilita completamenti inline automatici",
   "settings.autocomplete.autoTrigger.description":
     "Mostra automaticamente suggerimenti di completamento inline mentre scrivi",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1206,6 +1206,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Modello autocompletamento",
   "settings.autocomplete.model.description":
     "Seleziona un modello fill-in-the-middle (FIM). I modelli solo chat non sono supportati.",
+  "settings.autocomplete.model.customWarning.title": "Modello autocompletamento non verificato",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code non ha testato questo modello per l'autocompletamento. Deve supportare il fill-in-the-middle (FIM) tramite l'endpoint completions del provider. Se i suggerimenti appaiono come prosa o Markdown recintato, il modello sta rispondendo come chat. Passa a un modello compatibile con FIM.",
   "settings.autocomplete.autoTrigger.title": "Abilita completamenti inline automatici",
   "settings.autocomplete.autoTrigger.description":
     "Mostra automaticamente suggerimenti di completamento inline mentre scrivi",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1286,7 +1286,8 @@ export const dict = {
   "settings.display.title": "表示",
   "settings.autocomplete.title": "オートコンプリート",
   "settings.autocomplete.model.title": "オートコンプリートモデル",
-  "settings.autocomplete.model.description": "インラインでのコード補完に使用するモデルを選択します",
+  "settings.autocomplete.model.description":
+    "フィルインザミドル（FIM）対応モデルを選択します。チャット専用モデルはサポートされていません。",
   "settings.notifications.title": "通知",
   "settings.context.title": "コンテキスト",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1288,6 +1288,9 @@ export const dict = {
   "settings.autocomplete.model.title": "オートコンプリートモデル",
   "settings.autocomplete.model.description":
     "フィルインザミドル（FIM）対応モデルを選択します。チャット専用モデルはサポートされていません。",
+  "settings.autocomplete.model.customWarning.title": "未検証のオートコンプリートモデル",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code はこのモデルをオートコンプリート用に検証していません。プロバイダーの completions エンドポイント経由でフィルインザミドル（FIM）に対応している必要があります。候補が散文やコードフェンス付き Markdown として表示される場合、モデルはチャットとして応答しています。FIM 対応モデルに切り替えてください。",
   "settings.notifications.title": "通知",
   "settings.context.title": "コンテキスト",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1239,7 +1239,8 @@ export const dict = {
   "settings.display.title": "디스플레이",
   "settings.autocomplete.title": "자동 완성",
   "settings.autocomplete.model.title": "자동 완성 모델",
-  "settings.autocomplete.model.description": "인라인 코드 완성에 사용되는 모델 선택",
+  "settings.autocomplete.model.description":
+    "FIM(fill-in-the-middle) 모델을 선택하세요. 채팅 전용 모델은 지원되지 않습니다.",
   "settings.notifications.title": "알림",
   "settings.context.title": "컨텍스트",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1241,6 +1241,9 @@ export const dict = {
   "settings.autocomplete.model.title": "자동 완성 모델",
   "settings.autocomplete.model.description":
     "FIM(fill-in-the-middle) 모델을 선택하세요. 채팅 전용 모델은 지원되지 않습니다.",
+  "settings.autocomplete.model.customWarning.title": "검증되지 않은 자동 완성 모델",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code는 이 모델을 자동 완성용으로 테스트하지 않았습니다. 제공자의 completions 엔드포인트를 통해 FIM(fill-in-the-middle)을 지원해야 합니다. 제안이 산문이나 코드 펜스로 감싼 Markdown으로 표시되면 모델이 채팅으로 응답하고 있는 것입니다. FIM을 지원하는 모델로 전환하세요.",
   "settings.notifications.title": "알림",
   "settings.context.title": "컨텍스트",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1247,7 +1247,8 @@ export const dict = {
   "settings.display.title": "Weergave",
   "settings.autocomplete.title": "Automatisch Aanvullen",
   "settings.autocomplete.model.title": "Autocomplete-model",
-  "settings.autocomplete.model.description": "Selecteer het model dat wordt gebruikt voor inline code-aanvullingen",
+  "settings.autocomplete.model.description":
+    "Selecteer een fill-in-the-middle (FIM)-model. Modellen die alleen chat ondersteunen, worden niet ondersteund.",
   "settings.notifications.title": "Meldingen",
   "settings.context.title": "Context",
   "settings.indexing.title": "Indexering",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1249,6 +1249,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Autocomplete-model",
   "settings.autocomplete.model.description":
     "Selecteer een fill-in-the-middle (FIM)-model. Modellen die alleen chat ondersteunen, worden niet ondersteund.",
+  "settings.autocomplete.model.customWarning.title": "Niet-geverifieerd autocomplete-model",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code heeft dit model niet getest voor automatisch aanvullen. Het moet fill-in-the-middle (FIM) ondersteunen via het completions-endpoint van de provider. Als suggesties verschijnen als proza of omheinde Markdown, antwoordt het model als chat. Schakel over naar een model met FIM-ondersteuning.",
   "settings.notifications.title": "Meldingen",
   "settings.context.title": "Context",
   "settings.indexing.title": "Indexering",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1253,6 +1253,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Autocomplete-modell",
   "settings.autocomplete.model.description":
     "Velg en fill-in-the-middle-modell (FIM). Modeller kun for chat støttes ikke.",
+  "settings.autocomplete.model.customWarning.title": "Uverifisert autocomplete-modell",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code har ikke testet denne modellen for autofullføring. Den må støtte fill-in-the-middle (FIM) via leverandørens completions-endepunkt. Hvis forslag vises som prosa eller inngjerdet Markdown, svarer modellen som chat. Bytt til en modell som støtter FIM.",
   "settings.notifications.title": "Varslinger",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1251,7 +1251,8 @@ export const dict = {
   "settings.display.title": "Visning",
   "settings.autocomplete.title": "Autofullfør",
   "settings.autocomplete.model.title": "Autocomplete-modell",
-  "settings.autocomplete.model.description": "Velg modellen som brukes for inline kodefullføring",
+  "settings.autocomplete.model.description":
+    "Velg en fill-in-the-middle-modell (FIM). Modeller kun for chat støttes ikke.",
   "settings.notifications.title": "Varslinger",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1250,7 +1250,8 @@ export const dict = {
   "settings.display.title": "Wyświetlanie",
   "settings.autocomplete.title": "Autouzupełnianie",
   "settings.autocomplete.model.title": "Model autouzupełniania",
-  "settings.autocomplete.model.description": "Wybierz model używany do uzupełniania kodu w linii (inline)",
+  "settings.autocomplete.model.description":
+    "Wybierz model typu fill-in-the-middle (FIM). Modele wyłącznie czatowe nie są obsługiwane.",
   "settings.notifications.title": "Powiadomienia",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1252,6 +1252,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Model autouzupełniania",
   "settings.autocomplete.model.description":
     "Wybierz model typu fill-in-the-middle (FIM). Modele wyłącznie czatowe nie są obsługiwane.",
+  "settings.autocomplete.model.customWarning.title": "Niezweryfikowany model autouzupełniania",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code nie przetestował tego modelu pod kątem autouzupełniania. Model musi obsługiwać fill-in-the-middle (FIM) przez endpoint completions dostawcy. Jeśli podpowiedzi wyglądają jak proza lub Markdown w ogrodzeniach kodu, model odpowiada jak czat. Przełącz się na model obsługujący FIM.",
   "settings.notifications.title": "Powiadomienia",
   "settings.context.title": "Kontekst",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1297,7 +1297,8 @@ export const dict = {
   "settings.display.title": "Отображение",
   "settings.autocomplete.title": "Автодополнение",
   "settings.autocomplete.model.title": "Модель автодополнения",
-  "settings.autocomplete.model.description": "Выберите модель для встроенного (inline) автодополнения кода",
+  "settings.autocomplete.model.description":
+    "Выберите модель с поддержкой fill-in-the-middle (FIM). Модели только для чата не поддерживаются.",
   "settings.notifications.title": "Уведомления",
   "settings.context.title": "Контекст",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1299,6 +1299,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Модель автодополнения",
   "settings.autocomplete.model.description":
     "Выберите модель с поддержкой fill-in-the-middle (FIM). Модели только для чата не поддерживаются.",
+  "settings.autocomplete.model.customWarning.title": "Непроверенная модель автодополнения",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code не тестировал эту модель для автодополнения. Модель должна поддерживать fill-in-the-middle (FIM) через completions-эндпоинт провайдера. Если подсказки выглядят как проза или Markdown в ограждениях кода, модель отвечает как чат. Переключитесь на модель с поддержкой FIM.",
   "settings.notifications.title": "Уведомления",
   "settings.context.title": "Контекст",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1280,6 +1280,9 @@ export const dict = {
   "settings.autocomplete.title": "เติมข้อความอัตโนมัติ",
   "settings.autocomplete.model.title": "โมเดล Autocomplete",
   "settings.autocomplete.model.description": "เลือกโมเดลแบบเติมส่วนกลาง (FIM) ไม่รองรับโมเดลที่ใช้สำหรับแชทเท่านั้น",
+  "settings.autocomplete.model.customWarning.title": "โมเดล Autocomplete ที่ยังไม่ได้ตรวจสอบ",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code ยังไม่ได้ทดสอบโมเดลนี้สำหรับการเติมข้อความอัตโนมัติ โมเดลต้องรองรับการเติมส่วนกลาง (FIM) ผ่าน completions endpoint ของผู้ให้บริการ หากคำแนะนำแสดงเป็นข้อความร้อยแก้วหรือ Markdown ที่มีรั้วโค้ด แสดงว่าโมเดลตอบแบบแชท ให้เปลี่ยนไปใช้โมเดลที่รองรับ FIM",
   "settings.notifications.title": "การแจ้งเตือน",
   "settings.context.title": "บริบท",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1279,7 +1279,7 @@ export const dict = {
   "settings.display.title": "การแสดงผล",
   "settings.autocomplete.title": "เติมข้อความอัตโนมัติ",
   "settings.autocomplete.model.title": "โมเดล Autocomplete",
-  "settings.autocomplete.model.description": "เลือกโมเดลที่ใช้สำหรับการเติมโค้ดแบบอินไลน์ (inline completions)",
+  "settings.autocomplete.model.description": "เลือกโมเดลแบบเติมส่วนกลาง (FIM) ไม่รองรับโมเดลที่ใช้สำหรับแชทเท่านั้น",
   "settings.notifications.title": "การแจ้งเตือน",
   "settings.context.title": "บริบท",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1244,7 +1244,8 @@ export const dict = {
   "settings.display.title": "Görünüm",
   "settings.autocomplete.title": "Otomatik Tamamlama",
   "settings.autocomplete.model.title": "Otomatik tamamlama modeli",
-  "settings.autocomplete.model.description": "Satır içi (inline) kod tamamlamaları için kullanılacak modeli seçin",
+  "settings.autocomplete.model.description":
+    "Fill-in-the-middle (FIM) destekli bir model seçin. Yalnızca sohbet için olan modeller desteklenmez.",
   "settings.notifications.title": "Bildirimler",
   "settings.context.title": "Bağlam",
   "settings.indexing.title": "İndeksleme",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1246,6 +1246,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Otomatik tamamlama modeli",
   "settings.autocomplete.model.description":
     "Fill-in-the-middle (FIM) destekli bir model seçin. Yalnızca sohbet için olan modeller desteklenmez.",
+  "settings.autocomplete.model.customWarning.title": "Doğrulanmamış otomatik tamamlama modeli",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code bu modeli otomatik tamamlama için test etmedi. Model, sağlayıcının completions uç noktası üzerinden fill-in-the-middle (FIM) desteklemelidir. Öneriler düz metin veya çitli Markdown olarak görünüyorsa model sohbet gibi yanıt veriyordur. FIM destekleyen bir modele geçin.",
   "settings.notifications.title": "Bildirimler",
   "settings.context.title": "Bağlam",
   "settings.indexing.title": "İndeksleme",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1242,7 +1242,8 @@ export const dict = {
   "settings.display.title": "Відображення",
   "settings.autocomplete.title": "Автодоповнення",
   "settings.autocomplete.model.title": "Модель автодоповнення",
-  "settings.autocomplete.model.description": "Виберіть модель для вбудованого (inline) автодоповнення коду",
+  "settings.autocomplete.model.description":
+    "Виберіть модель із підтримкою fill-in-the-middle (FIM). Моделі лише для чату не підтримуються.",
   "settings.notifications.title": "Сповіщення",
   "settings.context.title": "Контекст",
   "settings.indexing.title": "Індексування",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1244,6 +1244,9 @@ export const dict = {
   "settings.autocomplete.model.title": "Модель автодоповнення",
   "settings.autocomplete.model.description":
     "Виберіть модель із підтримкою fill-in-the-middle (FIM). Моделі лише для чату не підтримуються.",
+  "settings.autocomplete.model.customWarning.title": "Неперевірена модель автодоповнення",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code не тестував цю модель для автодоповнення. Модель має підтримувати fill-in-the-middle (FIM) через completions-ендпоінт провайдера. Якщо підказки виглядають як проза або Markdown в огорожах коду, модель відповідає як чат. Перейдіть на модель з підтримкою FIM.",
   "settings.notifications.title": "Сповіщення",
   "settings.context.title": "Контекст",
   "settings.indexing.title": "Індексування",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1255,7 +1255,7 @@ export const dict = {
   "settings.display.title": "显示",
   "settings.autocomplete.title": "自动补全",
   "settings.autocomplete.model.title": "自动补全模型",
-  "settings.autocomplete.model.description": "选择用于内联代码补全的模型",
+  "settings.autocomplete.model.description": "选择支持中间填充（FIM）的模型。不支持仅限聊天的模型。",
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1256,6 +1256,9 @@ export const dict = {
   "settings.autocomplete.title": "自动补全",
   "settings.autocomplete.model.title": "自动补全模型",
   "settings.autocomplete.model.description": "选择支持中间填充（FIM）的模型。不支持仅限聊天的模型。",
+  "settings.autocomplete.model.customWarning.title": "未验证的自动补全模型",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code 尚未针对自动补全测试此模型。该模型必须通过提供商的 completions 端点支持中间填充（FIM）。如果建议显示为散文或带代码围栏的 Markdown，说明模型正在以聊天方式回复。请切换到支持 FIM 的模型。",
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1216,7 +1216,7 @@ export const dict = {
   "settings.display.title": "顯示",
   "settings.autocomplete.title": "自動完成",
   "settings.autocomplete.model.title": "自動補全模型",
-  "settings.autocomplete.model.description": "選擇用於內聯程式碼補全的模型",
+  "settings.autocomplete.model.description": "選擇支援中間填充（FIM）的模型。不支援僅限聊天的模型。",
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1217,6 +1217,9 @@ export const dict = {
   "settings.autocomplete.title": "自動完成",
   "settings.autocomplete.model.title": "自動補全模型",
   "settings.autocomplete.model.description": "選擇支援中間填充（FIM）的模型。不支援僅限聊天的模型。",
+  "settings.autocomplete.model.customWarning.title": "未驗證的自動補全模型",
+  "settings.autocomplete.model.customWarning.description":
+    "Kilo Code 尚未針對自動補全測試此模型。該模型必須透過提供者的 completions 端點支援中間填充（FIM）。如果建議顯示為散文或帶程式碼圍欄的 Markdown，表示模型正在以聊天方式回應。請切換到支援 FIM 的模型。",
   "settings.notifications.title": "通知",
   "settings.context.title": "上下文",
 

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilo-gateway.ts
@@ -166,6 +166,7 @@ export const FimBody = Schema.Struct({
   model: Schema.optional(Schema.String),
   maxTokens: Schema.optional(Schema.Finite),
   temperature: Schema.optional(Schema.Finite),
+  sessionId: Schema.optional(Schema.String),
 })
 
 // Next Edit (NES) — non-streaming. Clients send structured editor context; the

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -24,7 +24,14 @@ import {
   fetchOrganizationModes,
   fetchProfile,
 } from "@kilocode/kilo-gateway"
-import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget } from "@kilocode/kilo-gateway/fim"
+import {
+  buildOpenAICompletionsRequest,
+  DIRECT_FIM_ENV,
+  isLoopbackUrl,
+  openAICompletionsUrl,
+  requestMistralFim,
+  resolveFimTarget,
+} from "@kilocode/kilo-gateway/fim"
 import { DIRECT_EDIT_ENV, extractFencedBody, resolveEditTarget } from "@kilocode/kilo-gateway/edit"
 import { buildMercuryEditPrompt } from "@kilocode/kilo-gateway/edit-prompt"
 import { buildKiloHeaders } from "@kilocode/kilo-gateway"
@@ -45,8 +52,11 @@ import { Identifier } from "@/id/id"
 import { Instance } from "@/kilocode/instance"
 import { InstanceStore } from "@/project/instance-store"
 import { ModelCache } from "@/provider/model-cache"
+import { Provider } from "@/provider/provider"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { MessageTable, PartTable } from "@opencode-ai/core/session/sql"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Session } from "@/session/session"
 import { Storage } from "@/storage/storage"
 import { AudioTranscriptionsBody, ClawStatus, CloudSessionImportError, EditBody, FimBody } from "../groups/kilo-gateway"
@@ -67,6 +77,7 @@ function logError(route: string, err: unknown) {
 export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo", (handlers) =>
   Effect.gen(function* () {
     const auth = yield* Auth.Service
+    const providers = yield* Provider.Service
     const store = yield* InstanceStore.Service
     const cache = yield* ModelCache.Service
     const events = yield* EventV2Bridge.Service
@@ -119,16 +130,53 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
 
     const fim = Effect.fn("KiloGatewayHttpApi.fim")(function* (ctx: { payload: typeof FimBody.Type }) {
       const target = resolveFimTarget(ctx.payload.provider, ctx.payload.model)
+      const configured =
+        target.provider === "configured"
+          ? yield* Effect.gen(function* () {
+              const providerID = ProviderV2.ID.make(target.providerID)
+              const modelID = ModelV2.ID.make(target.model)
+              const model = yield* providers
+                .getModel(providerID, modelID)
+                .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+              const provider = yield* providers.getProvider(providerID)
+              if (!provider) return yield* Effect.fail(new HttpApiError.BadRequest({}))
+              const baseURL =
+                typeof provider.options.baseURL === "string" && provider.options.baseURL
+                  ? provider.options.baseURL
+                  : model.api.url
+              if (!baseURL) return yield* Effect.fail(new HttpApiError.BadRequest({}))
+              const providerHeaders =
+                provider.options.headers && typeof provider.options.headers === "object"
+                  ? Object.fromEntries(
+                      Object.entries(provider.options.headers).filter(
+                        (entry): entry is [string, string] => typeof entry[1] === "string",
+                      ),
+                    )
+                  : {}
+              return {
+                url: openAICompletionsUrl(baseURL),
+                model: model.api.id,
+                headers: { ...providerHeaders, ...model.headers },
+                token:
+                  typeof provider.options.apiKey === "string" && provider.options.apiKey
+                    ? provider.options.apiKey
+                    : provider.key,
+              }
+            })
+          : undefined
       const info = target.provider === "kilo" ? yield* proxyAuth() : undefined
       const token = yield* Effect.gen(function* () {
         if (target.provider === "kilo") return info?.token
+        if (target.provider === "configured") return configured?.token
         const item = yield* auth.get(target.provider).pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
         if (item?.type === "api") return item.key
         return DIRECT_FIM_ENV[target.provider].map((key) => process.env[key]).find(Boolean)
       })
 
       if (target.provider === "kilo" && !info?.auth) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
-      if (!token) return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      if (!token && (target.provider !== "configured" || !isLoopbackUrl(configured!.url))) {
+        return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      }
 
       const request = yield* HttpServerRequest.HttpServerRequest
       const signal =
@@ -138,29 +186,36 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
       const response = yield* Effect.promise(async () => {
         try {
           const run = async (url: string): Promise<Response> => {
-            console.info(`[FIM] request provider=${target.provider} model=${target.model} url=${url}`)
+            const requestModel = configured?.model ?? target.model
+            console.info(`[FIM] request provider=${target.provider} model=${requestModel} url=${url}`)
             return fetch(url, {
               method: "POST",
               headers: {
+                ...configured?.headers,
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
                 ...(target.provider === "kilo"
                   ? buildKiloHeaders(undefined, { kilocodeOrganizationId: info?.organizationId })
                   : {}),
                 ...(target.provider === "kilo" ? { [HEADER_FEATURE]: "autocomplete" } : {}),
+                ...(target.provider === "configured" && ctx.payload.sessionId
+                  ? { "x-kilo-autocomplete-session-id": ctx.payload.sessionId }
+                  : {}),
               },
               signal,
-              body: JSON.stringify({
-                model: target.model,
-                prompt: ctx.payload.prefix,
-                suffix: ctx.payload.suffix,
-                max_tokens: ctx.payload.maxTokens ?? 256,
-                temperature: ctx.payload.temperature ?? 0.2,
-                stream: true,
-              }),
+              body: JSON.stringify(
+                buildOpenAICompletionsRequest({
+                  model: requestModel,
+                  prefix: ctx.payload.prefix,
+                  suffix: ctx.payload.suffix,
+                  maxTokens: ctx.payload.maxTokens ?? 256,
+                  temperature: ctx.payload.temperature ?? 0.2,
+                }),
+              ),
             })
           }
           if (target.provider === "mistral") return requestMistralFim(run)
+          if (target.provider === "configured") return run(configured!.url)
           return run(target.url)
         } catch (err) {
           if (err instanceof DOMException && err.name === "TimeoutError")

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -9,6 +9,7 @@ import { KiloGatewayApi, KiloGatewayPaths } from "../../../src/kilocode/server/h
 import { kiloGatewayHandlers } from "../../../src/kilocode/server/httpapi/handlers/kilo-gateway"
 import { InstanceStore } from "../../../src/project/instance-store"
 import { ModelCache } from "../../../src/provider/model-cache"
+import { Provider } from "../../../src/provider/provider"
 import { Session } from "../../../src/session/session"
 import { Storage } from "../../../src/storage/storage"
 import { Authorization } from "../../../src/server/routes/instance/httpapi/middleware/authorization"
@@ -24,6 +25,38 @@ import { testEffect } from "../../lib/effect"
 const TestHttpApi = HttpApi.make("opencode-instance").addHttpApi(KiloGatewayApi)
 const auth = Layer.mock(Auth.Service)({
   get: () => Effect.succeed(new Auth.Api({ type: "api", key: "test-token" })),
+})
+const local = {
+  id: "lmstudio",
+  name: "LM Studio",
+  source: "config",
+  env: [],
+  key: "test-token",
+  options: {
+    baseURL: "https://lmstudio.test/v1",
+    headers: { "x-test-header": "configured" },
+  },
+  models: {
+    "qwen2.5-coder-1.5b": {
+      id: "qwen2.5-coder-1.5b",
+      providerID: "lmstudio",
+      api: {
+        id: "qwen2.5-coder-1.5b-fim",
+        npm: "@ai-sdk/openai-compatible",
+        url: "",
+      },
+      name: "Qwen2.5 Coder 1.5B",
+      headers: { "x-model-header": "configured" },
+    },
+  },
+} as unknown as Provider.Info
+const providers = Layer.mock(Provider.Service, {
+  getProvider: (id) => Effect.succeed(id === "lmstudio" ? local : (undefined as unknown as Provider.Info)),
+  getModel: (pid, mid) => {
+    const model = pid === "lmstudio" ? local.models[mid] : undefined
+    if (model) return Effect.succeed(model)
+    return Effect.fail(new Provider.ModelNotFoundError({ providerID: pid, modelID: mid }))
+  },
 })
 const store = Layer.mock(InstanceStore.Service)({})
 const cache = Layer.mock(ModelCache.Service)({})
@@ -52,6 +85,7 @@ const layer = HttpRouter.serve(
       passthroughInstanceContext,
       testWorkspaceRouting,
       auth,
+      providers,
       store,
       cache,
       session,
@@ -64,7 +98,7 @@ const layer = HttpRouter.serve(
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 const it = testEffect(layer)
 
-function stub(run: () => Response | Promise<Response>) {
+function stub(run: (input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>) {
   // These tests run sequentially; scope the process-global override and delegate in-process server traffic.
   const original = globalThis.fetch
   const fetch: typeof globalThis.fetch = Object.assign(
@@ -74,7 +108,7 @@ function stub(run: () => Response | Promise<Response>) {
       if (url.startsWith("http://127.0.0.1:") && headers.get("authorization") !== "Bearer test-token") {
         return original(input, init)
       }
-      return run()
+      return run(input, init)
     },
     { preconnect: original.preconnect },
   )
@@ -102,6 +136,57 @@ describe("Kilo gateway HttpApi statuses", () => {
 
       expect(response.status).toBe(200)
       expect(yield* response.json).toEqual({ authenticated: true, type: "api" })
+    }),
+  )
+
+  it.live("routes configured autocomplete through OpenAI-compatible completions", () =>
+    Effect.gen(function* () {
+      let upstream: Request | undefined
+      yield* stub((input, init) => {
+        upstream = new Request(input, init)
+        return new Response('data: {"choices":[]}\n\n', {
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      })
+
+      const response = yield* post(KiloGatewayPaths.fim, {
+        prefix: "function add(a, b) { return ",
+        suffix: "; }\n",
+        provider: "lmstudio",
+        model: "qwen2.5-coder-1.5b",
+        maxTokens: 64,
+        temperature: 0,
+        sessionId: "stable-file-session",
+      })
+
+      expect(response.status).toBe(200)
+      expect(upstream).toBeDefined()
+      expect(upstream?.url).toBe("https://lmstudio.test/v1/completions")
+      expect(upstream?.headers.get("authorization")).toBe("Bearer test-token")
+      expect(upstream?.headers.get("x-kilo-autocomplete-session-id")).toBe("stable-file-session")
+      expect(upstream?.headers.get("x-test-header")).toBe("configured")
+      expect(upstream?.headers.get("x-model-header")).toBe("configured")
+      const body = yield* Effect.promise(() => upstream!.json() as Promise<Record<string, unknown>>)
+      expect(body.model).toBe("qwen2.5-coder-1.5b-fim")
+      expect(body.max_tokens).toBe(64)
+      expect(body.prompt).toBe("function add(a, b) { return ")
+      expect(body.suffix).toBe("; }\n")
+      expect(body.stream).toBe(true)
+    }),
+  )
+
+  it.live("rejects an unknown configured autocomplete model without falling back to Kilo", () =>
+    Effect.gen(function* () {
+      yield* stub(() => Promise.reject(new Error("unexpected upstream request")))
+
+      const response = yield* post(KiloGatewayPaths.fim, {
+        prefix: "const value = ",
+        suffix: "\n",
+        provider: "lmstudio",
+        model: "missing-model",
+      })
+
+      expect(response.status).toBe(400)
     }),
   )
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -7049,6 +7049,7 @@ export class Kilo extends HeyApiClient {
       model?: string
       maxTokens?: number
       temperature?: number
+      sessionId?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7065,6 +7066,7 @@ export class Kilo extends HeyApiClient {
             { in: "body", key: "model" },
             { in: "body", key: "maxTokens" },
             { in: "body", key: "temperature" },
+            { in: "body", key: "sessionId" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -11982,6 +11982,7 @@ export type KiloFimData = {
     model?: string
     maxTokens?: number
     temperature?: number
+    sessionId?: string
   }
   path?: never
   query?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -13446,6 +13446,9 @@
                   },
                   "temperature": {
                     "type": "number"
+                  },
+                  "sessionId": {
+                    "type": "string"
                   }
                 },
                 "required": ["prefix", "suffix"],


### PR DESCRIPTION
## Issue

Related to #4498.

## Context

Adds inline autocomplete using configured BYOK completion models.

The selected endpoint and model must support fill-in-the-middle code completion; ordinary chat models are not expected to produce useful inline insertions. The Models settings row now states this directly: the autocomplete model description reads "Select a fill-in-the-middle (FIM) model. Chat-only models are not supported." (localized in all 20 locales, rendered visibly and via `aria-describedby`). Local validation has covered standard OpenAI-compatible completion endpoints, including:

- `mlx-community/Qwen2.5-Coder-1.5B-4bit` served through OMLX
- `mlx-community/Qwen2.5-Coder-3B-4bit` served through OMLX

The walkthrough below uses Ollama because its OpenAI-compatible API explicitly supports `/v1/completions`, streaming, and `suffix`. Other servers must pass the same protocol probe; llama.cpp's documented `/infill` endpoint is not called directly by this implementation.

### Qwen3-Coder-Next verification (negative result)

Verified against a hosted endpoint (OpenRouter `qwen/qwen3-coder-next`, instruct checkpoint) on 2026-07-15. It does not work with this implementation's `prompt`+`suffix` transport:

- **Kilo's exact request shape** — `POST /v1/completions` with `prompt`, `suffix`, `stream` — returns HTTP 200, but the `suffix` is ignored and the request is routed through the chat template. Output is conversational prose ("It looks like your function definition is incomplete. Here's the corrected version: ...") instead of an insertable completion.
- **ChatML with explicit Qwen FIM markers** (`<|fim_prefix|>…<|fim_suffix|>…<|fim_middle|>` in a user message) produces the correct middle content, but always wrapped in Markdown code fences (e.g. ` ```python\na + b\n``` `), even with a system prompt forbidding fences. This transport neither sends markers nor strips fences.
- **Latency is not the blocker**: warm chat-path completions took 0.32–0.53 s; the output format is.
- **Self-hosted stacks don't bridge the gap**: vLLM rejects `suffix`, OMLX v0.5.1 has no `suffix` field on `/v1/completions`. SGLang can map `prompt`+`suffix` via `--completion-template qwen_coder`, but only for the separate Base checkpoint (~42 GiB at 4-bit), which was not downloaded or tested due to disk constraints on the validation machine.

Reproduce the two probes:

```bash
# 1. Kilo's request shape — expect chat prose, not an insertion
curl -sS https://openrouter.ai/api/v1/completions \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "qwen/qwen3-coder-next",
    "prompt": "def add(a, b):\n    return ",
    "suffix": "\n\nprint(add(2, 3))\n",
    "max_tokens": 64,
    "temperature": 0.2,
    "stream": false
  }'

# 2. Explicit FIM markers via chat — expect correct content, fenced in Markdown
curl -sS https://openrouter.ai/api/v1/chat/completions \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "qwen/qwen3-coder-next",
    "messages": [{"role": "user", "content": "<|fim_prefix|>def add(a, b):\n    return <|fim_suffix|>\n\nprint(add(2, 3))\n<|fim_middle|>"}],
    "max_tokens": 64,
    "temperature": 0.2
  }'
```

The docs page now records this under "Models that do not work", alongside the general symptom for chat-tuned models.

## Measured latency

On an Apple M3 Pro with 36 GB unified memory, Qwen2.5-Coder 1.5B 4-bit through OMLX measured 283 ms cached TTFT p50 / 346 ms p90 and 284 ms complete p50 / 399 ms p90 at a 3,968-token code prompt. The server reused 3,840 prompt tokens, and 15/15 incremental edits were correct after trimming. Cold latency was about 2.3 s, so stable per-document cache identity is central to the design. These measurements exclude editor debounce; see the maintainer-response comment and the autocomplete docs for conditions and caveats.

## Implementation

- Show models from Kilo's normal connected-provider registry in the autocomplete selector.
- Resolve configured provider URLs, credentials, headers, and model aliases through the existing provider service.
- Send standard OpenAI-compatible text-completion requests with `prompt` and `suffix` to `/completions`.
- Allow keyless loopback servers while retaining authentication for remote endpoints.
- Fail closed when an explicitly selected provider or model is unavailable.
- Keep a stable, opaque per-model/per-file session identifier for cache-aware servers.
- Warn in the Models settings that only FIM models are supported, visibly and through the selector's `aria-describedby`, across all 20 locales.
- Show a warning card under the autocomplete model setting whenever the selection resolves to a configured-provider (BYOK) model rather than a curated entry: "Unverified autocomplete model: Kilo Code has not tested this model for autocomplete. It must support fill-in-the-middle (FIM) through its provider's completions endpoint. If suggestions appear as prose or fenced Markdown, the model is responding as chat. Switch to a FIM-capable model." The card uses the standard `kilo-ui` warning Card, is announced via `role="alert"`, is localized in all 20 locales, and never appears for curated Codestral/Mercury selections or the unset default. This addresses the warning-hint requests in #4498.
- Document provider setup, endpoint validation, model selection, known-incompatible models, and an editor smoke test.

## Screenshots / Video

N/A — the custom-model warning reuses the existing `kilo-ui` warning-card treatment already used by the Anaconda provider. Its conditional rendering, curated-model exclusions, accessible description, and `role=\"alert\"` behavior are covered by focused UI tests.

## How to Try It

1. Pull a FIM base model and start Ollama if it is not already running:

```bash
ollama pull qwen2.5-coder:1.5b-base
ollama serve
```

2. Confirm the model ID, then probe non-streaming FIM directly:

```bash
curl --silent --show-error http://127.0.0.1:11434/v1/models

curl --silent --show-error \
  http://127.0.0.1:11434/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "qwen2.5-coder:1.5b-base",
    "prompt": "function add(a, b) {\n  return ",
    "suffix": "\n}\n",
    "max_tokens": 32,
    "temperature": 0,
    "stream": false
  }'
```

`choices[0].text` should contain only the insertion, such as `a + b`. Repeat with `"stream": true` to exercise the path Kilo uses.

3. Register the same endpoint through the normal provider configuration:

```jsonc
{
  "$schema": "https://app.kilo.ai/config.json",
  "provider": {
    "ollama": {
      "npm": "@ai-sdk/openai-compatible",
      "name": "Ollama",
      "options": {
        "baseURL": "http://127.0.0.1:11434/v1"
      },
      "models": {
        "qwen2.5-coder:1.5b-base": {
          "name": "Qwen2.5 Coder 1.5B Base",
          "limit": { "context": 32768, "output": 256 }
        }
      }
    }
  }
}
```

For remote providers, put `"apiKey": "{env:MY_PROVIDER_API_KEY}"` under `options`, use HTTPS, and ensure the variable is visible to the VS Code process.

4. Run **Developer: Reload Window**, open **Kilo Code Settings → Models → Autocomplete model**, and choose the configured model. The description under the setting states the FIM requirement; the selector lists all connected models, and compatibility is established by the probe above, not by appearing in the picker.
5. Disable competing inline-completion extensions, put the cursor after `return ` in the example above, and type to trigger ghost text. For a manual request, enable `kilo-code.new.autocomplete.enableSmartInlineTaskKeybinding` and press `Cmd+L`/`Ctrl+L`. Press `Tab` to accept the suggestion.

LM Studio and other OpenAI-compatible servers can use the same configuration after their exact `/v1/models` ID passes the probe. llama.cpp requires an adapter or version that maps this request to its documented `/infill` API.

## How to Test

Added coverage for arbitrary configured provider/model resolution, OpenAI-compatible FIM payloads, endpoint construction, model aliases, custom headers, stable session identifiers, dynamic model selection, and fail-closed routing.

`packages/kilo-vscode/tests/unit/autocomplete-fim-hint.test.ts` guards the FIM-only hint text in English, the `FIM` token in every locale, the visible Models-row usage, and the `aria-describedby` wiring in the model selector.

New in this revision: `packages/kilo-vscode/tests/unit/autocomplete-custom-model-warning.test.ts` guards the custom-model detection (curated Kilo Gateway and direct Mistral/Inception entries are never flagged; configured-provider pairs are), the English warning copy, the presence of both warning keys with the `FIM` token in every locale, and the conditional `role="alert"` warning card rendering in the Models tab.

Verification completed locally:

```bash
bun turbo typecheck
bun run --cwd packages/kilo-gateway build
bun run --cwd packages/kilo-vscode compile
bun run --cwd packages/kilo-vscode lint
bun run --cwd packages/kilo-vscode knip
bun run --cwd packages/kilo-docs typecheck
bunx changeset status
```

For the FIM hint and custom-model warning revisions:

```bash
cd packages/kilo-vscode
bun test tests/unit/autocomplete-custom-model-warning.test.ts tests/unit/autocomplete-fim-hint.test.ts \
  tests/unit/i18n-keys.test.ts tests/unit/autocomplete-model-selector.test.ts \
  tests/unit/autocomplete-fim-session.test.ts tests/unit/autocomplete-settings-message.test.ts \
  tests/unit/autocomplete-models-sync.test.ts  # 34 pass
bun run typecheck
cd ../kilo-gateway
bun test test/fim.test.ts test/autocomplete.test.ts  # 10 pass
```

The CLI binary build smoke tests and a direct executable smoke check of configured model resolution and the generated `prompt`/`suffix` request also pass.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the final diff and can explain the changes, including any AI-assisted work.