### PR TITLE
fix(cli): restore external skill loading

### DIFF
--- a/.changeset/restore-external-skills.md
+++ b/.changeset/restore-external-skills.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Restore loading skills from plugin-provided and configured external directories while keeping project skill substitutions scoped.

--- a/packages/opencode/src/kilocode/plugin/config.ts
+++ b/packages/opencode/src/kilocode/plugin/config.ts
@@ -1,0 +1,20 @@
+import type { Config } from "@/config/config"
+
+export namespace KilocodePluginConfig {
+  export async function apply(cfg: Config.Info, hook: () => Promise<void>) {
+    const paths = new Set(cfg.skills?.paths)
+    try {
+      await hook()
+    } finally {
+      const next = cfg.skills?.paths ?? []
+      const origins = cfg.skill_path_origins
+      const added = next.filter((item) => !paths.has(item) && !origins?.[item])
+      if (added.length) {
+        cfg.skill_path_origins = {
+          ...origins,
+          ...Object.fromEntries(added.map((item) => [item, { trusted: true, source: "plugin config hook" }])),
+        }
+      }
+    }
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -34,6 +34,7 @@ import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { KilocodePluginConfig } from "@/kilocode/plugin/config" // kilocode_change
 
 type State = {
   hooks: Hooks[]
@@ -250,7 +251,7 @@ export const layer = Layer.effect(
         // Notify plugins of current config
         for (const hook of hooks) {
           yield* Effect.tryPromise({
-            try: () => Promise.resolve((hook as any).config?.(cfg)),
+            try: () => KilocodePluginConfig.apply(cfg, () => Promise.resolve((hook as any).config?.(cfg))), // kilocode_change
             catch: errorMessage,
           }).pipe(
             Effect.tapError((error) => Effect.logError("plugin config hook failed", { error })),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -276,6 +276,7 @@ const discoverSkills = Effect.fnUntraced(function* (
       trusted,
       root: trusted ? undefined : (origin?.root ?? projectRoot),
       projectRoot,
+      sourceRoot: trusted ? undefined : dir,
     })
     // kilocode_change end
   }

--- a/packages/opencode/test/kilocode/external-skill-paths.test.ts
+++ b/packages/opencode/test/kilocode/external-skill-paths.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+import { Config } from "@/config/config"
+import { Env } from "@/env"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Git } from "@/git"
+import { KilocodePluginConfig } from "@/kilocode/plugin/config"
+import { Plugin } from "@/plugin"
+import { Skill } from "@/skill"
+import { Discovery } from "@/skill/discovery"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+import { provideTmpdirInstance, testInstanceStoreLayer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const flags = RuntimeFlags.layer({
+  disableClaudeCodeSkills: true,
+  disableDefaultPlugins: true,
+  disableExternalSkills: true,
+})
+const config = Config.layer.pipe(
+  Layer.provide(Git.defaultLayer),
+  Layer.provide(flags),
+  Layer.provide(FSUtil.defaultLayer),
+  Layer.provide(Global.layer),
+  Layer.provide(Env.defaultLayer),
+  Layer.provide(AuthTest.empty),
+  Layer.provide(AccountTest.empty),
+  Layer.provide(NpmTest.noop),
+  Layer.provide(FetchHttpClient.layer),
+)
+const plugin = Plugin.layer.pipe(Layer.provide(EventV2Bridge.defaultLayer), Layer.provide(flags))
+const skill = Skill.layer.pipe(
+  Layer.provide(Git.defaultLayer),
+  Layer.provide(Discovery.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(FSUtil.defaultLayer),
+  Layer.provide(Global.layer),
+  Layer.provide(RuntimeFlags.layer({ disableClaudeCodeSkills: true, disableExternalSkills: true })),
+)
+const dependencies = Layer.mergeAll(config, plugin, skill).pipe(Layer.provideMerge(config))
+const layer = Layer.mergeAll(dependencies, CrossSpawnSpawner.defaultLayer, testInstanceStoreLayer).pipe(
+  Layer.provideMerge(dependencies),
+)
+const it = testEffect(layer)
+
+const markdown = (name: string, body: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+${body}
+`
+
+test("preserves config hook rejections after recording new skill paths", async () => {
+  const cfg: Config.Info = { skills: { paths: [] } }
+  const err = new Error("expected config hook failure")
+
+  await expect(
+    KilocodePluginConfig.apply(cfg, async () => {
+      cfg.skills!.paths!.push("/plugin-skills")
+      throw err
+    }),
+  ).rejects.toBe(err)
+  expect(cfg.skill_path_origins?.["/plugin-skills"]).toMatchObject({
+    source: "plugin config hook",
+    trusted: true,
+  })
+  await expect(KilocodePluginConfig.apply({}, async () => Promise.reject(err))).rejects.toBe(err)
+})
+
+it.instance(
+  "loads plugin skills while keeping configured external skills untrusted",
+  () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.dirname(dir)
+          const pluginSkills = path.join(root, `${path.basename(dir)}-plugin-skills`)
+          const projectSkills = path.join(root, `${path.basename(dir)}-project-skills`)
+          const secretFile = path.join(root, `${path.basename(dir)}-secret.txt`)
+          const plugin = path.join(dir, ".kilo", "plugin", "external-skills.ts")
+          const secret = "project skill secret"
+          const previous = process.env.KILO_EXTERNAL_SKILL_SECRET
+
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(() =>
+              Promise.all([
+                fs.rm(pluginSkills, { force: true, recursive: true }),
+                fs.rm(projectSkills, { force: true, recursive: true }),
+                fs.rm(secretFile, { force: true }),
+              ]),
+            ),
+          )
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              if (previous === undefined) delete process.env.KILO_EXTERNAL_SKILL_SECRET
+              else process.env.KILO_EXTERNAL_SKILL_SECRET = previous
+            }),
+          )
+          yield* Effect.sync(() => {
+            process.env.KILO_EXTERNAL_SKILL_SECRET = "plugin skill secret"
+          })
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(path.join(pluginSkills, "plugin", "SKILL.md"), markdown("plugin", "{env:KILO_EXTERNAL_SKILL_SECRET}")),
+              Bun.write(path.join(projectSkills, "plain", "SKILL.md"), markdown("plain", "safe project skill")),
+              Bun.write(
+                path.join(projectSkills, "unsafe-env", "SKILL.md"),
+                markdown("unsafe-env", "{env:KILO_EXTERNAL_SKILL_SECRET}"),
+              ),
+              Bun.write(
+                path.join(projectSkills, "unsafe-file", "SKILL.md"),
+                markdown("unsafe-file", `{file:../../${path.basename(secretFile)}}`),
+              ),
+              Bun.write(secretFile, secret),
+              Bun.write(
+                plugin,
+                `export default async () => ({
+  config: async (cfg: { skills?: { paths?: string[] } }) => {
+    cfg.skills ??= {}
+    cfg.skills.paths = [...(cfg.skills.paths ?? []), ${JSON.stringify(pluginSkills)}]
+  },
+})
+`,
+              ),
+              Bun.write(
+                path.join(dir, "kilo.json"),
+                JSON.stringify({
+                  plugin: [pathToFileURL(plugin).href],
+                  skills: { paths: [projectSkills] },
+                }),
+              ),
+            ]),
+          )
+
+          yield* Plugin.Service.use((svc) => svc.init())
+
+          const cfg = yield* Config.use.get()
+          expect(cfg.skill_path_origins?.[pluginSkills]).toMatchObject({
+            source: "plugin config hook",
+            trusted: true,
+          })
+          expect(cfg.skill_path_origins?.[projectSkills]).toMatchObject({ root: dir, trusted: false })
+
+          const skills = yield* Skill.Service
+          const list = yield* skills.all()
+          expect(list.find((item) => item.name === "plugin")?.content).toContain("plugin skill secret")
+          expect(list.find((item) => item.name === "plain")?.content).toContain("safe project skill")
+          expect(list.find((item) => item.name === "unsafe-env")).toBeUndefined()
+          expect(list.find((item) => item.name === "unsafe-file")).toBeUndefined()
+          expect(list.some((item) => item.content.includes(secret))).toBe(false)
+        }),
+      { git: true },
+    ),
+  30000,
+)


### PR DESCRIPTION
## Issue

Fixes #12222

## Context

Skills external to the canonical `~/.kilo/skills` directory currently fail to load. This breaks valid uses cases such as plugin skills.

## Implementation

Uses two targeted changes while preserving the security protections from #12168:

1. Record paths added by plugin config hooks as trusted runtime origins. Executing plugins already have full process access, so this grants no additional capability. Keep this logic in a Kilo-owned helper called from `plugin/index.ts`.
2. Allow project-configured external SKILL.md sources to be read without trusting their contents. This restores documented absolute skills.paths support while retaining:
- {env:...} rejection for project-selected skills.
- {file:...} confinement to the project root.
- Descriptor-pinned reads and realpath/symlink protections.
- Trusted substitutions for global and plugin-provided skills.


## Screenshots / Video

Superpowers skills now loaded successfully:

<img width="1472" height="849" alt="image" src="https://github.com/user-attachments/assets/f97d3b10-4829-48e1-bc72-9403ba98bb0a" />

## How to Test

- Have a plugin installed that loads skills, like Superpowers
- Verify Kilo loads its skills without erroring

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord
