### PR TITLE
fix: allow ES2023 library APIs

### DIFF
--- a/packages/kilo-vscode/tsconfig.json
+++ b/packages/kilo-vscode/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,

--- a/packages/kilo-vscode/webview-ui/tsconfig.json
+++ b/packages/kilo-vscode/webview-ui/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
     "strict": true,

--- a/packages/plugin-atomic-chat/tsconfig.json
+++ b/packages/plugin-atomic-chat/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2023", "dom", "dom.iterable"],
     "types": ["node"]
   },
   "include": ["src/**/*", "test/**/*"]

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "nodenext",
     "declaration": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2023", "dom", "dom.iterable"],
     "types": ["node"] // kilocode_change
   },
   "include": ["src"]

--- a/packages/sdk/js/tsconfig.json
+++ b/packages/sdk/js/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "nodenext",
     "declaration": true,
     "moduleResolution": "nodenext",
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2023", "dom", "dom.iterable"],
     "types": ["node"],
     "composite": true,
     "rootDir": "src"


### PR DESCRIPTION
## What changed
Use ES2023 standard-library definitions for the VS Code extension host and webview, SDK, plugin, and Atomic Chat plugin while retaining their existing emitted syntax targets.

## Why
The extension directly imports Kilo Gateway code for two extension-owned features:

- the browser-safe autocomplete model catalog through the dedicated `@kilocode/kilo-gateway/autocomplete` subpath
- the embedding model catalog fetcher used by indexing settings through the root `@kilocode/kilo-gateway` export

The root import causes TypeScript to resolve the gateway barrel and its re-export graph, including `gateway-metadata.ts`, under the extension tsconfig. That exposed the stale ES2022 library definition when the gateway implementation used `Array.findLast`.

## VS Code and Cursor compatibility
The extension deliberately supports VS Code `^1.105.1` for Cursor compatibility. VS Code 1.105.1 embeds Node 22.19 and Chromium 138; both support ES2023 APIs, including `Array.findLast`. Cursor versions compatible with this VS Code extension API baseline use a sufficiently modern Chromium/Node runtime as well. Raising `lib` therefore changes TypeScript standard-library declarations without raising the extension engine requirement.

The existing `target: ES2022` values remain unchanged, so emitted syntax compatibility is unaffected.

The SDK and plugin packages extend the Node 22 tsconfig, and Atomic Chat runs through that plugin runtime, so their ES2023 library declarations match their runtime floor.

This branch is based on main at `9ac93a4c90`, including #12289.