### PR TITLE
fix: reverted message re-submit adds nothing to the conversation until restart

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -183,9 +183,13 @@ export namespace SessionPrompt {
 
   export const prompt = fn(PromptInput, async (input) => {
     const session = await Session.get(input.sessionID)
-    await SessionRevert.cleanup(session)
-
-    const message = await createUserMessage(input)
+    // kilocode_change start - finish cleanup without removing an id reused by the new prompt
+    const kept = await SessionRevert.cleanup(session, input.messageID)
+    const message = await createUserMessage(input).catch(async (err) => {
+      if (kept) await Session.removeMessage({ sessionID: input.sessionID, messageID: kept })
+      throw err
+    })
+    // kilocode_change end
     await Session.touch(input.sessionID)
 
     // this is backwards compatibility for allowing `tools` to be specified when

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -88,8 +88,10 @@ export namespace SessionRevert {
     return Session.clearRevert(input.sessionID)
   }
 
-  export async function cleanup(session: Session.Info) {
+  export async function cleanup(session: Session.Info, retain?: string) {
+    // kilocode_change start - retain a resubmitted id so its removal event cannot race its recreation
     if (!session.revert) return
+    // kilocode_change end
     const sessionID = session.id
     const msgs = await Session.messages({ sessionID })
     const messageID = session.revert.messageID
@@ -112,8 +114,21 @@ export namespace SessionRevert {
       }
       remove.push(msg)
     }
+    const kept = remove.some((msg) => msg.info.id === retain) // kilocode_change
     for (const msg of remove) {
       Database.use((db) => db.delete(MessageTable).where(eq(MessageTable.id, msg.info.id)).run())
+      // kilocode_change start - clear stale parts without removing a replacement that reuses this id
+      if (msg.info.id === retain) {
+        for (const part of msg.parts) {
+          await Bus.publish(MessageV2.Event.PartRemoved, {
+            sessionID: sessionID,
+            messageID: msg.info.id,
+            partID: part.id,
+          })
+        }
+        continue
+      }
+      // kilocode_change end
       await Bus.publish(MessageV2.Event.Removed, { sessionID: sessionID, messageID: msg.info.id })
     }
     if (session.revert.partID && target) {
@@ -134,5 +149,6 @@ export namespace SessionRevert {
       }
     }
     await Session.clearRevert(sessionID)
+    return kept ? retain : undefined // kilocode_change
   }
 }

--- a/packages/opencode/test/kilocode/session/revert.test.ts
+++ b/packages/opencode/test/kilocode/session/revert.test.ts
@@ -1,0 +1,197 @@
+// kilocode_change - new file
+import { describe, expect, test } from "bun:test"
+import { Bus } from "../../../src/bus"
+import { Identifier } from "../../../src/id/id"
+import { Instance } from "../../../src/project/instance"
+import { Session } from "../../../src/session"
+import { MessageV2 } from "../../../src/session/message-v2"
+import { SessionPrompt } from "../../../src/session/prompt"
+import { SessionRevert } from "../../../src/session/revert"
+import { Log } from "../../../src/util/log"
+import { tmpdir } from "../../fixture/fixture"
+
+Log.init({ print: false })
+
+const model = {
+  providerID: "opencode",
+  modelID: "kimi-k2.5-free",
+}
+
+function deferred<T>() {
+  const result = {} as { promise: Promise<T>; resolve(value: T): void }
+  result.promise = new Promise((resolve) => {
+    result.resolve = resolve
+  })
+  return result
+}
+
+function submit(sid: string, text: string, id = Identifier.ascending("message")) {
+  return SessionPrompt.prompt({
+    sessionID: sid,
+    messageID: id,
+    model,
+    noReply: true,
+    parts: [{ type: "text", text }],
+  })
+}
+
+async function reply(root: string, sid: string, parent: string, text: string) {
+  const msg: MessageV2.Assistant = {
+    id: Identifier.ascending("message"),
+    sessionID: sid,
+    parentID: parent,
+    role: "assistant",
+    mode: "build",
+    agent: "build",
+    path: { cwd: root, root },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    modelID: model.modelID,
+    providerID: model.providerID,
+    time: { created: Date.now() },
+    finish: "end_turn",
+  }
+  await Session.updateMessage(msg)
+  await Session.updatePart({
+    id: Identifier.ascending("part"),
+    sessionID: sid,
+    messageID: msg.id,
+    type: "text",
+    text,
+  })
+  return msg
+}
+
+describe("session revert resubmit", () => {
+  test("removes the reverted range before adding a new prompt", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const keep = await submit(session.id, "keep")
+        const kept = await reply(tmp.path, session.id, keep.info.id, "kept reply")
+        const stale = await submit(session.id, "old prompt")
+        const dropped = await reply(tmp.path, session.id, stale.info.id, "stale reply")
+
+        await SessionRevert.revert({ sessionID: session.id, messageID: stale.info.id })
+
+        const fresh = await submit(session.id, "new prompt")
+        const msgs = await Session.messages({ sessionID: session.id })
+        expect(msgs.map((msg) => msg.info.id)).toEqual([keep.info.id, kept.id, fresh.info.id])
+        expect(msgs.some((msg) => msg.info.id === stale.info.id)).toBe(false)
+        expect(msgs.some((msg) => msg.info.id === dropped.id)).toBe(false)
+        expect((await Session.get(session.id)).revert).toBeUndefined()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("recreates a resubmission that requests the same id exactly once", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const id = Identifier.ascending("message")
+        await submit(session.id, "original", id)
+        await SessionRevert.revert({ sessionID: session.id, messageID: id })
+
+        const fresh = await submit(session.id, "edited", id)
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        const match = msgs.filter((msg) => msg.info.id === fresh.info.id)
+        expect(fresh.info.id).toBe(id)
+        expect(match).toHaveLength(1)
+        expect(match[0].parts.filter((part) => part.type === "text").map((part) => part.text)).toEqual(["edited"])
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("finishes revert events before recreating the user message", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const id = Identifier.ascending("message")
+        await submit(session.id, "original", id)
+        await SessionRevert.revert({ sessionID: session.id, messageID: id })
+
+        const gate = deferred<void>()
+        const started = deferred<void>()
+        const events: string[] = []
+        const removed: string[] = []
+        const clear = Bus.subscribe(MessageV2.Event.PartRemoved, async (event) => {
+          if (event.properties.sessionID !== session.id) return
+          events.push("part-removing")
+          started.resolve()
+          await gate.promise
+          events.push("part-removed")
+        })
+        const track = Bus.subscribe(MessageV2.Event.Removed, (event) => {
+          if (event.properties.sessionID !== session.id) return
+          removed.push(event.properties.messageID)
+        })
+        const cleared = Bus.subscribe(Session.Event.Updated, (event) => {
+          if (event.properties.info.id !== session.id || event.properties.info.revert) return
+          events.push("revert-cleared")
+        })
+        const create = Bus.subscribe(MessageV2.Event.Updated, (event) => {
+          if (event.properties.info.sessionID !== session.id) return
+          events.push("message-created")
+        })
+
+        const run = submit(session.id, "edited", id)
+        await started.promise
+        await Bun.sleep(20)
+        const pending = [...events]
+        gate.resolve()
+        const fresh = await run
+        clear()
+        track()
+        cleared()
+        create()
+
+        expect(pending).toEqual(["part-removing"])
+        expect(events).toEqual(["part-removing", "part-removed", "revert-cleared", "message-created"])
+        expect(removed).not.toContain(fresh.info.id)
+        expect((await Session.get(session.id)).revert).toBeUndefined()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("adds prompts without a revert and preserves existing messages", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const first = await submit(session.id, "first")
+        const removed: string[] = []
+        const unsub = Bus.subscribe(MessageV2.Event.Removed, (event) => {
+          if (event.properties.sessionID === session.id) removed.push(event.properties.messageID)
+        })
+
+        const second = await submit(session.id, "second")
+        unsub()
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        expect(msgs.map((msg) => msg.info.id)).toEqual([first.info.id, second.info.id])
+        expect(removed).toEqual([])
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #12235

## Context

After using the revert feature to modify a previously sent message, reverting it back to its original (or a new) content, and pressing Enter to re-submit, no new message appears in the conversation. The UI looks like the input was sent, but nothing gets added to the live view. Only a full quit-and-restart of Kilo makes the correct messages appear again. The issue reproduces identically in the CLI/TUI (ghostty) and in the VS Code extension, and a commenter confirms "it is working in the background" (server-side work is persisted) but "nothing shows" live until the session is exited and reopened.

## Implementation

The main prompt path (`SessionPrompt.prompt`, packages/opencode/src/session/prompt.ts:~1424) unconditionally calls `revert.cleanup(session)` before `KiloSessionPrompt.intake` creates the new user message. `cleanup` (packages/opencode/src/session/revert.ts) removes every message with id `>= session.revert.messageID` via `sessions.removeMessage`/`removePart` (each publishing `MessageRemoved`/`PartRemoved`) and then `clearRevert`. Because `removeMessage` only publishes the removal event (storage stays authoritative, which is why a restart re-renders correctly), the live client applies MessageRemoved and then must apply the newly-created follow-up message; when the re-submitted message reuses or is adjacent to a just-removed message id, or when the removal/clear events race the new user-message event, the client drops the new message and shows nothing. Fix the ordering/id-collision so the reverted range is fully cleared (and the client notified) before the fresh user message is intaken, ensuring the new message never collides with a still-in-flight removal. Add a regression test that reverts, re-submits, and asserts the new user message is present and no stale reverted message survives. Keep the change minimal and marked with `// kilocode_change` per the repo's shared-file convention.

This change was implemented with AI assistance (an agent) and reviewed before submission.

## Screenshots / Video

N/A - no visual change; the fix is at the session revert-cleanup -> new-prompt boundary in `packages/opencode/src/session/revert.ts` and `prompt.ts`.

## How to Test

### Manual/local verification

- Added a regression test in `test/kilocode/session/revert.test.ts` that reverts a message, re-submits, and asserts the new user message is present with no stale reverted message surviving. Executed by the agent via the repo test runner.

### Reviewer test steps

1. In a session, revert a previously sent message, then revert it back (or edit) and press Enter to re-submit.
2. Confirm the new message appears live without restarting Kilo.

### Blocked checks and substitute verification

- Full extension E2E was not run locally; the added unit regression test covers the revert-cleanup/new-prompt ordering that caused the live-vs-persisted desync.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
