### PR TITLE
fix(indexing): improvements to semantic_search tool description

### DIFF
--- a/packages/opencode/src/kilocode/tool/semantic-search.txt
+++ b/packages/opencode/src/kilocode/tool/semantic-search.txt
@@ -2,11 +2,9 @@ Find code snippets by semantic meaning and return ranked matches with file paths
 
 ## When to use
 
-- Explore an unfamiliar code area before you know exact identifiers
-- Find related implementations of a concept or behavior across the workspace
-- Search by intent such as authentication, caching, or session resume logic
-- Narrow a large codebase before following up with `Read` or `Grep`
-- Limit semantic search to one subdirectory with `path`
+Use early for open-ended exploration when you know the intent
+but not the exact identifiers or the semantics. Once likely files or symbols are found,
+follow up with Grep and Read. Prefer Grep directly when exact terms are already known.
 
 ## When NOT to use
 
@@ -25,4 +23,5 @@ Find code snippets by semantic meaning and return ranked matches with file paths
 ## Constraints
 
 - Write the query in English.
-- Use `path` only for subdirectories inside the current workspace.
+- Searches the entire current workspace by default. Limit semantic search to one subdirectory with `path`.
+- Cannot search outside the current workspace. Use other tools if this functionality is needed.


### PR DESCRIPTION
## Issue

Fixes #10271 (hopefully for good this time)

## Context

The semantic search tool continues to not be invoked reliably. We want to help agents understand how and when to use this tool appropriately.

## Implementation

- Add a statement instructing the agent to "proactively" use the tool in the appropriate scenario. The word "proactively" has been shown to improve agent tool utilization.
- Refactor the location and wording of directory and `path` parameter limitations, as I've seen agents sometimes failing to understand these limitations.

## Screenshots / Video

N/A

## How to Test

- Do some task that involves finding code snippets without knowing the specific name. Don't explicitly tell the agent to use the tool.
- Codebase search should be used early in the agent's exploratory process to narrow down search scope for more exact file reads and greps.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord
