### PR TITLE
perf(indexing): make incremental scans actually incremental

### DIFF
--- a/.changeset/calm-indexing-profile.md
+++ b/.changeset/calm-indexing-profile.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-indexing": patch
+"@kilocode/cli": patch
+---
+
+Add opt-in local performance profiling for codebase indexing.

--- a/.changeset/faster-incremental-indexing.md
+++ b/.changeset/faster-incremental-indexing.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": patch
+"@kilocode/kilo-indexing": patch
+"kilo-code": patch
+---
+
+Skip reading unchanged files during incremental codebase indexing scans.

--- a/packages/kilo-docs/pages/customize/context/codebase-indexing.md
+++ b/packages/kilo-docs/pages/customize/context/codebase-indexing.md
@@ -304,6 +304,20 @@ These advanced settings live under the `indexing` key and are exposed in the CLI
 
 ## Troubleshooting
 
+### Collect local indexing performance logs
+
+Start the kilo CLI with profiling and terminal logs enabled:
+
+```bash
+KILO_INDEXING_PROFILE=1 KILO_PRINT_LOGS=1 kilo
+```
+
+If you omit `KILO_PRINT_LOGS=1`, Kilo writes the records to rotating local log files in the normal Kilo data directory's `log/` folder. For the VS Code extension, JetBrains plugin, or another backend process, make sure the process inherits `KILO_INDEXING_PROFILE=1` and restart it.
+
+Profile records are INFO records with `message="indexing profile"`. They include an opaque `workspaceID`, event name, duration, outcome, and numeric counts. The workspace identity is a hash, not a workspace path. Records stay local and exclude file paths, query text, and code.
+
+Timings can overlap, scan batches can finish out of order, and batch-level profiling can be verbose for large repositories. Use the records to diagnose local indexing behavior rather than to compare elapsed times as a benchmark.
+
 ### Embeddings fail or indexing stalls (llama.cpp / Ollama)
 
 If your local embedding server is based on llama.cpp (including Ollama), indexing can fail with errors about `n_ubatch` or `GGML_ASSERT`. Ensure both batch size (`-b`) and micro-batch size (`-ub`) are set to the same value for embedding models, then restart the server. For Ollama, configure `num_batch` in your Modelfile or request options to match the same effective value.

--- a/packages/kilo-indexing/src/indexing/cache-manager.ts
+++ b/packages/kilo-indexing/src/indexing/cache-manager.ts
@@ -1,10 +1,27 @@
 import { createHash } from "crypto"
 import fs from "fs/promises"
 import path from "path"
-import type { ICacheManager } from "./interfaces/cache"
+import type { CacheMetadata, ICacheManager } from "./interfaces/cache"
 import { Log } from "../util/log"
 
 const log = Log.create({ service: "indexing-cache" })
+const VERSION = 2
+
+type Entry = {
+  hash: string
+  size?: number
+  mtimeMs?: number
+  ctimeMs?: number
+}
+
+type Data = {
+  version: typeof VERSION
+  files: Record<string, Entry>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
 
 /**
  * Manages the file-hash cache for code indexing.
@@ -14,7 +31,7 @@ const log = Log.create({ service: "indexing-cache" })
  */
 export class CacheManager implements ICacheManager {
   private readonly cachePath: string
-  private fileHashes: Record<string, string> = {}
+  private files: Record<string, Entry> = {}
   private saveTimer: ReturnType<typeof setTimeout> | undefined
   private saveTask = Promise.resolve()
 
@@ -28,10 +45,41 @@ export class CacheManager implements ICacheManager {
 
   async initialize(): Promise<void> {
     try {
-      const raw = await fs.readFile(this.cachePath, "utf-8")
-      this.fileHashes = JSON.parse(raw)
+      const data: unknown = JSON.parse(await fs.readFile(this.cachePath, "utf-8"))
+      if (!isRecord(data)) {
+        this.files = {}
+        return
+      }
+
+      if ("version" in data) {
+        if (data.version !== VERSION || !isRecord(data.files)) {
+          this.files = {}
+          return
+        }
+
+        this.files = Object.fromEntries(
+          Object.entries(data.files).flatMap(([file, value]) => {
+            if (!isRecord(value) || typeof value.hash !== "string") return []
+            const metadata =
+              typeof value.size === "number" &&
+              Number.isFinite(value.size) &&
+              typeof value.mtimeMs === "number" &&
+              Number.isFinite(value.mtimeMs) &&
+              typeof value.ctimeMs === "number" &&
+              Number.isFinite(value.ctimeMs)
+            return metadata
+              ? [[file, { hash: value.hash, size: value.size, mtimeMs: value.mtimeMs, ctimeMs: value.ctimeMs }]]
+              : [[file, { hash: value.hash }]]
+          }),
+        )
+        return
+      }
+
+      this.files = Object.fromEntries(
+        Object.entries(data).flatMap(([file, value]) => (typeof value === "string" ? [[file, { hash: value }]] : [])),
+      )
     } catch {
-      this.fileHashes = {}
+      this.files = {}
     }
   }
 
@@ -45,7 +93,8 @@ export class CacheManager implements ICacheManager {
   private async performSave(): Promise<void> {
     await fs.mkdir(path.dirname(this.cachePath), { recursive: true })
     const tmp = `${this.cachePath}.tmp`
-    await fs.writeFile(tmp, JSON.stringify(this.fileHashes), "utf-8")
+    const data: Data = { version: VERSION, files: this.files }
+    await fs.writeFile(tmp, JSON.stringify(data), "utf-8")
     await fs.rename(tmp, this.cachePath)
   }
 
@@ -60,35 +109,43 @@ export class CacheManager implements ICacheManager {
   }
 
   seedHashes(hashes: Readonly<Record<string, string>>): void {
-    this.fileHashes = { ...hashes }
+    this.files = Object.fromEntries(Object.entries(hashes).map(([file, hash]) => [file, { hash }]))
     this.scheduleSave()
   }
 
   async clearCacheFile(): Promise<void> {
-    this.fileHashes = {}
+    this.files = {}
     await this.flush()
   }
 
   getHash(filePath: string): string | undefined {
-    return this.fileHashes[filePath]
+    return this.files[filePath]?.hash
   }
 
-  updateHash(filePath: string, hash: string): void {
-    this.fileHashes[filePath] = hash
+  getMetadata(filePath: string): CacheMetadata | undefined {
+    const entry = this.files[filePath]
+    if (entry?.size === undefined || entry.mtimeMs === undefined || entry.ctimeMs === undefined) return
+    return { size: entry.size, mtimeMs: entry.mtimeMs, ctimeMs: entry.ctimeMs }
+  }
+
+  updateHash(filePath: string, hash: string, metadata?: CacheMetadata): void {
+    this.files[filePath] = metadata ? { hash, ...metadata } : { hash }
     this.scheduleSave()
   }
 
   deleteHash(filePath: string): void {
-    delete this.fileHashes[filePath]
+    delete this.files[filePath]
     this.scheduleSave()
   }
 
   getAllHashes(): Record<string, string> {
-    return { ...this.fileHashes }
+    return Object.fromEntries(Object.entries(this.files).map(([file, entry]) => [file, entry.hash]))
   }
 
   signature(): string {
-    const entries = Object.entries(this.fileHashes).sort(([left], [right]) => left.localeCompare(right))
+    const entries = Object.entries(this.files)
+      .map(([file, entry]) => [file, entry.hash])
+      .sort(([left], [right]) => left.localeCompare(right))
     return createHash("sha256").update(JSON.stringify(entries)).digest("hex")
   }
 

--- a/packages/kilo-indexing/src/indexing/index.ts
+++ b/packages/kilo-indexing/src/indexing/index.ts
@@ -33,3 +33,4 @@ export type {
 } from "./interfaces/file-processor"
 
 export type { ICacheManager } from "./interfaces/cache"
+export type { IndexingProfileRecord } from "../util/profile"

--- a/packages/kilo-indexing/src/indexing/interfaces/cache.ts
+++ b/packages/kilo-indexing/src/indexing/interfaces/cache.ts
@@ -1,6 +1,13 @@
+export type CacheMetadata = {
+  size: number
+  mtimeMs: number
+  ctimeMs: number
+}
+
 export interface ICacheManager {
   getHash(filePath: string): string | undefined
-  updateHash(filePath: string, hash: string): void
+  getMetadata?(filePath: string): CacheMetadata | undefined
+  updateHash(filePath: string, hash: string, metadata?: CacheMetadata): void
   deleteHash(filePath: string): void
   getAllHashes(): Record<string, string>
 }

--- a/packages/kilo-indexing/src/indexing/interfaces/file-processor.ts
+++ b/packages/kilo-indexing/src/indexing/interfaces/file-processor.ts
@@ -1,4 +1,5 @@
 import type { PointStruct } from "./vector-store"
+import type { CacheMetadata } from "./cache"
 import type { Disposable, Emitter } from "../runtime"
 import type { IndexingTelemetryMode } from "./telemetry"
 import type { WorktreeOverlay } from "../worktree-overlay"
@@ -62,6 +63,7 @@ export interface FileProcessingResult {
   error?: Error
   reason?: string
   newHash?: string
+  metadata?: CacheMetadata
   pointsToUpsert?: PointStruct[]
 }
 

--- a/packages/kilo-indexing/src/indexing/manager.ts
+++ b/packages/kilo-indexing/src/indexing/manager.ts
@@ -14,6 +14,7 @@ import { Log } from "../util/log"
 import { loadIgnore } from "./shared/load-ignore"
 import { sanitizeErrorMessage } from "./shared/validation-helpers"
 import { WorktreeOverlay } from "./worktree-overlay"
+import { IndexingProfile } from "../util/profile"
 
 const log = Log.create({ service: "indexing-manager" })
 const BASELINE_CHECK_INTERVAL = 1_000
@@ -285,6 +286,12 @@ export class CodeIndexManager {
     }
 
     const { requiresRestart } = this._configManager.loadConfiguration(input)
+    using span = IndexingProfile.start("indexing.manager.initialize")
+    span.add({
+      enabled: this.isFeatureEnabled,
+      configured: this.isFeatureConfigured,
+      requiresRestart,
+    })
     log.info("loaded indexing configuration", {
       workspacePath: this.workspacePath,
       featureEnabled: this.isFeatureEnabled,
@@ -297,12 +304,14 @@ export class CodeIndexManager {
     if (!this.isFeatureEnabled) {
       log.info("indexing disabled by configuration", { workspacePath: this.workspacePath })
       this._orchestrator?.stopWatcher()
+      span.outcome("disabled")
       return { requiresRestart }
     }
 
     if (!this.workspacePath) {
       log.info("indexing unavailable: no workspace path")
       this._stateManager.setSystemState("Standby", "No workspace folder open")
+      span.outcome("disabled")
       return { requiresRestart }
     }
 
@@ -316,6 +325,7 @@ export class CodeIndexManager {
         "Standby",
         "Code indexing is not configured. Save your settings to start indexing.",
       )
+      span.outcome("disabled")
       return { requiresRestart }
     }
 
@@ -323,7 +333,10 @@ export class CodeIndexManager {
       log.info("initializing indexing cache", { cacheDirectory: this.cacheDirectory })
       this._cacheManager = new CacheManager(this.cacheDirectory, this.workspacePath)
       await this._cacheManager.initialize()
-      if (this._disposed) return { requiresRestart }
+      if (this._disposed) {
+        span.outcome("cancelled")
+        return { requiresRestart }
+      }
       log.info("indexing cache initialized", { cacheDirectory: this.cacheDirectory })
     }
 
@@ -342,6 +355,7 @@ export class CodeIndexManager {
           this._orchestrator?.cancelIndexing()
           this._orchestrator = undefined
           this._searchService = undefined
+          span.outcome("cancelled")
           return { requiresRestart }
         }
         log.info("indexing services recreated", { workspacePath: this.workspacePath })
@@ -356,7 +370,10 @@ export class CodeIndexManager {
       }
     }
 
-    if (this.waiting()) return { requiresRestart }
+    if (this.waiting()) {
+      span.outcome("waiting")
+      return { requiresRestart }
+    }
 
     const shouldStartOrRestart =
       requiresRestart || (needsServiceRecreation && (!this._orchestrator || this._orchestrator.state !== "Indexing"))
@@ -372,6 +389,7 @@ export class CodeIndexManager {
       this._orchestrator?.startIndexing("background")
     }
 
+    span.outcome("success")
     return { requiresRestart }
   }
 
@@ -558,6 +576,15 @@ export class CodeIndexManager {
 
   private async _recreateServices(prepared?: Baseline): Promise<void> {
     log.info("starting indexing service recreation", { workspacePath: this.workspacePath })
+    const config = this._configManager!.getConfig()
+    using span = IndexingProfile.start("indexing.manager.services")
+    span.add({
+      provider: config.embedderProvider,
+      modelId: config.modelId,
+      vectorStore: config.vectorStoreProvider ?? DEFAULT_VECTOR_STORE,
+      baseline: "none",
+      validationMs: 0,
+    })
     const factory = new CodeIndexServiceFactory(
       this._configManager!,
       this.workspacePath,
@@ -566,8 +593,8 @@ export class CodeIndexManager {
       (event) => this.handleTelemetry(event),
     )
     const ignoreInstance = await loadIgnore(this.workspacePath)
-    const config = this._configManager!.getConfig()
     const baseline = prepared ?? (await this.createBaseline(factory))
+    span.add({ baseline: baseline?.store ? "ready" : baseline ? "waiting" : "none" })
     const { embedder, vectorStore, scanner, fileWatcher } = factory.createServices(this._cacheManager!, ignoreInstance)
     fileWatcher.setOverlay?.(baseline?.overlay)
     log.info("created indexing services", {
@@ -579,20 +606,25 @@ export class CodeIndexManager {
 
     const shouldValidate = embedder && embedder.embedderInfo.name === config.embedderProvider
     if (shouldValidate) {
+      const validation = performance.now()
       log.info("validating embedder configuration", {
         workspacePath: this.workspacePath,
         provider: embedder.embedderInfo.name,
       })
-      const validationResult = await factory.validateEmbedder(embedder)
-      if (!validationResult.valid) {
-        const errorMessage = validationResult.error || "Embedder configuration validation failed"
-        this._stateManager.setSystemState("Error", errorMessage)
-        throw new Error(errorMessage)
+      try {
+        const validationResult = await factory.validateEmbedder(embedder)
+        if (!validationResult.valid) {
+          const errorMessage = validationResult.error || "Embedder configuration validation failed"
+          this._stateManager.setSystemState("Error", errorMessage)
+          throw new Error(errorMessage)
+        }
+        log.info("embedder configuration validated", {
+          workspacePath: this.workspacePath,
+          provider: embedder.embedderInfo.name,
+        })
+      } finally {
+        span.add({ validationMs: Math.max(0, performance.now() - validation) })
       }
-      log.info("embedder configuration validated", {
-        workspacePath: this.workspacePath,
-        provider: embedder.embedderInfo.name,
-      })
     }
 
     const orchestrator = new CodeIndexOrchestrator(
@@ -619,6 +651,7 @@ export class CodeIndexManager {
     if (this._disposed) {
       await orchestrator.shutdown()
       await baseline?.store?.close?.()
+      span.outcome("cancelled")
       return
     }
 
@@ -632,6 +665,7 @@ export class CodeIndexManager {
     this._overlay = baseline?.overlay
     this._stateManager.setSystemState("Standby", "")
     log.info("indexing services are ready", { workspacePath: this.workspacePath })
+    span.outcome("success")
   }
 
   public async handleSettingsChange(input: IndexingConfigInput): Promise<void> {

--- a/packages/kilo-indexing/src/indexing/orchestrator.ts
+++ b/packages/kilo-indexing/src/indexing/orchestrator.ts
@@ -18,6 +18,7 @@ import { Log } from "../util/log"
 import { sanitizeErrorMessage } from "./shared/validation-helpers"
 import { DEFAULT_VECTOR_STORE } from "./constants"
 import type { WorktreeOverlay } from "./worktree-overlay"
+import { IndexingProfile } from "../util/profile"
 
 const log = Log.create({ service: "indexing-orchestrator" })
 
@@ -175,6 +176,19 @@ export class CodeIndexOrchestrator {
       return
     }
 
+    const cfg = this.configManager.getConfig()
+    using span = IndexingProfile.start("indexing.index.run", {
+      trigger,
+      mode: "full",
+      provider: cfg.embedderProvider,
+      modelId: cfg.modelId,
+      vectorStore: cfg.vectorStoreProvider ?? DEFAULT_VECTOR_STORE,
+      watcherInitMs: 0,
+      storeInitMs: 0,
+      storePrepareMs: 0,
+      scanMs: 0,
+      finalizeMs: 0,
+    })
     this._cancelRequested = false
     this._isProcessing = true
     this.stateManager.setSystemState("Indexing", "Initializing services...")
@@ -184,74 +198,105 @@ export class CodeIndexOrchestrator {
     let mode: IndexingTelemetryMode | undefined
 
     try {
+      const overlay = performance.now()
       this.overlay?.prepare()
-      await this._startWatcher()
+      const overlayMs = Math.max(0, performance.now() - overlay)
+      span.add({ storePrepareMs: overlayMs })
+      const watcher = performance.now()
+      await this._startWatcher().finally(() => {
+        span.add({ watcherInitMs: Math.max(0, performance.now() - watcher) })
+      })
 
       if (this._cancelRequested) {
         this.stateManager.setSystemState("Standby", "Indexing cancelled.")
+        span.outcome("cancelled")
         return
       }
 
       source = "scan"
-      const collectionCreated = await this.vectorStore.initialize()
+      const store = performance.now()
+      const collectionCreated = await this.vectorStore.initialize().finally(() => {
+        span.add({ storeInitMs: Math.max(0, performance.now() - store) })
+      })
       log.info("vector store initialized", { workspacePath: this.workspacePath, collectionCreated })
       started = true
 
       if (this._cancelRequested) {
         this.stateManager.setSystemState("Standby", "Indexing cancelled.")
+        span.outcome("cancelled")
         return
       }
 
-      if (this.overlay) {
-        if (!collectionCreated) await this.vectorStore.clearCollection()
-        await this.cacheManager.clearCacheFile()
-        this.cacheManager.seedHashes(this.overlay.seed())
-        await this.cacheManager.flush?.()
-        log.info("seeded worktree index from shared baseline", {
-          workspacePath: this.workspacePath,
-          baselinePath: this.overlay.baselinePath,
-          files: this.overlay.baseline.size,
-        })
-      }
+      const prepare = performance.now()
+      const hasExistingData = await (async () => {
+        try {
+          if (this.overlay) {
+            if (!collectionCreated) await this.vectorStore.clearCollection()
+            await this.cacheManager.clearCacheFile()
+            this.cacheManager.seedHashes(this.overlay.seed())
+            await this.cacheManager.flush?.()
+            log.info("seeded worktree index from shared baseline", {
+              workspacePath: this.workspacePath,
+              baselinePath: this.overlay.baselinePath,
+              files: this.overlay.baseline.size,
+            })
+          }
 
-      const hasExistingData = this.overlay ? false : await this.vectorStore.hasIndexedData()
-      if (!this.overlay && !hasExistingData) {
-        if (!collectionCreated) await this.vectorStore.clearCollection()
-        await this.cacheManager.clearCacheFile()
-        log.info("cleared indexing cache before full scan", {
-          workspacePath: this.workspacePath,
-          collectionCreated,
-        })
-      }
-      log.info("checked vector store indexed data", {
-        workspacePath: this.workspacePath,
-        hasExistingData,
-        collectionCreated,
-      })
+          const existing = this.overlay ? false : await this.vectorStore.hasIndexedData()
+          if (!this.overlay && !existing) {
+            if (!collectionCreated) await this.vectorStore.clearCollection()
+            await this.cacheManager.clearCacheFile()
+            log.info("cleared indexing cache before full scan", {
+              workspacePath: this.workspacePath,
+              collectionCreated,
+            })
+          }
+          log.info("checked vector store indexed data", {
+            workspacePath: this.workspacePath,
+            hasExistingData: existing,
+            collectionCreated,
+          })
+          return existing
+        } finally {
+          span.add({ storePrepareMs: overlayMs + Math.max(0, performance.now() - prepare) })
+        }
+      })()
 
       if (this._cancelRequested) {
         this.stateManager.setSystemState("Standby", "Indexing cancelled.")
+        span.outcome("cancelled")
         return
       }
 
       mode = hasExistingData && !collectionCreated ? "incremental" : "full"
+      span.add({ mode })
 
-      if (mode === "incremental") {
-        log.info("collection has existing data, running incremental scan")
+      const timing =
+        mode === "incremental"
+          ? await (async () => {
+              log.info("collection has existing data, running incremental scan")
+              this.stateManager.setSystemState("Indexing", "Checking for new or modified files...")
+              await this.vectorStore.markIndexingIncomplete()
+              return this._runScan(mode, trigger)
+            })()
+          : await (async () => {
+              log.info("running full scan", {
+                workspacePath: this.workspacePath,
+                hasExistingData,
+                collectionCreated,
+              })
+              this.stateManager.setSystemState("Indexing", "Services ready. Starting workspace scan...")
+              await this.vectorStore.markIndexingIncomplete()
+              return this._runScan(mode, trigger)
+            })()
+      span.add(timing)
 
-        this.stateManager.setSystemState("Indexing", "Checking for new or modified files...")
-        await this.vectorStore.markIndexingIncomplete()
-        await this._runScan(mode, trigger)
-      } else {
-        log.info("running full scan", {
-          workspacePath: this.workspacePath,
-          hasExistingData,
-          collectionCreated,
-        })
-        this.stateManager.setSystemState("Indexing", "Services ready. Starting workspace scan...")
-        await this.vectorStore.markIndexingIncomplete()
-        await this._runScan(mode, trigger)
+      if (this._cancelRequested || this.scanner.isCancelled) {
+        span.outcome("cancelled")
+        return
       }
+
+      span.outcome("success")
     } catch (err) {
       log.error("error during indexing", { err })
       this.emitError("orchestrator:startIndexing", err, source, trigger, mode)
@@ -274,12 +319,16 @@ export class CodeIndexOrchestrator {
     }
   }
 
-  private async _runScan(mode: IndexingTelemetryMode, trigger: IndexingTelemetryTrigger): Promise<void> {
+  private async _runScan(
+    mode: IndexingTelemetryMode,
+    trigger: IndexingTelemetryTrigger,
+  ): Promise<{ scanMs: number; finalizeMs: number }> {
     if (this._cancelRequested) {
+      const finalize = performance.now()
       if (mode === "incremental") await this.vectorStore.markIndexingComplete()
       this.stateManager.setSystemState("Standby", "Indexing cancelled.")
       log.info("scan skipped: cancellation was requested", { workspacePath: this.workspacePath, mode })
-      return
+      return { scanMs: 0, finalizeMs: Math.max(0, performance.now() - finalize) }
     }
 
     log.info("starting workspace scan", { workspacePath: this.workspacePath, mode })
@@ -297,6 +346,7 @@ export class CodeIndexOrchestrator {
       this.stateManager.reportFileProgress(cumulativeFilesIndexed, cumulativeFilesFound)
     }
 
+    const scan = performance.now()
     const result = await this.scanner.scanDirectory(
       this.workspacePath,
       (batchError: Error) => {
@@ -307,6 +357,7 @@ export class CodeIndexOrchestrator {
       handleFileParsed,
       mode,
     )
+    const scanMs = Math.max(0, performance.now() - scan)
 
     log.info("workspace scan completed", {
       workspacePath: this.workspacePath,
@@ -320,6 +371,7 @@ export class CodeIndexOrchestrator {
     })
 
     if (this._cancelRequested || this.scanner.isCancelled) {
+      const finalize = performance.now()
       if (mode === "incremental" && result.stats.processed === 0 && batchErrors.length === 0) {
         await this.vectorStore.markIndexingComplete()
         log.info("preserved unchanged index after cancelled scan", { workspacePath: this.workspacePath })
@@ -329,7 +381,7 @@ export class CodeIndexOrchestrator {
         this.stateManager.setSystemState("Standby", "Indexing cancelled.")
       }
       log.info("workspace scan cancelled", { workspacePath: this.workspacePath, mode })
-      return
+      return { scanMs, finalizeMs: Math.max(0, performance.now() - finalize) }
     }
 
     if (this.overlay && batchErrors.length > 0) {
@@ -356,12 +408,14 @@ export class CodeIndexOrchestrator {
       }
     }
 
+    const finalize = performance.now()
     this.overlay?.reconcile(this.cacheManager.getAllHashes())
     await this.cacheManager.flush?.()
     await this.vectorStore.markIndexingComplete()
     await this.vectorStore.close?.()
     this.fileWatcher.setCollecting(true)
     this.stateManager.setSystemState("Indexed", "File watcher started. Index up-to-date.")
+    const finalizeMs = Math.max(0, performance.now() - finalize)
     log.info("workspace scan finalized", {
       workspacePath: this.workspacePath,
       mode,
@@ -380,6 +434,7 @@ export class CodeIndexOrchestrator {
       totalBlocks: result.totalBlockCount,
       batchErrors: batchErrors.length,
     })
+    return { scanMs, finalizeMs }
   }
 
   public async shutdown(): Promise<void> {

--- a/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
+++ b/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
@@ -20,6 +20,7 @@ import {
   type IVectorStore,
   type PointStruct,
   type BatchProcessingSummary,
+  type CacheMetadata,
 } from "../interfaces"
 import type { IndexingTelemetryMeta, IndexingTelemetryReporter } from "../interfaces/telemetry"
 import { codeParser } from "./parser"
@@ -357,11 +358,11 @@ export class FileWatcher implements IFileWatcher {
     pathsToExplicitlyDelete: string[],
   ): Promise<{
     pointsForBatchUpsert: PointStruct[]
-    successfullyProcessedForUpsert: Array<{ path: string; newHash?: string }>
+    successfullyProcessedForUpsert: Array<{ path: string; newHash?: string; metadata?: CacheMetadata }>
     processedCount: number
   }> {
     const pointsForBatchUpsert: PointStruct[] = []
-    const successfullyProcessedForUpsert: Array<{ path: string; newHash?: string }> = []
+    const successfullyProcessedForUpsert: Array<{ path: string; newHash?: string; metadata?: CacheMetadata }> = []
     const filesToProcessConcurrently = [...filesToUpsertDetails]
 
     for (let i = 0; i < filesToProcessConcurrently.length; i += this.FILE_PROCESSING_CONCURRENCY_LIMIT) {
@@ -400,7 +401,11 @@ export class FileWatcher implements IFileWatcher {
             } else if (result.status === "processed_for_batching" && result.pointsToUpsert) {
               pointsForBatchUpsert.push(...result.pointsToUpsert)
               if (result.path && result.newHash) {
-                successfullyProcessedForUpsert.push({ path: result.path, newHash: result.newHash })
+                successfullyProcessedForUpsert.push({
+                  path: result.path,
+                  newHash: result.newHash,
+                  metadata: result.metadata,
+                })
               } else if (result.path && !result.newHash) {
                 successfullyProcessedForUpsert.push({ path: result.path })
               }
@@ -452,7 +457,7 @@ export class FileWatcher implements IFileWatcher {
    */
   private async _executeBatchUpsertOperations(
     pointsForBatchUpsert: PointStruct[],
-    successfullyProcessedForUpsert: Array<{ path: string; newHash?: string }>,
+    successfullyProcessedForUpsert: Array<{ path: string; newHash?: string; metadata?: CacheMetadata }>,
     batchResults: FileProcessingResult[],
     overallBatchError?: Error,
   ): Promise<Error | undefined> {
@@ -493,7 +498,7 @@ export class FileWatcher implements IFileWatcher {
         }
 
         for (const item of successfullyProcessedForUpsert) {
-          if (item.newHash) this.cacheManager.updateHash(item.path, item.newHash)
+          if (item.newHash) this.cacheManager.updateHash(item.path, item.newHash, item.metadata)
           batchResults.push({ path: item.path, status: "success", newHash: item.newHash })
         }
       } catch (error) {
@@ -810,6 +815,11 @@ export class FileWatcher implements IFileWatcher {
         path: filePath,
         status: "processed_for_batching" as const,
         newHash,
+        metadata: {
+          size: fileStat.size,
+          mtimeMs: fileStat.mtimeMs,
+          ctimeMs: fileStat.ctimeMs,
+        },
         pointsToUpsert,
       }
     } catch (error) {

--- a/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
+++ b/packages/kilo-indexing/src/indexing/processors/file-watcher.ts
@@ -35,6 +35,7 @@ import type { WorktreeOverlay } from "../worktree-overlay"
 import { sanitizeErrorMessage } from "../shared/validation-helpers"
 import type { IgnoreMatcher } from "../shared/load-ignore"
 import { isBinary } from "../shared/is-binary"
+import { IndexingProfile } from "../../util/profile"
 
 const log = Log.create({ service: "file-watcher" })
 
@@ -527,6 +528,24 @@ export class FileWatcher implements IFileWatcher {
   private async processBatch(
     eventsToProcess: Map<string, { path: string; type: "create" | "change" | "delete" }>,
   ): Promise<void> {
+    using profile = IndexingProfile.start("indexing.watcher.batch", {
+      source: "watcher",
+      mode: "incremental",
+      provider: this.telemetryMeta?.provider ?? this.embedder?.embedderInfo.name,
+      modelId: this.telemetryMeta?.modelId,
+      vectorStore: this.telemetryMeta?.vectorStore,
+      eventCount: eventsToProcess.size,
+      deleteCount: 0,
+      upsertFileCount: 0,
+      pointCount: 0,
+      successCount: 0,
+      skippedCount: 0,
+      errorCount: 0,
+      deleteMs: 0,
+      prepareMs: 0,
+      upsertMs: 0,
+      flushMs: 0,
+    })
     const batchResults: FileProcessingResult[] = []
     let processedCountInBatch = 0
     const totalFilesInBatch = eventsToProcess.size
@@ -577,15 +596,20 @@ export class FileWatcher implements IFileWatcher {
       deletes: pathsToExplicitlyDelete.length,
       upserts: filesToUpsertDetails.length,
     })
+    profile.add({
+      deleteCount: pathsToExplicitlyDelete.length,
+      upsertFileCount: filesToUpsertDetails.length,
+    })
 
     // Phase 1: Handle deletions
+    const deleteAt = performance.now()
     const { overallBatchError: deletionError, processedCount: deletionCount } = await this._handleBatchDeletions(
       batchResults,
       processedCountInBatch,
       totalFilesInBatch,
       pathsToExplicitlyDelete,
       filesToUpsertDetails,
-    )
+    ).finally(() => profile.add({ deleteMs: Math.max(0, performance.now() - deleteAt) }))
     overallBatchError = deletionError
     processedCountInBatch = deletionCount
     if (!deletionError) {
@@ -593,6 +617,7 @@ export class FileWatcher implements IFileWatcher {
     }
 
     // Phase 2: Process files and prepare upserts
+    const prepareAt = performance.now()
     const {
       pointsForBatchUpsert,
       successfullyProcessedForUpsert,
@@ -603,20 +628,23 @@ export class FileWatcher implements IFileWatcher {
       processedCountInBatch,
       totalFilesInBatch,
       pathsToExplicitlyDelete,
-    )
+    ).finally(() => profile.add({ prepareMs: Math.max(0, performance.now() - prepareAt) }))
     processedCountInBatch = upsertCount
+    profile.add({ pointCount: pointsForBatchUpsert.length })
 
     // Phase 3: Execute batch upsert
+    const upsertAt = performance.now()
     overallBatchError = await this._executeBatchUpsertOperations(
       pointsForBatchUpsert,
       successfullyProcessedForUpsert,
       batchResults,
       overallBatchError,
-    )
+    ).finally(() => profile.add({ upsertMs: Math.max(0, performance.now() - upsertAt) }))
 
     const resultError = batchResults.find((item) => item.status === "error" || item.status === "local_error")?.error
     overallBatchError ??= resultError
-    await this.cacheManager.flush()
+    const flushAt = performance.now()
+    await this.cacheManager.flush().finally(() => profile.add({ flushMs: Math.max(0, performance.now() - flushAt) }))
 
     for (const event of eventsToProcess.values()) {
       const result = batchResults.findLast((item) => item.path === event.path)
@@ -633,6 +661,8 @@ export class FileWatcher implements IFileWatcher {
     const successCount = batchResults.filter((item) => item.status === "success").length
     const skippedCount = batchResults.filter((item) => item.status === "skipped").length
     const errorCount = batchResults.filter((item) => item.status === "error" || item.status === "local_error").length
+    profile.add({ successCount, skippedCount, errorCount })
+    profile.outcome(overallBatchError ? "error" : "success")
 
     log.info("completed file watcher batch", {
       workspacePath: this.workspacePath,
@@ -739,6 +769,11 @@ export class FileWatcher implements IFileWatcher {
       let pointsToUpsert: PointStruct[] = []
       if (this.embedder && blocks.length > 0) {
         const texts = blocks.map((block) => block.content)
+        using profile = IndexingProfile.start("indexing.watcher.embedding", {
+          provider: this.telemetryMeta?.provider ?? this.embedder.embedderInfo.name,
+          modelId: this.telemetryMeta?.modelId,
+          textCount: texts.length,
+        })
         const { embeddings } = await this.embedder.createEmbeddings(texts)
         if (embeddings.length !== blocks.length) {
           return {
@@ -749,6 +784,7 @@ export class FileWatcher implements IFileWatcher {
             ),
           }
         }
+        profile.outcome("success")
 
         pointsToUpsert = blocks.map((block, index) => {
           const vector = embeddings[index]!

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -169,14 +169,18 @@ export class DirectoryScanner implements IDirectoryScanner {
         discoveredCount: 0,
         candidateCount: 0,
       })
-      const patterns = [...this.extensions].map((ext) => `**/*${ext}`)
+      // RATIONALE: Fold only extension letters so built-in ignores remain case-sensitive.
+      const patterns = [...this.extensions].map(
+        (ext) => `**/*${ext.replace(/[A-Za-z]/g, (char) => `[${char.toLowerCase()}${char.toUpperCase()}]`)}`,
+      )
       const allPaths = patterns.length
         ? await glob(patterns, {
             cwd: directoryPath,
             absolute: true,
             nodir: true,
             dot: false,
-            nocase: true,
+            ignore: FileIgnore.PATTERNS,
+            nocase: false,
             maxDepth: Infinity,
           })
         : []

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -29,6 +29,7 @@ import { sanitizeErrorMessage } from "../shared/validation-helpers"
 import type { IndexingTelemetryMeta, IndexingTelemetryMode, IndexingTelemetryReporter } from "../interfaces/telemetry"
 import type { IgnoreMatcher } from "../shared/load-ignore"
 import { isBinary } from "../shared/is-binary"
+import { IndexingProfile } from "../../util/profile"
 
 const log = Log.create({ service: "indexing-scanner" })
 
@@ -139,6 +140,21 @@ export class DirectoryScanner implements IDirectoryScanner {
     onFileParsed?: () => void,
     mode: IndexingTelemetryMode = "full",
   ): Promise<{ stats: { processed: number; skipped: number }; totalBlockCount: number }> {
+    using summary = IndexingProfile.start("indexing.scan.summary", {
+      mode,
+      discoveredCount: 0,
+      candidateCount: 0,
+      inspectedCount: 0,
+      readCount: 0,
+      bytesRead: 0,
+      unchangedCount: 0,
+      processedCount: 0,
+      skippedCount: 0,
+      blockCount: 0,
+      batchCount: 0,
+      changedDeleteCount: 0,
+      removedDeleteCount: 0,
+    })
     // reset cooperative cancel flag on new full scan
     this._cancelled = false
 
@@ -147,31 +163,46 @@ export class DirectoryScanner implements IDirectoryScanner {
     const scanWorkspace = directoryPath
     log.info("starting directory scan", { workspacePath: scanWorkspace })
 
-    // Get all files recursively, filtering out ignored directories via glob
-    const allPaths = await glob("**/*", {
-      cwd: directoryPath,
-      absolute: true,
-      nodir: true,
-      dot: false,
-      ignore: FileIgnore.PATTERNS,
-      maxDepth: Infinity,
-    })
+    const found = await (async () => {
+      using discovery = IndexingProfile.start("indexing.scan.discovery", {
+        mode,
+        discoveredCount: 0,
+        candidateCount: 0,
+      })
+      // Get all files recursively, filtering out ignored directories via glob
+      const allPaths = await glob("**/*", {
+        cwd: directoryPath,
+        absolute: true,
+        nodir: true,
+        dot: false,
+        ignore: FileIgnore.PATTERNS,
+        maxDepth: Infinity,
+      })
 
-    // Filter by supported extensions, ignore patterns, and excluded directories
-    const supportedPaths = allPaths.filter((filePath) => {
-      const ext = path.extname(filePath).toLowerCase()
-      const relativeFilePath = generateRelativeIgnorePath(filePath, scanWorkspace)
-      if (!relativeFilePath) {
-        return false
-      }
+      // Filter by supported extensions, ignore patterns, and excluded directories
+      const supportedPaths = allPaths.filter((filePath) => {
+        const ext = path.extname(filePath).toLowerCase()
+        const relativeFilePath = generateRelativeIgnorePath(filePath, scanWorkspace)
+        if (!relativeFilePath) {
+          return false
+        }
 
-      // Check if file is in an ignored directory using FileIgnore
-      if (FileIgnore.match(relativeFilePath)) {
-        return false
-      }
+        // Check if file is in an ignored directory using FileIgnore
+        if (FileIgnore.match(relativeFilePath)) {
+          return false
+        }
 
-      return this.extensions.has(ext) && !this.ignoreInstance.ignores(relativeFilePath)
-    })
+        return this.extensions.has(ext) && !this.ignoreInstance.ignores(relativeFilePath)
+      })
+      discovery.add({
+        discoveredCount: allPaths.length,
+        candidateCount: supportedPaths.length,
+      })
+      discovery.outcome("success")
+      return { allPaths, supportedPaths }
+    })()
+    const allPaths = found.allPaths
+    const supportedPaths = found.supportedPaths
     log.info("discovered candidate files for indexing", {
       workspacePath: scanWorkspace,
       discoveredFiles: allPaths.length,
@@ -183,6 +214,13 @@ export class DirectoryScanner implements IDirectoryScanner {
     const processedFiles = new Set<string>()
     let processedCount = 0
     let skippedCount = 0
+    let inspected = 0
+    let reads = 0
+    let bytesRead = 0
+    let unchanged = 0
+    let batches = 0
+    let changed = 0
+    let removed = 0
 
     // Initialize parallel processing tools
     const parseLimiter = pLimit(PARSING_CONCURRENCY) // Concurrency for file parsing
@@ -201,6 +239,21 @@ export class DirectoryScanner implements IDirectoryScanner {
     // Initialize block counter
     let totalBlockCount = 0
 
+    const fields = () => ({
+      discoveredCount: allPaths.length,
+      candidateCount: supportedPaths.length,
+      inspectedCount: inspected,
+      readCount: reads,
+      bytesRead,
+      unchangedCount: unchanged,
+      processedCount,
+      skippedCount,
+      blockCount: totalBlockCount,
+      batchCount: batches,
+      changedDeleteCount: changed,
+      removedDeleteCount: removed,
+    })
+
     const queueBatch = async (
       batchBlocks: CodeBlock[],
       batchTexts: string[],
@@ -214,8 +267,9 @@ export class DirectoryScanner implements IDirectoryScanner {
           if (pendingBatchCount < MAX_PENDING_BATCHES) {
             pendingBatchCount++
 
-            const batchPromise = batchLimiter(() =>
-              this.processBatch(
+            const batchPromise = batchLimiter(() => {
+              if (!this._cancelled && batchBlocks.length > 0) batches++
+              return this.processBatch(
                 batchBlocks,
                 batchTexts,
                 batchFileInfos,
@@ -226,8 +280,8 @@ export class DirectoryScanner implements IDirectoryScanner {
                 () => {
                   failed = true
                 },
-              ),
-            )
+              )
+            })
             activeBatchPromises.add(batchPromise)
 
             // Clean up completed promises to prevent memory accumulation
@@ -258,6 +312,7 @@ export class DirectoryScanner implements IDirectoryScanner {
 
         try {
           // Check file size
+          inspected++
           const stats = await stat(filePath)
           if (this._cancelled) {
             return
@@ -270,6 +325,8 @@ export class DirectoryScanner implements IDirectoryScanner {
 
           // Read file content using fs/promises
           const bytes = await readFile(filePath)
+          reads++
+          bytesRead += bytes.length
           if (isBinary(bytes)) {
             skippedCount++
             return
@@ -289,6 +346,7 @@ export class DirectoryScanner implements IDirectoryScanner {
           const isNewFile = !cachedFileHash
           if (cachedFileHash === currentFileHash) {
             // File is unchanged
+            unchanged++
             skippedCount++
             return
           }
@@ -306,6 +364,7 @@ export class DirectoryScanner implements IDirectoryScanner {
 
           if (!isNewFile && this.vectorStore) {
             await this.vectorStore.deletePointsByMultipleFilePaths([filePath])
+            changed++
           }
 
           // Process embeddings if configured
@@ -451,6 +510,8 @@ export class DirectoryScanner implements IDirectoryScanner {
         skippedCount,
         totalBlockCount,
       })
+      summary.add(fields())
+      summary.outcome("cancelled")
       return {
         stats: {
           processed: processedCount,
@@ -484,6 +545,7 @@ export class DirectoryScanner implements IDirectoryScanner {
           try {
             await this.vectorStore.deletePointsByFilePath(cachedFilePath)
             this.cacheManager.deleteHash(cachedFilePath)
+            removed++
           } catch (error: any) {
             const errorStatus = error?.status || error?.response?.status || error?.statusCode
             const errorMessage = error instanceof Error ? error.message : String(error)
@@ -514,6 +576,8 @@ export class DirectoryScanner implements IDirectoryScanner {
       skippedCount,
       totalBlockCount,
     })
+    summary.add(fields())
+    summary.outcome(this._cancelled ? "cancelled" : "success")
 
     return {
       stats: {
@@ -537,6 +601,20 @@ export class DirectoryScanner implements IDirectoryScanner {
     // Respect cooperative cancellation
     if (this._cancelled || batchBlocks.length === 0) return
 
+    using span = IndexingProfile.start("indexing.scan.batch", {
+      source: "scan",
+      mode,
+      provider: this.telemetryMeta?.provider,
+      modelId: this.telemetryMeta?.modelId,
+      vectorStore: this.telemetryMeta?.vectorStore,
+      fileCount: new Set(batchFileInfos.map((item) => item.filePath)).size,
+      blockCount: batchBlocks.length,
+      attemptCount: 0,
+      deleteMs: 0,
+      embeddingMs: 0,
+      upsertMs: 0,
+    })
+
     if (batchBlocks.length === 0) {
       log.debug("Skipping empty batch processing")
       return
@@ -547,60 +625,80 @@ export class DirectoryScanner implements IDirectoryScanner {
     let attempts = 0
     let success = false
     let lastError: Error | null = null
+    let deleted = 0
+    let embedded = 0
+    let upsert = 0
 
     while (attempts < this.maxBatchRetries && !success) {
       attempts++
+      span.add({ attemptCount: attempts })
 
-      if (this._cancelled) return
+      if (this._cancelled) {
+        span.outcome("cancelled")
+        return
+      }
 
       log.debug(`Processing batch attempt ${attempts}/${this.maxBatchRetries} for ${batchBlocks.length} blocks`)
 
       try {
         // --- Deletion Step ---
         log.debug("Starting deletion step for modified files")
-        const uniqueFilePaths = [
-          ...new Set(
-            batchFileInfos
-              .filter((info) => !info.isNew) // Only modified files (not new)
-              .map((info) => info.filePath),
-          ),
-        ]
-        log.debug(`Identified ${uniqueFilePaths.length} modified files to delete points for`)
+        const start = performance.now()
+        try {
+          const uniqueFilePaths = [
+            ...new Set(
+              batchFileInfos
+                .filter((info) => !info.isNew) // Only modified files (not new)
+                .map((info) => info.filePath),
+            ),
+          ]
+          log.debug(`Identified ${uniqueFilePaths.length} modified files to delete points for`)
 
-        if (uniqueFilePaths.length > 0) {
-          try {
-            await this.vectorStore.deletePointsByMultipleFilePaths(uniqueFilePaths)
-            log.debug(`Successfully deleted points for ${uniqueFilePaths.length} files`)
-          } catch (deleteError: any) {
-            const errorStatus = deleteError?.status || deleteError?.response?.status || deleteError?.statusCode
-            const errorMessage = deleteError instanceof Error ? deleteError.message : String(deleteError)
+          if (uniqueFilePaths.length > 0) {
+            try {
+              await this.vectorStore.deletePointsByMultipleFilePaths(uniqueFilePaths)
+              log.debug(`Successfully deleted points for ${uniqueFilePaths.length} files`)
+            } catch (deleteError: any) {
+              const errorStatus = deleteError?.status || deleteError?.response?.status || deleteError?.statusCode
+              const errorMessage = deleteError instanceof Error ? deleteError.message : String(deleteError)
 
-            log.error(
-              `Failed to delete points for ${uniqueFilePaths.length} files before upsert in workspace ${scanWorkspace}`,
-              {
-                error: sanitizeErrorMessage(errorMessage),
-                stack: deleteError instanceof Error ? sanitizeErrorMessage(deleteError.stack || "") : undefined,
-                location: "processBatch:deletePointsByMultipleFilePaths",
-                fileCount: uniqueFilePaths.length,
-                errorStatus,
-              },
-            )
+              log.error(
+                `Failed to delete points for ${uniqueFilePaths.length} files before upsert in workspace ${scanWorkspace}`,
+                {
+                  error: sanitizeErrorMessage(errorMessage),
+                  stack: deleteError instanceof Error ? sanitizeErrorMessage(deleteError.stack || "") : undefined,
+                  location: "processBatch:deletePointsByMultipleFilePaths",
+                  fileCount: uniqueFilePaths.length,
+                  errorStatus,
+                },
+              )
 
-            // Re-throw with workspace context
-            throw new Error(
-              `Failed to delete points for ${uniqueFilePaths.length} files. Workspace: ${scanWorkspace}. ${errorMessage}`,
-              { cause: deleteError },
-            )
+              // Re-throw with workspace context
+              throw new Error(
+                `Failed to delete points for ${uniqueFilePaths.length} files. Workspace: ${scanWorkspace}. ${errorMessage}`,
+                { cause: deleteError },
+              )
+            }
           }
+        } finally {
+          deleted += Math.max(0, performance.now() - start)
+          span.add({ deleteMs: deleted })
         }
         // --- End Deletion Step ---
 
         // Create embeddings for batch
-        if (this._cancelled) return
+        if (this._cancelled) {
+          span.outcome("cancelled")
+          return
+        }
 
         log.debug(`Creating embeddings for ${batchTexts.length} texts`)
 
-        const { embeddings } = await this.embedder.createEmbeddings(batchTexts)
+        const startEmbedding = performance.now()
+        const { embeddings } = await this.embedder.createEmbeddings(batchTexts).finally(() => {
+          embedded += Math.max(0, performance.now() - startEmbedding)
+          span.add({ embeddingMs: embedded })
+        })
         log.debug(`Successfully created ${embeddings.length} embeddings`)
 
         // Prepare points for Qdrant
@@ -632,15 +730,23 @@ export class DirectoryScanner implements IDirectoryScanner {
         log.debug(`Prepared ${points.length} points for Qdrant`)
 
         // Upsert points to Qdrant
-        if (this._cancelled) return
+        if (this._cancelled) {
+          span.outcome("cancelled")
+          return
+        }
 
         log.debug("Starting Qdrant upsert")
 
-        await this.vectorStore.upsertPoints(points)
+        const startUpsert = performance.now()
+        await this.vectorStore.upsertPoints(points).finally(() => {
+          upsert += Math.max(0, performance.now() - startUpsert)
+          span.add({ upsertMs: upsert })
+        })
         log.debug("Completed Qdrant upsert")
         onFilesIndexed?.(batchFileInfos.length)
 
         success = true
+        span.outcome("success")
         log.debug(`Successfully processed batch of ${batchBlocks.length} blocks after ${attempts} attempt(s)`)
       } catch (error) {
         lastError = error as Error

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -177,7 +177,6 @@ export class DirectoryScanner implements IDirectoryScanner {
             nodir: true,
             dot: false,
             nocase: true,
-            ignore: FileIgnore.PATTERNS,
             maxDepth: Infinity,
           })
         : []
@@ -530,7 +529,9 @@ export class DirectoryScanner implements IDirectoryScanner {
       await queueBatch(finalBatch.batchBlocks, finalBatch.batchTexts, finalBatch.batchFileInfos)
     }
 
-    // Short-circuit if cancelled before handling deletions
+    await Promise.all(activeBatchPromises)
+
+    // Short-circuit if cancellation was requested while batches were settling.
     if (this._cancelled) {
       log.info("directory scan cancelled", {
         workspacePath: scanWorkspace,
@@ -547,8 +548,6 @@ export class DirectoryScanner implements IDirectoryScanner {
         },
         totalBlockCount,
       }
-    } else {
-      await Promise.all(activeBatchPromises)
     }
 
     if (!failed) {

--- a/packages/kilo-indexing/src/indexing/processors/scanner.ts
+++ b/packages/kilo-indexing/src/indexing/processors/scanner.ts
@@ -169,15 +169,18 @@ export class DirectoryScanner implements IDirectoryScanner {
         discoveredCount: 0,
         candidateCount: 0,
       })
-      // Get all files recursively, filtering out ignored directories via glob
-      const allPaths = await glob("**/*", {
-        cwd: directoryPath,
-        absolute: true,
-        nodir: true,
-        dot: false,
-        ignore: FileIgnore.PATTERNS,
-        maxDepth: Infinity,
-      })
+      const patterns = [...this.extensions].map((ext) => `**/*${ext}`)
+      const allPaths = patterns.length
+        ? await glob(patterns, {
+            cwd: directoryPath,
+            absolute: true,
+            nodir: true,
+            dot: false,
+            nocase: true,
+            ignore: FileIgnore.PATTERNS,
+            maxDepth: Infinity,
+          })
+        : []
 
       // Filter by supported extensions, ignore patterns, and excluded directories
       const supportedPaths = allPaths.filter((filePath) => {
@@ -231,7 +234,7 @@ export class DirectoryScanner implements IDirectoryScanner {
     let currentBatchBlocks: CodeBlock[] = []
     let currentBatchTexts: string[] = []
     let currentBatchFileInfos: { filePath: string; fileHash: string; isNew: boolean }[] = []
-    const batched = new Map<string, string>()
+    const batched = new Map<string, { hash: string; metadata: { size: number; mtimeMs: number; ctimeMs: number } }>()
     let failed = false
     const activeBatchPromises = new Set<Promise<void>>()
     let pendingBatchCount = 0
@@ -323,6 +326,28 @@ export class DirectoryScanner implements IDirectoryScanner {
             return
           }
 
+          const metadata = {
+            size: stats.size,
+            mtimeMs: stats.mtimeMs,
+            ctimeMs: stats.ctimeMs,
+          }
+          const hash = this.cacheManager.getHash(filePath)
+          const cached = this.cacheManager.getMetadata(filePath)
+          const unchangedMetadata =
+            mode === "incremental" &&
+            hash !== undefined &&
+            cached !== undefined &&
+            cached.size === metadata.size &&
+            cached.mtimeMs === metadata.mtimeMs &&
+            cached.ctimeMs === metadata.ctimeMs
+
+          if (unchangedMetadata) {
+            processedFiles.add(filePath)
+            unchanged++
+            skippedCount++
+            return
+          }
+
           // Read file content using fs/promises
           const bytes = await readFile(filePath)
           reads++
@@ -342,10 +367,11 @@ export class DirectoryScanner implements IDirectoryScanner {
           processedFiles.add(filePath)
 
           // Check against cache
-          const cachedFileHash = this.cacheManager.getHash(filePath)
+          const cachedFileHash = hash
           const isNewFile = !cachedFileHash
           if (cachedFileHash === currentFileHash) {
             // File is unchanged
+            this.cacheManager.updateHash(filePath, currentFileHash, metadata)
             unchanged++
             skippedCount++
             return
@@ -432,7 +458,7 @@ export class DirectoryScanner implements IDirectoryScanner {
               const release = await mutex.acquire()
               try {
                 totalBlockCount += fileBlockCount
-                batched.set(filePath, currentFileHash)
+                batched.set(filePath, { hash: currentFileHash, metadata })
                 if (!queued) {
                   currentBatchFileInfos.push(info)
                   queued = true
@@ -440,10 +466,12 @@ export class DirectoryScanner implements IDirectoryScanner {
               } finally {
                 release()
               }
+            } else {
+              this.cacheManager.updateHash(filePath, currentFileHash, metadata)
             }
           } else {
             // Only update hash if not being processed in a batch
-            this.cacheManager.updateHash(filePath, currentFileHash)
+            this.cacheManager.updateHash(filePath, currentFileHash, metadata)
           }
         } catch (error) {
           log.error(`Error processing file ${filePath} in workspace ${scanWorkspace}`, {
@@ -524,8 +552,8 @@ export class DirectoryScanner implements IDirectoryScanner {
     }
 
     if (!failed) {
-      for (const [filePath, fileHash] of batched.entries()) {
-        this.cacheManager.updateHash(filePath, fileHash)
+      for (const [filePath, entry] of batched.entries()) {
+        this.cacheManager.updateHash(filePath, entry.hash, entry.metadata)
       }
     }
 

--- a/packages/kilo-indexing/src/indexing/search-service.ts
+++ b/packages/kilo-indexing/src/indexing/search-service.ts
@@ -6,6 +6,7 @@ import type { CodeIndexConfigManager } from "./config-manager"
 import type { CodeIndexStateManager } from "./state-manager"
 import { Log } from "../util/log"
 import type { WorktreeOverlay } from "./worktree-overlay"
+import { IndexingProfile } from "../util/profile"
 
 interface BaselineSearch {
   store: IVectorStore
@@ -30,6 +31,20 @@ export class CodeIndexSearchService {
   }
 
   public async searchIndex(query: string, directoryPrefix?: string): Promise<VectorStoreSearchResult[]> {
+    const config = this.configManager.getConfig()
+    using profile = IndexingProfile.start("indexing.search.request", {
+      provider: config.embedderProvider,
+      modelId: config.modelId,
+      vectorStore: config.vectorStoreProvider,
+      scope: this.baseline ? "worktree" : "local",
+      embeddingMs: 0,
+      currentSearchMs: 0,
+      baselineSearchMs: 0,
+      deltaCallCount: 0,
+      baselineCallCount: 0,
+      candidateCount: 0,
+      resultCount: 0,
+    })
     if (!this.configManager.isFeatureEnabled || !this.configManager.isFeatureConfigured) {
       throw new Error("Code index feature is disabled or not configured.")
     }
@@ -43,24 +58,46 @@ export class CodeIndexSearchService {
     }
 
     try {
-      const embeddingResponse = await this.embedder.createEmbeddings([query])
+      let embeddingMs = 0
+      let currentSearchMs = 0
+      let baselineSearchMs = 0
+      let deltaCallCount = 0
+      let baselineCallCount = 0
+      const embeddingAt = performance.now()
+      const embeddingResponse = await this.embedder.createEmbeddings([query]).finally(() => {
+        embeddingMs += Math.max(0, performance.now() - embeddingAt)
+        profile.add({ embeddingMs })
+      })
       const vector = embeddingResponse?.embeddings[0]
       if (!vector) {
         throw new Error("Failed to generate embedding for query.")
       }
 
       const normalizedPrefix = directoryPrefix ? path.normalize(directoryPrefix) : undefined
-      const extensions = new Set(this.configManager.getConfig().fileExtensions)
+      const extensions = new Set(config.fileExtensions)
       if (!this.baseline) {
-        const results = await this.vectorStore.search(vector, normalizedPrefix, minScore, maxResults)
-        return results.filter((result) => this.allowed(result, extensions))
+        const currentAt = performance.now()
+        deltaCallCount++
+        const candidates = await this.vectorStore.search(vector, normalizedPrefix, minScore, maxResults).finally(() => {
+          currentSearchMs += Math.max(0, performance.now() - currentAt)
+          profile.add({ currentSearchMs, deltaCallCount })
+        })
+        const results = candidates.filter((result) => this.allowed(result, extensions))
+        profile.add({ candidateCount: candidates.length, resultCount: results.length })
+        profile.outcome("success")
+        return results
       }
       if (!this.baseline.overlay.ready) throw new Error("Worktree index reconciliation is not complete.")
 
       const ceiling = Math.max(maxResults, Math.min(maxResults * 16, 1000))
       const delta = (async () => {
         const search = async (limit: number): Promise<VectorStoreSearchResult[]> => {
-          const results = await this.vectorStore.search(vector, normalizedPrefix, minScore, limit)
+          const currentAt = performance.now()
+          deltaCallCount++
+          const results = await this.vectorStore.search(vector, normalizedPrefix, minScore, limit).finally(() => {
+            currentSearchMs += Math.max(0, performance.now() - currentAt)
+            profile.add({ currentSearchMs, deltaCallCount })
+          })
           const filtered = results.filter((result) => this.baseline!.overlay.deltaResult(result))
           if (filtered.length >= maxResults || results.length < limit || limit >= ceiling) return filtered
           return search(Math.min(limit * 2, ceiling))
@@ -70,7 +107,12 @@ export class CodeIndexSearchService {
       const base = (async () => {
         const checks = new Map<string, Promise<boolean>>()
         const search = async (limit: number): Promise<VectorStoreSearchResult[]> => {
-          const results = await this.baseline!.store.search(vector, normalizedPrefix, minScore, limit)
+          const baselineAt = performance.now()
+          baselineCallCount++
+          const results = await this.baseline!.store.search(vector, normalizedPrefix, minScore, limit).finally(() => {
+            baselineSearchMs += Math.max(0, performance.now() - baselineAt)
+            profile.add({ baselineSearchMs, baselineCallCount })
+          })
           const accepted = await Promise.all(
             results.map((result) => this.baseline!.overlay.baselineResult(result, checks)),
           )
@@ -81,6 +123,7 @@ export class CodeIndexSearchService {
         return search(maxResults)
       })()
       const [baseline, current] = await Promise.all([base, delta])
+      const candidateCount = baseline.length + current.length
       const merged = new Map<string, VectorStoreSearchResult>()
       const key = (result: VectorStoreSearchResult) =>
         [result.payload?.filePath, result.payload?.startLine, result.payload?.endLine, result.payload?.codeChunk].join(
@@ -94,7 +137,10 @@ export class CodeIndexSearchService {
         if (this.allowed(result, extensions) && this.baseline.overlay.deltaResult(result))
           merged.set(key(result), result)
       }
-      return [...merged.values()].sort((left, right) => right.score - left.score).slice(0, maxResults)
+      const results = [...merged.values()].sort((left, right) => right.score - left.score).slice(0, maxResults)
+      profile.add({ candidateCount, resultCount: results.length })
+      profile.outcome("success")
+      return results
     } catch (err) {
       log.error("search failed", { err })
       throw err

--- a/packages/kilo-indexing/src/util/profile.ts
+++ b/packages/kilo-indexing/src/util/profile.ts
@@ -1,0 +1,74 @@
+export type IndexingProfileValue = string | number | boolean
+export type IndexingProfileFields = Record<string, IndexingProfileValue | undefined>
+export type IndexingProfileOutcome = "success" | "error" | "cancelled" | "disabled" | "waiting"
+
+export type IndexingProfileRecord = {
+  type: "kilo-indexing-profile"
+  event: string
+  durationMs: number
+  outcome: IndexingProfileOutcome
+  fields: Record<string, IndexingProfileValue>
+}
+
+export type IndexingProfileSpan = {
+  add(fields: IndexingProfileFields): void
+  outcome(value: IndexingProfileOutcome): void
+  end(): void
+  [Symbol.dispose](): void
+}
+
+const noop: IndexingProfileSpan = {
+  add() {},
+  outcome() {},
+  end() {},
+  [Symbol.dispose]() {},
+}
+
+function clean(input: IndexingProfileFields) {
+  const fields: Record<string, IndexingProfileValue> = {}
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) fields[key] = value
+  }
+  return fields
+}
+
+function emit(record: IndexingProfileRecord) {
+  try {
+    console.info(JSON.stringify(record))
+  } catch {
+    return
+  }
+}
+
+export namespace IndexingProfile {
+  export function start(event: string, fields: IndexingProfileFields = {}): IndexingProfileSpan {
+    if (process.env.KILO_INDEXING_PROFILE !== "1") return noop
+
+    const time = performance.now()
+    const data = clean(fields)
+    let outcome: IndexingProfileOutcome = "error"
+    let ended = false
+    const end = () => {
+      if (ended) return
+      ended = true
+      emit({
+        type: "kilo-indexing-profile",
+        event,
+        durationMs: Math.max(0, performance.now() - time),
+        outcome,
+        fields: data,
+      })
+    }
+
+    return {
+      add(fields) {
+        Object.assign(data, clean(fields))
+      },
+      outcome(value) {
+        outcome = value
+      },
+      end,
+      [Symbol.dispose]: end,
+    }
+  }
+}

--- a/packages/kilo-indexing/test/kilocode/indexing/cache-manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/cache-manager.test.ts
@@ -54,6 +54,7 @@ describe("CacheManager", () => {
 
       second.updateHash(source, "hash-without-metadata")
       expect(second.getMetadata(source)).toBeUndefined()
+      await second.flush()
     } finally {
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -110,6 +111,7 @@ describe("CacheManager", () => {
 
       second.updateHash(path.join(workspace, "a.ts"), "changed")
       expect(second.signature()).not.toBe(first.signature())
+      await second.flush()
     } finally {
       await rm(cacheDir, { recursive: true, force: true })
     }

--- a/packages/kilo-indexing/test/kilocode/indexing/cache-manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/cache-manager.test.ts
@@ -1,26 +1,117 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtemp } from "fs/promises"
+import { createHash } from "crypto"
+import { mkdtemp, rm } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { CacheManager } from "../../../src/indexing/cache-manager"
 
 describe("CacheManager", () => {
+  test("loads legacy hashes without metadata", async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "index-cache-"))
+
+    try {
+      const workspace = path.join(cacheDir, "workspace")
+      const id = createHash("sha256").update(workspace).digest("hex")
+      const file = path.join(cacheDir, `roo-index-cache-${id}.json`)
+      const source = path.join(workspace, "main.ts")
+      await Bun.write(file, JSON.stringify({ [source]: "legacy-hash" }))
+
+      const cache = new CacheManager(cacheDir, workspace)
+      await cache.initialize()
+
+      expect(cache.getHash(source)).toBe("legacy-hash")
+      expect(cache.getMetadata(source)).toBeUndefined()
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test("persists metadata without changing the hash signature", async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "index-cache-"))
+
+    try {
+      const workspace = path.join(cacheDir, "workspace")
+      const source = path.join(workspace, "main.ts")
+      const metadata = { size: 42, mtimeMs: 1000.25, ctimeMs: 1001.5 }
+      const first = new CacheManager(cacheDir, workspace)
+      await first.initialize()
+      first.updateHash(source, "hash", metadata)
+      const signature = first.signature()
+
+      first.updateHash(source, "hash", { ...metadata, size: 43 })
+      expect(first.signature()).toBe(signature)
+
+      first.updateHash(source, "changed", metadata)
+      expect(first.signature()).not.toBe(signature)
+
+      first.updateHash(source, "hash", metadata)
+      await first.flush()
+
+      const second = new CacheManager(cacheDir, workspace)
+      await second.initialize()
+      expect(second.getHash(source)).toBe("hash")
+      expect(second.getMetadata(source)).toEqual(metadata)
+
+      second.updateHash(source, "hash-without-metadata")
+      expect(second.getMetadata(source)).toBeUndefined()
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test("defensively decodes cache data", async () => {
+    const cacheDir = await mkdtemp(path.join(tmpdir(), "index-cache-"))
+
+    try {
+      const workspace = path.join(cacheDir, "workspace")
+      const id = createHash("sha256").update(workspace).digest("hex")
+      const file = path.join(cacheDir, `roo-index-cache-${id}.json`)
+      const source = path.join(workspace, "main.ts")
+
+      await Bun.write(file, "{")
+      const malformed = new CacheManager(cacheDir, workspace)
+      await malformed.initialize()
+      expect(malformed.getHash(source)).toBeUndefined()
+
+      await Bun.write(file, JSON.stringify({ version: 999, files: { [source]: { hash: "unsafe" } } }))
+      const unsupported = new CacheManager(cacheDir, workspace)
+      await unsupported.initialize()
+      expect(unsupported.getHash(source)).toBeUndefined()
+
+      await Bun.write(
+        file,
+        JSON.stringify({ version: 2, files: { [source]: { hash: "safe", size: 42 } } }),
+      )
+      const incomplete = new CacheManager(cacheDir, workspace)
+      await incomplete.initialize()
+      expect(incomplete.getHash(source)).toBe("safe")
+      expect(incomplete.getMetadata(source)).toBeUndefined()
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
   test("flushes a stable signature used to detect baseline changes", async () => {
     const cacheDir = await mkdtemp(path.join(tmpdir(), "index-cache-"))
-    const workspace = path.join(cacheDir, "workspace")
-    const first = new CacheManager(cacheDir, workspace)
-    await first.initialize()
-    first.seedHashes({
-      [path.join(workspace, "b.ts")]: "b",
-      [path.join(workspace, "a.ts")]: "a",
-    })
-    await first.flush()
 
-    const second = new CacheManager(cacheDir, workspace)
-    await second.initialize()
-    expect(second.signature()).toBe(first.signature())
+    try {
+      const workspace = path.join(cacheDir, "workspace")
+      const first = new CacheManager(cacheDir, workspace)
+      await first.initialize()
+      first.seedHashes({
+        [path.join(workspace, "b.ts")]: "b",
+        [path.join(workspace, "a.ts")]: "a",
+      })
+      await first.flush()
 
-    second.updateHash(path.join(workspace, "a.ts"), "changed")
-    expect(second.signature()).not.toBe(first.signature())
+      const second = new CacheManager(cacheDir, workspace)
+      await second.initialize()
+      expect(second.signature()).toBe(first.signature())
+
+      second.updateHash(path.join(workspace, "a.ts"), "changed")
+      expect(second.signature()).not.toBe(first.signature())
+    } finally {
+      await rm(cacheDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/manager.test.ts
@@ -6,6 +6,9 @@ import { CacheManager } from "../../../src/indexing/cache-manager"
 import { CodeIndexManager } from "../../../src/indexing/manager"
 import type { IndexingConfigInput } from "../../../src/indexing/config-manager"
 import type { IndexingTelemetryEvent, IndexingTelemetryTrigger } from "../../../src/indexing/interfaces/telemetry"
+import { CodeIndexOrchestrator } from "../../../src/indexing/orchestrator"
+import { CodeIndexServiceFactory } from "../../../src/indexing/service-factory"
+import { captureProfiles } from "./profile-capture"
 
 function createInput(input: Partial<IndexingConfigInput> = {}): IndexingConfigInput {
   return {
@@ -77,6 +80,169 @@ function createStartError(location = "orchestrator:startIndexing"): IndexingTele
 }
 
 describe("CodeIndexManager", () => {
+  test.serial("profiles disabled initialization without workspace details", async () => {
+    const root = "/tmp/kilo-indexing-profile-disabled"
+    const mgr = new CodeIndexManager(root, `${root}/cache`)
+
+    try {
+      const records = await captureProfiles(async () => {
+        await mgr.initialize(createInput({ enabled: false }))
+      })
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("disabled")
+      expect(records.every((item) => JSON.stringify(item).includes(root) === false)).toBe(true)
+    } finally {
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles missing workspace initialization as disabled", async () => {
+    const mgr = new CodeIndexManager("", "/tmp/kilo-indexing-profile-no-workspace")
+
+    try {
+      const records = await captureProfiles(async () => {
+        await mgr.initialize(createInput({ openAiKey: "sk-test" }))
+      })
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("disabled")
+    } finally {
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles unconfigured initialization as disabled", async () => {
+    const mgr = new CodeIndexManager("/tmp/kilo-indexing-profile-unconfigured", "/tmp/kilo-indexing-profile-cache")
+
+    try {
+      const records = await captureProfiles(async () => {
+        await mgr.initialize(createInput({ openAiKey: undefined }))
+      })
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("disabled")
+    } finally {
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles disposal during initialization as cancelled", async () => {
+    const mgr = new CodeIndexManager("/tmp/kilo-indexing-profile-disposed", "/tmp/kilo-indexing-profile-cache")
+    const data = mgr as unknown as { _cacheManager: CacheManager }
+    const gate = Promise.withResolvers<void>()
+    const started = Promise.withResolvers<void>()
+    data._cacheManager = {} as CacheManager
+    const validate = spyOn(CodeIndexServiceFactory.prototype, "validateEmbedder").mockImplementation(async () => {
+      started.resolve()
+      await gate.promise
+      return { valid: true }
+    })
+
+    try {
+      const records = await captureProfiles(async () => {
+        const task = mgr.initialize(createInput({ openAiKey: "sk-test" }))
+        await started.promise
+        await mgr.dispose()
+        gate.resolve()
+        await task
+      })
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("cancelled")
+      expect(records.find((item) => item.event === "indexing.manager.services")?.outcome).toBe("cancelled")
+    } finally {
+      gate.resolve()
+      validate.mockRestore()
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles configured manager initialization and service recreation", async () => {
+    const root = "/tmp/kilo-indexing-profile-configured"
+    const mgr = new CodeIndexManager(root, `${root}/cache`)
+    const data = mgr as unknown as { _cacheManager: CacheManager }
+    data._cacheManager = {} as CacheManager
+    const validate = spyOn(CodeIndexServiceFactory.prototype, "validateEmbedder").mockResolvedValue({ valid: true })
+    const start = spyOn(CodeIndexOrchestrator.prototype, "startIndexing").mockResolvedValue()
+
+    try {
+      const records = await captureProfiles(async () => {
+        await mgr.initialize(createInput({ openAiKey: "sk-test", modelId: "text-embedding-3-small" }))
+      })
+      const services = records.find((item) => item.event === "indexing.manager.services")
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("success")
+      expect(services?.outcome).toBe("success")
+      expect(services?.fields).toEqual({
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        baseline: "none",
+        validationMs: expect.any(Number),
+      })
+      expect(services?.fields.validationMs).toBeGreaterThanOrEqual(0)
+      expect(records.every((item) => JSON.stringify(item).includes(root) === false)).toBe(true)
+    } finally {
+      start.mockRestore()
+      validate.mockRestore()
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles waiting initialization when the baseline is unavailable", async () => {
+    const mgr = new CodeIndexManager(
+      "/tmp/kilo-indexing-profile-waiting",
+      "/tmp/kilo-indexing-profile-waiting/cache",
+      "/tmp/kilo-indexing-profile-waiting/baseline",
+    )
+    const data = mgr as unknown as {
+      _cacheManager: CacheManager
+      _recreateServices(): Promise<void>
+    }
+    data._cacheManager = {} as CacheManager
+    data._recreateServices = async () => {}
+
+    try {
+      const records = await captureProfiles(async () => {
+        await mgr.initialize(createInput({ openAiKey: "sk-test" }))
+      })
+
+      expect(records.find((item) => item.event === "indexing.manager.initialize")?.outcome).toBe("waiting")
+    } finally {
+      await mgr.dispose()
+    }
+  })
+
+  test.serial("profiles embedder validation failures without error details", async () => {
+    const root = "/tmp/kilo-indexing-profile-validation-failure"
+    const mgr = new CodeIndexManager(root, `${root}/cache`)
+    const data = mgr as unknown as { _cacheManager: CacheManager }
+    data._cacheManager = {} as CacheManager
+    const validate = spyOn(CodeIndexServiceFactory.prototype, "validateEmbedder").mockResolvedValue({
+      valid: false,
+      error: `validation failed at ${root}`,
+    })
+
+    try {
+      const records = await captureProfiles(async () => {
+        await expect(mgr.initialize(createInput({ openAiKey: "sk-test", modelId: "text-embedding-3-small" }))).rejects.toThrow(
+          "validation failed",
+        )
+      })
+      const services = records.find((item) => item.event === "indexing.manager.services")
+
+      expect(services?.outcome).toBe("error")
+      expect(services?.fields).toEqual({
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        baseline: "none",
+        validationMs: expect.any(Number),
+      })
+      expect(records.every((item) => JSON.stringify(item).includes(root) === false)).toBe(true)
+    } finally {
+      validate.mockRestore()
+      await mgr.dispose()
+    }
+  })
+
   test("falls back when the shared baseline is not ready", async () => {
     const mgr = new CodeIndexManager("/tmp/worktree", "/tmp/cache", "/tmp/main")
     let closed = 0

--- a/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/orchestrator.test.ts
@@ -14,6 +14,7 @@ import type {
   VectorStoreSearchResult,
 } from "../../../src/indexing/interfaces"
 import { Emitter } from "../../../src/indexing/runtime"
+import { captureProfiles } from "./profile-capture"
 
 class Store {
   public clearCount = 0
@@ -149,14 +150,23 @@ class BlockingScanner {
 }
 
 class FailScanner {
-  public readonly isCancelled = false
+  public isCancelled = false
+
+  constructor(private readonly cancelled = false) {}
 
   async scanDirectory(): Promise<{ stats: { processed: number; skipped: number }; totalBlockCount: number }> {
+    this.isCancelled = this.cancelled
     throw new Error("scan failed")
   }
 
   cancel(): void {}
   updateBatchSegmentThreshold(_newThreshold: number): void {}
+}
+
+class FailWatcher extends Watcher {
+  async initialize(): Promise<void> {
+    throw new Error("watcher failed")
+  }
 }
 
 function createConfig(): CodeIndexConfigManager {
@@ -170,6 +180,138 @@ function createConfig(): CodeIndexConfigManager {
 }
 
 describe("CodeIndexOrchestrator telemetry", () => {
+  test.serial("profiles a full indexing lifecycle without workspace details", async () => {
+    const root = "/tmp/kilo-indexing-profile-full"
+    const orchestrator = new CodeIndexOrchestrator(
+      createConfig(),
+      new CodeIndexStateManager(),
+      root,
+      { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+      new Store(false) as unknown as IVectorStore,
+      new Scanner(3, 3, 6) as unknown as DirectoryScanner,
+      new Watcher() as unknown as IFileWatcher,
+    )
+    const records = await captureProfiles(async () => {
+      await orchestrator.startIndexing("manual")
+    })
+    const run = records.find((item) => item.event === "indexing.index.run")
+
+    expect(run?.outcome).toBe("success")
+    expect(run?.fields).toEqual({
+      trigger: "manual",
+      mode: "full",
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      vectorStore: "lancedb",
+      watcherInitMs: expect.any(Number),
+      storeInitMs: expect.any(Number),
+      storePrepareMs: expect.any(Number),
+      scanMs: expect.any(Number),
+      finalizeMs: expect.any(Number),
+    })
+    expect(run?.fields.scanMs).toBeGreaterThanOrEqual(0)
+    expect(records.every((item) => JSON.stringify(item).includes(root) === false)).toBe(true)
+  })
+
+  test.serial("profiles incremental indexing mode", async () => {
+    const records = await captureProfiles(async () => {
+      const orchestrator = new CodeIndexOrchestrator(
+        createConfig(),
+        new CodeIndexStateManager(),
+        "/tmp/kilo-indexing-profile-incremental",
+        { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+        new Store(true) as unknown as IVectorStore,
+        new Scanner(2, 1, 2) as unknown as DirectoryScanner,
+        new Watcher() as unknown as IFileWatcher,
+      )
+
+      await orchestrator.startIndexing("manual")
+    })
+
+    expect(records.find((item) => item.event === "indexing.index.run")?.fields.mode).toBe("incremental")
+  })
+
+  test.serial("profiles cancelled indexing lifecycle", async () => {
+    const scanner = new BlockingScanner()
+    const records = await captureProfiles(async () => {
+      const orchestrator = new CodeIndexOrchestrator(
+        createConfig(),
+        new CodeIndexStateManager(),
+        "/tmp/kilo-indexing-profile-cancelled",
+        { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+        new Store(false) as unknown as IVectorStore,
+        scanner as unknown as DirectoryScanner,
+        new Watcher() as unknown as IFileWatcher,
+      )
+      const active = orchestrator.startIndexing("background")
+
+      await scanner.started.promise
+      await orchestrator.shutdown()
+      await active
+    })
+
+    expect(records.find((item) => item.event === "indexing.index.run")?.outcome).toBe("cancelled")
+  })
+
+  test.serial("profiles early cancellation as full mode", async () => {
+    const orchestrator = new CodeIndexOrchestrator(
+      createConfig(),
+      new CodeIndexStateManager(),
+      "/tmp/kilo-indexing-profile-early-cancelled",
+      { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+      new Store(false) as unknown as IVectorStore,
+      new Scanner(0, 0, 0) as unknown as DirectoryScanner,
+      new Watcher() as unknown as IFileWatcher,
+    )
+    const records = await captureProfiles(async () => {
+      const active = orchestrator.startIndexing("background")
+      orchestrator.cancelIndexing()
+      await active
+    })
+    const run = records.find((item) => item.event === "indexing.index.run")
+
+    expect(run?.outcome).toBe("cancelled")
+    expect(run?.fields.mode).toBe("full")
+  })
+
+  test.serial("profiles early watcher failures as full mode", async () => {
+    const records = await captureProfiles(async () => {
+      const orchestrator = new CodeIndexOrchestrator(
+        createConfig(),
+        new CodeIndexStateManager(),
+        "/tmp/kilo-indexing-profile-watcher-failure",
+        { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+        new Store(false) as unknown as IVectorStore,
+        new Scanner(0, 0, 0) as unknown as DirectoryScanner,
+        new FailWatcher() as unknown as IFileWatcher,
+      )
+
+      await orchestrator.startIndexing("background")
+    })
+    const run = records.find((item) => item.event === "indexing.index.run")
+
+    expect(run?.outcome).toBe("error")
+    expect(run?.fields.mode).toBe("full")
+  })
+
+  test.serial("profiles failures after cancellation as errors", async () => {
+    const records = await captureProfiles(async () => {
+      const orchestrator = new CodeIndexOrchestrator(
+        createConfig(),
+        new CodeIndexStateManager(),
+        "/tmp/kilo-indexing-profile-cancelled-failure",
+        { async clearCacheFile() {}, async flush() {} } as unknown as CacheManager,
+        new Store(false) as unknown as IVectorStore,
+        new FailScanner(true) as unknown as DirectoryScanner,
+        new Watcher() as unknown as IFileWatcher,
+      )
+
+      await orchestrator.startIndexing("background")
+    })
+
+    expect(records.find((item) => item.event === "indexing.index.run")?.outcome).toBe("error")
+  })
+
   test("emits full completion telemetry", async () => {
     const events: IndexingTelemetryEvent[] = []
     const orchestrator = new CodeIndexOrchestrator(

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { mkdtemp, mkdir, rm, writeFile } from "fs/promises"
+import { mkdtemp, mkdir, rm, stat, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { createHash } from "crypto"
@@ -506,6 +506,12 @@ describe("FileWatcher", () => {
     expect(overlay.shadows.has("file.ts")).toBe(true)
     expect(overlay.blocked.has("file.ts")).toBe(false)
     expect(cache.getHash(file)).toBe(createHash("sha256").update(changed).digest("hex"))
+    const info = await stat(file)
+    expect(cache.getMetadata(file)).toEqual({
+      size: info.size,
+      mtimeMs: info.mtimeMs,
+      ctimeMs: info.ctimeMs,
+    })
 
     await writeFile(file, baseline)
     overlay.block(file)
@@ -514,6 +520,7 @@ describe("FileWatcher", () => {
     expect(overlay.shadows.has("file.ts")).toBe(false)
     expect(overlay.blocked.has("file.ts")).toBe(false)
     expect(cache.getHash(file)).toBe(baselineHash)
+    expect(cache.getMetadata(file)).toBeUndefined()
     expect(store.points.length).toBeGreaterThan(0)
     const count = store.points.length
 
@@ -605,7 +612,10 @@ describe("FileWatcher", () => {
 
     const first = await watcher.processFile(custom)
     expect(first.status).toBe("processed_for_batching")
-    if (first.status === "processed_for_batching" && first.newHash) cache.updateHash(custom, first.newHash)
+    if (first.status === "processed_for_batching" && first.newHash) {
+      expect(first.metadata).toBeDefined()
+      cache.updateHash(custom, first.newHash, first.metadata)
+    }
     expect(await watcher.processFile(excluded)).toMatchObject({
       status: "skipped",
       reason: "File extension is not configured for indexing",

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
@@ -7,6 +7,8 @@ import { v5 as uuidv5 } from "uuid"
 import { CacheManager } from "../../../../src/indexing/cache-manager"
 import { QDRANT_CODE_BLOCK_NAMESPACE } from "../../../../src/indexing/constants"
 import type {
+  CodeBlock,
+  ICodeParser,
   IEmbedder,
   IndexingTelemetryEvent,
   IVectorStore,
@@ -17,6 +19,7 @@ import { FileWatcher } from "../../../../src/indexing/processors/file-watcher"
 import { CodeParser } from "../../../../src/indexing/processors/parser"
 import { loadIgnore } from "../../../../src/indexing/shared/load-ignore"
 import { WorktreeOverlay } from "../../../../src/indexing/worktree-overlay"
+import { captureProfiles } from "../profile-capture"
 
 function createEmbedder(): IEmbedder {
   return {
@@ -30,6 +33,39 @@ function createEmbedder(): IEmbedder {
     },
     get embedderInfo() {
       return { name: "openai" as const }
+    },
+  }
+}
+
+function createWrongCountEmbedder(): IEmbedder {
+  return {
+    async createEmbeddings() {
+      return { embeddings: [] }
+    },
+    async validateConfiguration() {
+      return { valid: true }
+    },
+    get embedderInfo() {
+      return { name: "openai" as const }
+    },
+  }
+}
+
+function createParser(): ICodeParser {
+  return {
+    async parseFile(filePath, options): Promise<CodeBlock[]> {
+      return [
+        {
+          file_path: filePath,
+          identifier: null,
+          type: "definition",
+          start_line: 1,
+          end_line: 1,
+          content: "const indexed = true",
+          fileHash: options?.fileHash ?? "",
+          segmentHash: "segment",
+        },
+      ]
     },
   }
 }
@@ -77,6 +113,228 @@ class RetryStore implements IVectorStore {
 }
 
 describe("FileWatcher", () => {
+  test.serial("profiles watcher batches and per-file embeddings without source data", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-profile-"))
+    const cacheDir = path.join(root, ".cache")
+    const first = path.join(root, "first.ts")
+    const second = path.join(root, "second.ts")
+
+    try {
+      await mkdir(cacheDir, { recursive: true })
+      await writeFile(first, "const watcherSecret = 'sensitive-file-code'\n")
+      await writeFile(second, "const watcherSecret = 'sensitive-file-code'\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const watcher = new FileWatcher(
+        root,
+        cache,
+        createEmbedder(),
+        new RetryStore(1),
+        undefined,
+        1,
+        2,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+        [".ts"],
+        createParser(),
+      )
+      const data = watcher as unknown as {
+        processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+      }
+
+      const records = await captureProfiles(async () => {
+        await data.processBatch(
+          new Map([
+            [first, { path: first, type: "create" }],
+            [second, { path: second, type: "create" }],
+          ]),
+        )
+      })
+      const batches = records.filter((item) => item.event === "indexing.watcher.batch")
+      const embeddings = records.filter((item) => item.event === "indexing.watcher.embedding")
+      expect(batches).toHaveLength(1)
+      const batch = batches[0]
+
+      expect(batch?.outcome).toBe("success")
+      expect(batch?.fields).toEqual({
+        source: "watcher",
+        mode: "incremental",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        eventCount: 2,
+        deleteCount: 0,
+        upsertFileCount: 2,
+        pointCount: 2,
+        successCount: 2,
+        skippedCount: 0,
+        errorCount: 0,
+        deleteMs: expect.any(Number),
+        prepareMs: expect.any(Number),
+        upsertMs: expect.any(Number),
+        flushMs: expect.any(Number),
+      })
+      expect(embeddings).toHaveLength(2)
+      for (const embedding of embeddings) {
+        expect(embedding.outcome).toBe("success")
+        expect(embedding.fields).toEqual({
+          provider: "openai",
+          modelId: "text-embedding-3-small",
+          textCount: 1,
+        })
+      }
+      expect(JSON.stringify(records)).not.toContain(root)
+      expect(JSON.stringify(records)).not.toContain(first)
+      expect(JSON.stringify(records)).not.toContain("sensitive-file-code")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles watcher batch errors without source data", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-profile-error-"))
+    const cacheDir = path.join(root, ".cache")
+    const file = path.join(root, "error.ts")
+
+    try {
+      await mkdir(cacheDir, { recursive: true })
+      await writeFile(file, "const watcherSecret = 'sensitive-file-code'\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const watcher = new FileWatcher(
+        root,
+        cache,
+        createEmbedder(),
+        new RetryStore(10),
+        undefined,
+        1,
+        2,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+        [".ts"],
+        createParser(),
+      )
+      const data = watcher as unknown as {
+        processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+      }
+
+      const records = await captureProfiles(async () => {
+        await data.processBatch(new Map([[file, { path: file, type: "create" }]]))
+      })
+      const batches = records.filter((item) => item.event === "indexing.watcher.batch")
+      expect(batches).toHaveLength(1)
+      const batch = batches[0]
+
+      expect(batch?.outcome).toBe("error")
+      expect(batch?.fields).toEqual({
+        source: "watcher",
+        mode: "incremental",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        eventCount: 1,
+        deleteCount: 0,
+        upsertFileCount: 1,
+        pointCount: 1,
+        successCount: 0,
+        skippedCount: 0,
+        errorCount: 1,
+        deleteMs: expect.any(Number),
+        prepareMs: expect.any(Number),
+        upsertMs: expect.any(Number),
+        flushMs: expect.any(Number),
+      })
+      expect(JSON.stringify(records)).not.toContain(root)
+      expect(JSON.stringify(records)).not.toContain(file)
+      expect(JSON.stringify(records)).not.toContain("watcher upsert failure")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles wrong-count watcher embeddings as errors without source data", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-profile-embedding-error-"))
+    const cacheDir = path.join(root, ".cache")
+    const file = path.join(root, "error.ts")
+
+    try {
+      await mkdir(cacheDir, { recursive: true })
+      await writeFile(file, "const watcherSecret = 'sensitive-file-code'\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const watcher = new FileWatcher(
+        root,
+        cache,
+        createWrongCountEmbedder(),
+        new RetryStore(0),
+        undefined,
+        1,
+        2,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+        [".ts"],
+        createParser(),
+      )
+      const data = watcher as unknown as {
+        processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+      }
+
+      const records = await captureProfiles(async () => {
+        await data.processBatch(new Map([[file, { path: file, type: "create" }]]))
+      })
+      const batches = records.filter((item) => item.event === "indexing.watcher.batch")
+      const embeddings = records.filter((item) => item.event === "indexing.watcher.embedding")
+      expect(batches).toHaveLength(1)
+      expect(embeddings).toHaveLength(1)
+      const batch = batches[0]
+      const embedding = embeddings[0]
+
+      expect(batch?.outcome).toBe("error")
+      expect(batch?.fields).toEqual({
+        source: "watcher",
+        mode: "incremental",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        eventCount: 1,
+        deleteCount: 0,
+        upsertFileCount: 1,
+        pointCount: 0,
+        successCount: 0,
+        skippedCount: 0,
+        errorCount: 1,
+        deleteMs: expect.any(Number),
+        prepareMs: expect.any(Number),
+        upsertMs: expect.any(Number),
+        flushMs: expect.any(Number),
+      })
+      expect(embedding?.outcome).toBe("error")
+      expect(embedding?.fields).toEqual({
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        textCount: 1,
+      })
+      expect(JSON.stringify(records)).not.toContain(root)
+      expect(JSON.stringify(records)).not.toContain(file)
+      expect(JSON.stringify(records)).not.toContain("sensitive-file-code")
+      expect(JSON.stringify(records)).not.toContain("Embedding count mismatch")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("processFile preserves same-line segments during incremental updates", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "file-watcher-test-"))
     const cacheDir = path.join(root, ".cache")

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/file-watcher.test.ts
@@ -260,6 +260,45 @@ describe("FileWatcher", () => {
     }
   })
 
+  test("preserves cached metadata when watcher upserts fail", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "file-watcher-test-"))
+    const cacheDir = path.join(root, ".cache")
+    const file = path.join(root, "error.ts")
+    const cache = new CacheManager(cacheDir, root)
+
+    try {
+      const metadata = { size: 7, mtimeMs: 11, ctimeMs: 13 }
+      await mkdir(cacheDir, { recursive: true })
+      await writeFile(file, "const watcher = true\n")
+      await cache.initialize()
+      cache.updateHash(file, "seeded-hash", metadata)
+      const watcher = new FileWatcher(
+        root,
+        cache,
+        createEmbedder(),
+        new RetryStore(1),
+        undefined,
+        1,
+        1,
+        undefined,
+        undefined,
+        [".ts"],
+        createParser(),
+      )
+      const data = watcher as unknown as {
+        processBatch(events: Map<string, { path: string; type: "create" | "change" | "delete" }>): Promise<void>
+      }
+
+      await data.processBatch(new Map([[file, { path: file, type: "create" }]]))
+
+      expect(cache.getHash(file)).toBe("seeded-hash")
+      expect(cache.getMetadata(file)).toEqual(metadata)
+    } finally {
+      await cache.flush()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test.serial("profiles wrong-count watcher embeddings as errors without source data", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "file-watcher-profile-embedding-error-"))
     const cacheDir = path.join(root, ".cache")

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto"
-import { mkdir, mkdtemp, rm } from "fs/promises"
+import { mkdir, mkdtemp, rm, stat } from "fs/promises"
 import ignore from "ignore"
 import { tmpdir } from "os"
 import { join } from "path"
@@ -107,6 +107,7 @@ class ManyParser implements ICodeParser {
 
 class Store implements IVectorStore {
   public multi: string[][] = []
+  public single: string[] = []
   public points = 0
 
   public async initialize(): Promise<boolean> {
@@ -126,7 +127,9 @@ class Store implements IVectorStore {
     return []
   }
 
-  public async deletePointsByFilePath(_filePath: string): Promise<void> {}
+  public async deletePointsByFilePath(filePath: string): Promise<void> {
+    this.single.push(filePath)
+  }
 
   public async deletePointsByMultipleFilePaths(filePaths: string[]): Promise<void> {
     this.multi.push(filePaths)
@@ -256,16 +259,15 @@ describe("DirectoryScanner", () => {
       expect(discovery[0]?.outcome).toBe("success")
       expect(discovery[0]?.fields).toEqual({
         mode: "full",
-        discoveredCount: 5,
+        discoveredCount: 4,
         candidateCount: 4,
       })
-      expect(discovery[0]?.fields.discoveredCount).toBeGreaterThan(discovery[0]?.fields.candidateCount as number)
 
       expect(summary).toHaveLength(1)
       expect(summary[0]?.outcome).toBe("success")
       expect(summary[0]?.fields).toEqual({
         mode: "full",
-        discoveredCount: 5,
+        discoveredCount: 4,
         candidateCount: 4,
         inspectedCount: 4,
         readCount: 3,
@@ -542,6 +544,8 @@ describe("DirectoryScanner", () => {
     await Bun.write(file, content)
 
     const hash = createHash("sha256").update(content).digest("hex")
+    const info = await stat(file)
+    const metadata = { size: info.size, mtimeMs: info.mtimeMs, ctimeMs: info.ctimeMs }
     const cache = new CacheManager(cacheDir, root)
     await cache.initialize()
     cache.updateHash(file, "old-hash")
@@ -557,6 +561,7 @@ describe("DirectoryScanner", () => {
     expect(store.points).toBe(1)
     expect(store.multi).toEqual([[file]])
     expect(cache.getHash(file)).toBe(hash)
+    expect(cache.getMetadata(file)).toEqual(metadata)
   })
 
   test("does not mark hash current when a later batch fails for the same file", async () => {
@@ -614,6 +619,99 @@ describe("DirectoryScanner", () => {
     expect(count?.mode).toBe("full")
     expect(count?.source).toBe("scan")
     expect(count?.candidate).toBe(1)
+  })
+
+  test("discovers uppercase configured extensions without unsupported files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+
+    try {
+      await Bun.write(join(root, "main.TS"), "export const value = 2\n")
+      await Bun.write(join(root, "notes.txt"), "unsupported\n")
+
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const events: IndexingTelemetryEvent[] = []
+      const scan = new DirectoryScanner(
+        new Emb(),
+        new Store(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        1,
+        (event) => events.push(event),
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+        [".ts"],
+      )
+
+      const result = await scan.scanDirectory(root)
+      const count = events.find((event) => event.type === "file_count")
+
+      expect(result.stats.processed).toBe(1)
+      expect(count?.type).toBe("file_count")
+      expect(count?.discovered).toBe(1)
+      expect(count?.candidate).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("skips incremental reads when cached metadata matches", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const file = join(root, "main.ts")
+    const content = "export const value = 2\n"
+
+    try {
+      await Bun.write(file, content)
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const info = await stat(file)
+      const metadata = { size: info.size, mtimeMs: info.mtimeMs, ctimeMs: info.ctimeMs }
+      const hash = createHash("sha256").update(content).digest("hex")
+      cache.updateHash(file, hash, metadata)
+
+      const store = new Store()
+      const scan = new DirectoryScanner(new Emb(), store, new Parser(), cache, ignore(), 1, 1)
+      const results: { stats: { processed: number; skipped: number }; totalBlockCount: number }[] = []
+      const incremental = await captureProfiles(() =>
+        scan
+          .scanDirectory(root, undefined, undefined, undefined, "incremental")
+          .then((result) => void results.push(result)),
+      )
+      const [result] = results
+      const first = incremental.find((item) => item.event === "indexing.scan.summary")
+
+      expect(result).toEqual({ stats: { processed: 0, skipped: 1 }, totalBlockCount: 0 })
+      expect(first?.fields.readCount).toBe(0)
+      expect(first?.fields.bytesRead).toBe(0)
+      expect(first?.fields.unchangedCount).toBe(1)
+      expect(store.points).toBe(0)
+      expect(store.multi).toEqual([])
+      expect(store.single).toEqual([])
+      expect(cache.getHash(file)).toBe(hash)
+
+      const full = await captureProfiles(() =>
+        scan.scanDirectory(root, undefined, undefined, undefined, "full").then(() => undefined),
+      )
+      expect(full.find((item) => item.event === "indexing.scan.summary")?.fields.readCount).toBe(1)
+
+      cache.updateHash(file, cache.getHash(file)!, { ...metadata, mtimeMs: metadata.mtimeMs - 1 })
+      const fallback = await captureProfiles(() =>
+        scan.scanDirectory(root, undefined, undefined, undefined, "incremental").then(() => undefined),
+      )
+      expect(fallback.find((item) => item.event === "indexing.scan.summary")?.fields.readCount).toBe(1)
+      expect(cache.getMetadata(file)).toEqual(metadata)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
   })
 
   test("skips files matched by .kilocodeignore during full scans", async () => {

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os"
 import { join } from "path"
 import { describe, expect, test } from "bun:test"
 import { CacheManager } from "../../../../src/indexing/cache-manager"
+import { MAX_FILE_SIZE_BYTES } from "../../../../src/indexing/constants"
 import type {
   CodeBlock,
   ICodeParser,
@@ -16,6 +17,7 @@ import type {
 } from "../../../../src/indexing/interfaces"
 import { loadIgnore } from "../../../../src/indexing/shared/load-ignore"
 import { DirectoryScanner } from "../../../../src/indexing/processors/scanner"
+import { captureProfiles } from "../profile-capture"
 
 class Emb implements IEmbedder {
   public async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
@@ -171,7 +173,333 @@ class RetryStore extends Store {
   }
 }
 
+class ExhaustedStore extends Store {
+  public override async upsertPoints(_points: PointStruct[]): Promise<void> {
+    throw new Error("permanent upsert failure")
+  }
+}
+
+class CancellingEmb extends Emb {
+  public onCreate?: () => void
+
+  public override async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
+    this.onCreate?.()
+    return super.createEmbeddings(texts)
+  }
+}
+
+class BlockingEmb extends Emb {
+  public readonly started = Promise.withResolvers<void>()
+  private readonly gate = Promise.withResolvers<void>()
+
+  public override async createEmbeddings(texts: string[]): Promise<{ embeddings: number[][] }> {
+    this.started.resolve()
+    await this.gate.promise
+    return super.createEmbeddings(texts)
+  }
+
+  public release(): void {
+    this.gate.resolve()
+  }
+}
+
 describe("DirectoryScanner", () => {
+  test.serial("profiles aggregate scanner discovery, summary, and batches without file data", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-profile-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const supported = join(root, "supported.ts")
+    const unsupported = join(root, "unsupported.txt")
+    const unchanged = join(root, "unchanged.ts")
+    const changed = join(root, "changed.ts")
+    const oversized = join(root, "oversized.ts")
+    const deleted = join(root, "deleted.ts")
+    const unchangedContent = "export const unchanged = 1\n"
+
+    try {
+      await Bun.write(supported, "export const supported = 1\n")
+      await Bun.write(unsupported, "unsupported\n")
+      await Bun.write(unchanged, unchangedContent)
+      await Bun.write(changed, "export const changed = 1\n")
+      await Bun.write(oversized, Buffer.alloc(MAX_FILE_SIZE_BYTES + 1))
+
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      cache.seedHashes({
+        [unchanged]: createHash("sha256").update(unchangedContent).digest("hex"),
+        [changed]: "old-hash",
+        [deleted]: "deleted-hash",
+      })
+
+      const scan = new DirectoryScanner(
+        new Emb(),
+        new Store(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        1,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+      )
+      const records = await captureProfiles(async () => {
+        await scan.scanDirectory(root)
+      })
+      const discovery = records.filter((item) => item.event === "indexing.scan.discovery")
+      const summary = records.filter((item) => item.event === "indexing.scan.summary")
+      const batches = records.filter((item) => item.event === "indexing.scan.batch")
+
+      expect(discovery).toHaveLength(1)
+      expect(discovery[0]?.outcome).toBe("success")
+      expect(discovery[0]?.fields).toEqual({
+        mode: "full",
+        discoveredCount: 5,
+        candidateCount: 4,
+      })
+      expect(discovery[0]?.fields.discoveredCount).toBeGreaterThan(discovery[0]?.fields.candidateCount as number)
+
+      expect(summary).toHaveLength(1)
+      expect(summary[0]?.outcome).toBe("success")
+      expect(summary[0]?.fields).toEqual({
+        mode: "full",
+        discoveredCount: 5,
+        candidateCount: 4,
+        inspectedCount: 4,
+        readCount: 3,
+        bytesRead: expect.any(Number),
+        unchangedCount: 1,
+        processedCount: 2,
+        skippedCount: 2,
+        blockCount: 2,
+        batchCount: 2,
+        changedDeleteCount: 1,
+        removedDeleteCount: 1,
+      })
+      expect(summary[0]?.fields.bytesRead).toBeGreaterThan(0)
+      expect(summary[0]?.fields.unchangedCount).toBe(1)
+
+      expect(batches).toHaveLength(2)
+      for (const batch of batches) {
+        expect(batch.outcome).toBe("success")
+        expect(batch.fields).toEqual({
+          source: "scan",
+          mode: "full",
+          provider: "openai",
+          modelId: "text-embedding-3-small",
+          vectorStore: "lancedb",
+          fileCount: 1,
+          blockCount: 1,
+          attemptCount: 1,
+          deleteMs: expect.any(Number),
+          embeddingMs: expect.any(Number),
+          upsertMs: expect.any(Number),
+        })
+        expect(batch.fields.blockCount).toBe(1)
+        expect(batch.fields.attemptCount).toBe(1)
+      }
+      expect(JSON.stringify(records)).not.toContain(root)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles retry attempts as one terminal batch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-profile-retry-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+
+    try {
+      await Bun.write(join(root, "main.ts"), "export const value = 2\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const scan = new DirectoryScanner(
+        new Emb(),
+        new RetryStore(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        2,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+      )
+      const records = await captureProfiles(async () => {
+        await scan.scanDirectory(root)
+      })
+      const batches = records.filter((item) => item.event === "indexing.scan.batch")
+
+      expect(batches).toHaveLength(1)
+      expect(batches[0]?.outcome).toBe("success")
+      expect(batches[0]?.fields).toEqual({
+        source: "scan",
+        mode: "full",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        fileCount: 1,
+        blockCount: 1,
+        attemptCount: 2,
+        deleteMs: expect.any(Number),
+        embeddingMs: expect.any(Number),
+        upsertMs: expect.any(Number),
+      })
+      expect(JSON.stringify(batches)).not.toContain(root)
+      expect(JSON.stringify(batches)).not.toContain("temporary upsert failure")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles exhausted retry batches without source data", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-profile-exhausted-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+
+    try {
+      await Bun.write(join(root, "main.ts"), "export const value = 2\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const scan = new DirectoryScanner(
+        new Emb(),
+        new ExhaustedStore(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        2,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+      )
+      const records = await captureProfiles(async () => {
+        await scan.scanDirectory(root)
+      })
+      const batches = records.filter((item) => item.event === "indexing.scan.batch")
+
+      expect(batches).toHaveLength(1)
+      expect(batches[0]?.outcome).toBe("error")
+      expect(batches[0]?.fields).toEqual({
+        source: "scan",
+        mode: "full",
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        fileCount: 1,
+        blockCount: 1,
+        attemptCount: 2,
+        deleteMs: expect.any(Number),
+        embeddingMs: expect.any(Number),
+        upsertMs: expect.any(Number),
+      })
+      expect(JSON.stringify(batches)).not.toContain(root)
+      expect(JSON.stringify(batches)).not.toContain("permanent upsert failure")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles cooperative scanner cancellation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-profile-cancelled-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+
+    try {
+      await Bun.write(join(root, "main.ts"), "export const value = 2\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const emb = new CancellingEmb()
+      const scan = new DirectoryScanner(
+        emb,
+        new Store(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        1,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+      )
+      emb.onCreate = () => scan.cancel()
+
+      const records = await captureProfiles(async () => {
+        await scan.scanDirectory(root)
+        await new Promise<void>((resolve) => setImmediate(resolve))
+      })
+      const summary = records.find((item) => item.event === "indexing.scan.summary")
+      const batches = records.filter((item) => item.event === "indexing.scan.batch")
+
+      expect(summary?.outcome).toBe("cancelled")
+      expect(summary?.fields.processedCount).toBe(1)
+      expect(summary?.fields.batchCount).toBe(1)
+      expect(batches).toHaveLength(1)
+      expect(batches[0]?.outcome).toBe("cancelled")
+      expect(batches[0]?.fields.blockCount).toBe(1)
+      expect(batches[0]?.fields.attemptCount).toBe(1)
+      expect(JSON.stringify(records)).not.toContain(root)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles cancellation requested while batches settle", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-profile-settling-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const emb = new BlockingEmb()
+
+    try {
+      await Bun.write(join(root, "main.ts"), "export const value = 2\n")
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const scan = new DirectoryScanner(
+        emb,
+        new Store(),
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        1,
+        undefined,
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+      )
+
+      const records = await captureProfiles(async () => {
+        const task = scan.scanDirectory(root)
+        await emb.started.promise
+        // RATIONALE: Keep the batch pending until scanDirectory is waiting for active batches.
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        scan.cancel()
+        emb.release()
+        await task
+      })
+      const summary = records.find((item) => item.event === "indexing.scan.summary")
+
+      expect(summary?.outcome).toBe("cancelled")
+    } finally {
+      emb.release()
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
   test("uses seeded baseline hashes to index only worktree changes", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -217,6 +217,7 @@ describe("DirectoryScanner", () => {
     const oversized = join(root, "oversized.ts")
     const deleted = join(root, "deleted.ts")
     const unchangedContent = "export const unchanged = 1\n"
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(supported, "export const supported = 1\n")
@@ -225,7 +226,6 @@ describe("DirectoryScanner", () => {
       await Bun.write(changed, "export const changed = 1\n")
       await Bun.write(oversized, Buffer.alloc(MAX_FILE_SIZE_BYTES + 1))
 
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       cache.seedHashes({
         [unchanged]: createHash("sha256").update(unchangedContent).digest("hex"),
@@ -304,6 +304,7 @@ describe("DirectoryScanner", () => {
       }
       expect(JSON.stringify(records)).not.toContain(root)
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -312,10 +313,10 @@ describe("DirectoryScanner", () => {
   test.serial("profiles retry attempts as one terminal batch", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-profile-retry-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(join(root, "main.ts"), "export const value = 2\n")
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const scan = new DirectoryScanner(
         new Emb(),
@@ -355,6 +356,7 @@ describe("DirectoryScanner", () => {
       expect(JSON.stringify(batches)).not.toContain(root)
       expect(JSON.stringify(batches)).not.toContain("temporary upsert failure")
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -363,10 +365,10 @@ describe("DirectoryScanner", () => {
   test.serial("profiles exhausted retry batches without source data", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-profile-exhausted-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(join(root, "main.ts"), "export const value = 2\n")
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const scan = new DirectoryScanner(
         new Emb(),
@@ -406,6 +408,7 @@ describe("DirectoryScanner", () => {
       expect(JSON.stringify(batches)).not.toContain(root)
       expect(JSON.stringify(batches)).not.toContain("permanent upsert failure")
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -414,10 +417,10 @@ describe("DirectoryScanner", () => {
   test.serial("profiles cooperative scanner cancellation", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-profile-cancelled-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(join(root, "main.ts"), "export const value = 2\n")
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const emb = new CancellingEmb()
       const scan = new DirectoryScanner(
@@ -453,6 +456,7 @@ describe("DirectoryScanner", () => {
       expect(batches[0]?.fields.attemptCount).toBe(1)
       expect(JSON.stringify(records)).not.toContain(root)
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -463,12 +467,12 @@ describe("DirectoryScanner", () => {
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
     const emb = new BlockingEmb()
     const file = join(root, "main.ts")
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       const content = "export const value = 2\n"
       const metadata = { size: 7, mtimeMs: 11, ctimeMs: 13 }
       await Bun.write(file, content)
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       cache.updateHash(file, "seeded-hash", metadata)
       const store = new Store()
@@ -522,6 +526,7 @@ describe("DirectoryScanner", () => {
       })
     } finally {
       emb.release()
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -651,12 +656,12 @@ describe("DirectoryScanner", () => {
   test("discovers uppercase configured extensions without unsupported files", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(join(root, "main.TS"), "export const value = 2\n")
       await Bun.write(join(root, "notes.txt"), "unsupported\n")
 
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const events: IndexingTelemetryEvent[] = []
       const scan = new DirectoryScanner(
@@ -684,6 +689,7 @@ describe("DirectoryScanner", () => {
       expect(count?.discovered).toBe(1)
       expect(count?.candidate).toBe(1)
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -693,31 +699,45 @@ describe("DirectoryScanner", () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
     const blocked = join(root, "logs", "blocked.TS")
-    const eligible = join(root, "LOGS", "eligible.TS")
-    const upper = join(root, "main.TS")
+    const eligible = join(root, "Logs.TS")
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await mkdir(join(root, "logs"), { recursive: true })
-      await mkdir(join(root, "LOGS"), { recursive: true })
       await Bun.write(blocked, "export const blocked = 1\n")
       await Bun.write(eligible, "export const eligible = 1\n")
-      await Bun.write(upper, "export const upper = 1\n")
 
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const store = new Store()
-      const scan = new DirectoryScanner(new Emb(), store, new Parser(), cache, ignore(), 1, 1, undefined, undefined, [
-        ".ts",
-      ])
+      const events: IndexingTelemetryEvent[] = []
+      const scan = new DirectoryScanner(
+        new Emb(),
+        store,
+        new Parser(),
+        cache,
+        ignore(),
+        1,
+        1,
+        (event) => events.push(event),
+        {
+          provider: "openai",
+          vectorStore: "lancedb",
+          modelId: "text-embedding-3-small",
+        },
+        [".ts"],
+      )
 
       const result = await scan.scanDirectory(root)
+      const count = events.find((event) => event.type === "file_count")
 
-      expect(result.stats.processed).toBe(2)
-      expect(store.points).toBe(2)
+      expect(result.stats.processed).toBe(1)
+      expect(store.points).toBe(1)
+      expect(count?.discovered).toBe(1)
+      expect(count?.candidate).toBe(1)
       expect(cache.getHash(blocked)).toBeUndefined()
       expect(cache.getHash(eligible)).toBeDefined()
-      expect(cache.getHash(upper)).toBeDefined()
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }
@@ -728,10 +748,10 @@ describe("DirectoryScanner", () => {
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
     const file = join(root, "main.ts")
     const content = "export const value = 2\n"
+    const cache = new CacheManager(cacheDir, root)
 
     try {
       await Bun.write(file, content)
-      const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
       const info = await stat(file)
       const metadata = { size: info.size, mtimeMs: info.mtimeMs, ctimeMs: info.ctimeMs }
@@ -770,6 +790,7 @@ describe("DirectoryScanner", () => {
       expect(fallback.find((item) => item.event === "indexing.scan.summary")?.fields.readCount).toBe(1)
       expect(cache.getMetadata(file)).toEqual(metadata)
     } finally {
+      await cache.flush()
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })
     }

--- a/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/processors/scanner.test.ts
@@ -458,18 +458,23 @@ describe("DirectoryScanner", () => {
     }
   })
 
-  test.serial("profiles cancellation requested while batches settle", async () => {
+  test.serial("waits for cancelled batches before allowing an incremental retry", async () => {
     const root = await mkdtemp(join(tmpdir(), "scanner-profile-settling-"))
     const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
     const emb = new BlockingEmb()
+    const file = join(root, "main.ts")
 
     try {
-      await Bun.write(join(root, "main.ts"), "export const value = 2\n")
+      const content = "export const value = 2\n"
+      const metadata = { size: 7, mtimeMs: 11, ctimeMs: 13 }
+      await Bun.write(file, content)
       const cache = new CacheManager(cacheDir, root)
       await cache.initialize()
+      cache.updateHash(file, "seeded-hash", metadata)
+      const store = new Store()
       const scan = new DirectoryScanner(
         emb,
-        new Store(),
+        store,
         new Parser(),
         cache,
         ignore(),
@@ -489,12 +494,32 @@ describe("DirectoryScanner", () => {
         // RATIONALE: Keep the batch pending until scanDirectory is waiting for active batches.
         await new Promise<void>((resolve) => setImmediate(resolve))
         scan.cancel()
+        const state = { settled: false }
+        void task.then(() => {
+          state.settled = true
+        })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        expect(state.settled).toBe(false)
         emb.release()
         await task
       })
       const summary = records.find((item) => item.event === "indexing.scan.summary")
 
       expect(summary?.outcome).toBe("cancelled")
+      expect(cache.getHash(file)).toBe("seeded-hash")
+      expect(cache.getMetadata(file)).toEqual(metadata)
+      expect(store.points).toBe(0)
+
+      await scan.scanDirectory(root, undefined, undefined, undefined, "incremental")
+
+      expect(store.points).toBe(1)
+      expect(cache.getHash(file)).toBe(createHash("sha256").update(content).digest("hex"))
+      const info = await stat(file)
+      expect(cache.getMetadata(file)).toEqual({
+        size: info.size,
+        mtimeMs: info.mtimeMs,
+        ctimeMs: info.ctimeMs,
+      })
     } finally {
       emb.release()
       await rm(root, { recursive: true, force: true })
@@ -573,7 +598,8 @@ describe("DirectoryScanner", () => {
 
     const cache = new CacheManager(cacheDir, root)
     await cache.initialize()
-    cache.updateHash(file, "old-hash")
+    const metadata = { size: 7, mtimeMs: 11, ctimeMs: 13 }
+    cache.updateHash(file, "old-hash", metadata)
 
     const emb = new Emb()
     const parser = new ManyParser()
@@ -583,6 +609,7 @@ describe("DirectoryScanner", () => {
     await scan.scanDirectory(root)
 
     expect(cache.getHash(file)).toBe("old-hash")
+    expect(cache.getMetadata(file)).toEqual(metadata)
   })
 
   test("emits candidate counts for scan telemetry", async () => {
@@ -656,6 +683,40 @@ describe("DirectoryScanner", () => {
       expect(count?.type).toBe("file_count")
       expect(count?.discovered).toBe(1)
       expect(count?.candidate).toBe(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(cacheDir, { recursive: true, force: true })
+    }
+  })
+
+  test("preserves case-sensitive built-in ignore patterns while discovering uppercase extensions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "scanner-test-"))
+    const cacheDir = await mkdtemp(join(tmpdir(), "scanner-cache-"))
+    const blocked = join(root, "logs", "blocked.TS")
+    const eligible = join(root, "LOGS", "eligible.TS")
+    const upper = join(root, "main.TS")
+
+    try {
+      await mkdir(join(root, "logs"), { recursive: true })
+      await mkdir(join(root, "LOGS"), { recursive: true })
+      await Bun.write(blocked, "export const blocked = 1\n")
+      await Bun.write(eligible, "export const eligible = 1\n")
+      await Bun.write(upper, "export const upper = 1\n")
+
+      const cache = new CacheManager(cacheDir, root)
+      await cache.initialize()
+      const store = new Store()
+      const scan = new DirectoryScanner(new Emb(), store, new Parser(), cache, ignore(), 1, 1, undefined, undefined, [
+        ".ts",
+      ])
+
+      const result = await scan.scanDirectory(root)
+
+      expect(result.stats.processed).toBe(2)
+      expect(store.points).toBe(2)
+      expect(cache.getHash(blocked)).toBeUndefined()
+      expect(cache.getHash(eligible)).toBeDefined()
+      expect(cache.getHash(upper)).toBeDefined()
     } finally {
       await rm(root, { recursive: true, force: true })
       await rm(cacheDir, { recursive: true, force: true })

--- a/packages/kilo-indexing/test/kilocode/indexing/profile-capture.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/profile-capture.ts
@@ -1,0 +1,25 @@
+import { spyOn } from "bun:test"
+import type { IndexingProfileRecord } from "../../../src/util/profile"
+
+export async function captureProfiles(run: () => Promise<void>): Promise<IndexingProfileRecord[]> {
+  const env = process.env.KILO_INDEXING_PROFILE
+  const info = spyOn(console, "info").mockImplementation(() => undefined)
+  try {
+    process.env.KILO_INDEXING_PROFILE = "1"
+    await run()
+    const records: IndexingProfileRecord[] = []
+    for (const [value] of info.mock.calls) {
+      try {
+        const record = JSON.parse(String(value)) as { type?: unknown }
+        if (record.type === "kilo-indexing-profile") records.push(record as IndexingProfileRecord)
+      } catch {
+        continue
+      }
+    }
+    return records
+  } finally {
+    info.mockRestore()
+    if (env === undefined) delete process.env.KILO_INDEXING_PROFILE
+    else process.env.KILO_INDEXING_PROFILE = env
+  }
+}

--- a/packages/kilo-indexing/test/kilocode/indexing/search-service.test.ts
+++ b/packages/kilo-indexing/test/kilocode/indexing/search-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createHash } from "crypto"
-import { mkdir, mkdtemp, writeFile } from "fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { CodeIndexConfigManager } from "../../../src/indexing/config-manager"
@@ -8,6 +8,7 @@ import type { IEmbedder, IVectorStore, VectorStoreSearchResult } from "../../../
 import { CodeIndexSearchService } from "../../../src/indexing/search-service"
 import { CodeIndexStateManager } from "../../../src/indexing/state-manager"
 import { WorktreeOverlay } from "../../../src/indexing/worktree-overlay"
+import { captureProfiles } from "./profile-capture"
 
 const result = (filePath: string, score: number, codeChunk = filePath, fileHash?: string): VectorStoreSearchResult => ({
   id: `${filePath}:${score}`,
@@ -47,6 +48,191 @@ const config = (fileExtensions?: string[]) =>
   })
 
 describe("CodeIndexSearchService worktree search", () => {
+  test.serial("profiles local searches without query or prefix data", async () => {
+    const calls: string[][] = []
+    const state = new CodeIndexStateManager()
+    state.setSystemState("Indexed")
+    const service = new CodeIndexSearchService(
+      new CodeIndexConfigManager({
+        enabled: true,
+        embedderProvider: "openai",
+        openAiKey: "test",
+        vectorStoreProvider: "lancedb",
+        modelId: "text-embedding-3-small",
+        searchMaxResults: 2,
+      }),
+      state,
+      embedder(calls),
+      store([result("src/first.ts", 0.9), result("src/second.ts", 0.8)], []),
+    )
+
+    const records = await captureProfiles(async () => {
+      await service.searchIndex("sensitive-query", "sensitive-prefix")
+    })
+    const requests = records.filter((item) => item.event === "indexing.search.request")
+    expect(requests).toHaveLength(1)
+    const record = requests[0]
+
+    expect(record?.outcome).toBe("success")
+    expect(record?.fields).toEqual({
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      vectorStore: "lancedb",
+      scope: "local",
+      embeddingMs: expect.any(Number),
+      currentSearchMs: expect.any(Number),
+      baselineSearchMs: 0,
+      deltaCallCount: 1,
+      baselineCallCount: 0,
+      candidateCount: 2,
+      resultCount: 2,
+    })
+    expect(JSON.stringify(record)).not.toContain("sensitive-query")
+    expect(JSON.stringify(record)).not.toContain("sensitive-prefix")
+  })
+
+  test.serial("profiles worktree search calls without source data", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "search-profile-worktree-"))
+    const main = await mkdtemp(path.join(tmpdir(), "search-profile-main-"))
+    const hash = (content: string) => createHash("sha256").update(content).digest("hex")
+
+    try {
+      await mkdir(path.join(root, "src"), { recursive: true })
+      await mkdir(path.join(main, "src"), { recursive: true })
+      await Promise.all(
+        ["c", "d"].flatMap((name) => [
+          writeFile(path.join(root, `src/${name}.ts`), `src/${name}.ts`),
+          writeFile(path.join(main, `src/${name}.ts`), `src/${name}.ts`),
+        ]),
+      )
+      const overlay = new WorktreeOverlay(
+        root,
+        main,
+        new Map([
+          ["src/a.ts", "a"],
+          ["src/b.ts", "b"],
+          ["src/c.ts", hash("src/c.ts")],
+          ["src/d.ts", hash("src/d.ts")],
+        ]),
+      )
+      overlay.reconcile({
+        [path.join(root, "src/a.ts")]: "changed-a",
+        [path.join(root, "src/b.ts")]: "changed-b",
+        [path.join(root, "src/c.ts")]: hash("src/c.ts"),
+        [path.join(root, "src/d.ts")]: hash("src/d.ts"),
+      })
+      const state = new CodeIndexStateManager()
+      state.setSystemState("Indexed")
+      const service = new CodeIndexSearchService(
+        new CodeIndexConfigManager({
+          enabled: true,
+          embedderProvider: "openai",
+          openAiKey: "test",
+          vectorStoreProvider: "lancedb",
+          modelId: "text-embedding-3-small",
+          searchMaxResults: 2,
+        }),
+        state,
+        embedder([]),
+        store([], []),
+        {
+          store: store(
+            [
+              result("src/a.ts", 0.99),
+              result("src/b.ts", 0.98),
+              result("src/c.ts", 0.8, "sensitive-code", hash("src/c.ts")),
+              result("src/d.ts", 0.7, "sensitive-code", hash("src/d.ts")),
+            ],
+            [],
+          ),
+          overlay,
+        },
+      )
+
+      const records = await captureProfiles(async () => {
+        await service.searchIndex("sensitive-query", "sensitive-prefix")
+      })
+      const requests = records.filter((item) => item.event === "indexing.search.request")
+      expect(requests).toHaveLength(1)
+      const record = requests[0]
+
+      expect(record?.outcome).toBe("success")
+      expect(record?.fields).toEqual({
+        provider: "openai",
+        modelId: "text-embedding-3-small",
+        vectorStore: "lancedb",
+        scope: "worktree",
+        embeddingMs: expect.any(Number),
+        currentSearchMs: expect.any(Number),
+        baselineSearchMs: expect.any(Number),
+        deltaCallCount: 1,
+        baselineCallCount: 2,
+        candidateCount: 2,
+        resultCount: 2,
+      })
+      expect(JSON.stringify(record)).not.toContain(root)
+      expect(JSON.stringify(record)).not.toContain(main)
+      expect(JSON.stringify(record)).not.toContain("sensitive-query")
+      expect(JSON.stringify(record)).not.toContain("sensitive-prefix")
+      expect(JSON.stringify(record)).not.toContain("sensitive-code")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(main, { recursive: true, force: true })
+    }
+  })
+
+  test.serial("profiles search errors without source data", async () => {
+    const state = new CodeIndexStateManager()
+    state.setSystemState("Indexed")
+    const service = new CodeIndexSearchService(
+      new CodeIndexConfigManager({
+        enabled: true,
+        embedderProvider: "openai",
+        openAiKey: "test",
+        vectorStoreProvider: "lancedb",
+        modelId: "text-embedding-3-small",
+      }),
+      state,
+      {
+        async createEmbeddings() {
+          throw new Error("search error sensitive-query sensitive-prefix")
+        },
+        async validateConfiguration() {
+          return { valid: true }
+        },
+        get embedderInfo() {
+          return { name: "openai" as const }
+        },
+      },
+      store([], []),
+    )
+
+    const records = await captureProfiles(async () => {
+      await expect(service.searchIndex("sensitive-query", "sensitive-prefix")).rejects.toThrow("search error")
+    })
+    const requests = records.filter((item) => item.event === "indexing.search.request")
+    expect(requests).toHaveLength(1)
+    const record = requests[0]
+
+    expect(record?.outcome).toBe("error")
+    expect(record?.fields).toEqual({
+      provider: "openai",
+      modelId: "text-embedding-3-small",
+      vectorStore: "lancedb",
+      scope: "local",
+      embeddingMs: expect.any(Number),
+      currentSearchMs: 0,
+      baselineSearchMs: 0,
+      deltaCallCount: 0,
+      baselineCallCount: 0,
+      candidateCount: 0,
+      resultCount: 0,
+    })
+    expect(JSON.stringify(record)).not.toContain("sensitive-query")
+    expect(JSON.stringify(record)).not.toContain("sensitive-prefix")
+    expect(JSON.stringify(record)).not.toContain("search error")
+  })
+
   test("filters stale results using one vector query", async () => {
     const limits: number[] = []
     const state = new CodeIndexStateManager()

--- a/packages/kilo-indexing/test/kilocode/util/profile.test.ts
+++ b/packages/kilo-indexing/test/kilocode/util/profile.test.ts
@@ -1,0 +1,81 @@
+import { expect, spyOn, test } from "bun:test"
+import { IndexingProfile, type IndexingProfileRecord } from "../../../src/util/profile"
+
+test.serial("emits enabled profiles with defined fields and explicit outcomes", () => {
+  const env = process.env.KILO_INDEXING_PROFILE
+  const info = spyOn(console, "info").mockImplementation(() => undefined)
+  try {
+    process.env.KILO_INDEXING_PROFILE = "1"
+    const span = IndexingProfile.start("indexing.test", { provider: "openai", omitted: undefined })
+    span.add({ count: 2 })
+    span.outcome("success")
+    span.end()
+    span.end()
+
+    expect(info).toHaveBeenCalledTimes(1)
+    const record = JSON.parse(String(info.mock.calls[0]?.[0])) as IndexingProfileRecord
+    expect(record.type).toBe("kilo-indexing-profile")
+    expect(record.event).toBe("indexing.test")
+    expect(record.outcome).toBe("success")
+    expect(record.durationMs).toBeGreaterThanOrEqual(0)
+    expect(record.fields).toEqual({ provider: "openai", count: 2 })
+  } finally {
+    info.mockRestore()
+    if (env === undefined) delete process.env.KILO_INDEXING_PROFILE
+    else process.env.KILO_INDEXING_PROFILE = env
+  }
+})
+
+test.serial("stays silent unless profiling is enabled with an exact one", () => {
+  const env = process.env.KILO_INDEXING_PROFILE
+  const info = spyOn(console, "info").mockImplementation(() => undefined)
+  try {
+    process.env.KILO_INDEXING_PROFILE = "true"
+    IndexingProfile.start("indexing.test").end()
+    delete process.env.KILO_INDEXING_PROFILE
+    IndexingProfile.start("indexing.test").end()
+
+    expect(info).not.toHaveBeenCalled()
+  } finally {
+    info.mockRestore()
+    if (env === undefined) delete process.env.KILO_INDEXING_PROFILE
+    else process.env.KILO_INDEXING_PROFILE = env
+  }
+})
+
+test.serial("disposes profiles only once and defaults to an error outcome", () => {
+  const env = process.env.KILO_INDEXING_PROFILE
+  const info = spyOn(console, "info").mockImplementation(() => undefined)
+  try {
+    process.env.KILO_INDEXING_PROFILE = "1"
+    const span = IndexingProfile.start("indexing.test")
+    span[Symbol.dispose]()
+    span[Symbol.dispose]()
+    span.end()
+
+    expect(info).toHaveBeenCalledTimes(1)
+    const record = JSON.parse(String(info.mock.calls[0]?.[0])) as IndexingProfileRecord
+    expect(record.outcome).toBe("error")
+  } finally {
+    info.mockRestore()
+    if (env === undefined) delete process.env.KILO_INDEXING_PROFILE
+    else process.env.KILO_INDEXING_PROFILE = env
+  }
+})
+
+test.serial("does not throw when optional profile emission fails", () => {
+  const env = process.env.KILO_INDEXING_PROFILE
+  const info = spyOn(console, "info").mockImplementation(() => {
+    throw new Error("profile emission failed")
+  })
+  try {
+    process.env.KILO_INDEXING_PROFILE = "1"
+
+    expect(() => IndexingProfile.start("indexing.test").end()).not.toThrow()
+    expect(info).toHaveBeenCalledTimes(1)
+  } finally {
+    info.mockRestore()
+    if (env === undefined) delete process.env.KILO_INDEXING_PROFILE
+    else process.env.KILO_INDEXING_PROFILE = env
+  }
+})

--- a/packages/opencode/src/kilocode/indexing-profile.ts
+++ b/packages/opencode/src/kilocode/indexing-profile.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto"
+import path from "node:path"
+import type { IndexingProfileRecord } from "@kilocode/kilo-indexing/engine"
+
+const allowed = new Set([
+  "enabled",
+  "configured",
+  "requiresRestart",
+  "provider",
+  "modelId",
+  "vectorStore",
+  "baseline",
+  "validationMs",
+  "trigger",
+  "mode",
+  "watcherInitMs",
+  "storeInitMs",
+  "storePrepareMs",
+  "scanMs",
+  "finalizeMs",
+  "discoveredCount",
+  "candidateCount",
+  "inspectedCount",
+  "readCount",
+  "bytesRead",
+  "unchangedCount",
+  "processedCount",
+  "skippedCount",
+  "blockCount",
+  "batchCount",
+  "changedDeleteCount",
+  "removedDeleteCount",
+  "fileCount",
+  "attemptCount",
+  "deleteMs",
+  "embeddingMs",
+  "upsertMs",
+  "eventCount",
+  "deleteCount",
+  "upsertFileCount",
+  "pointCount",
+  "successCount",
+  "errorCount",
+  "prepareMs",
+  "flushMs",
+  "textCount",
+  "scope",
+  "currentSearchMs",
+  "baselineSearchMs",
+  "deltaCallCount",
+  "baselineCallCount",
+  "resultCount",
+  "files",
+])
+
+function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function primitive(value: unknown): value is string | number | boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+}
+
+function fields(value: unknown): value is IndexingProfileRecord["fields"] {
+  return object(value) && Object.values(value).every(primitive)
+}
+
+function outcome(value: unknown): value is IndexingProfileRecord["outcome"] {
+  return value === "success" || value === "error" || value === "cancelled" || value === "disabled" || value === "waiting"
+}
+
+export function parseIndexingProfile(args: unknown[]): IndexingProfileRecord | undefined {
+  if (args.length !== 1 || typeof args[0] !== "string") return
+
+  try {
+    const value: unknown = JSON.parse(args[0])
+    if (!object(value)) return
+    if (value.type !== "kilo-indexing-profile") return
+    if (typeof value.event !== "string") return
+    if (typeof value.durationMs !== "number" || !Number.isFinite(value.durationMs) || value.durationMs < 0) return
+    if (!outcome(value.outcome)) return
+    if (!fields(value.fields)) return
+    return {
+      type: value.type,
+      event: value.event,
+      durationMs: value.durationMs,
+      outcome: value.outcome,
+      fields: value.fields,
+    }
+  } catch {
+    return
+  }
+}
+
+export function indexingProfileWorkspaceID(directory: string): string {
+  return createHash("sha256").update(path.resolve(directory)).digest("hex").slice(0, 16)
+}
+
+export function indexingProfileLogFields(
+  directory: string,
+  profile: IndexingProfileRecord,
+): Record<string, string | number | boolean> {
+  const fields: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(profile.fields)) {
+    if (allowed.has(key)) fields[key] = value
+  }
+
+  return {
+    ...fields,
+    source: "worker",
+    workspaceID: indexingProfileWorkspaceID(directory),
+    event: profile.event,
+    durationMs: profile.durationMs,
+    outcome: profile.outcome,
+  }
+}

--- a/packages/opencode/src/kilocode/indexing-worker-protocol.ts
+++ b/packages/opencode/src/kilocode/indexing-worker-protocol.ts
@@ -1,5 +1,6 @@
 import type {
   IndexingConfigInput,
+  IndexingProfileRecord,
   IndexingTelemetryEvent,
   VectorStoreSearchResult,
 } from "@kilocode/kilo-indexing/engine"
@@ -34,6 +35,7 @@ export type Result =
 export type Log = {
   level: "debug" | "info" | "warn" | "error"
   message: string
+  profile?: IndexingProfileRecord
 }
 
 export type Event =

--- a/packages/opencode/src/kilocode/indexing-worker.ts
+++ b/packages/opencode/src/kilocode/indexing-worker.ts
@@ -2,6 +2,7 @@ import type { CodeIndexManager } from "@kilocode/kilo-indexing/engine"
 import { AsyncLocalStorage } from "node:async_hooks"
 import { format } from "node:util"
 import type { Request, Result, Event, Log } from "./indexing-worker-protocol"
+import { parseIndexingProfile } from "./indexing-profile"
 import { parseQdrantWarning } from "./indexing-warning"
 
 type Entry = {
@@ -20,6 +21,11 @@ function send(message: Result | Event) {
 
 function write(level: Log["level"], args: unknown[]) {
   const key = context.getStore()
+  const profile = parseIndexingProfile(args)
+  if (profile) {
+    send({ type: "event", key, event: "log", data: { level: "info", message: "indexing profile", profile } })
+    return
+  }
   const message = format(...args)
   send({ type: "event", key, event: "log", data: { level, message } })
   if (level !== "warn") return

--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -21,6 +21,7 @@ import type { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { Event as IndexingEvent, Warning as IndexingWarningEvent } from "./indexing-event"
 import { indexingWarningKey, type IndexingWarning } from "./indexing-warning"
+import { indexingProfileLogFields } from "./indexing-profile"
 import { IndexingWorker } from "./indexing-worker-client"
 import { LanceDBRuntime } from "./lancedb" // kilocode_change
 import { indexingWithKiloDefault, resolveKiloIndexingAuth, type KiloIndexingAuth } from "./indexing-auth" // kilocode_change
@@ -374,6 +375,14 @@ export namespace KiloIndexing {
     })
     const output = Instance.bind((event: Parameters<IndexingWorker.Hooks["log"]>[0]) => {
       if (disposed) return
+      if (event.profile) {
+        try {
+          log.info(event.message, indexingProfileLogFields(dir, event.profile))
+        } catch {
+          return
+        }
+        return
+      }
       log[event.level](event.message, { source: "worker", workspacePath: dir })
     })
     const base: Entry = {

--- a/packages/opencode/test/kilocode/indexing-profile.test.ts
+++ b/packages/opencode/test/kilocode/indexing-profile.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import {
+  indexingProfileLogFields,
+  indexingProfileWorkspaceID,
+  parseIndexingProfile,
+} from "../../src/kilocode/indexing-profile"
+
+test("parses one valid indexing profile record", () => {
+  const record = parseIndexingProfile([
+    JSON.stringify({
+      type: "kilo-indexing-profile",
+      event: "indexing.scan.summary",
+      durationMs: 12.5,
+      outcome: "success",
+      fields: { mode: "full", files: 10 },
+    }),
+  ])
+
+  expect(record?.event).toBe("indexing.scan.summary")
+  expect(record?.fields).toEqual({ mode: "full", files: 10 })
+})
+
+test("rejects malformed indexing profile records", () => {
+  const values: unknown[][] = [
+    [],
+    ["{"],
+    [JSON.stringify({})],
+    [JSON.stringify({ type: "wrong", event: "event", durationMs: 1, outcome: "success", fields: {} })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: 1, durationMs: 1, outcome: "success", fields: {} })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: -1, outcome: "success", fields: {} })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: "1", outcome: "success", fields: {} })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: 1, outcome: "unknown", fields: {} })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: 1, outcome: "success", fields: [] })],
+    [
+      JSON.stringify({
+        type: "kilo-indexing-profile",
+        event: "event",
+        durationMs: 1,
+        outcome: "success",
+        fields: { nested: {} },
+      }),
+    ],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: 1, outcome: "success", fields: { none: null } })],
+    [JSON.stringify({ type: "kilo-indexing-profile", event: "event", durationMs: 1, outcome: "success", fields: {} }), "extra"],
+  ]
+
+  for (const args of values) expect(parseIndexingProfile(args)).toBeUndefined()
+})
+
+test("normalizes equivalent workspace paths before hashing", () => {
+  const directory = ".indexing-profile-workspace"
+  const resolved = path.resolve(directory)
+
+  expect(indexingProfileWorkspaceID(directory)).toBe(indexingProfileWorkspaceID(resolved))
+})
+
+test("routes only aggregate profile fields with authoritative metadata", () => {
+  const directory = "/private/example/workspace"
+  const record = parseIndexingProfile([
+    JSON.stringify({
+      type: "kilo-indexing-profile",
+      event: "indexing.scan.summary",
+      durationMs: 12.5,
+      outcome: "success",
+      fields: {
+        mode: "full",
+        files: 10,
+        blockCount: 2,
+        source: "profile",
+        workspaceID: "profile",
+        event: "profile",
+        durationMs: 0,
+        outcome: "error",
+        workspacePath: "/private/example/workspace",
+        path: "/private/example/file.ts",
+        query: "sensitive-query",
+        code: "const secret = true",
+        url: "https://example.com/private",
+        hash: "abc123",
+        credential: "token",
+        organizationId: "org-private",
+        error: "failed",
+        pointID: "point-private",
+        collectionName: "collection-private",
+      },
+    }),
+  ])
+
+  const id = indexingProfileWorkspaceID(directory)
+  expect(id).toMatch(/^[a-f0-9]{16}$/)
+  expect(id).toBe(indexingProfileWorkspaceID(directory))
+  expect(id).not.toContain("workspace")
+  expect(record).toBeDefined()
+
+  const fields = indexingProfileLogFields(directory, record!)
+  expect(fields).toEqual({
+    mode: "full",
+    files: 10,
+    blockCount: 2,
+    source: "worker",
+    workspaceID: id,
+    event: "indexing.scan.summary",
+    durationMs: 12.5,
+    outcome: "success",
+  })
+  expect(Object.keys(fields)).toEqual([
+    "mode",
+    "files",
+    "blockCount",
+    "source",
+    "workspaceID",
+    "event",
+    "durationMs",
+    "outcome",
+  ])
+  for (const key of [
+    "workspacePath",
+    "path",
+    "query",
+    "code",
+    "url",
+    "hash",
+    "credential",
+    "organizationId",
+    "error",
+    "pointID",
+    "collectionName",
+  ]) {
+    expect(fields[key]).toBeUndefined()
+  }
+})


### PR DESCRIPTION
## Issue

Part of https://github.com/Kilo-Org/kilocode/issues/12447

Depends on #12448

## Context

Both full and incremental modes call the same scanner (`orchestrator.ts:237-253`), which:

- Materializes every path using `glob("**/*")` (`scanner.ts:150-158`).
- Reads and hashes every supported file before consulting the cache (`scanner.ts:251-294`).

A probe against this checkout found:

- 31,159 paths materialized.
- 5,983 candidates after extension/ignore filtering.
- 5,981 eligible files totaling 41.2 MB read and hashed on an unchanged scan.
- 80.8% of discovered paths were filtered only after globbing.

## Implementation

First constrains glob patterns to configured extensions. Then extends the cache with size/mtime/ctime metadata to skip reads when safely unchanged, retaining content hashing as fallback.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Perform an incremental indexing scan
- The changed file scan should be faster than before, because the number of scanned files is decreased
- Incremental and full codebase indexing should both continue to work properly

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
