### PR TITLE
fix(vscode): respect terminal display for background processes

### DIFF
--- a/.changeset/background-process-display.md
+++ b/.changeset/background-process-display.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Respect the Terminal Command Blocks display setting for background process tool cards.

--- a/packages/kilo-vscode/tests/unit/tool-default-open.test.ts
+++ b/packages/kilo-vscode/tests/unit/tool-default-open.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test"
+import type { Part, ToolPart } from "@kilocode/sdk/v2"
+import { toolDefaultOpen } from "../../webview-ui/src/components/chat/tool-default-open"
+
+function tool(name: string) {
+  return { type: "tool", tool: name } as ToolPart
+}
+
+describe("toolDefaultOpen", () => {
+  it.each(["bash", "background_process"])("uses the terminal preference for %s", (name) => {
+    expect(toolDefaultOpen(tool(name), false, true)).toBe(false)
+    expect(toolDefaultOpen(tool(name), true, false)).toBe(true)
+  })
+
+  it.each(["edit", "write", "apply_patch"])("uses the code edit preference for %s", (name) => {
+    expect(toolDefaultOpen(tool(name), true, false)).toBe(false)
+    expect(toolDefaultOpen(tool(name), false, true)).toBe(true)
+  })
+
+  it("leaves unrelated parts unchanged", () => {
+    expect(toolDefaultOpen(tool("read"), true, true)).toBeUndefined()
+    expect(toolDefaultOpen({ type: "text" } as Part, true, true)).toBeUndefined()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -33,14 +33,7 @@ import type { Part as TimelinePart } from "../../types/messages"
 import type { TimelineHighlight } from "../../utils/timeline/highlight"
 import { QuestionDock } from "./QuestionDock"
 import { SuggestBar } from "./SuggestBar"
-
-const EDIT_TOOLS = new Set(["edit", "write", "apply_patch"])
-
-function editOpen(part: SDKPart, open: boolean) {
-  if (part.type !== "tool") return undefined
-  const tool = (part as unknown as ToolPart).tool
-  return EDIT_TOOLS.has(tool) ? open : undefined
-}
+import { toolDefaultOpen } from "./tool-default-open"
 
 /** Extract plan path from a completed plan_exit tool part. */
 function planExitInfo(part: SDKPart): { plan: string } | undefined {
@@ -296,7 +289,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                       part={part}
                                       message={props.message as SDKMessage}
                                       showAssistantCopyPartID={props.showAssistantCopyPartID}
-                                      defaultOpen={editOpen(part, edit())}
+                                      defaultOpen={toolDefaultOpen(part, open(), edit())}
                                       forceOpen={forceOpen()}
                                       forceOpenFile={forceOpen() ? props.forceOpenFile : undefined}
                                       reasoningAutoCollapse={display.reasoningAutoCollapse()}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/tool-default-open.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/tool-default-open.ts
@@ -1,0 +1,12 @@
+import type { Part as SDKPart, ToolPart } from "@kilocode/sdk/v2"
+
+const EDIT_TOOLS = new Set(["edit", "write", "apply_patch"])
+const TERMINAL_TOOLS = new Set(["bash", "background_process"])
+
+export function toolDefaultOpen(part: SDKPart, terminal: boolean, edit: boolean) {
+  if (part.type !== "tool") return undefined
+  const tool = (part as unknown as ToolPart).tool
+  if (TERMINAL_TOOLS.has(tool)) return terminal
+  if (EDIT_TOOLS.has(tool)) return edit
+  return undefined
+}


### PR DESCRIPTION
Background-process tool cards currently ignore the Terminal Command Blocks display preference, so start, status, logs, stop, and restart results can remain expanded even when terminal commands are configured to start collapsed. This makes repeated background-process activity clutter transcripts and leaves users without the display control available to normal shell commands.

Treat background-process cards as terminal tools when selecting their initial open state. The existing expanded or collapsed preference now applies consistently to both shell and background-process cards, while per-card manual toggles continue to be remembered.

<img width="538" height="105" alt="file-b5aba30ecb16356f2eca2c8b0d9dfcc9" src="https://github.com/user-attachments/assets/c7c58498-28ee-460b-8404-32b4aaabfb8e" />
<img width="687" height="133" alt="file-f60df2289356365dbd97f658f23de468" src="https://github.com/user-attachments/assets/aaae8da9-f351-49ef-ac32-dbaa048203a2" />


Closes #12268