### PR TITLE
OCP M1: opt-in .opencode scan (KILO_OCP_SCAN_OPENCODE)

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -131,6 +131,11 @@ export const Flag = {
   get KILO_DISABLE_PROJECT_CONFIG() {
     return truthy("KILO_DISABLE_PROJECT_CONFIG")
   },
+  // OCP M1 opt-in: also scan project `.opencode` dirs (after `.kilo`/`.kilocode`).
+  // See https://github.com/oakimov/opencode-plugin-compat/blob/main/patches/kilo-m1.md
+  get KILO_OCP_SCAN_OPENCODE() {
+    return truthy("KILO_OCP_SCAN_OPENCODE")
+  },
   get KILO_EXPERIMENTAL_REFERENCES() {
     return enabledByExperimental("KILO_EXPERIMENTAL_REFERENCES")
   },

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -22,17 +22,24 @@ export const files = Effect.fn("ConfigPaths.projectFiles")(function* (
 
 export const directories = Effect.fn("ConfigPaths.directories")(function* (directory: string, worktree?: string) {
   const afs = yield* FSUtil.Service
+  // kilocode_change — native dirs first; optional OCP dual-scan for `.opencode`
+  // See https://github.com/oakimov/opencode-plugin-compat/blob/main/patches/kilo-m1.md
+  const projectTargets = [
+    ".kilocode",
+    ".kilo",
+    ...(Flag.KILO_OCP_SCAN_OPENCODE ? [".opencode"] : []),
+  ]
   return unique([
     Global.Path.config,
     ...(!Flag.KILO_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
-          targets: [".kilocode", ".kilo"], // kilocode_change
+          targets: projectTargets, // kilocode_change
           start: directory,
           stop: worktree,
         })
       : []),
     ...(yield* afs.up({
-      targets: [".kilocode", ".kilo"], // kilocode_change
+      targets: projectTargets, // kilocode_change
       start: Global.Path.home,
       stop: Global.Path.home,
     })),


### PR DESCRIPTION
## Summary
- Add `KILO_OCP_SCAN_OPENCODE` flag (truthy `1`/`true`).
- When enabled, `ConfigPaths.directories` appends `.opencode` after `.kilocode`/`.kilo`.
- Default remains native-only (existing `.opencode` migrate-notice behavior unchanged).
- Part of OpenCode Plugin Compat (OCP) M1 Layer B / T2 — see https://github.com/oakimov/opencode-plugin-compat/blob/main/patches/kilo-m1.md

## Test plan
- [ ] Default (flag unset) — `.opencode` not scanned; migrate notice path unchanged
- [ ] `KILO_OCP_SCAN_OPENCODE=1` with only `.kilo` — unchanged
- [ ] Flag on with `.kilo` + `.opencode` — both discovered; native first
- [ ] Flag on with only `.opencode` — discovered