### PR TITLE
fix(cli): drop redundant latest channel from user agent

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -60,7 +60,10 @@ export const Info = Schema.Struct({
 export type Info = Schema.Schema.Type<typeof Info>
 
 export function userAgent(client = "cli") {
-  return `kilo/${InstallationChannel}/${InstallationVersion}/${client}` // kilocode_change
+  // kilocode_change start - drop redundant "latest" channel, keep it for beta/prod/local
+  const channel = InstallationChannel === "latest" ? "" : `${InstallationChannel}/`
+  return `kilo/${channel}${InstallationVersion}/${client}`
+  // kilocode_change end
 }
 
 export const USER_AGENT = userAgent()


### PR DESCRIPTION
The user agent included the installation channel even when it was `latest`, producing `kilo/latest/7.4.11/cli`. Since the concrete version is already present, the `latest` segment is redundant noise.

This omits the channel segment when it is `latest`, yielding `kilo/7.4.11/cli`, while preserving it for non-stable channels (`beta`/`prod`/`local`) where it carries meaningful telemetry, e.g. `kilo/beta/7.4.11/cli`.