### PR TITLE
fix(jetbrains): scale session UI with IDE zoom

### DIFF
--- a/.changeset/jetbrains-ide-zoom.md
+++ b/.changeset/jetbrains-ide-zoom.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Scale the Kilo session UI with IntelliJ IDE zoom and presentation mode.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/ConnectionPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/ConnectionPanel.kt
@@ -23,7 +23,6 @@ import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import java.awt.BorderLayout
@@ -274,7 +273,9 @@ class ConnectionPanel(
     override fun getPreferredSize(): Dimension {
         val size = super.getPreferredSize()
         if (!scroll.isVisible) return size
-        return JBDimension(size.width, header.preferredSize.height + scrollHeight())
+        // header/scroll heights are already scaled px; assign with plain Dimension so IDE
+        // zoom does not scale them a second time via the user scale factor.
+        return Dimension(size.width, header.preferredSize.height + scrollHeight())
     }
 
     private fun scrollHeight(): Int {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionLayout.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionLayout.kt
@@ -21,8 +21,8 @@ import java.awt.LayoutManager
  * 1. Uses the parent's *actual* width as the available width for all children.
  * 2. Calls `setSize(w, …)` on each child before reading `preferredSize.height`
  *    so that HTML components reflow and report the correct height.
- * 3. Applies layout-owned [pad] around the children.
- * 4. Stacks children top-to-bottom with a configurable [gap].
+ * 3. Applies layout-owned padding around the children.
+ * 4. Stacks children top-to-bottom with a configurable gap.
  * 5. Skips invisible children.
  *
  * Pair with [SessionLayoutPanel] (or any panel that implements [Scrollable]
@@ -30,8 +30,8 @@ import java.awt.LayoutManager
  * the panel width and the layout always has a valid width to work with.
  */
 class SessionLayout(
-    private val gap: Int = JBUI.scale(SessionUiStyle.SessionLayout.GAP),
-    private val pad: Insets = JBUI.emptyInsets(),
+    private val baseGap: Int = SessionUiStyle.SessionLayout.GAP,
+    private val basePad: Insets = JBUI.emptyInsets(),
 ) : LayoutManager {
 
     override fun addLayoutComponent(name: String, comp: Component) = Unit
@@ -86,16 +86,16 @@ class SessionLayout(
     private fun insets(parent: Container): Insets {
         val base = parent.insets
         return Insets(
-            base.top + pad.top,
-            base.left + pad.left,
-            base.bottom + pad.bottom,
-            base.right + pad.right,
+            base.top + JBUI.scale(basePad.top),
+            base.left + JBUI.scale(basePad.left),
+            base.bottom + JBUI.scale(basePad.bottom),
+            base.right + JBUI.scale(basePad.right),
         )
     }
 
     private fun gap(comp: Component): Int {
         if (view(comp)?.sessionGapKind == SessionView.Kind.UserPrompt) return JBUI.scale(SessionUiStyle.SessionLayout.USER_PROMPT_GAP)
-        return gap
+        return JBUI.scale(baseGap)
     }
 
     private fun view(comp: Component): SessionView? = comp as? SessionView
@@ -111,7 +111,7 @@ class SessionLayout(
  * [SessionLayout] a valid width to measure against.
  */
 open class SessionLayoutPanel(
-    gap: Int = JBUI.scale(SessionUiStyle.SessionLayout.GAP),
+    gap: Int = SessionUiStyle.SessionLayout.GAP,
     pad: Insets = JBUI.emptyInsets(),
 ) : BorderLayoutPanel(), javax.swing.Scrollable {
     init {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionLayout.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionLayout.kt
@@ -1,7 +1,6 @@
 package ai.kilocode.client.session.ui
 
 import ai.kilocode.client.session.ui.style.SessionUiStyle
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import java.awt.Component
@@ -51,7 +50,10 @@ class SessionLayout(
             comp.setSize(child.width, comp.height.coerceAtLeast(1))
             h += comp.preferredSize.height
         }
-        return JBDimension(w + ins.left + ins.right, h)
+        // w and h are already scaled px (child preferred heights + scaled gaps/insets) and
+        // match what layoutContainer stacks, so return a plain Dimension. A JBDimension would
+        // scale again by the user scale factor and inflate the transcript height under IDE zoom.
+        return Dimension(w + ins.left + ins.right, h)
     }
 
     override fun minimumLayoutSize(parent: Container): Dimension = preferredLayoutSize(parent)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionMessageListPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/SessionMessageListPanel.kt
@@ -18,7 +18,7 @@ import ai.kilocode.client.session.views.TurnView
 import ai.kilocode.client.session.views.base.PartView
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
-import com.intellij.util.ui.JBUI
+import java.awt.Insets
 import javax.swing.JComponent
 
 /**
@@ -62,12 +62,12 @@ class SessionMessageListPanel(
     private val cancelRevert: (() -> Unit)? = null,
     private val banner: RevertBanner? = null,
 ) : SessionLayoutPanel(
-    JBUI.scale(SessionUiStyle.SessionLayout.GAP),
-    JBUI.insets(
-        SessionUiStyle.SessionLayout.InnerInsets.top,
-        SessionUiStyle.SessionLayout.InnerInsets.left,
-        SessionUiStyle.SessionLayout.InnerInsets.bottom,
-        SessionUiStyle.SessionLayout.InnerInsets.right + SessionUiStyle.SessionLayout.TRANSCRIPT_SCROLLBAR_PADDING,
+    SessionUiStyle.SessionLayout.GAP,
+    Insets(
+        SessionUiStyle.SessionLayout.INNER_TOP,
+        SessionUiStyle.SessionLayout.INNER_HORIZONTAL,
+        SessionUiStyle.SessionLayout.INNER_BOTTOM,
+        SessionUiStyle.SessionLayout.INNER_HORIZONTAL,
     ),
 ), Disposable, SessionEditorStyleTarget {
 

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
@@ -78,6 +78,7 @@ import java.awt.BasicStroke
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Cursor
+import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.RenderingHints
@@ -313,6 +314,12 @@ class PromptPanel(
         syncBorder()
     }
 
+    override fun getPreferredSize(): Dimension = promptSize(super.getPreferredSize())
+
+    override fun getMinimumSize(): Dimension = promptSize(super.getMinimumSize())
+
+    override fun getMaximumSize(): Dimension = Dimension(super.getMaximumSize().width, preferredSize.height)
+
     private fun syncFocus(value: Boolean) {
         if (focused == value) {
             repaint()
@@ -333,6 +340,12 @@ class PromptPanel(
             },
             JBUI.Borders.empty(),
         )
+    }
+
+    private fun promptSize(size: Dimension): Dimension {
+        val chrome = (shell.preferredSize.height - editor.preferredSize.height).coerceAtLeast(0)
+        val ins = insets
+        return Dimension(size.width, editor.preferredSize.height + chrome + ins.top + ins.bottom)
     }
 
     override fun paintChildren(g: Graphics) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
@@ -916,7 +916,7 @@ class PromptPanel(
         val view = editor.getEditor(false)
         val line = view?.lineHeight ?: editor.getFontMetrics(editor.font).height
         val min = line * SessionUiStyle.View.Prompt.EDITOR_LINES + JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
-        val content = editor.preferredSize.height
+        val content = if (editor.text.isBlank()) min else editor.preferredSize.height
         val sessionCap = rootCap(min)
         val height = minOf(content, sessionCap ?: content).coerceAtLeast(min)
         syncEditorScroll(view, content > height)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/PromptPanel.kt
@@ -63,7 +63,6 @@ import com.intellij.ui.AnimatedIcon
 import com.intellij.ui.IslandsState
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.xml.util.XmlStringUtil
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.intellij.util.ui.components.BorderLayoutPanel
@@ -244,7 +243,7 @@ class PromptPanel(
         addActionListener { enhance() }
     }
     private val separator = object : JComponent() {
-        override fun getPreferredSize() = JBUI.size(1, JBUI.scale(16))
+        override fun getPreferredSize() = JBUI.size(1, 16)
         override fun getMinimumSize() = preferredSize
         override fun getMaximumSize() = preferredSize
     }.apply {
@@ -933,13 +932,15 @@ class PromptPanel(
         val sessionCap = rootCap(min)
         val height = minOf(content, sessionCap ?: content).coerceAtLeast(min)
         syncEditorScroll(view, content > height)
+        // height is already scaled px (from the editor lineHeight); assign with plain
+        // Dimension so IDE zoom does not scale it a second time via the user scale factor.
         if (before == height && lower == height) {
-            editor.preferredSize = JBDimension(0, height)
-            editor.minimumSize = JBDimension(0, height)
+            editor.preferredSize = Dimension(0, height)
+            editor.minimumSize = Dimension(0, height)
             return
         }
-        editor.preferredSize = JBDimension(0, height)
-        editor.minimumSize = JBDimension(0, height)
+        editor.preferredSize = Dimension(0, height)
+        editor.minimumSize = Dimension(0, height)
         revalidate()
         repaint()
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionEditorStyle.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionEditorStyle.kt
@@ -1,6 +1,7 @@
 package ai.kilocode.client.session.ui.style
 
 import ai.kilocode.client.ui.UiStyle
+import com.intellij.ide.ui.UISettingsUtils
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.ex.EditorEx
@@ -98,7 +99,11 @@ data class SessionEditorStyle(
         /** Builds a style snapshot from the current global editor color scheme. */
         fun current(): SessionEditorStyle {
             val scheme = EditorColorsManager.getInstance().globalScheme
-            return create(scheme, scheme.editorFontName, scheme.editorFontSize)
+            val size = UISettingsUtils.getInstance()
+                .scaleFontSize(scheme.editorFontSize.toFloat())
+                .roundToInt()
+                .coerceAtLeast(1)
+            return create(scheme, scheme.editorFontName, size)
         }
 
         internal fun create(

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
@@ -5,7 +5,6 @@ import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.Color
-import java.awt.Insets
 
 /** Static style tokens owned by the chat session UI. */
 object SessionUiStyle {
@@ -18,12 +17,13 @@ object SessionUiStyle {
         const val GAP = 3
         const val USER_PROMPT_GAP = 10
         const val TRANSCRIPT_SCROLLBAR_PADDING = 10
-        val InnerInsets = Insets(
-            UiStyle.Gap.md(),
-            UiStyle.Gap.sm() + TRANSCRIPT_SCROLLBAR_PADDING,
-            UiStyle.Gap.sm(),
-            UiStyle.Gap.sm(),
-        )
+
+        // Unscaled base transcript insets. Base 6 == UiStyle.Gap.md, base 4 == UiStyle.Gap.sm.
+        // Left and right reserve scrollbar allowance to match the previous symmetric padding.
+        const val INNER_TOP = 6
+        const val INNER_BOTTOM = 4
+        const val INNER_HORIZONTAL = 4 + TRANSCRIPT_SCROLLBAR_PADDING
+
         const val USER_PROMPT_INDENT = 100
         const val SCROLL_INCREMENT = 48
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/style/SessionUiStyle.kt
@@ -69,7 +69,7 @@ object SessionUiStyle {
 
         /** Prompt input dimensions and chrome inside the session view. */
         object Prompt {
-            const val EDITOR_LINES = 3
+            const val EDITOR_LINES = 1
             const val EDITOR_CHROME = 16
             const val SEND_BUTTON_SIZE = 24
             const val CORNER_ARC = 6

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/CompactionView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/CompactionView.kt
@@ -43,7 +43,7 @@ class CompactionView(@Suppress("UNUSED_PARAMETER") compaction: Compaction) : Par
         val line = { JPanel().apply {
             background = SessionUiStyle.View.Outline.color()
             isOpaque = true
-            preferredSize = JBDimension(0, JBUI.scale(1))
+            preferredSize = JBDimension(0, 1)
         } }
 
         val row = JPanel(GridBagLayout()).apply {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/MessageView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/MessageView.kt
@@ -57,7 +57,7 @@ class MessageView(
     private val hover: ((PartView, Boolean) -> Unit)? = null,
     private val revert: ((String) -> Unit)? = null,
 ) : ai.kilocode.client.session.ui.SessionLayoutPanel(
-    JBUI.scale(SessionUiStyle.SessionLayout.GAP),
+    SessionUiStyle.SessionLayout.GAP,
 ), Disposable, SessionEditorStyleTarget, SessionView {
 
     val role: String get() = msg.info.role

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/TextView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/TextView.kt
@@ -57,12 +57,14 @@ open class TextView(
         add(md.component, BorderLayout.CENTER)
         add(placeholder, BorderLayout.SOUTH)
         if (text.content.isNotEmpty()) md.set(text.content.toString())
+        syncContent()
         syncToolbar()
     }
 
     override fun update(content: Content) {
         if (content !is Text) return
         md.set(content.content.toString())
+        syncContent()
         syncToolbar()
         refresh()
     }
@@ -70,6 +72,7 @@ open class TextView(
     override fun appendDelta(delta: String) {
         if (delta.isEmpty()) return
         md.append(delta)
+        syncContent()
         syncToolbar()
         refresh()
     }
@@ -126,6 +129,11 @@ open class TextView(
     protected fun refresh() {
         revalidate()
         repaint()
+    }
+
+    @RequiresEdt
+    private fun syncContent() {
+        md.component.isVisible = md.markdown().isNotBlank()
     }
 
     @RequiresEdt

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/TurnView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/TurnView.kt
@@ -13,7 +13,6 @@ import ai.kilocode.client.session.views.base.PartView
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.intellij.util.ui.JBUI
 import javax.swing.JComponent
 
 /**
@@ -36,7 +35,7 @@ class TurnView(
     private val repo: String? = null,
     private val hover: ((PartView, Boolean) -> Unit)? = null,
     private val revert: ((String) -> Unit)? = null,
-) : SessionLayoutPanel(JBUI.scale(SessionUiStyle.SessionLayout.GAP)), Disposable, SessionEditorStyleTarget, SessionView {
+) : SessionLayoutPanel(SessionUiStyle.SessionLayout.GAP), Disposable, SessionEditorStyleTarget, SessionView {
 
     private val messages = LinkedHashMap<String, MessageView>()
 

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/question/QuestionView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/question/QuestionView.kt
@@ -29,7 +29,6 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBRadioButton
 import com.intellij.ui.components.JBTextArea
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import java.awt.BorderLayout
@@ -576,8 +575,10 @@ class QuestionView(
         val cap = rootCap(min)
         val height = minOf(content, cap ?: content).coerceAtLeast(min)
         syncEditorScroll(editor, content > height)
-        ed.preferredSize = JBDimension(0, height)
-        ed.minimumSize = JBDimension(0, height)
+        // height is already scaled px (from the editor lineHeight); assign with plain
+        // Dimension so IDE zoom does not scale it again via the user scale factor.
+        ed.preferredSize = Dimension(0, height)
+        ed.minimumSize = Dimension(0, height)
     }
 
     @RequiresEdt

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/TaskToolView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/TaskToolView.kt
@@ -16,7 +16,6 @@ import com.intellij.openapi.actionSystem.UiDataProvider
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -307,7 +306,8 @@ private class TaskRows : Stack(StackAxis.VERTICAL, UiStyle.Gap.sm()), Scrollable
         direction: Int,
     ) = visibleRect.height
 
-    override fun getMaximumSize() = JBDimension(Int.MAX_VALUE, super.getMaximumSize().height)
+    // super height is already scaled px; a JBDimension would scale it again under IDE zoom.
+    override fun getMaximumSize() = Dimension(Int.MAX_VALUE, super.getMaximumSize().height)
 }
 
 private fun rowTitleColor(tool: Tool) = if (tool.state == ToolExecState.ERROR) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/ToolSupport.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/ToolSupport.kt
@@ -33,13 +33,13 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.intellij.util.ui.JBDimension
 import com.intellij.util.ui.JBUI
 import com.intellij.xml.util.XmlStringUtil
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Color
 import java.awt.Cursor
+import java.awt.Dimension
 import java.awt.Font
 import java.awt.Point
 import java.awt.event.MouseAdapter
@@ -189,17 +189,20 @@ class ToolBody private constructor(
 
     private fun size() {
         val view = scroll.viewport.view as? JComponent ?: return
+        // height/width are already scaled px (from editor lineHeight and font metrics),
+        // so assign with plain Dimension. Wrapping in JBUI.size/JBDimension would scale
+        // again by the user scale factor and double-scale under IDE zoom.
         val height = height(view)
         val width = width(view)
-        view.preferredSize = JBUI.size(width, height)
-        view.minimumSize = JBUI.size(0, height)
-        view.maximumSize = JBDimension(Int.MAX_VALUE, height)
+        view.preferredSize = Dimension(width, height)
+        view.minimumSize = Dimension(0, height)
+        view.maximumSize = Dimension(Int.MAX_VALUE, height)
         val inset = scroll.viewportBorder?.getBorderInsets(scroll) ?: JBUI.emptyInsets()
         val pane = height + scroll.insets.top + scroll.insets.bottom + inset.top + inset.bottom +
             scroll.horizontalScrollBar.preferredSize.height
-        scroll.preferredSize = JBUI.size(0, pane)
-        scroll.minimumSize = JBUI.size(0, pane)
-        scroll.maximumSize = JBDimension(Int.MAX_VALUE, pane)
+        scroll.preferredSize = Dimension(0, pane)
+        scroll.minimumSize = Dimension(0, pane)
+        scroll.maximumSize = Dimension(Int.MAX_VALUE, pane)
     }
 
     private fun width(view: JComponent): Int {
@@ -356,14 +359,14 @@ internal fun toolParts(
     }
     val slot = JPanel(CardLayout()).apply {
         isOpaque = false
-        minimumSize = JBUI.size(0, minimumSize.height)
+        minimumSize = Dimension(0, minimumSize.height)
         add(sub, SUB_CARD)
         add(link, LINK_CARD)
     }
     val state = clip(JBLabel()).apply { foreground = UiStyle.Colors.weak() }
     val center = JPanel(BorderLayout(UiStyle.Gap.md(), 0)).apply {
         isOpaque = false
-        minimumSize = JBUI.size(0, minimumSize.height)
+        minimumSize = Dimension(0, minimumSize.height)
     }
     val controls = Stack.horizontal()
     val header = JPanel(BorderLayout(JBUI.scale(SessionUiStyle.View.Layout.GAP), 0)).apply {
@@ -393,7 +396,7 @@ internal fun searchParts(count: Int): ToolParts {
     val link = clip(JBLabel()).apply { isVisible = false }
     val slot = JPanel(CardLayout()).apply {
         isOpaque = false
-        minimumSize = JBUI.size(0, minimumSize.height)
+        minimumSize = Dimension(0, minimumSize.height)
         add(sub, SUB_CARD)
         add(link, LINK_CARD)
     }
@@ -402,7 +405,7 @@ internal fun searchParts(count: Int): ToolParts {
     val target = stack.align(HAlign.TRACK, VAlign.CENTER)
     val center = JPanel(BorderLayout(UiStyle.Gap.md(), 0)).apply {
         isOpaque = false
-        minimumSize = JBUI.size(0, minimumSize.height)
+        minimumSize = Dimension(0, minimumSize.height)
         add(title, BorderLayout.WEST)
         add(target, BorderLayout.CENTER)
     }
@@ -472,7 +475,7 @@ internal fun setLinkText(parts: ToolParts, text: String): Boolean {
 }
 
 private fun clip(label: JBLabel): JBLabel = label.apply {
-    minimumSize = JBUI.size(0, minimumSize.height)
+    minimumSize = Dimension(0, minimumSize.height)
 }
 
 private fun html(text: String): String {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
@@ -302,6 +302,19 @@ class PromptPanelTest : BasePlatformTestCase() {
         assertEquals(min, editor.preferredSize.height)
     }
 
+    fun `test empty prompt panel stays compact at narrow width`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+
+        realize(panel, 80, 900)
+        UIUtil.dispatchAllInvocationEvents()
+        val chrome = (panel.shellForTest().preferredSize.height - editor.preferredSize.height).coerceAtLeast(0)
+        val ins = panel.insets
+
+        assertEquals(editor.preferredSize.height + chrome + ins.top + ins.bottom, panel.preferredSize.height)
+        assertTrue(panel.preferredSize.height < 180)
+    }
+
     fun `test prompt editor grows when single line wraps`() {
         val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
         val editor = panel.defaultFocusedComponent as EditorTextField

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
@@ -277,11 +277,24 @@ class PromptPanelTest : BasePlatformTestCase() {
         assertTrue(editor.preferredSize.height > min)
     }
 
-    fun `test prompt editor keeps three line minimum`() {
+    fun `test prompt editor keeps compact empty minimum`() {
         val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
         val editor = panel.defaultFocusedComponent as EditorTextField
 
         realize(panel, 260, 400)
+        val view = editor.getEditor(false)!!
+        val min = view.lineHeight * SessionUiStyle.View.Prompt.EDITOR_LINES +
+            JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
+
+        assertEquals(min, editor.preferredSize.height)
+    }
+
+    fun `test empty prompt ignores narrow placeholder preferred height`() {
+        val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+        val editor = panel.defaultFocusedComponent as EditorTextField
+
+        realize(panel, 80, 400)
+        UIUtil.dispatchAllInvocationEvents()
         val view = editor.getEditor(false)!!
         val min = view.lineHeight * SessionUiStyle.View.Prompt.EDITOR_LINES +
             JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/PromptPanelTest.kt
@@ -71,6 +71,7 @@ import com.intellij.ui.LanguageTextField
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.Producer
 import com.intellij.util.ui.EmptyIcon
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import kotlinx.coroutines.CompletableDeferred
@@ -300,6 +301,27 @@ class PromptPanelTest : BasePlatformTestCase() {
             JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
 
         assertEquals(min, editor.preferredSize.height)
+    }
+
+    fun `test empty prompt minimum ignores user scale factor`() {
+        // The empty-prompt minimum is line height (ide scale) plus scaled chrome. Under a
+        // raised user scale factor it must equal that computed minimum, not a doubled value.
+        val original = JBUIScale.scale(1f)
+        try {
+            JBUIScale.setUserScaleFactorForTest(2f)
+            val panel = PromptPanel(project = project, onSend = { _, _ -> }, onAbort = {}, onEnhance = { _, _ -> })
+            val editor = panel.defaultFocusedComponent as EditorTextField
+
+            realize(panel, 400, 400)
+            UIUtil.dispatchAllInvocationEvents()
+            val view = editor.getEditor(false)!!
+            val min = view.lineHeight * SessionUiStyle.View.Prompt.EDITOR_LINES +
+                JBUI.scale(SessionUiStyle.View.Prompt.EDITOR_CHROME)
+
+            assertEquals(min, editor.preferredSize.height)
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
     }
 
     fun `test empty prompt panel stays compact at narrow width`() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionEditorStyleTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionEditorStyleTest.kt
@@ -2,11 +2,14 @@ package ai.kilocode.client.session.ui
 
 import ai.kilocode.client.session.ui.style.SessionEditorStyle
 import ai.kilocode.client.ui.UiStyle
+import com.intellij.ide.ui.UISettings
+import com.intellij.ide.ui.UISettingsUtils
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.awt.Font
+import kotlin.math.roundToInt
 
 @Suppress("UnstableApiUsage")
 class SessionEditorStyleTest : BasePlatformTestCase() {
@@ -15,12 +18,36 @@ class SessionEditorStyleTest : BasePlatformTestCase() {
         val scheme = EditorColorsManager.getInstance().globalScheme
         val style = SessionEditorStyle.current()
         val font = style.transcriptFont
+        val size = UISettingsUtils.getInstance()
+            .scaleFontSize(scheme.editorFontSize.toFloat())
+            .roundToInt()
 
         assertEquals(UiStyle.Fonts.regular().name, font.name)
-        assertEquals(scheme.editorFontSize, font.size)
+        assertEquals(size, font.size)
         assertEquals(scheme.defaultForeground, style.editorForeground)
         assertEquals(scheme.defaultBackground, style.editorBackground)
         assertEquals(Font.PLAIN, font.style)
+    }
+
+    fun `test current scales editor size with ide scale`() {
+        val settings = UISettings.getInstance()
+        val original = settings.ideScale
+        try {
+            val base = EditorColorsManager.getInstance().globalScheme.editorFontSize
+            settings.ideScale = 1.5f
+            settings.fireUISettingsChanged()
+
+            val style = SessionEditorStyle.current()
+
+            assertTrue(
+                "transcript should grow with ide scale (base=$base, got=${style.transcriptFont.size})",
+                style.transcriptFont.size > base,
+            )
+            assertEquals(style.editorSize, style.transcriptFont.size)
+        } finally {
+            settings.ideScale = original
+            settings.fireUISettingsChanged()
+        }
     }
 
     fun `test editor font uses editor family and size`() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionLayoutTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionLayoutTest.kt
@@ -107,15 +107,15 @@ class SessionLayoutTest : BasePlatformTestCase() {
     fun `test layout padding offsets children and reduces available width`() {
         val p = panel(
             width = 500,
-            pad = JBUI.insets(6, 12, 8, 16),
+            pad = Insets(6, 12, 8, 16),
         )
         val child = label(height = 20)
         p.add(child)
         p.doLayout()
 
-        assertEquals(12, child.x)
-        assertEquals(6, child.y)
-        assertEquals(500 - 12 - 16, child.width)
+        assertEquals(JBUI.scale(12), child.x)
+        assertEquals(JBUI.scale(6), child.y)
+        assertEquals(500 - JBUI.scale(12) - JBUI.scale(16), child.width)
         assertEquals(20, child.height)
     }
 
@@ -123,7 +123,7 @@ class SessionLayoutTest : BasePlatformTestCase() {
         val p = panel(
             gap = 8,
             width = 300,
-            pad = JBUI.insets(5, 10, 7, 11),
+            pad = Insets(5, 10, 7, 11),
         )
         val c1 = label(height = 20)
         val c2 = label(height = 30)
@@ -131,12 +131,12 @@ class SessionLayoutTest : BasePlatformTestCase() {
         p.add(c2)
         p.doLayout()
 
-        assertEquals(10, c1.x)
-        assertEquals(5, c1.y)
-        assertEquals(10, c2.x)
-        assertEquals(5 + 20 + 8, c2.y)
-        assertEquals(300 - 10 - 11, c1.width)
-        assertEquals(300 - 10 - 11, c2.width)
+        assertEquals(JBUI.scale(10), c1.x)
+        assertEquals(JBUI.scale(5), c1.y)
+        assertEquals(JBUI.scale(10), c2.x)
+        assertEquals(JBUI.scale(5) + 20 + JBUI.scale(8), c2.y)
+        assertEquals(300 - JBUI.scale(10) - JBUI.scale(11), c1.width)
+        assertEquals(300 - JBUI.scale(10) - JBUI.scale(11), c2.width)
     }
 
     fun `test user prompt is inset from left when enough width remains`() {
@@ -162,13 +162,13 @@ class SessionLayoutTest : BasePlatformTestCase() {
     }
 
     fun `test user prompt inset composes with layout padding`() {
-        val p = panel(width = 350, pad = JBUI.insets(0, 12, 0, 18))
+        val p = panel(width = 350, pad = Insets(0, 12, 0, 18))
         val child = view(height = 20, kind = SessionView.Kind.UserPrompt)
         p.add(child)
         p.doLayout()
 
-        assertEquals(12 + 100, child.x)
-        assertEquals(350 - 12 - 18 - 100, child.width)
+        assertEquals(JBUI.scale(12) + JBUI.scale(100), child.x)
+        assertEquals(350 - JBUI.scale(12) - JBUI.scale(18) - JBUI.scale(100), child.width)
         assertEquals(20, child.height)
     }
 
@@ -201,13 +201,13 @@ class SessionLayoutTest : BasePlatformTestCase() {
     }
 
     fun `test only invisible children produce padding height`() {
-        val p = panel(gap = 8, width = 300, pad = JBUI.insets(5, 0, 7, 0))
+        val p = panel(gap = 8, width = 300, pad = Insets(5, 0, 7, 0))
         val c = label(height = 20).also { it.isVisible = false }
         p.add(c)
         p.doLayout()
 
         val size = p.layout.preferredLayoutSize(p)
-        assertEquals(5 + 7, size.height)
+        assertEquals(JBUI.scale(5) + JBUI.scale(7), size.height)
     }
 
     // ---- preferred size ------
@@ -240,14 +240,25 @@ class SessionLayoutTest : BasePlatformTestCase() {
     }
 
     fun `test preferredLayoutSize includes layout padding`() {
-        val p = panel(gap = 4, width = 300, pad = JBUI.insets(5, 10, 7, 11))
+        val p = panel(gap = 4, width = 300, pad = Insets(5, 10, 7, 11))
         p.add(label(height = 10))
         p.add(label(height = 15))
         p.doLayout()
 
         val size = p.layout.preferredLayoutSize(p)
         assertEquals(300, size.width)
-        assertEquals(5 + 10 + 4 + 15 + 7, size.height)
+        assertEquals(JBUI.scale(5) + 10 + JBUI.scale(4) + 15 + JBUI.scale(7), size.height)
+    }
+
+    fun `test layout scales base gap at layout time`() {
+        val p = panel(gap = 8, width = 300)
+        val c1 = label(height = 20)
+        val c2 = label(height = 30)
+        p.add(c1)
+        p.add(c2)
+        p.doLayout()
+
+        assertEquals(20 + JBUI.scale(8), c2.y)
     }
 
     // ---- helpers ------

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionLayoutTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/SessionLayoutTest.kt
@@ -2,6 +2,7 @@ package ai.kilocode.client.session.ui
 
 import ai.kilocode.client.session.ui.style.SessionUiStyle
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import java.awt.Dimension
@@ -248,6 +249,25 @@ class SessionLayoutTest : BasePlatformTestCase() {
         val size = p.layout.preferredLayoutSize(p)
         assertEquals(300, size.width)
         assertEquals(JBUI.scale(5) + 10 + JBUI.scale(4) + 15 + JBUI.scale(7), size.height)
+    }
+
+    fun `test preferredLayoutSize is not double-scaled by user scale factor`() {
+        // IDE zoom raises the JBUI user scale factor. Child heights and gaps are already
+        // scaled px, so the transcript preferred height must not be scaled a second time.
+        val original = JBUIScale.scale(1f)
+        try {
+            JBUIScale.setUserScaleFactorForTest(2f)
+            val p = panel(gap = 4, width = 300)
+            p.add(label(height = 10))
+            p.add(label(height = 15))
+            p.add(label(height = 20))
+            p.doLayout()
+
+            val size = p.layout.preferredLayoutSize(p)
+            assertEquals(10 + JBUI.scale(4) + 15 + JBUI.scale(4) + 20, size.height)
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
     }
 
     fun `test layout scales base gap at layout time`() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/views/TextViewTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/views/TextViewTest.kt
@@ -38,6 +38,17 @@ class TextViewTest : BasePlatformTestCase() {
         assertEquals("", view.markdown())
     }
 
+    fun `test empty text view does not reserve transcript height`() {
+        val view = TextView(Text("p1"))
+        view.setSize(260, 1)
+
+        assertEquals(0, view.preferredSize.height)
+
+        view.appendDelta("hello")
+
+        assertTrue(view.preferredSize.height > 0)
+    }
+
     fun `test Text with content sets initial markdown`() {
         val text = Text("p1").also { it.content.append("hello **world**") }
         val view = TextView(text)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/views/ToolViewTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/views/ToolViewTest.kt
@@ -11,6 +11,7 @@ import ai.kilocode.client.session.views.tool.ToolView
 import ai.kilocode.client.ui.UiStyle
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.scale.JBUIScale
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.image.BufferedImage
@@ -303,6 +304,31 @@ class ToolViewTest : BasePlatformTestCase() {
 
         assertEquals(15, view.bodyMaxRows())
         assertTrue(view.preferredSize.height > 0)
+    }
+
+    fun `test expanded body height ignores user scale factor`() {
+        // The tool body height comes from the editor line height, which tracks the IDE
+        // scale (editor font), not the JBUI user scale factor. Raising the user scale
+        // factor alone must not change the body height; a double-scaling regression would.
+        val original = JBUIScale.scale(1f)
+        val t = tool("p1", "bash", ToolExecState.COMPLETED).also {
+            it.input = mapOf("command" to "log")
+            it.output = (1..6).joinToString("\n") { line -> "line $line" }
+        }
+        try {
+            JBUIScale.setUserScaleFactorForTest(1f)
+            val view = track(ToolView(t))
+            view.toggle()
+            val before = view.bodyEditor()!!.preferredSize.height
+
+            JBUIScale.setUserScaleFactorForTest(2f)
+            view.applyStyle(SessionEditorStyle.current())
+            val after = view.bodyEditor()!!.preferredSize.height
+
+            assertEquals(before, after)
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
     }
 
     fun `test large tool output is truncated in preview`() {


### PR DESCRIPTION
## Issue

No linked issue. Implements the JetBrains IDE zoom fix from `packages/kilo-jetbrains/JETBRAINS_ZOOM_PLAN.md`.

## Context

When IntelliJ interface zoom or Presentation Mode changes, Kilo session chrome and spacing scale through JBUI, but transcript text, markdown, code blocks, and the prompt editor stayed at the unzoomed editor font size. This made the session UI look misaligned with oversized controls around undersized text.

After applying font scaling, the prompt composer and transcript also needed to stay compact at high zoom instead of reserving large empty areas for blank prompt/editor content or empty streamed text parts.

## Implementation

Use the public `UISettingsUtils.scaleFontSize(...)` API when building `SessionEditorStyle.current()` so editor-derived session typography follows the current IDE scale. This keeps embedded editors, transcript markdown, and prompt text in sync with platform zoom updates already propagated through the existing LAF listener.

Treat `SessionLayout` gaps and padding as unscaled base values and apply `JBUI.scale(...)` during layout, so transcript spacing recalculates with the current zoom instead of freezing at construction time. The transcript list now passes raw inset constants to avoid double-scaling.

Keep the empty prompt composer compact by using a one-line minimum, ignoring placeholder-driven preferred height until the user enters text, and exposing a panel preferred height derived from the clamped editor height. The prompt editor still grows for wrapped or multiline content.

Hide empty assistant text markdown components until content arrives so blank streamed text parts do not reserve zoom-amplified transcript height.

## Screenshots / Video

<img width="1350" height="964" alt="GIF Recording 2026-07-14 at 2 40 24 PM" src="https://github.com/user-attachments/assets/543a24fe-f22a-4d0d-9438-a82339b8ba65" />


## How to Test

### Manual/local verification

- Agent ran `./gradlew typecheck` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew :frontend:test --tests "*SessionEditorStyleTest*"` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew :frontend:test --tests "*SessionLayout*" --tests "*SessionMessageListPanel*"` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew :frontend:test --tests "*PromptPanelTest*"` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew :frontend:test --tests "*TextViewTest*" --tests "*PromptPanelTest*"` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew test` from `packages/kilo-jetbrains/` before the compactness follow-ups.
- Push hook ran `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains` and `bun turbo typecheck --filter=@kilocode/kilo-jetbrains` successfully.

### Reviewer test steps

1. Run `./gradlew runIde` from `packages/kilo-jetbrains/`.
2. Open the Kilo tool window with a session containing markdown, code blocks, tool calls, and streaming text.
3. Use IntelliJ IDE zoom or Presentation Mode.
4. Confirm transcript text, markdown, code blocks, prompt editor text, and transcript padding scale together with the surrounding chrome.
5. Confirm empty streamed transcript parts do not create blank vertical blocks.
6. Confirm the empty prompt composer remains compact and grows only when the prompt wraps or contains multiple lines.

### Blocked checks and substitute verification

- Manual IDE visual verification was not run. Substitute verification is the targeted frontend tests plus JetBrains typecheck listed above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

