### PR TITLE
fix(agent-manager): preserve local HEAD when moving session to worktree

### DIFF
--- a/.changeset/preserve-moved-worktree-head.md
+++ b/.changeset/preserve-moved-worktree-head.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve the current local commit when moving a session into a worktree.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -146,6 +146,7 @@ export class WorktreeManager {
     prompt?: string
     existingBranch?: string
     baseBranch?: string
+    baseRef?: string
     branchName?: string
     onProgress?: (step: WorktreeProgressStep, message: string, detail?: string) => void
   }): Promise<CreateWorktreeResult> {
@@ -195,6 +196,7 @@ export class WorktreeManager {
     prompt?: string
     existingBranch?: string
     baseBranch?: string
+    baseRef?: string
     branchName?: string
     onProgress?: (step: WorktreeProgressStep, message: string, detail?: string) => void
   }): Promise<CreateWorktreeResult> {
@@ -243,6 +245,9 @@ export class WorktreeManager {
       startPoint = await this.resolveStartPoint(requestedBase, params.onProgress, {
         allowFallback: !params.baseBranch, // Only fallback if user didn't explicitly request a specific base
       })
+      if (params.baseRef && !(await this.refExistsLocally(params.baseRef))) {
+        throw new Error(`Could not resolve start point for ref "${params.baseRef}"`)
+      }
       parent = startPoint.branch
       parentRemote = startPoint.remote
     }
@@ -256,7 +261,7 @@ export class WorktreeManager {
     params.onProgress?.("creating", `Creating worktree for ${branch}...`)
 
     // Dereference to commit SHA to prevent upstream tracking for new branches
-    const startRef = params.existingBranch ? undefined : `${startPoint.ref}^{commit}`
+    const startRef = params.existingBranch ? undefined : `${params.baseRef ?? startPoint.ref}^{commit}`
 
     try {
       const args = params.existingBranch

--- a/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
+++ b/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
@@ -9,7 +9,7 @@ import { recordForkHandoff } from "./fork-handoff"
 export interface ContinueContext {
   root: string
   getClient: () => KiloClient
-  createWorktreeOnDisk: (opts: { baseBranch: string }) => Promise<{
+  createWorktreeOnDisk: (opts: { baseBranch: string; baseRef: string }) => Promise<{
     worktree: { id: string }
     result: CreateWorktreeResult
   } | null>
@@ -53,8 +53,9 @@ export async function captureState(ctx: ContinueContext): Promise<StepResult<Git
 export async function prepareWorktree(
   ctx: ContinueContext,
   branch: string,
+  head: string,
 ): Promise<StepResult<{ worktreeId: string; result: CreateWorktreeResult }>> {
-  const created = await ctx.createWorktreeOnDisk({ baseBranch: branch })
+  const created = await ctx.createWorktreeOnDisk({ baseBranch: branch, baseRef: head })
   if (!created) return { ok: false, error: "Failed to create worktree" }
   await ctx.runSetupScript(created.result.path, created.result.branch, created.worktree.id)
   return { ok: true, value: { worktreeId: created.worktree.id, result: created.result } }
@@ -150,7 +151,7 @@ export async function continueInWorktree(
   if (!captured.ok) return progress("error", undefined, captured.error)
 
   progress("creating", "Creating worktree...")
-  const prepared = await prepareWorktree(ctx, captured.value.branch)
+  const prepared = await prepareWorktree(ctx, captured.value.branch, captured.value.head)
   if (!prepared.ok) return progress("error", undefined, prepared.error)
 
   progress("transferring", "Transferring changes...")

--- a/packages/kilo-vscode/src/agent-manager/worktree-create.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-create.ts
@@ -8,6 +8,7 @@ import type { AgentManagerOutMessage } from "./types"
 export type CreateWorktreeOnDiskOptions = {
   groupId?: string
   baseBranch?: string
+  baseRef?: string
   branchName?: string
   existingBranch?: string
   name?: string
@@ -61,6 +62,7 @@ export async function createWorktreeOnDisk(
     result = await manager.createWorktree({
       prompt: opts?.name || "kilo",
       baseBranch: effectiveBase ?? opts?.baseBranch,
+      baseRef: opts?.baseRef,
       branchName: opts?.branchName,
       existingBranch: opts?.existingBranch,
     })

--- a/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
+++ b/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
@@ -35,6 +35,16 @@ async function repo(): Promise<string> {
   return dir
 }
 
+async function addOrigin(root: string): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "continue-worktree-origin-"))
+  dirs.push(dir)
+  const remote = path.join(dir, "origin.git")
+  await simpleGit().clone(root, remote, ["--bare"])
+  const git = simpleGit(root)
+  await git.addRemote("origin", remote)
+  await git.fetch("origin")
+}
+
 function client(fork = mock(async () => ({ data: session("forked") }))) {
   return {
     session: {
@@ -189,6 +199,38 @@ describe("continue-in-worktree steps", () => {
 })
 
 describe("continueInWorktree", () => {
+  it("starts from the captured local commit instead of the remote branch", async () => {
+    const root = await repo()
+    await addOrigin(root)
+    const git = simpleGit(root)
+    await fs.writeFile(path.join(root, "state.txt"), "local commit\n")
+    await git.add("state.txt")
+    await git.commit("local commit")
+    const head = await git.revparse(["HEAD"])
+    await fs.writeFile(path.join(root, "state.txt"), "local dirty\n")
+
+    const manager = new WorktreeManager(root, noop)
+    const api = client()
+    const progress: Array<{ status: string; error?: string }> = []
+    let created: CreateWorktreeResult | undefined
+    const c = ctx({
+      root,
+      getClient: () => api,
+      createWorktreeOnDisk: async (opts) => {
+        const value = await manager.createWorktree(opts)
+        created = value
+        return { worktree: { id: "wt-1" }, result: value }
+      },
+    })
+
+    await continueInWorktree(c, "source", (status, _detail, error) => progress.push({ status, error }))
+
+    expect(progress.at(-1)?.status).toBe("done")
+    expect(created).toBeDefined()
+    expect(await fs.readFile(path.join(created!.path, "state.txt"), "utf8")).toBe("local dirty\n")
+    expect(await simpleGit(created!.path).revparse(["HEAD"])).toBe(head)
+  })
+
   it("rolls back the created worktree when Git transfer fails", async () => {
     const root = await repo()
     const git = simpleGit(root)


### PR DESCRIPTION
## Problem

"Move to Worktree" captured the source repository HEAD but never used it. The destination worktree was created from `origin/<branch>` via `resolveStartPoint`, which fetches and prefers the remote tracking ref. When the source branch had unpushed local commits, the worktree started from an older commit than the one the captured patch was generated against. Applying the patch then failed (`Staged patch failed` / `Unstaged patch failed`), the move rolled back, and the freshly created worktree was deleted via the `.kilo-delete-*` rename-and-prune path, producing a large file-watcher burst under the watched repository root.

This is the most likely cause of the recurring "Move to Worktree keeps failing" report on extension 7.4.5, where the only visible artifact in the console log was a `.kilo/worktrees/.kilo-delete-<uuid>/script` path amid 24,671 file-watcher events and no explicit Agent Manager error.

## Fix

Create the destination worktree from the captured local commit SHA (`baseRef`) so the patch always applies against the same base it was generated from. Remote branch metadata (`parentBranch` / `remote`) is still resolved normally for later diff comparisons. The change is scoped to the move flow; normal worktree creation is unaffected when `baseRef` is absent.

## Changes

- `WorktreeManager.createWorktree` accepts an optional `baseRef` (a commit SHA) and dereferences it for `git worktree add` when present.
- `createWorktreeOnDisk` passes `baseRef` through to the manager.
- `continueInWorktree` threads the captured `head` into `prepareWorktree`, which supplies it as `baseRef`.
- Regression test using real Git repositories: a local commit ahead of `origin/main` plus an uncommitted edit, asserting the worktree lands on the captured commit with the dirty change applied and status `done`.

## Risk

Low. `baseRef` is optional and only set by the move flow. The existing rollback test still passes, and the 98-test worktree suite is green.