### PR TITLE
fix(vscode): show clear warning when reload is blocked by a running session

### DIFF
--- a/.changeset/reload-busy-session-warning.md
+++ b/.changeset/reload-busy-session-warning.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show a clear warning when reloading is blocked by a running session instead of a generic "Reload failed" error, and surface the server error message for other reload failures

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3787,18 +3787,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     try {
       await this.client.instance.reload({ directory: dir }, { throwOnError: true })
     } catch (err) {
+      // wrapClientError exposes the HTTP status via `cause`, not `response`.
+      const cause = err instanceof Error ? err.cause : undefined
       const status =
-        err && typeof err === "object" && "response" in err
-          ? (err as { response?: { status?: number } }).response?.status
-          : undefined
+        cause && typeof cause === "object" && "status" in cause ? (cause as { status?: number }).status : undefined
       if (status === 409) {
         vscode.window.showWarningMessage(
           "Cannot reload while a session is running. Wait for it to finish or abort it first.",
         )
-      } else {
-        console.error("[Kilo New] handleReload: reload endpoint failed:", err)
-        vscode.window.showErrorMessage("Reload failed. See extension logs for details.")
+        return
       }
+      console.error("[Kilo New] handleReload: reload endpoint failed:", err)
+      const detail = err instanceof Error && err.message ? err.message : "See extension logs for details."
+      vscode.window.showErrorMessage(`Reload failed. ${detail}`)
       return
     }
     this.clearCommandsCache()


### PR DESCRIPTION
Reloading the backend while a session is running fails with a 409 Conflict from the server, which already includes a clear explanation. The extension, however, looked for the HTTP status on `err.response.status`, a shape the SDK never produces: wrapped client errors carry the status on `err.cause.status` (see `wrapClientError` in `@kilocode/sdk`). Every failure therefore fell into the generic branch, and users only saw "Reload failed. See extension logs for details." while the actual reason sat in the extension host logs.

The reload handler now reads the status from `err.cause.status`, so the notification tells the user what is going on:

- 409 Conflict: a warning explains that a session is still running and must finish or be aborted first.
- Any other failure: the error notification now includes the server's message instead of only pointing at the logs.

<img width="700" alt="Warning notification reading: Cannot reload while a session is running. Wait for it to finish or abort it first." src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260722-reload-busy-session-warning.png?raw=true" />
