### PR TITLE
fix(ui): distinguish heredoc file content from executable commands in approval dialog

### DIFF
--- a/packages/kilo-vscode/tests/unit/permission-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-command.test.ts
@@ -101,7 +101,7 @@ describe("parseHeredoc", () => {
   })
 
   it("detects heredoc with double-quoted delimiter", () => {
-    const result = parseHeredoc("cat << \"EOF\"\nhello\nEOF")
+    const result = parseHeredoc('cat << "EOF"\nhello\nEOF')
     expect(result).not.toBeNull()
     expect(result!.head).toBe('cat << "EOF"\nEOF')
     expect(result!.body).toBe("hello")
@@ -109,7 +109,7 @@ describe("parseHeredoc", () => {
   })
 
   it("detects heredoc with delimiter containing hyphens", () => {
-    const result = parseHeredoc("cat << \"my-delim\"\nhello world\nmy-delim")
+    const result = parseHeredoc('cat << "my-delim"\nhello world\nmy-delim')
     expect(result).not.toBeNull()
     expect(result!.head).toBe('cat << "my-delim"\nmy-delim')
     expect(result!.body).toBe("hello world")

--- a/packages/kilo-vscode/tests/unit/permission-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-command.test.ts
@@ -83,4 +83,44 @@ describe("parseHeredoc", () => {
   it("does not match << inside a string or other context", () => {
     expect(parseHeredoc('echo "this << is not a heredoc"')).toBeNull()
   })
+
+  it("detects heredoc with <<- (indent-strip / tab-remove)", () => {
+    const result = parseHeredoc("cat <<- EOF\n\thello\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("cat <<- EOF\nEOF")
+    expect(result!.body).toBe("\thello")
+    expect(result!.count).toBe(1)
+  })
+
+  it("detects heredoc with <<- and quoted delimiter", () => {
+    const result = parseHeredoc("python3 <<- 'EOF'\nprint('hi')\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("python3 <<- 'EOF'\nEOF")
+    expect(result!.body).toBe("print('hi')")
+    expect(result!.count).toBe(1)
+  })
+
+  it("detects heredoc with double-quoted delimiter", () => {
+    const result = parseHeredoc("cat << \"EOF\"\nhello\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe('cat << "EOF"\nEOF')
+    expect(result!.body).toBe("hello")
+    expect(result!.count).toBe(1)
+  })
+
+  it("detects heredoc with delimiter containing hyphens", () => {
+    const result = parseHeredoc("cat << \"my-delim\"\nhello world\nmy-delim")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe('cat << "my-delim"\nmy-delim')
+    expect(result!.body).toBe("hello world")
+    expect(result!.count).toBe(1)
+  })
+
+  it("detects heredoc with <<- and double-quoted delimiter with hyphens", () => {
+    const result = parseHeredoc("python3 <<- \"my-script\"\nprint('hi')\nmy-script")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe('python3 <<- "my-script"\nmy-script')
+    expect(result!.body).toBe("print('hi')")
+    expect(result!.count).toBe(1)
+  })
 })

--- a/packages/kilo-vscode/tests/unit/permission-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-command.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test"
+import { parseHeredoc } from "../../webview-ui/src/components/chat/permission-command-utils"
+
+describe("parseHeredoc", () => {
+  it("returns null for a simple command without heredoc", () => {
+    expect(parseHeredoc("ls -la")).toBeNull()
+  })
+
+  it("returns null for a multi-line command without heredoc", () => {
+    expect(parseHeredoc("echo hello\necho world")).toBeNull()
+  })
+
+  it("detects heredoc with quoted delimiter", () => {
+    const result = parseHeredoc("python3 << 'EOF'\nprint('hi')\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("python3 << 'EOF'\nEOF")
+    expect(result!.body).toBe("print('hi')")
+    expect(result!.count).toBe(1)
+  })
+
+  it("detects heredoc with unquoted delimiter", () => {
+    const result = parseHeredoc("cat << EOF\nhello\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("cat << EOF\nEOF")
+    expect(result!.body).toBe("hello")
+    expect(result!.count).toBe(1)
+  })
+
+  it("handles multi-line heredoc content", () => {
+    const result = parseHeredoc("python3 << 'PY'\nimport json\nprint('hi')\nPY")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("python3 << 'PY'\nPY")
+    expect(result!.body).toBe("import json\nprint('hi')")
+    expect(result!.count).toBe(2)
+  })
+
+  it("preserves commands after heredoc in head", () => {
+    const result = parseHeredoc("cat << EOF\ndata\nEOF\necho 'done'")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("cat << EOF\nEOF\necho 'done'")
+    expect(result!.body).toBe("data")
+  })
+
+  it("returns null when closing delimiter is missing", () => {
+    expect(parseHeredoc("cat << EOF\ndata\nstill data")).toBeNull()
+  })
+
+  it("handles heredoc in a pipe/redirect command", () => {
+    const result = parseHeredoc("cat > file.mjs << 'SCRIPT'\ncontent\nSCRIPT\necho done")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("cat > file.mjs << 'SCRIPT'\nSCRIPT\necho done")
+    expect(result!.body).toBe("content")
+    expect(result!.count).toBe(1)
+  })
+
+  it("handles empty heredoc content", () => {
+    const result = parseHeredoc("cat << EOF\nEOF")
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("cat << EOF\nEOF")
+    expect(result!.body).toBe("")
+    expect(result!.count).toBe(0)
+  })
+
+  it("matches the storybook heredoc pattern correctly", () => {
+    const cmd = [
+      "python3 << 'EOF'",
+      "import json",
+      "from pathlib import Path",
+      "",
+      "events_path = Path('test_sound/events.json')",
+      'print("hi")',
+      "EOF",
+    ].join("\n")
+    const result = parseHeredoc(cmd)
+    expect(result).not.toBeNull()
+    expect(result!.head).toBe("python3 << 'EOF'\nEOF")
+    expect(result!.body).toBe(
+      "import json\nfrom pathlib import Path\n\nevents_path = Path('test_sound/events.json')\nprint(\"hi\")",
+    )
+    expect(result!.count).toBe(5)
+  })
+
+  it("does not match << inside a string or other context", () => {
+    expect(parseHeredoc('echo "this << is not a heredoc"')).toBeNull()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionCommand.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionCommand.tsx
@@ -1,14 +1,17 @@
 /**
  * PermissionCommand component
  * Renders a bash command with preserved newlines, scrollable when long.
+ * Detects heredoc patterns and shows file content in a collapsed section.
  * Includes a copy-to-clipboard button that appears on hover.
  */
 
-import { Component, createEffect, createSignal, onCleanup } from "solid-js"
+import { Component, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { Collapsible } from "@kilocode/kilo-ui/collapsible"
 import { deferredHighlight } from "@kilocode/kilo-ui/context/marked"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../context/language"
+import { parseHeredoc } from "./permission-command-utils"
 
 export const PermissionCommand: Component<{ command: string }> = (props) => {
   const language = useLanguage()
@@ -16,15 +19,18 @@ export const PermissionCommand: Component<{ command: string }> = (props) => {
   const state = { signal: { aborted: false } }
   let ref: HTMLDivElement | undefined
 
+  const heredoc = createMemo(() => parseHeredoc(props.command))
+  const display = createMemo(() => (heredoc() ? heredoc()!.head : props.command))
+
   createEffect(() => {
     state.signal.aborted = true
-    const command = props.command
-    if (!ref || !command) return
+    const cmd = display()
+    if (!ref || !cmd) return
 
     const pre = document.createElement("pre")
     const code = document.createElement("code")
     code.dataset.lang = "shellscript"
-    code.textContent = command
+    code.textContent = cmd
     pre.append(code)
     ref.replaceChildren(pre)
 
@@ -46,6 +52,23 @@ export const PermissionCommand: Component<{ command: string }> = (props) => {
   return (
     <div data-slot="permission-command">
       <div data-slot="permission-command-code" ref={ref} />
+      <Show when={heredoc()}>
+        {(h) => (
+          <Collapsible variant="ghost" data-slot="permission-heredoc">
+            <Collapsible.Trigger data-slot="permission-heredoc-trigger">
+              <span data-slot="permission-heredoc-label">
+                {language.t("ui.permission.heredocContent", { count: String(h().count) })}
+              </span>
+              <Collapsible.Arrow />
+            </Collapsible.Trigger>
+            <Collapsible.Content data-slot="permission-heredoc-content">
+              <pre data-slot="permission-heredoc-body">
+                <code>{h().body}</code>
+              </pre>
+            </Collapsible.Content>
+          </Collapsible>
+        )}
+      </Show>
       <Tooltip value={language.t("ui.permission.copyCommand")} placement="top">
         <button
           data-slot="permission-command-copy"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/permission-command-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/permission-command-utils.ts
@@ -14,10 +14,10 @@ export function parseHeredoc(raw: string): HeredocPart | null {
   let start = -1
   let delim = ""
   for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(/<<\s*'?(\w+)'?\s*$/)
+    const m = lines[i].match(/<<-?\s*(["']?)([\w-]+)\1\s*$/)
     if (m) {
       start = i
-      delim = m[1]
+      delim = m[2]
       break
     }
   }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/permission-command-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/permission-command-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Heredoc detection and parsing for permission command display.
+ * Extracted from PermissionCommand to allow unit testing without SolidJS JSX.
+ */
+
+export type HeredocPart = {
+  head: string
+  body: string
+  count: number
+}
+
+export function parseHeredoc(raw: string): HeredocPart | null {
+  const lines = raw.split("\n")
+  let start = -1
+  let delim = ""
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/<<\s*'?(\w+)'?\s*$/)
+    if (m) {
+      start = i
+      delim = m[1]
+      break
+    }
+  }
+  if (start === -1) return null
+
+  let end = -1
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === delim) {
+      end = i
+      break
+    }
+  }
+  if (end === -1) return null
+
+  const before = lines.slice(0, start + 1)
+  const content = lines.slice(start + 1, end)
+  const after = lines.slice(end)
+
+  return {
+    head: [...before, ...after].join("\n"),
+    body: content.join("\n"),
+    count: content.length,
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -635,6 +635,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "بحث الكود",
   "ui.permission.toggleWrap": "تبديل التفاف الكلمات",
   "ui.permission.copyCommand": "نسخ",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "سؤال",
   "notification.question.description": "{{sessionTitle}} في {{projectName}} لديه سؤال",
   "notification.action.goToSession": "انتقل إلى الجلسة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -644,6 +644,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Pesquisa de Código",
   "ui.permission.toggleWrap": "Alternar quebra de linha",
   "ui.permission.copyCommand": "Copiar",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Pergunta",
   "notification.question.description": "{{sessionTitle}} em {{projectName}} tem uma pergunta",
   "notification.action.goToSession": "Ir para sessão",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -645,6 +645,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Pretraga koda",
   "ui.permission.toggleWrap": "Prebaci prelamanje teksta",
   "ui.permission.copyCommand": "Kopiraj",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Pitanje",
   "notification.question.description": "{{sessionTitle}} u {{projectName}} ima pitanje",
   "notification.action.goToSession": "Idi na sesiju",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -642,6 +642,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Kodesøgning",
   "ui.permission.toggleWrap": "Skift tekstombrydning",
   "ui.permission.copyCommand": "Kopiér",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Spørgsmål",
   "notification.question.description": "{{sessionTitle}} i {{projectName}} har et spørgsmål",
   "notification.action.goToSession": "Gå til session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -654,6 +654,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Code-Suche",
   "ui.permission.toggleWrap": "Zeilenumbruch umschalten",
   "ui.permission.copyCommand": "Kopieren",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Frage",
   "notification.question.description": "{{sessionTitle}} in {{projectName}} hat eine Frage",
   "notification.action.goToSession": "Zur Sitzung gehen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -641,6 +641,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Code Search",
   "ui.permission.toggleWrap": "Toggle word wrap",
   "ui.permission.copyCommand": "Copy",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Question",
   "notification.question.description": "{{sessionTitle}} in {{projectName}} has a question",
   "notification.action.goToSession": "Go to session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -641,7 +641,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Code Search",
   "ui.permission.toggleWrap": "Toggle word wrap",
   "ui.permission.copyCommand": "Copy",
-  "ui.permission.heredocContent": "File content — {{count}} lines",
+  "ui.permission.heredocContent": "Heredoc content — {{count}} lines",
   "notification.question.title": "Question",
   "notification.question.description": "{{sessionTitle}} in {{projectName}} has a question",
   "notification.action.goToSession": "Go to session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -648,6 +648,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Búsqueda de Código",
   "ui.permission.toggleWrap": "Alternar ajuste de línea",
   "ui.permission.copyCommand": "Copiar",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Pregunta",
   "notification.question.description": "{{sessionTitle}} en {{projectName}} tiene una pregunta",
   "notification.action.goToSession": "Ir a sesión",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -652,6 +652,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Recherche de code",
   "ui.permission.toggleWrap": "Basculer le retour à la ligne",
   "ui.permission.copyCommand": "Copier",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Question",
   "notification.question.description": "{{sessionTitle}} dans {{projectName}} a une question",
   "notification.action.goToSession": "Aller à la session",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -520,6 +520,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Ricerca codice",
   "ui.permission.toggleWrap": "Attiva/disattiva ritorno a capo",
   "ui.permission.copyCommand": "Copia",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Domanda",
   "notification.question.description": "{{sessionTitle}} in {{projectName}} ha una domanda",
   "notification.action.goToSession": "Vai alla sessione",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -640,6 +640,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "コード検索",
   "ui.permission.toggleWrap": "折り返しを切り替え",
   "ui.permission.copyCommand": "コピー",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "質問",
   "notification.question.description": "{{projectName}} の {{sessionTitle}} から質問があります",
   "notification.action.goToSession": "セッションへ移動",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -640,6 +640,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "코드 검색",
   "ui.permission.toggleWrap": "줄 바꿈 전환",
   "ui.permission.copyCommand": "복사",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "질문",
   "notification.question.description": "{{projectName}}의 {{sessionTitle}}에서 질문이 있습니다",
   "notification.action.goToSession": "세션으로 이동",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -647,6 +647,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Code Zoeken",
   "ui.permission.toggleWrap": "Regelterugloop in-/uitschakelen",
   "ui.permission.copyCommand": "Kopiëren",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Vraag",
   "notification.question.description": "{{sessionTitle}} in {{projectName}} heeft een vraag",
   "notification.action.goToSession": "Ga naar sessie",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -647,6 +647,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Kodesøk",
   "ui.permission.toggleWrap": "Veksle tekstbryting",
   "ui.permission.copyCommand": "Kopier",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Spørsmål",
   "notification.question.description": "{{sessionTitle}} i {{projectName}} har et spørsmål",
   "notification.action.goToSession": "Gå til sesjon",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -644,6 +644,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Wyszukiwanie kodu",
   "ui.permission.toggleWrap": "Przełącz zawijanie tekstu",
   "ui.permission.copyCommand": "Kopiuj",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Pytanie",
   "notification.question.description": "{{sessionTitle}} w {{projectName}} ma pytanie",
   "notification.action.goToSession": "Przejdź do sesji",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -644,6 +644,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Поиск кода",
   "ui.permission.toggleWrap": "Переключить перенос строк",
   "ui.permission.copyCommand": "Копировать",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Вопрос",
   "notification.question.description": "У {{sessionTitle}} в {{projectName}} есть вопрос",
   "notification.action.goToSession": "Перейти к сессии",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -638,6 +638,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "ค้นหาโค้ด",
   "ui.permission.toggleWrap": "สลับการตัดคำ",
   "ui.permission.copyCommand": "คัดลอก",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "คำถาม",
   "notification.question.description": "{{sessionTitle}} ใน {{projectName}} มีคำถาม",
   "notification.action.goToSession": "ไปที่เซสชัน",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -644,6 +644,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Kod Araması",
   "ui.permission.toggleWrap": "Sözcük kaydırmayı aç/kapat",
   "ui.permission.copyCommand": "Kopyala",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Soru",
   "notification.question.description": "{{projectName}} içindeki {{sessionTitle}} bir soru soruyor",
   "notification.action.goToSession": "Oturuma git",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -646,6 +646,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "Пошук коду",
   "ui.permission.toggleWrap": "Перемкнути перенос рядків",
   "ui.permission.copyCommand": "Копіювати",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "Питання",
   "notification.question.description": "{{sessionTitle}} у {{projectName}} задає питання",
   "notification.action.goToSession": "Перейти до сесії",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -628,6 +628,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "代码搜索",
   "ui.permission.toggleWrap": "切换自动换行",
   "ui.permission.copyCommand": "复制",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "问题",
   "notification.question.description": "{{sessionTitle}}（{{projectName}}）有一个问题",
   "notification.action.goToSession": "前往会话",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -627,6 +627,7 @@ export const dict = {
   "ui.permission.toolLabel.codeSearch": "程式碼搜尋",
   "ui.permission.toggleWrap": "切換自動換行",
   "ui.permission.copyCommand": "複製",
+  "ui.permission.heredocContent": "File content — {{count}} lines",
   "notification.question.title": "問題",
   "notification.question.description": "{{sessionTitle}}（{{projectName}}）有一個問題",
   "notification.action.goToSession": "前往工作階段",

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -75,6 +75,55 @@
     }
   }
 
+  [data-slot="permission-heredoc"] {
+    margin: 0 10px 4px;
+  }
+
+  [data-slot="permission-heredoc-trigger"] {
+    all: unset;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: var(--kilo-font-size-11);
+    color: var(--vscode-descriptionForeground, var(--text-weak));
+    width: fit-content;
+  }
+
+  [data-slot="permission-heredoc-trigger"]:hover {
+    background: var(--surface-interactive-hover, var(--vscode-list-hoverBackground));
+  }
+
+  [data-slot="permission-heredoc-label"] {
+    font-weight: 500;
+  }
+
+  [data-slot="permission-heredoc-content"] {
+    font-size: var(--kilo-font-size-11);
+    font-family: var(--vscode-editor-font-family, monospace);
+  }
+
+  [data-slot="permission-heredoc-body"] {
+    margin: 4px 0 0;
+    padding: 8px;
+    border: 1px solid var(--vscode-editorWidget-border, var(--vscode-panel-border, transparent));
+    border-radius: 4px;
+    background: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+    overflow-x: auto;
+
+    code {
+      font-size: var(--kilo-font-size-12);
+      font-family: var(--vscode-editor-font-family, monospace);
+      color: var(--vscode-editor-foreground, var(--vscode-foreground));
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      line-height: 1.5;
+      background: transparent;
+    }
+  }
+
   [data-slot="permission-command-copy"] {
     all: unset;
     position: absolute;


### PR DESCRIPTION
## Issue
Closes #12260

## Context
When the agent generates a shell command using heredoc syntax (e.g., `cat > file.mjs << 'EOF' ... EOF`), the terminal approval dialog displays the entire string as a shell script block. The heredoc body content — literal file data, not shell commands — is indistinguishable from the actual executable command. This makes approval decisions harder than they should be.

## Implementation
Added heredoc detection to `PermissionCommand.tsx`:

- **`parseHeredoc()`** utility (`permission-command-utils.ts`): Parses shell command strings to separate the executable command from heredoc file content. Handles both quoted (`<<'DELIM'`) and unquoted (`<<DELIM`) delimiters, multi-line content, and edge cases (missing closing delimiter, `<<` inside strings).
- **`PermissionCommand`**: When a heredoc is detected, the executable command renders as before (syntax-highlighted shell script), while the file content appears in a collapsible section labeled "File content — N lines".
- **i18n**: Added `ui.permission.heredocContent` key for the label.
- **Styles**: Collapsible trigger and content styling in `permission-dock.css`.

No visual change when the command has no heredoc.

## How to test
```bash
cd packages/kilo-vscode && bun test tests/unit/permission-command.test.ts
```
11 unit tests pass covering: no heredoc, quoted/unquoted delimiters, multi-line content, post-heredoc commands, missing delimiter, pipe/redirect, empty content, and the real-world storybook scenario.