### PR TITLE
fix(vscode): correct cache token indicator

### DIFF
--- a/.changeset/fix-cache-token-arrow.md
+++ b/.changeset/fix-cache-token-arrow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Correct the token usage summary's cache-read indicator and group cached input with other input tokens.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-usage-collapsed-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-usage-collapsed-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e7e2a799380f0977f0328b287eced902293dc7f8eb365abcab7e3b17c30a1e2e
-size 2875
+oid sha256:0acc4a76a402ed79191953110f06303a37617cb7eabc7645f09a8b39c7602f5f
+size 2779

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
@@ -50,16 +50,16 @@ export const TaskUsage: Component<TaskUsageProps> = (props) => {
           {number(props.tokens.input)}
         </span>
       </Show>
+      <Show when={props.tokens.cached > 0}>
+        <span class="task-header-tokens-value">
+          <Icon name="arrow-up" size="small" />
+          cache {number(props.tokens.cached)}
+        </span>
+      </Show>
       <Show when={props.tokens.output > 0}>
         <span class="task-header-tokens-value">
           <Icon name="arrow-down-to-line" size="small" />
           {number(props.tokens.output)}
-        </span>
-      </Show>
-      <Show when={props.tokens.cached > 0}>
-        <span class="task-header-tokens-value">
-          <Icon name="arrow-down-to-line" size="small" />
-          cache {number(props.tokens.cached)}
         </span>
       </Show>
     </>


### PR DESCRIPTION
Supersedes #12170 by @mjnaderi. Full credit to Mohammad Javad Naderi for the original work; the feature commit was cherry-picked with original authorship preserved.

The original PR came from a fork, so the Visual Regression workflow could not auto-commit the updated screenshot baselines. This org-owned branch lets CI regenerate them.

## Context

Cached tokens are cache-read prompt tokens, so they belong to the input side of token usage. The summary previously showed them with the output/down-arrow icon and placed them after output, which made the token flow misleading.

## Implementation

The compact token summary now renders cache reads with the input/up-arrow icon and orders the values as fresh input, cached input, then generated output. A patch changeset is included because this corrects user-visible token usage information.