### PR TITLE
fix(vscode): prevent question submission freeze

### DIFF
--- a/.changeset/fix-question-dock-disposal.md
+++ b/.changeset/fix-question-dock-disposal.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Prevent sessions from freezing after submitting a question.
+Prevent sessions from freezing after submitting or dismissing a question.

--- a/.changeset/fix-question-dock-disposal.md
+++ b/.changeset/fix-question-dock-disposal.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent sessions from freezing after submitting a question.

--- a/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
+++ b/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
@@ -1,0 +1,60 @@
+import { Window } from "happy-dom"
+import type { QuestionRequest } from "../../webview-ui/src/types/messages"
+
+const window = new Window()
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  Node: window.Node,
+  Element: window.Element,
+  HTMLElement: window.HTMLElement,
+  SVGElement: window.SVGElement,
+  requestAnimationFrame: () => 0,
+})
+
+const { Show, createSignal } = await import("solid-js")
+const { render } = await import("solid-js/web")
+const { SessionContext } = await import("../../webview-ui/src/context/session")
+const { LanguageContext } = await import("../../webview-ui/src/context/language")
+const { QuestionDock } = await import("../../webview-ui/src/components/chat/QuestionDock")
+
+const request: QuestionRequest = {
+  id: "question-1",
+  sessionID: "session-1",
+  questions: [
+    {
+      question: "Continue?",
+      header: "Confirm",
+      options: [{ label: "Yes", description: "Continue" }],
+    },
+  ],
+}
+const session = {
+  questionErrors: () => new Set<string>(),
+  selectedAgent: () => "code",
+  selectAgent: () => {},
+  replyToQuestion: () => {},
+  rejectQuestion: () => {},
+  closeQuestion: () => {},
+}
+const language = {
+  locale: () => "en",
+  setLocale: () => {},
+  userOverride: () => "",
+  t: (key: string) => key,
+}
+const [active, setActive] = createSignal<QuestionRequest | undefined>(request)
+const root = document.createElement("div")
+const dispose = render(
+  () => (
+    <SessionContext.Provider value={session as never}>
+      <LanguageContext.Provider value={language as never}>
+        <Show when={active()}>{(item) => <QuestionDock request={item()} />}</Show>
+      </LanguageContext.Provider>
+    </SessionContext.Provider>
+  ),
+  root,
+)
+
+setActive(undefined)
+dispose()

--- a/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
+++ b/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
@@ -29,11 +29,16 @@ const request: QuestionRequest = {
     },
   ],
 }
+const [active, setActive] = createSignal<QuestionRequest | undefined>(request)
+const calls: Array<{ id: string; answers: string[][] }> = []
 const session = {
   questionErrors: () => new Set<string>(),
   selectedAgent: () => "code",
   selectAgent: () => {},
-  replyToQuestion: () => {},
+  replyToQuestion: (id: string, answers: string[][]) => {
+    calls.push({ id, answers })
+    setActive(undefined)
+  },
   rejectQuestion: () => {},
   closeQuestion: () => {},
 }
@@ -43,8 +48,8 @@ const language = {
   userOverride: () => "",
   t: (key: string) => key,
 }
-const [active, setActive] = createSignal<QuestionRequest | undefined>(request)
 const root = document.createElement("div")
+document.body.append(root)
 const dispose = render(
   () => (
     <SessionContext.Provider value={session as never}>
@@ -56,5 +61,14 @@ const dispose = render(
   root,
 )
 
-setActive(undefined)
+const option = root.querySelector<HTMLButtonElement>('[data-slot="question-option"]')
+const submit = root.querySelector<HTMLButtonElement>('[data-slot="question-footer-actions"] button')
+if (!option || !submit) throw new Error("Question controls did not render")
+option.click()
+if (submit.disabled) throw new Error("Submit did not enable after selecting an answer")
+submit.click()
+if (calls.length !== 1 || calls[0]?.id !== request.id || calls[0]?.answers[0]?.[0] !== "Yes") {
+  throw new Error(`Unexpected question reply: ${JSON.stringify(calls)}`)
+}
+if (root.querySelector('[data-component="question-dock"]')) throw new Error("Question dock did not unmount")
 dispose()

--- a/packages/kilo-vscode/tests/unit/question-dock-disposal.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-dock-disposal.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test"
+import { unlinkSync } from "node:fs"
+import path from "node:path"
+import { build } from "esbuild"
+import { solidPlugin } from "esbuild-plugin-solid"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+const WEBVIEW = path.join(ROOT, "webview-ui")
+const FIXTURE = path.join(ROOT, "tests/fixtures/question-dock-disposal.tsx")
+
+describe("QuestionDock disposal", () => {
+  it("does not read a stale callback-form Show accessor", async () => {
+    const solid = path.dirname(Bun.resolveSync("solid-js/package.json", WEBVIEW))
+    const aliases: Record<string, string> = {
+      "solid-js": path.join(solid, "dist/solid.js"),
+      "solid-js/web": path.join(solid, "web/dist/web.js"),
+      "solid-js/store": path.join(solid, "store/dist/store.js"),
+    }
+    const dedupe = {
+      name: "solid-dedupe",
+      setup(ctx: Parameters<NonNullable<Parameters<typeof build>[0]["plugins"]>[number]["setup"]>[0]) {
+        ctx.onResolve({ filter: /^solid-js(\/web|\/store)?$/ }, (args) => ({ path: aliases[args.path] }))
+      },
+    }
+    const result = await build({
+      entryPoints: [FIXTURE],
+      bundle: true,
+      conditions: ["browser"],
+      external: ["happy-dom"],
+      format: "esm",
+      logLevel: "silent",
+      platform: "node",
+      plugins: [dedupe, solidPlugin()],
+      target: "es2022",
+      write: false,
+    })
+    const file = path.join(ROOT, `.question-dock-disposal-${crypto.randomUUID()}.mjs`)
+    await Bun.write(file, result.outputFiles[0]!.contents)
+    const child = Bun.spawnSync(["bun", file], { cwd: WEBVIEW, stdout: "pipe", stderr: "pipe" })
+    unlinkSync(file)
+
+    const output = child.stdout.toString() + child.stderr.toString()
+    expect(child.exitCode, output).toBe(0)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -26,6 +26,7 @@ import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => {
   const session = useSession()
   const language = useLanguage()
+  const id = props.request.id
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -57,8 +58,8 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   // Chat search indexes only the mounted page's options, and there's no
   // other signal exposing which page that is — publish it here so search
   // stays in sync as the user navigates instead of always assuming page 0.
-  createEffect(() => setActiveQuestionTab(props.request.id, store.tab))
-  onCleanup(() => clearActiveQuestionTab(props.request.id))
+  createEffect(() => setActiveQuestionTab(id, store.tab))
+  onCleanup(() => clearActiveQuestionTab(id))
 
   const question = createMemo(() => questions()[store.tab])
   const confirm = createMemo(() => !single() && store.tab === questions().length)


### PR DESCRIPTION
Answering or dismissing an agent question removes `QuestionDock` from a callback-form Solid `<Show>`. The cleanup added for chat-search tab tracking re-read `props.request.id` after that narrowing accessor became stale, throwing an uncaught `Stale read from <Show>` exception even though the backend had accepted the reply. The exception left the webview unresponsive.

Capture the request ID while the accessor is valid and use that stable value for active-tab tracking and cleanup. The regression coverage compiles the real Solid component stack, selects an answer, submits it, and verifies teardown completes without a stale accessor read.

Fixes #12264
Fixes #12262