### PR TITLE
feat(vscode): cycle reasoning effort variants with Shift+Tab

### DIFF
--- a/.changeset/shift-tab-variant-cycle.md
+++ b/.changeset/shift-tab-variant-cycle.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Cycle reasoning effort variants with Shift+Tab in prompt inputs. Works in the sidebar chat, Agent Manager, and the New Worktree dialog. The variant selector tooltip shows the shortcut on hover, and the behavior can be turned off with the `kilo-code.new.chat.shiftTabCyclesVariant` setting (also available under Settings > Display) to restore Shift+Tab focus navigation.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1129,6 +1129,11 @@
           "default": true,
           "description": "Show the task timeline graph in the chat header"
         },
+        "kilo-code.new.chat.shiftTabCyclesVariant": {
+          "type": "boolean",
+          "default": true,
+          "description": "Cycle through reasoning effort variants with Shift+Tab in prompt inputs. Disable to keep Shift+Tab for keyboard focus navigation."
+        },
         "kilo-code.new.agentWorkStyle": {
           "type": "string",
           "scope": "application",

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -171,6 +171,7 @@ import {
   validIndexingSetting,
   watchIndexingConfig,
 } from "./kilo-provider/indexing-settings"
+import { buildChatSettingsMessage, validChatSetting, watchChatConfig } from "./kilo-provider/chat-settings"
 
 let maxCost = 0
 
@@ -391,6 +392,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private webviewMessageDisposable: vscode.Disposable | null = null
   private autocompleteConfigDisposable: vscode.Disposable | null = null
   private indexingConfigDisposable: vscode.Disposable | null = null
+  private chatConfigDisposable: vscode.Disposable | null = null
   private telemetryStateDisposable: vscode.Disposable | null = null
   private viewStateDisposable: vscode.Disposable | null = null
   private visibilityDisposable: vscode.Disposable | null = null
@@ -913,6 +915,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.autocompleteConfigDisposable = watchAutocompleteConfig((msg) => this.postMessage(msg))
     this.indexingConfigDisposable?.dispose()
     this.indexingConfigDisposable = watchIndexingConfig((msg) => this.postMessage(msg))
+    this.chatConfigDisposable?.dispose()
+    this.chatConfigDisposable = watchChatConfig((msg) => this.postMessage(msg))
     this.telemetryStateDisposable?.dispose()
     this.telemetryStateDisposable = watchTelemetryState((msg) => this.postMessage(msg))
     this.webviewMessageDisposable = webview.onDidReceiveMessage(async (message) => {
@@ -1249,6 +1253,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           break
         case "requestIndexingSettings":
           this.postMessage(buildIndexingSettingsMessage())
+          break
+        case "requestChatSettings":
+          this.postMessage(buildChatSettingsMessage())
           break
         case "requestKiloEmbeddingModels":
           this.fetchAndSendKiloEmbeddingModels().catch((e) =>
@@ -3665,6 +3672,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const { section, leaf } = buildSettingPath(key)
     if (section === "autocomplete" && !validAutocompleteSetting(leaf, value)) return
     if (section === "indexing" && !validIndexingSetting(leaf, value)) return
+    if (section === "chat" && !validChatSetting(leaf, value)) return
     const config = vscode.workspace.getConfiguration(`kilo-code.new${section ? `.${section}` : ""}`)
     // Normalize a webview-side clear to `undefined` so VS Code removes the
     // key from settings.json rather than persisting a literal `null`. This
@@ -4508,6 +4516,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.webviewMessageDisposable?.dispose()
     this.autocompleteConfigDisposable?.dispose()
     this.indexingConfigDisposable?.dispose()
+    this.chatConfigDisposable?.dispose()
     this.telemetryStateDisposable?.dispose()
     this.autoApproveBridge?.dispose()
     this.visibleTaskStreams.clear()

--- a/packages/kilo-vscode/src/kilo-provider/chat-settings.ts
+++ b/packages/kilo-vscode/src/kilo-provider/chat-settings.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode"
+
+type Post = (msg: unknown) => void
+
+export function buildChatSettingsMessage() {
+  const config = vscode.workspace.getConfiguration("kilo-code.new.chat")
+  return {
+    type: "chatSettingsLoaded" as const,
+    settings: {
+      shiftTabCyclesVariant: config.get<boolean>("shiftTabCyclesVariant", true),
+    },
+  }
+}
+
+export function watchChatConfig(post: Post): vscode.Disposable {
+  return vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration("kilo-code.new.chat")) {
+      post(buildChatSettingsMessage())
+    }
+  })
+}
+
+export function validChatSetting(key: string, value: unknown) {
+  return key === "shiftTabCyclesVariant" && typeof value === "boolean"
+}

--- a/packages/kilo-vscode/tests/unit/chat-settings-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/chat-settings-message.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import * as vscode from "vscode"
+import { buildChatSettingsMessage, validChatSetting } from "../../src/kilo-provider/chat-settings"
+
+type Stub = {
+  getConfiguration: (section?: string) => {
+    get: <T>(key: string, fallback?: T) => T | undefined
+  }
+}
+
+const original = vscode.workspace.getConfiguration
+
+function stubConfig(state: Map<string, unknown>) {
+  ;(vscode.workspace as unknown as Stub).getConfiguration = (section?: string) => {
+    if (section !== "kilo-code.new.chat") {
+      return { get: <T>(_key: string, fallback?: T) => fallback }
+    }
+    return {
+      get: <T>(key: string, fallback?: T) => (state.has(key) ? (state.get(key) as T) : fallback),
+    }
+  }
+}
+
+afterEach(() => {
+  ;(vscode.workspace as unknown as Stub).getConfiguration = original as Stub["getConfiguration"]
+})
+
+describe("buildChatSettingsMessage", () => {
+  let state: Map<string, unknown>
+
+  beforeEach(() => {
+    state = new Map()
+    stubConfig(state)
+  })
+
+  it("enables Shift+Tab variant cycling by default", () => {
+    expect(buildChatSettingsMessage().settings.shiftTabCyclesVariant).toBe(true)
+  })
+
+  it("returns the persisted cycling preference", () => {
+    state.set("shiftTabCyclesVariant", false)
+
+    expect(buildChatSettingsMessage().settings.shiftTabCyclesVariant).toBe(false)
+  })
+})
+
+describe("validChatSetting", () => {
+  it("accepts only boolean cycling updates", () => {
+    expect(validChatSetting("shiftTabCyclesVariant", true)).toBe(true)
+    expect(validChatSetting("shiftTabCyclesVariant", false)).toBe(true)
+    expect(validChatSetting("shiftTabCyclesVariant", "false")).toBe(false)
+    expect(validChatSetting("unknown", true)).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
+++ b/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
@@ -18,7 +18,7 @@ describe("NewWorktreeDialog sandbox toggle", () => {
       'vscode.postMessage({ type: "setSandboxDefault", enabled: next, requestID: sandboxRequestID })',
     )
     expect(src).toContain("sandbox: sandboxVisible() ? sandboxOverride() : undefined")
-    expect(src).toContain("const { config, globalConfig, features } = useConfig()")
+    expect(src).toContain("const { config, globalConfig, features, settings } = useConfig()")
     expect(src).toContain(
       "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true",
     )

--- a/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import {
+  cycleVariant,
   getVariant,
   sessionVariantKeys,
   sessionVariants,
@@ -90,5 +91,25 @@ describe("per-session variant selection", () => {
     store[variantKey(model, "code", "pending-local-2")] = "high"
 
     expect(sessionVariantKeys(store, "pending-local-1")).toEqual(["session/pending-local-1/anthropic/claude-sonnet-4"])
+  })
+})
+
+describe("cycleVariant", () => {
+  it("advances to the next variant", () => {
+    expect(cycleVariant("low", variants)).toBe("medium")
+    expect(cycleVariant("medium", variants)).toBe("high")
+  })
+
+  it("wraps back to the first variant after the last", () => {
+    expect(cycleVariant("high", variants)).toBe("low")
+  })
+
+  it("starts at the first variant when current is missing or unknown", () => {
+    expect(cycleVariant(undefined, variants)).toBe("low")
+    expect(cycleVariant("bogus", variants)).toBe("low")
+  })
+
+  it("returns undefined when no variants exist", () => {
+    expect(cycleVariant("low", [])).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -22,6 +22,7 @@ import { useServer } from "../src/context/server"
 import { useSession } from "../src/context/session"
 import { useProvider } from "../src/context/provider"
 import { useConfig } from "../src/context/config"
+import { cycleVariant } from "../src/context/session-variant-store"
 import { ModelSelectorBase } from "../src/components/shared/ModelSelector"
 import { ModeSwitcherBase } from "../src/components/shared/ModeSwitcher"
 import { SpeechToTextButton } from "../src/components/speech-to-text/SpeechToTextButton"
@@ -79,7 +80,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const server = useServer()
   const session = useSession()
   const provider = useProvider()
-  const { config, globalConfig, features } = useConfig()
+  const { config, globalConfig, features, settings } = useConfig()
   const metrics = tracker(vscode)
   const track = (button: string, properties?: Record<string, string | number | boolean | undefined>) =>
     metrics.track(button, "configure_worktree_dialog", properties)
@@ -339,6 +340,22 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
     textareaRef.focus()
   }
 
+  const onKey = (e: KeyboardEvent) => {
+    // Shift+Tab cycles reasoning effort variants (setting: chat.shiftTabCyclesVariant).
+    // When disabled or no variants exist, fall through to default focus navigation.
+    if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (settings()["chat.shiftTabCyclesVariant"] === false) return
+      const list = variants()
+      if (list.length === 0) return
+      const next = cycleVariant(effectiveVariant(), list)
+      if (!next) return
+      e.preventDefault()
+      setVariant(next)
+      return
+    }
+    undo(e)
+  }
+
   const adjustHeight = () => {
     if (!textareaRef) return
     textareaRef.style.height = "auto"
@@ -541,7 +558,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                       persistPrompt(val)
                       adjustHeight()
                     }}
-                    onKeyDown={undo}
+                    onKeyDown={onKey}
                     onPaste={(e) => imageAttach.handlePaste(e)}
                     rows={3}
                     dir="auto"
@@ -575,6 +592,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
                       onSelect={setVariant}
                       portal={false}
                       deferDismiss
+                      cycleHint={settings()["chat.shiftTabCyclesVariant"] !== false}
                     />
                     <Show when={overridden()}>
                       <Tooltip value={t("prompt.action.resetModel")} placement="top">

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -36,6 +36,7 @@ import { useSpeechToText } from "../speech-to-text/useSpeechToText"
 import { useImageAttachments, type ImageAttachment } from "../../hooks/useImageAttachments"
 import { convertToMentionPath } from "../../utils/path-mentions"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
+import { cycleVariant } from "../../context/session-variant-store"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
 import {
   fileName,
@@ -863,7 +864,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
     }
 
-    if (e.key === "Tab" && ghost.text()) {
+    // Shift+Tab cycles reasoning effort variants (setting: chat.shiftTabCyclesVariant).
+    // When disabled or no variants exist, fall through to default focus navigation.
+    if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (settings()["chat.shiftTabCyclesVariant"] === false) return
+      const list = session.variantList(sid())
+      if (list.length === 0) return
+      const next = cycleVariant(session.currentVariant(sid()), list)
+      if (!next) return
+      e.preventDefault()
+      session.selectVariant(next, sid())
+      return
+    }
+
+    if (e.key === "Tab" && !e.shiftKey && ghost.text()) {
       if (!isAtEnd()) return
       e.preventDefault()
       acceptSuggestion()

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -25,7 +25,7 @@ const CODE_EDIT_OPTIONS: LayoutOption[] = [
 ]
 
 const DisplayTab: Component = () => {
-  const { config, updateConfig } = useConfig()
+  const { config, updateConfig, settings, updateSetting } = useConfig()
   const display = useDisplay()
   const language = useLanguage()
 
@@ -75,6 +75,19 @@ const DisplayTab: Component = () => {
             hideLabel
           >
             {language.t("settings.display.reasoningAutoCollapse.title")}
+          </Switch>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.display.shiftTabCycle.title")}
+          description={language.t("settings.display.shiftTabCycle.description")}
+        >
+          <Switch
+            checked={Boolean(settings()["chat.shiftTabCyclesVariant"] ?? true)}
+            onChange={(checked: boolean) => updateSetting("chat.shiftTabCyclesVariant", checked)}
+            hideLabel
+          >
+            {language.t("settings.display.shiftTabCycle.title")}
           </Switch>
         </SettingsRow>
 

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -10,7 +10,10 @@
 import { type Accessor, Component, createSignal, For, onCleanup, Show } from "solid-js"
 import { PopupSelector } from "./PopupSelector"
 import { Button } from "@kilocode/kilo-ui/button"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useSession } from "../../context/session"
+import { useConfig } from "../../context/config"
+import { useLanguage } from "../../context/language"
 import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
 
 // ---------------------------------------------------------------------------
@@ -38,11 +41,14 @@ export interface ThinkingSelectorBaseProps {
   deferDismiss?: boolean
   /** Listen for the global prompt trigger event. Defaults to true. */
   globalTrigger?: boolean
+  /** Show the Shift+Tab cycle hint in the trigger tooltip. */
+  cycleHint?: boolean
 }
 
 export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [focused, setFocused] = createSignal(-1)
+  const language = useLanguage()
   let listRef: HTMLDivElement | undefined
 
   const rows = () => (props.allowClear ? [undefined, ...props.variants] : props.variants)
@@ -135,52 +141,64 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
 
   return (
     <Show when={rows().length > 0}>
-      <PopupSelector
-        expanded={false}
-        placement={props.placement ?? "top-start"}
-        preferredWidth={180}
-        minHeight={100}
-        portal={props.portal}
-        deferDismiss={props.deferDismiss}
-        open={open()}
-        onOpenChange={onOpen}
-        triggerAs={Button}
-        triggerProps={{ variant: "ghost", size: "small" }}
-        trigger={
-          <>
-            <span class="thinking-selector-trigger-label">{display(props.value)}</span>
-            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style={{ "flex-shrink": "0" }}>
-              <path d="M8 4l4 5H4l4-5z" />
-            </svg>
-          </>
-        }
-      >
-        {(bodyH) => (
-          <div
-            class="thinking-selector-list"
-            role="listbox"
-            ref={listRef}
-            onKeyDown={onKeyDown}
-            style={bodyH() !== undefined ? { "max-height": `${bodyH()}px` } : {}}
-          >
-            <For each={rows()}>
-              {(v, i) => (
-                <div
-                  class={`thinking-selector-item${props.value === v ? " selected" : ""}`}
-                  role="option"
-                  aria-selected={props.value === v}
-                  tabindex={focused() === i() ? 0 : -1}
-                  data-autofocus={focused() === i() ? "" : undefined}
-                  onClick={() => pick(v)}
-                  onFocus={() => setFocused(i())}
-                >
-                  <span class="thinking-selector-item-name">{display(v)}</span>
-                </div>
-              )}
-            </For>
+      <Tooltip
+        value={
+          <div data-slot="tooltip-keybind">
+            <span>{language.t("prompt.thinking.tooltip")}</span>
+            <Show when={props.cycleHint}>
+              <span data-slot="tooltip-keybind-key">Shift+Tab</span>
+            </Show>
           </div>
-        )}
-      </PopupSelector>
+        }
+        placement="top"
+      >
+        <PopupSelector
+          expanded={false}
+          placement={props.placement ?? "top-start"}
+          preferredWidth={180}
+          minHeight={100}
+          portal={props.portal}
+          deferDismiss={props.deferDismiss}
+          open={open()}
+          onOpenChange={onOpen}
+          triggerAs={Button}
+          triggerProps={{ variant: "ghost", size: "small" }}
+          trigger={
+            <>
+              <span class="thinking-selector-trigger-label">{display(props.value)}</span>
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" style={{ "flex-shrink": "0" }}>
+                <path d="M8 4l4 5H4l4-5z" />
+              </svg>
+            </>
+          }
+        >
+          {(bodyH) => (
+            <div
+              class="thinking-selector-list"
+              role="listbox"
+              ref={listRef}
+              onKeyDown={onKeyDown}
+              style={bodyH() !== undefined ? { "max-height": `${bodyH()}px` } : {}}
+            >
+              <For each={rows()}>
+                {(v, i) => (
+                  <div
+                    class={`thinking-selector-item${props.value === v ? " selected" : ""}`}
+                    role="option"
+                    aria-selected={props.value === v}
+                    tabindex={focused() === i() ? 0 : -1}
+                    data-autofocus={focused() === i() ? "" : undefined}
+                    onClick={() => pick(v)}
+                    onFocus={() => setFocused(i())}
+                  >
+                    <span class="thinking-selector-item-name">{display(v)}</span>
+                  </div>
+                )}
+              </For>
+            </div>
+          )}
+        </PopupSelector>
+      </Tooltip>
     </Show>
   )
 }
@@ -195,6 +213,7 @@ interface ThinkingSelectorProps {
 
 export const ThinkingSelector: Component<ThinkingSelectorProps> = (props) => {
   const session = useSession()
+  const { settings } = useConfig()
   const id = () => props.sessionID?.()
 
   return (
@@ -202,6 +221,7 @@ export const ThinkingSelector: Component<ThinkingSelectorProps> = (props) => {
       variants={session.variantList(id())}
       value={session.currentVariant(id())}
       onSelect={(value) => session.selectVariant(value, id())}
+      cycleHint={settings()["chat.shiftTabCyclesVariant"] !== false}
     />
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -102,6 +102,12 @@ export const ConfigProvider: ParentComponent = (props) => {
       })
       return
     }
+    if (message.type === "chatSettingsLoaded") {
+      mergeSettings({
+        "chat.shiftTabCyclesVariant": message.settings.shiftTabCyclesVariant,
+      })
+      return
+    }
     if (message.type === "configLoaded") {
       // Skip if a save is in-flight — a stale configLoaded must not overwrite
       // the optimistically-updated state while the write is being confirmed.
@@ -186,6 +192,7 @@ export const ConfigProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "requestConfig" })
     vscode.postMessage({ type: "requestAutocompleteSettings" })
     vscode.postMessage({ type: "requestIndexingSettings" })
+    vscode.postMessage({ type: "requestChatSettings" })
   }
 
   // Request config immediately; if the extension's httpClient is not yet ready,

--- a/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
@@ -24,6 +24,16 @@ export function getVariant(
   return stored && variants.includes(stored) ? stored : variants[0]
 }
 
+/**
+ * Next variant in the list, wrapping back to the first after the last.
+ * An unknown or missing current value starts at the first variant.
+ */
+export function cycleVariant(current: string | undefined, variants: string[]) {
+  if (variants.length === 0) return undefined
+  const idx = current ? variants.indexOf(current) : -1
+  return variants[(idx + 1) % variants.length]
+}
+
 export function transferVariants(store: Record<string, string>, from: string, to: string) {
   const prefix = `session/${from}/`
   return Object.fromEntries(

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -348,6 +348,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "تضمين الملف النشط",
   "prompt.context.removeActiveFile": "إزالة الملف النشط من السياق",
   "prompt.context.removeFile": "إزالة الملف من السياق",
+  "prompt.thinking.tooltip": "جهد الاستدلال",
   "prompt.action.attachFile": "إرفاق ملف",
   "prompt.attachment.remove": "إزالة المرفق",
   "prompt.action.send": "إرسال",
@@ -1679,6 +1680,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "طي الاستدلال تلقائيًا",
   "settings.display.reasoningAutoCollapse.description":
     "يطوي كتل الاستدلال بعد أن ينتهي الوكيل من كتابتها. اتركه معطلاً لإبقاء الاستدلال موسعًا ما لم تطوه يدويًا.",
+  "settings.display.shiftTabCycle.title": "تبديل جهد الاستدلال باستخدام Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "اضغط على Shift+Tab في حقل إدخال الموجه للتبديل إلى مستوى جهد الاستدلال التالي. عطّل هذا الخيار للاحتفاظ بـ Shift+Tab للتنقل بين عناصر التركيز باستخدام لوحة المفاتيح.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -350,6 +350,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Incluir arquivo ativo",
   "prompt.context.removeActiveFile": "Remover arquivo ativo do contexto",
   "prompt.context.removeFile": "Remover arquivo do contexto",
+  "prompt.thinking.tooltip": "Esforço de raciocínio",
   "prompt.action.attachFile": "Anexar arquivo",
   "prompt.attachment.remove": "Remover anexo",
   "prompt.action.send": "Enviar",
@@ -1728,6 +1729,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Recolher raciocínio automaticamente",
   "settings.display.reasoningAutoCollapse.description":
     "Recolhe os blocos de raciocínio depois que o agente termina de escrevê-los. Deixe desativado para manter o raciocínio expandido, a menos que você o recolha manualmente.",
+  "settings.display.shiftTabCycle.title": "Alternar o esforço de raciocínio com Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Pressione Shift+Tab em um campo de entrada de prompt para alternar para o próximo nível de esforço de raciocínio. Desative para manter Shift+Tab para navegação de foco pelo teclado.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -351,6 +351,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Uključi aktivnu datoteku",
   "prompt.context.removeActiveFile": "Ukloni aktivnu datoteku iz konteksta",
   "prompt.context.removeFile": "Ukloni datoteku iz konteksta",
+  "prompt.thinking.tooltip": "Napor razmišljanja",
   "prompt.action.attachFile": "Priloži datoteku",
   "prompt.attachment.remove": "Ukloni prilog",
   "prompt.action.send": "Pošalji",
@@ -1720,6 +1721,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Automatski sažmi razmišljanje",
   "settings.display.reasoningAutoCollapse.description":
     "Sažima blokove razmišljanja nakon što ih agent završi pisati. Ostavite isključeno da razmišljanje ostane prošireno, osim ako ga ručno sažmete.",
+  "settings.display.shiftTabCycle.title": "Promijeni napor razmišljanja pomoću Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Pritisnite Shift+Tab u polju za unos upita da pređete na sljedeći nivo napora razmišljanja. Onemogućite ovu opciju kako biste zadržali Shift+Tab za navigaciju fokusom putem tastature.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -350,6 +350,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Inkluder aktiv fil",
   "prompt.context.removeActiveFile": "Fjern aktiv fil fra kontekst",
   "prompt.context.removeFile": "Fjern fil fra kontekst",
+  "prompt.thinking.tooltip": "Ræsonnementsindsats",
   "prompt.action.attachFile": "Vedhæft fil",
   "prompt.attachment.remove": "Fjern vedhæftning",
   "prompt.action.send": "Send",
@@ -1711,6 +1712,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Skjul ræsonnement automatisk",
   "settings.display.reasoningAutoCollapse.description":
     "Skjuler ræsonnementsblokke, når agenten er færdig med at skrive dem. Lad den være slået fra for at holde ræsonnement udvidet, medmindre du skjuler det manuelt.",
+  "settings.display.shiftTabCycle.title": "Skift ræsonnementsindsats med Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Tryk på Shift+Tab i et promptindtastningsfelt for at skifte til næste niveau af ræsonnementsindsats. Deaktivér for at beholde Shift+Tab til tastaturnavigation af fokus.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -357,6 +357,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Aktive Datei einbeziehen",
   "prompt.context.removeActiveFile": "Aktive Datei aus dem Kontext entfernen",
   "prompt.context.removeFile": "Datei aus dem Kontext entfernen",
+  "prompt.thinking.tooltip": "Reasoning-Aufwand",
   "prompt.action.attachFile": "Datei anhängen",
   "prompt.attachment.remove": "Anhang entfernen",
   "prompt.action.send": "Senden",
@@ -1747,6 +1748,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Reasoning automatisch einklappen",
   "settings.display.reasoningAutoCollapse.description":
     "Klappt Reasoning-Blöcke ein, nachdem der Agent sie fertig geschrieben hat. Deaktiviert lassen, damit Reasoning erweitert bleibt, sofern du es nicht manuell einklappst.",
+  "settings.display.shiftTabCycle.title": "Reasoning-Aufwand mit Shift+Tab durchlaufen",
+  "settings.display.shiftTabCycle.description":
+    "Drücken Sie Shift+Tab in einem Prompt-Eingabefeld, um zur nächsten Stufe des Reasoning-Aufwands zu wechseln. Deaktivieren Sie dies, um Shift+Tab für die Tastaturfokusnavigation beizubehalten.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -350,6 +350,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Include active file",
   "prompt.context.removeActiveFile": "Remove active file from context",
   "prompt.context.removeFile": "Remove file from context",
+  "prompt.thinking.tooltip": "Reasoning effort",
   "prompt.action.attachFile": "Attach file",
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",
@@ -1690,6 +1691,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Auto-Collapse Reasoning",
   "settings.display.reasoningAutoCollapse.description":
     "Collapse reasoning blocks after the agent finishes writing them. Leave off to keep reasoning expanded unless you collapse it manually.",
+  "settings.display.shiftTabCycle.title": "Cycle Reasoning Effort with Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Press Shift+Tab in a prompt input to switch to the next reasoning effort level. Disable to keep Shift+Tab for keyboard focus navigation.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -352,6 +352,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Incluir archivo activo",
   "prompt.context.removeActiveFile": "Eliminar archivo activo del contexto",
   "prompt.context.removeFile": "Eliminar archivo del contexto",
+  "prompt.thinking.tooltip": "Esfuerzo de razonamiento",
   "prompt.action.attachFile": "Adjuntar archivo",
   "prompt.attachment.remove": "Eliminar adjunto",
   "prompt.action.send": "Enviar",
@@ -1736,6 +1737,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Contraer razonamiento automáticamente",
   "settings.display.reasoningAutoCollapse.description":
     "Contrae los bloques de razonamiento después de que el agente termine de escribirlos. Déjalo desactivado para mantener el razonamiento expandido, a menos que lo contraigas manualmente.",
+  "settings.display.shiftTabCycle.title": "Alternar el esfuerzo de razonamiento con Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Pulsa Shift+Tab en un campo de entrada de prompt para cambiar al siguiente nivel de esfuerzo de razonamiento. Desactívalo para conservar Shift+Tab para la navegación del foco con el teclado.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -352,6 +352,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Inclure le fichier actif",
   "prompt.context.removeActiveFile": "Retirer le fichier actif du contexte",
   "prompt.context.removeFile": "Retirer le fichier du contexte",
+  "prompt.thinking.tooltip": "Effort de raisonnement",
   "prompt.action.attachFile": "Joindre un fichier",
   "prompt.attachment.remove": "Supprimer la pièce jointe",
   "prompt.action.send": "Envoyer",
@@ -1757,6 +1758,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Réduire automatiquement le raisonnement",
   "settings.display.reasoningAutoCollapse.description":
     "Réduit les blocs de raisonnement une fois que l'agent a fini de les écrire. Laissez désactivé pour garder le raisonnement développé, sauf si vous le réduisez manuellement.",
+  "settings.display.shiftTabCycle.title": "Parcourir l'effort de raisonnement avec Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Appuyez sur Shift+Tab dans un champ de saisie de prompt pour passer au niveau d'effort de raisonnement suivant. Désactivez cette option pour conserver Shift+Tab pour la navigation du focus au clavier.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -296,6 +296,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Includi file attivo",
   "prompt.context.removeActiveFile": "Rimuovi file attivo dal contesto",
   "prompt.context.removeFile": "Rimuovi file dal contesto",
+  "prompt.thinking.tooltip": "Sforzo di ragionamento",
   "prompt.action.attachFile": "Allega file",
   "prompt.attachment.remove": "Rimuovi allegato",
   "prompt.action.send": "Invia",
@@ -1514,6 +1515,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Comprimi automaticamente ragionamento",
   "settings.display.reasoningAutoCollapse.description":
     "Comprimi i blocchi di ragionamento dopo che l'agente ha finito di scriverli. Lascia disattivato per tenerli espansi finché non li comprimi manualmente.",
+  "settings.display.shiftTabCycle.title": "Cambia lo sforzo di ragionamento con Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Premi Shift+Tab in un campo di inserimento del prompt per passare al livello di sforzo di ragionamento successivo. Disattiva l'opzione per mantenere Shift+Tab per la navigazione del focus tramite tastiera.",
   "settings.display.terminalCommand.title": "Blocchi comando terminale",
   "settings.display.terminalCommand.description": "Scegli se i blocchi comando terminale iniziano espansi o compressi.",
   "settings.display.terminalCommand.expanded": "Espansi",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -349,6 +349,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "アクティブなファイルを含める",
   "prompt.context.removeActiveFile": "コンテキストからアクティブなファイルを削除",
   "prompt.context.removeFile": "コンテキストからファイルを削除",
+  "prompt.thinking.tooltip": "推論の強度",
   "prompt.action.attachFile": "ファイルを添付",
   "prompt.attachment.remove": "添付ファイルを削除",
   "prompt.action.send": "送信",
@@ -1706,6 +1707,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "推論を自動で折りたたむ",
   "settings.display.reasoningAutoCollapse.description":
     "エージェントが推論の書き込みを終えた後に推論ブロックを自動で折りたたみます。手動で折りたたむまでは推論を展開したままにするには、オフのままにしてください。",
+  "settings.display.shiftTabCycle.title": "Shift+Tab で推論の強度を切り替える",
+  "settings.display.shiftTabCycle.description":
+    "プロンプト入力欄で Shift+Tab を押すと、次の推論の強度レベルに切り替わります。Shift+Tab をキーボードフォーカスの移動に使用する場合は、無効にしてください。",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -352,6 +352,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "활성 파일 포함",
   "prompt.context.removeActiveFile": "컨텍스트에서 활성 파일 제거",
   "prompt.context.removeFile": "컨텍스트에서 파일 제거",
+  "prompt.thinking.tooltip": "추론 강도",
   "prompt.action.attachFile": "파일 첨부",
   "prompt.attachment.remove": "첨부 파일 제거",
   "prompt.action.send": "전송",
@@ -1689,6 +1690,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "추론 자동 접기",
   "settings.display.reasoningAutoCollapse.description":
     "에이전트가 추론 작성을 마친 뒤 추론 블록을 자동으로 접습니다. 수동으로 접기 전까지 추론을 펼친 상태로 두려면 끄세요.",
+  "settings.display.shiftTabCycle.title": "Shift+Tab으로 추론 강도 전환",
+  "settings.display.shiftTabCycle.description":
+    "프롬프트 입력란에서 Shift+Tab을 눌러 다음 추론 강도 수준으로 전환합니다. Shift+Tab을 키보드 포커스 탐색에 사용하려면 비활성화하세요.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -352,6 +352,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Actief bestand opnemen",
   "prompt.context.removeActiveFile": "Actief bestand uit context verwijderen",
   "prompt.context.removeFile": "Bestand uit context verwijderen",
+  "prompt.thinking.tooltip": "Redeneringsinspanning",
   "prompt.action.attachFile": "Bestand bijvoegen",
   "prompt.attachment.remove": "Bijlage verwijderen",
   "prompt.action.send": "Verzenden",
@@ -1688,6 +1689,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Redenering automatisch inklappen",
   "settings.display.reasoningAutoCollapse.description":
     "Klapt redeneerblokken in nadat de agent klaar is met schrijven. Laat uitgeschakeld om redenering uitgeklapt te houden, tenzij je die handmatig inklapt.",
+  "settings.display.shiftTabCycle.title": "Doorloop niveaus van redeneringsinspanning met Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Druk op Shift+Tab in een promptinvoerveld om naar het volgende niveau van redeneringsinspanning te gaan. Schakel dit uit om Shift+Tab te behouden voor focusnavigatie via het toetsenbord.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -353,6 +353,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Inkluder aktiv fil",
   "prompt.context.removeActiveFile": "Fjern aktiv fil fra kontekst",
   "prompt.context.removeFile": "Fjern fil fra kontekst",
+  "prompt.thinking.tooltip": "Resonnementsinnsats",
   "prompt.action.attachFile": "Legg ved fil",
   "prompt.attachment.remove": "Fjern vedlegg",
   "prompt.action.send": "Send",
@@ -1709,6 +1710,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Skjul resonnement automatisk",
   "settings.display.reasoningAutoCollapse.description":
     "Skjuler resonnementblokker etter at agenten er ferdig med å skrive dem. La være av for å holde resonnement utvidet med mindre du skjuler det manuelt.",
+  "settings.display.shiftTabCycle.title": "Bytt resonnementsinnsats med Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Trykk Shift+Tab i et promptinndatafelt for å bytte til neste nivå for resonnementsinnsats. Deaktiver for å beholde Shift+Tab for tastaturnavigering av fokus.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -350,6 +350,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Dołącz aktywny plik",
   "prompt.context.removeActiveFile": "Usuń aktywny plik z kontekstu",
   "prompt.context.removeFile": "Usuń plik z kontekstu",
+  "prompt.thinking.tooltip": "Wysiłek rozumowania",
   "prompt.action.attachFile": "Załącz plik",
   "prompt.attachment.remove": "Usuń załącznik",
   "prompt.action.send": "Wyślij",
@@ -1719,6 +1720,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Automatycznie zwijaj rozumowanie",
   "settings.display.reasoningAutoCollapse.description":
     "Zwija bloki rozumowania po zakończeniu ich pisania przez agenta. Pozostaw wyłączone, aby rozumowanie pozostało rozwinięte, chyba że zwiniesz je ręcznie.",
+  "settings.display.shiftTabCycle.title": "Przełączaj wysiłek rozumowania za pomocą Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Naciśnij Shift+Tab w polu wprowadzania promptu, aby przełączyć się na następny poziom wysiłku rozumowania. Wyłącz tę opcję, aby zachować Shift+Tab do nawigacji fokusem za pomocą klawiatury.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -349,6 +349,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Включить активный файл",
   "prompt.context.removeActiveFile": "Удалить активный файл из контекста",
   "prompt.context.removeFile": "Удалить файл из контекста",
+  "prompt.thinking.tooltip": "Усилие рассуждения",
   "prompt.action.attachFile": "Прикрепить файл",
   "prompt.attachment.remove": "Удалить вложение",
   "prompt.action.send": "Отправить",
@@ -1717,6 +1718,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Автоматически сворачивать рассуждение",
   "settings.display.reasoningAutoCollapse.description":
     "Сворачивает блоки рассуждения после того, как агент закончит их писать. Оставьте выключенным, чтобы рассуждение оставалось раскрытым, пока вы не свернете его вручную.",
+  "settings.display.shiftTabCycle.title": "Переключать усилие рассуждения с помощью Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Нажмите Shift+Tab в поле ввода запроса, чтобы перейти к следующему уровню усилий рассуждения. Отключите эту настройку, чтобы сохранить Shift+Tab для навигации по фокусу с помощью клавиатуры.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -349,6 +349,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "รวมไฟล์ที่ใช้งานอยู่",
   "prompt.context.removeActiveFile": "เอาไฟล์ที่ใช้งานอยู่ออกจากบริบท",
   "prompt.context.removeFile": "เอาไฟล์ออกจากบริบท",
+  "prompt.thinking.tooltip": "ความพยายามในการให้เหตุผล",
   "prompt.action.attachFile": "แนบไฟล์",
   "prompt.attachment.remove": "เอาไฟล์แนบออก",
   "prompt.action.send": "ส่ง",
@@ -1687,6 +1688,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "ยุบเหตุผลอัตโนมัติ",
   "settings.display.reasoningAutoCollapse.description":
     "ยุบ block เหตุผลหลังจากเอเจนต์เขียนเสร็จ ปิดไว้เพื่อให้เหตุผลยังคงขยายอยู่ เว้นแต่คุณจะยุบเอง",
+  "settings.display.shiftTabCycle.title": "สลับระดับความพยายามในการให้เหตุผลด้วย Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "กด Shift+Tab ในช่องป้อนพรอมต์เพื่อสลับไปยังระดับความพยายามในการให้เหตุผลถัดไป ปิดใช้งานเพื่อคง Shift+Tab ไว้สำหรับการนำทางโฟกัสด้วยแป้นพิมพ์",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -350,6 +350,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Aktif dosyayı dahil et",
   "prompt.context.removeActiveFile": "Aktif dosyayı bağlamdan çıkar",
   "prompt.context.removeFile": "Dosyayı bağlamdan çıkar",
+  "prompt.thinking.tooltip": "Akıl yürütme eforu",
   "prompt.action.attachFile": "Dosya ekle",
   "prompt.attachment.remove": "Eki kaldır",
   "prompt.action.send": "Gönder",
@@ -1675,6 +1676,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Akıl yürütmeyi otomatik daralt",
   "settings.display.reasoningAutoCollapse.description":
     "Ajan yazmayı bitirdikten sonra akıl yürütme bloklarını daraltır. Manuel olarak daraltmadığınız sürece akıl yürütmenin geniş kalması için kapalı bırakın.",
+  "settings.display.shiftTabCycle.title": "Shift+Tab ile akıl yürütme eforunu değiştir",
+  "settings.display.shiftTabCycle.description":
+    "Bir sonraki akıl yürütme eforu seviyesine geçmek için komut girişinde Shift+Tab tuşlarına basın. Shift+Tab tuşunu klavye odağında gezinmek için korumak üzere devre dışı bırakın.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -351,6 +351,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "Включити активний файл",
   "prompt.context.removeActiveFile": "Видалити активний файл з контексту",
   "prompt.context.removeFile": "Видалити файл з контексту",
+  "prompt.thinking.tooltip": "Зусилля міркування",
   "prompt.action.attachFile": "Прикріпити файл",
   "prompt.attachment.remove": "Видалити вкладення",
   "prompt.action.send": "Надіслати",
@@ -1672,6 +1673,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "Автоматично згортати міркування",
   "settings.display.reasoningAutoCollapse.description":
     "Згортає блоки міркувань після того, як агент закінчить їх писати. Залиште вимкненим, щоб міркування залишалися розгорнутими, доки ви не згорнете їх вручну.",
+  "settings.display.shiftTabCycle.title": "Перемикати зусилля міркування за допомогою Shift+Tab",
+  "settings.display.shiftTabCycle.description":
+    "Натисніть Shift+Tab у полі введення запиту, щоб перейти до наступного рівня зусиль міркування. Вимкніть цю опцію, щоб зберегти Shift+Tab для навігації фокусом за допомогою клавіатури.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -346,6 +346,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "包含当前文件",
   "prompt.context.removeActiveFile": "从上下文移除活动文件",
   "prompt.context.removeFile": "从上下文移除文件",
+  "prompt.thinking.tooltip": "推理强度",
   "prompt.action.attachFile": "附加文件",
   "prompt.action.indexing": "索引设置",
   "prompt.action.autoApprove.enable": "启用自动审批",
@@ -1642,6 +1643,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "自动折叠推理",
   "settings.display.reasoningAutoCollapse.description":
     "在智能体写完推理后折叠推理块。保持关闭可让推理保持展开，除非你手动折叠它。",
+  "settings.display.shiftTabCycle.title": "使用 Shift+Tab 切换推理强度",
+  "settings.display.shiftTabCycle.description":
+    "在提示输入框中按 Shift+Tab 可切换到下一个推理强度等级。禁用此选项可将 Shift+Tab 用于键盘焦点导航。",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -346,6 +346,7 @@ export const dict = {
   "prompt.context.includeActiveFile": "包含作用中檔案",
   "prompt.context.removeActiveFile": "從上下文移除目前檔案",
   "prompt.context.removeFile": "從上下文移除檔案",
+  "prompt.thinking.tooltip": "推理強度",
   "prompt.action.attachFile": "附加檔案",
   "prompt.attachment.remove": "移除附件",
   "prompt.action.send": "傳送",
@@ -1606,6 +1607,9 @@ export const dict = {
   "settings.display.reasoningAutoCollapse.title": "自動收合推理",
   "settings.display.reasoningAutoCollapse.description":
     "在代理寫完推理後收合推理區塊。保持關閉可讓推理保持展開，除非你手動收合它。",
+  "settings.display.shiftTabCycle.title": "使用 Shift+Tab 切換推理強度",
+  "settings.display.shiftTabCycle.description":
+    "在提示輸入框中按 Shift+Tab 可切換至下一個推理強度等級。停用此選項可保留 Shift+Tab 用於鍵盤焦點導覽。",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -350,6 +350,13 @@ export interface IndexingSettingsLoadedMessage {
   }
 }
 
+export interface ChatSettingsLoadedMessage {
+  type: "chatSettingsLoaded"
+  settings: {
+    shiftTabCyclesVariant: boolean
+  }
+}
+
 export interface KiloEmbeddingModelsLoadedMessage {
   type: "kiloEmbeddingModelsLoaded"
   catalog: KiloEmbeddingModelCatalog
@@ -1128,6 +1135,7 @@ export type ExtensionMessage =
   | NavigateMessage
   | IndexingStatusLoadedMessage
   | IndexingSettingsLoadedMessage
+  | ChatSettingsLoadedMessage
   | KiloEmbeddingModelsLoadedMessage
   | ImageModelsLoadedMessage
   | ProvidersLoadedMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -477,6 +477,10 @@ export interface RequestIndexingSettingsMessage {
   type: "requestIndexingSettings"
 }
 
+export interface RequestChatSettingsMessage {
+  type: "requestChatSettings"
+}
+
 export interface RequestKiloEmbeddingModelsMessage {
   type: "requestKiloEmbeddingModels"
 }
@@ -1283,6 +1287,7 @@ export type WebviewMessage =
   | RequestGlobalConfigMessage
   | RequestIndexingStatusMessage
   | RequestIndexingSettingsMessage
+  | RequestChatSettingsMessage
   | RequestKiloEmbeddingModelsMessage
   | UpdateConfigMessage
   | OpenSettingsTabRequest


### PR DESCRIPTION
Switching reasoning effort currently requires opening the variant dropdown and picking the next level by hand, which is tedious when comparing outputs across effort levels. The CLI already offers variant cycling in the TUI; the VS Code extension had no keyboard path for it.

This adds Shift+Tab cycling to every prompt input that shows the reasoning variant selector:

- Sidebar chat and Agent Manager prompt (shared `PromptInput`)
- New Worktree dialog

Pressing Shift+Tab selects the next variant and wraps after the last one, matching the selector order. When a slash-command or file-mention dropdown is open it keeps its own Tab handling, and the ghost-text Tab accept is unaffected.

Because Shift+Tab is also the default backwards focus-navigation key, the behavior is gated by a new `kilo-code.new.chat.shiftTabCyclesVariant` setting (default on). Turning it off restores native focus navigation instantly, without reloading the webview. The toggle is also surfaced under Settings > Display in the Kilo settings panel. To keep the shortcut discoverable, the variant selector now shows a hover tooltip with the current meaning ("Reasoning effort") and a Shift+Tab keybind chip; the chip disappears when cycling is disabled.

The setting follows the existing extension-settings pipeline: a `chatSettingsLoaded`/`requestChatSettings` message pair, a config watcher pushing live updates, and validation in `handleUpdateSetting`. Includes translations for all 20 locales and unit tests for the cycle helper, the settings message, and validation.

<img width="500" alt="Sidebar prompt: variant selector tooltip with Shift+Tab hint" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260720-shift-tab-variant-tooltip.png?raw=true" />

<img width="700" alt="New Worktree dialog: variant selector tooltip with Shift+Tab hint" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260720-shift-tab-variant-am-tooltip.png?raw=true" />

<img width="700" alt="Display settings: Cycle Reasoning Effort with Shift+Tab toggle" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260720-shift-tab-variant-setting.png?raw=true" />