### PR TITLE
fix(indexing): allow validation timeout retries

### DIFF
--- a/.changeset/remote-embedders-retry-timeouts.md
+++ b/.changeset/remote-embedders-retry-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-indexing": patch
+---
+
+Allow remote embedder validation timeouts to retry before indexing reports a connection failure.

--- a/packages/kilo-indexing/src/indexing/service-factory.ts
+++ b/packages/kilo-indexing/src/indexing/service-factory.ts
@@ -32,21 +32,27 @@ import type { IgnoreMatcher } from "./shared/load-ignore"
 const log = Log.create({ service: "indexing-factory" })
 
 // RATIONALE: The OpenAI SDK applies the per-attempt timeout and retries internally.
-const sdk = new Set<AvailableEmbedders>([
-  "openai",
-  "openrouter",
-  "openai-compatible",
-  "kilo",
-  "gemini",
-  "mistral",
-  "vercel-ai-gateway",
-])
-
-function timeout(provider: AvailableEmbedders): number | undefined {
-  if (sdk.has(provider)) return
-  if (provider === "ollama") return OLLAMA_EMBEDDER_REQUEST_TIMEOUT_MS
-  return REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS
-}
+const policy = {
+  openai: undefined,
+  openrouter: undefined,
+  "openai-compatible": undefined,
+  kilo: undefined,
+  gemini: undefined,
+  mistral: undefined,
+  "vercel-ai-gateway": undefined,
+  ollama: {
+    timeout: OLLAMA_EMBEDDER_REQUEST_TIMEOUT_MS,
+    error: "Connection to embedding service failed (timeout)",
+  },
+  voyage: {
+    timeout: REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
+    error: "Connection failed. Please check the endpoint URL and network connectivity.",
+  },
+  bedrock: {
+    timeout: REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
+    error: "Connection failed. Please check the endpoint URL and network connectivity.",
+  },
+} satisfies Record<AvailableEmbedders, { timeout: number; error: string } | undefined>
 
 /**
  * Factory class responsible for creating and configuring code indexing service dependencies.
@@ -140,23 +146,20 @@ export class CodeIndexServiceFactory {
   }
 
   public async validateEmbedder(embedder: IEmbedder): Promise<{ valid: boolean; error?: string }> {
-    const ms = timeout(embedder.embedderInfo.name)
+    const deadline = policy[embedder.embedderInfo.name]
     let timer: ReturnType<typeof setTimeout> | undefined
     const wait = embedder.validateConfiguration()
     const fail =
-      ms === undefined
+      deadline === undefined
         ? undefined
         : new Promise<{ valid: boolean; error?: string }>((resolve) => {
             timer = setTimeout(
               () =>
                 resolve({
                   valid: false,
-                  error:
-                    embedder.embedderInfo.name === "ollama"
-                      ? "Connection to embedding service failed (timeout)"
-                      : "Connection failed. Please check the endpoint URL and network connectivity.",
+                  error: deadline.error,
                 }),
-              ms,
+              deadline.timeout,
             )
           })
 

--- a/packages/kilo-indexing/src/indexing/service-factory.ts
+++ b/packages/kilo-indexing/src/indexing/service-factory.ts
@@ -16,7 +16,7 @@ import { VoyageEmbedder } from "./embedders/voyage"
 import { QdrantVectorStore } from "./vector-store/qdrant-client"
 import { LanceDBVectorStore } from "./vector-store/lancedb-vector-store"
 import { codeParser, DirectoryScanner, FileWatcher } from "./processors"
-import type { ICodeParser, IEmbedder, IFileWatcher, IVectorStore } from "./interfaces"
+import type { AvailableEmbedders, ICodeParser, IEmbedder, IFileWatcher, IVectorStore } from "./interfaces"
 import type { CodeIndexConfigManager } from "./config-manager"
 import type { CacheManager } from "./cache-manager"
 import type { IndexingTelemetryMeta, IndexingTelemetryReporter } from "./interfaces/telemetry"
@@ -31,7 +31,19 @@ import type { IgnoreMatcher } from "./shared/load-ignore"
 
 const log = Log.create({ service: "indexing-factory" })
 
-function timeout(provider: string): number {
+// RATIONALE: The OpenAI SDK applies the per-attempt timeout and retries internally.
+const sdk = new Set<AvailableEmbedders>([
+  "openai",
+  "openrouter",
+  "openai-compatible",
+  "kilo",
+  "gemini",
+  "mistral",
+  "vercel-ai-gateway",
+])
+
+function timeout(provider: AvailableEmbedders): number | undefined {
+  if (sdk.has(provider)) return
   if (provider === "ollama") return OLLAMA_EMBEDDER_REQUEST_TIMEOUT_MS
   return REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS
 }
@@ -131,23 +143,26 @@ export class CodeIndexServiceFactory {
     const ms = timeout(embedder.embedderInfo.name)
     let timer: ReturnType<typeof setTimeout> | undefined
     const wait = embedder.validateConfiguration()
-    const fail = new Promise<{ valid: boolean; error?: string }>((resolve) => {
-      timer = setTimeout(
-        () =>
-          resolve({
-            valid: false,
-            error:
-              embedder.embedderInfo.name === "ollama"
-                ? "Connection to embedding service failed (timeout)"
-                : "Connection failed. Please check the endpoint URL and network connectivity.",
-          }),
-        ms,
-      )
-    })
+    const fail =
+      ms === undefined
+        ? undefined
+        : new Promise<{ valid: boolean; error?: string }>((resolve) => {
+            timer = setTimeout(
+              () =>
+                resolve({
+                  valid: false,
+                  error:
+                    embedder.embedderInfo.name === "ollama"
+                      ? "Connection to embedding service failed (timeout)"
+                      : "Connection failed. Please check the endpoint URL and network connectivity.",
+                }),
+              ms,
+            )
+          })
 
     try {
       log.info("validating embedder", { provider: embedder.embedderInfo.name })
-      const result = await Promise.race([wait, fail])
+      const result = fail ? await Promise.race([wait, fail]) : await wait
       if (result.valid) {
         log.info("embedder validation succeeded", { provider: embedder.embedderInfo.name })
       }

--- a/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/service-factory.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test, mock, beforeEach } from "bun:test"
 import path from "path"
 import { mockEmbeddingsCreate, openAIMockFactory, setOpenAIConstructorHook } from "./embedders/__helpers__/openai-mock"
+import {
+  OLLAMA_EMBEDDER_REQUEST_TIMEOUT_MS,
+  REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
+} from "../../../src/indexing/constants"
+import type { AvailableEmbedders, IEmbedder } from "../../../src/indexing/interfaces/embedder"
 
 mock.module("openai", openAIMockFactory)
 import { CodeIndexServiceFactory } from "../../../src/indexing/service-factory"
@@ -23,6 +28,20 @@ function createFactory(input?: Partial<ConstructorParameters<typeof CodeIndexCon
   return new CodeIndexServiceFactory(cfg, workspacePath, cache, cacheDirectory)
 }
 
+function createEmbedder(name: AvailableEmbedders): IEmbedder {
+  return {
+    async createEmbeddings() {
+      return { embeddings: [] }
+    },
+    async validateConfiguration() {
+      return { valid: true }
+    },
+    get embedderInfo() {
+      return { name }
+    },
+  }
+}
+
 describe("CodeIndexServiceFactory", () => {
   beforeEach(() => {
     mockEmbeddingsCreate.mockReset()
@@ -37,6 +56,55 @@ describe("CodeIndexServiceFactory", () => {
     })
 
     expect(factory.createEmbedder().embedderInfo).toEqual({ name: "openai-compatible" })
+  })
+
+  test("lets SDK-backed embedders own validation timeouts", async () => {
+    const original = globalThis.setTimeout
+    const timer = mock((...args: Parameters<typeof setTimeout>) => original(...args))
+    globalThis.setTimeout = timer
+
+    try {
+      const factory = createFactory()
+      const providers = [
+        "openai",
+        "openrouter",
+        "openai-compatible",
+        "kilo",
+        "gemini",
+        "mistral",
+        "vercel-ai-gateway",
+      ] satisfies AvailableEmbedders[]
+
+      for (const provider of providers) {
+        await expect(factory.validateEmbedder(createEmbedder(provider))).resolves.toEqual({ valid: true })
+      }
+
+      expect(timer).not.toHaveBeenCalled()
+    } finally {
+      globalThis.setTimeout = original
+    }
+  })
+
+  test("retains factory deadlines for non-SDK embedders", async () => {
+    const original = globalThis.setTimeout
+    const timer = mock((...args: Parameters<typeof setTimeout>) => original(...args))
+    globalThis.setTimeout = timer
+
+    try {
+      const factory = createFactory()
+
+      await factory.validateEmbedder(createEmbedder("voyage"))
+      await factory.validateEmbedder(createEmbedder("bedrock"))
+      await factory.validateEmbedder(createEmbedder("ollama"))
+
+      expect(timer.mock.calls.map((call) => call[1])).toEqual([
+        REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
+        REMOTE_EMBEDDER_VALIDATION_TIMEOUT_MS,
+        OLLAMA_EMBEDDER_REQUEST_TIMEOUT_MS,
+      ])
+    } finally {
+      globalThis.setTimeout = original
+    }
   })
 
   test("uses default LanceDB directory when config is unset", () => {


### PR DESCRIPTION
## Issue

#12186 followup

## Context/Implementation

Simply setting the retries constant to a non-zero value was not sufficient to retry the embedder validation attempts. This was traced to a condition where the embed provider would return a failed state before the retry would finish. This change ensures that we correctly wait on failure, to allow the validation retry loop to process, before we return.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

<!--
Describe local CLI, extension, or docs verification. Example:
- Opened the updated settings page and confirmed the new copy appears
-->

-
## How to Test

### Manual/local verification

- Set up indexing to use Qwen3-Embedding-8b via Kilo or OpenRouter provider as noted in the linked issue
- Restart Kilo until the validation timeout occurs
- Kilo should automatically retry validation, allowing indexing to start successfully

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

ExpedientFalcon on Discord