### PR TITLE
feat(cli): wire dev:local to local event service

### DIFF
--- a/packages/opencode/script/dev-local.ts
+++ b/packages/opencode/script/dev-local.ts
@@ -1,9 +1,10 @@
 // kilocode_change - new file
 // Launch the kilo CLI dev build against a locally running cloud dev server.
-//   bun dev:local <project-dir> [--cloud <dir>] [--no-ingest] [--print] [-- <kilo args>]
+//   bun dev:local <project-dir> [--cloud <dir>] [--no-ingest] [--no-events] [--print] [-- <kilo args>]
 //
 // Reads ports from <cloud>/dev/logs/manifest.json (+ .dev-port), probes the web
-// server, and points the CLI at it (KILO_API_URL / KILO_SESSION_INGEST_URL).
+// server, and points the CLI at it (KILO_API_URL / KILO_SESSION_INGEST_URL /
+// EVENT_SERVICE_URL).
 // Auth/config/state/cache are isolated under ~/.kilo-dev so it can't clash with
 // your main kilo install; real HOME is kept so git/ssh still work.
 
@@ -46,11 +47,13 @@ async function main() {
   let cloud = path.join(os.homedir(), "Projects", "cloud")
   let project = ""
   let noIngest = false
+  let noEvents = false
   let dry = false
   for (let i = 0; i < local.length; i++) {
     const a = local[i]
     if (a === "--cloud") cloud = local[++i] ?? die("--cloud requires a value")
     else if (a === "--no-ingest") noIngest = true
+    else if (a === "--no-events") noEvents = true
     else if (a === "--print") dry = true
     else if (!a.startsWith("--")) project = a
   }
@@ -62,6 +65,7 @@ async function main() {
   const svc = (name: string) => m.services?.find((s) => s.name === name)?.port
   const webPort = Number(read(path.join(cloud, ".dev-port"))) || svc("nextjs")
   const ingestPort = noIngest ? undefined : svc("cloudflare-session-ingest")
+  const eventsPort = noEvents ? undefined : svc("event-service")
   if (!webPort) die(`no web port found in ${cloud} — is the dev server started? (pnpm dev:start)`)
 
   const env: NodeJS.ProcessEnv = { ...process.env }
@@ -73,11 +77,14 @@ async function main() {
   env.KILO_DISABLE_AUTOUPDATE = "1"
   if (ingestPort) env.KILO_SESSION_INGEST_URL = `http://localhost:${ingestPort}`
   else env.KILO_DISABLE_SESSION_INGEST = "1"
+  if (eventsPort) env.EVENT_SERVICE_URL = `ws://localhost:${eventsPort}`
+  else env.KILO_DISABLE_PRESENCE = "1"
 
   const webUp = await alive(webPort)
   console.log(`${dim}project${rst}  ${project}`)
   console.log(`${dim}web${rst}      :${webPort}  ${webUp ? `${grn}up${rst}` : `${red}down${rst}`}`)
   console.log(`${dim}ingest${rst}   ${ingestPort ? `:${ingestPort}` : "off"}`)
+  console.log(`${dim}events${rst}   ${eventsPort ? `:${eventsPort}` : "off"}`)
   console.log(`${dim}home${rst}     ${home}`)
 
   if (dry) { if (!webUp) console.warn(`${ylw}web down — start it (pnpm dev:start)${rst}`); return }

--- a/packages/opencode/script/dev-local.ts
+++ b/packages/opencode/script/dev-local.ts
@@ -80,6 +80,7 @@ async function main() {
   if (eventsPort) {
     env.EVENT_SERVICE_URL = `ws://localhost:${eventsPort}`
     delete env.KILO_DISABLE_PRESENCE
+    delete env.KILO_EVENT_SERVICE_URL
   } else env.KILO_DISABLE_PRESENCE = "1"
 
   const webUp = await alive(webPort)

--- a/packages/opencode/script/dev-local.ts
+++ b/packages/opencode/script/dev-local.ts
@@ -77,8 +77,10 @@ async function main() {
   env.KILO_DISABLE_AUTOUPDATE = "1"
   if (ingestPort) env.KILO_SESSION_INGEST_URL = `http://localhost:${ingestPort}`
   else env.KILO_DISABLE_SESSION_INGEST = "1"
-  if (eventsPort) env.EVENT_SERVICE_URL = `ws://localhost:${eventsPort}`
-  else env.KILO_DISABLE_PRESENCE = "1"
+  if (eventsPort) {
+    env.EVENT_SERVICE_URL = `ws://localhost:${eventsPort}`
+    delete env.KILO_DISABLE_PRESENCE
+  } else env.KILO_DISABLE_PRESENCE = "1"
 
   const webUp = await alive(webPort)
   console.log(`${dim}project${rst}  ${project}`)


### PR DESCRIPTION
## Issue

No linked issue — small dev tooling enhancement.

## Context

`dev:local` launches the CLI dev build against a locally running cloud dev server. It already wires up the web API and session-ingest URLs from the dev manifest, but not the event service, so presence/events don't function during local dev. This wires the event service the same way, with an opt-out flag.

## Implementation

- Discover the `event-service` port from `<cloud>/dev/logs/manifest.json`, mirroring how `cloudflare-session-ingest` is found.
- Set `EVENT_SERVICE_URL=ws://localhost:<port>` when present; otherwise set `KILO_DISABLE_PRESENCE=1`, mirroring the existing `--no-ingest` / `KILO_DISABLE_SESSION_INGEST` pattern.
- Add a `--no-events` flag to skip the event service.
- Surface the events port in the diagnostic output alongside `web` and `ingest`.

## Screenshots / Video

N/A — dev-only script, no visual change.

## How to Test

### Manual/local verification

- Linted the file with `oxlint` and typechecked the CLI package (`tsgo --noEmit`) — both clean. (agent)
- Full workspace typecheck passed via the pre-push hook: non-JetBrains packages + JetBrains `BUILD SUCCESSFUL`. (agent)

### Reviewer test steps

1. Start the cloud dev server (`pnpm dev:start` in the cloud repo) so `dev/logs/manifest.json` lists `event-service`.
2. `bun dev:local <project> --print` — confirm the `events` line shows the event-service port.
3. `bun dev:local <project> --no-events --print` — confirm `events off`.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained (no issue — dev tooling enhancement)
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (N/A — dev-only script, not shipped to end users)
- [x] I personally reviewed the diff and can explain the changes
