### PR TITLE
Bounded automatic restart for stuck main sessions

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -156,5 +156,8 @@ export const Flag = {
   get KILO_SESSION_RETRY_LIMIT() {
     return number("KILO_SESSION_RETRY_LIMIT")
   },
+  get KILO_MAIN_SESSION_RESTART_LIMIT() {
+    return number("KILO_MAIN_SESSION_RESTART_LIMIT")
+  },
   // kilocode_change end
 }

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -9,6 +9,9 @@ import { Session } from "@/session/session"
 import { Agent } from "@/agent/agent"
 import { Instance } from "@/kilocode/instance"
 import type { SessionStatus } from "@/session/status"
+import { SessionRunState } from "@/session/run-state"
+import { SessionRetry } from "@/session/retry"
+import type { LoopInput } from "@/session/prompt"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { PlanFollowup } from "@/kilocode/plan-followup"
 import { PlanFile } from "@/kilocode/plan-file"
@@ -578,6 +581,152 @@ export namespace KiloSessionPrompt {
       return true
     })
   }
+
+  /**
+   * Drives a user turn for a (root) main session, including the bounded
+   * automatic-restart loop for stuck turns. Extracted from the shared
+   * `SessionPrompt.loop` so the upstream file stays thin and the Kilo
+   * restart policy (and its concurrency hold, Finding #2) lives in one place.
+   *
+   * Concurrency: between restart attempts, the per-attempt `state.ensureRunning`
+   * call's runner is removed by its `onIdle` (which also flips SessionStatus
+   * to idle so the idle-gated `recoverTerminalErrorTail` can run). Without a
+   * hold, a concurrent `revert` or HTTP session handler would see `assertNotBusy`
+   * pass during the backoff window and race the re-drive. We acquire a
+   * reference-counted busy hold on `SessionRunState` for the entire loop and
+   * release it only AFTER `publishTurnClose` (so the TurnClose event is
+   * observed before any new turn can start). The hold is purely additive:
+   * `assertNotBusy` reports busy when EITHER the runner is busy OR the hold
+   * count is > 0; non-restart callers never acquire the hold, so their
+   * behavior is unchanged. The hold does not interact with the inner
+   * `ensureRunning` lifecycle, so it cannot deadlock the runner.
+   */
+  export const driveMainSessionRestart = Effect.fn("KiloSessionPrompt.driveMainSessionRestart")(function* (input: {
+    loopInput: LoopInput
+    state: SessionRunState.Interface
+    status: Pick<SessionStatus.Interface, "get">
+    sessions: Pick<Session.Interface, "get" | "messages" | "removeMessage">
+    runLoop: (li: LoopInput) => Effect.Effect<MessageV2.WithParts, NotFoundError>
+    lastAssistant: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts, NotFoundError>
+    terminalErrors: Map<string, MessageV2.Assistant>
+    closeReasons: Map<string, KiloSession.CloseReason>
+  }) {
+    const session = yield* input.sessions.get(input.loopInput.sessionID)
+    let restartAttempts = 0
+
+    yield* KiloSessionPrompt.recoverDanglingAssistant({
+      sessionID: input.loopInput.sessionID,
+      status: input.status,
+      sessions: input.sessions,
+    })
+    yield* KiloSessionPrompt.recoverProviderFinishError({
+      sessionID: input.loopInput.sessionID,
+      status: input.status,
+      sessions: input.sessions,
+    })
+    yield* KiloSession.publishTurnOpen({ sessionID: input.loopInput.sessionID })
+
+    // Acquire the busy hold BEFORE the first ensureRunning so that the
+    // assertNotBusy gate reports busy for the entire logically in-flight
+    // turn, including every backoff window between restart attempts.
+    const release = yield* input.state.acquireBusyHold(input.loopInput.sessionID)
+
+    const terminalAssistant = (errored: MessageV2.Assistant, result: MessageV2.WithParts): MessageV2.WithParts => {
+      if (result.info.role === "assistant" && result.info.id === errored.id) {
+        result.info.error = errored.error
+        result.info.finish = errored.finish
+        return result
+      }
+      return { info: errored, parts: [] }
+    }
+
+    return yield* Effect.onExit(
+      Effect.gen(function* () {
+        while (true) {
+          yield* KiloSessionPrompt.recoverDanglingAssistant({
+            sessionID: input.loopInput.sessionID,
+            status: input.status,
+            sessions: input.sessions,
+          })
+          yield* KiloSessionPrompt.recoverProviderFinishError({
+            sessionID: input.loopInput.sessionID,
+            status: input.status,
+            sessions: input.sessions,
+          })
+
+          const result = yield* input.state.ensureRunning(
+            input.loopInput.sessionID,
+            input.lastAssistant(input.loopInput.sessionID).pipe(Effect.orDie),
+            input.runLoop(input.loopInput).pipe(Effect.orDie),
+          )
+
+          // Capture any terminal error from the just-finished turn using the
+          // in-memory message set by runLoop. Never re-read .error from the DB:
+          // the persisted error is not reliably visible to the immediate post-turn
+          // read, which makes the restart decision flaky.
+          const errored = input.terminalErrors.get(input.loopInput.sessionID)
+
+          // If the session has a parent (subagent), never auto-restart — parent-driven behavior only.
+          if (session.parentID !== undefined) {
+            if (errored) return terminalAssistant(errored, result)
+            return yield* input.lastAssistant(input.loopInput.sessionID)
+          }
+
+          // Only root sessions restart, and only on a retryable terminal error.
+          if (!errored || !errored.error) {
+            return result
+          }
+
+          const retryable = SessionRetry.retryable(errored.error)
+          if (retryable === undefined) {
+            return terminalAssistant(errored, result)
+          }
+
+          // Check restart limit
+          restartAttempts++
+          const guard = KiloSessionPrompt.guardMainSessionRestart({
+            sessionID: input.loopInput.sessionID,
+            attempts: restartAttempts,
+            closeReasons: input.closeReasons,
+            message: errored,
+          })
+          if (guard.exhausted) {
+            return terminalAssistant(errored, result)
+          }
+
+          // Remove the terminal-errored assistant tail before re-driving
+          yield* KiloSessionPrompt.recoverTerminalErrorTail({
+            sessionID: input.loopInput.sessionID,
+            status: input.status,
+            sessions: input.sessions,
+            message: errored,
+          })
+
+          // Back off before restart (hold keeps assertNotBusy busy across this gap)
+          const backoff = SessionRetry.delay(restartAttempts)
+          yield* Effect.sleep(`${backoff} millis`)
+
+          // Continue to next restart iteration
+          continue
+        }
+      }),
+      Effect.fnUntraced(function* (exit) {
+        // Publish TurnClose BEFORE releasing the hold so the close event is
+        // observed while the session is still busy to assertNotBusy, preventing
+        // a concurrent prompt from interleaving its TurnOpen between them.
+        yield* KiloSession.publishTurnClose({
+          sessionID: input.loopInput.sessionID,
+          parentID: session.parentID,
+          reason: KiloSessionPrompt.resolveCloseReason({
+            sessionID: input.loopInput.sessionID,
+            closeReasons: input.closeReasons,
+            exit,
+          }),
+        })
+        yield* release
+      }),
+    )
+  })
 
   /**
    * Returns true when `msgs` contains at least one completed, error-free summary

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -514,6 +514,13 @@ export namespace KiloSessionPrompt {
    * Determines whether a stuck main session should be automatically restarted.
    * Returns `{ exhausted: true }` when the restart limit has been reached,
    * otherwise `{ exhausted: false }`.
+   *
+   * On exhaustion, the assistant's `error` and `finish` are UNCONDITIONALLY
+   * overwritten with the exhaustion signal. The caller always passes an
+   * already-errored assistant (guarded by `if (!errored || !errored.error)
+   * return` upstream), so the previous `??=` was dead code that left the
+   * underlying retryable error (e.g. "internal server error") surfaced
+   * instead of the clear "restart limit exhausted" message.
    */
   export function guardMainSessionRestart(input: {
     sessionID: string
@@ -525,11 +532,11 @@ export namespace KiloSessionPrompt {
     if (input.attempts <= limit) return { exhausted: false as const }
     input.closeReasons.set(input.sessionID, "error")
     if (input.message) {
-      input.message.error ??= new MessageV2.APIError({
+      input.message.error = new MessageV2.APIError({
         message: `Main session restart limit (${limit}) exhausted`,
         isRetryable: false,
       }).toObject()
-      input.message.finish ??= "error"
+      input.message.finish = "error"
     }
     return { exhausted: true as const }
   }

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -28,6 +28,9 @@ import { KilocodeSystemPrompt } from "@/kilocode/system-prompt"
 import { KiloToolRegistry } from "@/kilocode/tool/registry"
 import CODE_SWITCH from "@/session/prompt/code-switch.txt"
 
+import type { NotFoundError } from "@/storage/storage"
+import { MessageID } from "@/session/schema"
+
 export namespace KiloSessionPrompt {
   const modes = ["ask", "plan", "architect"]
   type Intake = { cancelled: boolean; fiber?: Fiber.Fiber<unknown, unknown> }
@@ -499,6 +502,75 @@ export namespace KiloSessionPrompt {
       input.message.finish ??= "error"
     }
     return { exhausted: true as const, error }
+  }
+
+  /**
+   * Maximum number of automatic restarts allowed for a stuck main session.
+   * Matches the `KILO_MAIN_SESSION_RESTART_LIMIT` flag.
+   */
+  export const MAX_MAIN_SESSION_RESTARTS = 3
+
+  /**
+   * Determines whether a stuck main session should be automatically restarted.
+   * Returns `{ exhausted: true }` when the restart limit has been reached,
+   * otherwise `{ exhausted: false }`.
+   */
+  export function guardMainSessionRestart(input: {
+    sessionID: string
+    attempts: number
+    closeReasons: Map<string, KiloSession.CloseReason>
+    message?: MessageV2.Assistant
+  }) {
+    const limit = Flag.KILO_MAIN_SESSION_RESTART_LIMIT ?? MAX_MAIN_SESSION_RESTARTS
+    if (input.attempts <= limit) return { exhausted: false as const }
+    input.closeReasons.set(input.sessionID, "error")
+    if (input.message) {
+      input.message.error ??= new MessageV2.APIError({
+        message: `Main session restart limit (${limit}) exhausted`,
+        isRetryable: false,
+      }).toObject()
+      input.message.finish ??= "error"
+    }
+    return { exhausted: true as const }
+  }
+
+  /**
+   * Removes the terminal-errored assistant tail before a restart.
+   * The caller passes the in-memory errored assistant captured by runLoop;
+   * removal is by the known message id rather than by re-reading .error from
+   * the DB (that re-read is racy and caused the restart decision to be
+   * non-deterministic). The DB is only consulted to verify the id is still the
+   * answering tail for the current user turn.
+   *
+   * Returns true if a tail was removed.
+   */
+  export function recoverTerminalErrorTail(input: {
+    sessionID: string
+    status: Pick<SessionStatus.Interface, "get">
+    sessions: Pick<Session.Interface, "messages" | "removeMessage">
+    closeReasons: Map<string, KiloSession.CloseReason>
+    message?: MessageV2.Assistant
+  }): Effect.Effect<boolean, NotFoundError> {
+    return Effect.gen(function* () {
+      const state = yield* input.status.get(SessionID.make(input.sessionID))
+      if (state.type !== "idle") return false
+
+      if (!input.message) return false
+
+      const msgs = yield* input.sessions.messages({ sessionID: SessionID.make(input.sessionID), limit: 2 })
+      const tail = msgs.at(-1)
+      if (!tail || tail.info.role !== "assistant" || tail.info.id !== input.message.id) return false
+
+      const prev = msgs.at(-2)
+      if (!prev || prev.info.role !== "user") return false
+      if (tail.info.parentID !== prev.info.id) return false
+
+      yield* input.sessions.removeMessage({
+        sessionID: SessionID.make(input.sessionID),
+        messageID: MessageID.make(input.message.id),
+      })
+      return true
+    })
   }
 
   /**

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -548,7 +548,6 @@ export namespace KiloSessionPrompt {
     sessionID: string
     status: Pick<SessionStatus.Interface, "get">
     sessions: Pick<Session.Interface, "messages" | "removeMessage">
-    closeReasons: Map<string, KiloSession.CloseReason>
     message?: MessageV2.Assistant
   }): Effect.Effect<boolean, NotFoundError> {
     return Effect.gen(function* () {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -49,6 +49,7 @@ import { Config } from "@/config/config"
 import { ConfigMarkdown } from "@/config/markdown"
 import { SessionSummary } from "./summary"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { SessionRetry } from "./retry" // kilocode_change - bounded main-session restart backoff/retryable classification
 import { SessionProcessor } from "./processor"
 import { Tool } from "@/tool/tool"
 import { Permission } from "@/permission"
@@ -1447,6 +1448,9 @@ export const layer = Layer.effect(
 
     // kilocode_change — mutable close-reason per session, set by runLoop and read by loop
     const closeReasons = new Map<string, KiloSession.CloseReason>()
+    // kilocode_change — mutable terminal-error message per session, captured by runLoop so
+    // the restart decision never depends on a post-turn DB re-read of `.error`.
+    const terminalErrors = new Map<string, MessageV2.Assistant>()
 
     // kilocode_change start - retain request-scoped snapshot initialization policy
     const runLoop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts, NotFoundError> = Effect.fn(
@@ -1458,6 +1462,7 @@ export const layer = Layer.effect(
       const envCache: KiloSessionPrompt.EnvCache = {}
       const memoryCache = KiloSessionPrompt.memoryCache() // kilocode_change
       closeReasons.delete(sessionID) // kilocode_change
+      terminalErrors.delete(sessionID) // kilocode_change
       let compactionAttempts = 0 // kilocode_change - cap compaction attempts per turn to avoid infinite loops
       const ctx = yield* InstanceState.context
       let structured: unknown
@@ -1829,7 +1834,10 @@ export const layer = Layer.effect(
 
           // kilocode_change start
           if (result === "stop") {
-            if (handle.message.error) closeReasons.set(sessionID, "error")
+            if (handle.message.error) {
+              closeReasons.set(sessionID, "error")
+              terminalErrors.set(sessionID, handle.message)
+            }
             return "break" as const
           }
           // kilocode_change end
@@ -1897,17 +1905,77 @@ export const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts, NotFoundError> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: LoopInput) {
-      // kilocode_change start
+      // kilocode_change start - bounded automatic restart for stuck main sessions
       const session = yield* sessions.get(input.sessionID)
+      let restartAttempts = 0
+
       yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
       yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
       yield* KiloSession.publishTurnOpen({ sessionID: input.sessionID })
-      return yield* Effect.onExit(
-        state.ensureRunning(
-          input.sessionID,
-          lastAssistant(input.sessionID).pipe(Effect.orDie),
-          runLoop(input).pipe(Effect.orDie),
-        ), // kilocode_change
+
+      const result = yield* Effect.onExit(
+        Effect.gen(function* () {
+          while (true) {
+            yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
+            yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
+
+            const result = yield* state.ensureRunning(
+              input.sessionID,
+              lastAssistant(input.sessionID).pipe(Effect.orDie),
+              runLoop(input).pipe(Effect.orDie),
+            ) // kilocode_change
+
+            // Capture any terminal error from the just-finished turn using the
+            // in-memory message set by runLoop. Never re-read .error from the DB:
+            // the persisted error is not reliably visible to the immediate post-turn
+            // read, which makes the restart decision flaky.
+            const errored = terminalErrors.get(input.sessionID)
+
+            // If the session has a parent (subagent), never auto-restart — parent-driven behavior only.
+            if (session.parentID !== undefined) {
+              if (errored) return { info: errored, parts: [] }
+              return yield* lastAssistant(input.sessionID)
+            }
+
+            // Only root sessions restart, and only on a retryable terminal error.
+            if (!errored || !errored.error) {
+              return result
+            }
+
+            const retryable = SessionRetry.retryable(errored.error)
+            if (retryable === undefined) {
+              return { info: errored, parts: [] }
+            }
+
+            // Check restart limit
+            restartAttempts++
+            const guard = KiloSessionPrompt.guardMainSessionRestart({
+              sessionID: input.sessionID,
+              attempts: restartAttempts,
+              closeReasons,
+              message: errored,
+            })
+            if (guard.exhausted) {
+              return { info: errored, parts: [] }
+            }
+
+            // Remove the terminal-errored assistant tail before re-driving
+            yield* KiloSessionPrompt.recoverTerminalErrorTail({
+              sessionID: input.sessionID,
+              status,
+              sessions,
+              closeReasons,
+              message: errored,
+            })
+
+            // Back off before restart
+            const backoff = SessionRetry.delay(restartAttempts)
+            yield* Effect.sleep(`${backoff} millis`)
+
+            // Continue to next restart iteration
+            continue
+          }
+        }),
         Effect.fnUntraced(function* (exit) {
           yield* KiloSession.publishTurnClose({
             sessionID: input.sessionID,
@@ -1920,6 +1988,8 @@ export const layer = Layer.effect(
           })
         }),
       )
+
+      return result
       // kilocode_change end
     })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1913,6 +1913,15 @@ export const layer = Layer.effect(
       yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
       yield* KiloSession.publishTurnOpen({ sessionID: input.sessionID })
 
+      const terminalAssistant = (errored: MessageV2.Assistant, result: MessageV2.WithParts): MessageV2.WithParts => {
+        if (result.info.role === "assistant" && result.info.id === errored.id) {
+          result.info.error = errored.error
+          result.info.finish = errored.finish
+          return result
+        }
+        return { info: errored, parts: [] }
+      }
+
       const result = yield* Effect.onExit(
         Effect.gen(function* () {
           while (true) {
@@ -1933,7 +1942,7 @@ export const layer = Layer.effect(
 
             // If the session has a parent (subagent), never auto-restart — parent-driven behavior only.
             if (session.parentID !== undefined) {
-              if (errored) return { info: errored, parts: [] }
+              if (errored) return terminalAssistant(errored, result)
               return yield* lastAssistant(input.sessionID)
             }
 
@@ -1944,7 +1953,7 @@ export const layer = Layer.effect(
 
             const retryable = SessionRetry.retryable(errored.error)
             if (retryable === undefined) {
-              return { info: errored, parts: [] }
+              return terminalAssistant(errored, result)
             }
 
             // Check restart limit
@@ -1956,7 +1965,7 @@ export const layer = Layer.effect(
               message: errored,
             })
             if (guard.exhausted) {
-              return { info: errored, parts: [] }
+              return terminalAssistant(errored, result)
             }
 
             // Remove the terminal-errored assistant tail before re-driving
@@ -1964,7 +1973,6 @@ export const layer = Layer.effect(
               sessionID: input.sessionID,
               status,
               sessions,
-              closeReasons,
               message: errored,
             })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1905,99 +1905,17 @@ export const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<MessageV2.WithParts, NotFoundError> = Effect.fn(
       "SessionPrompt.loop",
     )(function* (input: LoopInput) {
-      // kilocode_change start - bounded automatic restart for stuck main sessions
-      const session = yield* sessions.get(input.sessionID)
-      let restartAttempts = 0
-
-      yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
-      yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
-      yield* KiloSession.publishTurnOpen({ sessionID: input.sessionID })
-
-      const terminalAssistant = (errored: MessageV2.Assistant, result: MessageV2.WithParts): MessageV2.WithParts => {
-        if (result.info.role === "assistant" && result.info.id === errored.id) {
-          result.info.error = errored.error
-          result.info.finish = errored.finish
-          return result
-        }
-        return { info: errored, parts: [] }
-      }
-
-      const result = yield* Effect.onExit(
-        Effect.gen(function* () {
-          while (true) {
-            yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
-            yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
-
-            const result = yield* state.ensureRunning(
-              input.sessionID,
-              lastAssistant(input.sessionID).pipe(Effect.orDie),
-              runLoop(input).pipe(Effect.orDie),
-            ) // kilocode_change
-
-            // Capture any terminal error from the just-finished turn using the
-            // in-memory message set by runLoop. Never re-read .error from the DB:
-            // the persisted error is not reliably visible to the immediate post-turn
-            // read, which makes the restart decision flaky.
-            const errored = terminalErrors.get(input.sessionID)
-
-            // If the session has a parent (subagent), never auto-restart — parent-driven behavior only.
-            if (session.parentID !== undefined) {
-              if (errored) return terminalAssistant(errored, result)
-              return yield* lastAssistant(input.sessionID)
-            }
-
-            // Only root sessions restart, and only on a retryable terminal error.
-            if (!errored || !errored.error) {
-              return result
-            }
-
-            const retryable = SessionRetry.retryable(errored.error)
-            if (retryable === undefined) {
-              return terminalAssistant(errored, result)
-            }
-
-            // Check restart limit
-            restartAttempts++
-            const guard = KiloSessionPrompt.guardMainSessionRestart({
-              sessionID: input.sessionID,
-              attempts: restartAttempts,
-              closeReasons,
-              message: errored,
-            })
-            if (guard.exhausted) {
-              return terminalAssistant(errored, result)
-            }
-
-            // Remove the terminal-errored assistant tail before re-driving
-            yield* KiloSessionPrompt.recoverTerminalErrorTail({
-              sessionID: input.sessionID,
-              status,
-              sessions,
-              message: errored,
-            })
-
-            // Back off before restart
-            const backoff = SessionRetry.delay(restartAttempts)
-            yield* Effect.sleep(`${backoff} millis`)
-
-            // Continue to next restart iteration
-            continue
-          }
-        }),
-        Effect.fnUntraced(function* (exit) {
-          yield* KiloSession.publishTurnClose({
-            sessionID: input.sessionID,
-            parentID: session.parentID,
-            reason: KiloSessionPrompt.resolveCloseReason({
-              sessionID: input.sessionID,
-              closeReasons,
-              exit,
-            }),
-          })
-        }),
-      )
-
-      return result
+      // kilocode_change start - bounded automatic restart for stuck main sessions is delegated to KiloSessionPrompt
+      return yield* KiloSessionPrompt.driveMainSessionRestart({
+        loopInput: input,
+        state,
+        status,
+        sessions,
+        runLoop,
+        lastAssistant,
+        terminalErrors,
+        closeReasons,
+      })
       // kilocode_change end
     })
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -22,6 +22,9 @@ export interface Interface {
     work: Effect.Effect<SessionV1.WithParts>,
     ready?: Latch.Latch,
   ) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
+  // kilocode_change start - busy hold bridges the per-attempt ensureRunning gap during bounded main-session restarts
+  readonly acquireBusyHold: (sessionID: SessionID) => Effect.Effect<Effect.Effect<void>>
+  // kilocode_change end
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRunState") {}
@@ -36,6 +39,11 @@ export const layer = Layer.effect(
       Effect.fn("SessionRunState.state")(function* () {
         const scope = yield* Scope.Scope
         const runners = new Map<SessionID, Runner.Runner<SessionV1.WithParts>>()
+        // kilocode_change start - busy-hold counter so the bounded main-session restart loop can keep assertNotBusy
+        // reporting busy across the gap between per-attempt ensureRunning calls (where the runner is removed by
+        // onIdle and SessionStatus goes idle for the idle-gated recovery helpers).
+        const busyHolds = new Map<SessionID, number>()
+        // kilocode_change end
         yield* Effect.addFinalizer(
           Effect.fnUntraced(function* () {
             yield* Effect.forEach(runners.values(), (runner) => runner.cancel, {
@@ -45,7 +53,7 @@ export const layer = Layer.effect(
             runners.clear()
           }),
         )
-        return { runners, scope }
+        return { runners, scope, busyHolds } // kilocode_change - expose busy-hold counter to assertNotBusy/acquireBusyHold
       }),
     )
 
@@ -71,7 +79,10 @@ export const layer = Layer.effect(
     const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID) {
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
-      if (existing?.busy) yield* busyError(sessionID)
+      // kilocode_change start - a Kilo restart-loop busy hold also marks the session busy to concurrent callers
+      const held = (data.busyHolds.get(sessionID) ?? 0) > 0
+      if (existing?.busy || held) yield* busyError(sessionID)
+      // kilocode_change end
     })
 
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
@@ -104,7 +115,27 @@ export const layer = Layer.effect(
         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    // kilocode_change start - acquireBusyHold: bumps a per-session busy hold so assertNotBusy reports busy
+    // across the Kilo restart-loop gap (recoverTerminalErrorTail + backoff sleep) where the per-attempt
+    // runner is gone and SessionStatus is idle. The returned release MUST be invoked (use Effect.ensuring);
+    // holds are reference-counted so overlapping acquisitions are safe. Ref-counting is a plain Map
+    // because all access happens on the Effect runtime's single thread per scheduler, so a synchronous
+    // get/set is race-free with assertNotBusy reads.
+    const acquireBusyHold = Effect.fn("SessionRunState.acquireBusyHold")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      data.busyHolds.set(sessionID, (data.busyHolds.get(sessionID) ?? 0) + 1)
+      let released = false
+      return Effect.sync(() => {
+        if (released) return
+        released = true
+        const next = (data.busyHolds.get(sessionID) ?? 1) - 1
+        if (next <= 0) data.busyHolds.delete(sessionID)
+        else data.busyHolds.set(sessionID, next)
+      })
+    })
+    // kilocode_change end
+
+    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell, acquireBusyHold }) // kilocode_change - acquireBusyHold
   }),
 )
 

--- a/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
@@ -526,4 +526,63 @@ describe("session main restart limit", () => {
       ),
     30000,
   )
+
+  it.live(
+    "keeps assertNotBusy busy across the restart backoff window (Finding #2 concurrency)",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "3"
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const state = yield* SessionRunState.Service
+
+          // Use a real (non-zero) backoff so the backoff window is observable,
+          // and a Deferred to deterministically signal "we are now inside the
+          // backoff". The Kilo restart-loop busy hold is acquired BEFORE
+          // SessionRetry.delay is called, so when the spy fires the latch the
+          // hold is already active and assertNotBusy must report busy.
+          const inBackoff = yield* Deferred.make<void>()
+          delaySpy = spyOn(SessionRetry, "delay").mockImplementation((_attempt: number) => {
+            Effect.runFork(Deferred.succeed(inBackoff, undefined))
+            return 400
+          })
+
+          const chat = yield* sessions.create({
+            title: "Backoff concurrency",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          // 1 initial turn + 3 restarts = 4 turns × 2 calls (initial + 1 layer-A retry) = 8, then exhausted.
+          for (let i = 0; i < 8; i++) yield* llm.error(500, serverError)
+
+          const promptFiber = yield* prompt
+            .prompt({ sessionID: chat.id, agent: "code", parts: [{ type: "text", text: "x" }] })
+            .pipe(Effect.forkChild)
+
+          // Wait until we are deterministically inside the first backoff window
+          yield* Deferred.await(inBackoff)
+          yield* Effect.yieldNow
+
+          // While the Kilo restart-loop busy hold is active, assertNotBusy must
+          // reject concurrent callers with a Session.BusyError — a concurrent
+          // revert or HTTP prompt must NOT be able to interleave during the gap
+          // between per-attempt ensureRunning calls.
+          const busy = yield* state.assertNotBusy(chat.id).pipe(Effect.flip)
+          expect(busy._tag).toBe("SessionBusyError")
+
+          // Let the prompt run to completion (exhaustion + onExit releases the hold).
+          const result = yield* Fiber.join(promptFiber)
+          expect(yield* llm.calls).toBe(8)
+          expect(errorOf(result)).toBeDefined()
+
+          // Sanity: after the prompt completes, the hold is released, so a fresh
+          // assertNotBusy for the same session now succeeds.
+          yield* state.assertNotBusy(chat.id)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
 })

--- a/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
@@ -1,0 +1,511 @@
+// Regression for the bounded automatic restart of stuck MAIN (root) sessions.
+// Drives the real SessionPrompt.prompt/loop path (NOT SessionProcessor.process),
+// so the turn-level restart loop is actually exercised. Layer-A in-turn stream
+// retry is bounded to a single retry (KILO_SESSION_RETRY_LIMIT=1), so each stuck turn
+// terminates after exactly 2 LLM calls (1 initial + 1 layer-A retry) and the coarser
+// turn-level restart re-runs the whole turn.
+process.env.KILO_SESSION_RETRY_LIMIT = "1"
+
+import { NodeFileSystem } from "@effect/platform-node"
+import { afterEach, describe, expect, spyOn } from "bun:test"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Database } from "@opencode-ai/core/database/database"
+import { Agent as AgentSvc } from "../../src/agent/agent"
+import { BackgroundJob } from "../../src/background/job"
+import { Bus } from "../../src/bus"
+import { Command } from "../../src/command"
+import { Auth } from "../../src/auth"
+import { Config } from "../../src/config/config"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Env } from "../../src/env"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Format } from "../../src/format"
+import { Git } from "../../src/git"
+import { Image } from "../../src/image/image"
+import { LSP } from "../../src/lsp/lsp"
+import { MCP } from "../../src/mcp"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider as ProviderSvc } from "../../src/provider/provider"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { Question } from "../../src/question"
+import { RepositoryCache } from "@opencode-ai/core/repository-cache"
+import { Session } from "../../src/session/session"
+import { SessionCompaction } from "../../src/session/compaction"
+import { Instruction } from "../../src/session/instruction"
+import { LLM } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionRetry } from "../../src/session/retry"
+import { SessionRevert } from "../../src/session/revert"
+import { SessionRunState } from "../../src/session/run-state"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { SessionStatus } from "../../src/session/status"
+import { SystemPrompt } from "../../src/session/system"
+import { SessionSummary } from "../../src/session/summary"
+import { Todo } from "../../src/session/todo"
+import { Skill } from "../../src/skill"
+import { Snapshot } from "../../src/snapshot"
+import { Storage } from "../../src/storage/storage"
+import { SyncEvent } from "../../src/sync"
+import { ToolRegistry } from "../../src/tool/registry"
+import { Truncate } from "../../src/tool/truncate"
+import { KiloSession } from "@/kilocode/session"
+import { KiloSessions } from "../../src/kilo-sessions/kilo-sessions"
+import * as Log from "@opencode-ai/core/util/log"
+import { MemoryService } from "@kilocode/kilo-memory/effect/service"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { reply, TestLLMServer } from "../lib/llm-server"
+
+Log.init({ print: false })
+
+let delaySpy: { mockRestore(): void } | undefined
+
+const ref = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const plugin = Layer.mock(Plugin.Service)({
+  trigger: <Name extends string, Input, Output>(_name: Name, _input: Input, output: Output) => Effect.succeed(output),
+  list: () => Effect.succeed([]),
+  init: () => Effect.void,
+})
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in restart-limit tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in restart-limit tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in restart-limit tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const status = Layer.mergeAll(SessionStatus.defaultLayer, Bus.layer)
+const run = SessionRunState.layer.pipe(Layer.provide(status))
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+
+function makeHttp() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    BackgroundJob.defaultLayer,
+    Snapshot.defaultLayer,
+    LLM.defaultLayer,
+    Env.defaultLayer,
+    AgentSvc.defaultLayer,
+    Command.defaultLayer,
+    Permission.defaultLayer,
+    plugin,
+    Config.defaultLayer,
+    mcp,
+    ProviderSvc.defaultLayer,
+    lsp,
+    FSUtil.defaultLayer,
+    SyncEvent.defaultLayer,
+    EventV2Bridge.defaultLayer,
+    Database.defaultLayer,
+    status,
+    MemoryService.layer,
+  ).pipe(Layer.provideMerge(infra))
+  const question = Question.layer.pipe(Layer.provideMerge(deps))
+  const todo = Todo.layer.pipe(Layer.provideMerge(deps))
+  const registry = ToolRegistry.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(CrossSpawnSpawner.defaultLayer),
+    Layer.provide(RepositoryCache.defaultLayer),
+    Layer.provide(Ripgrep.defaultLayer),
+    Layer.provide(Format.defaultLayer),
+    Layer.provide(Git.defaultLayer),
+    Layer.provide(Command.defaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(KiloSessions.testLayer),
+    Layer.provideMerge(todo),
+    Layer.provideMerge(question),
+    Layer.provideMerge(deps),
+  )
+  const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
+  const proc = SessionProcessor.layer.pipe(
+    Layer.provide(summary),
+    Layer.provide(Image.defaultLayer),
+    Layer.provideMerge(deps),
+  )
+  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    SessionPrompt.layer.pipe(
+      Layer.provide(SessionRevert.defaultLayer),
+      Layer.provide(Image.defaultLayer),
+      Layer.provide(summary),
+      Layer.provideMerge(run),
+      Layer.provideMerge(compact),
+      Layer.provideMerge(proc),
+      Layer.provideMerge(registry),
+      Layer.provideMerge(trunc),
+      Layer.provideMerge(question),
+      Layer.provide(Instruction.defaultLayer),
+      Layer.provide(SystemPrompt.defaultLayer),
+      Layer.provideMerge(deps),
+    ),
+  ).pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        summary,
+        deps,
+        Config.defaultLayer,
+        RuntimeFlags.layer(),
+        BackgroundJob.defaultLayer,
+        Bus.layer,
+        infra,
+        Storage.defaultLayer,
+      ),
+    ),
+  )
+}
+
+const it = testEffect(makeHttp())
+
+const cfg = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+const serverError = { error: { message: "internal server error" } }
+const badRequest = { error: { message: "bad request" } }
+
+const user = Effect.fn("restart-limit.user")(function* (sessionID: SessionID, text: string) {
+  const sessions = yield* Session.Service
+  const msg = yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "code",
+    model: ref,
+    time: { created: Date.now() },
+    tools: {},
+  } satisfies MessageV2.User)
+  yield* sessions.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  } satisfies MessageV2.TextPart)
+  return msg
+})
+
+const errorOf = (m: MessageV2.WithParts) => (m.info.role === "assistant" ? m.info.error : undefined)
+
+afterEach(() => {
+  delaySpy?.mockRestore()
+  delaySpy = undefined
+  delete process.env.KILO_MAIN_SESSION_RESTART_LIMIT
+  delete process.env.KILO_SESSION_RETRY_LIMIT
+})
+
+describe("session main restart limit", () => {
+  it.live(
+    "restarts a stuck root session and recovers on a retryable error",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "3"
+          delaySpy = spyOn(SessionRetry, "delay").mockReturnValue(0)
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+
+          const closes: KiloSession.CloseReason[] = []
+          const off = Bus.subscribe(KiloSession.Event.TurnClose, (event) => {
+            if (event.properties.sessionID) closes.push(event.properties.reason)
+          })
+
+          const chat = yield* sessions.create({
+            title: "Stuck main recover",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          expect(chat.parentID).toBeUndefined()
+
+          yield* llm.error(500, serverError) // turn 1: initial call
+          yield* llm.error(500, serverError) // turn 1: layer-A retry -> turn terminates retryable
+          yield* llm.text("recovered") // turn-level restart re-drives the turn and succeeds
+
+          const result = yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "code",
+            parts: [{ type: "text", text: "do the thing" }],
+          })
+          off()
+
+          // 1 failed turn (2 calls) + 1 successful turn-level restart (1 call)
+          expect(yield* llm.calls).toBe(3)
+          expect(result.info.role).toBe("assistant")
+          expect(errorOf(result)).toBeUndefined()
+          expect(result.parts.some((p) => p.type === "text" && p.text === "recovered")).toBe(true)
+
+          // exactly one completed assistant answering the user turn (no duplicate/orphan)
+          const msgs = yield* sessions.messages({ sessionID: chat.id })
+          const assistants = msgs.filter((m) => m.info.role === "assistant")
+          expect(assistants).toHaveLength(1)
+          expect(assistants[0]?.info.id).toBe(result.info.id)
+
+          // coalesced: exactly one TurnClose for the user turn, and it is "completed"
+          expect(closes).toEqual(["completed"])
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
+
+  it.live(
+    "stops with a terminal error after the restart limit is exhausted",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "2"
+          delaySpy = spyOn(SessionRetry, "delay").mockReturnValue(0)
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+
+          const closes: KiloSession.CloseReason[] = []
+          const off = Bus.subscribe(KiloSession.Event.TurnClose, (event) => {
+            if (event.properties.sessionID) closes.push(event.properties.reason)
+          })
+
+          const chat = yield* sessions.create({
+            title: "Stuck main exhaust",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          // Always fail retryably. Each stuck turn = 2 calls (initial + 1 layer-A retry).
+          // With restart limit 2: 1 initial turn + 2 restarts = 3 turns = 6 calls, then a
+          // terminal error (no infinite loop). Queue exactly 6; a 7th call (over-run) would
+          // fail with "unexpected extra llm call" and make this assertion fail loudly.
+          for (let i = 0; i < 6; i++) yield* llm.error(500, serverError)
+
+          const result = yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "code",
+            parts: [{ type: "text", text: "keep failing" }],
+          })
+          off()
+
+          expect(yield* llm.calls).toBe(6)
+          expect(result.info.role).toBe("assistant")
+          expect(errorOf(result)).toBeDefined()
+          // coalesced: exactly one TurnClose, reason error
+          expect(closes).toEqual(["error"])
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
+
+  it.live(
+    "does not restart on a non-retryable error",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "3"
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+
+          const chat = yield* sessions.create({
+            title: "Stuck main non-retryable",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+
+          yield* llm.error(400, badRequest) // non-retryable: no layer-A retry, no turn-level restart
+          yield* llm.error(400, badRequest) // guard: must not be consumed
+
+          const result = yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "code",
+            parts: [{ type: "text", text: "bad" }],
+          })
+
+          expect(yield* llm.calls).toBe(1) // no restart
+          expect(result.info.role).toBe("assistant")
+          expect(errorOf(result)).toBeDefined()
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
+
+  it.live(
+    "does not auto-restart a subagent (child) session",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "3"
+          delaySpy = spyOn(SessionRetry, "delay").mockReturnValue(0)
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+
+          const parent = yield* sessions.create({
+            title: "Parent",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          const child = yield* sessions.create({
+            parentID: parent.id,
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          expect(child.parentID).toBe(parent.id)
+
+          // retryable errors, but a subagent must NOT auto-restart (parent-driven only).
+          // The turn still exhausts layer-A (2 calls) before terminating; there is no
+          // turn-level restart, so exactly 2 calls and no more.
+          for (let i = 0; i < 4; i++) yield* llm.error(500, serverError)
+
+          const result = yield* prompt.prompt({
+            sessionID: child.id,
+            agent: "code",
+            parts: [{ type: "text", text: "child fails" }],
+          })
+
+          expect(yield* llm.calls).toBe(2) // 1 initial + 1 layer-A retry; no turn-level restart
+          expect(errorOf(result)).toBeDefined()
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
+
+  it.live(
+    "does not restart when the user cancels the turn",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          process.env.KILO_SESSION_RETRY_LIMIT = "1"
+          process.env.KILO_MAIN_SESSION_RESTART_LIMIT = "3"
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+
+          const closes: KiloSession.CloseReason[] = []
+          const offClose = Bus.subscribe(KiloSession.Event.TurnClose, (event) => {
+            if (event.properties.sessionID) closes.push(event.properties.reason)
+          })
+          const opened = yield* Deferred.make<void>()
+          const offOpen = Bus.subscribe(KiloSession.Event.TurnOpen, (event) => {
+            if (event.properties.sessionID) Effect.runFork(Deferred.succeed(opened, undefined))
+          })
+
+          const chat = yield* sessions.create({
+            title: "Stuck main cancel",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* user(chat.id, "please hang")
+          yield* llm.push(reply().hang()) // turn hangs until cancelled
+
+          const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+          yield* Deferred.await(opened)
+          yield* Effect.yieldNow
+          yield* prompt.cancel(chat.id)
+          const exit = yield* Fiber.await(fiber)
+          offClose()
+          offOpen()
+
+          expect(Exit.isSuccess(exit)).toBe(true)
+          // a cancelled turn is not "stuck"; it must not trigger any restart (<=1 call, no re-drive)
+          expect(yield* llm.calls).toBeLessThanOrEqual(1)
+          expect(closes).toEqual(["completed"])
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30000,
+  )
+})

--- a/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
@@ -384,6 +384,12 @@ describe("session main restart limit", () => {
           expect(yield* llm.calls).toBe(6)
           expect(result.info.role).toBe("assistant")
           expect(errorOf(result)).toBeDefined()
+
+          const msgs = yield* sessions.messages({ sessionID: chat.id })
+          const lastAssistant = msgs.filter((m) => m.info.role === "assistant").at(-1)
+          expect(lastAssistant?.info.id).toBe(result.info.id)
+          expect(result.parts).toEqual(lastAssistant?.parts ?? [])
+
           // coalesced: exactly one TurnClose, reason error
           expect(closes).toEqual(["error"])
         }),
@@ -419,6 +425,11 @@ describe("session main restart limit", () => {
           expect(yield* llm.calls).toBe(1) // no restart
           expect(result.info.role).toBe("assistant")
           expect(errorOf(result)).toBeDefined()
+
+          const msgs = yield* sessions.messages({ sessionID: chat.id })
+          const lastAssistant = msgs.filter((m) => m.info.role === "assistant").at(-1)
+          expect(lastAssistant?.info.id).toBe(result.info.id)
+          expect(result.parts).toEqual(lastAssistant?.parts ?? [])
         }),
         { git: true, config: providerCfg },
       ),

--- a/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-main-restart-limit.test.ts
@@ -383,7 +383,14 @@ describe("session main restart limit", () => {
 
           expect(yield* llm.calls).toBe(6)
           expect(result.info.role).toBe("assistant")
-          expect(errorOf(result)).toBeDefined()
+          const surfaced = errorOf(result)
+          expect(surfaced).toBeDefined()
+          // The exhaustion signal must be clearly surfaced (Finding #1: a clear,
+          // non-retryable "restart limit exhausted" message), not the underlying
+          // retryable error from the last failed attempt.
+          const message = (surfaced as { data?: { message?: string } } | undefined)?.data?.message
+          expect(typeof message).toBe("string")
+          expect(message).toMatch(/restart limit .*exhausted/i)
 
           const msgs = yield* sessions.messages({ sessionID: chat.id })
           const lastAssistant = msgs.filter((m) => m.info.role === "assistant").at(-1)


### PR DESCRIPTION
## Problem

When a main (root) session's turn terminates in a retryable terminal error — after the in-turn stream retry budget is exhausted — the runtime just stopped with an error and was never restarted. Subagent (child) sessions already recover in this situation: their parent re-drives them via the task tool's `task_id` resume. A root session has no parent to re-drive it, so a stuck main session simply died. This asymmetry is the bug.

## Fix

Add a **bounded, root-only, turn-level automatic restart** in the shared `SessionPrompt.loop`, mirroring the recovery subagents already get:

- Engages only for root sessions (`parentID === undefined`); subagents keep their existing parent-driven behavior (no double restart).
- Only restarts when the turn's terminal error is **retryable** (`SessionRetry.retryable`) and the close reason is `error` — user cancel (`completed`/`interrupted`) and non-retryable errors never restart.
- Bounded by a new `KILO_MAIN_SESSION_RESTART_LIMIT` flag (default 3), mirroring the existing `KILO_SESSION_RETRY_LIMIT`; once exhausted the session ends in a clear terminal error — no infinite loop.
- Backs off between attempts via the existing `SessionRetry.delay`.
- Removes the terminal-errored assistant tail before re-driving so the LLM is actually re-run (not a no-op) without leaving a duplicate assistant.
- Emits exactly **one** `TurnOpen`/`TurnClose` pair per user turn (coalesced), so mobile/remote clients see a single clean transition instead of an error→reopen→completed flicker.
- Terminal-error paths preserve the assistant's already-streamed partial parts.

Layer-A in-turn stream retry (`retryOpts` / `KILO_SESSION_RETRY_LIMIT`) and the stall watchdog are unchanged.

## Tests

`test/kilocode/session-main-restart-limit.test.ts` drives the real `SessionPrompt.prompt`/`loop` path (not `SessionProcessor.process`) via the `TestLLMServer` harness and covers every applicable state: retryable→restart recovers; bound exhausted→terminal error with exactly N restarts and no loop; non-retryable→0 restarts; subagent→no auto-restart; user cancel→0 restarts + `completed`; one coalesced `TurnClose` per turn; preserved partial parts. Deterministic across repeated runs. `bun run typecheck` clean; the two sibling retry-limit suites are unchanged.

## Note on the related "tool execution aborted" symptom

The separate "tool execution aborted" symptom on auto/efficient sessions is already fixed by #12459 (merged) — no additional code here for it. This PR is only the bounded main-session restart.