### PR TITLE
fix: skip unused PowerShell native build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -845,7 +845,6 @@
   },
   "trustedDependencies": [
     "esbuild",
-    "tree-sitter-powershell",
     "protobufjs",
     "web-tree-sitter",
     "tree-sitter-bash",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "protobufjs",
     "tree-sitter",
     "tree-sitter-bash",
-    "tree-sitter-powershell",
     "web-tree-sitter",
     "electron"
   ],


### PR DESCRIPTION
`tree-sitter-powershell` is listed as a trusted dependency, so Bun runs its `node-gyp-build` install script. The package does not ship a usable prebuild for every contributor environment, which makes a normal install depend on Python and native compiler tooling even though Kilo never loads the resulting Node binding.

Keep `tree-sitter-powershell` as a CLI dependency and continue loading its packaged WASM grammar for shell command parsing, but stop authorizing its lifecycle script. This removes the unnecessary native build without changing PowerShell parsing. Semantic search is unaffected because indexing uses `web-tree-sitter` with `tree-sitter-wasms`, not this package or its native binding.

This supersedes the root `node-gyp` workaround proposed in #12384, which would retain the unnecessary compilation and still require platform-specific build tools.