### PR TITLE
fix(cli): re-land stalled-stream watchdog with post-v1.17.4 test wiring

### DIFF
--- a/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
@@ -28,8 +28,7 @@ import { Permission } from "../../src/permission"
 import { Plugin } from "../../src/plugin"
 import { Provider as ProviderSvc } from "../../src/provider/provider"
 import { Question } from "../../src/question"
-import { Reference } from "../../src/reference/reference"
-import { RepositoryCache } from "../../src/reference/repository-cache"
+import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Instruction } from "../../src/session/instruction"
 import { LLM } from "../../src/session/llm"
@@ -46,7 +45,7 @@ import { Skill } from "../../src/skill"
 import { Snapshot } from "../../src/snapshot"
 import { Storage } from "../../src/storage/storage"
 import { SyncEvent } from "../../src/sync"
-import { Ripgrep } from "@opencode-ai/core/filesystem/ripgrep"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { ToolRegistry } from "../../src/tool/registry"
 import { Truncate } from "../../src/tool/truncate"
 import { MemoryService } from "@kilocode/kilo-memory/effect/service"
@@ -135,7 +134,6 @@ function makeHttp() {
     lsp,
     mcp,
     FSUtil.defaultLayer,
-    Reference.defaultLayer,
     SyncEvent.defaultLayer,
     EventV2Bridge.defaultLayer,
     Database.defaultLayer,
@@ -152,7 +150,6 @@ function makeHttp() {
     Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Format.defaultLayer),
     Layer.provide(Git.defaultLayer),
-    Layer.provide(Reference.defaultLayer),
     Layer.provide(Command.defaultLayer),
     Layer.provide(Auth.defaultLayer),
     Layer.provideMerge(todo),
@@ -193,7 +190,6 @@ function makeHttp() {
         Bus.layer,
         infra,
         Storage.defaultLayer,
-        Reference.defaultLayer,
       ),
     ),
   )


### PR DESCRIPTION
Re-lands #12249 (reverted by open PR #12435) and fixes the compile error that broke `@kilocode/cli` typecheck on `main`.

## What broke

#12249's test (`packages/opencode/test/kilocode/session-stream-watchdog.test.ts`) imported three modules that `2855ebbe48 refactor: kilo compat for v1.17.4` had already removed/relocated on `main`:

- `Reference` / `RepositoryCache` from `../../src/reference/*` — consolidated into `packages/core`
- `Ripgrep` from `@opencode-ai/core/filesystem/ripgrep` — moved to `@opencode-ai/core/ripgrep`

The PR's CI ran five days before merge against a branch tip that still carried the old files, so the squash merge landed the importing test onto a `main` that no longer had the modules → `TS2307` plus cascading `TS2345`/`TS2322`.

## Fix

Fix-forward instead of reverting the production fix in `packages/opencode/src/session/llm.ts`:

- Point `RepositoryCache` at `@opencode-ai/core/repository-cache` and `Ripgrep` at `@opencode-ai/core/ripgrep`.
- Drop the now-nonexistent `Reference.defaultLayer` from the test's layer stack (three sites), matching the current full-stack sibling `session-prompt-compaction-safety.test.ts`, which builds the same Session/SessionProcessor/ToolRegistry graph without it.

Net diff is 2 insertions / 6 deletions in one test file.

## Verification

- `bun run typecheck` (from `packages/opencode/`) — passes.
- `bun test ./test/kilocode/session-stream-watchdog.test.ts` — 3 pass, 0 fail.

Supersedes #12435 (revert can be closed).