### PR TITLE
feat(vscode): discover custom provider variants

### DIFF
--- a/.changeset/pull-custom-provider-variants.md
+++ b/.changeset/pull-custom-provider-variants.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+---
+
+Pull configurable reasoning variants from models.dev for custom-provider models.

--- a/.kilo/plans/auto-variant-discovery.md
+++ b/.kilo/plans/auto-variant-discovery.md
@@ -1,0 +1,251 @@
+# Plan: Pull reasoning variants from models.dev
+
+## Decision
+
+Add an explicit **Pull reasoning variants** action to the custom-provider dialog.
+
+This should use structured `reasoning_options` from models.dev rather than expanding the hardcoded model-family heuristics in `ProviderTransform.variants()`.
+
+The approach has two separate confidence levels:
+
+1. The variant values are catalog data, not guesses. For example, models.dev currently describes OpenAI `gpt-5.2` with `none`, `low`, `medium`, `high`, and `xhigh` effort values.
+2. Matching a custom-provider model to the correct models.dev provider entry can be uncertain. Exact provider and model matches can be applied directly; broad name matches must be presented for confirmation.
+
+This means the button is useful and substantially more reliable than family heuristics, but it must not silently configure a fuzzy match.
+
+## Available data
+
+The current models.dev provider catalog includes:
+
+```ts
+type ReasoningOption =
+  | { type: "effort"; values: Array<string | null> }
+  | { type: "toggle" }
+  | { type: "budget_tokens"; min?: number; max?: number }
+```
+
+Important constraints:
+
+- `reasoning_options` is provider-specific. Different providers serving the same model ID can expose different options.
+- `models.json` contains provider-independent model facts but not `reasoning_options`.
+- `api.json` and `catalog.json.providers` contain the provider-specific options needed here.
+- The repo's `packages/core/src/models-dev.ts` schema does not yet include `reasoning_options`, although the live catalog and current upstream schema do.
+- The custom-provider `/models` fetch currently retains only `id` and `name`; it discards `owned_by`, which could help disambiguate matches.
+
+## User flow
+
+1. The user fetches or manually adds models in the custom-provider dialog.
+2. The user clicks **Pull reasoning variants** once for the provider, not once per model.
+3. Kilo matches all configured models against the cached models.dev provider catalog in one request.
+4. The UI shows a stable summary, for example:
+
+   `5 models checked | 3 matched | 11 variants found | 1 needs review | 1 unmatched`
+
+5. Each model gets one compact row:
+
+   - `gpt-5.2: 5 variants, exact OpenAI match`
+   - `claude-sonnet-latest: 3 possible matches, review required`
+   - `internal-code-model: no catalog match`
+
+6. Exact, high-confidence matches are preselected. Ambiguous or broad matches remain unselected until the user chooses a catalog candidate.
+7. **Apply selected** adds the variants to the form. Nothing is persisted until the user saves the custom provider.
+
+The existing detailed per-variant editor remains available after applying suggestions, but it is collapsed by default. This avoids rendering and updating every variant control while discovery is in progress.
+
+## Matching rules
+
+Return candidates with `confidence`, `reason`, and the selected models.dev provider/model identity. Do not return only a guessed variant list.
+
+### High confidence
+
+Preselect these matches:
+
+1. The custom provider `baseURL` matches a models.dev provider API URL after normalizing trailing slashes, and the model ID matches exactly.
+2. The fetched model ID is provider-scoped, such as `openai/gpt-5.2`, and both the provider prefix and remaining model ID match exactly.
+3. `owned_by` maps to a models.dev provider and the model ID matches exactly. Treat this as high confidence only for recognized provider IDs; LiteLLM deployments may return custom `owned_by` values.
+
+### Medium confidence
+
+Show these as preselected suggestions only when all eligible catalog entries agree on the same non-empty effort list:
+
+1. Exact unscoped model ID match across providers.
+2. Exact normalized model name match with the same version and size tokens.
+
+If matching entries disagree, require review instead. For example, catalog providers currently disagree about `gpt-5.2`, and some advertise no configurable reasoning options at all.
+
+### Low confidence
+
+Never preselect these:
+
+1. Prefix or suffix removal, such as matching `team-gpt-5.2-prod` to `gpt-5.2`.
+2. Punctuation-normalized aliases, such as `claude-sonnet-4.6` versus `claude-sonnet-4-6`, when multiple provider entries remain.
+3. Broad token or fuzzy name matches.
+
+Numeric model version, parameter size, date, and `pro`/`mini`/`flash`/`thinking` qualifiers must match. A broad match must never cross these tokens.
+
+## Mapping catalog options to custom-provider variants
+
+### First version: effort variants only
+
+For `@ai-sdk/openai-compatible` and `@ai-sdk/openai`, map each non-null effort value to:
+
+```json
+{
+  "low": { "reasoningEffort": "low" },
+  "medium": { "reasoningEffort": "medium" },
+  "high": { "reasoningEffort": "high" }
+}
+```
+
+- Add `max` and `default` to the custom-provider form types if the catalog value needs them.
+- Skip `null`; omission already represents provider-default behavior.
+- Consider skipping catalog `default` as a selectable variant unless it maps to a meaningful provider option.
+- Set the model's `reasoning` capability to `true` when applying an effort match.
+
+### Defer toggle and token-budget generation
+
+Do not automatically synthesize variants for these in the first version:
+
+- `toggle` says reasoning can be enabled or disabled, but it does not specify the wire field. Depending on the upstream this may be `enable_thinking`, `thinking`, `chat_template_args`, or another parameter.
+- `budget_tokens` supplies a valid range but not meaningful preset values or the provider-specific request field.
+
+Show these capabilities in the summary instead:
+
+- `Thinking toggle available, manual mapping required`
+- `Reasoning budget 1,024-32,768, manual mapping required`
+
+A later provider-specific translator can map these shapes when the transport encoding is known.
+
+## Merge behavior
+
+- Never replace an existing variant automatically.
+- Add missing catalog variants only.
+- If a catalog variant name already exists with different configuration, mark it as a conflict and keep the user's value selected by default.
+- Allow the user to choose **Replace**, **Keep existing**, or **Skip model** from the review summary.
+- Applying suggestions updates only the dialog form. The normal provider save flow persists the result to `kilo.json`.
+
+This avoids hidden ephemeral state and makes the generated configuration inspectable and portable.
+
+## Backend work
+
+### 1. Preserve models.dev reasoning metadata
+
+- Add `ReasoningOption` and `reasoning_options` to `packages/core/src/models-dev.ts`, aligned with the current models.dev schema.
+- Continue using the existing `ModelsDev.Service` cache. Do not fetch the 3 MB catalog separately from the webview.
+
+### 2. Add a Kilo-owned matcher
+
+Create `packages/opencode/src/kilocode/provider/variant-discovery.ts` with pure functions for:
+
+- URL and identifier normalization.
+- Candidate collection and confidence classification.
+- Agreement checks across exact-ID candidates.
+- Converting effort options into target-package variant configuration.
+- Merging suggestions with existing model variants without overwriting them.
+
+Keep this out of shared upstream provider code.
+
+### 3. Expose one batch API
+
+Add an instance API endpoint accepting:
+
+```ts
+{
+  baseURL: string
+  npm: "@ai-sdk/openai-compatible" | "@ai-sdk/openai" | "@ai-sdk/anthropic"
+  models: Array<{
+    id: string
+    name?: string
+    ownedBy?: string
+    variants?: Record<string, Record<string, unknown>>
+  }>
+}
+```
+
+Return, per model:
+
+```ts
+{
+  modelID: string
+  status: "matched" | "review" | "unmatched" | "unsupported"
+  selected?: {
+    providerID: string
+    modelID: string
+    confidence: "high" | "medium" | "low"
+    reason: string
+    variants: Record<string, Record<string, unknown>>
+    reasoningOptions: ReasoningOption[]
+  }
+  candidates: Array<{
+    providerID: string
+    modelID: string
+    confidence: "high" | "medium" | "low"
+    reason: string
+    reasoningOptions: ReasoningOption[]
+  }>
+}
+```
+
+Regenerate the SDK after adding the endpoint.
+
+## Extension and UI work
+
+### 1. Preserve provider ownership metadata
+
+Update `packages/kilo-vscode/src/shared/fetch-models.ts` to retain optional `owned_by` as `ownedBy` in fetched model entries and pass it through the dialog's temporary fetched-model state.
+
+Do not persist `ownedBy` into the provider model configuration; it is matching evidence only.
+
+### 2. Add the batch action
+
+- Add **Pull reasoning variants** beside the model section actions in `CustomProviderDialog.tsx`.
+- Send all current models in one request.
+- Keep the previous model cards mounted while the request runs to avoid flicker.
+- Show a spinner only in the button and summary area.
+
+### 3. Add a compact review summary
+
+Use a collapsed summary card with:
+
+- Total models checked.
+- Models matched.
+- Effort variants found.
+- Ambiguous matches requiring review.
+- Unsupported toggle/budget-only models.
+- Unmatched models.
+
+Expand a row only when the user wants to inspect candidates or resolve a conflict. Do not render every variant editor in the discovery result.
+
+## Testing
+
+### Unit tests
+
+- Exact base URL plus exact ID selects the matching provider entry.
+- Provider-scoped IDs select the correct catalog provider.
+- Exact unscoped IDs auto-select only when all eligible effort lists agree.
+- Conflicting exact-ID entries require review.
+- Fuzzy aliases never auto-apply.
+- Numeric/version qualifiers cannot be crossed during normalization.
+- Effort values map to `reasoningEffort` for OpenAI-compatible providers.
+- Toggle and budget-only entries are reported but not synthesized.
+- Existing variants are preserved and conflicts are reported.
+
+### Integration tests
+
+- The endpoint reads `reasoning_options` from the cached models.dev catalog.
+- A fetched LiteLLM model with `owned_by: "openai"` receives the expected exact candidate.
+- An internal alias returns review candidates without changing configuration.
+
+### Manual test
+
+- Add a LiteLLM provider and fetch several models.
+- Pull reasoning variants and confirm the summary remains stable while loading.
+- Apply an exact GPT match and verify the effort variants appear in the existing editor.
+- Verify an ambiguous Claude alias requires selection.
+- Save, reopen the provider, and confirm applied variants persisted.
+
+## Scope recommendation
+
+Implement the explicit, catalog-backed button with effort variants first. Do not broaden the runtime hardcoded heuristics as part of this work.
+
+This delivers a reliable variant list after a user-approved catalog match, gives useful summaries for every model, and avoids pretending that broad LiteLLM alias matching is authoritative.

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -42,6 +42,24 @@ const Cost = Schema.Struct({
   ),
 })
 
+// kilocode_change start - reasoning_options support for variant discovery
+export const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+export type ReasoningOption = Schema.Schema.Type<typeof ReasoningOption>
+// kilocode_change end
+
 export const Model = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
@@ -51,6 +69,9 @@ export const Model = Schema.Struct({
   reasoning: Schema.Boolean,
   temperature: Schema.Boolean,
   tool_call: Schema.Boolean,
+  // kilocode_change start - reasoning_options support for variant discovery
+  reasoning_options: Schema.optional(Schema.Array(ReasoningOption)),
+  // kilocode_change end
   interleaved: Schema.optional(
     Schema.Union([
       Schema.Literal(true),

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1146,6 +1146,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
             console.error("[Kilo New] fetchCustomProviderModels failed:", e),
           )
           break
+        case "discoverVariants":
+          this.handleDiscoverVariants(message).catch((e) => console.error("[Kilo New] discoverVariants failed:", e))
+          break
         case "compact":
           await this.handleCompact(message.sessionID, message.providerID, message.modelID)
           break
@@ -2293,6 +2296,40 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const message = err instanceof Error ? err.message : "Failed to fetch models"
       const auth = err instanceof FetchModelsError && err.auth
       this.postMessage({ type: "customProviderModelsFetched", requestId: rid, error: message, auth })
+    }
+  }
+
+  private async handleDiscoverVariants(msg: Record<string, unknown>): Promise<void> {
+    const rid = typeof msg.requestId === "string" ? msg.requestId : ""
+    if (!rid) return
+    const config = this.connectionService.getServerConfig()
+    if (!config) {
+      this.postMessage({ type: "variantsDiscovered", requestId: rid, error: "Not connected to CLI backend" })
+      return
+    }
+    try {
+      const auth = Buffer.from(`kilo:${config.password}`).toString("base64")
+      const res = await fetch(`${config.baseUrl}/provider/discover-variants`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Basic ${auth}`,
+        },
+        body: JSON.stringify({
+          baseURL: msg.baseURL,
+          npm: msg.npm,
+          models: msg.models,
+        }),
+      })
+      if (!res.ok) {
+        const text = await res.text().catch(() => "")
+        throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`)
+      }
+      const summary = await res.json()
+      this.postMessage({ type: "variantsDiscovered", requestId: rid, summary })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to discover variants"
+      this.postMessage({ type: "variantsDiscovered", requestId: rid, error: message })
     }
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
@@ -196,6 +196,18 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
   const [selected, setSelected] = createSignal<Set<string>>(new Set())
   const [fetchStatus, setFetchStatus] = createSignal<string>()
 
+  // ── Variant discovery state ─────────────────────────────────────────
+  const [discoveringVariants, setDiscoveringVariants] = createSignal(false)
+  const [variantSummary, setVariantSummary] = createSignal<{
+    total: number
+    matched: number
+    review: number
+    unmatched: number
+    unsupported: number
+    totalVariants: number
+  }>()
+  const [variantError, setVariantError] = createSignal<string>()
+
   // Search within fetched models
   const [search, setSearch] = createSignal("")
   const [debouncedSearch, setDebouncedSearch] = createSignal("")
@@ -441,6 +453,70 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
       { id: "", name: "", reasoning: false, supportsImages: false, modalities: {}, variants: [] },
     ])
     setErrors("models", (v) => [...v, { variants: [] }])
+  }
+
+  function discoverVariants() {
+    if (form.models.length === 0) return
+    setDiscoveringVariants(true)
+    setVariantError(undefined)
+    setVariantSummary(undefined)
+
+    const models = form.models.map((m) => ({
+      id: m.id,
+      name: m.name || undefined,
+      ownedBy: undefined,
+      variants: m.variants.length > 0 ? Object.fromEntries(m.variants.map((v) => [v.name, {}])) : undefined,
+    }))
+
+    const rid = crypto.randomUUID()
+    const unsub = vscode.onMessage((msg: ExtensionMessage) => {
+      if (msg.type !== "variantsDiscovered") return
+      if (!("requestId" in msg) || msg.requestId !== rid) return
+      unsub()
+
+      if (msg.error) {
+        setVariantError(msg.error)
+        return
+      }
+
+      if (msg.summary) {
+        setVariantSummary({
+          total: msg.summary.total,
+          matched: msg.summary.matched,
+          review: msg.summary.review,
+          unmatched: msg.summary.unmatched,
+          unsupported: msg.summary.unsupported,
+          totalVariants: msg.summary.totalVariants,
+        })
+
+        for (const result of msg.summary.results) {
+          if (result.status === "matched" && result.selected && result.variants) {
+            const modelIdx = form.models.findIndex((m) => m.id === result.modelID)
+            if (modelIdx >= 0) {
+              const newVariants = Object.entries(result.variants).map(([name, cfg]) => ({
+                name,
+                enableThinking: undefined,
+                thinking: undefined,
+                splitReasoning: undefined,
+                reasoningEffort: undefined,
+                outputEffort: undefined,
+                chatTemplateArgs: undefined,
+                ...((cfg as Record<string, unknown>) || {}),
+              }))
+              setForm("models", modelIdx, "variants", newVariants)
+            }
+          }
+        }
+      }
+    })
+
+    vscode.postMessage({
+      type: "discoverVariants",
+      requestId: rid,
+      baseURL: form.baseURL,
+      npm: form.npm,
+      models,
+    })
   }
 
   function removeModel(index: number) {
@@ -705,6 +781,45 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
             <Button type="button" size="small" variant="ghost" icon="plus-small" onClick={addModel}>
               {language.t("provider.custom.models.add")}
             </Button>
+
+            <Button
+              type="button"
+              size="small"
+              variant="ghost"
+              icon="brain"
+              onClick={discoverVariants}
+              disabled={discoveringVariants() || form.models.length === 0}
+            >
+              {discoveringVariants() ? (
+                <Spinner style={{ width: "12px", height: "12px" }} />
+              ) : (
+                language.t("provider.custom.models.discoverVariants")
+              )}
+            </Button>
+
+            <Show when={variantError()}>
+              {(err) => (
+                <span
+                  style={{ "font-size": "var(--kilo-font-size-12)", color: "var(--vscode-errorForeground, #f14c4c)" }}
+                >
+                  {err()}
+                </span>
+              )}
+            </Show>
+
+            <Show when={!variantError() && variantSummary()}>
+              {(s) => (
+                <span
+                  style={{
+                    "font-size": "var(--kilo-font-size-12)",
+                    color: "var(--text-weak-base, var(--vscode-descriptionForeground))",
+                  }}
+                >
+                  {s().matched} matched | {s().review} review | {s().unmatched} unmatched | {s().unsupported}{" "}
+                  unsupported | {s().totalVariants} variants found
+                </span>
+              )}
+            </Show>
 
             {/* Fetch error */}
             <Show when={fetchError()}>

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -955,6 +955,7 @@ export const dict = {
   "provider.custom.models.variants.outputEffort.max": "max",
   "provider.custom.models.remove": "Remove model",
   "provider.custom.models.add": "Add model",
+  "provider.custom.models.discoverVariants": "Pull reasoning variants",
   "provider.custom.models.fetch": "Fetch models",
   "provider.custom.models.fetching": "Fetching\u2026",
   "provider.custom.models.fetch.error": "Failed to fetch models: {{error}}",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -1049,6 +1049,47 @@ export interface CustomProviderModelsFetchedMessage {
   auth?: boolean
 }
 
+export interface VariantsDiscoveredMessage {
+  type: "variantsDiscovered"
+  requestId: string
+  summary?: {
+    total: number
+    matched: number
+    review: number
+    unmatched: number
+    unsupported: number
+    totalVariants: number
+    results: Array<{
+      modelID: string
+      status: "matched" | "review" | "unmatched" | "unsupported"
+      selected?: {
+        providerID: string
+        modelID: string
+        modelName: string
+        confidence: "high" | "medium" | "low"
+        reason: string
+        effortValues: string[]
+        hasEffortOptions: boolean
+        hasToggleOptions: boolean
+        hasBudgetOptions: boolean
+      }
+      candidates: Array<{
+        providerID: string
+        modelID: string
+        modelName: string
+        confidence: "high" | "medium" | "low"
+        reason: string
+        hasEffortOptions: boolean
+        hasToggleOptions: boolean
+        hasBudgetOptions: boolean
+      }>
+      variants: Record<string, Record<string, unknown>>
+      conflicts?: string[]
+    }>
+  }
+  error?: string
+}
+
 export interface McpStatusEntry {
   status: "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration"
   error?: string
@@ -1228,6 +1269,7 @@ export type ExtensionMessage =
   | ProviderActionErrorMessage
   | AnacondaDesktopExtensionMessage
   | CustomProviderModelsFetchedMessage
+  | VariantsDiscoveredMessage
   | RecentsLoadedMessage
   | ModelSelectorExpandedLoadedMessage
   | FavoritesLoadedMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -1088,6 +1088,19 @@ export interface FetchCustomProviderModelsMessage {
   headers?: Record<string, string>
 }
 
+export interface DiscoverVariantsMessage {
+  type: "discoverVariants"
+  requestId: string
+  baseURL: string
+  npm: string
+  models: Array<{
+    id: string
+    name?: string
+    ownedBy?: string
+    variants?: Record<string, Record<string, unknown>>
+  }>
+}
+
 export interface PersistRecentsRequest {
   type: "persistRecents"
   recents: ModelSelection[]
@@ -1391,6 +1404,7 @@ export type WebviewMessage =
   | AnacondaDesktopWebviewMessage
   | SaveCustomProviderMessage
   | FetchCustomProviderModelsMessage
+  | DiscoverVariantsMessage
   | PersistRecentsRequest
   | RequestRecentsMessage
   | PersistModelSelectorExpandedRequest

--- a/packages/opencode/src/kilocode/provider/variant-discovery.ts
+++ b/packages/opencode/src/kilocode/provider/variant-discovery.ts
@@ -1,0 +1,346 @@
+// Variant discovery: match custom-provider models against the models.dev catalog
+// to find configurable reasoning effort values.
+//
+// The models.dev catalog exposes structured `reasoning_options` per provider+model.
+// We use that to build a variant list (e.g. ["low","medium","high"]) for models that
+// support configurable reasoning effort, without guessing for models that only
+// expose a toggle or budget_tokens (those require provider-specific transport fields).
+
+import * as ModelsDev from "@opencode-ai/core/models-dev"
+
+export type ReasoningEffortValue = string
+
+export interface VariantCandidate {
+  providerID: string
+  modelID: string
+  modelName: string
+  reasoningOptions: readonly ModelsDev.ReasoningOption[]
+  confidence: "high" | "medium" | "low"
+  reason: string
+}
+
+export interface VariantDiscoveryResult {
+  modelID: string
+  status: "matched" | "review" | "unmatched" | "unsupported"
+  selected?: VariantCandidate
+  candidates: VariantCandidate[]
+  variants: Record<string, Record<string, unknown>>
+  conflicts?: string[]
+}
+
+export interface VariantDiscoverySummary {
+  total: number
+  matched: number
+  review: number
+  unmatched: number
+  unsupported: number
+  totalVariants: number
+  results: VariantDiscoveryResult[]
+}
+
+export interface DiscoverVariantsInput {
+  baseURL: string
+  npm: string
+  models: ReadonlyArray<{
+    id: string
+    name?: string
+    ownedBy?: string
+    variants?: Readonly<Record<string, Readonly<Record<string, unknown>>>>
+  }>
+}
+
+function normalizeUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "").toLowerCase()
+}
+
+function normalizeId(id: string): string {
+  return id.trim().toLowerCase()
+}
+
+function splitScopedId(id: string): { provider: string | undefined; model: string } {
+  const idx = id.indexOf("/")
+  if (idx <= 0) return { provider: undefined, model: id }
+  return { provider: id.slice(0, idx), model: id.slice(idx + 1) }
+}
+
+function extractEffortValues(options: readonly ModelsDev.ReasoningOption[]): ReasoningEffortValue[] | null {
+  for (const opt of options) {
+    if (opt.type === "effort") {
+      return opt.values.filter((v: string | null): v is string => typeof v === "string")
+    }
+  }
+  return null
+}
+
+function hasOnlyNonEffortOptions(options: readonly ModelsDev.ReasoningOption[]): boolean {
+  if (!options.length) return false
+  return !options.some((o) => o.type === "effort")
+}
+
+function buildVariantsFromEffort(
+  values: ReasoningEffortValue[],
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {}
+  for (const v of values) {
+    out[v] = { reasoningEffort: v }
+  }
+  return out
+}
+
+function mergeVariants(
+  existing: Readonly<Record<string, Readonly<Record<string, unknown>>>>,
+  discovered: Record<string, Record<string, unknown>>,
+): { merged: Record<string, Record<string, unknown>>; conflicts: string[] } {
+  const merged: Record<string, Record<string, unknown>> = {}
+  const conflicts: string[] = []
+  for (const [k, v] of Object.entries(existing)) {
+    merged[k] = v
+  }
+  for (const [k, v] of Object.entries(discovered)) {
+    if (k in merged) {
+      const current = merged[k]
+      if (JSON.stringify(current) !== JSON.stringify(v)) {
+        conflicts.push(k)
+      }
+      continue
+    }
+    merged[k] = v
+  }
+  return { merged, conflicts }
+}
+
+function classifyCandidate(
+  providerID: string,
+  modelID: string,
+  baseURL: string,
+  ownedBy: string | undefined,
+  catalog: Record<string, ModelsDev.Provider>,
+): { confidence: "high" | "medium" | "low"; reason: string } | null {
+  const normalizedBase = normalizeUrl(baseURL)
+  const scoped = splitScopedId(modelID)
+
+  // 1. Base URL + exact ID match
+  for (const [pid, provider] of Object.entries(catalog)) {
+    if (provider.api && normalizeUrl(provider.api) === normalizedBase) {
+      if (provider.models[modelID] || provider.models[scoped.model]) {
+        return {
+          confidence: "high",
+          reason: `Exact match on base URL and model ID for provider "${pid}"`,
+        }
+      }
+    }
+  }
+
+  // 2. Provider-scoped ID match
+  if (scoped.provider) {
+    const provider = catalog[scoped.provider]
+    if (provider?.models[scoped.model]) {
+      return {
+        confidence: "high",
+        reason: `Provider-scoped ID "${scoped.provider}/${scoped.model}" matches catalog entry`,
+      }
+    }
+  }
+
+  // 3. owned_by maps to a provider and exact ID matches
+  if (ownedBy) {
+    const provider = catalog[ownedBy.toLowerCase()]
+    if (provider?.models[modelID] || provider?.models[scoped.model]) {
+      return {
+        confidence: "high",
+        reason: `owned_by "${ownedBy}" maps to provider "${provider.id}" with exact model ID match`,
+      }
+    }
+  }
+
+  // 4. Exact unscoped ID match across providers
+  let exactCount = 0
+  for (const [pid, provider] of Object.entries(catalog)) {
+    if (provider.models[modelID] || provider.models[scoped.model]) {
+      exactCount++
+    }
+  }
+  if (exactCount === 1) {
+    return {
+      confidence: "medium",
+      reason: `Exact model ID match in a single provider`,
+    }
+  }
+  if (exactCount > 1) {
+    return {
+      confidence: "low",
+      reason: `Model ID matches ${exactCount} providers; disambiguation required`,
+    }
+  }
+
+  return null
+}
+
+function collectCandidates(
+  modelID: string,
+  baseURL: string,
+  ownedBy: string | undefined,
+  catalog: Record<string, ModelsDev.Provider>,
+): VariantCandidate[] {
+  const candidates: VariantCandidate[] = []
+  const seen = new Set<string>()
+  const normalized = normalizeId(modelID)
+  const scoped = splitScopedId(normalized)
+
+  for (const [pid, provider] of Object.entries(catalog)) {
+    const model = provider.models[scoped.model] ?? provider.models[normalized]
+    if (!model) continue
+    const key = `${pid}/${model.id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const options = model.reasoning_options ?? []
+    if (!options.length) continue
+    const classification = classifyCandidate(pid, model.id, baseURL, ownedBy, catalog)
+    candidates.push({
+      providerID: pid,
+      modelID: model.id,
+      modelName: model.name,
+      reasoningOptions: options,
+      confidence: classification?.confidence ?? "low",
+      reason: classification?.reason ?? "Fuzzy name match",
+    })
+  }
+
+  return candidates
+}
+
+export function discoverVariants(
+  input: DiscoverVariantsInput,
+  catalog: Record<string, ModelsDev.Provider>,
+): VariantDiscoverySummary {
+  const results: VariantDiscoveryResult[] = []
+  let matched = 0
+  let review = 0
+  let unmatched = 0
+  let unsupported = 0
+  let totalVariants = 0
+
+  for (const model of input.models) {
+    const modelID = model.id
+    const classification = classifyCandidate(
+      "",
+      modelID,
+      input.baseURL,
+      model.ownedBy,
+      catalog,
+    )
+
+    const candidates = collectCandidates(modelID, input.baseURL, model.ownedBy, catalog)
+
+    if (!candidates.length) {
+      results.push({
+        modelID,
+        status: "unmatched",
+        candidates: [],
+        variants: {},
+      })
+      unmatched++
+      continue
+    }
+
+    // Find the best candidate based on classification
+    let selected: VariantCandidate | undefined
+    let confidence: "high" | "medium" | "low" = "low"
+    let reason = ""
+
+    if (classification) {
+      if (classification.confidence === "high") {
+        selected = candidates[0]
+        confidence = "high"
+        reason = classification.reason
+      } else if (classification.confidence === "medium") {
+        // Only auto-select if all candidates agree on effort values
+        const effortLists = candidates
+          .map((c) => extractEffortValues(c.reasoningOptions))
+          .filter((v): v is ReasoningEffortValue[] => v !== null)
+
+        if (effortLists.length > 0) {
+          const first = JSON.stringify(effortLists[0].sort())
+          const allAgree = effortLists.every((l) => JSON.stringify(l.sort()) === first)
+          if (allAgree) {
+            selected = candidates[0]
+            confidence = "medium"
+            reason = `${classification.reason}; all candidates agree on effort values`
+          }
+        }
+        if (!selected) {
+          reason = classification.reason
+        }
+      } else {
+        reason = classification.reason
+      }
+    }
+
+    if (!selected) {
+      // Check if any candidate has effort options
+      const hasEffort = candidates.some(
+        (c) => extractEffortValues(c.reasoningOptions) !== null,
+      )
+      if (!hasEffort && candidates.every((c) => hasOnlyNonEffortOptions(c.reasoningOptions))) {
+        results.push({
+          modelID,
+          status: "unsupported",
+          candidates,
+          variants: {},
+        })
+        unsupported++
+      } else {
+        results.push({
+          modelID,
+          status: "review",
+          candidates,
+          variants: {},
+        })
+        review++
+      }
+      continue
+    }
+
+    // Build variants from the selected candidate
+    const effortValues = extractEffortValues(selected.reasoningOptions)
+    if (!effortValues || effortValues.length === 0) {
+      results.push({
+        modelID,
+        status: "unsupported",
+        selected: { ...selected, confidence, reason },
+        candidates,
+        variants: {},
+      })
+      unsupported++
+      continue
+    }
+
+    const discoveredVariants = buildVariantsFromEffort(effortValues)
+
+    // Merge with existing variants
+    const existing = model.variants ?? {}
+    const { merged, conflicts } = mergeVariants(existing, discoveredVariants)
+
+    totalVariants += Object.keys(discoveredVariants).length
+
+    results.push({
+      modelID,
+      status: "matched",
+      selected: { ...selected, confidence, reason },
+      candidates,
+      variants: merged,
+      conflicts: conflicts.length > 0 ? conflicts : undefined,
+    })
+    matched++
+  }
+
+  return {
+    total: input.models.length,
+    matched,
+    review,
+    unmatched,
+    unsupported,
+    totalVariants,
+    results,
+  }
+}

--- a/packages/opencode/src/kilocode/server/httpapi/groups/provider.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/provider.ts
@@ -1,0 +1,104 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { Authorization } from "@/server/routes/instance/httpapi/middleware/authorization"
+import { InstanceContextMiddleware } from "@/server/routes/instance/httpapi/middleware/instance-context"
+import {
+  WorkspaceRoutingMiddleware,
+  WorkspaceRoutingQuery,
+} from "@/server/routes/instance/httpapi/middleware/workspace-routing"
+import { described } from "@/server/routes/instance/httpapi/groups/metadata"
+
+const root = "/provider"
+
+const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+
+export const VariantDiscoveryCandidate = Schema.Struct({
+  providerID: Schema.String,
+  modelID: Schema.String,
+  modelName: Schema.String,
+  reasoningOptions: Schema.Array(ReasoningOption),
+  confidence: Schema.Literals(["high", "medium", "low"]),
+  reason: Schema.String,
+})
+
+export const VariantDiscoveryResult = Schema.Struct({
+  modelID: Schema.String,
+  status: Schema.Literals(["matched", "review", "unmatched", "unsupported"]),
+  selected: Schema.optional(VariantDiscoveryCandidate),
+  candidates: Schema.Array(VariantDiscoveryCandidate),
+  variants: Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Unknown)),
+  conflicts: Schema.optional(Schema.Array(Schema.String)),
+})
+
+export const VariantDiscoverySummary = Schema.Struct({
+  total: Schema.Number,
+  matched: Schema.Number,
+  review: Schema.Number,
+  unmatched: Schema.Number,
+  unsupported: Schema.Number,
+  totalVariants: Schema.Number,
+  results: Schema.Array(VariantDiscoveryResult),
+})
+
+export const VariantDiscoveryBody = Schema.Struct({
+  baseURL: Schema.String,
+  npm: Schema.String,
+  models: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      name: Schema.optional(Schema.String),
+      ownedBy: Schema.optional(Schema.String),
+      variants: Schema.optional(Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.Unknown))),
+    }),
+  ),
+})
+
+export const VariantDiscoveryApi = HttpApi.make("variant-discovery")
+  .add(
+    HttpApiGroup.make("variant-discovery")
+      .add(
+        HttpApiEndpoint.post("discoverVariants", `${root}/discover-variants`, {
+          query: WorkspaceRoutingQuery,
+          payload: VariantDiscoveryBody,
+          success: described(VariantDiscoverySummary, "Variant discovery summary"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "provider.discoverVariants",
+            summary: "Discover reasoning variants for custom-provider models",
+            description:
+              "Match custom-provider models against the models.dev catalog to find configurable reasoning effort values. " +
+              "Returns a summary with per-model match status, candidate catalog entries, and discovered variant configurations.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "provider",
+          description: "Provider variant discovery routes.",
+        }),
+      )
+      .middleware(InstanceContextMiddleware)
+      .middleware(WorkspaceRoutingMiddleware)
+      .middleware(Authorization),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode experimental HttpApi",
+      version: "0.0.1",
+      description: "Experimental HttpApi surface for selected instance routes.",
+    }),
+  )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/provider.ts
@@ -1,0 +1,21 @@
+import { Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
+import { discoverVariants } from "@/kilocode/provider/variant-discovery"
+import { VariantDiscoveryBody } from "@/kilocode/server/httpapi/groups/provider"
+
+export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "variant-discovery", (handlers) =>
+  Effect.gen(function* () {
+    const modelsDev = yield* ModelsDev.Service
+
+    const discoverVariantsHandler = Effect.fn("ProviderHttpApi.discoverVariants")(function* (ctx: {
+      payload: typeof VariantDiscoveryBody.Type
+    }) {
+      const catalog = yield* modelsDev.get()
+      return discoverVariants(ctx.payload, catalog)
+    })
+
+    return handlers.handle("discoverVariants", discoverVariantsHandler)
+  }),
+)

--- a/packages/opencode/src/kilocode/server/httpapi/server.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/server.ts
@@ -21,6 +21,7 @@ import { instanceReloadHandlers } from "./handlers/instance-reload"
 import { interactiveTerminalHandlers } from "./handlers/interactive-terminal"
 import { kiloGatewayHandlers } from "./handlers/kilo-gateway"
 import { kilocodeHandlers } from "./handlers/kilocode"
+import { providerHandlers } from "./handlers/provider"
 import { memoryHandlers } from "./handlers/memory"
 import { networkHandlers } from "./handlers/network"
 import { remoteHandlers } from "./handlers/remote"
@@ -42,6 +43,7 @@ export const provide = Layer.provide([
   interactiveTerminalHandlers,
   kiloGatewayHandlers,
   kilocodeHandlers,
+  providerHandlers,
   memoryHandlers,
   networkHandlers,
   remoteHandlers,

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -35,6 +35,7 @@ import { InteractiveTerminalApi } from "@/kilocode/server/httpapi/groups/interac
 import { KiloGatewayApi } from "@/kilocode/server/httpapi/groups/kilo-gateway"
 import { KilocodeApi } from "@/kilocode/server/httpapi/groups/kilocode"
 import { NetworkApi } from "@/kilocode/server/httpapi/groups/network"
+import { VariantDiscoveryApi as KiloProviderApi } from "@/kilocode/server/httpapi/groups/provider"
 import { RemoteApi } from "@/kilocode/server/httpapi/groups/remote"
 import { SandboxApi } from "@/kilocode/server/httpapi/groups/sandbox"
 import { SessionImportApi } from "@/kilocode/server/httpapi/groups/session-import"
@@ -84,6 +85,7 @@ export const InstanceHttpApi = HttpApi.make("opencode-instance")
   .addHttpApi(InteractiveTerminalApi)
   .addHttpApi(KiloGatewayApi)
   .addHttpApi(KilocodeApi)
+  .addHttpApi(KiloProviderApi)
   .addHttpApi(NetworkApi)
   .addHttpApi(RemoteApi)
   .addHttpApi(SandboxApi)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -302,6 +302,8 @@ import type {
   Prompt,
   ProviderAuthErrors,
   ProviderAuthResponses,
+  ProviderDiscoverVariantsErrors,
+  ProviderDiscoverVariantsResponses,
   ProviderListErrors,
   ProviderListResponses,
   ProviderOauthAuthorizeErrors,
@@ -4068,6 +4070,60 @@ export class Provider extends HeyApiClient {
       url: "/provider/auth",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Discover reasoning variants for custom-provider models
+   *
+   * Match custom-provider models against the models.dev catalog to find configurable reasoning effort values. Returns a summary with per-model match status, candidate catalog entries, and discovered variant configurations.
+   */
+  public discoverVariants<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      baseURL?: string
+      npm?: string
+      models?: Array<{
+        id: string
+        name?: string
+        ownedBy?: string
+        variants?: {
+          [key: string]: {
+            [key: string]: unknown
+          }
+        }
+      }>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "baseURL" },
+            { in: "body", key: "npm" },
+            { in: "body", key: "models" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      ProviderDiscoverVariantsResponses,
+      ProviderDiscoverVariantsErrors,
+      ThrowOnError
+    >({
+      url: "/provider/discover-variants",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -12877,6 +12877,107 @@ export type AnacondaDesktopSyncResponses = {
 
 export type AnacondaDesktopSyncResponse = AnacondaDesktopSyncResponses[keyof AnacondaDesktopSyncResponses]
 
+export type ProviderDiscoverVariantsData = {
+  body?: {
+    baseURL: string
+    npm: string
+    models: Array<{
+      id: string
+      name?: string
+      ownedBy?: string
+      variants?: {
+        [key: string]: {
+          [key: string]: unknown
+        }
+      }
+    }>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/provider/discover-variants"
+}
+
+export type ProviderDiscoverVariantsErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type ProviderDiscoverVariantsError = ProviderDiscoverVariantsErrors[keyof ProviderDiscoverVariantsErrors]
+
+export type ProviderDiscoverVariantsResponses = {
+  /**
+   * Variant discovery summary
+   */
+  200: {
+    total: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    matched: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    review: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    unmatched: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    unsupported: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    totalVariants: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+    results: Array<{
+      modelID: string
+      status: "matched" | "review" | "unmatched" | "unsupported"
+      selected?: {
+        providerID: string
+        modelID: string
+        modelName: string
+        reasoningOptions: Array<
+          | {
+              type: "effort"
+              values: Array<string>
+            }
+          | {
+              type: "toggle"
+            }
+          | {
+              type: "budget_tokens"
+              min?: number
+              max?: number
+            }
+        >
+        confidence: "high" | "medium" | "low"
+        reason: string
+      }
+      candidates: Array<{
+        providerID: string
+        modelID: string
+        modelName: string
+        reasoningOptions: Array<
+          | {
+              type: "effort"
+              values: Array<string>
+            }
+          | {
+              type: "toggle"
+            }
+          | {
+              type: "budget_tokens"
+              min?: number
+              max?: number
+            }
+        >
+        confidence: "high" | "medium" | "low"
+        reason: string
+      }>
+      variants: {
+        [key: string]: {
+          [key: string]: unknown
+        }
+      }
+      conflicts?: Array<string>
+    }>
+  }
+}
+
+export type ProviderDiscoverVariantsResponse =
+  ProviderDiscoverVariantsResponses[keyof ProviderDiscoverVariantsResponses]
+
 export type NetworkListData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15983,6 +15983,450 @@
         ]
       }
     },
+    "/provider/discover-variants": {
+      "post": {
+        "tags": ["provider"],
+        "operationId": "provider.discoverVariants",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Variant discovery summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "matched": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "review": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "unmatched": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "unsupported": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "totalVariants": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["NaN"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["-Infinity"]
+                        },
+                        {
+                          "type": "string",
+                          "enum": ["Infinity", "-Infinity", "NaN"]
+                        }
+                      ]
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "modelID": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": ["matched", "review", "unmatched", "unsupported"]
+                          },
+                          "selected": {
+                            "type": "object",
+                            "properties": {
+                              "providerID": {
+                                "type": "string"
+                              },
+                              "modelID": {
+                                "type": "string"
+                              },
+                              "modelName": {
+                                "type": "string"
+                              },
+                              "reasoningOptions": {
+                                "type": "array",
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": ["effort"]
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "required": ["type", "values"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": ["toggle"]
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": ["budget_tokens"]
+                                        },
+                                        "min": {
+                                          "type": "number"
+                                        },
+                                        "max": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "required": ["type"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "confidence": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"]
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "providerID",
+                              "modelID",
+                              "modelName",
+                              "reasoningOptions",
+                              "confidence",
+                              "reason"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "candidates": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "providerID": {
+                                  "type": "string"
+                                },
+                                "modelID": {
+                                  "type": "string"
+                                },
+                                "modelName": {
+                                  "type": "string"
+                                },
+                                "reasoningOptions": {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": ["effort"]
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "required": ["type", "values"],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": ["toggle"]
+                                          }
+                                        },
+                                        "required": ["type"],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": ["budget_tokens"]
+                                          },
+                                          "min": {
+                                            "type": "number"
+                                          },
+                                          "max": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": ["type"],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "confidence": {
+                                  "type": "string",
+                                  "enum": ["high", "medium", "low"]
+                                },
+                                "reason": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "providerID",
+                                "modelID",
+                                "modelName",
+                                "reasoningOptions",
+                                "confidence",
+                                "reason"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "variants": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "object"
+                            }
+                          },
+                          "conflicts": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": ["modelID", "status", "candidates", "variants"],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": ["total", "matched", "review", "unmatched", "unsupported", "totalVariants", "results"],
+                  "additionalProperties": false,
+                  "description": "Variant discovery summary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Match custom-provider models against the models.dev catalog to find configurable reasoning effort values. Returns a summary with per-model match status, candidate catalog entries, and discovered variant configurations.",
+        "summary": "Discover reasoning variants for custom-provider models",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "baseURL": {
+                    "type": "string"
+                  },
+                  "npm": {
+                    "type": "string"
+                  },
+                  "models": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ownedBy": {
+                          "type": "string"
+                        },
+                        "variants": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": ["id"],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": ["baseURL", "npm", "models"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.provider.discoverVariants({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/network": {
       "get": {
         "tags": ["network"],
@@ -33488,6 +33932,52 @@
                       }
                     ]
                   },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "removed": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
                   "skippedCount": {
                     "anyOf": [
                       {
@@ -33785,6 +34275,52 @@
                       }
                     ]
                   },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "removed": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
                   "skippedCount": {
                     "anyOf": [
                       {
@@ -34060,6 +34596,52 @@
                     ]
                   },
                   "operationCount": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "removed": {
                     "anyOf": [
                       {
                         "type": "number"
@@ -41219,6 +41801,44 @@
                       }
                     ]
                   },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "removed": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
                   "skippedCount": {
                     "anyOf": [
                       {
@@ -41480,6 +42100,44 @@
                       }
                     ]
                   },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "removed": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
                   "skippedCount": {
                     "anyOf": [
                       {
@@ -41723,6 +42381,44 @@
                     ]
                   },
                   "operationCount": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "added": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "removed": {
                     "anyOf": [
                       {
                         "type": "number"
@@ -42203,6 +42899,10 @@
     {
       "name": "anaconda-desktop",
       "description": "Local Anaconda Desktop provider setup routes."
+    },
+    {
+      "name": "provider",
+      "description": "Provider variant discovery routes."
     },
     {
       "name": "network",


### PR DESCRIPTION
Custom OpenAI-compatible providers can expose model IDs without exposing which reasoning settings those models support. This draft introduces a catalog-backed flow that matches configured models against models.dev `reasoning_options`, converts supported effort values into custom-provider variants, and surfaces a compact result summary in the provider dialog.

The implementation deliberately treats provider/model matching separately from the catalog data itself: exact matches may be selected, while ambiguous matches are represented for review instead of silently inventing variants. Toggle and token-budget options remain metadata because their request fields are provider-specific.

The full matching rules, user flow, merge behavior, endpoint shape, UI design, and follow-up phases are committed in `.kilo/plans/auto-variant-discovery.md` and are part of this PR.

This PR is draft because the initial vertical slice still has known end-to-end gaps. Those are documented in a separate PR comment so the remaining work is explicit before this can be marked ready.