### PR TITLE
fix(gateway): support ES2022 metadata consumers

### DIFF
--- a/packages/kilo-gateway/src/gateway-metadata.ts
+++ b/packages/kilo-gateway/src/gateway-metadata.ts
@@ -54,7 +54,7 @@ type Data = z.infer<typeof dataSchema>
 function routed(meta: Gateway) {
   const route = meta.routing
   if (!route) return
-  const hit = route.modelAttempts?.findLast((item) => item.success === true)
+  const hit = route.modelAttempts?.slice().reverse().find((item) => item.success === true)
   const id = hit?.canonicalSlug ?? route.canonicalSlug
   if (!id) return
   const value = id.trim()


### PR DESCRIPTION
Replace `Array.prototype.findLast` in gateway routing metadata handling with an ES2022-compatible reverse search.

This unblocks VS Code GA packaging, which type-checks imported gateway source against its ES2022 library target, while preserving the existing last-successful-attempt behavior.