### PR TITLE
fix(sandbox): tolerate unreadable directories during Linux writable-root scan

### DIFF
--- a/.changeset/sandbox-unreadable-directory-scan.md
+++ b/.changeset/sandbox-unreadable-directory-scan.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Keep Linux sandbox setup working when a writable directory contains an unreadable subdirectory (for example a folder with mode 600); unreadable subdirectories are now protected with a read-only mount instead of failing every sandboxed tool call with an access error.

--- a/packages/kilo-sandbox/src/bubblewrap.ts
+++ b/packages/kilo-sandbox/src/bubblewrap.ts
@@ -98,6 +98,26 @@ function validate(allow: ReadonlyArray<PathRule>, executable: string, mounts: Re
   }
 }
 
+function code(cause: unknown) {
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) return undefined
+  const value = (cause as { code: unknown }).code
+  return typeof value === "string" ? value : undefined
+}
+
+// Lists one directory during the deny-name scan. A directory that vanished mid-scan
+// (ENOENT/ENOTDIR) is treated as empty, and an unreadable directory (EACCES/EPERM)
+// yields undefined so the caller can protect it instead of failing the whole scan.
+function list(dir: string) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+  } catch (cause) {
+    const tag = code(cause)
+    if (tag === "ENOENT" || tag === "ENOTDIR") return []
+    if (tag === "EACCES" || tag === "EPERM") return undefined
+    throw cause
+  }
+}
+
 function scan(root: string, names: ReadonlySet<string>, found: Set<string>) {
   if (names.has(path.basename(root))) {
     found.add(root)
@@ -109,7 +129,16 @@ function scan(root: string, names: ReadonlySet<string>, found: Set<string>) {
   while (pending.length > 0) {
     const dir = pending.pop()
     if (!dir) continue
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entries = list(dir)
+    if (!entries) {
+      // Fail closed: a nested directory that cannot be enumerated might hide a deny-name
+      // match, so it is re-bound read-only as a whole rather than aborting sandbox setup.
+      // The writable root itself must stay readable, or there is nothing to scan.
+      if (dir === root) throw new Error(`Writable root is not readable: ${root}`)
+      found.add(dir)
+      continue
+    }
+    for (const entry of entries) {
       const target = path.join(dir, entry.name)
       if (names.has(entry.name)) {
         found.add(target)

--- a/packages/kilo-sandbox/test/backend.test.ts
+++ b/packages/kilo-sandbox/test/backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { Effect, PlatformError, Result } from "effect"
@@ -32,6 +32,17 @@ const launch: Launch = {
     HTTPS_PROXY: "http://127.0.0.1:9000",
     no_proxy: "*",
   },
+}
+
+// chmod-based permission tests only work when the test user is not root,
+// since root bypasses filesystem permission checks entirely.
+function readable(dir: string) {
+  try {
+    readdirSync(dir)
+    return true
+  } catch {
+    return false
+  }
 }
 
 describe("sandbox launch preparation", () => {
@@ -122,6 +133,60 @@ describe("sandbox launch preparation", () => {
       expect(result.args.indexOf("--unshare-net")).toBeGreaterThan(result.args.indexOf("--unshare-pid"))
       expect(result.args.slice(-3)).toEqual(["--", "/bin/echo", "hello"])
     } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test("re-binds unreadable directories read-only instead of failing Linux setup", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "kilo-bubblewrap-unreadable-"))
+    const git = path.join(root, ".git")
+    const secrets = path.join(root, "secrets")
+    mkdirSync(git)
+    mkdirSync(secrets)
+    chmodSync(secrets, 0o000)
+    const profile: Profile = {
+      ...makeProfile("allow"),
+      filesystem: {
+        allowWrite: [{ path: root, kind: "subtree" }],
+        denyWrite: [],
+        denyNames: [".git"],
+      },
+    }
+
+    try {
+      if (readable(secrets)) return
+      const result = generateBubblewrap(profile, { ...launch, cwd: root }, "/opt/kilo/bwrap")
+      const writable = result.args.indexOf("--bind")
+      expect(result.args.slice(writable, writable + 3)).toEqual(["--bind", root, root])
+      const first = result.args.indexOf("--ro-bind", writable + 3)
+      expect(result.args.slice(first, first + 3)).toEqual(["--ro-bind", git, git])
+      const second = result.args.indexOf("--ro-bind", first + 3)
+      expect(result.args.slice(second, second + 3)).toEqual(["--ro-bind", secrets, secrets])
+    } finally {
+      chmodSync(secrets, 0o700)
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test("rejects an unreadable writable root", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "kilo-bubblewrap-root-"))
+    chmodSync(root, 0o000)
+    const profile: Profile = {
+      ...makeProfile("allow"),
+      filesystem: {
+        allowWrite: [{ path: root, kind: "subtree" }],
+        denyWrite: [],
+        denyNames: [".git"],
+      },
+    }
+
+    try {
+      if (readable(root)) return
+      expect(() => generateBubblewrap(profile, { ...launch, cwd: root }, "/opt/kilo/bwrap")).toThrow(
+        `Writable root is not readable: ${root}`,
+      )
+    } finally {
+      chmodSync(root, 0o700)
       rmSync(root, { recursive: true, force: true })
     }
   })


### PR DESCRIPTION
On Linux, the bubblewrap backend prepares every sandboxed process launch by scanning each writable root for deny-name matches (`.git`) that must be re-mounted read-only. That scan used a bare recursive `readdirSync`, so a single unreadable directory anywhere beneath a writable path (for example a restricted folder like `/kilo/secrets`) threw `EACCES ... scandir` and aborted the entire launch preparation. Every sandboxed tool call then failed with an access error, no matter which path the agent actually tried to write.

The deny-name scan in `packages/kilo-sandbox` now tolerates per-directory failures instead of aborting setup:

- An unreadable nested directory (EACCES/EPERM) is itself re-bound read-only via `--ro-bind`. This fails closed: a directory that cannot be enumerated might hide a `.git`, so the whole subtree is protected rather than silently skipped. Bind-mounting only needs search permission on the ancestors, so the launch succeeds while the directory stays inaccessible and read-only inside the sandbox. Silently skipping would have left a `.git` writable in the execute-only directory corner.
- A directory that vanishes mid-scan (ENOENT/ENOTDIR race) is skipped.
- An unreadable writable root still fails setup, now with a clear `Writable root is not readable: <path>` instead of a raw scandir error.
- Any other error still aborts the launch, so nothing ever falls back to unsandboxed execution.

The macOS seatbelt backend is unaffected (deny names are enforced by a kernel-level regex, no filesystem scan), so this only changes the Linux bubblewrap path. Writes inside the restricted directory itself remain impossible: a permission-denied directory rejects writes at the OS level regardless of sandbox setup.

The generated mount layout is covered by new tests that build a writable tree containing a permission-denied subdirectory and assert the launch still constructs, with both the discovered `.git` and the unreadable directory mounted read-only. Actual `bwrap` execution has not been exercised yet (development machine is macOS), so one quick smoke check on Linux is worthwhile before merge: create `project/` plus a restricted `secrets/` inside a writable path, enable the sandbox, and confirm sandboxed writes into `project/` succeed while `secrets/` stays inaccessible.