### PR TITLE
fix(cli): preserve console daemon authentication

### DIFF
--- a/.changeset/quiet-consoles-load.md
+++ b/.changeset/quiet-consoles-load.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep daemon credentials when opening Kilo Console so its projects and settings load correctly.

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -9,10 +9,12 @@ import { warnPort } from "@/kilocode/cli/port-warning"
 import { hasDisplay } from "@/kilocode/cli/cmd/tui/util/display"
 import { StopCommand } from "@/kilocode/cli/cmd/daemon"
 
-function browserUrl(state: Daemon.State) {
-  const url = new URL("/console", state.url)
-  url.username = state.username
-  url.password = state.password
+export function browserUrl(state: Daemon.State) {
+  const server = new URL(state.url)
+  server.username = state.username
+  server.password = state.password
+  const url = new URL("/console", server)
+  url.searchParams.set("server", server.toString())
   return url.toString()
 }
 

--- a/packages/opencode/test/kilocode/console.test.ts
+++ b/packages/opencode/test/kilocode/console.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { browserUrl } from "../../src/kilocode/cli/cmd/console"
+import type { Daemon } from "../../src/kilocode/daemon/daemon"
+
+test("console launch URL carries daemon credentials into the server query", () => {
+  const state = {
+    url: "http://127.0.0.1:4097",
+    username: "kilo",
+    password: "secret",
+  } as Daemon.State
+
+  const url = new URL(browserUrl(state))
+  const server = new URL(url.searchParams.get("server") ?? "")
+
+  expect(url.pathname).toBe("/console")
+  expect(url.username).toBe("kilo")
+  expect(url.password).toBe("secret")
+  expect(server.origin).toBe("http://127.0.0.1:4097")
+  expect(server.username).toBe("kilo")
+  expect(server.password).toBe("secret")
+})


### PR DESCRIPTION
The daemon now uses a generated password, but Kilo Console lost the credentials after its initial authenticated page load because browsers do not expose URL userinfo to frontend code. This left the UI loading indefinitely while API requests fell back to `kilo:kilo`.

This change passes the authenticated daemon URL through the console's existing `server` parameter so frontend API and terminal connections retain the generated credentials without prompting the user.

A sanitized launch URL looks like:

```text
http://kilo:REDACTED@127.0.0.1:4097/console?server=http%3A%2F%2Fkilo%3AREDACTED%40127.0.0.1%3A4097%2F
```

The credential is duplicated intentionally: URL userinfo authenticates the initial document request, while the encoded `server` parameter makes the same credential available to frontend JavaScript after the browser hides userinfo from `window.location`.

## Security concern

The generated password is a real daemon credential. Including it in the query parameter can retain it in browser history and expose it to browser extensions, diagnostics, screenshots, or URL logging. Random per-daemon credentials and loopback-only binding reduce the blast radius, but do not make credentials in URLs a desirable long-term design. Before merging, consider replacing this with a short-lived bootstrap exchange that sets an `HttpOnly`, `SameSite=Strict` cookie and redirects to a clean `/console` URL.