### PR TITLE
fix(cli): clean test runner temp environments

### DIFF
--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -188,6 +188,10 @@ if (ci) await fs.mkdir(xmldir, { recursive: true })
 const counter = { done: 0 }
 const pad = String(files.length).length
 const progress = { width: 80 }
+const active = new Map<number, ReturnType<typeof Bun.spawn>>()
+const pending = new Map<number, Promise<void>>()
+const stopping = { promise: undefined as Promise<void> | undefined }
+const stopped = { value: false }
 const marks = {
   pass: ".",
   retry: "R",
@@ -218,32 +222,64 @@ async function run(file: string): Promise<Result> {
     stderr: "pipe",
     windowsHide: true,
   })
+  active.set(proc.pid, proc)
 
   const timer = setTimeout(() => {
     killed.value = true
     proc.kill()
   }, deadline)
 
-  const [stdout, stderr, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]).finally(async () => {
+  const stdout = new Response(proc.stdout).text()
+  const stderr = new Response(proc.stderr).text()
+  const code = await proc.exited.finally(async () => {
     clearTimeout(timer)
-    await cleanup(proc.pid)
+    await finish(proc)
   })
+  const output = await Promise.all([stdout, stderr])
 
   return {
     file,
     passed: code === 0,
     code,
-    stdout,
-    stderr,
+    stdout: output[0],
+    stderr: output[1],
     duration: performance.now() - start,
     timedout: killed.value,
     attempts: 1,
   }
 }
+
+function finish(proc: ReturnType<typeof Bun.spawn>) {
+  const found = pending.get(proc.pid)
+  if (found) return found
+
+  const promise = (async () => {
+    await proc.exited
+    await cleanup(proc.pid)
+  })().finally(() => {
+    active.delete(proc.pid)
+    pending.delete(proc.pid)
+  })
+  pending.set(proc.pid, promise)
+  return promise
+}
+
+function shutdown(code: number) {
+  if (stopping.promise) return stopping.promise
+  stopping.promise = (async () => {
+    stopped.value = true
+    const children = [...active.values()]
+    for (const proc of children) {
+      if (proc.exitCode === null) proc.kill("SIGKILL")
+    }
+    await Promise.all(children.map(finish))
+    process.exit(code)
+  })()
+  return stopping.promise
+}
+
+process.once("SIGINT", () => void shutdown(130))
+process.once("SIGTERM", () => void shutdown(143))
 
 // ---------------------------------------------------------------------------
 // Report a single result
@@ -304,7 +340,6 @@ console.log()
 const start = performance.now()
 const results: Result[] = []
 const queue = TestShard.order(files, weight)
-const stopped = { value: false }
 
 const workers = Array.from({ length: Math.min(concurrency, files.length) }, async () => {
   while (queue.length > 0 && !stopped.value) {

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -9,6 +9,7 @@ import path from "path"
 import fs from "fs/promises"
 import { TestProfile } from "./kilocode/test-profile"
 import { TestShard } from "./kilocode/test-shard"
+import { remove } from "../test/kilocode/cleanup"
 
 const root = path.resolve(import.meta.dir, "..")
 const argv = process.argv.slice(2)
@@ -227,9 +228,10 @@ async function run(file: string): Promise<Result> {
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
-  ])
-
-  clearTimeout(timer)
+  ]).finally(async () => {
+    clearTimeout(timer)
+    await cleanup(proc.pid)
+  })
 
   return {
     file,
@@ -479,6 +481,13 @@ async function merge() {
   ].join("\n")
 
   await Bun.write(path.join(dir, "junit.xml"), body)
+}
+
+async function cleanup(pid: number) {
+  const dir = path.join(os.tmpdir(), `opencode-test-data-${pid}`)
+  await remove(dir).catch((err) => {
+    console.error(`cleanup failed for ${dir}:`, err)
+  })
 }
 
 // Grab everything between the outer <testsuites ...> and </testsuites> of a

--- a/packages/opencode/test/kilocode/test-runner-cleanup.test.ts
+++ b/packages/opencode/test/kilocode/test-runner-cleanup.test.ts
@@ -7,6 +7,33 @@ import { remove } from "./cleanup"
 
 const root = path.resolve(import.meta.dir, "../..")
 
+function env(marker: string) {
+  const vars: NodeJS.ProcessEnv = { ...process.env, KILO_TEST_RUNNER_PID_FILE: marker }
+  delete vars.KILO_TEST_PROFILE
+  delete vars.KILO_TEST_SHARD
+  return vars
+}
+
+function spawn(name: string, marker: string) {
+  return Bun.spawn(
+    ["bun", "run", "script/test-runner.ts", "--concurrency", "1", "--retries", "-1", `kilocode/${name}`],
+    {
+      cwd: root,
+      env: env(marker),
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+    },
+  )
+}
+
+async function deadline<T>(promise: Promise<T>, timeout: number) {
+  const expired = Symbol("expired")
+  const result = await Promise.race([promise, Bun.sleep(timeout).then(() => expired)])
+  if (result === expired) throw new Error(`Timed out after ${timeout}ms`)
+  return result
+}
+
 describe("test runner cleanup", () => {
   test("removes the temp environment after an abrupt child exit", async () => {
     await using tmp = await tmpdir()
@@ -15,51 +42,80 @@ describe("test runner cleanup", () => {
     const marker = path.join(tmp.path, "pid")
     const state = { pid: 0 }
     const src = [
-      'const marker = process.env.KILO_TEST_RUNNER_PID_FILE',
+      "const marker = process.env.KILO_TEST_RUNNER_PID_FILE",
       'if (!marker) throw new Error("KILO_TEST_RUNNER_PID_FILE is required")',
-      'await Bun.write(marker, String(process.pid))',
-      'process.exit(1)',
-      '',
+      "await Bun.write(marker, String(process.pid))",
+      "process.exit(1)",
+      "",
     ].join("\n")
 
     await fs.writeFile(file, src)
+    const proc = spawn(name, marker)
+    const stdout = new Response(proc.stdout).text()
+    const stderr = new Response(proc.stderr).text()
 
     try {
-      const proc = Bun.spawn(
-        [
-          "bun",
-          "run",
-          "script/test-runner.ts",
-          "--concurrency",
-          "1",
-          "--retries",
-          "-1",
-          `kilocode/${name}`,
-        ],
-        {
-          cwd: root,
-          env: { ...process.env, KILO_TEST_RUNNER_PID_FILE: marker },
-          stdout: "pipe",
-          stderr: "pipe",
-          windowsHide: true,
-        },
-      )
-      const [stdout, stderr, code] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-        proc.exited,
-      ])
+      const code = await deadline(proc.exited, 15_000)
+      const output = await Promise.all([stdout, stderr])
 
       if (!(await Bun.file(marker).exists())) {
-        throw new Error(`child did not record its pid\n${stderr || stdout}`)
+        throw new Error(`child did not record its pid\n${output[1] || output[0]}`)
       }
 
       state.pid = Number(await fs.readFile(marker, "utf8"))
       expect(code).not.toBe(0)
       expect(await Bun.file(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`)).exists()).toBe(false)
     } finally {
+      if (proc.exitCode === null) proc.kill("SIGKILL")
+      await proc.exited
       await fs.rm(file, { force: true })
       if (state.pid) await remove(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`))
     }
   })
+
+  test.skipIf(process.platform === "win32")(
+    "removes active temp environments when the runner is terminated",
+    async () => {
+      await using tmp = await tmpdir()
+      const name = `runner-signal-${process.pid}-${Date.now()}.test.ts`
+      const file = path.join(import.meta.dir, name)
+      const marker = path.join(tmp.path, "pid")
+      const state = { pid: 0 }
+      const src = [
+        "const marker = process.env.KILO_TEST_RUNNER_PID_FILE",
+        'if (!marker) throw new Error("KILO_TEST_RUNNER_PID_FILE is required")',
+        "await Bun.write(marker, String(process.pid))",
+        "const parent = process.ppid",
+        "setInterval(() => process.ppid === parent || process.exit(1), 50)",
+        "await Bun.sleep(60_000)",
+        "",
+      ].join("\n")
+
+      await fs.writeFile(file, src)
+      const proc = spawn(name, marker)
+      const stdout = new Response(proc.stdout).text()
+      const stderr = new Response(proc.stderr).text()
+
+      try {
+        await deadline(
+          (async () => {
+            while (!(await Bun.file(marker).exists())) await Bun.sleep(10)
+          })(),
+          10_000,
+        )
+        state.pid = Number(await fs.readFile(marker, "utf8"))
+        proc.kill("SIGTERM")
+
+        expect(await deadline(proc.exited, 10_000)).toBe(143)
+        await Promise.all([stdout, stderr])
+        expect(await Bun.file(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`)).exists()).toBe(false)
+      } finally {
+        if (proc.exitCode === null) proc.kill("SIGKILL")
+        await proc.exited
+        await fs.rm(file, { force: true })
+        if (state.pid) await remove(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`))
+      }
+    },
+    30_000,
+  )
 })

--- a/packages/opencode/test/kilocode/test-runner-cleanup.test.ts
+++ b/packages/opencode/test/kilocode/test-runner-cleanup.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { remove } from "./cleanup"
+
+const root = path.resolve(import.meta.dir, "../..")
+
+describe("test runner cleanup", () => {
+  test("removes the temp environment after an abrupt child exit", async () => {
+    await using tmp = await tmpdir()
+    const name = `runner-abrupt-${process.pid}-${Date.now()}.test.ts`
+    const file = path.join(import.meta.dir, name)
+    const marker = path.join(tmp.path, "pid")
+    const state = { pid: 0 }
+    const src = [
+      'const marker = process.env.KILO_TEST_RUNNER_PID_FILE',
+      'if (!marker) throw new Error("KILO_TEST_RUNNER_PID_FILE is required")',
+      'await Bun.write(marker, String(process.pid))',
+      'process.exit(1)',
+      '',
+    ].join("\n")
+
+    await fs.writeFile(file, src)
+
+    try {
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "run",
+          "script/test-runner.ts",
+          "--concurrency",
+          "1",
+          "--retries",
+          "-1",
+          `kilocode/${name}`,
+        ],
+        {
+          cwd: root,
+          env: { ...process.env, KILO_TEST_RUNNER_PID_FILE: marker },
+          stdout: "pipe",
+          stderr: "pipe",
+          windowsHide: true,
+        },
+      )
+      const [stdout, stderr, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ])
+
+      if (!(await Bun.file(marker).exists())) {
+        throw new Error(`child did not record its pid\n${stderr || stdout}`)
+      }
+
+      state.pid = Number(await fs.readFile(marker, "utf8"))
+      expect(code).not.toBe(0)
+      expect(await Bun.file(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`)).exists()).toBe(false)
+    } finally {
+      await fs.rm(file, { force: true })
+      if (state.pid) await remove(path.join(os.tmpdir(), `opencode-test-data-${state.pid}`))
+    }
+  })
+})


### PR DESCRIPTION
Fixes #12223

## What changed

Run parent-side cleanup for each isolated test process after it settles, using the existing retrying cleanup helper. Add regression coverage that starts a real test process, forces an abrupt exit, and verifies its `opencode-test-data-<pid>` directory is gone.

## Root cause

The test preload creates one temporary environment per process and removes it from `afterAll`. Abrupt exits and runner-enforced termination can skip `afterAll`, while the parent runner previously never cleaned the directory despite knowing the child PID. Those abandoned environments accumulated across suite runs.

## Validation

- `bun test ./test/kilocode/test-runner-cleanup.test.ts`
- `bun run script/test-runner.ts --concurrency 1 --retries -1 kilocode/test-runner-cleanup.test.ts`
- `bun run typecheck`
- Targeted Oxlint: 0 errors