### PR TITLE
fix(config): prioritize kilo.jsonc over opencode.json in project config merge

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -358,12 +358,12 @@ export const layer = Layer.effect(
       }
       // kilocode_change - global config is user-owned and trusted to resolve {file:}/{env:} tokens
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "config.json"), env, true))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.json"), env, true))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"), env, true))
       // kilocode_change start
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "kilo.json"), env, true))
       result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "kilo.jsonc"), env, true))
       // kilocode_change end
-      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.json"), env, true)) // kilocode_change
-      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"), env, true)) // kilocode_change
 
       const legacy = path.join(Global.Path.config, "config")
       if (existsSync(legacy)) {
@@ -627,7 +627,7 @@ export const layer = Layer.effect(
 
         if (!Flag.KILO_DISABLE_PROJECT_CONFIG) {
           // kilocode_change start - also discover kilo.json project files
-          for (const name of ["kilo", "opencode"] as const) {
+          for (const name of ["opencode", "kilo"] as const) {
             for (const file of yield* ConfigPaths.files(name, ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
               yield* merge(
                 file,
@@ -677,7 +677,7 @@ export const layer = Layer.effect(
             ? undefined
             : { root: primarySet.has(dir) ? path.dirname(dir) : projectRoot, source: dir }
           if (KilocodeConfig.isConfigDir(dir, Flag.KILO_CONFIG_DIR)) {
-            for (const file of KilocodeConfig.ALL_CONFIG_FILES) {
+            for (const file of KilocodeConfig.ALL_CONFIG_FILES.toReversed()) {
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)
               // kilocode_change - untrusted config dirs confine {file:} reads to projectRoot
@@ -816,7 +816,7 @@ export const layer = Layer.effect(
         const managedDir = ConfigManaged.managedConfigDir()
         // kilocode_change start - include kilo.json/kilo.jsonc in managed dir loading
         if (existsSync(managedDir)) {
-          for (const file of KilocodeConfig.ALL_CONFIG_FILES) {
+          for (const file of KilocodeConfig.ALL_CONFIG_FILES.toReversed()) {
             const source = path.join(managedDir, file)
             // kilocode_change - MDM/enterprise-managed config is a trusted source
             yield* merge(source, yield* loadFile(source, undefined, true), "global")

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -333,7 +333,7 @@ export namespace KilocodeConfig {
 
   // ── Bash permission migration ────────────────────────────────────────
 
-  const GLOBAL_CONFIG_FILES = ["config.json", "kilo.json", "kilo.jsonc", "opencode.json", "opencode.jsonc"]
+  const GLOBAL_CONFIG_FILES = ["config.json", "opencode.json", "opencode.jsonc", "kilo.json", "kilo.jsonc"]
 
   /**
    * Migrate bash permission for existing users before config is consumed.

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1353,15 +1353,17 @@ it.instance(
   { config: { autoupdate: true, disabled_providers: [] } },
 )
 
-it.instance("managed jsonc settings override managed json settings", () =>
+// kilocode_change start - merge order fix: kilo.json now wins over opencode.jsonc
+it.instance("managed kilo.json takes priority over managed opencode.jsonc", () =>
   Effect.gen(function* () {
     yield* writeManagedSettingsEffect({ model: "managed/json" })
     yield* writeManagedSettingsEffect({ model: "managed/jsonc" }, "opencode.jsonc")
 
     const config = yield* Config.use.get()
-    expect(config.model).toBe("managed/jsonc")
+    expect(config.model).toBe("managed/json")
   }),
 )
+// kilocode_change end
 
 it.instance(
   "missing managed settings file is not an error",


### PR DESCRIPTION
## Issue
Closes #12278

## Context
`ALL_CONFIG_FILES = ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"]` documents the correct precedence (kilo > opencode), but merge loops iterate in list order with last-wins semantics. Since `opencode.json` is last in the array, it silently overrides `kilo.jsonc` when both coexist. This also creates a mismatch with `projectConfigUpdateTarget`, which uses `.find()` (first-wins) and correctly writes to `kilo.jsonc` — making UI saves effectively no-ops when alternates coexist.

## Implementation
Reversed the iteration order in three merge loops so that last-wins respects the documented precedence:

1. **Config dirs loop** (`config/config.ts`): `ALL_CONFIG_FILES` → `ALL_CONFIG_FILES.toReversed()` so `kilo.jsonc` is merged last
2. **Managed config dir**: Same `.toReversed()` fix
3. **Project root files**: Swapped outer loop from `["kilo", "opencode"]` to `["opencode", "kilo"]` so `kilo.*` values win
4. **Global config**: Reordered `kilo.*` after `opencode.*` so `kilo.jsonc` takes priority
5. **`GLOBAL_CONFIG_FILES`** (`kilocode/config/config.ts`): Reordered for consistency with `migrateBashPermission`

`projectConfigUpdateTarget` was already correct — it uses `.find()` with the existing order, which finds `kilo.jsonc` first.

## How to test
```bash
cd packages/opencode && bun test test/config/config.test.ts
```
All 134 tests pass (102 config + 32 kilocode/config), 0 failures. One test updated: `"managed kilo.json takes priority over managed opencode.jsonc"` now correctly expects `kilo.json` to win over `opencode.jsonc`.

Manual repro:
```bash
echo '{ "model": "kilo/from-kilo-jsonc" }' > .kilo/kilo.jsonc
echo '{ "model": "kilo/from-opencode-json" }' > .kilo/opencode.json
kilo debug config  # should show "kilo/from-kilo-jsonc"
```