### PR TITLE
fix(cli): make agent manager schema provider-compatible

### DIFF
--- a/.changeset/calm-tools-speak.md
+++ b/.changeset/calm-tools-speak.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Agent Manager tool calls through providers that require object-root input schemas.

--- a/.changeset/calm-tools-speak.md
+++ b/.changeset/calm-tools-speak.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix Agent Manager tool calls through providers that require object-root input schemas.
+Fix Agent Manager tool calls through providers that require object-root input schemas without root combinators.

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -77,6 +77,16 @@ const PromptParams = Schema.Struct({
 
 export const Params = Schema.Union([StartParams, ListParams, PromptParams])
 
+const WireParams = Schema.Struct({
+  mode: Schema.optional(StartParams.fields.mode),
+  versions: Schema.optional(StartParams.fields.versions),
+  tasks: Schema.optional(StartParams.fields.tasks),
+  action: Schema.optional(Schema.Literals(["list", "prompt"])),
+  filter: Schema.optional(ListParams.fields.filter),
+  sessionID: Schema.optional(PromptParams.fields.sessionID),
+  prompt: Schema.optional(PromptParams.fields.prompt),
+})
+
 type Input = Schema.Schema.Type<typeof Task>
 type Selected = { task?: AgentManagerTask; error?: string }
 type Candidate = { providerID: string; model: Provider.Info["models"][string] }
@@ -238,7 +248,7 @@ export const AgentManagerTool = Tool.define<
     return {
       description: DESCRIPTION,
       parameters: Params,
-      jsonSchema: { ...ToolJsonSchema.fromSchema(Params), type: "object" },
+      jsonSchema: ToolJsonSchema.fromSchema(WireParams),
       execute: (params, ctx) =>
         Effect.gen(function* () {
           if ("action" in params) {

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -8,6 +8,7 @@ import * as SandboxInheritance from "@/kilocode/sandbox/inheritance"
 import { KiloSessionMessageOrder } from "@/kilocode/session/message-order"
 import { Provider } from "@/provider/provider"
 import { SessionID } from "@/session/schema"
+import * as ToolJsonSchema from "@/tool/json-schema"
 import { Tool } from "@/tool/tool"
 import { Effect, Schema } from "effect"
 import { matchesQuery } from "./model-search"
@@ -237,6 +238,7 @@ export const AgentManagerTool = Tool.define<
     return {
       description: DESCRIPTION,
       parameters: Params,
+      jsonSchema: { ...ToolJsonSchema.fromSchema(Params), type: "object" },
       execute: (params, ctx) =>
         Effect.gen(function* () {
           if ("action" in params) {

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -8,6 +8,7 @@ import { AgentManagerEvent, type AgentManagerStart } from "../../src/kilocode/ag
 import { AgentManager } from "../../src/kilocode/agent-manager/service"
 import { Bus } from "../../src/bus"
 import { Tool } from "../../src/tool/tool"
+import * as ToolJsonSchema from "../../src/tool/json-schema"
 import { Truncate } from "../../src/tool/truncate"
 import { Agent } from "../../src/agent/agent"
 import { Provider } from "../../src/provider/provider"
@@ -149,6 +150,14 @@ function publish(
 }
 
 describe("agent_manager tool", () => {
+  test("uses an object-root input schema", async () => {
+    const tool = await init()
+    const schema = ToolJsonSchema.fromTool(tool)
+
+    expect(schema.type).toBe("object")
+    expect(schema.anyOf).toHaveLength(3)
+  })
+
   test("asks for agent_manager permission", async () => {
     const tool = await init()
     const calls: unknown[] = []

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -150,12 +150,23 @@ function publish(
 }
 
 describe("agent_manager tool", () => {
-  test("uses an object-root input schema", async () => {
+  test("uses an object-root input schema without combinators", async () => {
     const tool = await init()
     const schema = ToolJsonSchema.fromTool(tool)
 
     expect(schema.type).toBe("object")
-    expect(schema.anyOf).toHaveLength(3)
+    expect(schema.anyOf).toBeUndefined()
+    expect(schema.oneOf).toBeUndefined()
+    expect(schema.allOf).toBeUndefined()
+    expect(Object.keys(schema.properties ?? {})).toEqual([
+      "mode",
+      "versions",
+      "tasks",
+      "action",
+      "filter",
+      "sessionID",
+      "prompt",
+    ])
   })
 
   test("asks for agent_manager permission", async () => {


### PR DESCRIPTION
Fix Agent Manager requests rejected by Anthropic and Bedrock routes because the generated union schema lacked an explicit object root and exposed a top-level `anyOf`, which these providers reject.

Keep the existing Effect union as the authoritative runtime validator while supplying providers with a plain object schema containing the fields for start, list, and prompt operations. Add regression coverage that requires an object root and forbids top-level `anyOf`, `oneOf`, and `allOf`.

This follows the existing [MCP tool conversion precedent](https://github.com/Kilo-Org/kilocode/blob/19bd048e21464f69b45e0d7a27c98a77037ebb08/packages/opencode/src/mcp/index.ts#L182-L192), which preserves tool input fields while explicitly enforcing a provider-compatible object root.