### PR TITLE
feat: show live input progress for pending tool calls and speed up focused subagent streams

### DIFF
--- a/.changeset/subagent-streaming-progress.md
+++ b/.changeset/subagent-streaming-progress.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+---
+
+Show live input progress on pending tool cards while the model is still generating a tool call's arguments, so large writes and edits no longer look frozen, and stream subagent sessions of the focused session at near-parent cadence in Agent Manager instead of throttling them as background sessions.

--- a/packages/kilo-i18n/src/ar.ts
+++ b/packages/kilo-i18n/src/ar.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "تشغيل",
+  "session.messages.receivingToolInput": "جارٍ استلام الإدخال {{size}}",
   "ui.reasoning.label": "الاستدلال",
 
   // Marketplace

--- a/packages/kilo-i18n/src/br.ts
+++ b/packages/kilo-i18n/src/br.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Executar",
+  "session.messages.receivingToolInput": "Recebendo entrada {{size}}",
   "ui.reasoning.label": "Raciocínio",
 
   // Marketplace

--- a/packages/kilo-i18n/src/bs.ts
+++ b/packages/kilo-i18n/src/bs.ts
@@ -30,6 +30,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Pokreni",
+  "session.messages.receivingToolInput": "Primanje unosa {{size}}",
   "ui.reasoning.label": "Rezonovanje",
 
   // Marketplace

--- a/packages/kilo-i18n/src/da.ts
+++ b/packages/kilo-i18n/src/da.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Kør",
+  "session.messages.receivingToolInput": "Modtager input {{size}}",
   "ui.reasoning.label": "Ræsonnement",
 
   // Marketplace

--- a/packages/kilo-i18n/src/de.ts
+++ b/packages/kilo-i18n/src/de.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Ausführen",
+  "session.messages.receivingToolInput": "Eingabe wird empfangen {{size}}",
   "ui.reasoning.label": "Denken",
 
   // Marketplace

--- a/packages/kilo-i18n/src/en.ts
+++ b/packages/kilo-i18n/src/en.ts
@@ -27,6 +27,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Run",
+  "session.messages.receivingToolInput": "Receiving input {{size}}",
   "ui.reasoning.label": "Reasoning",
 
   // Marketplace

--- a/packages/kilo-i18n/src/es.ts
+++ b/packages/kilo-i18n/src/es.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Ejecutar",
+  "session.messages.receivingToolInput": "Recibiendo entrada {{size}}",
   "ui.reasoning.label": "Razonamiento",
 
   // Marketplace

--- a/packages/kilo-i18n/src/fr.ts
+++ b/packages/kilo-i18n/src/fr.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Exécuter",
+  "session.messages.receivingToolInput": "Réception de l'entrée {{size}}",
   "ui.reasoning.label": "Raisonnement",
 
   // Marketplace

--- a/packages/kilo-i18n/src/it.ts
+++ b/packages/kilo-i18n/src/it.ts
@@ -27,6 +27,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Esegui",
+  "session.messages.receivingToolInput": "Ricezione input {{size}}",
   "ui.reasoning.label": "Ragionamento",
 
   // Marketplace

--- a/packages/kilo-i18n/src/ja.ts
+++ b/packages/kilo-i18n/src/ja.ts
@@ -24,6 +24,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "実行",
+  "session.messages.receivingToolInput": "入力を受信中 {{size}}",
   "ui.reasoning.label": "推論",
 
   // Marketplace

--- a/packages/kilo-i18n/src/ko.ts
+++ b/packages/kilo-i18n/src/ko.ts
@@ -24,6 +24,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "실행",
+  "session.messages.receivingToolInput": "입력 받는 중 {{size}}",
   "ui.reasoning.label": "추론",
 
   // Marketplace

--- a/packages/kilo-i18n/src/nl.ts
+++ b/packages/kilo-i18n/src/nl.ts
@@ -27,6 +27,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Uitvoeren",
+  "session.messages.receivingToolInput": "Invoer ontvangen {{size}}",
   "ui.reasoning.label": "Redenering",
 
   // Marketplace

--- a/packages/kilo-i18n/src/no.ts
+++ b/packages/kilo-i18n/src/no.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Kjør",
+  "session.messages.receivingToolInput": "Mottar inndata {{size}}",
   "ui.reasoning.label": "Resonnement",
 
   // Marketplace

--- a/packages/kilo-i18n/src/pl.ts
+++ b/packages/kilo-i18n/src/pl.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Uruchom",
+  "session.messages.receivingToolInput": "Odbieranie danych wejściowych {{size}}",
   "ui.reasoning.label": "Rozumowanie",
 
   // Marketplace

--- a/packages/kilo-i18n/src/ru.ts
+++ b/packages/kilo-i18n/src/ru.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Запустить",
+  "session.messages.receivingToolInput": "Получение ввода {{size}}",
   "ui.reasoning.label": "Рассуждение",
 
   // Marketplace

--- a/packages/kilo-i18n/src/th.ts
+++ b/packages/kilo-i18n/src/th.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "เรียกใช้",
+  "session.messages.receivingToolInput": "กำลังรับอินพุต {{size}}",
   "ui.reasoning.label": "การให้เหตุผล",
 
   // Marketplace

--- a/packages/kilo-i18n/src/tr.ts
+++ b/packages/kilo-i18n/src/tr.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Çalıştır",
+  "session.messages.receivingToolInput": "Girdi alınıyor {{size}}",
   "ui.reasoning.label": "Akıl Yürütme",
 
   // Marketplace

--- a/packages/kilo-i18n/src/uk.ts
+++ b/packages/kilo-i18n/src/uk.ts
@@ -25,6 +25,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "Виконати",
+  "session.messages.receivingToolInput": "Отримання введення {{size}}",
   "ui.reasoning.label": "Міркування",
 
   // Marketplace

--- a/packages/kilo-i18n/src/zh.ts
+++ b/packages/kilo-i18n/src/zh.ts
@@ -23,6 +23,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "运行",
+  "session.messages.receivingToolInput": "正在接收输入 {{size}}",
   "ui.reasoning.label": "推理",
 
   // Marketplace

--- a/packages/kilo-i18n/src/zht.ts
+++ b/packages/kilo-i18n/src/zht.ts
@@ -23,6 +23,7 @@ export const dict = {
 
   // Reasoning block label
   "ui.permission.run": "執行",
+  "session.messages.receivingToolInput": "正在接收輸入 {{size}}",
   "ui.reasoning.label": "推理",
 
   // Marketplace

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -80,6 +80,7 @@ import {
 } from "./kilo-provider/notifications"
 import { childID } from "./kilo-provider/task-session"
 import { VisibleTaskStreams } from "./kilo-provider/visible-task-streams"
+import { FamilyStreamLanes } from "./kilo-provider/family-stream-lanes"
 import { handleNetworkEvent, clearNetworkWaits } from "./kilo-provider/network"
 import { SessionAbort } from "./kilo-provider/abort"
 import {
@@ -361,6 +362,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private pendingSessionRefresh = false // Refresh requested before the client is ready.
   private readonly streams = new SessionStreamScheduler((msg) => this.postMessage(msg))
   private readonly visibleTaskStreams = new VisibleTaskStreams((id, visible) => this.streams.setVisible(id, visible))
+  private readonly familyLanes = new FamilyStreamLanes((id, visible) =>
+    this.visibleTaskStreams.handle({ type: "streamSessionVisible", sessionID: id, visible }),
+  )
   private readonly confirmations = new MessageConfirmation()
   private readonly costs = new MaxCostNudge()
   private readonly activeAlerts = new Map<string, number>() // sid -> limit currently shown in UI
@@ -501,6 +505,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
   private focusSession(id?: string): void {
     this.streams.focus(id)
+    this.familyLanes.focus(id)
     this.registerPresence()
   }
 
@@ -973,6 +978,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           console.log("[Kilo New] KiloProvider: ✅ webviewReady received")
           this.isWebviewReady = true
           this.visibleTaskStreams.clear()
+          this.familyLanes.reassert()
           this.flushPendingKiloModel()
           await this.syncWebviewState("webviewReady")
           this.flushPendingReviewComments()
@@ -2072,6 +2078,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
     this.streams.drop(sessionID)
     this.visibleTaskStreams.delete(sessionID)
+    this.familyLanes.delete(sessionID)
     this.syncedChildSessions.delete(sessionID)
     this.sessionDirectories.delete(sessionID)
     this.aborts.delete(sessionID)
@@ -4104,9 +4111,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         sessionID?: string
       }
       const childId = childID(part)
-      if (childId && !this.trackedSessionIds.has(childId)) {
-        console.log("[Kilo New] KiloProvider: 🔗 Auto-adopting child session from task tool", { childId })
-        void this.handleSyncSession(childId, part.sessionID ?? sessionID)
+      if (childId) {
+        this.familyLanes.link(childId, part.sessionID ?? sessionID)
+        if (!this.trackedSessionIds.has(childId)) {
+          console.log("[Kilo New] KiloProvider: 🔗 Auto-adopting child session from task tool", { childId })
+          void this.handleSyncSession(childId, part.sessionID ?? sessionID)
+        }
       }
     }
 
@@ -4511,6 +4521,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.telemetryStateDisposable?.dispose()
     this.autoApproveBridge?.dispose()
     this.visibleTaskStreams.clear()
+    this.familyLanes.clear()
     this.streams.dispose()
     this.isWebviewReady = false
     // Release any waitForReady() awaiters so their callers don't hang after disposal.

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -484,6 +484,24 @@ function mapPartEvent(event: PartEvent, sessionID: string | undefined): WebviewM
   }
   if (!sessionID) return null
   const props = event.properties
+  if (props.field === "raw") {
+    // Tool-call argument fragments: carry them as a distinct delta type so the
+    // webview appends to the pending tool part's state.raw instead of treating
+    // the fragment as text-part content.
+    return {
+      type: "partUpdated",
+      sessionID: props.sessionID,
+      messageID: props.messageID,
+      part: {
+        id: props.partID,
+        type: "tool",
+        messageID: props.messageID,
+        sessionID: props.sessionID,
+        state: { status: "pending", input: {}, raw: props.delta },
+      },
+      delta: { type: "tool-input-delta", textDelta: props.delta },
+    }
+  }
   return {
     type: "partUpdated",
     sessionID: props.sessionID,

--- a/packages/kilo-vscode/src/kilo-provider/family-stream-lanes.ts
+++ b/packages/kilo-vscode/src/kilo-provider/family-stream-lanes.ts
@@ -1,0 +1,83 @@
+/**
+ * Family stream lanes.
+ *
+ * Grants the scheduler's "visible" lane (~50ms) to every session in the
+ * focused session's task family. Subagent sessions are discovered from task
+ * tool parts and normally sit in the adaptive background lane (150-400ms),
+ * which is right for sessions nobody watches — but the subagents of the
+ * session you ARE watching should stream at near-parent cadence. The sidebar
+ * only granted this when a task accordion was expanded, and Agent Manager
+ * never expands accordions, so its subagents always rendered 10-25x slower
+ * than their parent.
+ *
+ * Emissions must be ref-count compatible with VisibleTaskStreams (one
+ * "visible" ref per grant, one "hidden" ref per revoke) so accordion-driven
+ * visibility composes instead of clobbering.
+ */
+export class FamilyStreamLanes {
+  private readonly parents = new Map<string, string>()
+  private readonly grants = new Set<string>()
+  private focused: string | undefined
+
+  constructor(private readonly emit: (id: string, visible: boolean) => void) {}
+
+  /** Record a child→parent link discovered from a task tool part. */
+  link(child: string, parent: string | undefined): void {
+    if (!parent || child === parent) return
+    if (this.parents.get(child) === parent) return
+    this.parents.set(child, parent)
+    this.refresh()
+  }
+
+  focus(id: string | undefined): void {
+    if (this.focused === id) return
+    this.focused = id
+    this.refresh()
+  }
+
+  delete(id: string): void {
+    this.parents.delete(id)
+    if (!this.grants.delete(id)) return
+    this.emit(id, false)
+  }
+
+  /** Re-emit all active grants after the downstream ref store was reset. */
+  reassert(): void {
+    for (const id of this.grants) this.emit(id, true)
+  }
+
+  clear(): void {
+    for (const id of this.grants) this.emit(id, false)
+    this.grants.clear()
+    this.parents.clear()
+    this.focused = undefined
+  }
+
+  private reaches(id: string, root: string): boolean {
+    let cur: string | undefined = id
+    const seen = new Set<string>()
+    while (cur && cur !== root && !seen.has(cur)) {
+      seen.add(cur)
+      cur = this.parents.get(cur)
+    }
+    return cur === root
+  }
+
+  private refresh(): void {
+    const next = new Set<string>()
+    if (this.focused) {
+      for (const child of this.parents.keys()) {
+        if (child === this.focused) continue
+        if (this.reaches(child, this.focused)) next.add(child)
+      }
+    }
+    for (const id of this.grants) {
+      if (!next.has(id)) this.emit(id, false)
+    }
+    for (const id of next) {
+      if (!this.grants.has(id)) this.emit(id, true)
+    }
+    this.grants.clear()
+    for (const id of next) this.grants.add(id)
+  }
+}

--- a/packages/kilo-vscode/src/kilo-provider/session-stream-scheduler.ts
+++ b/packages/kilo-vscode/src/kilo-provider/session-stream-scheduler.ts
@@ -84,9 +84,15 @@ function partField(part: unknown, key: string): unknown {
   return (part as Record<string, unknown>)[key]
 }
 
-function appendPart(part: unknown, text: string): unknown {
+function appendPart(part: unknown, text: string, raw: boolean): unknown {
   if (!part || typeof part !== "object") return part
   const item = part as Record<string, unknown>
+  if (raw) {
+    if (item.type !== "tool") return part
+    const state = (item.state ?? {}) as Record<string, unknown>
+    const base = typeof state.raw === "string" ? state.raw : ""
+    return { ...item, state: { ...state, raw: base + text } }
+  }
   if ((item.type !== "text" && item.type !== "reasoning") || typeof item.text !== "string") return part
   return { ...item, text: item.text + text }
 }
@@ -103,11 +109,15 @@ function mergePartUpdate(prev: PartUpdate | undefined, msg: PartUpdate): PartUpd
   if (!prev) return msg
   const text = msg.delta?.textDelta
   if (!text) return msg.delta ? prev : msg
-  if (!prev.delta) return { ...prev, part: appendPart(prev.part, text) }
+  const type = msg.delta!.type
+  const raw = type === "tool-input-delta"
+  // A part only ever streams one field, so prev.delta and msg.delta always
+  // share the same type here; a full part with deltas baked in carries none.
+  if (!prev.delta || prev.delta.type !== type) return { ...prev, part: appendPart(prev.part, text, raw) }
   return {
     ...prev,
-    part: appendPart(prev.part, text),
-    delta: { type: "text-delta", textDelta: `${prev.delta.textDelta}${text}` },
+    part: appendPart(prev.part, text, raw),
+    delta: { type, textDelta: `${prev.delta.textDelta}${text}` } as PartUpdate["delta"],
   }
 }
 

--- a/packages/kilo-vscode/src/shared/stream-messages.ts
+++ b/packages/kilo-vscode/src/shared/stream-messages.ts
@@ -10,12 +10,20 @@
 
 export type PartTextDelta = { type: "text-delta"; textDelta: string }
 
+/**
+ * Incremental tool-call argument fragments (server `message.part.delta` with
+ * `field: "raw"`). Streamed while the model is still generating a tool call's
+ * arguments, so pending tool cards can show live input progress instead of
+ * sitting frozen for the many seconds a large write/edit takes to generate.
+ */
+export type PartToolInputDelta = { type: "tool-input-delta"; textDelta: string }
+
 export type PartUpdate<P = unknown> = {
   type: "partUpdated"
   sessionID: string
   messageID: string
   part: P
-  delta?: PartTextDelta
+  delta?: PartTextDelta | PartToolInputDelta
 }
 
 export type PartBatch<P = unknown> = {

--- a/packages/kilo-vscode/tests/unit/family-stream-lanes.test.ts
+++ b/packages/kilo-vscode/tests/unit/family-stream-lanes.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "bun:test"
+import { FamilyStreamLanes } from "../../src/kilo-provider/family-stream-lanes"
+
+function make() {
+  const sent: { id: string; visible: boolean }[] = []
+  const lanes = new FamilyStreamLanes((id, visible) => sent.push({ id, visible }))
+  return { lanes, sent }
+}
+
+describe("FamilyStreamLanes", () => {
+  it("grants the lane when a linked child's parent is focused", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("child", "root")
+    expect(sent).toEqual([{ id: "child", visible: true }])
+  })
+
+  it("grants immediately when focus arrives after the link", () => {
+    const { lanes, sent } = make()
+    lanes.link("child", "root")
+    expect(sent).toEqual([])
+    lanes.focus("root")
+    expect(sent).toEqual([{ id: "child", visible: true }])
+  })
+
+  it("grants nested grandchildren through the link chain", () => {
+    const { lanes, sent } = make()
+    lanes.link("child", "root")
+    lanes.link("grand", "child")
+    lanes.focus("root")
+    expect(sent).toEqual([
+      { id: "child", visible: true },
+      { id: "grand", visible: true },
+    ])
+  })
+
+  it("resolves chains that arrive out of order", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("grand", "child")
+    expect(sent).toEqual([])
+    lanes.link("child", "root")
+    expect(sent).toEqual([
+      { id: "grand", visible: true },
+      { id: "child", visible: true },
+    ])
+  })
+
+  it("ignores sessions outside the focused family", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("other", "elsewhere")
+    expect(sent).toEqual([])
+  })
+
+  it("revokes grants for the old family when focus changes", () => {
+    const { lanes, sent } = make()
+    lanes.link("child", "root")
+    lanes.link("next", "second")
+    lanes.focus("root")
+    lanes.focus("second")
+    expect(sent).toEqual([
+      { id: "child", visible: true },
+      { id: "child", visible: false },
+      { id: "next", visible: true },
+    ])
+  })
+
+  it("revokes everything when focus is cleared", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("child", "root")
+    lanes.focus(undefined)
+    expect(sent).toEqual([
+      { id: "child", visible: true },
+      { id: "child", visible: false },
+    ])
+  })
+
+  it("delete stops tracking and revokes an active grant", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("child", "root")
+    lanes.delete("child")
+    expect(sent).toEqual([
+      { id: "child", visible: true },
+      { id: "child", visible: false },
+    ])
+    // Link again: without a recorded parent there is no chain to the focus.
+    lanes.link("child", "root")
+    expect(sent).toHaveLength(3)
+    expect(sent[2]).toEqual({ id: "child", visible: true })
+  })
+
+  it("reassert re-emits active grants after a downstream reset", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("child", "root")
+    sent.length = 0
+    lanes.reassert()
+    expect(sent).toEqual([{ id: "child", visible: true }])
+  })
+
+  it("clear revokes all grants and forgets links", () => {
+    const { lanes, sent } = make()
+    lanes.focus("root")
+    lanes.link("child", "root")
+    lanes.clear()
+    expect(sent).toEqual([
+      { id: "child", visible: true },
+      { id: "child", visible: false },
+    ])
+    lanes.focus("root")
+    expect(sent).toHaveLength(2)
+  })
+
+  it("handles link cycles without looping", () => {
+    const { lanes, sent } = make()
+    lanes.link("a", "b")
+    lanes.link("b", "a")
+    lanes.focus("a")
+    // b reaches a through the cycle, a itself is never a "child" to grant.
+    expect(sent).toEqual([{ id: "b", visible: true }])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-stream-scheduler.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-stream-scheduler.test.ts
@@ -94,6 +94,44 @@ describe("SessionStreamScheduler / coalescing", () => {
     expect(partText(flat[0]!)).toBe("queued")
     expect(partText(flat[1]!)).toBe("noId")
   })
+
+  function toolUpdate(raw: string, delta?: string, sid = "sess-1", partID = "t1") {
+    const msg: Item = {
+      type: "partUpdated",
+      sessionID: sid,
+      messageID: "m1",
+      part: { id: partID, type: "tool", messageID: "m1", state: { status: "pending", input: {}, raw } },
+    }
+    if (delta === undefined) return msg
+    return { ...msg, delta: { type: "tool-input-delta", textDelta: delta } } as Item
+  }
+
+  function partRaw(msg: Item): string {
+    return (msg.part as { state: { raw: string } }).state.raw
+  }
+
+  it("merges repeated tool input deltas into state.raw", () => {
+    const sent = items(flushSync(toolUpdate("a", "a"), toolUpdate("b", "b")))
+    expect(sent).toHaveLength(1)
+    expect(partRaw(sent[0]!)).toBe("ab")
+    expect(sent[0]!.delta?.type).toBe("tool-input-delta")
+    expect(sent[0]!.delta?.textDelta).toBe("ab")
+  })
+
+  it("appends tool input deltas onto a queued pending tool part", () => {
+    const sent = items(flushSync(toolUpdate("{"), toolUpdate('"a"', '"a"')))
+    expect(sent).toHaveLength(1)
+    expect(partRaw(sent[0]!)).toBe('{"a"')
+    expect(sent[0]!.delta).toBeUndefined()
+  })
+
+  it("does not bake tool input deltas into non-tool parts", () => {
+    // A raw fragment for a part that isn't a tool (shouldn't happen on the
+    // wire) must not corrupt the queued part; the delta itself still merges.
+    const sent = items(flushSync(update("txt", undefined, "sess-1", "t1"), toolUpdate("x", "x")))
+    expect(sent).toHaveLength(1)
+    expect(partText(sent[0]!)).toBe("txt")
+  })
 })
 
 describe("SessionStreamScheduler / session isolation", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -19,6 +19,7 @@ import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import { childID } from "../../context/session-utils"
+import { formatCompactCount } from "../../utils/format"
 import { taskResult, taskRunning, taskVisible } from "./task-tool-state"
 
 const TaskToolRenderer: Component<ToolProps> = (props) => {
@@ -170,8 +171,16 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
               {(item) => {
                 const info = createMemo(() => getToolInfo(item().tool, item().state?.input))
                 const subtitle = createMemo(() => {
+                  const state = item().state as { status: string; title?: string; raw?: string }
+                  // While the model is still generating a tool call's arguments
+                  // (seconds for big writes/edits), show live input progress
+                  // instead of a row that looks frozen.
+                  if (state.status === "pending" && state.raw) {
+                    return language.t("session.messages.receivingToolInput", {
+                      size: `${formatCompactCount(state.raw.length)}B`,
+                    })
+                  }
                   if (info().subtitle) return info().subtitle
-                  const state = item().state as { status: string; title?: string }
                   if (state.status === "completed" || state.status === "running") return state.title
                   return undefined
                 })

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1446,6 +1446,35 @@ export const SessionProvider: ParentComponent = (props) => {
     setTools(sid, tools)
   }
 
+  /**
+   * Append a tool-call argument fragment to the pending tool part's state.raw,
+   * in both the message part list and the per-session tool index (they hold
+   * separate copies). No-op when the part hasn't arrived yet — the pending
+   * full-part update always precedes the first fragment on the wire.
+   */
+  function appendToolRaw(sessionID: string | undefined, messageID: string, partID: string, text: string) {
+    if (!text) return
+    setStore(
+      "parts",
+      produce((parts) => {
+        const item = parts[messageID]?.find((p) => p.id === partID)
+        if (!item || item.type !== "tool") return
+        const state = item.state as { raw?: string }
+        state.raw = (state.raw ?? "") + text
+      }),
+    )
+    if (!sessionID) return
+    const tools = store.toolParts[sessionID]
+    const index = tools?.findIndex((p) => p.id === partID) ?? -1
+    if (!tools || index < 0) return
+    const item = tools[index]!
+    // Only pending parts receive argument fragments; later states replace raw.
+    if (item.state.status !== "pending") return
+    const next = tools.slice()
+    next[index] = { ...item, state: { ...item.state, raw: (item.state.raw ?? "") + text } }
+    setTools(sessionID, next)
+  }
+
   function dropToolPart(sessionID: string | undefined, partID: string) {
     if (!sessionID) return
     setTools(sessionID, removeSessionToolPart(store.toolParts[sessionID] ?? [], partID))
@@ -1622,6 +1651,21 @@ export const SessionProvider: ParentComponent = (props) => {
     }
 
     if (sessionID) patchPage(sessionID, { lastMutation: "update" })
+
+    // Tool-call argument fragments append to the pending tool part's state.raw.
+    // They never go through patchToolPart/the generic replace path: the update
+    // carries only a minimal stub part, and upserting that stub would clobber
+    // the real tool part's name/input in the session tool index.
+    if (delta?.type === "tool-input-delta") {
+      const stashed = stash.peek(effectiveMessageID)
+      if (stashed) {
+        stash.remove(effectiveMessageID)
+        setStore("parts", effectiveMessageID, stashed)
+      }
+      appendToolRaw(sessionID ?? part.sessionID, effectiveMessageID, part.id, delta.textDelta ?? "")
+      return
+    }
+
     patchToolPart(sessionID, effectiveMessageID, part)
 
     // If the stash has parts for this message, hydrate them first so the

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -1,6 +1,8 @@
 // Tool state for tool parts
 export type ToolState =
-  | { status: "pending"; input: Record<string, unknown> }
+  // raw holds the still-generating tool-call arguments while pending, streamed
+  // via tool-input-delta updates so pending cards can show live input progress.
+  | { status: "pending"; input: Record<string, unknown>; raw?: string }
   | { status: "running"; input: Record<string, unknown>; title?: string }
   | {
       status: "completed"
@@ -90,10 +92,7 @@ export interface CompactionPart extends BasePart {
 export type Part = TextPart | FilePart | ToolPart | ReasoningPart | StepStartPart | StepFinishPart | CompactionPart
 
 // Part delta for streaming updates
-export interface PartDelta {
-  type: "text-delta"
-  textDelta?: string
-}
+export type PartDelta = { type: "text-delta"; textDelta?: string } | { type: "tool-input-delta"; textDelta?: string }
 
 // Token usage for assistant messages
 export interface TokenUsage {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -552,6 +552,17 @@ export const layer = Layer.effect(
                 })
               }
               ctx.toolcalls[value.id] = { ...toolCall.call, raw: toolCall.call.raw + value.text }
+              // kilocode_change start - stream tool input progress so clients can
+              // render live feedback while a large tool call's arguments are
+              // still being generated (big writes/edits take many seconds)
+              yield* session.updatePartDelta({
+                sessionID: toolCall.call.sessionID,
+                messageID: toolCall.call.messageID,
+                partID: toolCall.call.partID,
+                field: "raw",
+                delta: value.text,
+              })
+              // kilocode_change end
             }
             return
 


### PR DESCRIPTION
Subagent sessions in Agent Manager looked frozen or throttled while their parent session streamed smoothly. Two compounding causes:

1. While a model generates a tool call's arguments, no events reached the UI between the "pending" and "running" states. A single response containing a large write or a multi-file apply_patch streams 10-20KB of arguments at model token speed, which meant 10-35 seconds of total UI silence per tool call. File-editing and research subagents spent most of their wall time in these invisible windows, so they appeared to crawl even though token generation was normal. Measured at the raw SSE level: a solo subagent and four concurrent subagents show identical step timings, so this is not provider throttling.

2. The extension's stream scheduler flushes the focused session at 16ms but throttles every other tracked session adaptively up to 400ms. Only an expanded, mounted task accordion granted a child the 50ms "visible" lane, so nested subagents and any child whose card was scrolled out of the virtualized transcript always rendered at background cadence, even while the user was watching their parent.

What changed:

- The CLI now emits a lightweight `message.part.delta` (`field: "raw"`) for each tool-call argument fragment. The extension maps it to a new `tool-input-delta` wire type that the scheduler coalesces like text deltas, and the webview appends it to the pending tool part's `state.raw`. Pending tool rows in the expanded task tool list now show live "Receiving input N KB" progress, turning the multi-second frozen windows into visible streaming. Existing consumers (ACP, `kilo run`, remote sessions) all filter `field === "text"`, so the new fragments are inert outside the extension.
- A new `FamilyStreamLanes` tracker grants the 50ms visible lane to every session in the focused session's task family (including nested subagents), ref-counted through the existing `VisibleTaskStreams` so it composes with accordion-driven visibility instead of clobbering it. Grants follow focus changes, are released on session deletion, and are re-asserted after webview reloads.

<img width="700" alt="Agent Manager showing a pending Write tool row with live 'Receiving input 4.8KB' progress inside an expanded subagent task card" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260720-subagent-tool-input-progress.png?raw=true" />
