### PR TITLE
fix(docs): exclude t.me links from lychee link checker

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -61,6 +61,8 @@ exclude = [
   '^https?://zod\.dev/v4/changelog',
   # Example punycode domain used in homograph attack documentation — does not exist
   '^https?://xn--pitest',
-  # OpenAI docs return 404 to plain GET link checks but resolve in browsers
-  '^https?://platform\.openai\.com/docs/api-reference/responses/create',
+   # OpenAI docs return 404 to plain GET link checks but resolve in browsers
+   '^https?://platform\.openai\.com/docs/api-reference/responses/create',
+   # Telegram deep links reject automated requests from CI runners with connection failures
+   '^https?://t\.me/',
 ]


### PR DESCRIPTION
## Problem

The docs link checker CI job (`Check Links` / `docs-check-links.yml`) is failing on `packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md` because the two `t.me` deep links in that page (`https://t.me/BotFather` and `https://t.me/userinfobot`) return connection failures when probed from GitHub Actions runners.

Telegram's servers reject automated HTTP requests from CI runners, so the link checker can never reach them. The links themselves are valid and work for users clicking them in the docs.

## Fix

Add `'^https?://t\.me/'` to the `exclude` list in `packages/kilo-docs/lychee.toml`, following the existing convention of excluding legitimate-but-uncheckable URLs (GitHub URLs, login-redirecting domains, POST-only API endpoints, etc.).