### PR TITLE
fix: show messages after reverting and resubmitting

### DIFF
--- a/.changeset/fresh-revert-resubmit.md
+++ b/.changeset/fresh-revert-resubmit.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show newly submitted messages immediately after reverting a conversation.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -28,8 +28,6 @@ import {
 } from "./services/telemetry"
 import {
   sessionToWebview,
-  applySessionPatch,
-  sessionPatchToWebview,
   indexProvidersById,
   filterVisibleAgents,
   mapSSEEventToWebviewMessage,
@@ -3842,10 +3840,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       case "session.updated":
         return {
           type: "sessionUpdated" as const,
-          session:
-            this.currentSession?.id === event.properties.sessionID
-              ? this.sessionToWebview(this.currentSession)
-              : sessionPatchToWebview(event.properties.sessionID, event.properties.info),
+          session: this.sessionToWebview(event.properties.info),
         }
       case "session.deleted":
         return {
@@ -4080,7 +4075,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.trackedSessionIds.add(event.properties.info.id)
     }
     if (event.type === "session.updated" && this.currentSession?.id === event.properties.sessionID) {
-      this.setCurrentSession(applySessionPatch(this.currentSession, event.properties.info))
+      this.setCurrentSession(event.properties.info)
       this.contextSessionID = event.properties.sessionID
     }
     if (event.type === "session.deleted") {

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -209,73 +209,6 @@ export function sessionToWebview(session: Session) {
   }
 }
 
-type SessionPatch = SyncEventSessionUpdated["data"]["info"]
-export type WebviewSessionPatch = Partial<ReturnType<typeof sessionToWebview>> & { id: string }
-
-function set<T extends object, K extends keyof T>(target: T, key: K, value: T[K] | null | undefined): void {
-  if (value === undefined || value === null) return
-  target[key] = value
-}
-
-function update<T extends object, K extends keyof T>(target: T, key: K, value: T[K] | null | undefined): void {
-  if (value === undefined) return
-  if (value === null) {
-    Reflect.deleteProperty(target, key)
-    return
-  }
-  target[key] = value
-}
-
-function share(session: Session, url: string | null | undefined): void {
-  if (url === undefined) return
-  if (url === null) {
-    delete session.share
-    return
-  }
-  session.share = { url }
-}
-
-export function applySessionPatch(current: Session, patch: SessionPatch): Session {
-  const next: Session = { ...current, time: { ...current.time } }
-
-  set(next, "slug", patch.slug)
-  set(next, "projectID", patch.projectID)
-  set(next, "directory", patch.directory)
-  set(next, "title", patch.title)
-  set(next, "version", patch.version)
-  update(next, "workspaceID", patch.workspaceID)
-  update(next, "path", patch.path)
-  update(next, "parentID", patch.parentID)
-  update(next, "summary", patch.summary)
-  update(next, "cost", patch.cost)
-  update(next, "tokens", patch.tokens)
-  share(next, patch.share?.url)
-  update(next, "agent", patch.agent)
-  update(next, "model", patch.model)
-  update(next, "permission", patch.permission)
-  update(next, "revert", patch.revert)
-  set(next.time, "created", patch.time?.created)
-  set(next.time, "updated", patch.time?.updated)
-  update(next.time, "compacting", patch.time?.compacting)
-  update(next.time, "archived", patch.time?.archived)
-
-  return next
-}
-
-export function sessionPatchToWebview(sessionID: string, patch: SessionPatch): WebviewSessionPatch {
-  return {
-    id: sessionID,
-    ...(patch.parentID !== undefined && { parentID: patch.parentID }),
-    ...(patch.title !== undefined && patch.title !== null && { title: patch.title }),
-    ...(patch.time?.created !== undefined &&
-      patch.time.created !== null && { createdAt: new Date(patch.time.created).toISOString() }),
-    ...(patch.time?.updated !== undefined &&
-      patch.time.updated !== null && { updatedAt: new Date(patch.time.updated).toISOString() }),
-    ...(patch.revert !== undefined && { revert: patch.revert }),
-    ...(patch.summary !== undefined && { summary: patch.summary }),
-  }
-}
-
 export function indexProvidersById(all: ProviderInfo[]): Record<string, ProviderInfo> {
   const normalized: Record<string, ProviderInfo> = {}
   for (const provider of all) {
@@ -511,7 +444,7 @@ export type WebviewMessage =
   | { type: "permissionResolved"; permissionID: string }
   | { type: "permissionError"; permissionID: string; stale?: boolean }
   | { type: "sessionCreated"; session: ReturnType<typeof sessionToWebview>; draftID?: string }
-  | { type: "sessionUpdated"; session: WebviewSessionPatch }
+  | { type: "sessionUpdated"; session: ReturnType<typeof sessionToWebview> }
   | { type: "sessionDeleted"; sessionID: string }
   | { type: "messageRemoved"; sessionID: string; messageID: string }
   | { type: "sessionError"; sessionID?: string; error?: unknown }

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -577,7 +577,7 @@ describe("KiloProvider revert ordering", () => {
         id: "evt_clear",
         seq: 0,
         aggregateID: "sessionID",
-        data: { sessionID: "s1", info: { revert: null } },
+        data: { sessionID: "s1", info: mkSession() },
       },
     })
 
@@ -586,7 +586,7 @@ describe("KiloProvider revert ordering", () => {
       id: "evt_clear",
       seq: 0,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { revert: null } },
+      properties: { sessionID: "s1", info: mkSession() },
     })
   })
 
@@ -654,7 +654,7 @@ describe("KiloProvider revert ordering", () => {
     error.mockRestore()
   })
 
-  it("does not restore a stale revert boundary after a newer clear update", () => {
+  it("clears a stale revert boundary from a full snapshot that omits revert", () => {
     const client = createClient()
     const { internal, sent } = makeProvider(client)
     internal.currentSession = mkSession({ messageID: "m1" })
@@ -665,7 +665,12 @@ describe("KiloProvider revert ordering", () => {
       id: "evt_000000000002",
       seq: 0,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { revert: null } },
+      properties: { sessionID: "s1", info: mkSession() },
+    })
+    internal.handleEvent({
+      id: "evt_000000000003",
+      type: "message.updated",
+      properties: { sessionID: "s1", info: mkMessage("m2", "user", 2).info },
     })
     const count = sent.length
 
@@ -674,7 +679,7 @@ describe("KiloProvider revert ordering", () => {
       id: "evt_000000000001",
       seq: 0,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { revert: { messageID: "m1" } } },
+      properties: { sessionID: "s1", info: mkSession({ messageID: "m1" }) },
     })
     internal.handleEvent({
       id: "evt_000000000001",
@@ -685,7 +690,10 @@ describe("KiloProvider revert ordering", () => {
     expect(internal.currentSession?.revert).toBeUndefined()
     expect(internal.revisions.get("s1")).toEqual({ id: "evt_000000000002", seq: 0 })
     expect(sent).toHaveLength(count)
-    expect(sent.at(-1)).toMatchObject({ type: "sessionUpdated", session: { id: "s1", revert: null } })
+    expect(sent.slice(-2)).toEqual([
+      expect.objectContaining({ type: "sessionUpdated", session: expect.objectContaining({ id: "s1", revert: null }) }),
+      expect.objectContaining({ type: "messageCreated", message: expect.objectContaining({ id: "m2" }) }),
+    ])
   })
 
   it("uses sequence ordering for workspace-replayed session updates", () => {
@@ -699,14 +707,14 @@ describe("KiloProvider revert ordering", () => {
       id: "evt_ffffffffffff",
       seq: 1,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { revert: { messageID: "m1" } } },
+      properties: { sessionID: "s1", info: mkSession({ messageID: "m1" }) },
     })
     internal.handleEvent({
       source: "sync",
       id: "evt_000000000001",
       seq: 2,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { revert: null } },
+      properties: { sessionID: "s1", info: mkSession() },
     })
 
     expect(internal.currentSession?.revert).toBeUndefined()
@@ -748,7 +756,7 @@ describe("KiloProvider revert ordering", () => {
       id: "evt_000000000001",
       seq: 0,
       type: "session.updated",
-      properties: { sessionID: "s1", info: { title: "updated" } },
+      properties: { sessionID: "s1", info: { ...mkSession(), title: "updated" } },
     })
     first.resolve({ data: mkSession() })
     await Bun.sleep(0)

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import {
   sessionToWebview,
-  applySessionPatch,
-  sessionPatchToWebview,
   indexProvidersById,
   filterVisibleAgents,
   buildSettingPath,
@@ -166,115 +164,6 @@ describe("sessionToWebview", () => {
     const result = sessionToWebview(makeSession())
     expect(result.revert).toBeNull()
     expect(result.summary).toBeNull()
-  })
-})
-
-describe("applySessionPatch", () => {
-  it("applies values without dropping unrelated session fields", () => {
-    const session = makeSession({
-      workspaceID: "workspace-1",
-      cost: 1,
-      tokens: { input: 1, output: 2, reasoning: 3, cache: { read: 4, write: 5 } },
-    })
-
-    const result = applySessionPatch(session, { title: "Updated", cost: 2, time: { updated: 1700002000000 } })
-
-    expect(result.title).toBe("Updated")
-    expect(result.cost).toBe(2)
-    expect(result.workspaceID).toBe("workspace-1")
-    expect(result.tokens).toEqual(session.tokens)
-    expect(result.time).toEqual({ created: 1700000000000, updated: 1700002000000 })
-  })
-
-  it("clears optional fields when the patch contains null", () => {
-    const session = makeSession({
-      workspaceID: "workspace-1",
-      summary: { additions: 1, deletions: 2, files: 3 },
-      cost: 4,
-      tokens: { input: 1, output: 2, reasoning: 3, cache: { read: 4, write: 5 } },
-      share: { url: "https://example.com" },
-      agent: "code",
-      model: { id: "model-1", providerID: "provider-1" },
-      permission: [],
-      revert: { messageID: "msg-1" },
-      time: { created: 1, updated: 2, compacting: 3, archived: 4 },
-    })
-
-    const result = applySessionPatch(session, {
-      workspaceID: null,
-      summary: null,
-      cost: null,
-      tokens: null,
-      share: { url: null },
-      agent: null,
-      model: null,
-      permission: null,
-      revert: null,
-      time: { compacting: null, archived: null },
-    })
-
-    expect(result.workspaceID).toBeUndefined()
-    expect(result.summary).toBeUndefined()
-    expect(result.cost).toBeUndefined()
-    expect(result.tokens).toBeUndefined()
-    expect(result.share).toBeUndefined()
-    expect(result.agent).toBeUndefined()
-    expect(result.model).toBeUndefined()
-    expect(result.permission).toBeUndefined()
-    expect(result.revert).toBeUndefined()
-    expect(result.time).toEqual({ created: 1, updated: 2 })
-  })
-
-  it("ignores null patches for required session fields", () => {
-    const session = makeSession()
-    const result = applySessionPatch(session, {
-      slug: null,
-      projectID: null,
-      directory: null,
-      title: null,
-      version: null,
-      time: { created: null, updated: null },
-    })
-
-    expect(result.slug).toBe(session.slug)
-    expect(result.projectID).toBe(session.projectID)
-    expect(result.directory).toBe(session.directory)
-    expect(result.title).toBe(session.title)
-    expect(result.version).toBe(session.version)
-    expect(result.time).toEqual(session.time)
-  })
-
-  it("does not mutate the original session", () => {
-    const session = makeSession({ revert: { messageID: "msg-1" }, time: { created: 1, updated: 2, compacting: 3 } })
-
-    applySessionPatch(session, { revert: null, time: { updated: 4, compacting: null } })
-
-    expect(session.revert).toEqual({ messageID: "msg-1" })
-    expect(session.time).toEqual({ created: 1, updated: 2, compacting: 3 })
-  })
-})
-
-describe("sessionPatchToWebview", () => {
-  it("converts relevant patch timestamps and preserves explicit clears", () => {
-    const result = sessionPatchToWebview("sess-1", {
-      parentID: null,
-      summary: null,
-      revert: null,
-      time: { created: 1700000000000, updated: 1700001000000 },
-    })
-
-    expect(result).toEqual({
-      id: "sess-1",
-      parentID: null,
-      summary: null,
-      revert: null,
-      createdAt: new Date(1700000000000).toISOString(),
-      updatedAt: new Date(1700001000000).toISOString(),
-    })
-  })
-
-  it("omits fields not present in the patch", () => {
-    expect(sessionPatchToWebview("sess-1", { cost: 2 })).toEqual({ id: "sess-1" })
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
+++ b/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
@@ -40,14 +40,14 @@ describe("revert session synchronization", () => {
     expect(unrevert).toContain('type: "sessionUpdated"')
   })
 
-  it("uses ordered sync patches instead of duplicate bus snapshots", () => {
+  it("uses ordered sync snapshots instead of duplicate bus snapshots", () => {
     expect(provider).toMatch(/source: "sync"/)
     expect(provider).toMatch(
       /if \(event\.type === "session\.updated"\) return "source" in event && event\.source === "sync"/,
     )
     expect(provider).toMatch(/if \(!isLegacySyncEvent\(event\)\) return/)
     expect(provider).toMatch(
-      /this\.setCurrentSession\(applySessionPatch\(this\.currentSession, event\.properties\.info\)\)/,
+      /this\.setCurrentSession\(event\.properties\.info\)/,
     )
   })
 })

--- a/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
+++ b/packages/kilo-vscode/tests/unit/revert-checkpoints.test.ts
@@ -46,8 +46,6 @@ describe("revert session synchronization", () => {
       /if \(event\.type === "session\.updated"\) return "source" in event && event\.source === "sync"/,
     )
     expect(provider).toMatch(/if \(!isLegacySyncEvent\(event\)\) return/)
-    expect(provider).toMatch(
-      /this\.setCurrentSession\(event\.properties\.info\)/,
-    )
+    expect(provider).toMatch(/this\.setCurrentSession\(event\.properties\.info\)/)
   })
 })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -564,9 +564,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           setStore(
             "session",
             match.index,
-            produce((draft) => {
-              Object.assign(draft, event.data.info)
-            }),
+            reconcile(event.data.info), // kilocode_change - session.updated carries a full snapshot, including omitted optional fields
           )
           break
         }

--- a/packages/opencode/test/kilocode/tui-sync-event.test.ts
+++ b/packages/opencode/test/kilocode/tui-sync-event.test.ts
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/solid */
 import { describe, expect, test } from "bun:test"
-import type { BackgroundProcessInfo, GlobalEvent } from "@kilocode/sdk/v2"
+import type { BackgroundProcessInfo, GlobalEvent, Session } from "@kilocode/sdk/v2"
 import { normalizeSyncEvent } from "../../src/cli/cmd/tui/context/event"
-import { mount, wait } from "../cli/cmd/tui/sync-fixture"
+import { json, mount, wait } from "../cli/cmd/tui/sync-fixture"
 
 function processInfo(id: string, sessionID: string, lifetime: BackgroundProcessInfo["lifetime"], updated: number) {
   return {
@@ -17,6 +17,19 @@ function processInfo(id: string, sessionID: string, lifetime: BackgroundProcessI
     output: "",
     time: { started: 1, updated },
   } satisfies BackgroundProcessInfo
+}
+
+function sessionInfo(id: string, revert?: Session["revert"]): Session {
+  return {
+    id,
+    slug: "session",
+    projectID: "proj_test",
+    directory: "/tmp/opencode/packages/opencode",
+    title: "Session",
+    version: "1",
+    time: { created: 1, updated: 1 },
+    revert,
+  }
 }
 
 describe("TUI sync event wire format", () => {
@@ -315,6 +328,63 @@ describe("TUI sync event wire format", () => {
       await wait(() => sync.data.part[messageID]?.[0]?.type === "text")
       expect(sync.data.message[sessionID]?.[0]?.id).toBe(messageID)
       expect(sync.data.part[messageID]?.[0]).toMatchObject({ type: "text", text: "rendered response" })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("clears an omitted revert before accepting a fresh message id", async () => {
+    const sessionID = "ses_revert"
+    const revertedID = "msg_000000000001"
+    const freshID = "msg_000000000002"
+    const { app, emit, sync } = await mount((url) => {
+      if (url.pathname === "/session") return json([sessionInfo(sessionID, { messageID: revertedID })])
+    })
+
+    try {
+      await wait(() => sync.data.session.some((item) => item.id === sessionID))
+      emit({
+        directory: "/tmp/opencode/packages/opencode",
+        project: "proj_test",
+        payload: {
+          type: "sync",
+          syncEvent: {
+            type: "session.updated.1",
+            id: "evt_clear",
+            seq: 1,
+            aggregateID: sessionID,
+            data: { sessionID, info: sessionInfo(sessionID) },
+          },
+        },
+      } as unknown as GlobalEvent)
+      emit({
+        directory: "/tmp/opencode/packages/opencode",
+        project: "proj_test",
+        payload: {
+          type: "sync",
+          syncEvent: {
+            type: "message.updated.1",
+            id: "evt_fresh",
+            seq: 2,
+            aggregateID: sessionID,
+            data: {
+              sessionID,
+              info: {
+                id: freshID,
+                sessionID,
+                role: "user",
+                agent: "code",
+                model: { providerID: "kilo", modelID: "kilo-auto/free" },
+                time: { created: 2 },
+              },
+            },
+          },
+        },
+      } as unknown as GlobalEvent)
+
+      await wait(() => sync.data.message[sessionID]?.some((item) => item.id === freshID) === true)
+      expect(sync.session.get(sessionID)?.revert).toBeUndefined()
+      expect(sync.data.message[sessionID]?.at(-1)?.id).toBe(freshID)
     } finally {
       app.renderer.destroy()
     }

--- a/packages/opencode/test/kilocode/tui-sync-event.test.ts
+++ b/packages/opencode/test/kilocode/tui-sync-event.test.ts
@@ -28,7 +28,7 @@ function sessionInfo(id: string, revert?: Session["revert"]): Session {
     title: "Session",
     version: "1",
     time: { created: 1, updated: 1 },
-    revert,
+    ...(revert !== undefined ? { revert } : {}),
   }
 }
 
@@ -337,6 +337,8 @@ describe("TUI sync event wire format", () => {
     const sessionID = "ses_revert"
     const revertedID = "msg_000000000001"
     const freshID = "msg_000000000002"
+    const cleared = sessionInfo(sessionID)
+    expect(Object.hasOwn(cleared, "revert")).toBe(false)
     const { app, emit, sync } = await mount((url) => {
       if (url.pathname === "/session") return json([sessionInfo(sessionID, { messageID: revertedID })])
     })
@@ -353,7 +355,7 @@ describe("TUI sync event wire format", () => {
             id: "evt_clear",
             seq: 1,
             aggregateID: sessionID,
-            data: { sessionID, info: sessionInfo(sessionID) },
+            data: { sessionID, info: cleared },
           },
         },
       } as unknown as GlobalEvent)


### PR DESCRIPTION
After a conversation is reverted, the backend clears the revert boundary before accepting the replacement prompt. The resulting `session.updated.1` event contains a complete session snapshot, but optional fields that are no longer present are omitted from its encoded payload. Both the TUI and VS Code merged that snapshot into existing client state, so the previous `revert` field survived and continued hiding newly submitted messages until a full reload replaced the session.

Treat ordered `session.updated.1` payloads as authoritative snapshots in both clients. The TUI now reconciles the complete session value, while the extension replaces its SDK session and sends a complete webview session where absent optional state is represented explicitly. This also removes the partial-patch helpers whose semantics conflicted with the generated full-session event contract.

Regression coverage starts from a reverted session, applies a full snapshot with `revert` omitted, then delivers a newly generated higher message ID and verifies that the replacement turn remains visible.

Fixes #12235. Supersedes #12265 and #12272: #12265 depends on reusing the reverted message ID, which the built-in clients do not do, while #12272 clears revert heuristically on message updates and only covers VS Code.