### PR TITLE
fix(cli): bound skill discovery in non-git projects

### DIFF
--- a/.changeset/bound-non-git-skill-discovery.md
+++ b/.changeset/bound-non-git-skill-discovery.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Load global skills reliably from projects outside Git repositories.

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -218,7 +218,7 @@ const discoverSkills = Effect.fnUntraced(function* (
 
     // kilocode_change start
     const local = yield* fsys
-      .up({ targets: externalDirs, start: directory, stop: worktree })
+      .up({ targets: externalDirs, start: directory, stop: projectRoot })
       .pipe(Effect.catch(() => Effect.succeed([] as string[])))
     const fallbacks = yield* primaryPaths(directory, worktree, externalDirs) // kilocode_change
     const upDirs = [...fallbacks, ...local]

--- a/packages/opencode/test/kilocode/non-git-global-skills.test.ts
+++ b/packages/opencode/test/kilocode/non-git-global-skills.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import fs from "fs/promises"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Skill } from "../../src/skill"
+import { Discovery } from "../../src/skill/discovery"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { Config } from "../../src/config/config"
+import { Git } from "../../src/git"
+import { provideInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const skills = (home: string) =>
+  Skill.layer.pipe(
+    Layer.provide(Git.defaultLayer),
+    Layer.provide(Discovery.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(EventV2Bridge.defaultLayer),
+    Layer.provide(FSUtil.defaultLayer),
+    Layer.provide(Global.layerWith({ home })),
+    Layer.provide(RuntimeFlags.layer({ disableExternalSkills: false, disableClaudeCodeSkills: false })),
+  )
+
+const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, testInstanceStoreLayer))
+
+describe("non-Git global skills", () => {
+  it.live("loads global skills when the project is below the home directory", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const project = path.join(tmp.path, "projects", "plain")
+      const roots = [".agents", ".claude"] as const
+
+      yield* Effect.promise(async () => {
+        await fs.mkdir(project, { recursive: true })
+        await Promise.all(
+          roots.map(async (root) => {
+            const name = `${root.slice(1)}-global`
+            const dir = path.join(tmp.path, root, "skills", name)
+            await fs.mkdir(dir, { recursive: true })
+            await Bun.write(
+              path.join(dir, "SKILL.md"),
+              `---
+name: ${name}
+description: Global ${root} skill.
+---
+
+# Global skill
+`,
+            )
+          }),
+        )
+      })
+
+      yield* Effect.gen(function* () {
+        const skill = yield* Skill.Service
+        const list = yield* skill.all()
+
+        for (const root of roots) {
+          const name = `${root.slice(1)}-global`
+          expect(list.find((item) => item.name === name)?.location).toBe(
+            path.join(tmp.path, root, "skills", name, "SKILL.md"),
+          )
+        }
+      }).pipe(Effect.provide(skills(tmp.path)), provideInstance(project))
+    }),
+  )
+})


### PR DESCRIPTION
## Issue

Fixes #12461

## Context

Global skills under `~/.agents/skills` and `~/.claude/skills` fail to load when the selected project is below the home directory and is not a Git repository.

Non-Git projects use `/` as the worktree sentinel. The external project-skill scan currently uses that sentinel as its upper bound, so it can walk past the selected project, rediscover home-level global skills, and replace their trusted discovery metadata with project-scoped metadata. Markdown loading then rejects the valid global skill as outside the project scope.

## Implementation

Use the normalized `projectRoot` as the upper bound for external project-skill discovery. For Git projects, `projectRoot` is already the worktree, so existing worktree behavior is unchanged. For non-Git projects, discovery now stops at the selected project directory and cannot overwrite trusted global matches found above it.

The regression test creates a temporary home containing both `.agents` and `.claude` global skills, then loads them from a nested non-Git project. A patch changeset is included for `@kilocode/cli`.

## Screenshots / Video

N/A — no visual changes.

## How to Test

### Manual/local verification

- Before the implementation change, `bun test ./test/kilocode/non-git-global-skills.test.ts` failed with the expected global skill path receiving `undefined`; after the change, it passed with 1 test and 2 assertions.
- `bun test ./test/skill/skill.test.ts` passed: 16 tests, 44 assertions.
- `bun run typecheck` passed from `packages/opencode`.
- `bun run script/check-opencode-annotations.ts --worktree` passed.
- The repository pre-push checks passed for all 22 non-JetBrains package tasks and the JetBrains typecheck task under JDK 21.
- Prettier, `git diff --check`, and strict UTF-8 without BOM checks passed for all changed files.

### Reviewer test steps

1. From `packages/opencode`, run `bun test ./test/kilocode/non-git-global-skills.test.ts`.
2. Confirm both home-level `.agents` and `.claude` skills load from the nested non-Git project fixture.
3. Run `bun test ./test/skill/skill.test.ts` to verify existing Git and global skill discovery behavior.

### Blocked checks and substitute verification

None.

## Checklist

- [x] Issue linked above
- [x] Tests and verification described
- [x] Screenshots/video marked N/A because there are no visual changes
- [x] Patch changeset added for `@kilocode/cli`
- [x] I personally reviewed the diff and can explain the change
