### PR TITLE
review: post-merge reports for OpenCode v1.17.5

### DIFF
--- a/BROKEN_PIPELINE_CHAINS.md
+++ b/BROKEN_PIPELINE_CHAINS.md
@@ -1,0 +1,115 @@
+# Broken Pipeline Chains Review: OpenCode v1.17.5 Merge
+
+## Scope And Method
+
+Reviewed `origin/main...HEAD` on `marius-kilocode/review-opencode-v1.17.5` (PR #12404), with the Kilo-base reference at `.worktrees/opencode-merge/kilo-main` and pristine OpenCode `v1.17.5` at `.worktrees/opencode-merge/opencode`.
+
+The range changes 194 files across 46 commits. I enumerated the 18 changed paths whose diff includes `kilocode_change`, then traced producer, handoff, and consumer links for the merge conflict domains and the Kilo-specific paths most exposed to silent wiring loss. This included source inspection, base/upstream comparisons, targeted tests, generated SDK inspection, and a temporary authenticated `kilo serve` probe. The probe database and server were removed afterward.
+
+The marker-bearing changes fell into these grouped domains:
+
+- Session-message compatibility migrations and projection ordering.
+- Connector-to-Integration and credential model migration, including Kilo legacy JSON credential handling and OpenAI OAuth headers.
+- Database and Ripgrep LayerNode composition.
+- AppRuntime ProjectCopy composition, InstanceStore exit settlement, HTTP route composition, and prompt hooks.
+- TUI Integration data refresh and Kilo-specific TUI rendering.
+
+The reviewed conflict resolutions also included the requested nullable `seq` migration, credential Kilo blocks, ProjectCopy dependencies, lazy `Database.node`, InstanceStore `onExit`, Integration settlement guards, and `server.ts` Kilo route assembly.
+
+## Findings
+
+### High: Fresh databases bypass the nullable `session_message.seq` compatibility migration
+
+**Chain:** Kilo compatibility requirement for released writers -> `SessionMessageTable.seq` nullable -> `20260714141136_session-message-legacy-writer-compat` rebuilds the table with nullable `seq` -> fresh database initialization -> released client writes a legacy message without `seq`.
+
+The producer and existing-database migration are correct, but the new upstream fresh-database bootstrap introduced a different intermediate path that was not reconciled with Kilo's compatibility change:
+
+- `packages/core/src/session/sql.ts:127` declares `seq: integer()` with the Kilo compatibility comment.
+- `packages/core/src/database/migration/20260714141136_session-message-legacy-writer-compat.ts:14` creates `seq integer`, also nullable.
+- `packages/core/src/database/schema.gen.ts:177` instead creates `seq integer NOT NULL`.
+- `packages/core/src/database/migration.ts:28-36` uses `schema.up(tx)` for an empty database and then records every migration as completed. Therefore the nullable compatibility migration is deliberately not replayed for fresh databases.
+
+This is a real behavior split, not just a declarative mismatch. An existing database upgraded through the migration accepts the older writer's row without `seq`; a database first created by the merged build does not. The intended cross-version sharing guarantee fails whenever a current Kilo creates the database before a released client accesses it.
+
+The base worktree's `DatabaseMigration.apply` replayed the migration sequence for fresh databases. Upstream v1.17.5 changed it to bootstrap `schema.gen.ts` and mark the migration list complete. The merge introduced `schema.gen.ts` with upstream's `NOT NULL` table definition while retaining Kilo's nullable runtime schema and migration.
+
+Current tests cover upgrade/repair paths but not this path. `packages/core/test/kilocode/database-migration-compat.test.ts` starts from an older schema and applies the compatibility migration. `packages/core/test/database-migration.test.ts` checks that a fresh database has the expected tables and indexes, but does not inspect `session_message.seq` nullability or write a legacy no-`seq` row after fresh initialization.
+
+### High: Production `kilo serve` drops all `@opencode-ai/server` V2 server routes
+
+**Chain:** `Api` registers Integration, Credential, and ProjectCopy groups -> `handlers` supplies their handlers -> `serverRoutes` mounts `HttpApiBuilder.layer(Api)` -> `createRoutes` includes `serverRoutes` -> `kilo serve` should expose the generated SDK endpoints.
+
+The upstream listener refactor split the full route graph from a new listener graph, and the Kilo resolution leaves `serverRoutes` out of the production listener:
+
+- `packages/opencode/src/server/routes/instance/httpapi/server.ts:187-192` builds `serverRoutes` from `@opencode-ai/server` `Api` and provides Kilo's reference-aware handler graph.
+- `packages/server/src/handlers.ts:26-51` merges `IntegrationHandler`, `CredentialHandler`, and `ProjectCopyHandler` into that graph.
+- `packages/opencode/src/server/routes/instance/httpapi/server.ts:285-291` includes `serverRoutes` in `createRoutes`.
+- `packages/opencode/src/server/routes/instance/httpapi/server.ts:318-320` builds `createListenerRoutes` from only root, event, PTY, instance, documentation, and UI routes. It omits `serverRoutes`.
+- `packages/opencode/src/server/server.ts:111-113` starts `createListenerRoutes`, and `packages/opencode/src/cli/cmd/serve.ts:15-21` calls `Server.listen` for the shipped `kilo serve` command.
+
+The SDK and OpenAPI promise the absent endpoints. `packages/sdk/openapi.json` and the generated client include `/api/integration/*`, `/api/credential/{credentialID}`, and `/experimental/project/{projectID}/copy*`; `packages/tui/src/context/data.tsx:543-554` calls `sdk.client.v2.integration.list`, while `packages/tui/src/component/prompt/move.tsx:40-49` and `packages/tui/src/component/dialog-move-session.tsx:70-73` call V2 ProjectCopy endpoints.
+
+The temporary real-listener probe confirmed the wiring result after authenticating as `kilo`:
+
+```text
+GET /api/integration       -> 404 {"error":"Not Found"}
+GET /indexing/status       -> 200
+```
+
+`/indexing/status` is an `InstanceHttpApi` Kilo route and remains in the listener. This controls for listener startup/authentication and isolates the omission to the `serverRoutes` branch. The normal server therefore advertises SDK operations that return 404, including the only HTTP path that reaches the new Integration attempt completion/cancellation handlers. In-process `Server.Default()` and tests built from `HttpApiApp.routes` do include the routes, which explains why compilation and existing HTTP API tests remain green.
+
+### Needs Human Verification, Low: InstanceStore interruption fix has no focused retry regression test
+
+**Chain:** `load` or `reload` inserts an `Entry` -> a boot fiber runs `completeLoad` -> scope interruption/failure occurs -> `onExit` removes the failed cache entry and completes its deferred -> a later caller can load the directory.
+
+The source chain appears correct. `packages/opencode/src/project/instance-store.ts:80-88` wraps boot in `Effect.onExit`, removes failed entries, and settles the deferred. Both `load` and `reload` fork that effect into the store scope and await the deferred at lines 122-165. This fixes the previously possible permanently pending cache entry.
+
+No focused test was found that blocks `InstanceBootstrap.run`, interrupts the boot fiber or enclosing scope, and then proves a second `load` resolves. The existing `packages/opencode/test/kilocode/project/instance-store.test.ts` covers concurrent and interrupted disposal rather than boot interruption. This is not evidence of a current break, but this race is important enough to exercise manually or with a targeted regression test.
+
+## Notable Non-Findings
+
+- **Integration settlement implementation is internally intact.** Plugins receive the location-scoped `Integration.Service` through `PluginBoot` (`packages/core/src/plugin/boot.ts:60-96`) and register methods, including OpenAI's OAuth methods. `Integration.connect.oauth` records the pending attempt, `settle` persists through `Credential.create`, and the completion/cancellation handlers call `service.attempt.complete` and `service.attempt.cancel` directly (`packages/server/src/handlers/integration.ts:51-101`). The restored `settling` guards prevent cancellation or expiry from overtaking credential persistence. `packages/core/test/integration.test.ts` covers code completion, cancellation, automatic completion, expiry, and persistence. The production HTTP exposure for this otherwise intact path is broken by the listener finding above.
+
+- **Kilo credential removal follows the new Integration identity.** Legacy imports and `KILO_AUTH_CONTENT` normalize keys with `replace(/\/+$/, "")` before constructing `IntegrationSchema.ID` in `packages/core/src/credential.ts:142`, `163`, and `230`. `KiloAuth.remove` applies the same normalization, calls `credentials.list(integration)`, removes each returned record, then removes legacy auth (`packages/opencode/src/kilocode/auth/remove.ts:6-15`). The new `Credential.remove` implementation handles both persistent and injected process-local values (`packages/core/src/credential.ts:394-405`). `packages/opencode/test/kilocode/auth-remove.test.ts` passes.
+
+- **ProjectCopy dependencies are present in both service constructions.** The AppRuntime conflict resolution provides Database, FSUtil, core Git, EventV2, and ProjectDirectories to `ProjectCopy.layer` (`packages/opencode/src/effect/app-runtime.ts:126-132`). The LayerNode route graph uses `ProjectCopy.node`, whose declared dependencies match that service (`packages/core/src/project/copy.ts:146-299`). The full route graph's handler consumes `ProjectCopy.Service`. No direct `ProjectCopy.Service` consumer through `AppRuntime.runPromise` was found; this is an observation, not a missing dependency.
+
+- **Lazy `Database.node` remains connected.** `Database.node` now defers `path()` until layer construction (`packages/core/src/database/database.ts:70-71`). The LayerNode route graph includes that single node (`packages/opencode/src/server/routes/instance/httpapi/server.ts:223-280`), and LayerNode caches nodes while recursively providing dependencies. AppRuntime uses its independent `Database.defaultLayer`, as intended for process-wide services. No dangling `Database.node` consumer or missing LayerNode dependency was found.
+
+- **Prompt requirement and review telemetry hooks survive the merge.** Command execution still resolves the command-selected agent, invokes `agents.guardRequirements(agent)`, marks template text parts with `KiloSessionProcessor.markReviewTelemetry`, and passes the resulting parts to `prompt` (`packages/opencode/src/session/prompt.ts:2074-2127`). The metadata extractor and completion telemetry consumer remain in `packages/opencode/src/kilocode/session/processor.ts` and `packages/opencode/src/session/processor.ts`.
+
+- **SDK regeneration restored the requested Kilo surface.** `packages/sdk/js/src/v2/gen/sdk.gen.ts` includes client classes for `BackgroundProcess`, `Indexing`, `InteractiveTerminal`, `Notebook`, `AgentManager`, and `Memory`. Its event union includes `session.network.asked`, `interactive_terminal.*`, `memory.*`, `indexing.*`, Agent Manager, and Notebook events in `packages/sdk/js/src/v2/gen/types.gen.ts:7-123`. Representative VS Code consumers still import generated `NotebookRequest`, `AgentManagerRequest`, `MemoryStatusResponse`, and `IndexingStatus` types. The listener probe also confirmed a Kilo instance route (`/indexing/status`) remains live.
+
+## Short Command Excerpts
+
+```text
+$ bun test ./test/database-migration.test.ts ./test/kilocode/database-migration-compat.test.ts ./test/integration.test.ts ./test/credential.test.ts
+30 pass
+0 fail
+
+$ bun test ./test/kilocode/auth-remove.test.ts ./test/server/project-copy.test.ts
+2 pass
+0 fail
+```
+
+```text
+$ git diff --name-only origin/main...HEAD | wc -l
+194
+
+$ git diff --name-only origin/main...HEAD ... kilocode_change marker files | wc -l
+18
+```
+
+```text
+$ authenticated real `kilo serve` probe
+GET /api/integration  -> 404
+GET /indexing/status  -> 200
+```
+
+`git diff --check origin/main...HEAD` produced no whitespace errors.
+
+## Limitations
+
+- This was a source-and-runtime-chain audit, not a full clean build or full integration suite. CI was already reported green; focused core and CLI tests above were run instead.
+- The real listener probe intentionally used a temporary database and did not perform external OAuth or gateway authentication.
+- The source tree was not edited. This report is the only file created by this review; pre-existing untracked report files were left untouched.

--- a/CONFIG_REGRESSION.md
+++ b/CONFIG_REGRESSION.md
@@ -1,0 +1,119 @@
+# Config Regression Review: OpenCode v1.17.5 Merge (PR #12404)
+
+## Scope and Methodology
+
+Reviewed the PR tip `06d871409b` (`marius-kilocode/review-opencode-v1.17.5`) against `origin/main` (`0cf9f902e0`) for configuration discovery, loading, path resolution, and config-adjacent discovery. The supplied comparison trees were also inspected:
+
+- Pristine upstream: `.worktrees/opencode-merge/opencode` at `8d78715d64` (`v1.17.5`).
+- Kilo merge base: `.worktrees/opencode-merge/kilo-main` at `12147d1602`.
+
+The review covered `packages/opencode/src/config/`, `packages/opencode/src/kilocode/config/`, `packages/core/src/config.ts`, global/flag paths, MCP config writes, instructions, skills, agents, commands, TUI/theme/keybind migration, and ignore files. No source files were edited. This report is the only file created by the review.
+
+## Findings
+
+### High: Automatic `opencode.json*` and legacy `config.json` loading remains in the reviewed tree
+
+**Classification:** Pre-existing in `origin/main` and the supplied Kilo merge base. This is **not introduced by the v1.17.5 PR diff**, but it conflicts with the stated `.kilo`/`kilo.json`-only policy and should be resolved separately or explicitly accepted by a human.
+
+The main v1 loader still reads legacy files automatically:
+
+- `packages/opencode/src/config/config.ts:193` chooses a global update target from `kilo.jsonc`, `kilo.json`, `opencode.jsonc`, `opencode.json`, and `config.json`.
+- `packages/opencode/src/config/config.ts:360-366` merges global `config.json`, `kilo.json`, `kilo.jsonc`, `opencode.json`, and `opencode.jsonc`.
+- `packages/opencode/src/config/config.ts:628-645` walks both root-level `kilo.json*` and `opencode.json*` project files.
+- `packages/opencode/src/config/config.ts:679-701` loads `KilocodeConfig.ALL_CONFIG_FILES` from every `.kilo` / `.kilocode` config directory, and that constant includes both `opencode.jsonc` and `opencode.json`.
+- `packages/opencode/src/config/config.ts:816-825` also accepts those OpenCode files from the managed config directory.
+- `packages/opencode/src/kilocode/config/config.ts:41-44` defines `ALL_CONFIG_FILES = ["kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json"]`.
+
+This is observable behavior, not merely an obsolete comment or a notification scan: a present OpenCode-named file is parsed and merged as config. Its `// kilocode_change` annotations establish that it is deliberate Kilo-side compatibility code rather than v1.17.5 upstream code.
+
+The unmerged branch `fix-opencode-configs-used-for-kilo` contains commit `8f6a2cd04d` (`fix(cli): remove automatic OpenCode config support, use Kilo config files only`). Its diff removes these readers by restricting the loader to `KILO_CONFIG_FILES`. That branch is not an ancestor of `origin/main` (the ancestry check exited `1`), which explains why the reviewed PR and base retain this behavior.
+
+### High: The v2/core config service independently reads the same OpenCode fallback files
+
+**Classification:** Pre-existing in `origin/main` and the supplied Kilo merge base. Not a v1.17.5 merge delta.
+
+`packages/core/src/config.ts` has a separate discovery path from the v1 loader:
+
+- `:142` defines `names = ["config.json", "kilo.json", "kilo.jsonc", "opencode.json", "opencode.jsonc"]`.
+- `:164-170` loads every filename in that list from the global and discovered config directories.
+- `:177-205` searches root-level files and `.kilo`/`.kilocode` directories, then applies the loaded documents in precedence order.
+
+Consequently, even if the v1 loader were restricted, this service would still automatically consume `opencode.json*` and `config.json` at the global, project-root, `.kilo`, and `.kilocode` locations. The supplied Kilo-base copy is byte-identical to the PR for this file; pristine v1.17.5 differs because it uses upstream OpenCode paths rather than Kilo's modified mixed candidate list.
+
+### High: Settings overlay and `mcp add` can select and write an existing OpenCode-named config file
+
+**Classification:** Pre-existing in `origin/main` and the supplied Kilo merge base. Not a v1.17.5 merge delta.
+
+The configuration-management surfaces preserve the same fallback policy:
+
+- `packages/opencode/src/kilocode/config/overlay.ts:76,132-144,179-195` discovers `opencode.json*` at project root, in `.kilo`/`.kilocode`, and in the global config directory. It can select such a file as the active settings write target.
+- `packages/opencode/src/cli/cmd/mcp.ts:406-436` checks existing `opencode.json*` files at project root and inside `.kilo`/`.kilocode`, then returns the first match as the file that `mcp add` modifies.
+- `packages/opencode/src/kilocode/config/sources.ts:60,121-159` reports OpenCode-named global, project, and config-directory files as config sources.
+- `packages/opencode/src/kilocode/config/global-stamp.ts:6` monitors `config.json`, `opencode.json`, and `opencode.jsonc`, so changes to them invalidate the global config cache.
+
+`packages/opencode/src/kilocode/permission/config-paths.ts:23` also treats root-level `opencode.json*` as protected config. That protection alone does not load the files, but it corroborates that the current product regards them as active config paths.
+
+### Medium, needs human verification: macOS MDM preferences still use the OpenCode bundle identifier
+
+**Classification:** Pre-existing, not a PR diff.
+
+`packages/opencode/src/config/managed.ts:8,53-65` reads `ai.opencode.managed.plist` through `MANAGED_PLIST_DOMAIN = "ai.opencode.managed"`. `packages/opencode/src/kilocode/config/sources.ts:254-271` surfaces the same OpenCode-named managed preference locations. These files are parsed as high-precedence managed configuration.
+
+This might be an intentional deployment-compatibility identifier rather than a filesystem fallback that the `.kilo`-only rule aims to remove. A human should decide whether existing MDM profiles must remain supported. If not, it is another automatic OpenCode configuration input that needs migration/removal.
+
+## Notable Non-Findings
+
+- **No v1.17.5 PR regression relative to `origin/main`:** `git diff origin/main...HEAD` contains no changes in the principal config loaders/path resolvers, `packages/core/src/config.ts`, flags/global paths, settings overlay, MCP resolver, instructions, skills, TUI config, or ignore migration. The supplied Kilo merge-base copies of the reviewed v1 loader, Kilo config helper, overlay, sources, global stamp, core config service, and MCP resolver are also unchanged from the PR where compared.
+- **No `.opencode` directory loading:** `packages/opencode/src/config/paths.ts:23-40` discovers only `.kilo` and `.kilocode`; `KilocodeConfig.isConfigDir` accepts only those directories or `KILO_CONFIG_DIR`. `detectOpencodeConfig` only calls `existsSync` to show a migration notification, not to load the directory.
+- **No `OPENCODE_CONFIG*` flag fallback:** `packages/core/src/flag/flag.ts:45-46,131-142` exposes `KILO_CONFIG`, `KILO_CONFIG_CONTENT`, `KILO_CONFIG_DIR`, and `KILO_DISABLE_PROJECT_CONFIG`; no `OPENCODE_CONFIG*` equivalents remain in the reviewed runtime config flags.
+- **Instructions remain Kilo-oriented:** `packages/opencode/src/session/instruction.ts:62-93,147-158` uses global/project `AGENTS.md` (with optional Claude interoperability) and `KILO_CONFIG_DIR`; it does not discover OpenCode-specific instruction filenames or `.opencode` directories.
+- **Skills, agents, and commands use Kilo config directories:** skills are scanned from `.kilo`/`.kilocode` config directories (`packages/opencode/src/skill/index.ts:240-255`), while command/agent discovery is driven by those same directories. External `.claude` and `.agents` skill support is separate interoperability behavior, not OpenCode config fallback.
+- **Ignore-file handling is `.kilocodeignore` only:** `packages/opencode/src/kilocode/ignore-migrator.ts:10-12,156-172` reads global/project `.kilocodeignore`; no `.opencodeignore` reader was found.
+- **TUI/keybind/theme discovery is Kilo-only in behavior:** `packages/opencode/src/config/tui.ts:184-231` uses global/project `tui.json*`, `.kilo`, `.kilocode`, and `KILO_TUI_CONFIG`. `packages/opencode/src/config/tui-migrate.ts:126-145` has stale OpenCode wording/function naming, but its candidates are `kilo.json*`, not `opencode.json*`.
+- **Global runtime config directory is Kilo:** `packages/core/src/global.ts:12,22-25,75-86` resolves `$XDG_CONFIG_HOME/kilo` and honors only `KILO_CONFIG_DIR`.
+
+## Command Output Excerpts
+
+```text
+$ git -C .worktrees/opencode-merge/opencode describe --tags --exact-match
+v1.17.5
+
+$ git rev-parse --short origin/main
+0cf9f902e0
+
+$ git rev-parse --short HEAD
+06d871409b
+```
+
+```text
+$ git diff --name-status origin/main...HEAD -- \
+  packages/opencode/src/config packages/opencode/src/kilocode/config \
+  packages/core/src/config.ts packages/core/src/global.ts \
+  packages/core/src/flag/flag.ts packages/opencode/src/session/instruction.ts \
+  packages/opencode/src/skill packages/opencode/src/kilocode/ignore-migrator.ts \
+  packages/opencode/src/cli/cmd/mcp.ts packages/opencode/src/kilocode/permission/config-paths.ts
+# no output
+```
+
+The requested added-line scan did not find added functional OpenCode config candidates. Its literal pipeline output was only a diff header and an unrelated temporary-directory name:
+
+```text
++++ b/.opencode-version
++  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-core-migration-"))
+```
+
+```text
+$ git merge-base --is-ancestor fix-opencode-configs-used-for-kilo origin/main; printf '%s\n' $?
+1
+
+$ git log --oneline --max-count=3 fix-opencode-configs-used-for-kilo
+76bca926e1 refactor(cli): centralize Kilo config candidates
+4289a220be test(cli): update Kilo config path fixtures
+8f6a2cd04d fix(cli): remove automatic OpenCode config support, use Kilo config files only
+```
+
+## Limitations
+
+- This was a static source and Git-history review. It did not execute the CLI with fixture directories containing both Kilo and OpenCode config files.
+- The report attributes regressions relative to `origin/main`, as requested. Existing fallback behavior is therefore called out separately rather than attributed to PR #12404.
+- No source code was edited, no commits were created, and no changes were pushed. The pre-existing untracked file `upstream-merge-report-1.17.5.md` was left untouched.

--- a/INFRASTRUCTURE_CHANGE.md
+++ b/INFRASTRUCTURE_CHANGE.md
@@ -1,0 +1,119 @@
+# Infrastructure Change Review: OpenCode v1.17.5
+
+## Scope and Methodology
+
+Reviewed the PR range `origin/main...HEAD` for infrastructure that Kilo must own: CI/workflows, release and publishing automation, root/workspace dependency configuration, patches, and generated SDK automation. Compared ambiguous changes with the provided pristine OpenCode v1.17.5 worktree (`.worktrees/opencode-merge/opencode`) and Kilo base worktree (`.worktrees/opencode-merge/kilo-main`). No source files were modified as part of this review.
+
+## Findings
+
+### High: The merge disables CI tests for six non-CLI packages
+
+**Files:**
+
+- `packages/core/package.json`
+- `packages/effect-drizzle-sqlite/package.json`
+- `packages/http-recorder/package.json`
+- `packages/llm/package.json`
+- `packages/tui/package.json`
+- `packages/ui/package.json`
+
+The merge removes the Kilo-specific `test:ci` script from all six packages. The removal is upstream-sourced: every script is absent in the pristine OpenCode v1.17.5 worktree, while Kilo base defines each script with a JUnit reporter and `.artifacts/unit/junit.xml` output.
+
+Kilo's unchanged `.github/workflows/test.yml` still runs `bun turbo test:ci --filter='!@kilocode/cli' --filter='!@kilocode/kilo-jetbrains'` and publishes `packages/*/.artifacts/unit/junit.xml`. `turbo.json` defines a generic `test:ci` task but does not supply commands, so the missing package scripts are silently scheduled as `<NONEXISTENT>` rather than failing the workflow. The verified `bun turbo test:ci --filter=@opencode-ai/core` run reported `Tasks: 0 successful, 0 total` and `WARNING No tasks were executed`.
+
+This drops test execution and JUnit artifacts for all six packages from Kilo's non-CLI CI job. Restore the Kilo `test:ci` scripts, or intentionally redesign `.github/workflows/test.yml` and `turbo.json` to run and report the replacement test commands.
+
+### High: Kilo's `dev:local` root entrypoint was removed
+
+**File:** `package.json`
+
+The merge removes:
+
+```json
+"dev:local": "bun run packages/opencode/script/dev-local.ts"
+```
+
+This is a Kilo-specific entrypoint. The target `packages/opencode/script/dev-local.ts` exists in Kilo base and final HEAD, but does not exist in the pristine OpenCode worktree. `bun run dev:local --help` now fails with `error: Script not found "dev:local"`. The script transform preserves selected Kilo root scripts, but its `PRESERVE_SCRIPTS["package.json"]` allowlist does not include `dev:local`, which explains the drop during the upstream-shaped merge.
+
+Restore the script and add it to `script/upstream/transforms/transform-package-json.ts`'s preserved root scripts so a future merge cannot drop it again.
+
+### Medium: The merge re-authorizes an unused native lifecycle build
+
+**Files:** `package.json`, `bun.lock`
+
+`tree-sitter-powershell` was added to root `trustedDependencies`, making Bun run its native `node-gyp-build` lifecycle action during install. This matches pristine upstream v1.17.5, but conflicts with Kilo's existing decision: retain this dependency for its WASM grammar while not permitting its unused native build, avoiding a root `node-gyp` requirement.
+
+Final source uses `tree-sitter-powershell/tree-sitter-powershell.wasm` from `packages/opencode/src/tool/shell.ts`; no native module import was found. Remove `tree-sitter-powershell` from root `trustedDependencies` and regenerate `bun.lock`, unless Kilo intentionally changes the native-build policy.
+
+### Needs Human Verification: Upstream turns `@opencode-ai/http-recorder` into a public package
+
+**File:** `packages/http-recorder/package.json`
+
+The merge removes `private: true` and adds `publishConfig.access: public`. This exactly matches the pristine upstream package and is therefore upstream-sourced, not an accidental Kilo conflict resolution. Kilo's root `script/publish.ts` versions every package manifest, but only explicitly publishes the CLI, SDK, plugin, and VS Code extension; the reviewed workflow does not show a dedicated `http-recorder` publication step.
+
+No immediate automatic publish path was established from the checked release scripts, but this changes package policy and allows a future publication command to publish `@opencode-ai/http-recorder` publicly. Retain it only if Kilo intends to support that public package; otherwise restore `private: true` and remove `publishConfig`.
+
+## Accepted / Coherent Infrastructure Changes
+
+### Root patch map, lockfile, and MCP session-recovery patch
+
+**Files:** `package.json`, `bun.lock`, `patches/@modelcontextprotocol%2Fsdk@1.29.0.patch`
+
+The patch map is coherent with the final dependency graph:
+
+- Stale upstream entries are absent: `@ff-labs/fff-bun@0.9.3`, `pacote@21.5.0`, `@ai-sdk/xai@3.0.82`, and `gcp-metadata@8.1.2`.
+- Kilo's retained current replacements are present and locked: `@ff-labs/fff-bun@0.9.4`, `pacote@21.5.1`, and `@ai-sdk/xai@3.0.92`.
+- `@modelcontextprotocol/sdk@1.29.0` is present in `packages/opencode/package.json`, the root patch map, and `bun.lock`.
+- All 11 declared `patchedDependencies` files exist.
+- The new MCP patch is byte-identical to the pristine upstream v1.17.5 patch (SHA-256 `5523454ba911504128126cca0b929f2a8f95597a3a2ac88d1d026d2892f465c7`).
+
+This is an upstream-sourced dependency and generated-lock update, with Kilo's current-version patch replacements preserved. No action identified.
+
+### Generated SDK artifacts
+
+**Files:** `packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/sdk.gen.ts`, `packages/sdk/js/src/v2/gen/types.gen.ts`
+
+Only the OpenAPI document and generated v2 SDK outputs changed in the final PR. `script/generate.ts`, `packages/sdk/js/script/build.ts`, `packages/sdk/js/script/publish.ts`, and `packages/sdk/js/package.json` are unchanged from `origin/main...HEAD`. The final artifacts are consistent with the upstream API changes without replacing Kilo's SDK build/publish automation. No action identified.
+
+## Notable Non-Findings
+
+- No `.github/workflows/` or `.github/actions/` files changed. `bun run script/check-workflows.ts` passed with `check-workflows: ok (27 workflows)`, so the hardcoded workflow allowlist remains synchronized.
+- No CI configuration, Docker file, `turbo.json`, `bunfig.toml`, Husky configuration, `script/check-*.ts` guard, `script/upstream/` transform, release script, publishing workflow, or `.changeset/` file changed in the PR range.
+- No Kilo-specific workflow jobs or steps were dropped as a file diff. The CI coverage regression above results from package script removal against Kilo's unchanged workflow.
+- `git diff --check origin/main...HEAD` reported no whitespace errors.
+
+## Command Output Excerpts
+
+```text
+$ git diff --name-status origin/main...HEAD -- .github .changeset script Dockerfile docker-compose.yml turbo.json bunfig.toml .husky
+(no output)
+
+$ bun run script/check-workflows.ts
+check-workflows: ok (27 workflows).
+```
+
+```text
+$ bun turbo test:ci --filter=@opencode-ai/core
+Packages in scope: @opencode-ai/core
+Running test:ci in 1 packages
+WARNING No tasks were executed as part of this run.
+Tasks:    0 successful, 0 total
+```
+
+```text
+$ bun run dev:local --help
+error: Script not found "dev:local"
+```
+
+```text
+$ patch-file verification
+patched=11
+missing=0
+MCP patch byte-identical to pristine upstream: yes
+```
+
+## Limitations
+
+- This review is static plus targeted command validation. It did not run the full CI matrix, install dependencies, build distributions, or publish packages.
+- The provided upstream comparison worktree had unrelated local changes (`bun.lock` and `packages/opencode/.kilo/`); provenance comparisons were restricted to committed files and direct file content.
+- Publication behavior was traced through the root publish script and `publish.yml`; external registry state and unpublished release tooling paths were not exercised.

--- a/KILOCODE_CHANGE_MARKERS.md
+++ b/KILOCODE_CHANGE_MARKERS.md
@@ -1,0 +1,76 @@
+# `kilocode_change` Marker Audit: OpenCode v1.17.5 Merge (PR #12404)
+
+## Scope and Methodology
+
+Reviewed all 194 files in `git diff --name-only origin/main...HEAD` for PR #12404, with particular attention to every changed shared-upstream file containing a `kilocode_change` marker on either side of the merge.
+
+`origin/main` has advanced since this merge branch was created. Git topology identifies `084bceadaedf193568ccf71256bd299c0d11e90c` as the merge base of current `origin/main` and `HEAD`, so that commit was used as the effective pre-merge Kilo baseline. The supplied `kilo-main` worktree is at `12147d1602a6dd59647085e56226a815592cff08`, the recorded upstream-merge commit whose first parent is that baseline. Pristine upstream was verified as tag `v1.17.5`.
+
+Method:
+
+- Enumerated the 194 changed paths from the PR diff.
+- Compared each path's marker presence and, for all 36 marker-bearing changed files, inspected marker additions, removals, and movement in the contextual diff.
+- Compared the marker-changing shared files against the supplied pre-merge and pristine-upstream worktrees.
+- Checked commit attribution for the marker-changing paths and validated the final marker locations in `HEAD`.
+
+## Findings
+
+No actual or suspected accidentally removed `kilocode_change` markers were found. No items need human verification from this marker audit.
+
+## Notable Non-Findings
+
+- `packages/core/src/connector.ts` and `packages/core/test/connector.test.ts` were deleted by upstream's integration/credential rewrite. The Kilo OAuth settlement, timeout, cancellation, and persistence guards were correctly re-applied to `packages/core/src/integration.ts` with 12 new markers. The final repair commit is `06d871409b fix: restore oauth attempt settlement guards in integration`.
+- `packages/core/src/credential.ts` has fewer individual markers because upstream removed connector selection and lifecycle-event semantics. The remaining Kilo behavior was ported to the integration-shaped credential model: account JSON import, `auth.json` reconciliation and dual writes, `KILO_AUTH_CONTENT` process-local credentials, and isolated create/update/remove behavior are all still enclosed or line-marked.
+- The two deleted SQL migration files were replaced by Kilo-marked TypeScript migrations with the same IDs:
+  `packages/core/src/database/migration/20260603040000_session_message_projection_order.ts` retains the `seq` projection migration, and `packages/core/src/database/migration/20260714141136_session-message-legacy-writer-compat.ts` retains the legacy writer-compatible nullable `seq` table rebuild.
+- `packages/opencode/src/server/routes/instance/httpapi/server.ts` moved from explicit default-layer assembly to upstream's `LayerNode` composition. Marker count dropped from 24 to 19 only because upstream service entries such as `Git` are now unmodified upstream nodes. Kilo-specific services and routes remain marked, including `ModelCache`, credentials, memory, Agent Manager, notebook, viewers, sync events, reference reconciliation, and listener routes.
+- The new markers in `packages/core/src/database/database.ts` (lazy `KILO_DB` path resolution), `packages/opencode/src/effect/app-runtime.ts` (ProjectCopy dependency composition), and `packages/opencode/src/project/instance-store.ts` (deferred completion on interruption) all enclose Kilo-specific behavior rather than upstream code.
+- Root patch-entry cleanup and the HTTP recorder package changes did not introduce marker changes or expose an unmarked Kilo modification in this audit scope.
+
+## Relevant Command Excerpts
+
+```text
+$ git diff --name-only origin/main...HEAD | wc -l
+194
+
+$ git merge-base origin/main HEAD
+084bceadaedf193568ccf71256bd299c0d11e90c
+
+$ git -C .worktrees/opencode-merge/opencode describe --tags --exact-match
+v1.17.5
+
+$ git diff --check 084bceadaedf193568ccf71256bd299c0d11e90c...HEAD
+(no output)
+```
+
+Marker-count differences were limited to these intentional migrations or reapplications:
+
+```text
+packages/core/migration/20260603040000_session_message_projection_order/migration.sql  1 -> 0
+packages/core/migration/20260714141136_session-message-legacy-writer-compat/migration.sql  1 -> 0
+packages/core/src/connector.ts  12 -> 0
+packages/core/src/credential.ts  33 -> 26
+packages/core/src/database/database.ts  3 -> 4
+packages/core/src/integration.ts  0 -> 12
+packages/core/test/connector.test.ts  3 -> 0
+packages/core/test/credential.test.ts  6 -> 5
+packages/opencode/src/project/instance-store.ts  10 -> 12
+packages/opencode/src/server/routes/instance/httpapi/server.ts  24 -> 19
+```
+
+Relevant branch commits, newest first:
+
+```text
+06d871409b fix: restore oauth attempt settlement guards in integration
+92f8d0b0de fix: complete instance boot deferreds on interruption
+0644aee49d fix: kilo compat for v1.17.5 test infrastructure
+95db2da8e9 refactor: kilo compat for v1.17.5
+3591852931 resolve merge conflicts
+4327386ff8 refactor: kilo compat for v1.17.5
+```
+
+## Limitations
+
+- This is a static marker and source-history audit. It does not independently prove runtime behavior or execute the affected test suites.
+- The current `origin/main` is newer than the branch's merge-time base. The audit used the actual merge base after verifying the supplied worktree topology, rather than assuming current `origin/main` was the pre-merge snapshot.
+- No source files, Git refs, staging state, commits, or remote branches were changed. This report is the only file created by the audit.

--- a/OPENCODE_MENTIONS.md
+++ b/OPENCODE_MENTIONS.md
@@ -63,9 +63,9 @@ currently disabled, so the audit did not rely on that pass alone.
 
 ## Notable Non-Findings
 
-- No added OpenCode web-property URL or legacy `sst/opencode` /
-  `anomalyco/opencode` repository link was found in merge-added lines after
-  excluding explicit upstream context and package/type namespaces.
+- No added OpenCode web-property URL or legacy repository link (the old
+  upstream org path or `anomalyco/opencode`) was found in merge-added lines
+  after excluding explicit upstream context and package/type namespaces.
 - No added match was found in the changed `packages/kilo-docs/`,
   `packages/opencode/src/cli/cmd/tui/`, `packages/opencode/src/server/`,
   `packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/`, `packages/ui/`,

--- a/OPENCODE_MENTIONS.md
+++ b/OPENCODE_MENTIONS.md
@@ -1,0 +1,113 @@
+# OpenCode Branding Audit: v1.17.5 Merge (PR #12404)
+
+## Scope and Methodology
+
+Reviewed merge-added lines only: `origin/main...HEAD` on
+`marius-kilocode/review-opencode-v1.17.5` (current `HEAD`:
+`06d871409b`). The merge changes 194 files, with 6,121 additions and
+51,674 deletions.
+
+The audit started with the PR file list, then searched added diff lines for
+`OpenCode`, OpenCode web properties (`opencode.ai`, `docs.opencode`,
+`opncd.ai`, `oc.dev`), and legacy GitHub repository URLs. It specifically
+reviewed the changed TUI, UI, server, OpenAPI/generated SDK, documentation,
+desktop/web/app, package metadata, and CLI surfaces. Clear internal package
+references (`@opencode-ai/*`), Effect service tags (`@opencode/*`), migration
+temporary-path names, test assertions, and upstream attribution were excluded
+from findings.
+
+`bun script/check-forbidden-strings.ts` also passed. Its active checks are
+intentionally narrow: legacy share URLs, legacy upstream GitHub URLs (with
+allowlists), two upstream HTTP referer strings, and three known UI phrases.
+Its `opencode.ai` auth, docs, schema, theme, and default-share-url checks are
+currently disabled, so the audit did not rely on that pass alone.
+
+## Findings
+
+1. **User-facing branding violation**
+   - File: `packages/opencode/src/plugin/snowflake-cortex.ts:161,165,173`
+   - Added strings:
+     - `OpenCode - Snowflake Authorization Successful`
+     - `You can close this window and return to OpenCode.`
+     - `OpenCode - Snowflake Authorization Failed`
+   - Why: These title and body strings are rendered by the local browser
+     callback page after a user completes or fails the Snowflake OAuth flow.
+   - Suggested fix: Change the title and body branding to `Kilo`, for example
+     `Kilo - Snowflake Authorization Successful`, `return to Kilo`, and
+     `Kilo - Snowflake Authorization Failed`.
+
+2. **User-facing branding violation**
+   - File: `packages/opencode/src/plugin/snowflake-cortex.ts:500`
+   - Added string: `Complete Snowflake sign-in in your browser. OpenCode will
+     capture the OAuth callback and store the bearer token automatically.`
+   - Why: This is returned as the OAuth authorization instruction and displayed
+     to the user by the provider connection UI.
+   - Suggested fix: Replace `OpenCode` with `Kilo`.
+
+## Needs Human Verification
+
+1. **Externally observable product identity, not local UI copy**
+   - File: `packages/opencode/src/plugin/snowflake-cortex.ts:82,405`
+   - Added string: `User-Agent: opencode/${InstallationVersion}`
+   - Why: Both the Snowflake OAuth token request and Cortex model API request
+     send this header to Snowflake. It is not displayed in Kilo, but it exposes
+     the upstream product name to a third party and could affect provider
+     diagnostics or policy.
+   - Suggested fix if outbound attribution must be Kilo-branded: use the
+     established Kilo user-agent convention (`kilo/...`, `kilocode/...`, or
+     `Kilo-Code/...`) selected by the provider-integration owner. Retain only
+     if Snowflake specifically requires `opencode/...`.
+   - Context: Other existing provider integrations still send
+     `opencode/...`, while Kilo-specific integrations use several Kilo forms;
+     this merge did not establish a single project-wide convention.
+
+## Notable Non-Findings
+
+- No added OpenCode web-property URL or legacy `sst/opencode` /
+  `anomalyco/opencode` repository link was found in merge-added lines after
+  excluding explicit upstream context and package/type namespaces.
+- No added match was found in the changed `packages/kilo-docs/`,
+  `packages/opencode/src/cli/cmd/tui/`, `packages/opencode/src/server/`,
+  `packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/`, `packages/ui/`,
+  `packages/web/`, `packages/app/`, or `packages/desktop/` surfaces.
+- `packages/http-recorder/package.json` remains correctly Kilo-branded:
+  repository `git+https://github.com/Kilo-Org/kilocode.git`, homepage
+  `https://github.com/Kilo-Org/kilocode/tree/main/packages/http-recorder`, and
+  bugs URL `https://github.com/Kilo-Org/kilocode/issues`. The merge only
+  removes `private` and adds `publishConfig`; those Kilo URLs were already
+  present in `origin/main`.
+- Added `@opencode-ai/*` imports, `@opencode/*` Effect service tags,
+  `opencode-core-migration-` temporary directories, and the Snowflake test
+  assertion for the User-Agent are implementation/test details rather than
+  direct end-user branding copy.
+
+## Command Output Excerpts
+
+```text
+$ git diff --stat origin/main...HEAD
+194 files changed, 6121 insertions(+), 51674 deletions(-)
+
+$ bun script/check-forbidden-strings.ts
+check-forbidden-strings: 8344 file(s) checked, no forbidden strings found.
+
+$ git diff --unified=0 origin/main...HEAD | ... suspicious branding filter
++    "User-Agent": `opencode/${InstallationVersion}`,
++  <head><title>OpenCode - Snowflake Authorization Successful</title></head>
++      <p>You can close this window and return to OpenCode.</p>
++  <head><title>OpenCode - Snowflake Authorization Failed</title></head>
++              headers.set("User-Agent", `opencode/${InstallationVersion}`)
++                "Complete Snowflake sign-in in your browser. OpenCode will capture the OAuth callback and store the bearer token automatically.",
++    expect(captured[0].get("user-agent")).toMatch(/^opencode\\//)
+```
+
+## Limitations
+
+- This is a static review of merge-added lines, not an end-to-end Snowflake
+  OAuth exercise. The direct browser and instruction strings are unambiguous
+  from their rendering/authorization paths.
+- Existing OpenCode references outside the merge diff were not reported unless
+  needed to classify a new line. The repository contains known pre-existing
+  upstream URLs, schemas, compatibility names, package namespaces, fixtures,
+  and attribution that are outside this PR-addition audit.
+- No source files, commits, branches, or remote state were modified. This
+  report is the only file created by the audit.

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,137 @@
+# Kilo-Specific Test Audit: OpenCode v1.17.5 Merge (PR #12404)
+
+## Scope and Methodology
+
+Reviewed `origin/main...HEAD` on `marius-kilocode/review-opencode-v1.17.5` for removed or weakened Kilo-specific tests. The audit covered:
+
+- Test/spec paths changed by the PR and deleted test files.
+- Full diffs of the Kilo-sensitive shared and Kilo-owned tests: catalog credential routing, credential storage, auth-v2 migration, logout removal, and JSON storage migration.
+- Removed `kilocode_change` test blocks, added `.skip` / `.todo` markers, and Kilo test-directory counts relative to `.worktrees/opencode-merge/kilo-main`.
+- Pristine upstream `v1.17.5` and upstream commit `30aec297d8` (OpenCode PR #31968) to distinguish intended connector-to-integration changes from Kilo-specific merge fallout.
+- Targeted execution of the reviewed Core and CLI test files.
+
+No source files were edited. This report is the only file created by this audit.
+
+## Findings
+
+### Needs Human Verification: six Kilo OAuth regression tests were deleted without integration-suite replacements
+
+`packages/core/test/connector.test.ts` was removed as part of upstream PR #31968, which replaces `Connector` with `Integration`. The replacement `packages/core/test/integration.test.ts` retains general OAuth success, normal cancellation, and expiry coverage, but it does not recreate the six Kilo-marked regression cases that were at `origin/main:packages/core/test/connector.test.ts:361-640`:
+
+- Auto OAuth reports a failed attempt when credential persistence fails.
+- Code OAuth reports a failed attempt when credential persistence fails.
+- Credential persistence completes if cancellation races after persistence has started.
+- A code OAuth attempt remains valid while its callback is completing.
+- A stalled code callback times out, fails, and releases its attempt.
+- A stalled credential write times out, fails, and releases its attempt.
+
+The current implementation has Kilo guards for this behavior in `packages/core/src/integration.ts:250,378-380,428,523-557`. Commit `06d871409b` restored atomic settlement, cancellation/expiry exclusion while settling, and a 30-second timeout after the connector-to-integration migration. The new `packages/core/test/integration.test.ts:167-336` covers code completion, cancellation before settlement, auto completion, and expiry, but not persistence failure, completion/cancellation races, or either timeout path.
+
+This is a real loss of regression coverage, even though the production safeguards are present. Confirm whether those six tests are intentionally retired with the old API or should be ported to `Integration`.
+
+### No Finding: auth-v2 migration keeps the required active-account and organization behavior
+
+`packages/core/test/kilocode/account-auth-v2-migration.test.ts` changed from preserving two credentials plus an active selection to the new one-credential-per-integration model. The test still supplies two Kilo OAuth accounts and selects `acc_second`; it asserts that exactly `second` is imported, that the integration list has one credential, and that it retains both `access-second` and `metadata.accountID = org-second` (`:50-97`).
+
+The removed assertion that both accounts survive is intentional under the documented new model: `// one credential per integration: only the active account is imported`. The active-account import and Kilo organization metadata are still explicitly asserted.
+
+### No Finding: OAuth organization routing and provider logout cleanup remain asserted
+
+- `packages/core/test/catalog.test.ts:41-75` still injects a Kilo OAuth credential with `accountID: "organization"` and asserts `apiKey: "access"` plus `kilocodeOrganizationId: "organization"` in the provider request body.
+- `packages/opencode/test/kilocode/auth-remove.test.ts:23-43` still creates two Anthropic credentials, invokes `remove("anthropic")`, asserts the integration list is empty, and verifies legacy `Auth.remove()` ran. The old `active()` assertion was removed because the integration API has no active credential concept.
+
+### No Finding: Kilo JSON migration coverage is intact
+
+`packages/opencode/test/kilocode/storage/json-migration.test.ts` has 24 test cases before and after the merge. The diff only changes database setup from hand-loading legacy migration SQL to initializing a temporary database through the production Core migration runner, then tolerates delayed Windows SQLite WAL cleanup. The project, session, message, part, todo, permission, sharing, bootstrap/retry, and corruption cases remain present.
+
+### No Finding: credential-test reductions follow removed active-credential semantics
+
+The Kilo `KILO_AUTH_CONTENT` isolation test remains in `packages/core/test/credential.test.ts:55-123`, including environment parsing, Kilo organization metadata, process-local create/update/remove behavior, and confirmation that no durable credentials are written. The downgraded-client `auth.json` dual-write test also remains at `:207-275`.
+
+The deleted Kilo assertions in the shared credential test cover selecting an active credential, reconciling a separately selected row, and dual-writing whichever credential is active. The new upstream `Credential` model stores one credential per integration, so the test now asserts replacement, update, and removal of that stored credential. This matches upstream commit `30aec297d8` and the API removed from `Connector`; it does not look like an accidental Kilo test deletion.
+
+## Notable Non-Findings
+
+- `packages/core/test/connector.test.ts` deletion is structurally justified by upstream PR #31968: `packages/core/src/connector.ts` and its test are deleted, while `packages/core/src/integration.ts` and `packages/core/test/integration.test.ts` are added. The only concern is the six Kilo regression cases listed above, not the file deletion itself.
+- `packages/opencode/test/storage/workspace-time-migration.test.ts` is also absent from pristine upstream `v1.17.5` and was deleted in upstream commit `30aec297d8`. Its beta-reset behavior is covered by `packages/core/test/database-migration.test.ts:153-226`, which builds legacy workspace data, applies the event-sourced reset migration, and asserts the workspace table is empty. The current migration remains in `packages/core/src/database/migration/20260507164347_add_workspace_time.ts`.
+- No new `.skip` or `.todo` markers were added in changed test/spec files.
+- No Kilo test directory lost files: `packages/opencode/test/kilocode` is 214 files on both PR and base; `packages/core/test/kilocode` is 16 on both; `packages/kilo-vscode/tests` is 274 on both. There is no `packages/kilo-vscode/test/kilocode` directory in either tree.
+- No deleted Kilo fixture or Kilo-owned test path was found. The deleted connector suite is shared, although it contained the six Kilo-marked cases above.
+
+## Command Output Excerpts
+
+Changed test/spec paths: 35
+
+```text
+packages/core/test/catalog.test.ts
+packages/core/test/connector.test.ts
+packages/core/test/credential.test.ts
+packages/core/test/database-migration.test.ts
+packages/core/test/integration.test.ts
+packages/core/test/kilocode/account-auth-v2-migration.test.ts
+packages/core/test/location-layer.test.ts
+packages/core/test/move-session.test.ts
+packages/core/test/plugin/models-dev.test.ts
+packages/core/test/plugin/provider-azure.test.ts
+packages/core/test/plugin/provider-cloudflare-workers-ai.test.ts
+packages/core/test/plugin/provider-gitlab.test.ts
+packages/core/test/plugin/provider-helper.ts
+packages/core/test/plugin/provider-openai.test.ts
+packages/core/test/plugin/provider-snowflake-cortex.test.ts
+packages/core/test/project-copy.test.ts
+packages/core/test/project-directories.test.ts
+packages/core/test/project.test.ts
+packages/opencode/test/cli/run/footer.view.test.tsx
+packages/opencode/test/fixture/mcp-session-recovery.ts
+packages/opencode/test/kilocode/auth-remove.test.ts
+packages/opencode/test/kilocode/storage/json-migration.test.ts
+packages/opencode/test/mcp/session-recovery.test.ts
+packages/opencode/test/plugin/snowflake-cortex.test.ts
+packages/opencode/test/project/project-directory.test.ts
+packages/opencode/test/project/project.test.ts
+packages/opencode/test/server/httpapi-exercise/index.ts
+packages/opencode/test/server/httpapi-public-openapi.test.ts
+packages/opencode/test/server/project-copy.test.ts
+packages/opencode/test/storage/workspace-time-migration.test.ts
+packages/tui/test/cli/tui/__snapshots__/inline-tool-wrap-snapshot.test.tsx.snap
+packages/tui/test/cli/tui/data.test.tsx
+packages/tui/test/cli/tui/diff-viewer.test.tsx
+packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+packages/tui/test/fixture/tui-sdk.ts
+```
+
+Deleted test/spec paths:
+
+```text
+D packages/core/test/connector.test.ts
+D packages/opencode/test/storage/workspace-time-migration.test.ts
+```
+
+Kilo test-directory count comparison:
+
+```text
+packages/opencode/test/kilocode: 214 (PR) / 214 (kilo-main)
+packages/core/test/kilocode: 16 (PR) / 16 (kilo-main)
+packages/kilo-vscode/tests: 274 (PR) / 274 (kilo-main)
+packages/kilo-vscode/test/kilocode: absent in both trees
+```
+
+Targeted tests:
+
+```text
+$ bun test test/catalog.test.ts test/credential.test.ts test/integration.test.ts test/kilocode/account-auth-v2-migration.test.ts
+28 pass
+0 fail
+75 expect() calls
+
+$ bun test test/kilocode/auth-remove.test.ts test/kilocode/storage/json-migration.test.ts
+25 pass
+0 fail
+135 expect() calls
+```
+
+## Limitations
+
+- This is a diff and targeted-test audit, not a complete repository test run or a manual OAuth flow test.
+- The upstream deletion rationale is supported by the pristine v1.17.5 tree and upstream commit history, but upstream PR discussion was not reviewed.
+- The six deleted OAuth regression cases were not reimplemented or run against an equivalent test harness because this task is report-only. Their absence from the integration suite is the outstanding human-verification item.

--- a/UNNECESSARY_MARKERS.md
+++ b/UNNECESSARY_MARKERS.md
@@ -1,0 +1,165 @@
+# Unnecessary `kilocode_change` Marker Review
+
+## Scope and Methodology
+
+Reviewed Kilo's OpenCode v1.17.5 merge branch (`marius-kilocode/review-opencode-v1.17.5`, `HEAD` `06d871409b`) against `origin/main` and the supplied pristine upstream v1.17.5 worktree at `.worktrees/opencode-merge/opencode` (`8d78715d64d6f2401e5dfcd93745d082aaa1d163`). The PR range contains 194 paths.
+
+This was dry-run and report-only work. No source file was reset, edited, committed, or pushed.
+
+Primary commands run from the repository root:
+
+```sh
+git diff --name-only origin/main...HEAD
+git diff --name-only origin/main...HEAD | wc -l
+bun run script/upstream/find-reset-candidates.ts --help
+bun run script/upstream/find-reset-candidates.ts --dry-run
+bun run script/upstream/reset-to-upstream.ts --help
+bun run script/upstream/reset-to-upstream.ts <repo-relative-file> --dry-run
+grep -rn "kilocode_change" <repo-relative-file>
+git diff --no-index --unified=0 -- <repo-relative-file> .worktrees/opencode-merge/opencode/<repo-relative-file>
+```
+
+Additional read-only cross-checks:
+
+```sh
+git diff --name-only origin/main...HEAD | while IFS= read -r f; do test -f "$f" && test -f ".worktrees/opencode-merge/opencode/$f" && cmp -s "$f" ".worktrees/opencode-merge/opencode/$f" && printf '%s\n' "$f"; done
+git diff --name-only origin/main...HEAD | while IFS= read -r f; do test -f "$f" || continue; test -f ".worktrees/opencode-merge/opencode/$f" || continue; grep -q "kilocode_change" "$f" || continue; git diff --no-index --unified=0 -- "$f" ".worktrees/opencode-merge/opencode/$f" 2>/dev/null | grep -E '^[+-].*kilocode_change' || true; done
+```
+
+I also used a read-only `bun -e` checker based on `script/upstream/utils/markers.ts` to remove marker syntax from each changed marked file, compare the remaining regions with pristine v1.17.5, and identify marked regions whose code is already equal to upstream. This check intentionally compares raw pristine upstream for marker necessity. The reset scripts compare Kilo's transformed upstream output, which includes package-name and branding transforms.
+
+## Findings
+
+### Confirmed stale markers in PR-changed files
+
+These marker annotations do not mark a code difference from pristine v1.17.5. Their surrounding files still have other Kilo changes, so remove only the listed marker annotations, not the full files.
+
+| File | Stale marker location | Evidence | `reset-to-upstream.ts --dry-run` |
+|---|---|---|---|
+| `packages/opencode/src/session/prompt.ts` | 757 | `const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()` equals upstream after removing the inline marker. | Would reset the entire file. Do not use that as the fix because the file has 691 other non-marker diff lines. |
+| `packages/opencode/src/session/prompt.ts` | 1089 | `const exit = yield* execRead(args).pipe(Effect.exit)` equals upstream after removing the inline marker. | Would reset the entire file. |
+| `packages/opencode/src/session/prompt.ts` | 1471-1475 | The marker block around `MessageV2.filterCompactedEffect(sessionID).pipe(Effect.provideService(Database.Service, database))` equals upstream. | Would reset the entire file. |
+| `packages/opencode/src/session/prompt.ts` | 2074 | `const agent = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()` equals upstream after removing the inline marker. | Would reset the entire file. |
+| `packages/opencode/src/session/prompt.ts` | 2176 | `Layer.provide(Image.defaultLayer)` equals upstream after removing the inline marker. | Would reset the entire file. |
+| `packages/opencode/src/session/prompt.ts` | 2204-2208 | The marker block around the upstream `format`, `system`, and `variant` input fields equals upstream. | Would reset the entire file. |
+| `packages/tui/src/routes/session/index.tsx` | 1758 | The marker on the `AssistantMessage` closing brace marks no difference. | Would reset the entire file. Do not use that as the fix because the file has 402 other non-marker diff lines. |
+| `packages/tui/src/routes/session/index.tsx` | 1769 | `const INLINE_TOOL_ICON_WIDTH = 2` equals upstream after removing the inline marker. | Would reset the entire file. |
+
+The direct, minimal cleanup for these findings is marker removal only. The `--dry-run` reset result is intentionally not a recommended whole-file operation for either file.
+
+### Whole-file reset candidates within the PR
+
+The full candidate tool classified the 194 PR paths as 66 `identical`, 16 `small-diff`, 36 `large-diff`, and 76 `upstream-missing`. No PR-changed path was classified `markers-only` or `cosmetic-only`.
+
+The following 16 PR files are `small-diff` candidates. `reset-to-upstream.ts --dry-run` reported `Would reset ... to transformed upstream v1.17.5` for all 16:
+
+| File | Tool's non-marker diff count | Assessment |
+|---|---:|---|
+| `packages/core/schema.json` | 2 | Needs human verification. |
+| `packages/core/src/catalog.ts` | 5 | Do not reset. The marked OAuth organization routing is Kilo-specific. |
+| `packages/core/src/database/migration.gen.ts` | 1 | Needs human verification. |
+| `packages/core/src/plugin/boot.ts` | 2 | Do not reset. Kilo intentionally omits upstream `SkillPlugin` registration. |
+| `packages/core/src/project.ts` | 4 | Needs human verification. |
+| `packages/core/src/ripgrep/binary.ts` | 2 | Do not reset. Kilo's Windows `rg.exe` handling is intentional. |
+| `packages/effect-drizzle-sqlite/package.json` | 5 | Needs human verification. Includes Kilo release/version metadata. |
+| `packages/llm/package.json` | 5 | Needs human verification. Includes Kilo release/version metadata. |
+| `packages/opencode/src/cli/cmd/run/footer.permission.tsx` | 4 | Do not reset. Kilo SDK import and Kilo-facing permission copy are intentional. |
+| `packages/opencode/src/cli/cmd/run/splash.ts` | 4 | Do not reset. Kilo branding and `kilo run` usage are intentional. |
+| `packages/opencode/src/mcp/catalog.ts` | 2 | Do not reset. Kilo intentionally distinguishes collection from direct fetch. |
+| `packages/server/src/api.ts` | 2 | Do not reset. `Kilo HttpApi` title is intentional branding. |
+| `packages/server/src/handlers.ts` | 2 | Do not reset. Kilo supplies a different location-layer arrangement for effective-reference initialization. |
+| `packages/tui/package.json` | 5 | Needs human verification. Includes Kilo package identities and release/version metadata. |
+| `packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx` | 3 | Do not reset. The assertions retain dedicated Kilo tool renderers. |
+| `packages/ui/src/theme/themes/oc-2.json` | 2 | Needs human verification. It is byte-identical to pristine upstream, but differs from the reset tool's transformed upstream output; a transformed reset would make a change rather than no-op. |
+
+The `small-diff` bucket is a review threshold, not an assertion that a reset is safe. This review found no whole PR file that should be reset solely because it appears in that bucket.
+
+### Files already identical to upstream
+
+Of the 194 PR paths, 60 are byte-identical to the supplied pristine upstream worktree. They do not need resetting and none carries a `kilocode_change` marker. Fifty-nine are also identical to the reset tool's transformed upstream output; the exception is `packages/ui/src/theme/themes/oc-2.json`, explained above.
+
+Seven further PR paths are identical after Kilo's configured package-name and branding transforms, though not byte-identical to raw upstream. `reset-to-upstream.ts --dry-run` confirmed all seven as `already matches transformed upstream v1.17.5`:
+
+- `packages/core/test/plugin/models-dev.test.ts`
+- `packages/opencode/src/cli/cmd/run/footer.question.tsx`
+- `packages/opencode/src/project/project.ts`
+- `packages/tui/src/component/dialog-move-session.tsx`
+- `packages/tui/src/context/project.tsx`
+- `packages/tui/src/feature-plugins/system/diff-viewer.tsx`
+- `packages/tui/test/cli/tui/diff-viewer.test.tsx`
+
+These are merge results already aligned with Kilo's transformed upstream baseline, not candidates for a reset.
+
+### Marker-only candidates found outside the PR range
+
+The full-repository candidate scan found two genuine `markers-only` files. Neither appears in `git diff --name-only origin/main...HEAD`, so they are not introduced or changed by this PR. They are included for completeness because the requested candidate scan surfaced them.
+
+| File | Stale marker lines | Evidence | `reset-to-upstream.ts --dry-run` |
+|---|---|---|---|
+| `packages/opencode/src/cli/cmd/run/permission.shared.ts` | 128, 132 | Removing the inline markers leaves the Kilo-transformed upstream text unchanged. | Would reset to transformed upstream. |
+| `packages/sdk/js/src/error-interceptor.ts` | 40 | Removing the standalone marker leaves the Kilo-transformed upstream text unchanged. | Would reset to transformed upstream. |
+
+`packages/opencode/src/session/prompt/anthropic.txt` was the sole `cosmetic-only` global candidate. It has no `kilocode_change` marker and is outside the PR range.
+
+### Needs human verification
+
+The following standalone marker comments could not be mechanically tied to a block by the marker parser. Manual context comparison shows a real Kilo difference for all except the final item, which remains ambiguous because the surrounding conditional changed upstream:
+
+| File | Line(s) | Assessment |
+|---|---:|---|
+| `packages/core/src/database/database.ts` | 70 | Keep. The marker documents Kilo's deferred database-path node construction. |
+| `packages/core/src/plugin/boot.ts` | 104 | Keep. It documents intentional omission of upstream `SkillPlugin`. |
+| `packages/core/src/ripgrep/binary.ts` | 94 | Keep. It documents Kilo's Windows `rg.exe` fallback behavior. |
+| `packages/opencode/src/cli/cmd/run/footer.prompt.tsx` | 180 | Keep. It accompanies Kilo's `slashMatches` behavior rather than upstream exact matching. |
+| `packages/opencode/src/mcp/index.ts` | 675 | Keep. It accompanies Kilo's `McpCatalog.collect` versus upstream `fetch`. |
+| `packages/opencode/src/plugin/index.ts` | 80, 112 | Keep. These document Kilo plugin type bridging and non-plugin named-export handling. |
+| `packages/opencode/src/session/prompt.ts` | 1277, 1448, 1457, 1856 | Keep. Each documents a Kilo-only prompt/compaction behavior. |
+| `packages/server/src/handlers.ts` | 50 | Keep. It documents Kilo's host-provided location-layer behavior. |
+| `packages/tui/src/routes/session/index.tsx` | 433 | Needs human verification. The marker is immediately before an upstream-equivalent `plan_enter` body, but Kilo lacks upstream's preceding `plan_exit` branch. Removing this comment appears safe, but the standalone placement makes its intended region ambiguous. |
+
+## Notable Non-Findings
+
+- None of the 34 PR-changed files containing `kilocode_change` markers is wholly marker-only or cosmetic-only.
+- No PR file carrying a marker is byte-identical to raw pristine upstream.
+- The eight confirmed stale markers are limited to two otherwise divergent files. There is no evidence that either full file should be reset.
+- Manual comparison of the marked `small-diff` files found substantive Kilo behavior or branding at the marked locations. The reset tool's 16 `Would reset` results should therefore not be treated as an approval to discard them.
+
+## Command Output Excerpts
+
+`find-reset-candidates.ts --dry-run`:
+
+```text
+[OK] Last merged upstream: v1.17.5 (8d78715d)
+[INFO] Candidate files: 1025
+| markers-only | 2 | would reset |
+| cosmetic-only | 1 | would reset |
+| small-diff | 199 | would reset |
+| large-diff | 416 | skipped |
+| identical | 146 | nothing to do |
+```
+
+PR cross-reference:
+
+```text
+git diff --name-only origin/main...HEAD | wc -l
+194
+
+PR classifications: identical=66, small-diff=16, large-diff=36, upstream-missing=76
+```
+
+Examples of individual reset dry-runs:
+
+```text
+[INFO] [DRY-RUN] Would reset packages/opencode/src/session/prompt.ts to transformed upstream v1.17.5
+[INFO] [DRY-RUN] Would reset packages/tui/src/routes/session/index.tsx to transformed upstream v1.17.5
+[OK] packages/opencode/src/project/project.ts already matches transformed upstream v1.17.5
+[OK] packages/tui/src/context/project.tsx already matches transformed upstream v1.17.5
+```
+
+## Limitations
+
+- `reset-to-upstream.ts` compares the working tree to transformed upstream, not raw pristine upstream. Its dry-run result is a safe indication of what the script would write, not proof that a whole-file reset preserves Kilo behavior.
+- The bulk classifier intentionally treats up to five non-marker diff lines as `small-diff`; it does not establish that those lines are unnecessary.
+- Marker-block analysis is exact for parsable blocks and inline markers. Standalone comments that conceptually annotate adjacent control flow require context review and are marked `needs human verification` where ownership is ambiguous.
+- The audit only evaluates the stated PR range against v1.17.5. It does not judge whether remaining intentional Kilo changes are correct, complete, or desirable.
+- The working tree contained pre-existing untracked review reports. This task added only `UNNECESSARY_MARKERS.md` and did not alter those files.


### PR DESCRIPTION
Post-merge review reports for #12404, one file per review area at the repository root:

| Report | Result |
|---|---|
| `KILOCODE_CHANGE_MARKERS.md` | No accidentally removed markers; all removals verified intentional |
| `INFRASTRUCTURE_CHANGE.md` | 3 merge regressions (fixed on the merge branch) + 1 policy item for human decision |
| `OPENCODE_MENTIONS.md` | 2 user-facing OpenCode strings in upstream snowflake-cortex (upstream-inherited, for human decision) + 2 UA strings to verify |
| `UNNECESSARY_MARKERS.md` | 8 stale markers confirmed via dry-run (marker-only cleanup candidates) |
| `BROKEN_PIPELINE_CHAINS.md` | 2 high-severity chain breaks (both fixed on the merge branch) + 1 low item |
| `CONFIG_REGRESSION.md` | No merge-introduced config regressions; pre-existing opencode fallback behavior documented |
| `TESTS.md` | 6 dropped Kilo settlement tests (ported back on the merge branch) |

Fixes applied directly to the merge branch `marius-kilocode/kilo-opencode-v1.17.5`:

- `2ff1ad8253` regenerate `schema.gen.ts` with nullable `session_message.seq` (fresh-DB chain break)
- `c3c704e67f` serve v2 server routes in the production listener (SDK-advertised `/api/*` endpoints 404'd)
- `82dda99b94` restore `test:ci` in six upstream-shared packages, `dev:local`, and trustedDependencies policy
- `8f6b48af63` port the six OAuth settlement guard regression tests to the Integration API

Left for human decision (documented in the reports): upstream snowflake-cortex user-facing strings, `@opencode-ai/http-recorder` public publishConfig, stale marker cleanup, pre-existing opencode config fallback behavior.