### PR TITLE
chore(ci): trim darwin test profile

### DIFF
--- a/packages/opencode/script/kilocode/test-profile.ts
+++ b/packages/opencode/script/kilocode/test-profile.ts
@@ -3,49 +3,30 @@ export namespace TestProfile {
   // Full Linux and Windows runs remain the backstop for platform-neutral behavior.
   const profiles = {
     darwin: {
-      description: "Darwin-native process, terminal, filesystem, worktree, and runtime coverage",
+      // Only tests whose failure would indicate a macOS-specific problem belong
+      // here: the seatbelt sandbox, node-pty, FSEvents watching, process/terminal
+      // spawning, and the darwin runtime artifact. Platform-neutral application
+      // logic (session loops, snapshots, HTTP routing, config, worktrees) is
+      // covered by the full Linux and Windows suites and must stay out — every
+      // file in this profile costs ~3x its Linux duration on the macos-15 runner.
+      description: "Darwin seatbelt sandbox, PTY, filesystem, and process runtime coverage",
       groups: {
-        cli: [
-          "cli/acp/lifecycle.test.ts",
-          "cli/run/run-process.test.ts",
-          "cli/serve/*.test.ts",
-          "cli/smokes/*.test.ts",
-          "cli/tui/{plugin-lifecycle,plugin-loader-entrypoint,thread}.test.ts",
-        ],
-        config: [
-          "config/{config,tui}.test.ts",
-          "control-plane/workspace.test.ts",
-        ],
         filesystem: [
           "filesystem/*.test.ts",
-          "fixture/fixture.test.ts",
-          "git/*.test.ts",
-          "image/*.test.ts",
-          "plugin/{install-concurrency,loader-shared}.test.ts",
-          "server/httpapi-reference.test.ts",
-          "snapshot/*.test.ts",
-          "tool/{apply_patch,edit,glob,grep,read,recall,registry,repo_clone,repo_overview,shell,skill,truncation,write}.test.ts",
-          "util/{filesystem,glob,module,process,which}.test.ts",
+          "kilocode/{external-directory-boundary,read-directory}.test.ts",
+          "util/filesystem.test.ts",
         ],
-        kilo: [
-          "kilocode/{background-process,daemon,diff-full,external-directory-boundary,indexing-worker,indexing-worktree,interactive-terminal,mcp-oauth-callback,primary-worktree,project-id,read-directory,session-diff-restore,snapshot-cache,snapshot-freeze-repro,snapshot-revert-move,snapshot-seed,task-nesting}.test.ts",
-          "kilocode/cli/cmd/serve.test.ts",
+        pty: ["pty/*.test.ts", "server/httpapi-pty.test.ts"],
+        runtime: [
+          "cli/serve/*.test.ts",
+          "kilocode/background-process.test.ts",
           "kilocode/cli/install-artifact.test.ts",
-          "kilocode/config/config.test.ts",
           "kilocode/core-watcher.test.ts",
-          "kilocode/sandbox/*.test.ts",
-          "kilocode/server/{config-overlay,listener-runtime,tui-config,worktree-list}.test.ts",
-          "kilocode/session-export/{e2e,sequence,worker,workspace-provider}.test.ts",
-          "kilocode/session-export/worker/{storage,zstd}.test.ts",
-          "kilocode/tool/repo_clone.test.ts",
-          "kilocode/worktree*.test.ts",
+          "kilocode/interactive-terminal.test.ts",
+          "tool/shell.test.ts",
+          "util/{process,which}.test.ts",
         ],
-        process: ["session/prompt.test.ts"],
-        project: ["project/*.test.ts"],
-        pty: ["pty/pty-*.test.ts", "server/httpapi-pty.test.ts"],
-        server: [
-          "server/{experimental-session-list,httpapi-experimental,httpapi-file,httpapi-listen,httpapi-workspace-routing,project-init-git,worktree-endpoint-repro}.test.ts",
-        ],
+        sandbox: ["kilocode/sandbox/*.test.ts"],
       },
     },
   } as const

--- a/packages/opencode/test/kilocode/test-profile.test.ts
+++ b/packages/opencode/test/kilocode/test-profile.test.ts
@@ -11,12 +11,12 @@ describe("test profiles", () => {
     const result = TestProfile.resolve("darwin", all)
     expect(result.ok).toBe(true)
     if (!result.ok) return
-    expect(result.files.length).toBeGreaterThan(50)
+    expect(result.files.length).toBeGreaterThan(20)
     expect(result.files).toContain("pty/pty-shell.test.ts")
     expect(result.files).toContain("kilocode/cli/install-artifact.test.ts")
     expect(result.files).toContain("kilocode/sandbox/macos-confinement.test.ts")
     expect(result.files).toContain("kilocode/core-watcher.test.ts")
-    expect(result.files).toContain("kilocode/tool/repo_clone.test.ts")
+    expect(result.files).toContain("kilocode/background-process.test.ts")
     expect(result.files).toContain("filesystem/filesystem.test.ts")
     expect(result.files).toContain("kilocode/interactive-terminal.test.ts")
     const sandbox = all.filter((file) => file.startsWith("kilocode/sandbox/"))
@@ -27,6 +27,17 @@ describe("test profiles", () => {
     expect(result.files).not.toContain("shell/shell.test.ts")
     expect(result.files).not.toContain("kilocode/sessions/remote-ws.test.ts")
     expect(result.files).not.toContain("provider/header-timeout.test.ts")
+    // Platform-neutral application logic is covered by the full Linux and
+    // Windows suites. Keep these heavy, darwin-agnostic files out of the
+    // profile so the single macOS shard stays fast.
+    expect(result.files).not.toContain("session/prompt.test.ts")
+    expect(result.files).not.toContain("snapshot/snapshot.test.ts")
+    expect(result.files).not.toContain("kilocode/daemon.test.ts")
+    expect(result.files).not.toContain("cli/smokes/read-only.test.ts")
+    expect(result.files).not.toContain("cli/acp/lifecycle.test.ts")
+    expect(result.files).not.toContain("cli/run/run-process.test.ts")
+    expect(result.files).not.toContain("kilocode/server/config-overlay.test.ts")
+    expect(result.files).not.toContain("server/httpapi-listen.test.ts")
   })
 
   test("normalizes Windows test paths", () => {


### PR DESCRIPTION
## Problem

On CLI-touching PRs the unit pipeline gates at **11-14 minutes**, set by the single `unit (macos)` job. Linux (2 shards) and Windows (4 shards) usually finish in 5-8 minutes.

The darwin profile drifted far beyond macOS-specific coverage. It ran 100 files containing ~1300s of test time, dominated by platform-neutral application logic that the full Linux and Windows suites already cover. From a recent main junit artifact:

| File | macOS | Linux | Coverage |
|---|---|---|---|
| `session/prompt.test.ts` | 213s | 98s | Session loop logic, no darwin API |
| `kilocode/daemon.test.ts` | 93s | 29s | Daemon lifecycle over HTTP, no darwin API |
| `cli/acp/lifecycle.test.ts` | 85s | 26s | ACP protocol logic |
| `cli/smokes/read-only.test.ts` | 83s | 24s | Covered by the retained serve-process smoke |
| `cli/run/run-process.test.ts` | 81s | 22s | Run command logic |
| `snapshot/snapshot.test.ts` | 78s | 26s | Git snapshot logic |
| `kilocode/server/config-overlay.test.ts` | 77s | 28s | Server config logic |

Every file also runs roughly 3x slower on the 3-vCPU `macos-15` runner, making macOS the most expensive place to duplicate platform-neutral coverage.

## Change

Trim the darwin profile to 24 files whose failure would indicate a macOS-specific problem:

- Seatbelt sandbox coverage (`kilocode/sandbox/*`, including tests that no-op on Linux)
- node-pty and HTTP PTY coverage
- FSEvents watching (`core-watcher`)
- Process and terminal behavior (`background-process`, `interactive-terminal`, `tool/shell`, `util/process`)
- Filesystem boundary behavior
- One `kilo serve` boot smoke and the darwin install artifact

Every removed test continues to run in the full Linux and Windows suites. Existing Linux and Windows sharding is unchanged. Non-CLI package tests also remain on macOS because `kilo-sandbox` contains genuine seatbelt coverage.

The profile's recorded test workload drops from ~1300s to ~218s without committing generated test inventories or timing snapshots.

<details>
<summary>Full list of the 76 files removed from the darwin profile (all still run on Linux and Windows)</summary>

- Session loops and snapshots: `session/prompt.test.ts`, `snapshot/snapshot.test.ts`, `kilocode/snapshot-{cache,freeze-repro,revert-move,seed}.test.ts`, `kilocode/session-diff-restore.test.ts`
- Daemon and CLI runtime: `kilocode/daemon.test.ts`, `cli/acp/lifecycle.test.ts`, `cli/run/run-process.test.ts`, `cli/smokes/read-only.test.ts`, `cli/tui/{plugin-lifecycle,plugin-loader-entrypoint,thread}.test.ts`, `kilocode/cli/cmd/serve.test.ts`
- HTTP API and server routing: `server/{experimental-session-list,httpapi-experimental,httpapi-file,httpapi-listen,httpapi-reference,httpapi-workspace-routing,project-init-git,worktree-endpoint-repro}.test.ts`, `kilocode/server/{config-overlay,listener-runtime,tui-config,worktree-list}.test.ts`, `kilocode/mcp-oauth-callback.test.ts`
- Config and project: `config/{config,tui}.test.ts`, `control-plane/workspace.test.ts`, `kilocode/config/config.test.ts`, `project/{instance,instance-bootstrap,migrate-global,project,project-directory,vcs,worktree,worktree-remove}.test.ts`
- Session export: `kilocode/session-export/{e2e,sequence,worker,workspace-provider}.test.ts`, `kilocode/session-export/worker/{storage,zstd}.test.ts`
- Worktrees: `kilocode/{primary-worktree,worktree-diff,worktree-diff-summary,worktree-family,worktree-family-submodule,worktree-project-skills,worktree-remove-lock}.test.ts`
- Tools and plugins: `tool/{apply_patch,edit,glob,grep,read,recall,registry,skill,truncation,write}.test.ts`, `plugin/{install-concurrency,loader-shared}.test.ts`, `kilocode/tool/repo_clone.test.ts`
- Misc neutral: `kilocode/{diff-full,indexing-worker,indexing-worktree,project-id,task-nesting}.test.ts`, `fixture/fixture.test.ts`, `git/git.test.ts`, `image/image.test.ts`, `util/{glob,module}.test.ts`

Kept (24 files): `kilocode/sandbox/*` (11, seatbelt is macOS-only), `pty/*` + `server/httpapi-pty.test.ts`, `kilocode/{background-process,core-watcher,external-directory-boundary,interactive-terminal,read-directory}.test.ts`, `kilocode/cli/install-artifact.test.ts`, `cli/serve/serve-process.test.ts`, `tool/shell.test.ts`, `filesystem/filesystem.test.ts`, `util/{filesystem,process,which}.test.ts`.

</details>
