### PR TITLE
feat: added optional model and variant arguments to task tool to let main agents pick subagent model and variant

### DIFF
--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -94,7 +94,7 @@ export namespace KiloTask {
 
   type Model = { providerID: ProviderV2.ID; modelID: ModelV2.ID }
   type Saved = Model & { variant?: string }
-  type Choice = { model: Model; variant?: string; sticky?: boolean; direct?: boolean }
+  type Choice = { model: Model; variant?: string; sticky?: boolean; direct?: boolean; callSite?: boolean }
 
   function key(model: Model) {
     return `${model.providerID}/${model.modelID}`
@@ -136,12 +136,16 @@ export namespace KiloTask {
     config: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
     parent: Model
     variant?: string
+    callModel?: string
+    callVariant?: string
     provider: Provider.Interface
   }) {
     const state = yield* saved(input.name)
     const cfg = parse(input.config.subagent_model)
+    const call = parse(input.callModel)
     const override = (model: Model) => input.config.subagent_variant_overrides?.[key(model)] ?? undefined
     const choices: Array<Choice | undefined> = [
+      call ? { model: call, variant: input.callVariant, callSite: true } : undefined,
       state
         ? {
             model: { providerID: state.providerID, modelID: state.modelID },
@@ -157,10 +161,10 @@ export namespace KiloTask {
       if (!choice) continue
       if (choice.direct) {
         const value = override(choice.model)
-        if (!value) return { model: choice.model, variant: choice.variant }
+        if (!value) return { model: choice.model, variant: input.callVariant ?? choice.variant }
         const full = yield* input.provider.getModel(choice.model.providerID, choice.model.modelID)
         const variant = full.variants?.[value] ? value : choice.variant
-        return { model: choice.model, variant }
+        return { model: choice.model, variant: input.callVariant ?? variant }
       }
       const full = yield* input.provider.getModel(choice.model.providerID, choice.model.modelID).pipe(
         Effect.catchTag("ProviderModelNotFoundError", (err) =>
@@ -175,21 +179,26 @@ export namespace KiloTask {
         ),
       )
       if (!full) continue
+      if (choice.callSite) {
+        const value = override(choice.model)
+        const variant = value && full.variants?.[value] ? value : undefined
+        return { model: choice.model, variant: input.callVariant ?? variant }
+      }
       const fallback = choice.variant && full.variants?.[choice.variant] ? choice.variant : undefined
       const value = override(choice.model)
       const variant = value && full.variants?.[value] ? value : fallback
       return {
         model: choice.sticky && variant ? { ...choice.model, variant } : choice.model,
-        variant,
+        variant: input.callVariant ?? variant,
       }
     }
 
     const value = override(input.parent)
-    if (!value) return { model: input.parent, variant: input.variant }
+    if (!value) return { model: input.parent, variant: input.callVariant ?? input.variant }
     const full = yield* input.provider
       .getModel(input.parent.providerID, input.parent.modelID)
       .pipe(Effect.catchTag("ProviderModelNotFoundError", () => Effect.succeed(undefined)))
     const variant = full?.variants?.[value] ? value : input.variant
-    return { model: input.parent, variant }
+    return { model: input.parent, variant: input.callVariant ?? variant }
   })
 }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -56,6 +56,12 @@ const BaseParameterFields = {
     description:
       "This should only be set if you mean to resume a previous task (you can pass a prior task_id and the task will continue the same subagent session as before instead of creating a fresh one)",
   }),
+  model: Schema.optional(Schema.String).annotate({
+    description: "The provider/model to use for this task, overriding configured subagent model selection",
+  }),
+  variant: Schema.optional(Schema.String).annotate({
+    description: "The model variant or reasoning effort to use for this task",
+  }),
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this task" }),
 }
 
@@ -225,6 +231,8 @@ export const TaskTool = Tool.define(
           providerID: msg.info.providerID,
         },
         variant: msg.info.variant,
+        callModel: params.model,
+        callVariant: params.variant,
         provider,
       })
       const model = selected.model

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -201,6 +201,8 @@ function run(input: {
   state?: unknown
   client?: string
   variant?: string
+  model?: string
+  callVariant?: string
   config?: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
 }) {
   return provideTmpdirInstance(
@@ -220,6 +222,8 @@ function run(input: {
             description: `run ${input.agent}`,
             prompt: "inspect resolution",
             subagent_type: input.agent,
+            model: input.model,
+            variant: input.callVariant,
           },
           {
             sessionID: chat.id,
@@ -254,6 +258,71 @@ function run(input: {
 }
 
 describe("tool.task model resolution", () => {
+   it.live("call-site model and variant beat saved and configured choices", () =>
+    run({
+      agent: "pinned",
+      model: "sub-provider/sub-model",
+      callVariant: "max",
+      state: { model: { pinned: saved }, variant: { "saved-provider/saved-model": savedVariant } },
+      config: { subagent_variant_overrides: { "sub-provider/sub-model": overrideVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(sub)
+          expect(result.variant).toEqual("max")
+          expect(result.model).toEqual(sub)
+          expect(result.metadataVariant).toEqual("max")
+        }),
+      ),
+    ),
+  )
+
+  it.live("unavailable call-site model falls back while preserving call-site variant", () =>
+    run({
+      agent: "pinned",
+      model: "missing-provider/missing-model",
+      callVariant: "max",
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(cfg)
+          expect(result.variant).toEqual("max")
+          expect(result.model).toEqual(cfg)
+          expect(result.metadataVariant).toEqual("max")
+        }),
+      ),
+    ),
+  )
+  
+  it.live("model-specific override applies to a call-site model without a call-site variant", () =>
+    run({
+      agent: "worker",
+      model: "sub-provider/sub-model",
+      config: { subagent_variant_overrides: { "sub-provider/sub-model": overrideVariant } },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(sub)
+          expect(result.variant).toEqual(overrideVariant)
+          expect(result.model).toEqual(sub)
+          expect(result.metadataVariant).toEqual(overrideVariant)
+        }),
+      ),
+    ),
+  )
+
+  it.live("call-site variant overrides the inherited parent variant", () =>
+    run({ agent: "worker", variant: inherited, callVariant: "max" }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(parent)
+          expect(result.variant).toEqual("max")
+          expect(result.metadataVariant).toEqual("max")
+        }),
+      ),
+    ),
+  )
+
   it.live("saved model beats agent config for pinned", () =>
     run({
       agent: "pinned",

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -264,7 +264,10 @@ describe("tool.task model resolution", () => {
       model: "sub-provider/sub-model",
       callVariant: "max",
       state: { model: { pinned: saved }, variant: { "saved-provider/saved-model": savedVariant } },
-      config: { subagent_variant_overrides: { "sub-provider/sub-model": overrideVariant } },
+      config: {
+        subagent_model: "parent-provider/parent-model",
+        subagent_variant_overrides: { "sub-provider/sub-model": overrideVariant },
+      },
     }).pipe(
       Effect.tap((result) =>
         Effect.sync(() => {


### PR DESCRIPTION
These changes allow agents to pick what model and variant/reasoning to use for a subagent task rather then only using the main agent model and variant/reasoning. This allows users to save costs by using cheaper models for tasks such as exploration. Tests are included. 

These new fields are optional, if left blank it will use the main model and variant/reasoning.

For example, the tool arguments look like
```json
{
  "subagent_type": "explore",
  "model": "tencent/hy3",
}
```
or 
```json
{
  "subagent_type": "explore",
  "model": "openai/gpt-5.6-sol",
  "variant": "high"
}
```

You can tell the agent to use provider/model and variant in your message or put it in your agents.md or other instructions.

This was written and adversarially reviewed for reachable failures by OpenAI GPT 5.6 Sol and I have personally tested/used this new feature for multiple threads of work with 0 issue.

Thank you for your work overall. Apologies for not including all of the other required changes in my previous PR.