### PR TITLE
fix(cli): ignore late tool input events

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -538,10 +538,12 @@ export const layer = Layer.effect(
             yield* ensureToolCall(value)
             return
 
+          // kilocode_change start
           case "tool-input-delta":
             {
               const toolCall = yield* readToolCall(value.id)
               if (!toolCall) return
+              // kilocode_change end
               const assistantMessageID = mirrorAssistant ? yield* requireV2AssistantMessage(toolCall.call) : undefined
               if (assistantMessageID) {
                 yield* events.publish(SessionEvent.Tool.Input.Delta, {
@@ -556,9 +558,11 @@ export const layer = Layer.effect(
             }
             return
 
+          // kilocode_change start
           case "tool-input-end": {
             const toolCall = yield* readToolCall(value.id)
             if (!toolCall) return
+            // kilocode_change end
             // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
             if (mirrorAssistant) {
               const assistantMessageID = yield* requireV2AssistantMessage(toolCall.call)

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -540,7 +540,8 @@ export const layer = Layer.effect(
 
           case "tool-input-delta":
             {
-              const toolCall = yield* ensureToolCall(value)
+              const toolCall = yield* readToolCall(value.id)
+              if (!toolCall) return
               const assistantMessageID = mirrorAssistant ? yield* requireV2AssistantMessage(toolCall.call) : undefined
               if (assistantMessageID) {
                 yield* events.publish(SessionEvent.Tool.Input.Delta, {
@@ -556,7 +557,8 @@ export const layer = Layer.effect(
             return
 
           case "tool-input-end": {
-            const toolCall = yield* ensureToolCall(value)
+            const toolCall = yield* readToolCall(value.id)
+            if (!toolCall) return
             // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
             if (mirrorAssistant) {
               const assistantMessageID = yield* requireV2AssistantMessage(toolCall.call)

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -224,6 +224,34 @@ const providerErrorEnv = LayerNode.buildLayer(root, {
 })
 const itProviderError = testEffect(providerErrorEnv)
 
+const lateToolInputLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.toolInputStart({ id: "call-1", name: "read" }),
+        LLMEvent.toolInputDelta({ id: "call-1", name: "read", text: '{"filePath":"package.json"}' }),
+        LLMEvent.toolInputEnd({ id: "call-1", name: "read" }),
+        LLMEvent.toolCall({ id: "call-1", name: "read", input: { filePath: "package.json" }, providerExecuted: true }),
+        LLMEvent.toolResult({
+          id: "call-1",
+          name: "read",
+          result: { type: "text", value: "contents" },
+          providerExecuted: true,
+        }),
+        LLMEvent.toolInputDelta({ id: "call-1", name: "unknown", text: "" }),
+        LLMEvent.toolInputEnd({ id: "call-1", name: "unknown" }),
+        LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+        LLMEvent.finish({ reason: "tool-calls" }),
+      ),
+  }),
+)
+const lateToolInputEnv = LayerNode.buildLayer(root, {
+  replacements: [...replacements, LayerNode.replace(LLM.node, lateToolInputLLM)],
+})
+const itLateToolInput = testEffect(lateToolInputEnv)
+
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
   LLM.Service.of({
@@ -1078,6 +1106,46 @@ itProviderError.live("session.processor effect tests fail provider-executed erro
           result: { type: "error", value: "provider boom" },
           provider: { executed: true },
         })
+      }),
+    { config: cfg },
+  ),
+)
+
+itLateToolInput.live("session.processor effect tests ignore tool input after the call settles", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "read a file")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "read a file" }],
+          tools: {},
+        })
+
+        const calls = (yield* MessageV2.parts(msg.id)).filter(
+          (part): part is SessionV1.ToolPart => part.type === "tool",
+        )
+        expect(calls).toHaveLength(1)
+        expect(calls[0]?.callID).toBe("call-1")
+        expect(calls[0]?.tool).toBe("read")
+        expect(calls[0]?.state.status).toBe("completed")
       }),
     { config: cfg },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -224,6 +224,7 @@ const providerErrorEnv = LayerNode.buildLayer(root, {
 })
 const itProviderError = testEffect(providerErrorEnv)
 
+// kilocode_change start
 const lateToolInputLLM = Layer.succeed(
   LLM.Service,
   LLM.Service.of({
@@ -251,6 +252,7 @@ const lateToolInputEnv = LayerNode.buildLayer(root, {
   replacements: [...replacements, LayerNode.replace(LLM.node, lateToolInputLLM)],
 })
 const itLateToolInput = testEffect(lateToolInputEnv)
+// kilocode_change end
 
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
@@ -1109,8 +1111,9 @@ itProviderError.live("session.processor effect tests fail provider-executed erro
       }),
     { config: cfg },
   ),
-)
+) // kilocode_change
 
+// kilocode_change start
 itLateToolInput.live("session.processor effect tests ignore tool input after the call settles", () =>
   provideTmpdirInstance(
     (dir) =>
@@ -1150,6 +1153,7 @@ itLateToolInput.live("session.processor effect tests ignore tool input after the
     { config: cfg },
   ),
 )
+// kilocode_change end
 
 itFragmentFailure.live("session.processor effect tests flush partial v2 fragments before step failure", () =>
   provideTmpdirInstance(


### PR DESCRIPTION
## Summary
- prevent late `tool-input-delta` and `tool-input-end` events from recreating already-settled tool calls
- keep update-only input events scoped to active calls through `readToolCall`
- add a deterministic regression for the Qwen/OpenRouter event order observed in live Auto Balanced sessions

## Root cause
Qwen 3.7 through OpenRouter can emit a trailing empty input delta/end after the matching tool result. The processor previously called `ensureToolCall` for those late events, recreating the completed call as an `unknown` pending tool. Cleanup then surfaced the phantom call as `Tool execution aborted`.

## Verification
- regression test fails before the fix with two tool parts and passes afterward with one completed call
- `bun test --timeout 10000 ./test/session/processor-effect.test.ts` (17 passed)
- `bun run typecheck` in `packages/opencode`
- pre-push monorepo TypeScript and JetBrains typechecks
- three isolated VS Code Auto Balanced scenarios completed with no phantom or aborted tools: two parallel-read cases and one sequential-read case

Related: Kilo-Org/kilocode#12337, anomalyco/opencode#33622