### PR TITLE
fix(cli): attribute image generation usage

### DIFF
--- a/.changeset/attribute-generated-images.md
+++ b/.changeset/attribute-generated-images.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Attribute Kilo image generation usage to the active client feature

--- a/packages/opencode/src/kilocode/tool/generate-image.ts
+++ b/packages/opencode/src/kilocode/tool/generate-image.ts
@@ -1,6 +1,6 @@
 // kilocode_change - new file
 import { Effect, Schema } from "effect"
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import * as path from "path"
 import { readFile } from "fs/promises"
 import * as Tool from "../../tool/tool"
@@ -10,7 +10,8 @@ import { InstanceState } from "@/effect/instance-state"
 import * as Log from "@opencode-ai/core/util/log"
 import { assertExternalDirectoryEffect } from "../../tool/external-directory"
 import { Config } from "@/config/config"
-import { KILO_OPENROUTER_BASE } from "@kilocode/kilo-gateway"
+import { HEADER_FEATURE, HEADER_ORGANIZATIONID, KILO_OPENROUTER_BASE } from "@kilocode/kilo-gateway"
+import { KiloSession } from "@/kilocode/session"
 import DESCRIPTION from "./generate-image.txt"
 
 const log = Log.create({ service: "tool.generate_image" })
@@ -101,12 +102,22 @@ export function ensureExtension(relPath: string, format: ImageFormat): string {
 
 type ResolvedRequest = { url: string; headers: Record<string, string>; body: string }
 
-function buildRequest(resolved: ResolvedProvider, prompt: string, model: string, inputImage?: string): ResolvedRequest {
+export function buildRequest(
+  resolved: ResolvedProvider,
+  prompt: string,
+  model: string,
+  sessionID: string,
+  inputImage?: string,
+): ResolvedRequest {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${resolved.token}`,
     "Content-Type": "application/json",
   }
-  if (resolved.organizationId) headers["X-KILOCODE-ORGANIZATIONID"] = resolved.organizationId
+  if (resolved.provider === "kilo") {
+    const feature = KiloSession.attribution(sessionID).feature
+    if (feature) headers[HEADER_FEATURE] = feature
+    if (resolved.organizationId) headers[HEADER_ORGANIZATIONID] = resolved.organizationId
+  }
 
   const content = inputImage
     ? [
@@ -197,7 +208,7 @@ export const GenerateImageTool = Tool.define(
 
           const cfg = yield* configSvc.get()
           const model = params.model ?? cfg.experimental?.image_generation_model ?? DEFAULT_MODEL
-          const req = buildRequest(resolved, params.prompt, model, inputImage)
+          const req = buildRequest(resolved, params.prompt, model, ctx.sessionID, inputImage)
 
           const response = yield* http.execute(
             HttpClientRequest.post(req.url).pipe(

--- a/packages/opencode/test/kilocode/tool/generate-image.test.ts
+++ b/packages/opencode/test/kilocode/tool/generate-image.test.ts
@@ -1,12 +1,32 @@
 // kilocode_change - new file
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { ENV_FEATURE, HEADER_FEATURE, HEADER_ORGANIZATIONID } from "@kilocode/kilo-gateway"
+import { KiloSession } from "../../../src/kilocode/session"
 import {
+  buildRequest,
   parseImageResponse,
   resolveProvider,
   ensureExtension,
   IMAGE_MODELS,
   DEFAULT_MODEL,
 } from "../../../src/kilocode/tool/generate-image"
+
+const env = {
+  feature: process.env[ENV_FEATURE],
+  platform: process.env["KILO_PLATFORM"],
+}
+
+beforeEach(() => {
+  delete process.env[ENV_FEATURE]
+  delete process.env["KILO_PLATFORM"]
+})
+
+afterEach(() => {
+  if (env.feature === undefined) delete process.env[ENV_FEATURE]
+  else process.env[ENV_FEATURE] = env.feature
+  if (env.platform === undefined) delete process.env["KILO_PLATFORM"]
+  else process.env["KILO_PLATFORM"] = env.platform
+})
 
 describe("generate-image response parser", () => {
   test("extracts PNG from data URL in choices[0].message.images[0]", () => {
@@ -88,6 +108,54 @@ describe("generate-image provider resolver", () => {
     const result = resolveProvider({ type: "oauth", access: "kilo-token" }, "or-key")
     expect(result!.provider).toBe("kilo")
     expect(result!.token).toBe("kilo-token")
+  })
+})
+
+describe("generate-image request headers", () => {
+  test("includes session-derived feature and existing Kilo headers", () => {
+    const id = "image-vscode"
+    KiloSession.register({ id, platform: "vscode" })
+
+    try {
+      const resolved = resolveProvider({ type: "oauth", access: "kilo-token", accountId: "org-123" }, undefined)!
+      const req = buildRequest(resolved, "draw a fox", DEFAULT_MODEL, id)
+
+      expect(req.headers.Authorization).toBe("Bearer kilo-token")
+      expect(req.headers[HEADER_ORGANIZATIONID]).toBe("org-123")
+      expect(req.headers[HEADER_FEATURE]).toBe("vscode-extension")
+    } finally {
+      KiloSession.clearPlatformOverride(id)
+    }
+  })
+
+  test("honors session and launcher-derived feature values", () => {
+    const id = "image-agent-manager"
+    KiloSession.register({ id, platform: "agent-manager" })
+
+    try {
+      const resolved = resolveProvider({ type: "api", key: "kilo-api-key" }, undefined)!
+      expect(buildRequest(resolved, "draw a fox", DEFAULT_MODEL, id).headers[HEADER_FEATURE]).toBe("agent-manager")
+
+      KiloSession.clearPlatformOverride(id)
+      process.env[ENV_FEATURE] = "jetbrains-plugin"
+      expect(buildRequest(resolved, "draw a fox", DEFAULT_MODEL, id).headers[HEADER_FEATURE]).toBe("jetbrains-plugin")
+
+      delete process.env[ENV_FEATURE]
+      process.env["KILO_PLATFORM"] = "cli"
+      expect(buildRequest(resolved, "draw a fox", DEFAULT_MODEL, id).headers[HEADER_FEATURE]).toBe("cli")
+    } finally {
+      KiloSession.clearPlatformOverride(id)
+    }
+  })
+
+  test("omits Kilo-specific headers for direct OpenRouter requests", () => {
+    process.env[ENV_FEATURE] = "cloud-agent"
+    const resolved = resolveProvider(undefined, "or-key-123")!
+    const req = buildRequest(resolved, "draw a fox", DEFAULT_MODEL, "image-openrouter")
+
+    expect(req.headers.Authorization).toBe("Bearer or-key-123")
+    expect(req.headers[HEADER_FEATURE]).toBeUndefined()
+    expect(req.headers[HEADER_ORGANIZATIONID]).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## What changed

Kilo-authenticated `generate_image` requests now include the feature attribution resolved for the active session and launcher, using the same `KiloSession.attribution()` source and gateway header constants as normal Kilo chat requests. Organization and authorization headers remain unchanged, while direct OpenRouter requests continue to omit all Kilo-specific headers.

## Why

`generate_image` sends its billable request directly to the Kilo OpenRouter-compatible gateway and previously omitted `X-KILOCODE-FEATURE` entirely. The Cloud gateway stores only allowlisted `X-KILOCODE-FEATURE` values in `microdollar_usage_metadata.feature_id`, so those image-generation charges were unattributed. This change preserves session-specific VS Code and Agent Manager attribution and launcher-provided values for JetBrains, CLI, Cloud, and other clients.