### PR TITLE
fix(jetbrains): normalize editor usage attribution

### DIFF
--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloBackendCliManager.kt
@@ -609,10 +609,9 @@ internal fun buildKiloCliEnv(
 private fun ideEnv(log: KiloLog): Map<String, String> = buildMap {
     runCatching {
         val info = ApplicationInfo.getInstance()
-        val name = info.fullApplicationName
-        val build = info.build.asString()
-        put("KILO_EDITOR_NAME", name)
-        put("KILOCODE_EDITOR_NAME", "$name $build")
+        val app = info.fullApplicationName
+        put("KILO_EDITOR_NAME", app)
+        put("KILOCODE_EDITOR_NAME", editorAttribution(info))
     }.onFailure { log.info("Could not read ApplicationInfo: ${it.message}") }
 
     runCatching {
@@ -624,6 +623,8 @@ private fun ideEnv(log: KiloLog): Map<String, String> = buildMap {
         put("KILO_MACHINE_ID", machineId())
     }.onFailure { log.info("Could not read machine ID: ${it.message}") }
 }
+
+internal fun editorAttribution(info: ApplicationInfo): String = "${info.versionName} ${info.shortVersion}"
 
 private fun machineId(): String {
     val file = File(PathManager.getSystemPath(), "kilo/machine-id")

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloBackendCliManagerEnvTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloBackendCliManagerEnvTest.kt
@@ -1,5 +1,8 @@
 package ai.kilocode.backend.cli
 
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.util.BuildNumber
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -8,6 +11,8 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import java.io.File
 import java.nio.file.Files
+import java.time.ZonedDateTime
+import java.util.Calendar
 
 class KiloBackendCliManagerEnvTest {
 
@@ -43,6 +48,34 @@ class KiloBackendCliManagerEnvTest {
         assertEquals("true", env["KILO_DISABLE_CLAUDE_CODE"])
         assertEquals("jetbrains-plugin", env["KILOCODE_FEATURE"])
         assertEquals("pwd123", env["KILO_SERVER_PASSWORD"])
+    }
+
+    @Test
+    fun `editor attribution uses product short version without build`() {
+        val info = object : ApplicationInfo() {
+            override fun getBuildDate(): Calendar = Calendar.getInstance()
+            override fun getBuildTime(): ZonedDateTime = ZonedDateTime.now()
+            override fun getBuild(): BuildNumber = BuildNumber.fromString("IU-241.15989.150")!!
+            override fun getApiVersion(): String = "241"
+            override fun getMajorVersion(): String = "2024"
+            override fun getMinorVersion(): String = "1.4"
+            override fun getMicroVersion(): String = "4"
+            override fun getPatchVersion(): String = ""
+            override fun getVersionName(): String = "IntelliJ IDEA"
+            override fun getCompanyName(): String = "JetBrains s.r.o."
+            override fun getShortCompanyName(): String = "JetBrains"
+            override fun getCompanyURL(): String = "https://www.jetbrains.com"
+            override fun getFullVersion(): String = "2024.1.4"
+            override fun getStrictVersion(): String = "2024.1.4"
+            override fun getFullApplicationName(): String = "IntelliJ IDEA 2024.1.4"
+            override fun isEssentialPlugin(id: String): Boolean = false
+            override fun isEssentialPlugin(id: PluginId): Boolean = false
+        }
+
+        val name = editorAttribution(info)
+
+        assertEquals("IntelliJ IDEA 2024.1", name)
+        assertFalse(name.contains(info.build.asString()))
     }
 
     @Test


### PR DESCRIPTION
## What
- Normalize the native JetBrains usage attribution editor header to product name plus short IDE version.
- Keep the existing full application name for the non-usage KILO_EDITOR_NAME env var.
- Add coverage that noisy JetBrains build IDs are excluded from the usage attribution value.

## Why
The native JetBrains plugin was sending values like `IntelliJ IDEA 2024.1.4 IU-241.15989.150` for `X-KILOCODE-EDITORNAME`, fragmenting usage analytics by patch/build. The old JetBrains integration grouped by lower-cardinality values like `IntelliJ IDEA 2024.1`.

## Validation
- `./gradlew :backend:test --tests "ai.kilocode.backend.cli.KiloBackendCliManagerEnvTest"`
- `./gradlew typecheck`
- Push hook: `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains`
- Push hook: `bun turbo typecheck --filter=@kilocode/kilo-jetbrains`