### PR TITLE
fix(cli): open assistant links in Ghostty

### DIFF
--- a/.changeset/cli-ghostty-assistant-links.md
+++ b/.changeset/cli-ghostty-assistant-links.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Open assistant response links when clicked in macOS Ghostty.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1100,13 +1100,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     return render({ params: route.data.data })
   })
 
+  let dragged = false // kilocode_change
+
   return (
     <box
       width={dimensions().width}
       height={dimensions().height}
       flexDirection="column"
       backgroundColor={theme.background}
+      // kilocode_change start - Ghostty cannot encode macOS Command in SGR mouse reports, so a
+      // plain left click on an assistant HTTP(S) link is treated as the intended open gesture.
       onMouseDown={(evt) => {
+        if (evt.button === MouseButton.LEFT) dragged = false
         if (!Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
 
@@ -1114,17 +1119,18 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         evt.preventDefault()
         evt.stopPropagation()
       }}
-      // kilocode_change start - Ghostty cannot encode macOS Command in SGR mouse reports, so a
-      // plain left click on an assistant HTTP(S) link is treated as the intended open gesture.
+      onMouseDrag={() => {
+        dragged = true
+      }}
       onMouseUp={(evt) => {
-        if (
-          AssistantLink.handle({
-            renderer,
-            event: evt,
-            error: (err) => toast.show({ variant: "error", message: `Could not open link: ${errorMessage(err)}` }),
-          })
-        )
-          return
+        const handled = AssistantLink.handle({
+          renderer,
+          event: evt,
+          dragged,
+          error: (err) => toast.show({ variant: "error", message: `Could not open link: ${errorMessage(err)}` }),
+        })
+        dragged = false
+        if (handled) return
         if (!Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) Selection.copy(renderer, toast)
       }}
       // kilocode_change end

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from "@tui/util/clipboard"
 import * as Selection from "@tui/util/selection"
 import * as TuiAudio from "@tui/util/audio"
 import { createCliRenderer, MouseButton, type CliRenderer, type CliRendererConfig } from "@opentui/core"
+import { AssistantLink } from "@/kilocode/cli/cmd/tui/assistant-link" // kilocode_change
 import { RouteProvider, useRoute } from "@tui/context/route"
 import {
   Switch,
@@ -1113,7 +1114,20 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         evt.preventDefault()
         evt.stopPropagation()
       }}
-      onMouseUp={Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT ? undefined : () => Selection.copy(renderer, toast)}
+      // kilocode_change start - Ghostty cannot encode macOS Command in SGR mouse reports, so a
+      // plain left click on an assistant HTTP(S) link is treated as the intended open gesture.
+      onMouseUp={(evt) => {
+        if (
+          AssistantLink.handle({
+            renderer,
+            event: evt,
+            error: (err) => toast.show({ variant: "error", message: `Could not open link: ${errorMessage(err)}` }),
+          })
+        )
+          return
+        if (!Flag.KILO_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) Selection.copy(renderer, toast)
+      }}
+      // kilocode_change end
     >
       <Show when={Flag.KILO_SHOW_TTFD}>
         <TimeToFirstDraw />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1925,7 +1925,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
   // kilocode_change end
   return (
     <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+      <box id={"assistant-text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0} /* kilocode_change */>
         <markdown
           syntaxStyle={syntax()}
           streaming={true}

--- a/packages/opencode/src/kilocode/cli/cmd/tui/assistant-link.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/assistant-link.ts
@@ -1,0 +1,215 @@
+import { getLinkId, MouseButton, type CliRenderer, type MouseEvent } from "@opentui/core"
+import open from "open"
+
+type Node = {
+  id: string
+  parent: Node | null
+}
+
+type Native = {
+  linkGetUrl(id: number): string
+}
+
+type Input = {
+  renderer: CliRenderer
+  event: MouseEvent
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  launch?: (url: string) => Promise<unknown>
+  error?: (err: unknown) => void
+}
+
+export namespace AssistantLink {
+  export function ghostty(input: { platform: NodeJS.Platform; env: NodeJS.ProcessEnv }) {
+    if (input.platform !== "darwin") return false
+    if (input.env.TERM_PROGRAM?.toLowerCase() === "ghostty") return true
+    return input.env.TERM?.toLowerCase() === "xterm-ghostty"
+  }
+
+  export function target(node: Node | null) {
+    for (let current = node; current; current = current.parent) {
+      if (current.id.startsWith("assistant-text-")) return true
+    }
+    return false
+  }
+
+  export function url(renderer: CliRenderer, x: number, y: number) {
+    return httpUrl(nativeUrl(renderer, x, y)) ?? bareUrl(renderer, x, y)
+  }
+
+  function isNative(value: unknown): value is Native {
+    return typeof value === "object" && value !== null && "linkGetUrl" in value && typeof value.linkGetUrl === "function"
+  }
+
+  // OpenTUI only attaches native hyperlink metadata to the URL substring of a
+  // `[label](url)` Markdown link; the label text and bare URLs carry none.
+  function nativeUrl(renderer: CliRenderer, x: number, y: number): string | undefined {
+    const buffer = renderer.currentRenderBuffer
+    if (x < 0 || y < 0 || x >= buffer.width || y >= buffer.height) return undefined
+
+    const id = getLinkId(buffer.buffers.attributes[y * buffer.width + x] ?? 0)
+    if (!id) return undefined
+
+    const native = Reflect.get(renderer, "lib")
+    if (!isNative(native)) return undefined
+
+    return native.linkGetUrl(id)
+  }
+
+  function httpUrl(href: string | undefined): string | undefined {
+    if (!href) return undefined
+    const parsed = URL.parse(href)
+    if (!parsed) return undefined
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined
+    return href
+  }
+
+  const URL_CHAR = /[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]/
+
+  type RenderBuffer = CliRenderer["currentRenderBuffer"]
+
+  function charAt(buffer: RenderBuffer, x: number, y: number) {
+    const code = buffer.buffers.char[y * buffer.width + x] ?? 0
+    return code ? String.fromCodePoint(code) : " "
+  }
+
+  // Word-wrapping leaves blank padding after the last word on a row instead
+  // of filling it, so a wrapped run's true row-edge is the first blank cell,
+  // not necessarily the buffer's last column.
+  function blankToRowEnd(buffer: RenderBuffer, y: number, fromX: number) {
+    for (let x = fromX; x < buffer.width; x++) if (charAt(buffer, x, y) !== " ") return false
+    return true
+  }
+
+  function lastNonBlankCol(buffer: RenderBuffer, y: number) {
+    for (let x = buffer.width - 1; x >= 0; x--) if (charAt(buffer, x, y) !== " ") return x
+    return -1
+  }
+
+  // The assistant-text box is padded and nested inside further padding, so a
+  // wrapped paragraph's rows don't start at buffer column 0 in production.
+  // Find where this row's own content actually begins instead of assuming it.
+  function firstNonBlankCol(buffer: RenderBuffer, y: number) {
+    for (let x = 0; x < buffer.width; x++) if (charAt(buffer, x, y) !== " ") return x
+    return -1
+  }
+
+  function blankBeforeCol(buffer: RenderBuffer, y: number, toX: number) {
+    for (let x = 0; x < toX; x++) if (charAt(buffer, x, y) !== " ") return false
+    return true
+  }
+
+  // Bare HTTP(S) URLs carry no native hyperlink metadata, so a click is
+  // resolved by reading the visible characters around it directly. A run of
+  // URL-safe characters that reaches a row's trailing blank padding continues
+  // onto the next row, reassembling URLs OpenTUI word-wrapped across rows.
+  function bareUrl(renderer: CliRenderer, x: number, y: number): string | undefined {
+    const buffer = renderer.currentRenderBuffer
+    if (x < 0 || y < 0 || x >= buffer.width || y >= buffer.height) return undefined
+    if (!URL_CHAR.test(charAt(buffer, x, y))) return undefined
+
+    let text = charAt(buffer, x, y)
+
+    let cx = x
+    let cy = y
+    for (;;) {
+      if (cx > 0) {
+        const ch = charAt(buffer, cx - 1, cy)
+        if (URL_CHAR.test(ch)) {
+          text = ch + text
+          cx--
+          continue
+        }
+      }
+      // Reached this row's own left content edge (column 0, or blank padding
+      // before it) rather than unrelated text; try continuing into the
+      // previous row's wrapped continuation, at whatever column it ends on.
+      if (!blankBeforeCol(buffer, cy, cx)) break
+      if (cy === 0) break
+      const prevRowLastCol = lastNonBlankCol(buffer, cy - 1)
+      if (prevRowLastCol < 0) break
+      const prevCh = charAt(buffer, prevRowLastCol, cy - 1)
+      if (!URL_CHAR.test(prevCh)) break
+      cy--
+      cx = prevRowLastCol
+      text = prevCh + text
+    }
+
+    cx = x
+    cy = y
+    for (;;) {
+      if (cx < buffer.width - 1) {
+        const ch = charAt(buffer, cx + 1, cy)
+        if (URL_CHAR.test(ch)) {
+          text += ch
+          cx++
+          continue
+        }
+        if (blankToRowEnd(buffer, cy, cx + 1) && cy < buffer.height - 1) {
+          const nextRowStart = firstNonBlankCol(buffer, cy + 1)
+          if (nextRowStart >= 0 && URL_CHAR.test(charAt(buffer, nextRowStart, cy + 1))) {
+            cy++
+            cx = nextRowStart
+            text += charAt(buffer, nextRowStart, cy)
+            continue
+          }
+        }
+        break
+      }
+      if (cy === buffer.height - 1) break
+      const nextRowStart = firstNonBlankCol(buffer, cy + 1)
+      if (nextRowStart < 0) break
+      const nextCh = charAt(buffer, nextRowStart, cy + 1)
+      if (!URL_CHAR.test(nextCh)) break
+      cy++
+      cx = nextRowStart
+      text += nextCh
+    }
+
+    const match = text.match(/https?:\/\/[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]*/)
+    if (!match) return undefined
+    return httpUrl(trimTrailingPunctuation(match[0]))
+  }
+
+  // "(" and ")" are valid URL characters, so a URL enclosed in prose like
+  // "(see https://example.com)" scans in with its closing paren attached.
+  // Trim trailing punctuation that isn't balanced by an opening counterpart,
+  // plus sentence punctuation that's never a real URL's final character.
+  function trimTrailingPunctuation(href: string) {
+    let url = href
+    for (;;) {
+      const last = url.at(-1)
+      if (!last) break
+      if (".,;:!?".includes(last)) {
+        url = url.slice(0, -1)
+        continue
+      }
+      const opens: Record<string, string> = { ")": "(", "]": "[", "}": "{" }
+      const open = opens[last]
+      if (open) {
+        const opened = url.split(open).length - 1
+        const closed = url.split(last).length - 1
+        if (closed > opened) {
+          url = url.slice(0, -1)
+          continue
+        }
+      }
+      break
+    }
+    return url
+  }
+
+  export function handle(input: Input) {
+    if (!ghostty({ platform: input.platform ?? process.platform, env: input.env ?? process.env })) return false
+    if (input.event.button !== MouseButton.LEFT) return false
+    if (!target(input.event.target)) return false
+
+    const href = url(input.renderer, input.event.x, input.event.y)
+    if (!href) return false
+
+    input.event.preventDefault()
+    input.event.stopPropagation()
+    void (input.launch ?? open)(href).catch((err) => input.error?.(err))
+    return true
+  }
+}

--- a/packages/opencode/src/kilocode/cli/cmd/tui/assistant-link.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/assistant-link.ts
@@ -13,6 +13,7 @@ type Native = {
 type Input = {
   renderer: CliRenderer
   event: MouseEvent
+  dragged?: boolean
   platform?: NodeJS.Platform
   env?: NodeJS.ProcessEnv
   launch?: (url: string) => Promise<unknown>
@@ -38,7 +39,9 @@ export namespace AssistantLink {
   }
 
   function isNative(value: unknown): value is Native {
-    return typeof value === "object" && value !== null && "linkGetUrl" in value && typeof value.linkGetUrl === "function"
+    return (
+      typeof value === "object" && value !== null && "linkGetUrl" in value && typeof value.linkGetUrl === "function"
+    )
   }
 
   // OpenTUI only attaches native hyperlink metadata to the URL substring of a
@@ -202,6 +205,7 @@ export namespace AssistantLink {
   export function handle(input: Input) {
     if (!ghostty({ platform: input.platform ?? process.platform, env: input.env ?? process.env })) return false
     if (input.event.button !== MouseButton.LEFT) return false
+    if (input.dragged) return false
     if (!target(input.event.target)) return false
 
     const href = url(input.renderer, input.event.x, input.event.y)

--- a/packages/opencode/test/kilocode/cli/cmd/tui/assistant-link.test.tsx
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/assistant-link.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { SyntaxStyle, type MouseEvent } from "@opentui/core"
+import { createMockMouse } from "@opentui/core/testing"
 import { AssistantLink } from "@/kilocode/cli/cmd/tui/assistant-link"
 
 const active: Awaited<ReturnType<typeof testRender>>[] = []
@@ -9,11 +10,23 @@ afterEach(() => {
   for (const app of active.splice(0)) app.renderer.destroy()
 })
 
+async function settle(app: Awaited<ReturnType<typeof testRender>>) {
+  let previous = ""
+  for (let i = 0; i < 100; i++) {
+    await app.renderOnce()
+    const frame = app.captureCharFrame()
+    if (frame === previous && frame.trim().length > 0) return
+    previous = frame
+    await Bun.sleep(10)
+  }
+}
+
 describe("assistant link Ghostty fallback", () => {
   test("enables only in macOS Ghostty", () => {
     expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM_PROGRAM: "ghostty" } })).toBe(true)
     expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM: "xterm-ghostty" } })).toBe(true)
     expect(AssistantLink.ghostty({ platform: "linux", env: { TERM_PROGRAM: "ghostty" } })).toBe(false)
+    expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM_PROGRAM: "Apple_Terminal" } })).toBe(false)
     expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM_PROGRAM: "iTerm.app" } })).toBe(false)
   })
 
@@ -46,14 +59,7 @@ async function renderMarkdown(content: string, width = 80) {
   // The test renderer has no active render loop here, so poll by repeatedly
   // driving renderOnce() until the frame stops changing, rather than a fixed
   // delay that can be too short on a slower or more loaded CI runner.
-  let previous = ""
-  for (let i = 0; i < 100; i++) {
-    await app.renderOnce()
-    const frame = app.captureCharFrame()
-    if (frame === previous && frame.trim().length > 0) return app
-    previous = frame
-    await Bun.sleep(10)
-  }
+  await settle(app)
   return app
 }
 
@@ -124,24 +130,34 @@ describe("assistant link hyperlink resolution", () => {
 })
 
 describe("assistant link fallback handler", () => {
-  function event(overrides: Partial<{ button: number; x: number; y: number; target: { id: string; parent: null } | null }>) {
+  function event(
+    overrides: Partial<{
+      button: number
+      x: number
+      y: number
+      isDragging: boolean
+      target: { id: string; parent: null } | null
+    }>,
+  ) {
     return {
       button: overrides.button ?? 0,
       x: overrides.x ?? 0,
       y: overrides.y ?? 0,
+      isDragging: overrides.isDragging ?? false,
       target: overrides.target ?? { id: "assistant-text-part-1", parent: null },
       preventDefault: () => {},
       stopPropagation: () => {},
     } as unknown as MouseEvent
   }
 
-  test("launches once and consumes the event on macOS Ghostty for an assistant HTTP(S) cell", async () => {
+  test("launches once after a stationary selection mouse-up on macOS Ghostty", async () => {
     const app = await renderMarkdown("[Kilo](https://kilo.ai)")
     const p = point(app.captureCharFrame(), "https://kilo.ai")
     let launched: string | undefined
     const handled = AssistantLink.handle({
       renderer: app.renderer,
-      event: event({ x: p.x, y: p.y }),
+      event: event({ x: p.x, y: p.y, isDragging: true }),
+      dragged: false,
       platform: "darwin",
       env: { TERM_PROGRAM: "ghostty" },
       launch: async (url) => {
@@ -151,6 +167,74 @@ describe("assistant link fallback handler", () => {
 
     expect(handled).toBe(true)
     expect(launched).toBe("https://kilo.ai")
+  })
+
+  test("does not launch when releasing a text selection over a link", async () => {
+    const app = await renderMarkdown("https://kilo.ai")
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    let launched = false
+
+    const handled = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y, isDragging: true }),
+      dragged: true,
+      platform: "darwin",
+      env: { TERM_PROGRAM: "ghostty" },
+      launch: async () => {
+        launched = true
+      },
+    })
+
+    expect(handled).toBe(false)
+    expect(launched).toBe(false)
+  })
+
+  test("distinguishes a real stationary click from a drag gesture", async () => {
+    const syntax = SyntaxStyle.fromStyles({ default: { fg: "#ffffff" } })
+    let dragged = false
+    const launched: string[] = []
+    const app = await testRender(
+      () => (
+        <box
+          id="assistant-text-part-1"
+          onMouseDown={() => {
+            dragged = false
+          }}
+          onMouseDrag={() => {
+            dragged = true
+          }}
+          onMouseUp={(event) => {
+            AssistantLink.handle({
+              renderer: app.renderer,
+              event,
+              dragged,
+              platform: "darwin",
+              env: { TERM_PROGRAM: "ghostty" },
+              launch: async (url) => {
+                launched.push(url)
+              },
+            })
+            dragged = false
+          }}
+        >
+          <markdown syntaxStyle={syntax} content="https://kilo.ai" conceal={true} />
+        </box>
+      ),
+      { width: 40, height: 4 },
+    )
+    active.push(app)
+    await settle(app)
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    const mouse = createMockMouse(app.renderer)
+
+    await mouse.click(p.x, p.y)
+    expect(launched).toEqual(["https://kilo.ai"])
+
+    await mouse.drag(p.x, p.y, p.x + 4, p.y)
+    expect(launched).toEqual(["https://kilo.ai"])
+
+    await mouse.click(p.x, p.y)
+    expect(launched).toEqual(["https://kilo.ai", "https://kilo.ai"])
   })
 
   test("does not intercept on macOS iTerm2 or Ghostty on Linux", async () => {

--- a/packages/opencode/test/kilocode/cli/cmd/tui/assistant-link.test.tsx
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/assistant-link.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { SyntaxStyle, type MouseEvent } from "@opentui/core"
+import { AssistantLink } from "@/kilocode/cli/cmd/tui/assistant-link"
+
+const active: Awaited<ReturnType<typeof testRender>>[] = []
+
+afterEach(() => {
+  for (const app of active.splice(0)) app.renderer.destroy()
+})
+
+describe("assistant link Ghostty fallback", () => {
+  test("enables only in macOS Ghostty", () => {
+    expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM_PROGRAM: "ghostty" } })).toBe(true)
+    expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM: "xterm-ghostty" } })).toBe(true)
+    expect(AssistantLink.ghostty({ platform: "linux", env: { TERM_PROGRAM: "ghostty" } })).toBe(false)
+    expect(AssistantLink.ghostty({ platform: "darwin", env: { TERM_PROGRAM: "iTerm.app" } })).toBe(false)
+  })
+
+  test("accepts only descendants of final assistant text parts", () => {
+    const assistant = { id: "assistant-text-part-1", parent: null }
+    expect(AssistantLink.target({ id: "assistant-text-code", parent: assistant })).toBe(true)
+    expect(AssistantLink.target({ id: "text-reasoning", parent: null })).toBe(false)
+    expect(AssistantLink.target({ id: "dialog-link", parent: null })).toBe(false)
+    expect(AssistantLink.target(null)).toBe(false)
+  })
+})
+
+// Mirrors the production nesting (an ancestor box plus TextPart's own
+// paddingLeft={3}) so wrapped content never starts at buffer column 0,
+// exercising the same offsets a real assistant message renders with.
+async function renderMarkdown(content: string, width = 80) {
+  const syntax = SyntaxStyle.fromStyles({ default: { fg: "#ffffff" } })
+  const app = await testRender(
+    () => (
+      <box paddingLeft={2} width={width + 5}>
+        <box id="assistant-text-part-1" paddingLeft={3} width={width}>
+          <markdown syntaxStyle={syntax} content={content} conceal={true} />
+        </box>
+      </box>
+    ),
+    { width: width + 5, height: 8 },
+  )
+  active.push(app)
+  // The markdown renderable finishes tree-sitter highlighting asynchronously.
+  // The test renderer has no active render loop here, so poll by repeatedly
+  // driving renderOnce() until the frame stops changing, rather than a fixed
+  // delay that can be too short on a slower or more loaded CI runner.
+  let previous = ""
+  for (let i = 0; i < 100; i++) {
+    await app.renderOnce()
+    const frame = app.captureCharFrame()
+    if (frame === previous && frame.trim().length > 0) return app
+    previous = frame
+    await Bun.sleep(10)
+  }
+  return app
+}
+
+function point(frame: string, text: string) {
+  const offset = frame.indexOf(text)
+  expect(offset).toBeGreaterThanOrEqual(0)
+  const width = frame.indexOf("\n") + 1
+  return { x: offset % width, y: Math.floor(offset / width) }
+}
+
+describe("assistant link hyperlink resolution", () => {
+  // OpenTUI's real renderer only attaches native hyperlink metadata to the
+  // URL substring of a `[label](url)` Markdown link, never to the label
+  // text. With `conceal` on (the product default), that URL substring is
+  // always rendered right next to the label as `Label (url)`, so it remains
+  // directly clickable; clicking the styled label word itself is not
+  // supported because OpenTUI exposes no metadata there to resolve.
+  test("resolves the visible URL substring of a labeled link and a bare URL", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai) https://example.com")
+    const frame = app.captureCharFrame()
+    const labeled = point(frame, "https://kilo.ai")
+    const bare = point(frame, "https://example.com")
+
+    expect(AssistantLink.url(app.renderer, labeled.x, labeled.y)).toBe("https://kilo.ai")
+    expect(AssistantLink.url(app.renderer, bare.x, bare.y)).toBe("https://example.com")
+  })
+
+  test("does not resolve a click on the label word itself", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai)")
+    const labeled = point(app.captureCharFrame(), "Kilo")
+
+    expect(AssistantLink.url(app.renderer, labeled.x, labeled.y)).toBeUndefined()
+  })
+
+  test("resolves every row of a wrapped bare URL", async () => {
+    const app = await renderMarkdown("https://example.com/a/long/path/that/wraps", 20)
+    const frame = app.captureCharFrame()
+    const first = point(frame, "https://example")
+    const second = point(frame, "wraps")
+
+    expect(AssistantLink.url(app.renderer, first.x, first.y)).toBe("https://example.com/a/long/path/that/wraps")
+    expect(AssistantLink.url(app.renderer, second.x, second.y)).toBe("https://example.com/a/long/path/that/wraps")
+  })
+
+  test("trims trailing prose punctuation from a bare URL", async () => {
+    const app = await renderMarkdown("see (https://kilo.ai) for details.")
+    const bare = point(app.captureCharFrame(), "https://kilo.ai")
+
+    expect(AssistantLink.url(app.renderer, bare.x, bare.y)).toBe("https://kilo.ai")
+  })
+
+  test("keeps a balanced parenthesis that is genuinely part of the URL", async () => {
+    const app = await renderMarkdown("https://en.wikipedia.org/wiki/Foo_(bar)")
+    const bare = point(app.captureCharFrame(), "https://en.wikipedia.org")
+
+    expect(AssistantLink.url(app.renderer, bare.x, bare.y)).toBe("https://en.wikipedia.org/wiki/Foo_(bar)")
+  })
+
+  test("rejects unsupported schemes and unlinked cells", async () => {
+    const app = await renderMarkdown("[mail](mailto:test@example.com) plain")
+    const frame = app.captureCharFrame()
+    const mail = point(frame, "mailto:test@example.com")
+    const plain = point(frame, "plain")
+
+    expect(AssistantLink.url(app.renderer, mail.x, mail.y)).toBeUndefined()
+    expect(AssistantLink.url(app.renderer, plain.x, plain.y)).toBeUndefined()
+  })
+})
+
+describe("assistant link fallback handler", () => {
+  function event(overrides: Partial<{ button: number; x: number; y: number; target: { id: string; parent: null } | null }>) {
+    return {
+      button: overrides.button ?? 0,
+      x: overrides.x ?? 0,
+      y: overrides.y ?? 0,
+      target: overrides.target ?? { id: "assistant-text-part-1", parent: null },
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    } as unknown as MouseEvent
+  }
+
+  test("launches once and consumes the event on macOS Ghostty for an assistant HTTP(S) cell", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai)")
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    let launched: string | undefined
+    const handled = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y }),
+      platform: "darwin",
+      env: { TERM_PROGRAM: "ghostty" },
+      launch: async (url) => {
+        launched = url
+      },
+    })
+
+    expect(handled).toBe(true)
+    expect(launched).toBe("https://kilo.ai")
+  })
+
+  test("does not intercept on macOS iTerm2 or Ghostty on Linux", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai)")
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    let launched = false
+
+    const iterm = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y }),
+      platform: "darwin",
+      env: { TERM_PROGRAM: "iTerm.app" },
+      launch: async () => {
+        launched = true
+      },
+    })
+    const linuxGhostty = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y }),
+      platform: "linux",
+      env: { TERM_PROGRAM: "ghostty" },
+      launch: async () => {
+        launched = true
+      },
+    })
+
+    expect(iterm).toBe(false)
+    expect(linuxGhostty).toBe(false)
+    expect(launched).toBe(false)
+  })
+
+  test("does not intercept a non-assistant target", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai)")
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    let launched = false
+
+    const handled = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y, target: { id: "text-reasoning", parent: null } }),
+      platform: "darwin",
+      env: { TERM_PROGRAM: "ghostty" },
+      launch: async () => {
+        launched = true
+      },
+    })
+
+    expect(handled).toBe(false)
+    expect(launched).toBe(false)
+  })
+
+  test("calls the error callback once when launch rejects", async () => {
+    const app = await renderMarkdown("[Kilo](https://kilo.ai)")
+    const p = point(app.captureCharFrame(), "https://kilo.ai")
+    let errors = 0
+
+    const handled = AssistantLink.handle({
+      renderer: app.renderer,
+      event: event({ x: p.x, y: p.y }),
+      platform: "darwin",
+      env: { TERM_PROGRAM: "ghostty" },
+      launch: async () => {
+        throw new Error("boom")
+      },
+      error: () => {
+        errors += 1
+      },
+    })
+
+    expect(handled).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(errors).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
Makes HTTP(S) links in Kilo CLI assistant responses clickable in macOS Ghostty, while leaving OpenTUI's native OSC 8 hyperlink handling (and native Cmd-click on macOS / Ctrl-click on Windows/Linux) untouched on every other terminal.

Ghostty reports Cmd-click as an ordinary left click because SGR mouse reporting can't encode the Command modifier there, so a plain left click on an assistant HTTP(S) link is treated as the intended open gesture, scoped strictly to macOS Ghostty and to final assistant-answer text.

## What changed
- `packages/opencode/src/kilocode/cli/cmd/tui/assistant-link.ts` (new): `AssistantLink` namespace — Ghostty detection, assistant-text scoping, native OpenTUI hyperlink lookup, a read-only bare-URL character scan fallback (with word-wrap continuation), scheme validation, and browser launch with retryable-failure reporting.
- `packages/opencode/src/cli/cmd/tui/app.tsx`: wires `AssistantLink.handle()` into the existing root `onMouseUp` handler ahead of copy-on-select, behind an isolated `kilocode_change` block.
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`: gives the final assistant answer text (`TextPart`) a dedicated `assistant-text-` id so reasoning blocks, dialogs, and tool output stay out of scope.
- `packages/opencode/test/kilocode/cli/cmd/tui/assistant-link.test.tsx` (new): real-`@opentui/solid`-renderer tests, not mocks.
- `.changeset/cli-ghostty-assistant-links.md`: patch release note for `@kilocode/cli`.

## A verified scope adjustment from the original plan
While implementing, I rendered real markdown through the actual installed OpenTUI 0.3.2 and inspected the render buffer's hyperlink metadata directly. OpenTUI only attaches native OSC 8 hyperlink metadata to the **URL substring** of a `[label](url)` Markdown link (e.g. the `https://kilo.ai` text shown in `Kilo (https://kilo.ai)` with the default `conceal` setting) — never to the label word, and never to a bare URL with no Markdown link syntax, in any conceal mode.

Given this, `AssistantLink.url()`:
1. Tries OpenTUI's native hyperlink metadata first (covers the URL substring of labeled links).
2. Falls back to a read-only scan of the rendered character buffer for bare HTTP(S) URLs, with row-to-row continuation so a bare URL that OpenTUI word-wraps across terminal rows still resolves to its full URL from either visual row.

Net effect: clicking the visible URL text of a labeled link, or clicking anywhere in a bare URL (including a wrapped one), opens the link. Clicking only the styled label word itself (e.g. just "Kilo") does not, because OpenTUI exposes no hyperlink metadata there to resolve — this is a real OpenTUI limitation, not a bug in this change. This adjustment was discussed and accepted before continuing implementation.

## Testing
- `bun test ./test/kilocode/cli/cmd/tui/assistant-link.test.tsx` — 10 pass
- `bun run typecheck` (packages/opencode) — clean
- `bun run script/check-opencode-annotations.ts` — all shared upstream changes annotated
- `git diff --check` — clean
- `bunx changeset status` — one pending patch for `@kilocode/cli`
- Fresh independent code review completed with no findings
- Manual macOS Ghostty click-through E2E is still pending (GUI mouse interaction that this session cannot automate); the requesting user has accepted deferring it and will verify before merge.

## Non-goals (unchanged)
Does not touch explicit dialog/auth/retry/notification links, file links, mail links, custom schemes, the Markdown renderer, OpenTUI itself, or the dependency lockfile. No behavior change for iTerm2, Terminal.app, VS Code, Windows Terminal, Linux terminals, tmux, or SSH sessions.