### PR TITLE
fix: move FILE_PICKER_RESULT to end of @-mention results to prevent default selection

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
@@ -62,8 +62,8 @@ export function buildMentionResults(query: string, items: Array<FileSearchItem |
   return [
     ...getTerminalMentionResult(query),
     ...(git ? getGitChangesMentionResult(query) : []),
-    FILE_PICKER_RESULT,
     ...results,
+    FILE_PICKER_RESULT,
   ]
 }
 


### PR DESCRIPTION
## Description
Fixes #12182

The 'Browse files...' option was always placed at the top of @-mention dropdown results, making it the default selection. Pressing Enter would open the file picker instead of selecting the closest matching file.

## Fix
Moved FILE_PICKER_RESULT from the beginning of the mention results array to the end, so that actual file matches appear first and are selected by default.

## Changes
- packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts - Reordered the uildMentionResults return array to place FILE_PICKER_RESULT after actual file results.