### PR TITLE
feat(memory): add verbose flag and marker content snippets

### DIFF
--- a/.changeset/memory-verbose-markers.md
+++ b/.changeset/memory-verbose-markers.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": minor
+"@kilocode/sdk": minor
+"kilo-code": minor
+---
+
+Support verbose project-memory settings and show recalled memory snippets in conversation markers when enabled.

--- a/packages/kilo-memory/src/commands.ts
+++ b/packages/kilo-memory/src/commands.ts
@@ -7,6 +7,7 @@ export const MEMORY_COMMAND_CATALOG = [
   { usage: "correct <text>", description: "Save a correction to project memory" },
   { usage: "forget <query>", description: "Remove matching project memory" },
   { usage: "auto on|off", description: "Turn automatic memory saves on or off" },
+  { usage: "verbose on|off", description: "Turn verbose memory details on or off" },
   { usage: "edit", description: "Open project.md in $VISUAL/$EDITOR, then rebuild" },
   { usage: "rebuild", description: "Rebuild the memory index from source files" },
   { usage: "purge confirm", description: "Delete all project memory files" },
@@ -25,6 +26,7 @@ export const MEMORY_OPERATIONS = [
   "forget",
   "purge",
   "auto",
+  "verbose",
 ] as const
 export const MEMORY_PROMPT_OPERATIONS = ["remember", "forget"] as const
 
@@ -60,7 +62,7 @@ type Operation =
     }
   | {
       kind: "operation"
-      operation: "auto"
+      operation: "auto" | "verbose"
       mode: "on" | "off"
     }
   | {
@@ -70,7 +72,7 @@ type Operation =
     }
   | {
       kind: "operation"
-      operation: Exclude<MemoryOperation, "remember" | "correct" | "forget" | "purge" | "auto">
+      operation: Exclude<MemoryOperation, "remember" | "correct" | "forget" | "purge" | "auto" | "verbose">
     }
 
 type Usage = {
@@ -113,6 +115,11 @@ function operation(verb: string, text: string): ParsedMemoryCommand | undefined 
     const mode = text.toLowerCase()
     if (mode === "on" || mode === "off") return { kind: "operation", operation: "auto", mode }
     return usage("Missing auto mode. Run /memory auto on or /memory auto off.")
+  }
+  if (verb === "verbose") {
+    const mode = text.toLowerCase()
+    if (mode === "on" || mode === "off") return { kind: "operation", operation: "verbose", mode }
+    return usage("Missing verbose mode. Run /memory verbose on or /memory verbose off.")
   }
   if (verb === "remember") {
     if (text) return { kind: "operation", operation: "remember", text }

--- a/packages/kilo-memory/src/effect/httpapi.ts
+++ b/packages/kilo-memory/src/effect/httpapi.ts
@@ -48,6 +48,7 @@ export namespace MemoryContract {
     scope: Schema.Literal("project"),
     autoInject: Schema.Boolean,
     autoConsolidate: Schema.Boolean,
+    verbose: Schema.Boolean,
     capture: Capture,
     limits: Limits,
     stats: Stats,
@@ -150,6 +151,7 @@ export namespace MemoryContract {
 
   export const ConfigurePayload = Schema.Struct({
     autoConsolidate: Schema.optional(Schema.Boolean),
+    verbose: Schema.optional(Schema.Boolean),
   })
 
   export const PurgePayload = Schema.Struct({

--- a/packages/kilo-memory/src/effect/index.ts
+++ b/packages/kilo-memory/src/effect/index.ts
@@ -108,7 +108,7 @@ export namespace KiloMemory {
 
   export async function configure(
     input: Input & {
-      settings: Partial<Pick<MemorySchema.State, "autoConsolidate">>
+      settings: Partial<Pick<MemorySchema.State, "autoConsolidate" | "verbose">>
     },
   ) {
     const result = await Memory.configure({ root: await prepare(input), settings: input.settings })

--- a/packages/kilo-memory/src/effect/service.ts
+++ b/packages/kilo-memory/src/effect/service.ts
@@ -15,7 +15,7 @@ type SessionID = string
 const IDLE_SETTLE_MS = 30_000
 
 type ConfigureInput = KiloMemory.Input & {
-  settings: Partial<Pick<MemorySchema.State, "autoConsolidate">>
+  settings: Partial<Pick<MemorySchema.State, "autoConsolidate" | "verbose">>
 }
 
 type ApplyInput = KiloMemory.Input & {

--- a/packages/kilo-memory/src/marker-meta.ts
+++ b/packages/kilo-memory/src/marker-meta.ts
@@ -1,4 +1,7 @@
 export namespace MemoryMarkerMeta {
+  const LIMIT = 5
+  const CHARS = 120
+
   export type Type = "recall" | "startup"
 
   export type Info = {
@@ -7,6 +10,7 @@ export namespace MemoryMarkerMeta {
     tokens: number
     count: number
     files: string[]
+    items: string[]
   }
 
   export type Part = {
@@ -21,9 +25,10 @@ export namespace MemoryMarkerMeta {
     tokens: number
     count: number
     files: string[]
+    items: string[]
   }
 
-  export function metadata(marker: Info) {
+  export function metadata(marker: Info, verbose = false) {
     return {
       kiloMemory: {
         type: marker.type,
@@ -31,6 +36,7 @@ export namespace MemoryMarkerMeta {
         tokens: marker.tokens,
         count: marker.count,
         files: marker.files,
+        ...(verbose && marker.type === "recall" ? { items: marker.items } : {}),
       },
     }
   }
@@ -48,6 +54,25 @@ export namespace MemoryMarkerMeta {
     }
   }
 
+  function clip(input: string) {
+    return Array.from(input).slice(0, CHARS).join("")
+  }
+
+  function list(input: readonly string[]) {
+    return input.filter(Boolean).slice(0, LIMIT).map(clip)
+  }
+
+  function items(input: string) {
+    return list(
+      input.split("\n").flatMap((line) => (line.startsWith("text:") ? [line.slice("text:".length).trim()] : [])),
+    )
+  }
+
+  export function snippets(input: Decoded | undefined, verbose: boolean) {
+    if (!verbose || input?.type !== "recall") return []
+    return input.items
+  }
+
   export function fromBlocks(blocks: readonly { text: string; bytes: number; estimatedTokens: number }[]) {
     const records = blocks.flatMap((block) =>
       block.text
@@ -63,6 +88,7 @@ export namespace MemoryMarkerMeta {
       tokens: blocks.reduce((sum, block) => sum + block.estimatedTokens, 0),
       count: records.length,
       files,
+      items: [],
     } satisfies Info
   }
 
@@ -78,6 +104,7 @@ export namespace MemoryMarkerMeta {
       tokens: input.tokens,
       count: typeof input.metadata?.count === "number" ? input.metadata.count : files.length,
       files: [...new Set(files)],
+      items: items(text),
     } satisfies Info
   }
 
@@ -86,7 +113,14 @@ export namespace MemoryMarkerMeta {
       if (part.type !== "text") continue
       const meta = part.metadata?.kiloMemory
       if (!meta || typeof meta !== "object") continue
-      const value = meta as { type?: unknown; tokens?: unknown; count?: unknown; files?: unknown; sources?: unknown }
+      const value = meta as {
+        type?: unknown
+        tokens?: unknown
+        count?: unknown
+        files?: unknown
+        sources?: unknown
+        items?: unknown
+      }
       const type = value.type === "startup" ? "startup" : "recall"
       const tokens = typeof value.tokens === "number" ? value.tokens : 0
       // `sources` fallback covers parts persisted before the key was dropped from metadata().
@@ -96,7 +130,10 @@ export namespace MemoryMarkerMeta {
           ? value.sources.filter((item) => typeof item === "string")
           : []
       const count = typeof value.count === "number" ? value.count : files.length
-      return { type, tokens, count, files }
+      const items = Array.isArray(value.items)
+        ? list(value.items.filter((item): item is string => typeof item === "string"))
+        : []
+      return { type, tokens, count, files, items }
     }
     return undefined
   }

--- a/packages/kilo-memory/src/memory.ts
+++ b/packages/kilo-memory/src/memory.ts
@@ -112,13 +112,14 @@ export namespace Memory {
 
   export async function configure(input: {
     root: string
-    settings: Partial<Pick<MemorySchema.State, "autoConsolidate">>
+    settings: Partial<Pick<MemorySchema.State, "autoConsolidate" | "verbose">>
   }) {
     return MemoryFiles.queue(input.root, async () => {
       const state = await MemoryFiles.readState(input.root)
       const next = {
         ...state,
         ...(input.settings.autoConsolidate === undefined ? {} : { autoConsolidate: input.settings.autoConsolidate }),
+        ...(input.settings.verbose === undefined ? {} : { verbose: input.settings.verbose }),
       }
       await MemoryFiles.writeState(input.root, next)
       await MemoryFiles.append(
@@ -126,6 +127,7 @@ export namespace Memory {
         [
           `settings ${next.scope}`,
           input.settings.autoConsolidate === undefined ? "" : `autoConsolidate=${next.autoConsolidate}`,
+          input.settings.verbose === undefined ? "" : `verbose=${next.verbose}`,
         ]
           .filter(Boolean)
           .join(" "),

--- a/packages/kilo-memory/src/schema.ts
+++ b/packages/kilo-memory/src/schema.ts
@@ -51,6 +51,7 @@ export namespace MemorySchema {
     scope: "project"
     autoInject: boolean
     autoConsolidate: boolean
+    verbose: boolean
     capture: Capture
     limits: Limits
     stats: Stats
@@ -153,6 +154,7 @@ export namespace MemorySchema {
       scope: "project",
       autoInject: true,
       autoConsolidate: true,
+      verbose: false,
       capture: { ...capture },
       limits: { ...limits },
       stats: { ...stats },
@@ -170,6 +172,7 @@ export namespace MemorySchema {
       scope: input.scope,
       autoInject: input.autoInject,
       autoConsolidate: input.autoConsolidate,
+      verbose: input.verbose,
       capture: input.capture,
       stats: input.stats,
     }
@@ -190,6 +193,7 @@ export namespace MemorySchema {
       scope: "project",
       autoInject: true,
       autoConsolidate: bool(input.autoConsolidate, base.autoConsolidate),
+      verbose: bool(input.verbose, base.verbose),
       capture: {
         mode: "selective",
         turnClose: bool(cap.turnClose, base.capture.turnClose),

--- a/packages/kilo-memory/test/command-cases.json
+++ b/packages/kilo-memory/test/command-cases.json
@@ -95,6 +95,26 @@
     "mode": "off"
   },
   {
+    "name": "verbose mode usage",
+    "input": "/memory verbose",
+    "result": "usage",
+    "reason": "Missing verbose mode"
+  },
+  {
+    "name": "verbose on operation",
+    "input": "/memory verbose on",
+    "result": "operation",
+    "operation": "verbose",
+    "mode": "on"
+  },
+  {
+    "name": "verbose off operation",
+    "input": "/memory verbose off",
+    "result": "operation",
+    "operation": "verbose",
+    "mode": "off"
+  },
+  {
     "name": "remember operation keeps text",
     "input": "/memory remember use bun test from packages/opencode",
     "result": "operation",

--- a/packages/kilo-memory/test/commands.test.ts
+++ b/packages/kilo-memory/test/commands.test.ts
@@ -29,7 +29,7 @@ function expected(item: Case): ParsedMemoryCommand | undefined {
     if (!item.query) throw new Error(`Missing query for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, query: item.query }
   }
-  if (item.operation === "auto") {
+  if (item.operation === "auto" || item.operation === "verbose") {
     if (!item.mode) throw new Error(`Missing mode for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, mode: item.mode }
   }

--- a/packages/kilo-memory/test/core.test.ts
+++ b/packages/kilo-memory/test/core.test.ts
@@ -49,12 +49,13 @@ describe("memory core package", () => {
   test("enable preserves existing memory settings", async () => {
     await use(async (t) => {
       const enabled = await Memory.enable({ root: t.root })
-      await MemoryFiles.writeState(t.root, { ...enabled.state, autoInject: false, autoConsolidate: false })
+      await MemoryFiles.writeState(t.root, { ...enabled.state, autoInject: false, autoConsolidate: false, verbose: true })
 
       const next = await Memory.enable({ root: t.root })
 
       expect(next.state.autoInject).toBe(true)
       expect(next.state.autoConsolidate).toBe(false)
+      expect(next.state.verbose).toBe(true)
     })
   })
 
@@ -72,8 +73,10 @@ describe("memory core package", () => {
 
     expect(paused.autoInject).toBe(true)
     expect(paused.autoConsolidate).toBe(true)
+    expect(paused.verbose).toBe(false)
     expect(missing.enabled).toBe(false)
     expect(missing.autoConsolidate).toBe(true)
+    expect(missing.verbose).toBe(false)
     expect(state.limits.maxSessionFiles).toBe(20)
     expect(state.limits.maxRecentSessions).toBe(5)
     expect(state.limits.maxProjectIndexBytes).toBe(8192)
@@ -91,7 +94,20 @@ describe("memory core package", () => {
       const state = await MemoryFiles.readState(t.root)
 
       expect(raw.limits).toBeUndefined()
+      expect(raw.verbose).toBe(false)
       expect(state.limits.maxSessionLineChars).toBe(480)
+    })
+  })
+
+  test("configures and persists verbose memory details", async () => {
+    await use(async (t) => {
+      await Memory.enable({ root: t.root })
+      const result = await Memory.configure({ root: t.root, settings: { verbose: true } })
+      const raw = JSON.parse(await Bun.file(MemoryPaths.files(t.root).state).text())
+
+      expect(result.state.verbose).toBe(true)
+      expect(raw.verbose).toBe(true)
+      expect((await MemoryFiles.readState(t.root)).verbose).toBe(true)
     })
   })
 

--- a/packages/kilo-memory/test/decisions.test.ts
+++ b/packages/kilo-memory/test/decisions.test.ts
@@ -156,13 +156,15 @@ describe("memory marker metadata", () => {
       tokens: 4,
       count: 2,
       files: ["project.md", "environment.md"],
+      items: ["first memory", "second memory"],
     }
 
-    expect(MemoryMarkerMeta.fromParts([{ type: "text", metadata: MemoryMarkerMeta.metadata(marker) }])).toEqual({
+    expect(MemoryMarkerMeta.fromParts([{ type: "text", metadata: MemoryMarkerMeta.metadata(marker, true) }])).toEqual({
       type: "recall",
       tokens: 4,
       count: 2,
       files: ["project.md", "environment.md"],
+      items: ["first memory", "second memory"],
     })
   })
 
@@ -176,22 +178,80 @@ describe("memory marker metadata", () => {
       tokens: 3,
       count: 1,
       files: ["project.md"],
+      items: [],
     })
   })
 
   test("builds recall metadata from sources", () => {
     expect(
       MemoryMarkerMeta.fromRecall({
-        output: "remembered",
+        output: "record id=remembered source=project.md\ntext: remembered",
         metadata: { sources: ["project.md", "project.md"], count: 1 },
         tokens: 3,
       }),
     ).toEqual({
       type: "recall",
-      bytes: Buffer.byteLength("remembered"),
+      bytes: Buffer.byteLength("record id=remembered source=project.md\ntext: remembered"),
       tokens: 3,
       count: 1,
       files: ["project.md"],
+      items: ["remembered"],
     })
+  })
+
+  test("does not retain startup context snippets", () => {
+    const text = Array.from(
+      { length: 6 },
+      (_, index) => `record id=${index} source=project.md\ntext: ${"x".repeat(121)}`,
+    ).join("\n")
+    expect(MemoryMarkerMeta.fromBlocks([{ text, bytes: Buffer.byteLength(text), estimatedTokens: 8 }])).toMatchObject({
+      type: "startup",
+      count: 6,
+      files: ["project.md"],
+      items: [],
+    })
+  })
+
+  test("persists recall snippets only in verbose mode", () => {
+    const marker: MemoryMarkerMeta.Info = {
+      type: "recall",
+      bytes: 10,
+      tokens: 4,
+      count: 1,
+      files: ["project.md"],
+      items: ["private memory"],
+    }
+
+    expect(MemoryMarkerMeta.metadata(marker).kiloMemory).not.toHaveProperty("items")
+    expect(MemoryMarkerMeta.metadata(marker, true).kiloMemory).toHaveProperty("items", ["private memory"])
+  })
+
+  test("bounds recall snippets without splitting surrogate pairs", () => {
+    const text = Array.from(
+      { length: 6 },
+      (_, index) => `record id=${index} source=project.md\ntext: ${"x".repeat(119)}😀z`,
+    ).join("\n")
+    const marker = MemoryMarkerMeta.fromRecall({
+      output: text,
+      metadata: { sources: ["project.md"], count: 6 },
+      tokens: 8,
+    })
+
+    expect(marker?.items).toEqual(Array.from({ length: 5 }, () => `${"x".repeat(119)}😀`))
+  })
+
+  test("shows recall snippets only when verbose", () => {
+    const recall: MemoryMarkerMeta.Decoded = {
+      type: "recall",
+      tokens: 4,
+      count: 1,
+      files: ["project.md"],
+      items: ["remembered"],
+    }
+    const startup = { ...recall, type: "startup" as const }
+
+    expect(MemoryMarkerMeta.snippets(recall, false)).toEqual([])
+    expect(MemoryMarkerMeta.snippets(startup, true)).toEqual([])
+    expect(MemoryMarkerMeta.snippets(recall, true)).toEqual(["remembered"])
   })
 })

--- a/packages/kilo-vscode/src/kilo-provider/memory.ts
+++ b/packages/kilo-vscode/src/kilo-provider/memory.ts
@@ -414,6 +414,7 @@ export class KiloProviderMemory {
     if (op === "rebuild") return (await api.rebuild({ directory }, { throwOnError: true })).data
     if (op === "purge") return this.purge(api, directory, message)
     if (op === "auto") return this.auto(api, directory, message)
+    if (op === "verbose") return this.verbose(api, directory, message)
     if (op === "remember") return this.remember(api, directory, message)
     if (op === "correct") return this.correct(api, directory, message)
     return this.forget(api, directory, message)
@@ -479,5 +480,12 @@ export class KiloProviderMemory {
       return (await api.configure({ directory, autoConsolidate: message.mode === "on" }, { throwOnError: true })).data
     }
     throw new Error("Auto-save mode is required")
+  }
+
+  private async verbose(api: MemoryApi, directory: string, message: KiloProviderMemoryMessage) {
+    if (message.mode === "on" || message.mode === "off") {
+      return (await api.configure({ directory, verbose: message.mode === "on" }, { throwOnError: true })).data
+    }
+    throw new Error("Verbose mode is required")
   }
 }

--- a/packages/kilo-vscode/tests/unit/kilo-provider-memory.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-memory.test.ts
@@ -180,11 +180,12 @@ describe("KiloProviderMemory", () => {
     )
   })
 
-  it("routes auto-save and purge operations with explicit payloads", async () => {
+  it("routes auto-save, verbose, and purge operations with explicit payloads", async () => {
     const calls: unknown[] = []
     const state = status("/repo")
     const view = show("/repo")
     state.state.autoConsolidate = false
+    state.state.verbose = true
     const item = subject({
       memory: {
         configure: async (input: unknown) => {
@@ -201,12 +202,14 @@ describe("KiloProviderMemory", () => {
     } as unknown as KiloClient)
 
     await item.memory.run({ operation: "auto", mode: "off", sessionID: "ses_memory" })
+    await item.memory.run({ operation: "verbose", mode: "on", sessionID: "ses_memory" })
     await item.memory.run({ operation: "purge", confirm: true, sessionID: "ses_memory" })
 
     expect(calls).toEqual([
       ["configure", { directory: "/repo", autoConsolidate: false }],
+      ["configure", { directory: "/repo", verbose: true }],
       ["purge", { directory: "/repo", confirm: true }],
     ])
-    expect(item.posts.filter((post) => (post as { type?: string }).type === "memoryOperationResult")).toHaveLength(2)
+    expect(item.posts.filter((post) => (post as { type?: string }).type === "memoryOperationResult")).toHaveLength(3)
   })
 })

--- a/packages/kilo-vscode/tests/unit/memory-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/memory-command.test.ts
@@ -12,6 +12,7 @@ type MemoryOperation =
   | "forget"
   | "purge"
   | "auto"
+  | "verbose"
 type Case = {
   name: string
   input: string
@@ -42,7 +43,7 @@ function expected(item: Case): ParsedMemoryCommand | undefined {
     if (!item.query) throw new Error(`Missing query for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, query: item.query }
   }
-  if (item.operation === "auto") {
+  if (item.operation === "auto" || item.operation === "verbose") {
     if (!item.mode) throw new Error(`Missing mode for fixture: ${item.name}`)
     return { kind: "operation", operation: item.operation, mode: item.mode }
   }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -199,6 +199,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
   const meta = createMemo(() =>
     MemoryMarkerMeta.fromParts((props.parts ?? data.store.part?.[props.message.id] ?? []) as MemoryMarkerMeta.Part[]),
   )
+  const verbose = createMemo(() => Boolean(mem.status()?.state.verbose))
   const fmt = (value: number) => value.toLocaleString(language.locale())
   const count = (item: MemoryItem) => fmt(item.count)
   const tokens = (item: MemoryItem) => fmt(item.tokens)
@@ -241,6 +242,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
         <Show when={item.files.length > 0}>
           <div>{language.t("chat.memory.badge.files", { files: item.files.join(", ") })}</div>
         </Show>
+        <For each={MemoryMarkerMeta.snippets(item, verbose())}>{(value) => <div>{value}</div>}</For>
       </div>
     )
   }
@@ -365,6 +367,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           <Tooltip value={tip(item())} placement="top">
             <div data-component="assistant-memory-badge">
               {label(item())} · {detail(item())} · {language.t("chat.memory.badge.tokens", { tokens: tokens(item()) })}
+              <Show when={MemoryMarkerMeta.snippets(item(), verbose())[0]}>{(value) => <> · {value()}</>}</Show>
             </div>
           </Tooltip>
         )}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -992,7 +992,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         type: "memoryOperation",
         operation: memory.operation,
         sessionID: sid(),
-        ...(memory.operation === "auto" ? { mode: memory.mode } : {}),
+        ...(memory.operation === "auto" || memory.operation === "verbose" ? { mode: memory.mode } : {}),
         ...(memory.operation === "purge" ? { confirm: memory.confirm } : {}),
         ...(memory.operation === "remember" || memory.operation === "correct" ? { text: memory.text } : {}),
         ...(memory.operation === "forget" ? { query: memory.query } : {}),

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -206,6 +206,7 @@ const context = createContext<{
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
   tui: ReturnType<typeof useTuiConfig>
+  memory: () => boolean // kilocode_change
 }>()
 
 function use() {
@@ -337,6 +338,7 @@ export function Session() {
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
   const toast = useToast()
   const sdk = useSDK()
+  const memory = MemorySessionTui.verbose({ sessionID: () => route.sessionID }) // kilocode_change
   const editor = useEditorContext()
 
   // kilocode_change start - background processes are scoped to the visible session
@@ -1319,6 +1321,7 @@ export function Session() {
           providers,
           sync,
           tui: tuiConfig,
+          memory, // kilocode_change
         }}
       >
         <box flexDirection="row" flexGrow={1} minHeight={0}>
@@ -1761,7 +1764,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>
-              <MemoryMessageMeta parts={props.parts} color={theme.textMuted} /> {/* kilocode_change */}
+              {/* kilocode_change start */}
+              <MemoryMessageMeta parts={props.parts} color={theme.textMuted} verbose={ctx.memory()} />
+              {/* kilocode_change end */}
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
               </Show>

--- a/packages/opencode/src/kilocode/cli/cmd/tui/memory-command.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/memory-command.ts
@@ -48,6 +48,10 @@ function auto(input: boolean) {
   return `Memory auto-save ${input ? "on" : "off"}`
 }
 
+function verbose(input: boolean) {
+  return `Memory verbose ${input ? "on" : "off"}`
+}
+
 async function edit(input: { file: string; cwd?: string; renderer?: CliRenderer }) {
   const editor = (process.env["VISUAL"] || process.env["EDITOR"])?.trim()
   if (!editor) throw new Error("Set $VISUAL or $EDITOR to use /memory edit")
@@ -131,6 +135,16 @@ export async function runMemoryCommand(input: {
         }),
       )
       input.toast.show({ variant: "info", message: auto(result.state.autoConsolidate) })
+      return true
+    }
+    if (parsed.operation === "verbose") {
+      const result = read(
+        await input.client.memory.configure({
+          ...route(input),
+          verbose: parsed.mode === "on",
+        }),
+      )
+      input.toast.show({ variant: "info", message: verbose(result.state.verbose) })
       return true
     }
     if (parsed.operation === "disable") {

--- a/packages/opencode/src/kilocode/cli/cmd/tui/memory-meta.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/memory-meta.ts
@@ -4,4 +4,8 @@ export namespace MemoryTuiMeta {
   export function fromParts(parts: readonly MemoryMarkerMeta.Part[]) {
     return MemoryMarkerMeta.fromParts(parts)
   }
+
+  export function snippets(input: MemoryMarkerMeta.Decoded | undefined, verbose: boolean) {
+    return MemoryMarkerMeta.snippets(input, verbose)
+  }
 }

--- a/packages/opencode/src/kilocode/cli/cmd/tui/routes/session/memory.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/routes/session/memory.tsx
@@ -1,19 +1,52 @@
-import { Show } from "solid-js"
+import { createMemo, createResource, createSignal, For, onCleanup, Show } from "solid-js"
 import type { RGBA } from "@opentui/core"
 import type { Part } from "@kilocode/sdk/v2"
+import * as Log from "@opencode-ai/core/util/log"
+import { useEvent } from "@tui/context/event"
+import { useProject } from "@tui/context/project"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
 import { MemoryTuiEvents } from "@/kilocode/cli/cmd/tui/memory-events"
+import { route } from "@/kilocode/cli/cmd/tui/memory-command"
 import { MemoryTuiMeta } from "@/kilocode/cli/cmd/tui/memory-meta"
+import { errorMessage } from "@/util/error"
 
 type Event = Parameters<typeof MemoryTuiEvents.attach>[0]["event"]
 type Toast = Parameters<typeof MemoryTuiEvents.attach>[0]["toast"]
+const log = Log.create({ service: "tui.memory-message" })
 
 export namespace MemorySessionTui {
   export function attach(input: { event: Event; toast: Toast; sessionID: string }) {
     return MemoryTuiEvents.attach(input)
   }
+
+  export function verbose(input: { sessionID(): string }) {
+    const sdk = useSDK()
+    const event = useEvent()
+    const project = useProject()
+    const sync = useSync()
+    const [tick, setTick] = createSignal(0)
+    const session = createMemo(() => sync.session.get(input.sessionID()))
+    const workspace = createMemo(() => session()?.workspaceID ?? project.workspace.current())
+    const dir = createMemo(() => session()?.directory ?? project.instance.path().directory)
+    const [data] = createResource(
+      () => [workspace(), dir(), tick()] as const,
+      async ([workspace, directory]) => {
+        const result = await sdk.client.memory.status(route({ workspace, directory })).catch((err: unknown) => {
+          log.warn("memory verbose status unavailable", { error: errorMessage(err) })
+          return undefined
+        })
+        if (!result?.data || result.error) return false
+        return result.data.state.verbose
+      },
+    )
+    const dispose = event.on("memory.status", () => setTick((value) => value + 1))
+    onCleanup(dispose)
+    return createMemo(() => data() ?? false)
+  }
 }
 
-export function MemoryMessageMeta(props: { parts: Part[]; color: string | RGBA }) {
+export function MemoryMessageMeta(props: { parts: Part[]; color: string | RGBA; verbose: boolean }) {
   return (
     <Show when={MemoryTuiMeta.fromParts(props.parts)}>
       {(item) => {
@@ -23,6 +56,7 @@ export function MemoryMessageMeta(props: { parts: Part[]; color: string | RGBA }
           <span style={{ fg: props.color }}>
             {" "}
             · Memory · {label()} · {item().tokens.toLocaleString()} Tokens
+            <For each={MemoryTuiMeta.snippets(item(), props.verbose).slice(0, 2)}>{(value) => <> · {value}</>}</For>
           </span>
         )
       }}

--- a/packages/opencode/src/kilocode/memory/marker.ts
+++ b/packages/opencode/src/kilocode/memory/marker.ts
@@ -11,13 +11,15 @@ export namespace MemoryMarker {
   export type Cache = {
     marker?: Info
     marked?: boolean
+    verbose?: boolean
   }
 
   export function fromBlocks(blocks: KiloMemory.Block[]): Info | undefined {
     return MemoryMarkerMeta.fromBlocks(blocks)
   }
 
-  export function startup(input: { marker?: Info; cache: Cache }) {
+  export function startup(input: { marker?: Info; cache: Cache; verbose: boolean }) {
+    input.cache.verbose = input.verbose
     if (input.cache.marker) return
     if (!input.marker || input.marker.count === 0) return
     input.cache.marker = input.marker
@@ -47,7 +49,7 @@ export namespace MemoryMarker {
       text: "",
       synthetic: true,
       ignored: true,
-      metadata: MemoryMarkerMeta.metadata(marker),
+      metadata: MemoryMarkerMeta.metadata(marker, input.cache.verbose),
     } satisfies MessageV2.TextPart
   }
 }

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/memory.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/memory.ts
@@ -53,7 +53,12 @@ export const memoryHandlers = HttpApiBuilder.group(InstanceHttpApi, "memory", (h
     }) {
       const ctx = yield* InstanceState.context
       return MemoryContract.output(
-        yield* api(svc.configure({ ctx, settings: { autoConsolidate: req.payload.autoConsolidate } })),
+        yield* api(
+          svc.configure({
+            ctx,
+            settings: { autoConsolidate: req.payload.autoConsolidate, verbose: req.payload.verbose },
+          }),
+        ),
       )
     })
 

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -21,6 +21,7 @@ import { environmentDetails } from "@/kilocode/editor-context"
 import { Identifier } from "@/id/id"
 import { Filesystem } from "@/util/filesystem"
 import NATIVE_PLAN_PROMPT from "@/kilocode/session/native-plan-prompt.txt"
+import { KiloMemory } from "@kilocode/kilo-memory/effect"
 import { MemoryPaths } from "@kilocode/kilo-memory/effect/paths"
 import { MemoryMarker } from "@/kilocode/memory/marker"
 import { KilocodeSystemPrompt } from "@/kilocode/system-prompt"
@@ -290,6 +291,15 @@ export namespace KiloSessionPrompt {
     cache: MemoryMarker.Cache
   }) {
     const enabled = yield* memoryToolEnabled({ ctx: input.ctx })
+    const verbose =
+      input.cache.verbose ??
+      (enabled
+        ? yield* Effect.tryPromise(() => KiloMemory.status({ ctx: input.ctx })).pipe(
+            Effect.map((item) => item.state.verbose),
+            // Fail closed: unavailable state must not persist memory snippets.
+            Effect.catch(() => Effect.succeed(false)),
+          )
+        : false)
     const cached = pinnedMemory.get(input.sessionID)
     const built =
       cached?.enabled === enabled
@@ -303,7 +313,7 @@ export namespace KiloSessionPrompt {
             Effect.map((mem) => ({ blocks: mem.blocks, enabled, marker: mem.marker })),
             Effect.tap((mem) => Effect.sync(() => writePinnedMemory(input.sessionID, mem))),
           )
-    MemoryMarker.startup({ marker: built.marker, cache: input.cache })
+    MemoryMarker.startup({ marker: built.marker, cache: input.cache, verbose })
     return built.blocks
   })
 

--- a/packages/opencode/test/kilocode/cli/cmd/tui/memory-command.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/memory-command.test.ts
@@ -43,16 +43,16 @@ describe("memory TUI command parser", () => {
     expect(shown.join("\n")).not.toContain("memory tokens")
   })
 
-  test("auto-save and purge commands call explicit endpoints", async () => {
+  test("auto-save, verbose, and purge commands call explicit endpoints", async () => {
     const shown: string[] = []
     const calls: unknown[] = []
-    const state = { autoConsolidate: true }
+    const state = { autoConsolidate: true, verbose: false }
     const client = {
       memory: {
         status: async () => ({ data: { state } }),
         configure: async (input: unknown) => {
           calls.push(input)
-          return { data: { state: { autoConsolidate: false } } }
+          return { data: { state: { autoConsolidate: false, verbose: true } } }
         },
         purge: async (input: unknown) => {
           calls.push(input)
@@ -75,15 +75,17 @@ describe("memory TUI command parser", () => {
     }
 
     await runMemoryCommand({ ...base, text: "/memory auto off" })
+    await runMemoryCommand({ ...base, text: "/memory verbose on" })
     await runMemoryCommand({ ...base, text: "/memory auto status" })
     await runMemoryCommand({ ...base, text: "/memory purge" })
     await runMemoryCommand({ ...base, text: "/memory purge confirm" })
 
     expect(shown[0]).toBe("Memory auto-save off")
-    expect(shown[1]).toContain("Missing auto mode")
-    expect(shown[2]).toContain("Purge requires confirmation")
-    expect(shown[3]).toBe("Memory purged")
-    expect(calls).toEqual([{ autoConsolidate: false }, { confirm: true }])
+    expect(shown[1]).toBe("Memory verbose on")
+    expect(shown[2]).toContain("Missing auto mode")
+    expect(shown[3]).toContain("Purge requires confirmation")
+    expect(shown[4]).toBe("Memory purged")
+    expect(calls).toEqual([{ autoConsolidate: false }, { verbose: true }, { confirm: true }])
   })
 
   test("status opens overview dialog", async () => {
@@ -181,7 +183,7 @@ describe("memory TUI command parser", () => {
 
   test("memory commands route to session directory when no workspace is active", async () => {
     const calls: unknown[] = []
-    const state = { autoConsolidate: false }
+    const state = { autoConsolidate: false, verbose: false }
     const client = {
       memory: {
         configure: async (input: unknown) => {
@@ -199,6 +201,7 @@ describe("memory TUI command parser", () => {
     }
 
     await runMemoryCommand({ ...base, text: "/memory auto off", directory: "/repo/packages/opencode" })
+    await runMemoryCommand({ ...base, text: "/memory verbose on", directory: "/repo/packages/opencode" })
     await runMemoryCommand({
       ...base,
       text: "/memory auto off",
@@ -208,6 +211,7 @@ describe("memory TUI command parser", () => {
 
     expect(calls).toEqual([
       { directory: "/repo/packages/opencode", autoConsolidate: false },
+      { directory: "/repo/packages/opencode", verbose: true },
       { workspace: "wrk_123", autoConsolidate: false },
     ])
   })

--- a/packages/opencode/test/kilocode/memory/memory-integration.test.ts
+++ b/packages/opencode/test/kilocode/memory/memory-integration.test.ts
@@ -179,7 +179,7 @@ describe("KiloMemory integration", () => {
 
   test("targeted recall metadata replaces startup memory badge marker", () => {
     const cache: MemoryMarker.Cache = {
-      marker: { type: "startup", bytes: 20, tokens: 5, count: 1, files: ["project.md"] },
+      marker: { type: "startup", bytes: 20, tokens: 5, count: 1, files: ["project.md"], items: [] },
       marked: true,
     }
 
@@ -580,6 +580,38 @@ describe("KiloMemory integration", () => {
       KiloToolRegistry.invalidateMemoryEnabled(root)
       const removed = await build()
       expect(removed.join("\n")).not.toContain("toggle_fact")
+    })
+  })
+
+  test("memorySystem refreshes verbose marker state for each turn", async () => {
+    await using tmp = await tmpdir()
+    await withConfig(path.join(tmp.path, "global", ".kilo"), async () => {
+      const context = ctx(tmp.path)
+      await KiloMemory.enable({ ctx: context })
+      KiloSessionPrompt.clearPinnedMemory()
+
+      const first = KiloSessionPrompt.memoryCache()
+      await Effect.runPromise(
+        KiloSessionPrompt.memoryInject({
+          ctx: context,
+          sessionID: SessionID.make("ses_verbose"),
+          record: false,
+          cache: first,
+        }),
+      )
+      expect(first.verbose).toBe(false)
+
+      await KiloMemory.configure({ ctx: context, settings: { verbose: true } })
+      const second = KiloSessionPrompt.memoryCache()
+      await Effect.runPromise(
+        KiloSessionPrompt.memoryInject({
+          ctx: context,
+          sessionID: SessionID.make("ses_verbose"),
+          record: false,
+          cache: second,
+        }),
+      )
+      expect(second.verbose).toBe(true)
     })
   })
 

--- a/packages/opencode/test/kilocode/server/httpapi-memory.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-memory.test.ts
@@ -85,10 +85,11 @@ describe("HttpApi memory", () => {
     const status = await json("GET", MemoryPaths.status)
     expect(keys(status)).toEqual(["exists", "index", "root", "state"].sort())
     expect(keys(status.state)).toEqual(
-      ["autoConsolidate", "autoInject", "capture", "enabled", "limits", "scope", "stats", "version"].sort(),
+      ["autoConsolidate", "autoInject", "capture", "enabled", "limits", "scope", "stats", "verbose", "version"].sort(),
     )
     expect(rec(status.state).enabled).toBe(false)
     expect(rec(status.state).autoConsolidate).toBe(true)
+    expect(rec(status.state).verbose).toBe(false)
     expect(rec(status.index).estimatedTokens).toBe(0)
     const stats = rec(rec(status.state).stats)
     expectStats(stats)
@@ -101,9 +102,10 @@ describe("HttpApi memory", () => {
     expect(rec(enable.state).enabled).toBe(true)
     expect(rec(rec(enable.state).stats).lastInjectedSessionID).toBe("")
 
-    const configured = await json("POST", MemoryPaths.configure, { autoConsolidate: false })
+    const configured = await json("POST", MemoryPaths.configure, { autoConsolidate: false, verbose: true })
     expect(rec(configured.state).enabled).toBe(true)
     expect(rec(configured.state).autoConsolidate).toBe(false)
+    expect(rec(configured.state).verbose).toBe(true)
 
     const remembered = await json("POST", MemoryPaths.remember, {
       key: "httpapi_memory",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -8834,6 +8834,7 @@ export class Memory extends HeyApiClient {
       directory?: string
       workspace?: string
       autoConsolidate?: boolean
+      verbose?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -8845,6 +8846,7 @@ export class Memory extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "body", key: "autoConsolidate" },
+            { in: "body", key: "verbose" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -13671,6 +13671,7 @@ export type MemoryStatusResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean
@@ -13751,6 +13752,7 @@ export type MemoryShowResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean
@@ -13831,6 +13833,7 @@ export type MemoryEnableResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean
@@ -13908,6 +13911,7 @@ export type MemoryDisableResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean
@@ -13947,6 +13951,7 @@ export type MemoryDisableResponse = MemoryDisableResponses[keyof MemoryDisableRe
 export type MemoryConfigureData = {
   body?: {
     autoConsolidate?: boolean
+    verbose?: boolean
   }
   path?: never
   query?: {
@@ -13981,6 +13986,7 @@ export type MemoryConfigureResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean
@@ -14052,6 +14058,7 @@ export type MemoryRebuildResponses = {
       scope: "project"
       autoInject: boolean
       autoConsolidate: boolean
+      verbose: boolean
       capture: {
         mode: "selective"
         turnClose: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -17911,6 +17911,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -18032,6 +18035,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"
@@ -18166,6 +18170,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -18287,6 +18294,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"
@@ -18420,6 +18428,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -18541,6 +18552,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"
@@ -18665,6 +18677,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -18786,6 +18801,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"
@@ -18891,6 +18907,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -19012,6 +19031,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"
@@ -19063,6 +19083,9 @@
                 "type": "object",
                 "properties": {
                   "autoConsolidate": {
+                    "type": "boolean"
+                  },
+                  "verbose": {
                     "type": "boolean"
                   }
                 },
@@ -19132,6 +19155,9 @@
                         "autoConsolidate": {
                           "type": "boolean"
                         },
+                        "verbose": {
+                          "type": "boolean"
+                        },
                         "capture": {
                           "type": "object",
                           "properties": {
@@ -19253,6 +19279,7 @@
                         "scope",
                         "autoInject",
                         "autoConsolidate",
+                        "verbose",
                         "capture",
                         "limits",
                         "stats"


### PR DESCRIPTION
## Context

Project memory markers currently expose counts and token totals but not which recalled facts were used. Add an opt-in verbose setting so users can inspect recalled memory snippets in VS Code and the TUI while keeping the default metadata minimal.

## Implementation

- Add a persisted `verbose` project-memory setting, exposed through the HTTP API, generated SDK, and `/memory verbose on|off`.
- Capture bounded recall snippets only when verbose mode is enabled: at most five snippets, each capped at 120 Unicode code points.
- Keep startup-context content out of marker metadata and fail closed when verbose status is unavailable.
- Refresh client display state when memory status changes and render snippets in VS Code marker details and the TUI footer.

## Screenshots / Video


## How to Test

### Manual/local verification

Executed by the coding agent:

- `packages/kilo-memory`: full test suite (158 passing) and typecheck.
- `packages/opencode`: targeted memory HTTP, integration, and TUI command tests (32 passing), plus typecheck.
- `packages/kilo-vscode`: targeted memory unit tests (19 passing), typecheck, and lint.
- Root OpenCode annotation and Promise-facade guards passed.
- The pre-push hook completed all TypeScript and JetBrains typechecks successfully.

### Reviewer test steps

1. Run `/memory verbose on`.
2. Trigger a `kilo_memory_recall` result and confirm recalled snippets appear in the VS Code memory badge/tooltip and TUI message footer.
3. Run `/memory verbose off`, trigger another recall, and confirm marker counts remain visible but snippet content is neither persisted nor displayed.
4. Restart the client and confirm the verbose setting remains in its last selected state.


## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.