### PR TITLE
fix(ui): stop diff content bleeding through sticky tool card headers

### DIFF
--- a/.changeset/edit-tool-sticky-header.md
+++ b/.changeset/edit-tool-sticky-header.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix diff content painting through and above the sticky headers of expanded Edit, Write, and Apply Patch tool cards when scrolling large diffs.

--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -286,6 +286,31 @@ html[data-theme="kilo-vscode"] [data-component="tool-part-wrapper"][data-part-ty
     }
   }
 
+  /* Expanded edit/write/apply_patch triggers stick to the top while their diff scrolls
+     underneath, so they must stay opaque in every state; otherwise diff rows show
+     through the header. !important because the trigger hover rule below uses a
+     translucent hover background and would re-open the leak on hover. */
+  :is([data-component="edit-tool"], [data-component="write-tool"], [data-component="apply-patch-tool"])
+    > [data-component="collapsible"]
+    > [data-slot="collapsible-trigger"][aria-expanded="true"] {
+    background-color: var(--background-stronger) !important;
+  }
+
+  /* The sticky headers pin to the visible top edge of the transcript. The message
+     list's 12px top padding otherwise leaves a strip above the stuck trigger where
+     the scrolling diff stays visible. Both the trigger and the inner file header
+     consume --sticky-accordion-top, so they shift up together and stay flush. */
+  :is([data-component="edit-tool"], [data-component="write-tool"], [data-component="apply-patch-tool"]) {
+    --sticky-accordion-top: -12px;
+  }
+
+  /* The inner file accordion sticks below the compact 28px tool trigger. The inline
+     default offset (37px) matches the taller upstream trigger and leaves a gap where
+     diff rows peek through between the two stuck headers. */
+  [data-component="accordion"][data-scope="apply-patch"] {
+    --sticky-accordion-offset: 28px !important;
+  }
+
   /* Reposition copy button tooltip to appear below (not above) to avoid clipping */
   [data-component="tool-output"] [data-slot="markdown-copy-button"]::after {
     bottom: auto;


### PR DESCRIPTION
When an Edit, Write, or Apply Patch tool card is expanded and its diff is taller than the viewport, the card headers pin to the top of the transcript while the diff scrolls underneath. Three leaks let the scrolling diff paint through where it should be occluded:

- The expanded trigger kept its default background, and the hover rule applies a translucent background, so diff rows showed through the header itself, most visibly on hover.
- The trigger pinned below the message list's 12px top padding instead of at the visible transcript edge, leaving a strip above the stuck header where the diff stayed visible.
- The inner apply-patch file accordion stuck 37px below the top, matching the taller upstream trigger. Kilo's compact 28px trigger left a gap between the two stuck headers where diff rows peeked through.

The fix makes expanded edit, write, and apply-patch triggers fully opaque in every state (including hover), shifts their sticky position up by the list's top padding so they pin flush with the visible top edge, and reduces the apply-patch accordion's sticky offset to match the compact trigger height.

Before:
<img width="875" height="232" alt="file-910cfa7fe94792ac5e783ec895ecef04" src="https://github.com/user-attachments/assets/ca31edc0-ba4a-4a7f-9df5-9e26e0fb3b0d" />

After:
<img width="977" height="228" alt="file-73a1558f4d5e16304e9f2db3d71eae6c" src="https://github.com/user-attachments/assets/bbed4c5a-06ba-47c9-b634-30a02e398a2b" />
