### PR TITLE
fix(cli): harden plan edit permissions

### DIFF
--- a/.changeset/harden-planning-agent-edits.md
+++ b/.changeset/harden-planning-agent-edits.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep Plan and Architect mode source edits denied when agent-specific permissions request edit approval.

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -380,6 +380,7 @@ export const layer = Layer.effect(
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
           // kilocode_change start
           KiloAgent.processConfigItem(item)
+          KiloAgent.hardenPlan(key, item, ctx.worktree, user, Permission.fromConfig(value.permission ?? {}))
         }
 
         function referencePrompt(reference: KiloReference.Resolved) {

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -173,6 +173,24 @@ function denies(user: Permission.Ruleset) {
   return user.filter((rule) => rule.action === "deny")
 }
 
+function editRestrictions(rules: Permission.Ruleset) {
+  const edit = rules.filter((rule) => rule.permission === "edit")
+  return edit.filter((rule, index) => {
+    if (rule.action !== "deny") return false
+    if (rule.pattern !== "*") return true
+    // A wildcard before a later edit exception is an allowlist baseline. The
+    // plan guard supplies the source catch-all, so do not append it alone.
+    return !edit.slice(index + 1).some((next) => next.action !== "deny")
+  })
+}
+
+function restrictions(user: Permission.Ruleset) {
+  return [
+    ...user.filter((rule) => rule.action === "deny" && rule.permission !== "edit"),
+    ...editRestrictions(user),
+  ]
+}
+
 function askEditGuard() {
   return Permission.fromConfig({ edit: "deny" })
 }
@@ -193,6 +211,17 @@ function planEditRules(worktree: string) {
 
 function planEditGuard(worktree: string) {
   return Permission.fromConfig({ edit: planEditRules(worktree) })
+}
+
+export function hardenPlan(
+  key: string,
+  item: { permission: Permission.Ruleset },
+  worktree: string,
+  ...explicit: Permission.Ruleset[]
+) {
+  if (key !== "plan" && key !== "architect") return
+  const edit = explicit.map(editRestrictions)
+  item.permission = Permission.merge(item.permission, planEditGuard(worktree), ...edit)
 }
 
 function planGuard(worktree: string, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
@@ -402,7 +431,7 @@ export function patchAgents(
         planGuard(worktree, kilo.mcpRules),
         user,
         planEditGuard(worktree),
-        denies(user),
+        restrictions(user),
       ),
     }
   }

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
+import type { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { Effect } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { Permission } from "../../src/permission"
@@ -12,6 +13,21 @@ function load<A>(dir: string, fn: (svc: Agent.Interface) => Effect.Effect<A>) {
       Effect.provide(testInstanceStoreLayer),
     ),
   )
+}
+
+async function get(config: Partial<ConfigV1.Info>, name = "plan") {
+  await using tmp = await tmpdir({ config })
+  const item = await provideTestInstance({
+    directory: tmp.path,
+    fn: () => load(tmp.path, (svc) => svc.get(name)),
+  })
+  return item
+}
+
+function expectPlan(item: Agent.Info | undefined, action: Permission.Action = "allow") {
+  expect(item).toBeDefined()
+  expect(Permission.evaluate("edit", "src/output.log", item!.permission).action).toBe("deny")
+  expect(Permission.evaluate("edit", ".kilo/plans/fix.md", item!.permission).action).toBe(action)
 }
 
 afterEach(async () => {
@@ -79,6 +95,194 @@ test("plan agent still hard-denies non-plan edits after user edit allow", async 
       expect(Permission.evaluate("edit", ".plans/fix.md", plan!.permission).action).toBe("allow")
     },
   })
+})
+
+test("plan agent still hard-denies non-plan edits after per-agent edit ask", async () => {
+  const plan = await get(
+    {
+      agent: {
+        plan: {
+          permission: {
+            edit: "ask",
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan)
+})
+
+test("plan agent honors global and per-agent plan allows after wildcard edit deny", async () => {
+  const edit = {
+    "*": "deny" as const,
+    ".kilo/plans/*": "allow" as const,
+  }
+  for (const config of [
+    { permission: { edit } },
+    {
+      agent: {
+        plan: {
+          permission: {
+            edit,
+          },
+        },
+      },
+    },
+  ]) {
+    expectPlan(await get(config))
+  }
+})
+
+test("plan agent preserves scalar edit deny", async () => {
+  const plan = await get(
+    {
+      agent: {
+        plan: {
+          permission: {
+            edit: "deny",
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan, "deny")
+})
+
+test("plan agent preserves a terminal wildcard edit deny", async () => {
+  const plan = await get(
+    {
+      agent: {
+        plan: {
+          permission: {
+            edit: {
+              ".kilo/plans/*": "allow",
+              "*": "deny",
+            },
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan, "deny")
+})
+
+test("plan agent preserves explicit per-agent edit denies", async () => {
+  const plan = await get(
+    {
+      agent: {
+        plan: {
+          permission: {
+            edit: {
+              ".kilo/plans/private.md": "deny",
+            },
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan)
+  expect(Permission.evaluate("edit", ".kilo/plans/private.md", plan!.permission).action).toBe("deny")
+})
+
+test("plan agent preserves global edit denies after per-agent edit ask", async () => {
+  const plan = await get(
+    {
+      permission: {
+        edit: {
+          ".kilo/plans/private.md": "deny",
+        },
+      },
+      agent: {
+        plan: {
+          permission: {
+            edit: "ask",
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan)
+  expect(Permission.evaluate("edit", ".kilo/plans/private.md", plan!.permission).action).toBe("deny")
+})
+
+test("plan agent preserves global non-edit denies before broader allows", async () => {
+  const plan = await get({
+    permission: {
+      bash: {
+        "rm *": "deny",
+        "*": "allow",
+      },
+    },
+  })
+  expect(Permission.evaluate("bash", "rm -rf x", plan!.permission).action).toBe("deny")
+  expect(Permission.evaluate("bash", "ls", plan!.permission).action).toBe("allow")
+})
+
+test("plan agent preserves per-agent tool allows with a wildcard deny", async () => {
+  const plan = await get(
+    {
+      agent: {
+        plan: {
+          permission: {
+            "*": "deny",
+            read: "allow",
+            glob: "allow",
+            edit: "ask",
+          },
+        },
+      },
+    },
+  )
+  expectPlan(plan)
+  expect(Permission.evaluate("read", "src/output.log", plan!.permission).action).toBe("allow")
+  expect(Permission.evaluate("glob", "*", plan!.permission).action).toBe("allow")
+})
+
+test("marketplace architect honors plan allow after wildcard edit deny", async () => {
+  const architect = await get(
+    {
+      agent: {
+        architect: {
+          mode: "primary",
+          options: {
+            displayName: "Architect",
+          },
+          permission: {
+            "*": "deny",
+            read: "allow",
+            glob: "allow",
+            edit: {
+              "*": "deny",
+              ".kilo/plans/*": "allow",
+            },
+          },
+        },
+      },
+    },
+    "architect",
+  )
+  expectPlan(architect)
+  expect(architect!.name).toBe("architect")
+  expect(architect!.displayName).toBe("Architect")
+  expect(Permission.evaluate("read", "src/output.log", architect!.permission).action).toBe("allow")
+  expect(Permission.evaluate("glob", "*", architect!.permission).action).toBe("allow")
+})
+
+test("non-planning agents retain per-agent edit permissions", async () => {
+  const code = await get(
+    {
+      agent: {
+        code: {
+          permission: {
+            edit: "ask",
+          },
+        },
+      },
+    },
+    "code",
+  )
+  expect(code).toBeDefined()
+  expect(Permission.evaluate("edit", "src/output.log", code!.permission).action).toBe("ask")
 })
 
 test("system utility agents ignore per-agent permission allows", async () => {


### PR DESCRIPTION
## Issue

Fixes #12338

## Context

Agent-specific Plan permissions were merged after the hard Plan edit guard. Configuring `agent.plan.permission.edit` as `ask` could therefore allow source edits that Plan mode must deny.

## Implementation

Reapply the Plan edit ceiling after per-agent configuration merges, while preserving explicit edit deny rules without changing the ordering of other tool permissions. Apply the same ceiling to the lowercase `architect` key used by Marketplace Architect agents. Source edits remain denied and `.kilo/plans/**` remains writable unless explicitly denied.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Confirmed the pre-fix CLI allowed Plan and Marketplace Architect to edit source files with `edit: "ask"`.
- Confirmed the fixed CLI denies those source edits while allowing Plan-file edits.

### Reviewer test steps

1. Configure `agent.plan.permission.edit` as `ask`.
2. Confirm Plan cannot edit a source file.
3. Confirm Plan can edit `.kilo/plans/demo.md`.
4. Add a lowercase `architect` agent with display name `Architect` and confirm the same behavior.

Additional executed verification:

- Focused permission regression suite: 11 passed.
- Adjacent Plan, config, and subagent suite: 13 passed.
- CLI typecheck passed.
- Full pre-push monorepo and JetBrains typechecks passed.
- OpenCode annotation and Promise-facade guards passed.
- `git diff --check` passed.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.