### PR TITLE
perf(cli): speed up local recall searches

### DIFF
--- a/.changeset/fast-local-recall.md
+++ b/.changeset/fast-local-recall.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Speed up local conversation recall searches on large histories.

--- a/packages/opencode/src/kilocode/session/recall-search.ts
+++ b/packages/opencode/src/kilocode/session/recall-search.ts
@@ -11,7 +11,7 @@ import { ProjectV2 } from "@opencode-ai/core/project"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 
 export namespace RecallSearch {
-  const PAGE_SIZE = 1_024
+  const BATCH = 128
   const MAX_QUERY = 256
   const MAX_TERMS = 12
   const MAX_SNIPPETS = 3
@@ -51,14 +51,23 @@ export namespace RecallSearch {
     OR (json_extract(p.data, '$.type') = 'tool'
       AND json_extract(p.data, '$.state.status') = 'error')`
 
-  const searchSql = (ids: PartID[], sessionID: SessionID | "", messageID: MessageID | "") => sql`
+  const searchSql = (
+    ids: SessionID[],
+    rowid: number,
+    partID: string,
+    sessionID: SessionID | "",
+    messageID: MessageID | "",
+  ) => sql`
     SELECT ${sql.raw(FIELDS_SQL)}
-    FROM json_each(${JSON.stringify(ids)}) AS ids
-    CROSS JOIN part AS p
-    CROSS JOIN message AS m
-    WHERE p.id = ids.value
-      AND m.id = p.message_id
+    FROM part AS p INDEXED BY part_session_idx
+    JOIN message AS m ON m.id = p.message_id
       AND m.session_id = p.session_id
+    WHERE p.session_id IN (${sql.join(
+      ids.map((id) => sql`${id}`),
+      sql`,`,
+    )})
+      AND p.rowid <= ${rowid}
+      AND p.id <= ${partID}
       AND NOT (
         m.session_id = ${sessionID} AND (
           (json_extract(m.data, '$.role') = 'user' AND m.id >= ${messageID})
@@ -67,12 +76,15 @@ export namespace RecallSearch {
       )
       AND (${sql.raw(FILTER_SQL)})`
 
-  const pageSql = (sessionID: SessionID, cursor: number, rowid: number, partID: string) => sql`
-    SELECT p.rowid AS rowid, p.id AS partID
+  const countSql = (ids: SessionID[], rowid: number, partID: string) => sql`
+    SELECT count(*) AS parts
     FROM part AS p INDEXED BY part_session_idx
-    WHERE p.session_id = ${sessionID} AND p.rowid > ${cursor} AND p.rowid <= ${rowid} AND p.id <= ${partID}
-    ORDER BY p.rowid
-    LIMIT ${PAGE_SIZE}`
+    WHERE p.session_id IN (${sql.join(
+      ids.map((id) => sql`${id}`),
+      sql`,`,
+    )})
+      AND p.rowid <= ${rowid}
+      AND p.id <= ${partID}`
 
   export type Source = "user" | "assistant" | "reference" | "error"
 
@@ -116,9 +128,8 @@ export namespace RecallSearch {
     text: string
   }
 
-  type PageRow = {
-    rowid: number
-    partID: PartID
+  type CountRow = {
+    parts: number
   }
 
   export const search = Effect.fn("RecallSearch.search")(function* (input: {
@@ -210,32 +221,17 @@ export namespace RecallSearch {
       )
     }
 
-    for (let index = 0; index < ids.length; index++) {
+    for (let index = 0; index < ids.length; index += BATCH) {
       yield* abort(input.signal)
-      const sessionID = ids[index]
-      let cursor = 0
-      while (cursor < rowid) {
-        const rows = yield* db.all<PageRow>(pageSql(sessionID, cursor, rowid, partID)).pipe(Effect.orDie)
-        if (rows.length === 0) break
-        cursor = rows.at(-1)!.rowid
-        const found = yield* db
-          .all<Row>(
-            searchSql(
-              rows.map((entry) => entry.partID),
-              excludeSessionID,
-              excludeFromMessageID,
-            ),
-          )
-          .pipe(Effect.orDie)
-        for (const row of found) {
-          consume(row)
-        }
-        parts += rows.length
-        if (rows.length < PAGE_SIZE) break
-        yield* pause
-        yield* abort(input.signal)
+      const batch = ids.slice(index, index + BATCH)
+      const count = yield* db.get<CountRow>(countSql(batch, rowid, partID)).pipe(Effect.orDie)
+      const found = yield* db
+        .all<Row>(searchSql(batch, rowid, partID, excludeSessionID, excludeFromMessageID))
+        .pipe(Effect.orDie)
+      for (const row of found) {
+        consume(row)
       }
-      if (index % 16 !== 15) continue
+      parts += count?.parts ?? 0
       yield* pause
       yield* abort(input.signal)
     }

--- a/packages/opencode/src/kilocode/session/recall-search.ts
+++ b/packages/opencode/src/kilocode/session/recall-search.ts
@@ -12,6 +12,8 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 
 export namespace RecallSearch {
   const BATCH = 128
+  const PAGE_SIZE = 1_024
+  const SCAN_SIZE = 16_384
   const MAX_QUERY = 256
   const MAX_TERMS = 12
   const MAX_SNIPPETS = 3
@@ -20,6 +22,7 @@ export namespace RecallSearch {
   const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" })
 
   const FIELDS_SQL = `
+    p.rowid AS rowid,
     p.id AS partID,
     p.session_id AS sessionID,
     CASE
@@ -51,40 +54,63 @@ export namespace RecallSearch {
     OR (json_extract(p.data, '$.type') = 'tool'
       AND json_extract(p.data, '$.state.status') = 'error')`
 
-  const searchSql = (
+  const pageSql = (
     ids: SessionID[],
+    cursor: { sessionID: SessionID | ""; rowid: number },
     rowid: number,
     partID: string,
     sessionID: SessionID | "",
     messageID: MessageID | "",
   ) => sql`
-    SELECT ${sql.raw(FIELDS_SQL)}
-    FROM part AS p INDEXED BY part_session_idx
-    JOIN message AS m ON m.id = p.message_id
-      AND m.session_id = p.session_id
-    WHERE p.session_id IN (${sql.join(
-      ids.map((id) => sql`${id}`),
-      sql`,`,
-    )})
-      AND p.rowid <= ${rowid}
-      AND p.id <= ${partID}
-      AND NOT (
-        m.session_id = ${sessionID} AND (
-          (json_extract(m.data, '$.role') = 'user' AND m.id >= ${messageID})
-          OR (json_extract(m.data, '$.role') = 'assistant' AND json_extract(m.data, '$.parentID') >= ${messageID})
+    WITH page AS (
+      SELECT p.rowid, p.id, p.message_id, p.session_id, p.data
+      FROM part AS p INDEXED BY part_session_idx
+      WHERE p.session_id IN (${sql.join(
+        ids.map((id) => sql`${id}`),
+        sql`,`,
+      )})
+        AND (p.session_id > ${cursor.sessionID} OR (p.session_id = ${cursor.sessionID} AND p.rowid > ${cursor.rowid}))
+        AND p.rowid <= ${rowid}
+        AND p.id <= ${partID}
+      ORDER BY p.session_id, p.rowid
+      LIMIT ${SCAN_SIZE}
+    ), found AS (
+      SELECT ${sql.raw(FIELDS_SQL)}
+      FROM page AS p
+      JOIN message AS m ON m.id = p.message_id
+        AND m.session_id = p.session_id
+      WHERE NOT (
+          m.session_id = ${sessionID} AND (
+            (json_extract(m.data, '$.role') = 'user' AND m.id >= ${messageID})
+            OR (json_extract(m.data, '$.role') = 'assistant' AND json_extract(m.data, '$.parentID') >= ${messageID})
+          )
         )
-      )
-      AND (${sql.raw(FILTER_SQL)})`
-
-  const countSql = (ids: SessionID[], rowid: number, partID: string) => sql`
-    SELECT count(*) AS parts
-    FROM part AS p INDEXED BY part_session_idx
-    WHERE p.session_id IN (${sql.join(
-      ids.map((id) => sql`${id}`),
-      sql`,`,
-    )})
-      AND p.rowid <= ${rowid}
-      AND p.id <= ${partID}`
+        AND (${sql.raw(FILTER_SQL)})
+      ORDER BY p.session_id, p.rowid
+      LIMIT ${PAGE_SIZE}
+    ), next AS (
+      SELECT
+        CASE WHEN (SELECT count(*) FROM found) = ${PAGE_SIZE}
+          THEN (SELECT sessionID FROM found ORDER BY sessionID DESC, rowid DESC LIMIT 1)
+          ELSE (SELECT session_id FROM page ORDER BY session_id DESC, rowid DESC LIMIT 1)
+        END AS sessionID,
+        CASE WHEN (SELECT count(*) FROM found) = ${PAGE_SIZE}
+          THEN (SELECT rowid FROM found ORDER BY sessionID DESC, rowid DESC LIMIT 1)
+          ELSE (SELECT rowid FROM page ORDER BY session_id DESC, rowid DESC LIMIT 1)
+        END AS rowid
+    ), meta AS (
+      SELECT next.sessionID, next.rowid, count(*) AS parts
+      FROM next
+      JOIN page AS p ON p.session_id < next.sessionID OR (p.session_id = next.sessionID AND p.rowid <= next.rowid)
+      WHERE next.sessionID IS NOT NULL
+      GROUP BY next.sessionID, next.rowid
+    )
+    SELECT rowid, partID, sessionID, source, text, 0 AS meta, 0 AS parts
+    FROM found
+    UNION ALL
+    SELECT rowid, NULL AS partID, sessionID, NULL AS source, NULL AS text, 1 AS meta, parts
+    FROM meta
+    ORDER BY meta, sessionID, rowid`
 
   export type Source = "user" | "assistant" | "reference" | "error"
 
@@ -128,7 +154,13 @@ export namespace RecallSearch {
     text: string
   }
 
-  type CountRow = {
+  type PageRow = {
+    rowid: number
+    partID: PartID | null
+    sessionID: SessionID
+    source: Source | null
+    text: string | null
+    meta: number
     parts: number
   }
 
@@ -224,16 +256,22 @@ export namespace RecallSearch {
     for (let index = 0; index < ids.length; index += BATCH) {
       yield* abort(input.signal)
       const batch = ids.slice(index, index + BATCH)
-      const count = yield* db.get<CountRow>(countSql(batch, rowid, partID)).pipe(Effect.orDie)
-      const found = yield* db
-        .all<Row>(searchSql(batch, rowid, partID, excludeSessionID, excludeFromMessageID))
-        .pipe(Effect.orDie)
-      for (const row of found) {
-        consume(row)
+      let cursor = { sessionID: "" as SessionID | "", rowid: 0 }
+      while (cursor.rowid <= rowid) {
+        const found = yield* db
+          .all<PageRow>(pageSql(batch, cursor, rowid, partID, excludeSessionID, excludeFromMessageID))
+          .pipe(Effect.orDie)
+        if (found.length === 0) break
+        const last = found.at(-1)!
+        cursor = { sessionID: last.sessionID, rowid: last.rowid }
+        parts += last.parts
+        for (const row of found) {
+          if (row.meta || !row.partID || !row.source) continue
+          consume({ partID: row.partID, sessionID: row.sessionID, source: row.source, text: row.text ?? "" })
+        }
+        yield* pause
+        yield* abort(input.signal)
       }
-      parts += count?.parts ?? 0
-      yield* pause
-      yield* abort(input.signal)
     }
     yield* pause
     yield* abort(input.signal)

--- a/packages/opencode/test/kilocode/recall-search.test.ts
+++ b/packages/opencode/test/kilocode/recall-search.test.ts
@@ -247,7 +247,7 @@ it.instance(
 )
 
 it.instance(
-  "searches every batch while respecting worktree scope",
+  "searches every page and batch while respecting worktree scope",
   () =>
     Effect.gen(function* () {
       yield* seedProject
@@ -258,8 +258,9 @@ it.instance(
       yield* add(child.id, "user", { type: "text", text: "archived-child-needle" })
 
       const broad = yield* sessions.create({ title: "Broad" })
-      for (let index = 0; index < 300; index++) {
-        yield* add(broad.id, "user", { type: "text", text: `page ${index}` })
+      for (let index = 0; index < 1_100; index++) {
+        const text = index === 1_099 ? "page-boundary-needle" : `page ${index}`
+        yield* add(broad.id, "user", { type: "text", text })
       }
       for (let index = 0; index < 140; index++) {
         const session = yield* sessions.create({ title: `Batch ${index}` })
@@ -277,10 +278,11 @@ it.instance(
         .pipe(Effect.orDie)
 
       expect((yield* run("archived-child-needle")).results.map((item) => item.id)).toEqual([child.id])
+      expect((yield* run("page-boundary-needle")).results.map((item) => item.id)).toEqual([broad.id])
       const result = yield* run("last-session-needle")
       expect(result.results).toHaveLength(1)
       expect(result.sessions).toBe(143)
-      expect(result.parts).toBe(302)
+      expect(result.parts).toBe(1_102)
     }),
   { git: true },
 )
@@ -298,7 +300,7 @@ it.instance(
         type: "text",
         text: `terminal ${"x".repeat(20_000)} terminal needle ${"y".repeat(20_000)}`,
       })
-      for (let index = 0; index < 300; index++) {
+      for (let index = 0; index < 1_100; index++) {
         yield* add(session.id, "user", { type: "text", text: `noise ${index}` })
       }
 

--- a/packages/opencode/test/kilocode/recall-search.test.ts
+++ b/packages/opencode/test/kilocode/recall-search.test.ts
@@ -247,7 +247,7 @@ it.instance(
 )
 
 it.instance(
-  "searches every page while respecting worktree scope",
+  "searches every batch while respecting worktree scope",
   () =>
     Effect.gen(function* () {
       yield* seedProject
@@ -261,9 +261,9 @@ it.instance(
       for (let index = 0; index < 300; index++) {
         yield* add(broad.id, "user", { type: "text", text: `page ${index}` })
       }
-      for (let index = 0; index < 70; index++) {
+      for (let index = 0; index < 140; index++) {
         const session = yield* sessions.create({ title: `Batch ${index}` })
-        if (index === 69) yield* add(session.id, "user", { type: "text", text: "last-session-needle" })
+        if (index === 139) yield* add(session.id, "user", { type: "text", text: "last-session-needle" })
       }
 
       const outside = yield* sessions.create({ title: "Outside" })
@@ -279,7 +279,7 @@ it.instance(
       expect((yield* run("archived-child-needle")).results.map((item) => item.id)).toEqual([child.id])
       const result = yield* run("last-session-needle")
       expect(result.results).toHaveLength(1)
-      expect(result.sessions).toBe(73)
+      expect(result.sessions).toBe(143)
       expect(result.parts).toBe(302)
     }),
   { git: true },


### PR DESCRIPTION
Large local transcript histories made `kilo_local_recall` issue thousands of SQLite round trips by scanning each session separately.

Batch eligible sessions into indexed SQLite scans while preserving snapshot bounds, exact coverage counts, current-turn exclusion, cancellation, and exhaustive matching. Each query returns at most 1,024 searchable rows and scans at most 16,384 transcript parts before yielding, keeping pathological histories bounded without giving up the batching speedup.

Add regression coverage for matches beyond both the first page and the first session batch.