### PR TITLE
fix(vscode): remember initial prompts in history

### DIFF
--- a/.changeset/remember-initial-prompts.md
+++ b/.changeset/remember-initial-prompts.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember initial session prompts when navigating chat input history with the arrow keys.

--- a/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
@@ -310,6 +310,20 @@ describe("PromptInput send origin contract", () => {
     expect(source).toMatch(/session\.sendMessage\([\s\S]*origin \?\? null\)/)
     expect(source).toMatch(/session\.sendCommand\([\s\S]*origin \?\? null\)/)
   })
+
+  it("records sent prompts before a pending session key change can return", () => {
+    const start = source.indexOf("const handleSend = async () =>")
+    const end = source.indexOf("\n  return (", start)
+    const body = source.slice(start, end)
+    const send = Math.max(body.indexOf("session.sendMessage("), body.indexOf("session.sendCommand("))
+    const append = body.lastIndexOf("history.append(draft)")
+    const guard = body.indexOf("if (draftKey() !== key) return")
+
+    expect(send).toBeGreaterThan(-1)
+    expect(append).toBeGreaterThan(send)
+    expect(append).toBeLessThan(guard)
+    expect(body.indexOf('setText("")', guard)).toBeGreaterThan(guard)
+  })
 })
 
 describe("SessionContext userClearedSession contract", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1119,9 +1119,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     reviewDrafts.delete(key)
     imageDrafts.delete(key)
     scrollDrafts.delete(key)
+    history.append(draft)
     if (draftKey() !== key) return
 
-    history.append(draft)
     history.reset()
     setText("")
     clearReviewComments()


### PR DESCRIPTION
## What changed
Record a dispatched prompt in chat history before the pending draft is promoted to a real session key.

## Why
The initial prompt could be sent successfully while session creation changed the active draft key. The cleanup guard then returned before recording that prompt, so ArrowUp only recalled later prompts from the established session.

The existing guard remains around visible draft cleanup, preventing an asynchronous send from clearing another tab's input.