### PR TITLE
fix(cli): include credentials in console URLs printed for headless users

### DIFF
--- a/.changeset/console-headless-credentials.md
+++ b/.changeset/console-headless-credentials.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Include basic-auth credentials in the Local and Network Console URLs printed by `kilo console`, so users on headless hosts (no `DISPLAY`/`WAYLAND_DISPLAY`, SSH sessions, CI runners) can open the URL in a browser on another machine and reach the Console.

--- a/packages/opencode/src/kilocode/cli/cmd/console.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/console.ts
@@ -9,8 +9,8 @@ import { warnPort } from "@/kilocode/cli/port-warning"
 import { hasDisplay } from "@/kilocode/cli/cmd/tui/util/display"
 import { StopCommand } from "@/kilocode/cli/cmd/daemon"
 
-function browserUrl(state: Daemon.State) {
-  const url = new URL("/console", state.url)
+function withCredentials(base: string, state: Daemon.State) {
+  const url = new URL("/console", base)
   url.username = state.username
   url.password = state.password
   return url.toString()
@@ -56,11 +56,11 @@ const OpenCommand = cmd({
       if (daemon.restarted) console.warn("Restarted the Kilo daemon to apply the requested network options")
 
       const urls = state.urls ?? serverUrls(state.hostname, state.port)
-      const consoleLocal = `${urls.local}/console`
-      const consoleNetwork = urls.network ? `${urls.network}/console` : undefined
+      const consoleLocal = withCredentials(urls.local, state)
+      const consoleNetwork = urls.network ? withCredentials(urls.network, state) : undefined
 
       if (hasDisplay()) {
-        await launch(browserUrl(state)).catch((err) => {
+        await launch(consoleLocal).catch((err) => {
           console.warn(`Could not open browser automatically: ${err instanceof Error ? err.message : String(err)}`)
         })
       } else {


### PR DESCRIPTION
## Issue

Closes #12332

## Context

Running `kilo console` on a headless host (Linux without `DISPLAY`/`WAYLAND_DISPLAY`, SSH sessions, CI runners) does not launch a browser. The command instead prints the Local and Network Console URLs and tells the user to open one manually. Those printed URLs were missing basic-auth credentials, leaving headless users with no way to authenticate into the Console.

Credentials were only embedded into the URL used by the in-process `open()` call, which is unreachable without a display.

## Implementation

- Renamed `browserUrl(state)` to `withCredentials(base, state)` so any base URL can be augmented with `state.username` / `state.password`. Behavior is identical (`new URL("/console", base)` with `url.username`/`url.password` set); the rename is what unlocks reuse.
- Applied `withCredentials` to both printed URLs (`consoleLocal`, `consoleNetwork`) so headless users can copy/paste an authenticated URL into a browser on another machine.
- Switched the `hasDisplay()` branch's `open()` call from `browserUrl(state)` to `withCredentials(urls.local, state)`, so the URL it launches is the same one a headless user would copy from the terminal.

## Screenshots / Video

<img width="994" height="133" alt="image" src="https://github.com/user-attachments/assets/d66d3990-caf8-4d66-a92c-db22e074f03c" />

## How to Test

### Manual/local verification

- Run `kilo console`
- Ensure that the console URL is printed with the correct username and password

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18