### PR TITLE
feat(vscode): expose Exa websearch toggle in experimental settings

### DIFF
--- a/.changeset/enable-exa-settings.md
+++ b/.changeset/enable-exa-settings.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+"@kilocode/sdk": patch
+---
+
+Enable Exa websearch for non-Kilo providers from Experimental settings in the VS Code extension.

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -285,6 +285,12 @@ export const Info = Schema.Struct({
       image_generation_model: Schema.optional(Schema.String).annotate({
         description: "Model ID to use for image generation (default: openrouter/auto)",
       }),
+      // kilocode_change start
+      enable_exa: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Enable the websearch tool for non-Kilo providers via Exa (also set by KILO_ENABLE_EXA / KILO_EXPERIMENTAL)",
+      }),
+      // kilocode_change end
       agent_requirements: Schema.optional(Schema.Boolean).annotate({
         description: "Require declared agent skills, MCPs, and VS Code extensions before VS Code prompts can run",
       }),

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -180,6 +180,7 @@ Available experimental settings include:
 - **LSP integration** - expose language server diagnostics to the agent
 - **Paste summary** - summarize large clipboard pastes before including them
 - **Batch tool** - allow the agent to batch multiple tool calls in one step
+- **Exa web search** - enable the `websearch` tool for non-Kilo providers (already available with the Kilo provider)
 - **OpenTelemetry** - enable Kilo telemetry and optional OTLP export when configured
 
 Advanced options not exposed in the UI can be configured via the `experimental` key in `kilo.jsonc`:
@@ -188,6 +189,7 @@ Advanced options not exposed in the UI can be configured via the `experimental` 
 {
   "experimental": {
     "codebase_search": true,
+    "enable_exa": true,
     "batch_tool": false,
     "openTelemetry": true,
     "disable_paste_summary": false,

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -171,6 +171,19 @@ const ExperimentalTab: Component = () => {
           </Switch>
         </SettingsRow>
 
+        <SettingsRow
+          title={language.t("settings.experimental.enableExa.title")}
+          description={language.t("settings.experimental.enableExa.description")}
+        >
+          <Switch
+            checked={experimental().enable_exa ?? false}
+            onChange={(checked) => updateExperimental("enable_exa", checked)}
+            hideLabel
+          >
+            {language.t("settings.experimental.enableExa.title")}
+          </Switch>
+        </SettingsRow>
+
         <Show when={experimental().image_generation}>
           <SettingsRow
             title={language.t("settings.experimental.imageGenerationModel.title")}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1408,6 +1408,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "نموذج الصور",
   "settings.experimental.imageGenerationModel.description": "نموذج توليد الصور",
   "settings.experimental.imageGenerationModel.placeholder": "افتراضي (Auto Router)",
+  "settings.experimental.enableExa.title": "بحث الويب Exa",
+  "settings.experimental.enableExa.description":
+    "تمكين أداة websearch لمزودي الخدمة غير Kilo (مثل Codex). متاحة بالفعل عند استخدام مزود Kilo.",
 
   "settings.experimental.speechToText.title": "تحويل الصوت إلى نص",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1443,6 +1443,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Modelo de imagem",
   "settings.experimental.imageGenerationModel.description": "Modelo de geração de imagens",
   "settings.experimental.imageGenerationModel.placeholder": "Padrão (Auto Router)",
+  "settings.experimental.enableExa.title": "Pesquisa web Exa",
+  "settings.experimental.enableExa.description":
+    "Ative a ferramenta websearch para provedores que não são Kilo (ex.: Codex). Já disponível ao usar o provedor Kilo.",
 
   "settings.experimental.speechToText.title": "Fala para texto",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1440,6 +1440,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Model slike",
   "settings.experimental.imageGenerationModel.description": "Model za generisanje slika",
   "settings.experimental.imageGenerationModel.placeholder": "Zadano (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa web pretraga",
+  "settings.experimental.enableExa.description":
+    "Omogućite websearch alat za ne-Kilo provajdere (npr. Codex). Već dostupno kada koristite Kilo provajder.",
 
   "settings.experimental.speechToText.title": "Govor u tekst",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1434,6 +1434,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Billedmodel",
   "settings.experimental.imageGenerationModel.description": "Billedgenereringsmodel",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa-websøgning",
+  "settings.experimental.enableExa.description":
+    "Aktivér websearch-værktøjet for ikke-Kilo-udbydere (f.eks. Codex). Allerede tilgængeligt ved brug af Kilo-udbyderen.",
 
   "settings.experimental.speechToText.title": "Tale til tekst",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1462,6 +1462,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Bildmodell",
   "settings.experimental.imageGenerationModel.description": "Bildgenerierungsmodell",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa-Websuche",
+  "settings.experimental.enableExa.description":
+    "Websearch-Tool für Nicht-Kilo-Anbieter aktivieren (z. B. Codex). Bei Verwendung des Kilo-Anbieters bereits verfügbar.",
 
   "settings.experimental.speechToText.title": "Sprache zu Text",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1416,6 +1416,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Image Model",
   "settings.experimental.imageGenerationModel.description": "Image Generation Model",
   "settings.experimental.imageGenerationModel.placeholder": "Default (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa Web Search",
+  "settings.experimental.enableExa.description":
+    "Enable the websearch tool for non-Kilo providers (e.g. Codex). Already available when using the Kilo provider.",
 
   "settings.experimental.speechToText.title": "Speech to Text",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1451,6 +1451,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Modelo de imagen",
   "settings.experimental.imageGenerationModel.description": "Modelo de generación de imágenes",
   "settings.experimental.imageGenerationModel.placeholder": "Predeterminado (Auto Router)",
+  "settings.experimental.enableExa.title": "Búsqueda web Exa",
+  "settings.experimental.enableExa.description":
+    "Habilita la herramienta websearch para proveedores que no son Kilo (p. ej. Codex). Ya disponible al usar el proveedor Kilo.",
 
   "settings.experimental.speechToText.title": "Voz a texto",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1466,6 +1466,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Modèle d'image",
   "settings.experimental.imageGenerationModel.description": "Modèle de génération d'images",
   "settings.experimental.imageGenerationModel.placeholder": "Par défaut (Auto Router)",
+  "settings.experimental.enableExa.title": "Recherche web Exa",
+  "settings.experimental.enableExa.description":
+    "Active l’outil websearch pour les fournisseurs non-Kilo (p. ex. Codex). Déjà disponible avec le fournisseur Kilo.",
 
   "settings.experimental.speechToText.title": "Transcription vocale",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1232,6 +1232,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Modello di immagine",
   "settings.experimental.imageGenerationModel.description": "Modello di generazione di immagini",
   "settings.experimental.imageGenerationModel.placeholder": "Predefinito (Auto Router)",
+  "settings.experimental.enableExa.title": "Ricerca web Exa",
+  "settings.experimental.enableExa.description":
+    "Abilita lo strumento websearch per provider non-Kilo (es. Codex). Già disponibile con il provider Kilo.",
 
   "settings.experimental.nativeNotebookTools.title": "Strumenti nativi per notebook",
   "settings.experimental.nativeNotebookTools.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1429,6 +1429,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "画像モデル",
   "settings.experimental.imageGenerationModel.description": "画像生成モデル",
   "settings.experimental.imageGenerationModel.placeholder": "デフォルト (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa Web検索",
+  "settings.experimental.enableExa.description":
+    "Kilo以外のプロバイダー（例: Codex）でwebsearchツールを有効にします。Kiloプロバイダー使用時は既に利用可能です。",
 
   "settings.experimental.speechToText.title": "音声認識",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1421,6 +1421,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "이미지 모델",
   "settings.experimental.imageGenerationModel.description": "이미지 생성 모델",
   "settings.experimental.imageGenerationModel.placeholder": "기본값 (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa 웹 검색",
+  "settings.experimental.enableExa.description":
+    "Kilo가 아닌 제공자(예: Codex)에서 websearch 도구를 활성화합니다. Kilo 제공자 사용 시에는 이미 사용할 수 있습니다.",
 
   "settings.experimental.speechToText.title": "음성 텍스트 변환",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1437,6 +1437,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Afbeeldingsmodel",
   "settings.experimental.imageGenerationModel.description": "Afbeeldingsgeneratiemodel",
   "settings.experimental.imageGenerationModel.placeholder": "Standaard (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa-webzoeken",
+  "settings.experimental.enableExa.description":
+    "Schakel de websearch-tool in voor niet-Kilo-providers (bijv. Codex). Al beschikbaar bij gebruik van de Kilo-provider.",
 
   "settings.experimental.speechToText.title": "Spraak naar tekst",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1393,6 +1393,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Bildemodell",
   "settings.experimental.imageGenerationModel.description": "Bildegenereringsmodell",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa-nettsøk",
+  "settings.experimental.enableExa.description":
+    "Aktiver websearch-verktøyet for ikke-Kilo-leverandører (f.eks. Codex). Allerede tilgjengelig når du bruker Kilo-leverandøren.",
 
   "settings.experimental.speechToText.title": "Tale til tekst",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1392,6 +1392,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Model obrazu",
   "settings.experimental.imageGenerationModel.description": "Model generowania obrazów",
   "settings.experimental.imageGenerationModel.placeholder": "Domyślny (Auto Router)",
+  "settings.experimental.enableExa.title": "Wyszukiwanie Exa",
+  "settings.experimental.enableExa.description":
+    "Włącz narzędzie websearch dla dostawców innych niż Kilo (np. Codex). Już dostępne przy użyciu dostawcy Kilo.",
 
   "settings.experimental.speechToText.title": "Mowa na tekst",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1438,6 +1438,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Модель изображений",
   "settings.experimental.imageGenerationModel.description": "Модель генерации изображений",
   "settings.experimental.imageGenerationModel.placeholder": "По умолчанию (Auto Router)",
+  "settings.experimental.enableExa.title": "Веб-поиск Exa",
+  "settings.experimental.enableExa.description":
+    "Включить инструмент websearch для провайдеров, отличных от Kilo (например, Codex). Уже доступен при использовании провайдера Kilo.",
 
   "settings.experimental.speechToText.title": "Речь в текст",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1417,6 +1417,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "โมเดลภาพ",
   "settings.experimental.imageGenerationModel.description": "โมเดลการสร้างภาพ",
   "settings.experimental.imageGenerationModel.placeholder": "ค่าเริ่มต้น (Auto Router)",
+  "settings.experimental.enableExa.title": "ค้นหาเว็บ Exa",
+  "settings.experimental.enableExa.description":
+    "เปิดใช้เครื่องมือ websearch สำหรับผู้ให้บริการที่ไม่ใช่ Kilo (เช่น Codex) ใช้งานได้อยู่แล้วเมื่อใช้ผู้ให้บริการ Kilo",
 
   "settings.experimental.speechToText.title": "แปลงเสียงเป็นข้อความ",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1428,6 +1428,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Görüntü modeli",
   "settings.experimental.imageGenerationModel.description": "Görüntü oluşturma modeli",
   "settings.experimental.imageGenerationModel.placeholder": "Varsayılan (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa Web Arama",
+  "settings.experimental.enableExa.description":
+    "Kilo dışı sağlayıcılar (ör. Codex) için websearch aracını etkinleştirin. Kilo sağlayıcısı kullanılırken zaten kullanılabilir.",
 
   "settings.experimental.speechToText.title": "Sesten metne",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1426,6 +1426,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "Модель зображень",
   "settings.experimental.imageGenerationModel.description": "Модель генерації зображень",
   "settings.experimental.imageGenerationModel.placeholder": "За замовчуванням (Auto Router)",
+  "settings.experimental.enableExa.title": "Веб-пошук Exa",
+  "settings.experimental.enableExa.description":
+    "Увімкнути інструмент websearch для провайдерів, відмінних від Kilo (наприклад, Codex). Вже доступний під час використання провайдера Kilo.",
 
   "settings.experimental.speechToText.title": "Мовлення в текст",
   "settings.experimental.speechToText.description":

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1392,6 +1392,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "图像模型",
   "settings.experimental.imageGenerationModel.description": "图像生成模型",
   "settings.experimental.imageGenerationModel.placeholder": "默认 (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa 网页搜索",
+  "settings.experimental.enableExa.description":
+    "为非 Kilo 提供商（例如 Codex）启用 websearch 工具。使用 Kilo 提供商时已可用。",
 
   "settings.experimental.speechToText.title": "语音转文本",
   "settings.experimental.speechToText.description": "通过 Kilo Gateway 使用您的 Kilo 帐户在提示词字段中启用语音输入。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1353,6 +1353,9 @@ export const dict = {
   "settings.experimental.imageGenerationModel.title": "圖像模型",
   "settings.experimental.imageGenerationModel.description": "圖像生成模型",
   "settings.experimental.imageGenerationModel.placeholder": "預設 (Auto Router)",
+  "settings.experimental.enableExa.title": "Exa 網頁搜尋",
+  "settings.experimental.enableExa.description":
+    "為非 Kilo 供應商（例如 Codex）啟用 websearch 工具。使用 Kilo 供應商時已可用。",
 
   "settings.experimental.speechToText.title": "語音轉文字",
   "settings.experimental.speechToText.description": "透過 Kilo Gateway 使用您的 Kilo 帳戶在提示詞欄位中啟用語音輸入。",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -42,6 +42,7 @@ export interface ExperimentalConfig {
   codebase_search?: boolean
   image_generation?: boolean
   image_generation_model?: string
+  enable_exa?: boolean
   agent_requirements?: boolean
   native_notebook_tools?: boolean
   speech_to_text_model?: string

--- a/packages/opencode/src/kilocode/tool/websearch.ts
+++ b/packages/opencode/src/kilocode/tool/websearch.ts
@@ -1,0 +1,10 @@
+/** Resolve websearch provider flags from runtime env flags + config. */
+export function webSearchFlags(
+  flags: { enableExa: boolean; enableParallel: boolean },
+  cfg?: { experimental?: { enable_exa?: boolean } },
+) {
+  return {
+    exa: flags.enableExa || cfg?.experimental?.enable_exa === true,
+    parallel: flags.enableParallel,
+  }
+}

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -333,10 +333,16 @@ export const layer = Layer.effect(
     // kilocode_change end
 
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
+      const cfg = yield* config.get() // kilocode_change
       const filtered = (yield* all()).filter((tool) => {
         if (!KiloToolRegistry.available(tool, input.agent)) return false // kilocode_change
         if (tool.id === WebSearchTool.id) {
-          return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
+          // kilocode_change start
+          return webSearchEnabled(input.providerID, {
+            exa: flags.enableExa || cfg.experimental?.enable_exa === true,
+            parallel: flags.enableParallel,
+          })
+          // kilocode_change end
         }
 
         const usePatch = KiloToolRegistry.usePatch(input) // kilocode_change

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -68,6 +68,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache" // kilocode_change
 import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary" // kilocode_change
 import { AppProcess } from "@opencode-ai/core/process" // kilocode_change
+import { webSearchFlags } from "@/kilocode/tool/websearch" // kilocode_change
 
 export function webSearchEnabled(
   providerID: ProviderV2.ID,
@@ -337,12 +338,7 @@ export const layer = Layer.effect(
       const filtered = (yield* all()).filter((tool) => {
         if (!KiloToolRegistry.available(tool, input.agent)) return false // kilocode_change
         if (tool.id === WebSearchTool.id) {
-          // kilocode_change start
-          return webSearchEnabled(input.providerID, {
-            exa: flags.enableExa || cfg.experimental?.enable_exa === true,
-            parallel: flags.enableParallel,
-          })
-          // kilocode_change end
+          return webSearchEnabled(input.providerID, webSearchFlags(flags, cfg)) // kilocode_change
         }
 
         const usePatch = KiloToolRegistry.usePatch(input) // kilocode_change

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -6,6 +6,7 @@ import DESCRIPTION from "./websearch.txt"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Config } from "@/config/config" // kilocode_change
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({ description: "Websearch query" }),
@@ -101,6 +102,7 @@ export const WebSearchTool = Tool.define(
   Effect.gen(function* () {
     const http = yield* HttpClient.HttpClient
     const flags = yield* RuntimeFlags.Service
+    const config = yield* Config.Service // kilocode_change
 
     return {
       get description() {
@@ -109,10 +111,13 @@ export const WebSearchTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          // kilocode_change start
+          const cfg = yield* config.get()
           const provider = selectWebSearchProvider(ctx.sessionID, {
-            exa: flags.enableExa,
+            exa: flags.enableExa || cfg.experimental?.enable_exa === true,
             parallel: flags.enableParallel,
           })
+          // kilocode_change end
           const title = webSearchProviderLabel(provider)
           yield* ctx.metadata({ title: `${title} "${params.query}"`, metadata: { provider } })
 

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -7,6 +7,7 @@ import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Config } from "@/config/config" // kilocode_change
+import { webSearchFlags } from "@/kilocode/tool/websearch" // kilocode_change
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({ description: "Websearch query" }),
@@ -113,10 +114,7 @@ export const WebSearchTool = Tool.define(
         Effect.gen(function* () {
           // kilocode_change start
           const cfg = yield* config.get()
-          const provider = selectWebSearchProvider(ctx.sessionID, {
-            exa: flags.enableExa || cfg.experimental?.enable_exa === true,
-            parallel: flags.enableParallel,
-          })
+          const provider = selectWebSearchProvider(ctx.sessionID, webSearchFlags(flags, cfg))
           // kilocode_change end
           const title = webSearchProviderLabel(provider)
           yield* ctx.metadata({ title: `${title} "${params.query}"`, metadata: { provider } })

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -168,6 +168,21 @@ describe("kilocode indexing config", () => {
     })
   })
 
+  test("accepts experimental.enable_exa for non-Kilo websearch", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await writeConfig(tmp.path, {
+      experimental: { enable_exa: true },
+    })
+
+    await provideTestInstance({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await load()
+        expect(config.experimental?.enable_exa).toBe(true)
+      },
+    })
+  })
+
   test("keeps global indexing enabled in global config", async () => {
     await using globalTmp = await tmpdir()
     await using tmp = await tmpdir()

--- a/packages/opencode/test/kilocode/tool/websearch-flags.test.ts
+++ b/packages/opencode/test/kilocode/tool/websearch-flags.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { webSearchFlags } from "../../../src/kilocode/tool/websearch"
+
+describe("webSearchFlags", () => {
+  test("uses runtime enableExa flag", () => {
+    expect(webSearchFlags({ enableExa: true, enableParallel: false })).toEqual({
+      exa: true,
+      parallel: false,
+    })
+  })
+
+  test("uses experimental.enable_exa config", () => {
+    expect(
+      webSearchFlags({ enableExa: false, enableParallel: false }, { experimental: { enable_exa: true } }),
+    ).toEqual({
+      exa: true,
+      parallel: false,
+    })
+  })
+
+  test("keeps parallel independent of exa config", () => {
+    expect(
+      webSearchFlags({ enableExa: false, enableParallel: true }, { experimental: { enable_exa: true } }),
+    ).toEqual({
+      exa: true,
+      parallel: true,
+    })
+  })
+
+  test("defaults to disabled without flags or config", () => {
+    expect(webSearchFlags({ enableExa: false, enableParallel: false })).toEqual({
+      exa: false,
+      parallel: false,
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1713,6 +1713,7 @@ export type Config = {
     codebase_search?: boolean
     image_generation?: boolean
     image_generation_model?: string
+    enable_exa?: boolean
     agent_requirements?: boolean
     native_notebook_tools?: boolean
     speech_to_text_model?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -28474,6 +28474,9 @@
               "image_generation_model": {
                 "type": "string"
               },
+              "enable_exa": {
+                "type": "boolean"
+              },
               "agent_requirements": {
                 "type": "boolean"
               },


### PR DESCRIPTION
## Summary

Websearch was only enabled when `providerID === "kilo"` or via env vars (`KILO_ENABLE_EXA` / `KILO_ENABLE_PARALLEL`). Non-Kilo providers such as Codex had no settings path to turn it on.

This adds:

- `experimental.enable_exa` config key (CLI + SDK schema)
- Experimental settings toggle in the VS Code extension
- Tool registry / websearch routing that honors the config flag (in addition to existing env flags)
- Docs note and i18n for all locales

## Why

Users on Codex and other non-Kilo providers could not manually enable Exa websearch without env vars. Settings UI now exposes the toggle.

## Test plan

- [ ] Open VS Code extension Settings → Experimental
- [ ] Toggle **Exa Web Search** on while using a non-Kilo provider (e.g. Codex)
- [ ] Confirm the agent has the `websearch` tool available
- [ ] Toggle off and confirm websearch is no longer offered for non-Kilo providers
- [ ] Confirm Kilo provider still has websearch without the toggle
- [ ] Optionally set `"experimental": { "enable_exa": true }` in `kilo.jsonc` and verify the same behavior outside the UI