### PR TITLE
fix(tui): restore variant cycle keybind hint in prompt footer

### DIFF
--- a/.changeset/tui-variant-shortcut-hint.md
+++ b/.changeset/tui-variant-shortcut-hint.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show the `Ctrl+T` variant cycling shortcut in the TUI prompt hint row whenever the active model exposes reasoning variants, as the first hint before the agent and command palette hints

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -177,6 +177,7 @@ export function Prompt(props: PromptProps) {
   const keymap = useOpencodeKeymap()
   const agentShortcut = useCommandShortcut("agent.cycle")
   const paletteShortcut = useCommandShortcut("command.palette.show")
+  const variantShortcut = useCommandShortcut("variant.cycle")
   const renderer = useRenderer()
   const exit = useExit()
   const dimensions = useTerminalDimensions()
@@ -1835,6 +1836,11 @@ export function Prompt(props: PromptProps) {
               </Show>
               <Switch>
                 <Match when={store.mode === "normal"}>
+                  <Show when={local.model.variant.list().length > 0}>
+                    <text fg={theme.text}>
+                      {variantShortcut()} <span style={{ fg: theme.textMuted }}>variants</span>
+                    </text>
+                  </Show>
                   <Switch>
                     <Match when={usage()}>
                       {(item) => (


### PR DESCRIPTION
## Issue

Closes #12464

## Context

The TUI prompt footer shows keybind hints for switching agents and opening the command palette, but the `Ctrl+T` hint for cycling reasoning/thinking variants was not rendered even when a thinking variant was selected. The keybind itself still fired correctly, the shortcut was simply not discoverable from the UI.

Git history shows this hint was originally added upstream in `anomalyco/opencode` commit `cd56845dce` ("tui: add hint for variants toggle", Jan 12 2026) and later made conditional on `local.model.variant.list().length > 0` in `93e43d8e5e` ("Hide variants hint when list empty"). It was removed in `81eb6e670b` ("refactor(prompt): remove variant cycle display from footer", Mar 28, 2026), and the variant information was relocated to the top metadata row instead. The footer hint was never restored.

This PR restores the hint at its original position and re-establishes discoverability of the `variant.cycle` keybind in the prompt footer.

## Implementation

The TUI prompt component has two hint areas:

- **Top metadata row** — shows the current agent, model name, provider, and (when applicable) the active variant name.
- **Footer hint row** — shows keyboard shortcut hints for cycling agents (`agent.cycle`) and opening the command palette (`command.palette.show`).

This change adds a third entry to the footer:

- Registers `const variantShortcut = useCommandShortcut("variant.cycle")` alongside the existing `agentShortcut` and `paletteShortcut` hook calls at the top of the `Prompt` component.
- Renders it as the first `<text>` inside the `<Match when={store.mode === "normal"}>` branch of the footer's `<Switch>`, wrapped in `<Show when={showVariant()}>`.
- `showVariant()` is the existing `createMemo` in this file (around line 1448) that returns true only when the active model has at least one variant.

The placement (first in the row, before agents and commands) matches the original upstream placement. The keybind follows the configured `variant.cycle` keybind (defaults to `Ctrl+T`), so users who have remapped it will see their own key string.

A changeset is included.

## Screenshots / Video

<img width="811" height="180" alt="image" src="https://github.com/user-attachments/assets/3093ef2f-12cf-48a8-9ae0-ac9675e28df1" />
<img width="795" height="171" alt="image" src="https://github.com/user-attachments/assets/caf1b4e3-213c-4a68-a9ff-4f3e1dae30dc" />

## How to Test

### Manual/local verification

- Run the TUI against a model with reasoning variants (Anthropic extended thinking, OpenAI reasoning effort, etc.). Confirm `Ctrl+T variants` appears as the first hint in the footer row beneath the input.
- Press `Ctrl+T` while focused in the input, confirm the variant actually cycles and the footer hint reflects the new keybind resolution if the user has remapped it.

### Reviewer test steps

1. Launch the TUI (`bun dev`).
2. Pick a session using a reasoning-capable model.
3. Read the footer hint row directly under the box.
4. Confirm `Ctrl+T variants` is the leftmost hint, before `agents` and `commands`.
5. Press `Ctrl+T` and confirm the variant cycles and the hint updates if the user has remapped the keybind in config.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18