### PR TITLE
fix(cli): explain missing Zig build dependency

### DIFF
--- a/packages/opencode/script/kilocode/bubblewrap.ts
+++ b/packages/opencode/script/kilocode/bubblewrap.ts
@@ -93,6 +93,12 @@ function muslLicense(zig: string) {
 }
 
 async function compile(arch: "x64" | "arm64") {
+  const zig = process.env.ZIG ?? Bun.which("zig")
+  if (!zig) {
+    throw new Error(
+      "Building Linux CLI artifacts requires Zig to compile the bundled Bubblewrap helper. Install Zig, set $ZIG, or use --single when building on macOS or Windows.",
+    )
+  }
   const sourceTree = await source()
   const out = path.join(cache, `bwrap-${arch}`)
   const include = path.join(cache, "include", "sys")
@@ -102,7 +108,6 @@ async function compile(arch: "x64" | "arm64") {
   await Bun.write(path.join(include, "capability.h"), capability)
   await Bun.write(path.join(generated, "config.h"), config)
 
-  const zig = process.env.ZIG ?? "zig"
   const args = [
     zig,
     "cc",


### PR DESCRIPTION
Full CLI builds produce bundled Linux Bubblewrap helpers and therefore require Zig even when the build host is macOS or Windows. Without Zig, the build currently fails through process spawning after it has already started preparing Bubblewrap sources, without explaining why the toolchain is needed or how to provide it.

Resolve Zig from the existing `$ZIG` override or `PATH` at the Bubblewrap compilation boundary and fail immediately with an actionable message when neither is available. Normal dependency installation, development, tests, and native `--single` builds on macOS or Windows remain independent of Zig. Release and Linux sandbox workflows continue using their existing checksum-pinned Zig 0.14.0 setup.

This supersedes the broader auto-install approach in #12385 without adding a root postinstall download, platform extraction logic, dependencies, or lockfile changes.