### PR TITLE
test(cli): stabilize global skill permission test on slow CI

### DIFF
--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -1012,6 +1012,9 @@ it.live(
         const call = { command: "pwd", workdir: skill, description: "Run global skill resource" }
 
         yield* Effect.promise(() => fs.mkdir(skill, { recursive: true }))
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(() => rm(skill, { recursive: true, force: true }).catch(() => {})),
+        )
         yield* llm.push(reply().tool("bash", call), reply().text("first complete").stop())
 
         yield* prompt.prompt({
@@ -1028,6 +1031,7 @@ it.live(
             return list.find((item) => item.sessionID === chat.id)
           }),
           "global skill permission was never surfaced",
+          "15 seconds",
         )
         expect(pending?.permission).toBe("external_directory")
         const always = (pending?.always ?? []) as string[]
@@ -1040,7 +1044,9 @@ it.live(
 
         yield* permission.reply({ requestID: pending.id, reply: "always" })
         expect(
-          Exit.isSuccess(yield* awaitWithTimeout(Fiber.await(first), "first global skill run did not finish")),
+          Exit.isSuccess(
+            yield* awaitWithTimeout(Fiber.await(first), "first global skill run did not finish", "15 seconds"),
+          ),
         ).toBe(true)
 
         yield* llm.push(reply().tool("bash", call), reply().text("second complete").stop())
@@ -1052,7 +1058,13 @@ it.live(
         })
         const second = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkScoped)
         expect(
-          Exit.isSuccess(yield* awaitWithTimeout(Fiber.await(second), "trusted global skill prompted a second time")),
+          Exit.isSuccess(
+            yield* awaitWithTimeout(
+              Fiber.await(second),
+              "trusted global skill prompted a second time",
+              "15 seconds",
+            ),
+          ),
         ).toBe(true)
         expect(yield* permission.list()).toEqual([])
       }),
@@ -1064,7 +1076,7 @@ it.live(
         }),
       },
     ),
-  { timeout: 15_000 },
+  { timeout: 30_000 },
 )
 
 it.live("active tool calls use permissions changed after model streaming starts", () =>

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -1012,9 +1012,6 @@ it.live(
         const call = { command: "pwd", workdir: skill, description: "Run global skill resource" }
 
         yield* Effect.promise(() => fs.mkdir(skill, { recursive: true }))
-        yield* Effect.addFinalizer(() =>
-          Effect.promise(() => rm(skill, { recursive: true, force: true }).catch(() => {})),
-        )
         yield* llm.push(reply().tool("bash", call), reply().text("first complete").stop())
 
         yield* prompt.prompt({
@@ -1031,7 +1028,6 @@ it.live(
             return list.find((item) => item.sessionID === chat.id)
           }),
           "global skill permission was never surfaced",
-          "15 seconds",
         )
         expect(pending?.permission).toBe("external_directory")
         const always = (pending?.always ?? []) as string[]


### PR DESCRIPTION
The global skill permission test runs a complete post-approval agent turn: persist the global skill approval, execute the shell tool, request the model again, and finish the session loop. That sequence was bounded by `awaitWithTimeout`'s generic two-second default, which is shorter than normal execution on loaded Windows runners and caused the test to fail even though it used the correct completion signal.

Give each of the two complete session loops a 15-second safety bound and raise the encompassing Bun test timeout to 30 seconds. The test continues to wait on `Fiber.await`, so it remains event-driven and still fails when a loop does not complete; only the unsuitable generic timeout is replaced.