### PR TITLE
fix(cli): keep sidebar branch in sync

### DIFF
--- a/.changeset/cli-branch-watcher.md
+++ b/.changeset/cli-branch-watcher.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep the CLI sidebar branch label in sync when Git changes the active branch.

--- a/packages/opencode/src/kilocode/project/watcher.ts
+++ b/packages/opencode/src/kilocode/project/watcher.ts
@@ -1,0 +1,30 @@
+import { InstanceState } from "@/effect/instance-state"
+import { EventV2 } from "@opencode-ai/core/event"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { Global } from "@opencode-ai/core/global"
+import { Location } from "@opencode-ai/core/location"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Effect, Layer } from "effect"
+
+const watcher = (dir: string) => {
+  const location = Location.layer({ directory: AbsolutePath.make(dir) }).pipe(Layer.provide(ProjectV2.defaultLayer))
+  return Watcher.locationLayer.pipe(
+    Layer.provide(location),
+    Layer.provide(EventV2.defaultLayer),
+    Layer.provide(FSUtil.defaultLayer),
+    Layer.provide(Global.defaultLayer),
+  )
+}
+
+export const make = Effect.gen(function* () {
+  const state = yield* InstanceState.make(
+    Effect.fn("WatcherBootstrap.state")(function* (ctx) {
+      yield* Watcher.Service.use(() => Effect.void).pipe(Effect.provide(watcher(ctx.directory)))
+    }),
+  )
+  return InstanceState.get(state).pipe(Effect.asVoid)
+})
+
+export * as WatcherBootstrap from "./watcher"

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -7,6 +7,7 @@ import * as Vcs from "./vcs"
 import { InstanceState } from "@/effect/instance-state"
 // kilocode_change start - ShareNext init is handled by KilocodeBootstrap; upstream dropped File/FileWatcher bootstrap init
 import { KilocodeBootstrap } from "@/kilocode/bootstrap"
+import { WatcherBootstrap } from "@/kilocode/project/watcher"
 // import { ShareNext } from "@/share/share-next"
 // kilocode_change end
 import { Effect, Layer } from "effect"
@@ -31,6 +32,7 @@ export const layer = Layer.effect(
     const reference = yield* Reference.Service
     // kilocode_change start
     const kilocode = yield* KilocodeBootstrap.Service
+    const watcher = yield* WatcherBootstrap.make
     // const shareNext = yield* ShareNext.Service
     // kilocode_change end
     const snapshot = yield* Snapshot.Service
@@ -44,6 +46,7 @@ export const layer = Layer.effect(
       // Plugin can mutate config so it has to be initialized before anything else.
       yield* plugin.init()
       yield* kilocode.init().pipe(Effect.catchCause((cause) => Effect.logWarning("kilocode init failed", { cause }))) // kilocode_change
+      yield* watcher // kilocode_change
       // Each service self-manages its own slow work via Effect.forkScoped against
       // its per-instance state scope. We just await materialization here.
       yield* Effect.forEach(

--- a/packages/opencode/test/kilocode/project/watcher.test.ts
+++ b/packages/opencode/test/kilocode/project/watcher.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { Deferred, Effect, Layer, Schema } from "effect"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Git } from "@/git"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { InstanceStore } from "@/project/instance-store"
+import { Vcs } from "@/project/vcs"
+import { tmpdirScoped } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+const layer = Layer.mergeAll(
+  Vcs.layer.pipe(Layer.provideMerge(Git.defaultLayer), Layer.provideMerge(EventV2Bridge.defaultLayer)),
+  CrossSpawnSpawner.defaultLayer,
+  FSUtil.defaultLayer,
+  InstanceStore.defaultLayer.pipe(Layer.provide(InstanceBootstrap.defaultLayer)),
+)
+const it = testEffect(layer)
+
+const git = Effect.fn("WatcherBootstrapTest.git")(function* (cwd: string, args: string[]) {
+  const result = yield* Git.Service.use((git) => git.run(args, { cwd }))
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString("utf8")}`)
+})
+
+const next = Effect.fn("WatcherBootstrapTest.next")(function* (branch: string) {
+  const events = yield* EventV2Bridge.Service
+  const pending = yield* Deferred.make<string | undefined>()
+  const off = yield* events.listen((event) => {
+    if (event.type !== Vcs.Event.BranchUpdated.type) return Effect.void
+    const data = Schema.decodeUnknownSync(Vcs.Event.BranchUpdated.data)(event.data)
+    if (data.branch === branch) Deferred.doneUnsafe(pending, Effect.succeed(data.branch))
+    return Effect.void
+  })
+  yield* Effect.addFinalizer(() => off)
+  return pending
+})
+
+it.live(
+  "publishes a branch update when the CLI instance changes HEAD",
+  () =>
+    Effect.gen(function* () {
+      expect(Watcher.hasNativeBinding()).toBe(true)
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const ctx = yield* Effect.acquireRelease(store.load({ directory: dir }), store.dispose)
+
+      yield* Effect.gen(function* () {
+        const branch = `watch-${Math.random().toString(36).slice(2)}`
+        yield* git(dir, ["branch", branch])
+
+        const vcs = yield* Vcs.Service
+        yield* vcs.init()
+        const initial = yield* vcs.branch()
+        expect(initial).toBeDefined()
+        const pending = yield* next(branch)
+
+        for (let attempt = 0; attempt < 20 && !(yield* Deferred.isDone(pending)); attempt++) {
+          yield* git(dir, ["switch", branch])
+          yield* Effect.sleep("50 millis")
+          if (yield* Deferred.isDone(pending)) break
+          if (initial) yield* git(dir, ["switch", initial])
+          yield* Effect.sleep("50 millis")
+        }
+
+        const updated = yield* Deferred.await(pending).pipe(Effect.timeout("5 seconds"))
+        expect(updated).toBe(branch)
+      }).pipe(Effect.provideService(InstanceRef, ctx))
+    }),
+  30_000,
+)


### PR DESCRIPTION
## Issue

Fixes #12225

## Context

The VCS service already refreshes the branch on `.git/HEAD` watcher events, but the legacy CLI bootstrap stopped starting the core watcher during the OpenCode v1.16.2 migration. This leaves the sidebar branch stale after an external `git switch`.

## Implementation

Acquire the core `Watcher.locationLayer` once per legacy CLI instance and retain it through `InstanceState`, so its subscription is released with the instance. The Kilo-specific lifecycle code stays under `src/kilocode`; the shared bootstrap only imports, creates, and runs it.

## Screenshots / Video

N/A. This restores the event source without changing UI rendering.

## How to Test

### Manual/local verification

Agent-executed local verification used a real temporary Git repository and native watcher. It loaded the legacy CLI instance, changed `HEAD`, and observed the resulting `vcs.branch.updated` event.

Commands run:

- `bun test test/kilocode/project/watcher.test.ts` - 1 passed
- `bun run typecheck` - passed
- `bun x oxlint packages/opencode/src/project/bootstrap.ts packages/opencode/src/kilocode/project/watcher.ts packages/opencode/test/kilocode/project/watcher.test.ts` - 0 warnings, 0 errors
- `bun x prettier --check packages/opencode/src/project/bootstrap.ts packages/opencode/src/kilocode/project/watcher.ts packages/opencode/test/kilocode/project/watcher.test.ts` - passed
- `bun run script/check-opencode-annotations.ts --base origin/main` - passed
- `bun x changeset status --since origin/main` - passed
- Repository pre-push typechecks, including the JetBrains package - passed

### Reviewer test steps

1. From `packages/opencode`, run `bun test test/kilocode/project/watcher.test.ts`.
2. Start the CLI in a Git repository and run `git switch <another-branch>` in a second terminal.
3. Confirm the sidebar branch updates without restarting the CLI.

### Blocked checks and substitute verification

- `bun run script/check-opencode-promise-facades.ts` fails on Windows path-separator mismatches in its existing classified-site list, all in unrelated files. This change adds no Promise facade or `AppRuntime` dependency; the targeted lint, typecheck, and integration test passed.

## AI Assistance

OpenAI Codex assisted with investigation, implementation, and the checks listed above. This draft is pending final contributor review.

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] Screenshots/video marked N/A
- [x] Changeset included
- [ ] I personally reviewed the diff and can explain the changes, including AI-assisted work