### PR TITLE
fix(cli): bound background process probes

### DIFF
--- a/.changeset/tidy-process-probes.md
+++ b/.changeset/tidy-process-probes.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent stalled operating system process queries from blocking background process management.

--- a/packages/opencode/src/kilocode/background-process/index.ts
+++ b/packages/opencode/src/kilocode/background-process/index.ts
@@ -653,6 +653,7 @@ export namespace BackgroundProcess {
     if (!pid || !token) return "unknown"
     const out = await Process.text(["ps", "eww", "-axo", "pid=,pgid=,command="], {
       nothrow: true,
+      abort: AbortSignal.timeout(2_000),
       timeout: 2_000,
     })
     if (out.code !== 0) return "unknown"
@@ -672,6 +673,7 @@ export namespace BackgroundProcess {
     const query = `$p=Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; if ($p) { [Console]::Out.Write($p.CommandLine) }`
     const out = await Process.text(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", query], {
       nothrow: true,
+      abort: AbortSignal.timeout(2_000),
       timeout: 2_000,
     })
     if (out.code !== 0) return "unknown"

--- a/packages/opencode/src/kilocode/background-process/runner.ts
+++ b/packages/opencode/src/kilocode/background-process/runner.ts
@@ -97,6 +97,7 @@ export namespace BackgroundProcessRunner {
       "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate | ConvertTo-Json -Compress"
     const out = await Process.text(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", query], {
       nothrow: true,
+      abort: AbortSignal.timeout(2_000),
       timeout: 2_000,
     })
     if (out.code !== 0 || !out.text.trim()) return seen


### PR DESCRIPTION
Background process ownership and descendant checks invoke operating-system process queries before adopting or terminating persistent processes. Those calls supplied a process kill grace period but no abort signal, so a stalled PowerShell CIM query could block background process management indefinitely and eventually time out the Windows test shard.

Give each ownership and process-tree query an explicit two-second abort deadline. A failed or timed-out query still produces an unknown ownership result, preserving the existing safety rule that unverifiable persistent processes must not be adopted or killed.