### PR TITLE
fix(cli): bound time-to-first-content by request timeout, not the idle watchdog

### DIFF
--- a/.changeset/first-content-watchdog.md
+++ b/.changeset/first-content-watchdog.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix CLI agent stream stalls caused by the idle watchdog firing during time-to-first-content. The per-chunk idle watchdog armed on the AI SDK's synthetic `start` part and raced the wait for the first content-bearing part (prompt processing / time-to-first-token) against the same idle window as inter-chunk gaps, so a healthy but slow first response was falsely aborted and immediately retried (regression #12467). The watchdog now bounds the pre-content phase by the provider's configured request `timeout` (falling back to a 5-minute default) and only applies the per-chunk idle window after the first content/tool part. The same first-content-aware split is applied to the lower-level SSE fetch watchdog (`wrapSSE`) so provider-level `chunkTimeout` no longer aborts slow first content, while mid-response stall detection is preserved at both layers.

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -119,7 +119,7 @@ export const Info = Schema.Struct({
         // watchdog. PositiveInt already excludes 0, so a public zero stays invalid.
         chunkTimeout: Schema.optional(Schema.Union([PositiveInt, Schema.Literal(false)])).annotate({
           description:
-            "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted. Set to false to disable the idle watchdog.",
+            "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted. Set to false to disable the idle watchdog. The pre-content bound is only shape-aware for OpenAI-compatible SSE and otherwise uses the request `timeout` budget.",
         }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -6,6 +6,7 @@
 // This module exports patch functions and data that the upstream provider.ts
 // calls at well-defined injection points (each marked with kilocode_change).
 
+import { ProviderError } from "@/provider/error"
 import { createKilo, type KiloProvider, AI_SDK_PROVIDERS, PROMPTS } from "@kilocode/kilo-gateway"
 import { DEFAULT_HEADERS } from "@/kilocode/const"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -17,6 +18,173 @@ import { mapValues, omit, pickBy } from "remeda"
 
 /** Default timeout (ms) for provider HTTP requests (connection phase). */
 export const REQUEST_TIMEOUT_MS = 300_000 // 5 minutes
+
+/**
+ * Pre-content (time-to-first-content) budget for raw SSE streams. Mirrors the
+ * value of `KiloLLM.DEFAULT_FIRST_TOKEN_MS` in `src/kilocode/session/llm.ts` —
+ * keep these two constants in sync if either ever changes.
+ */
+export const SSE_FIRST_TOKEN_MS = 300_000 // 5 minutes
+
+/**
+ * Resolves the pre-content timeout budget for `wrapSSEFirstContent`, mirroring
+ * `KiloLLM.resolveFirstTokenMs` semantics: a positive finite `options.timeout`
+ * wins; otherwise falls back to a positive finite provider `timeout`; otherwise
+ * `SSE_FIRST_TOKEN_MS`. `false` / `0` / unset / invalid / non-finite all map to
+ * the default, because a never-first-content hang must remain bounded.
+ */
+export function resolveSseFirstTokenMs(options: Record<string, any>, fallback: Record<string, any> = {}): number {
+  const val = options["timeout"]
+  if (typeof val === "number" && Number.isFinite(val) && val > 0) return val
+  const fb = fallback["timeout"]
+  if (typeof fb === "number" && Number.isFinite(fb) && fb > 0) return fb
+  return SSE_FIRST_TOKEN_MS
+}
+
+// ---------------------------------------------------------------------------
+// SSE first-content detection
+// ---------------------------------------------------------------------------
+
+type ContentEventResult = { found: boolean; carry: string }
+
+/**
+ * Returns `found: true` iff any COMPLETE SSE event in `text` has a `data:` line
+ * whose JSON `choices[0].delta` carries `content`, `reasoning_content`, or
+ * `tool_calls`. The last (incomplete) event is skipped — it will be re-checked
+ * as the head of the next read's buffer.
+ *
+ * To bound memory usage, callers should replace `decoderBuf` with `carry`
+ * after each call. `carry` is the trailing incomplete event fragment (the text
+ * after the last `\n\n` boundary), so completed events are never retained or
+ * re-scanned.
+ */
+export function looksLikeContentEvent(text: string): ContentEventResult {
+  const events = text.split(/\r?\n\r?\n/)
+  if (events.length <= 1) return { found: false, carry: text }
+
+  const complete = events.slice(0, -1)
+  for (const evt of complete) {
+    const dataLines: string[] = []
+    for (const line of evt.split(/\r?\n/)) {
+      if (line.startsWith(":")) continue
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).replace(/^ /, ""))
+      }
+    }
+    if (dataLines.length === 0) continue
+    const payload = dataLines.join("\n")
+    if (payload === "[DONE]") continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(payload)
+    } catch {
+      continue
+    }
+    if (!parsed || typeof parsed !== "object") continue
+    const choices = (parsed as { choices?: unknown }).choices
+    if (!Array.isArray(choices) || choices.length === 0) continue
+    const delta = (choices[0] as { delta?: unknown })?.delta
+    if (!delta || typeof delta !== "object") continue
+    const d = delta as { content?: unknown; reasoning_content?: unknown; tool_calls?: unknown }
+    if (typeof d.content === "string" && d.content.length > 0) return { found: true, carry: "" }
+    if (typeof d.reasoning_content === "string" && d.reasoning_content.length > 0) return { found: true, carry: "" }
+    if (Array.isArray(d.tool_calls) && d.tool_calls.length > 0) return { found: true, carry: "" }
+  }
+
+  return { found: false, carry: events[events.length - 1] }
+}
+
+/**
+ * Wraps an SSE `Response` body so that reads before the first content-bearing
+ * `data:` event are bounded by `firstTokenMs`, while reads after content are
+ * bounded by the per-chunk `chunkTimeout`. Original bytes are enqueued
+ * untouched — the text decoder is observational only.
+ *
+ * This is the Kilo-specific first-content-aware layer; the upstream provider
+ * calls it at the single `wrapSSE` injection point.
+ *
+ * Scope note: this is installed for every provider SDK built by `resolveSDK`,
+ * but `looksLikeContentEvent` only recognizes the OpenAI chat-completions SSE
+ * shape (`choices[0].delta` with `content` / `reasoning_content` /
+ * `tool_calls`). For other provider-native shapes (Anthropic
+ * `content_block_delta`, OpenAI Responses `response.output_text.delta`, Google
+ * `candidates`, etc.) `seenContent` never flips, so pre-content reads remain
+ * bounded by `firstTokenMs` (the request `timeout` budget) rather than by
+ * `chunkTimeout` once content starts. This is intentional:
+ *   (a) the stream is still bounded (no hang);
+ *   (b) the provider-agnostic session-layer `KiloLLM.watchIterator` guards the
+ *       main session path for all providers using normalized AI SDK parts;
+ *   (c) treating the first arbitrary `data:` event as content would arm on
+ *       OpenAI's immediate role-delta and reintroduce the #12467 false-positive;
+ *   (d) this only arms when a positive provider-level `chunkTimeout` is
+ *       configured (no built-in default).
+ */
+export function wrapSSEFirstContent(
+  res: Response,
+  chunkTimeout: number,
+  ctl: AbortController,
+  firstTokenMs: number,
+): Response {
+  if (typeof chunkTimeout !== "number" || chunkTimeout <= 0) return res
+  if (!res.body) return res
+  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder("utf-8")
+  let decoderBuf = ""
+  let seenContent = false
+
+  const body = new ReadableStream<Uint8Array>({
+    async pull(ctrl) {
+      const budget = seenContent ? chunkTimeout : firstTokenMs
+      const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
+        const id = setTimeout(() => {
+          const err = new ProviderError.ResponseStreamError("SSE read timed out")
+          ctl.abort(err)
+          void reader.cancel(err)
+          reject(err)
+        }, budget)
+
+        reader.read().then(
+          (part) => {
+            clearTimeout(id)
+            resolve(part)
+          },
+          (err) => {
+            clearTimeout(id)
+            reject(err)
+          },
+        )
+      })
+
+      if (part.done) {
+        ctrl.close()
+        return
+      }
+
+      if (!seenContent && part.value) {
+        decoderBuf += decoder.decode(part.value, { stream: true })
+        const result = looksLikeContentEvent(decoderBuf)
+        if (result.found) {
+          seenContent = true
+        }
+        decoderBuf = result.carry
+      }
+
+      ctrl.enqueue(part.value)
+    },
+    async cancel(reason) {
+      ctl.abort(reason)
+      await reader.cancel(reason)
+    },
+  })
+
+  return new Response(body, {
+    headers: new Headers(res.headers),
+    status: res.status,
+    statusText: res.statusText,
+  })
+}
 
 // ---------------------------------------------------------------------------
 // Bundled providers

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -9,6 +9,14 @@ import { KiloSessionOverflow } from "./overflow"
 const SAFETY = 2048
 const MIN_OUTPUT = 1024
 const DEFAULT_CHUNK_IDLE_MS = 60_000
+// Kilo default for the pre-content (time-to-first-content / prompt-processing)
+// bound. The provider's own request `timeout` signal is cleared once response
+// headers arrive (see `buildTimeoutSignal` in src/kilocode/provider/provider.ts),
+// so the watchdog is the only thing that bounds the pre-content phase, and it
+// uses the configured `timeout` value (or this default) as its budget. 5 min is
+// generous for slow prompt processing on large-context / local models while
+// still bounding a genuine never-first-content hang.
+const DEFAULT_FIRST_TOKEN_MS = 300_000
 
 type FullStreamPart = LanguageModelV2StreamPart
 
@@ -50,6 +58,44 @@ export namespace KiloLLM {
     return DEFAULT_CHUNK_IDLE_MS
   }
 
+  /**
+   * Resolves the pre-content (time-to-first-content / prompt-processing) budget
+   * in milliseconds. Unlike `resolveIdleMs`, this value is NEVER `undefined`:
+   * the pre-content phase is disabled only when the whole watchdog is disabled
+   * (`chunkTimeout: false` → `idleMs === undefined` → `watchdogStream` returns
+   * the stream unchanged), which is decided at the watchdog entry point, not
+   * here.
+   *
+   * Rationale: the provider's own request `timeout` signal is cleared once HTTP
+   * response headers arrive (`buildTimeoutSignal`,
+   * `src/kilocode/provider/provider.ts:254-272`), so it does NOT bound the
+   * pre-content phase (which is post-header). The watchdog is therefore the
+   * only enforcement mechanism for time-to-first-content, and using the
+   * configured `timeout` VALUE as its budget is the only way to give a
+   * never-first-content hang a finite bound. Mapping `timeout: false`/`0`/
+   * invalid/unset to "disabled" would leave such a hang with no bound at all
+   * (idleMs only arms AFTER the first content part).
+   *
+   * Precedence:
+   *  1. prepared `options.timeout` (positive finite number)
+   *  2. provider `fallback.timeout` (positive finite number)
+   *  3. DEFAULT_FIRST_TOKEN_MS (5 min)
+   */
+  export function resolveFirstTokenMs(input: {
+    options: Record<string, unknown>
+    fallback?: Record<string, unknown>
+  }): number {
+    const prepared = input.options["timeout"]
+    if (isPositiveFiniteMs(prepared)) return prepared
+    const fallback = input.fallback?.["timeout"]
+    if (isPositiveFiniteMs(fallback)) return fallback
+    return DEFAULT_FIRST_TOKEN_MS
+  }
+
+  function isPositiveFiniteMs(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value) && value > 0
+  }
+
   // Tri-state: `disabled` means "explicitly off"; `value` is a usable ms count.
   // `null`/`undefined`/invalid numeric values are treated as not-configured.
   function resolve(value: unknown): { value: number | undefined; disabled: boolean } {
@@ -65,8 +111,23 @@ export namespace KiloLLM {
    * Wraps an AI SDK `fullStream` with a Kilo-owned per-event idle watchdog.
    *
    * Behavior:
-   *  - `idleMs === undefined` returns the stream unchanged (disabled).
-   *  - every raw AI SDK event resets the idle timer.
+   *  - `idleMs === undefined` returns the stream unchanged (disabled). In that
+   *    case `firstTokenMs` is also unused; the whole watchdog is off.
+   *  - The watchdog arms in two phases, keyed off the first content-bearing
+   *    part (the AI SDK emits a synthetic `start` immediately on stream open,
+   *    well before any provider byte, so arming on the first raw event would
+   *    race the time-to-first-content / prompt-processing phase — see issue
+   *    #12467):
+   *      * Pre-content: every pull before the first content/tool part is
+   *        raced against `firstTokenMs` (the request-timeout budget, see
+   *        `resolveFirstTokenMs`).
+   *      * Post-content: every pull after the first content/tool part is raced
+   *        against `idleMs` (the per-event inter-chunk idle).
+   *  - Content-bearing part types (verified against
+   *    `src/session/llm/ai-sdk.ts:140-223`): `text-delta`, `reasoning-delta`,
+   *    `tool-call`, `tool-input-start`, `tool-input-delta`. Structural parts
+   *    (`start`, `start-step`, `text-start`, `reasoning-start`, `stream-start`)
+   *    do NOT arm the post-content phase.
    *  - non-provider-executed `tool-call` adds an active tool id; matching
    *    `tool-result` / `tool-error` removes it. While any local tool id is
    *    active, the watchdog is suspended (long-running tool work is not a
@@ -78,6 +139,10 @@ export namespace KiloLLM {
    *  - the wrapper fails the stream with `ProviderError.ResponseStreamError`
    *    on stall. Existing `MessageV2` retry mapping handles that error.
    *
+   * `firstTokenMs` defaults to `idleMs` so legacy callers (and the many
+   * direct-unit tests that omit it) keep their exact current behavior
+   * (pre- and post-content budgets both equal to `idleMs`).
+   *
    * The wrapper is implemented against `AsyncIterable` so it composes with
    * any stream the AI SDK exposes, including its native `fullStream`. The
    * outer `Stream` is rebuilt from the wrapped iterable, which keeps the
@@ -87,10 +152,11 @@ export namespace KiloLLM {
     stream: Stream.Stream<FullStreamPart, unknown>,
     idleMs: number | undefined,
     abort?: AbortController,
+    firstTokenMs: number = idleMs as number,
   ): Stream.Stream<FullStreamPart, unknown> {
     if (idleMs === undefined) return stream
     const source = Stream.toAsyncIterable(stream)
-    return Stream.fromAsyncIterable(watchdogAsyncIterable(source, idleMs, abort), (e) =>
+    return Stream.fromAsyncIterable(watchdogAsyncIterable(source, idleMs, abort, firstTokenMs), (e) =>
       e instanceof Error ? e : new Error(String(e)),
     )
   }
@@ -99,15 +165,18 @@ export namespace KiloLLM {
    * Wraps an `AsyncIterable` of raw AI SDK `fullStream` parts with the same
    * Kilo-owned per-event idle watchdog. Use this when the upstream is already
    * an `AsyncIterable` (e.g. the AI SDK's `fullStream`) so we avoid a
-   * Stream → AsyncIterable → Stream round-trip.
+   * Stream → AsyncIterable → Stream round-trip. See `watchdogStream` for the
+   * pre-content / post-content phase semantics; `firstTokenMs` defaults to
+   * `idleMs` at this boundary for legacy callers.
    */
   export function watchdogAsyncIterable(
     source: AsyncIterable<FullStreamPart>,
     idleMs: number | undefined,
     abort?: AbortController,
+    firstTokenMs: number = idleMs as number,
   ): AsyncIterable<FullStreamPart> {
     if (idleMs === undefined) return source
-    return { [Symbol.asyncIterator]: () => watchIterator(source, idleMs, abort) }
+    return { [Symbol.asyncIterator]: () => watchIterator(source, idleMs, abort, firstTokenMs) }
   }
 
   /**
@@ -128,11 +197,21 @@ export namespace KiloLLM {
     source: AsyncIterable<FullStreamPart>,
     idleMs: number,
     abort?: AbortController,
+    firstTokenMs: number = idleMs,
   ): AsyncIterator<FullStreamPart> {
     const local = new Set<string>()
     const iter = source[Symbol.asyncIterator]()
     let suspended = false
     let closed = false
+    // The AI SDK emits a synthetic `start` part at t+2ms, well before any
+    // provider byte. Arming the per-event idle timer on the first pull would
+    // therefore race the time-to-first-content / prompt-processing phase and
+    // falsely abort healthy slow streams (issue #12467). Instead, we arm the
+    // post-content budget (`idleMs`) only after the first content-bearing
+    // part (text-delta / reasoning-delta / tool-call / tool-input-*) has
+    // been observed. The pre-content wait is bounded by `firstTokenMs` (the
+    // request-timeout budget, see `resolveFirstTokenMs`).
+    let seenContent = false
     return {
       async next(): Promise<IteratorResult<FullStreamPart>> {
         if (closed) return { done: true, value: undefined }
@@ -140,8 +219,11 @@ export namespace KiloLLM {
           // Decide BEFORE pulling whether the next event is allowed to take as
           // long as upstream needs. Local tool work in flight must not be timed
           // out — the AI SDK only emits a tool-result / tool-error once the
-          // client-side tool has actually finished.
-          const pull = suspended ? iter.next() : raceWithTimeout(iter.next(), idleMs, abort)
+          // client-side tool has actually finished. The pre-content phase uses
+          // the larger firstTokenMs budget; the post-content phase uses
+          // idleMs.
+          const budget = suspended ? undefined : seenContent ? idleMs : firstTokenMs
+          const pull = budget === undefined ? iter.next() : raceWithTimeout(iter.next(), budget, abort)
           const value = await pull
           suspended = false
           if (value.done) {
@@ -150,7 +232,8 @@ export namespace KiloLLM {
             return value
           }
           const part = value.value
-          trackPart(local, part)
+          const isContent = trackPart(local, part)
+          if (isContent) seenContent = true
           suspended = local.size > 0
           return { done: false, value: part }
         } catch (e) {
@@ -169,24 +252,58 @@ export namespace KiloLLM {
     }
   }
 
-  function trackPart(local: Set<string>, part: FullStreamPart) {
-    if (!part || typeof part !== "object") return
+  /**
+   * Inspects a raw AI SDK `fullStream` part and updates the local-tool
+   * suspension set. Returns `true` iff the part is content-bearing (i.e.
+   * arms the post-content `seenContent` gate in `watchIterator`), so the
+   * pre-content `firstTokenMs` budget only applies until the first
+   * content/tool part is observed.
+   *
+   * Content-bearing part types (verified against
+   * `src/session/llm/ai-sdk.ts:140-223`): `text-delta`, `reasoning-delta`,
+   * `tool-call`, `tool-input-start`, `tool-input-delta`. Structural parts
+   * (`start`, `start-step`, `text-start`, `reasoning-start`, `stream-start`)
+   * do NOT arm the post-content phase.
+   *
+   * Suspension logic (unchanged): non-provider-executed `tool-call` adds
+   * the id to the local set; matching `tool-result` / `tool-error` removes
+   * it. Provider-executed `tool-call` is content-bearing but does NOT add
+   * to the local set (those calls are settled server-side, so a missing
+   * result is a real stall).
+   */
+  function trackPart(local: Set<string>, part: FullStreamPart): boolean {
+    if (!part || typeof part !== "object") return false
     const t = (part as { type?: unknown }).type
     if (t === "tool-call") {
       const call = part as unknown as {
         toolCallId?: unknown
         providerExecuted?: unknown
       }
-      if (call.providerExecuted === true) return
-      if (typeof call.toolCallId !== "string") return
+      if (call.providerExecuted === true) {
+        // Provider-executed tool-call: content-bearing (carries the call
+        // payload) but does NOT suspend the watchdog — a missing server-side
+        // result is a genuine stall.
+        return true
+      }
+      if (typeof call.toolCallId !== "string") return false
       local.add(call.toolCallId)
-      return
+      return true
     }
     if (t === "tool-result" || t === "tool-error") {
       const call = part as unknown as { toolCallId?: unknown }
-      if (typeof call.toolCallId !== "string") return
+      if (typeof call.toolCallId !== "string") return false
       local.delete(call.toolCallId)
+      return false
     }
+    if (
+      t === "text-delta" ||
+      t === "reasoning-delta" ||
+      t === "tool-input-start" ||
+      t === "tool-input-delta"
+    ) {
+      return true
+    }
+    return false
   }
 
   function raceWithTimeout<T>(promise: Promise<T>, ms: number, abort?: AbortController): Promise<T> {

--- a/packages/opencode/src/kilocode/session/llm.ts
+++ b/packages/opencode/src/kilocode/session/llm.ts
@@ -8,7 +8,7 @@ import { KiloSessionOverflow } from "./overflow"
 
 const SAFETY = 2048
 const MIN_OUTPUT = 1024
-const DEFAULT_CHUNK_IDLE_MS = 60_000
+const DEFAULT_CHUNK_IDLE_MS = 300_000
 // Kilo default for the pre-content (time-to-first-content / prompt-processing)
 // bound. The provider's own request `timeout` signal is cleared once response
 // headers arrive (see `buildTimeoutSignal` in src/kilocode/provider/provider.ts),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -41,6 +41,8 @@ import {
   patchKiloProviderPrivacy,
   kiloSmallModelPriority,
   buildTimeoutSignal,
+  resolveSseFirstTokenMs,
+  wrapSSEFirstContent,
 } from "@/kilocode/provider/provider"
 import * as ModelsRefresh from "@/kilocode/provider/models-refresh"
 // kilocode_change end
@@ -49,140 +51,10 @@ import { ProviderError } from "./error"
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
 // kilocode_change start
-// Pre-content (time-to-first-content / prompt-processing) bound. Mirrors the
-// S2 default in `KiloLLM.DEFAULT_FIRST_TOKEN_MS` in
-// `src/kilocode/session/llm.ts:19` — keep these in sync if either ever changes.
-// The provider's own request `timeout` signal is cleared once HTTP response
-// headers arrive (see `buildTimeoutSignal` in `src/kilocode/provider/provider.ts`),
-// so the SSE chunk-idle watchdog is the only thing that bounds the pre-content
-// phase, and it uses the configured `timeout` value (or this default) as its
-// budget. 5 min is generous for slow prompt processing on large-context / local
-// models while still bounding a genuine never-first-content hang.
-const SSE_FIRST_TOKEN_MS = 300_000
-
-// Scope note: `wrapSSE` is installed for every provider SDK built by `resolveSDK`,
-// but the first-content detector (`looksLikeContentEvent`) only recognizes the
-// OpenAI chat-completions SSE shape (`choices[0].delta` with `content`,
-// `reasoning_content`, or `tool_calls`). For other provider-native shapes
-// (Anthropic `content_block_delta`, OpenAI Responses `response.output_text.delta`,
-// Google `candidates`, etc.) `seenContent` never flips, so pre-content reads
-// remain bounded by `firstTokenMs` (the request `timeout` budget) rather than
-// by `chunkTimeout` once content starts. This is intentional:
-//   (a) the stream is still bounded (no hang);
-//   (b) the provider-agnostic session-layer `watchIterator` guards the main
-//       session path for all providers using normalized AI SDK parts;
-//   (c) treating the first arbitrary `data:` event as content would arm on
-//       OpenAI's immediate role-delta and reintroduce the #12467 false-positive;
-//   (d) `wrapSSE` only arms when a positive provider-level `chunkTimeout` is
-//       configured (no built-in default).
+// Kilo-specific SSE first-content-aware chunk-idle wrapper. The implementation
+// lives in `src/kilocode/provider/provider.ts` so upstream diffs stay minimal.
 function wrapSSE(res: Response, chunkTimeout: number, ctl: AbortController, firstTokenMs: number) {
-  if (typeof chunkTimeout !== "number" || chunkTimeout <= 0) return res
-  if (!res.body) return res
-  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
-
-  const reader = res.body.getReader()
-  // Decode bytes observationally to detect the first content-bearing SSE
-  // `data:` event. The original bytes are still enqueued untouched — this
-  // decoder/buffer is for timing-budget selection only, not for re-serializing
-  // the stream.
-  const decoder = new TextDecoder("utf-8")
-  let decoderBuf = ""
-  let seenContent = false
-
-  // Returns true iff any COMPLETE SSE event in `text` so far has a `data:` line
-  // whose JSON `choices[0].delta` carries `content` / `reasoning_content` /
-  // `tool_calls`. The last (incomplete) event is skipped — it will be
-  // re-checked as the head of the next read's buffer. Structural/empty deltas
-  // (e.g. `{delta:{role:"assistant"}}`, `{delta:{}}`), `data: [DONE]`, and
-  // comment heartbeats do NOT count.
-  function looksLikeContentEvent(text: string): boolean {
-    const events = text.split(/\r?\n\r?\n/)
-    if (events.length <= 1) return false
-    const complete = events.slice(0, -1)
-    for (const evt of complete) {
-      const dataLines: string[] = []
-      for (const line of evt.split(/\r?\n/)) {
-        if (line.startsWith(":")) continue
-        if (line.startsWith("data:")) {
-          dataLines.push(line.slice(5).replace(/^ /, ""))
-        }
-        // `event:` / `id:` / `retry:` lines do not carry content.
-      }
-      if (dataLines.length === 0) continue
-      const payload = dataLines.join("\n")
-      if (payload === "[DONE]") continue
-      let parsed: unknown
-      try {
-        parsed = JSON.parse(payload)
-      } catch {
-        continue
-      }
-      if (!parsed || typeof parsed !== "object") continue
-      const choices = (parsed as { choices?: unknown }).choices
-      if (!Array.isArray(choices) || choices.length === 0) continue
-      const delta = (choices[0] as { delta?: unknown })?.delta
-      if (!delta || typeof delta !== "object") continue
-      const d = delta as { content?: unknown; reasoning_content?: unknown; tool_calls?: unknown }
-      if (typeof d.content === "string" && d.content.length > 0) return true
-      if (typeof d.reasoning_content === "string" && d.reasoning_content.length > 0) return true
-      if (Array.isArray(d.tool_calls) && d.tool_calls.length > 0) return true
-    }
-    return false
-  }
-
-  const body = new ReadableStream<Uint8Array>({
-    async pull(ctrl) {
-      // Pre-content reads are bounded by `firstTokenMs` (the request-timeout
-      // budget, see `SSE_FIRST_TOKEN_MS` above); once the first content-bearing
-      // `data:` event has been observed, subsequent reads are bounded by
-      // `chunkTimeout` (the per-chunk inter-content idle, unchanged behavior).
-      const budget = seenContent ? chunkTimeout : firstTokenMs
-      const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-        const id = setTimeout(() => {
-          const err = new ProviderError.ResponseStreamError("SSE read timed out")
-          ctl.abort(err)
-          void reader.cancel(err)
-          reject(err)
-        }, budget)
-
-        reader.read().then(
-          (part) => {
-            clearTimeout(id)
-            resolve(part)
-          },
-          (err) => {
-            clearTimeout(id)
-            reject(err)
-          },
-        )
-      })
-
-      if (part.done) {
-        ctrl.close()
-        return
-      }
-
-      if (!seenContent && part.value) {
-        decoderBuf += decoder.decode(part.value, { stream: true })
-        if (looksLikeContentEvent(decoderBuf)) {
-          seenContent = true
-          decoderBuf = ""
-        }
-      }
-
-      ctrl.enqueue(part.value)
-    },
-    async cancel(reason) {
-      ctl.abort(reason)
-      await reader.cancel(reason)
-    },
-  })
-
-  return new Response(body, {
-    headers: new Headers(res.headers),
-    status: res.status,
-    statusText: res.statusText,
-  })
+  return wrapSSEFirstContent(res, chunkTimeout, ctl, firstTokenMs)
 }
 // kilocode_change end
 
@@ -1849,11 +1721,8 @@ export const layer = Layer.effect(
         // Pre-content (time-to-first-content) budget for `wrapSSE`. Mirrors
         // `KiloLLM.resolveFirstTokenMs` semantics from S2: a positive finite
         // `options["timeout"]` wins; `false`/`0`/unset/invalid fall back to
-        // `SSE_FIRST_TOKEN_MS`. See `wrapSSE` for why this is needed.
-        const firstTokenMs =
-          typeof options["timeout"] === "number" && Number.isFinite(options["timeout"]) && options["timeout"] > 0
-            ? options["timeout"]
-            : SSE_FIRST_TOKEN_MS
+        // `SSE_FIRST_TOKEN_MS` in the Kilo mirror. See `resolveSseFirstTokenMs`.
+        const firstTokenMs = resolveSseFirstTokenMs(options)
         // kilocode_change end
         delete options["chunkTimeout"]
         delete options["headerTimeout"]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -60,6 +60,21 @@ const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 // models while still bounding a genuine never-first-content hang.
 const SSE_FIRST_TOKEN_MS = 300_000
 
+// Scope note: `wrapSSE` is installed for every provider SDK built by `resolveSDK`,
+// but the first-content detector (`looksLikeContentEvent`) only recognizes the
+// OpenAI chat-completions SSE shape (`choices[0].delta` with `content`,
+// `reasoning_content`, or `tool_calls`). For other provider-native shapes
+// (Anthropic `content_block_delta`, OpenAI Responses `response.output_text.delta`,
+// Google `candidates`, etc.) `seenContent` never flips, so pre-content reads
+// remain bounded by `firstTokenMs` (the request `timeout` budget) rather than
+// by `chunkTimeout` once content starts. This is intentional:
+//   (a) the stream is still bounded (no hang);
+//   (b) the provider-agnostic session-layer `watchIterator` guards the main
+//       session path for all providers using normalized AI SDK parts;
+//   (c) treating the first arbitrary `data:` event as content would arm on
+//       OpenAI's immediate role-delta and reintroduce the #12467 false-positive;
+//   (d) `wrapSSE` only arms when a positive provider-level `chunkTimeout` is
+//       configured (no built-in default).
 function wrapSSE(res: Response, chunkTimeout: number, ctl: AbortController, firstTokenMs: number) {
   if (typeof chunkTimeout !== "number" || chunkTimeout <= 0) return res
   if (!res.body) return res

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -48,6 +48,7 @@ import { ProviderError } from "./error"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
+// kilocode_change start
 // Pre-content (time-to-first-content / prompt-processing) bound. Mirrors the
 // S2 default in `KiloLLM.DEFAULT_FIRST_TOKEN_MS` in
 // `src/kilocode/session/llm.ts:19` — keep these in sync if either ever changes.
@@ -168,6 +169,7 @@ function wrapSSE(res: Response, chunkTimeout: number, ctl: AbortController, firs
     statusText: res.statusText,
   })
 }
+// kilocode_change end
 
 function timeoutController(ms: number) {
   const ctl = new AbortController()
@@ -1828,6 +1830,7 @@ export const layer = Layer.effect(
         const customFetch = options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
         const headerTimeout = options["headerTimeout"]
+        // kilocode_change start
         // Pre-content (time-to-first-content) budget for `wrapSSE`. Mirrors
         // `KiloLLM.resolveFirstTokenMs` semantics from S2: a positive finite
         // `options["timeout"]` wins; `false`/`0`/unset/invalid fall back to
@@ -1836,6 +1839,7 @@ export const layer = Layer.effect(
           typeof options["timeout"] === "number" && Number.isFinite(options["timeout"]) && options["timeout"] > 0
             ? options["timeout"]
             : SSE_FIRST_TOKEN_MS
+        // kilocode_change end
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -48,21 +48,86 @@ import { ProviderError } from "./error"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
-function wrapSSE(res: Response, ms: number, ctl: AbortController) {
-  if (typeof ms !== "number" || ms <= 0) return res
+// Pre-content (time-to-first-content / prompt-processing) bound. Mirrors the
+// S2 default in `KiloLLM.DEFAULT_FIRST_TOKEN_MS` in
+// `src/kilocode/session/llm.ts:19` — keep these in sync if either ever changes.
+// The provider's own request `timeout` signal is cleared once HTTP response
+// headers arrive (see `buildTimeoutSignal` in `src/kilocode/provider/provider.ts`),
+// so the SSE chunk-idle watchdog is the only thing that bounds the pre-content
+// phase, and it uses the configured `timeout` value (or this default) as its
+// budget. 5 min is generous for slow prompt processing on large-context / local
+// models while still bounding a genuine never-first-content hang.
+const SSE_FIRST_TOKEN_MS = 300_000
+
+function wrapSSE(res: Response, chunkTimeout: number, ctl: AbortController, firstTokenMs: number) {
+  if (typeof chunkTimeout !== "number" || chunkTimeout <= 0) return res
   if (!res.body) return res
   if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
 
   const reader = res.body.getReader()
+  // Decode bytes observationally to detect the first content-bearing SSE
+  // `data:` event. The original bytes are still enqueued untouched — this
+  // decoder/buffer is for timing-budget selection only, not for re-serializing
+  // the stream.
+  const decoder = new TextDecoder("utf-8")
+  let decoderBuf = ""
+  let seenContent = false
+
+  // Returns true iff any COMPLETE SSE event in `text` so far has a `data:` line
+  // whose JSON `choices[0].delta` carries `content` / `reasoning_content` /
+  // `tool_calls`. The last (incomplete) event is skipped — it will be
+  // re-checked as the head of the next read's buffer. Structural/empty deltas
+  // (e.g. `{delta:{role:"assistant"}}`, `{delta:{}}`), `data: [DONE]`, and
+  // comment heartbeats do NOT count.
+  function looksLikeContentEvent(text: string): boolean {
+    const events = text.split(/\r?\n\r?\n/)
+    if (events.length <= 1) return false
+    const complete = events.slice(0, -1)
+    for (const evt of complete) {
+      const dataLines: string[] = []
+      for (const line of evt.split(/\r?\n/)) {
+        if (line.startsWith(":")) continue
+        if (line.startsWith("data:")) {
+          dataLines.push(line.slice(5).replace(/^ /, ""))
+        }
+        // `event:` / `id:` / `retry:` lines do not carry content.
+      }
+      if (dataLines.length === 0) continue
+      const payload = dataLines.join("\n")
+      if (payload === "[DONE]") continue
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(payload)
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== "object") continue
+      const choices = (parsed as { choices?: unknown }).choices
+      if (!Array.isArray(choices) || choices.length === 0) continue
+      const delta = (choices[0] as { delta?: unknown })?.delta
+      if (!delta || typeof delta !== "object") continue
+      const d = delta as { content?: unknown; reasoning_content?: unknown; tool_calls?: unknown }
+      if (typeof d.content === "string" && d.content.length > 0) return true
+      if (typeof d.reasoning_content === "string" && d.reasoning_content.length > 0) return true
+      if (Array.isArray(d.tool_calls) && d.tool_calls.length > 0) return true
+    }
+    return false
+  }
+
   const body = new ReadableStream<Uint8Array>({
     async pull(ctrl) {
+      // Pre-content reads are bounded by `firstTokenMs` (the request-timeout
+      // budget, see `SSE_FIRST_TOKEN_MS` above); once the first content-bearing
+      // `data:` event has been observed, subsequent reads are bounded by
+      // `chunkTimeout` (the per-chunk inter-content idle, unchanged behavior).
+      const budget = seenContent ? chunkTimeout : firstTokenMs
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
         const id = setTimeout(() => {
           const err = new ProviderError.ResponseStreamError("SSE read timed out")
           ctl.abort(err)
           void reader.cancel(err)
           reject(err)
-        }, ms)
+        }, budget)
 
         reader.read().then(
           (part) => {
@@ -79,6 +144,14 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
       if (part.done) {
         ctrl.close()
         return
+      }
+
+      if (!seenContent && part.value) {
+        decoderBuf += decoder.decode(part.value, { stream: true })
+        if (looksLikeContentEvent(decoderBuf)) {
+          seenContent = true
+          decoderBuf = ""
+        }
       }
 
       ctrl.enqueue(part.value)
@@ -1755,6 +1828,14 @@ export const layer = Layer.effect(
         const customFetch = options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
         const headerTimeout = options["headerTimeout"]
+        // Pre-content (time-to-first-content) budget for `wrapSSE`. Mirrors
+        // `KiloLLM.resolveFirstTokenMs` semantics from S2: a positive finite
+        // `options["timeout"]` wins; `false`/`0`/unset/invalid fall back to
+        // `SSE_FIRST_TOKEN_MS`. See `wrapSSE` for why this is needed.
+        const firstTokenMs =
+          typeof options["timeout"] === "number" && Number.isFinite(options["timeout"]) && options["timeout"] > 0
+            ? options["timeout"]
+            : SSE_FIRST_TOKEN_MS
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
 
@@ -1784,7 +1865,7 @@ export const layer = Layer.effect(
             }).finally(() => headerTimeoutCtl?.clear())
             timeout.clear()
             if (!chunkAbortCtl) return res
-            return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+            return wrapSSE(res, chunkTimeout, chunkAbortCtl, firstTokenMs)
           } catch (err) {
             timeout.clear()
             throw err

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -478,7 +478,7 @@ const live: Layer.Layer<
             // Adapter seam: both runtimes expose the same LLMEvent stream. Native
             // already returns one; AI SDK streams are converted here.
             const state = LLMAISDK.adapterState()
-            // kilocode_change: wrap the raw AI SDK fullStream with the Kilo
+            // kilocode_change start: wrap the raw AI SDK fullStream with the Kilo
             // idle watchdog before normalization. Per-subscription timers
             // (post-content `idleMs` and pre-content `firstTokenMs`) were
             // resolved inside `run` and travel with the result. Pass the
@@ -490,6 +490,7 @@ const live: Layer.Layer<
               ctrl,
               result.firstTokenMs,
             )
+            // kilocode_change end
             return Stream.fromAsyncIterable(watched, (e) => (e instanceof Error ? e : new Error(String(e)))).pipe(
               // kilocode_change: the watchdog consumes raw LanguageModelV2 parts;
               // cast back to the TextStreamPart shape LLMAISDK.toLLMEvents expects.

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -429,7 +429,20 @@ const live: Layer.Layer<
         options: prepared.params.options,
         fallback: item.options,
       })
-      if (!exportable) return { type: "ai-sdk" as const, result, idleMs }
+      // kilocode_change: also resolve the pre-content (time-to-first-content /
+      // prompt-processing) budget. The provider's own request `timeout` signal
+      // is cleared once response headers arrive (buildTimeoutSignal,
+      // src/kilocode/provider/provider.ts:254-272), so it does NOT bound the
+      // pre-content phase — the watchdog is the enforcement mechanism here,
+      // using the configured `timeout` VALUE as its budget. unset / false / 0
+      // / invalid maps to DEFAULT_FIRST_TOKEN_MS (5 min), never to "disabled".
+      // The same two option bags as `idleMs` are read so a model-level
+      // `timeout` always wins over a provider-level `timeout`.
+      const firstTokenMs = KiloLLM.resolveFirstTokenMs({
+        options: prepared.params.options,
+        fallback: item.options,
+      })
+      if (!exportable) return { type: "ai-sdk" as const, result, idleMs, firstTokenMs }
       return {
         type: "ai-sdk" as const,
         result: {
@@ -444,6 +457,7 @@ const live: Layer.Layer<
           }),
         },
         idleMs,
+        firstTokenMs,
       }
       // kilocode_change end
     })
@@ -465,14 +479,16 @@ const live: Layer.Layer<
             // already returns one; AI SDK streams are converted here.
             const state = LLMAISDK.adapterState()
             // kilocode_change: wrap the raw AI SDK fullStream with the Kilo
-            // idle watchdog before normalization. Per-subscription timer was
-            // resolved inside `run` and travels with the result. Pass the
+            // idle watchdog before normalization. Per-subscription timers
+            // (post-content `idleMs` and pre-content `firstTokenMs`) were
+            // resolved inside `run` and travel with the result. Pass the
             // scoped controller so the watchdog can abort a stalled source
             // and avoid hanging cleanup.
             const watched = KiloLLM.watchdogAsyncIterable(
               result.result.fullStream as AsyncIterable<import("@ai-sdk/provider").LanguageModelV2StreamPart>,
               result.idleMs,
               ctrl,
+              result.firstTokenMs,
             )
             return Stream.fromAsyncIterable(watched, (e) => (e instanceof Error ? e : new Error(String(e)))).pipe(
               // kilocode_change: the watchdog consumes raw LanguageModelV2 parts;

--- a/packages/opencode/test/kilocode/provider/provider.test.ts
+++ b/packages/opencode/test/kilocode/provider/provider.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test"
+import { looksLikeContentEvent, resolveSseFirstTokenMs, SSE_FIRST_TOKEN_MS, wrapSSEFirstContent } from "@/kilocode/provider/provider"
+import { ProviderError } from "@/provider/error"
+
+describe("kilocode.provider.resolveSseFirstTokenMs", () => {
+  test("returns a positive finite timeout as-is", () => {
+    expect(resolveSseFirstTokenMs({ timeout: 90_000 })).toBe(90_000)
+  })
+
+  test("falls back to a positive finite provider timeout", () => {
+    expect(resolveSseFirstTokenMs({ timeout: "90_000" }, { timeout: 30_000 })).toBe(30_000)
+  })
+
+  test("maps false to the default", () => {
+    expect(resolveSseFirstTokenMs({ timeout: false })).toBe(SSE_FIRST_TOKEN_MS)
+  })
+
+  test("maps 0 to the default", () => {
+    expect(resolveSseFirstTokenMs({ timeout: 0 })).toBe(SSE_FIRST_TOKEN_MS)
+  })
+
+  test("maps negative / non-finite / invalid to the default", () => {
+    expect(resolveSseFirstTokenMs({ timeout: -1 })).toBe(SSE_FIRST_TOKEN_MS)
+    expect(resolveSseFirstTokenMs({ timeout: Number.POSITIVE_INFINITY })).toBe(SSE_FIRST_TOKEN_MS)
+    expect(resolveSseFirstTokenMs({ timeout: Number.NaN })).toBe(SSE_FIRST_TOKEN_MS)
+    expect(resolveSseFirstTokenMs({ timeout: "x" })).toBe(SSE_FIRST_TOKEN_MS)
+    expect(resolveSseFirstTokenMs({})).toBe(SSE_FIRST_TOKEN_MS)
+  })
+})
+
+describe("kilocode.provider.looksLikeContentEvent", () => {
+  test("returns false + full carry when no event boundary is present", () => {
+    const text = 'data: {"choices":[{"delta":{"content":"incomplete'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe(text)
+  })
+
+  test("role-only delta is not content", () => {
+    const text = 'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe("")
+  })
+
+  test("empty delta is not content", () => {
+    const text = 'data: {"choices":[{"delta":{}}]}\n\n'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe("")
+  })
+
+  test(":heartbeat comment is not content", () => {
+    const text = ":heartbeat\n\n"
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe("")
+  })
+
+  test("data: [DONE] is not content", () => {
+    const text = "data: [DONE]\n\n"
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe("")
+  })
+
+  test("content delta is content", () => {
+    const text = 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(true)
+    expect(result.carry).toBe("")
+  })
+
+  test("reasoning_content delta is content", () => {
+    const text = 'data: {"choices":[{"delta":{"reasoning_content":"thinking"}}]}\n\n'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(true)
+    expect(result.carry).toBe("")
+  })
+
+  test("tool_calls delta is content", () => {
+    const text = 'data: {"choices":[{"delta":{"tool_calls":[{"id":"1"}]}}]}\n\n'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(true)
+    expect(result.carry).toBe("")
+  })
+
+  test("content event split across two reads is detected once the boundary arrives", () => {
+    const head = 'data: {"choices":[{"delta":{"content":"h'
+    const tail = 'i"}}]}\n\n'
+
+    const r1 = looksLikeContentEvent(head)
+    expect(r1.found).toBe(false)
+
+    const r2 = looksLikeContentEvent(r1.carry + tail)
+    expect(r2.found).toBe(true)
+  })
+
+  test("keeps only the trailing fragment after a complete non-content event (buffer trimming)", () => {
+    const text =
+      'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\ndata: {"choices":[{"delta":{"con'
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe('data: {"choices":[{"delta":{"con')
+  })
+
+  test("drops many complete heartbeats and keeps only the trailing fragment (Repair B)", () => {
+    const text = Array.from({ length: 20 }, (_, i) => `:heartbeat${i}`).join("\n\n") + "\n\n:incomplete"
+    const result = looksLikeContentEvent(text)
+    expect(result.found).toBe(false)
+    expect(result.carry).toBe(":incomplete")
+  })
+})
+
+describe("kilocode.provider.wrapSSEFirstContent", () => {
+  test("returns the original response when chunkTimeout is not positive", () => {
+    const res = new Response("body")
+    expect(wrapSSEFirstContent(res, 0, new AbortController(), 60_000)).toBe(res)
+  })
+
+  test("returns the original response when there is no body", () => {
+    const res = new Response(null, { headers: { "content-type": "text/event-stream" } })
+    expect(wrapSSEFirstContent(res, 50, new AbortController(), 60_000)).toBe(res)
+  })
+
+  test("returns the original response when content-type is not SSE", () => {
+    const res = new Response(new ReadableStream(), { headers: { "content-type": "application/json" } })
+    expect(wrapSSEFirstContent(res, 50, new AbortController(), 60_000)).toBe(res)
+  })
+
+  test("enqueues original bytes untouched and uses pre-content budget until first content", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        // Feed a non-content event first, then a content event.
+        ctrl.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n'))
+        ctrl.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'))
+        ctrl.close()
+      },
+    })
+    const res = new Response(stream, { headers: { "content-type": "text/event-stream" } })
+    const ctl = new AbortController()
+    const wrapped = wrapSSEFirstContent(res, 1_000, ctl, 1_000)
+    const reader = wrapped.body!.getReader()
+    const chunks: string[] = []
+    let done = false
+    while (!done) {
+      const { value, done: d } = await reader.read()
+      done = d
+      if (value) chunks.push(new TextDecoder().decode(value))
+    }
+    expect(chunks.join("")).toContain('"role":"assistant"')
+    expect(chunks.join("")).toContain('"content":"ok"')
+    expect(ctl.signal.aborted).toBe(false)
+  })
+
+  test("aborts a stalled pre-content SSE stream within firstTokenMs", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // Never enqueues — simulates a headers-only SSE connection.
+      },
+    })
+    const res = new Response(stream, { headers: { "content-type": "text/event-stream" } })
+    const ctl = new AbortController()
+    const wrapped = wrapSSEFirstContent(res, 60_000, ctl, 50)
+    const reader = wrapped.body!.getReader()
+    await expect(reader.read()).rejects.toBeInstanceOf(ProviderError.ResponseStreamError)
+  })
+})

--- a/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
@@ -245,6 +245,26 @@ function providerCfg(url: string) {
   }
 }
 
+// Model-level chunkTimeout arms the session-stream watchdog for AC1. The
+// provider-level option is intentionally left unset so baseline's resolveIdleMs
+// reads the model option (chunkTimeout: 1_000) and does not fall back to the
+// provider false that disables wrapSSE.
+function enabledWatchdogCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
 const worktreeFile = (dir: string, name: string) => path.join(dir, name)
 
 const exists = (file: string) =>
@@ -550,6 +570,55 @@ describe("session stream watchdog integration", () => {
             },
           }),
         },
+      ),
+    { timeout: 30_000 },
+  )
+
+  it.live(
+    "AC1: slow time-to-first-content is not aborted or retried",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const chat = yield* sessions.create({ title: "AC1 slow first content" })
+          const gate = Promise.withResolvers<void>()
+
+          yield* llm.hold("done", gate.promise)
+
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            noReply: true,
+            parts: [{ type: "text", text: "say something after a long think" }],
+          })
+
+          const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+
+          yield* llm.wait(1)
+          yield* Effect.sleep("2500 millis")
+          gate.resolve(undefined)
+
+          const exit = yield* awaitWithTimeout(
+            Fiber.await(fiber),
+            "AC1 loop did not finish",
+            "15 seconds",
+          )
+          expect(Exit.isSuccess(exit)).toBe(true)
+
+          const calls = yield* llm.calls
+          expect(calls).toBe(1)
+
+          const messages = yield* sessions.messages({ sessionID: chat.id })
+          const assistantText = messages
+            .filter((msg) => msg.info.role === "assistant")
+            .flatMap((msg) => msg.parts)
+            .filter((part) => part.type === "text")
+            .map((part) => part.text)
+            .join("")
+          expect(assistantText).toContain("done")
+        }),
+        { git: true, config: (url) => enabledWatchdogCfg(url) },
       ),
     { timeout: 30_000 },
   )

--- a/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session-stream-watchdog.test.ts
@@ -245,10 +245,11 @@ function providerCfg(url: string) {
   }
 }
 
-// Model-level chunkTimeout arms the session-stream watchdog for AC1. The
-// provider-level option is intentionally left unset so baseline's resolveIdleMs
-// reads the model option (chunkTimeout: 1_000) and does not fall back to the
-// provider false that disables wrapSSE.
+// Model-level `chunkTimeout: 1_000` (from the base `cfg`'s `test-model`
+// options) is what arms the session watchdog because `resolveIdleMs` reads model
+// options first. The provider-level option is intentionally left unset so this
+// test exercises only the session-layer `watchIterator` path (not `wrapSSE`,
+// which arms only on a positive provider-level `chunkTimeout`).
 function enabledWatchdogCfg(url: string) {
   return {
     ...cfg,

--- a/packages/opencode/test/kilocode/session/llm.test.ts
+++ b/packages/opencode/test/kilocode/session/llm.test.ts
@@ -31,8 +31,8 @@ describe("kilocode.session.llm.resolveIdleMs", () => {
     ).toBe(30_000)
   })
 
-  test("defaults the chunk idle timeout to 60_000 ms when no override is configured", () => {
-    expect(KiloLLM.resolveIdleMs({ options: {} })).toBe(60_000)
+  test("defaults the chunk idle timeout to 300_000 ms when no override is configured", () => {
+    expect(KiloLLM.resolveIdleMs({ options: {} })).toBe(300_000)
   })
 
   test("returns undefined when prepared is false (disabled)", () => {

--- a/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
@@ -34,6 +34,30 @@ function fromSchedule(events: Array<[number, FullStreamPart]>, end: number): Str
   )
 }
 
+// kilocode_change: raw AsyncIterable version of `fromSchedule` for tests that
+// exercise `watchdogAsyncIterable` directly (matching the production call
+// site in `session/llm.ts`, which wraps the AI SDK's native `fullStream`
+// AsyncIterable — not a Stream). Going through `Stream.toAsyncIterable` from
+// the `watchdogStream` entry point blocks the Node event loop on long stalls
+// (Effect's Stream round-trip drives the underlying generator synchronously
+// on the consumer's `next()` call), which prevents the watchdog's setTimeout
+// from firing. The production path does not go through that round-trip, so
+// the raw AsyncIterable is the accurate test target.
+function iterableFromSchedule(
+  events: Array<[number, FullStreamPart]>,
+  end: number,
+): AsyncIterable<FullStreamPart> {
+  return (async function* () {
+    const start = Date.now()
+    for (const [at, value] of events) {
+      const wait = at - (Date.now() - start)
+      if (wait > 0) await new Promise((r) => setTimeout(r, wait))
+      yield value
+    }
+    await new Promise((r) => setTimeout(r, end))
+  })()
+}
+
 describe("kilocode.session.llm.resolveIdleMs", () => {
   test("returns prepared positive finite value as-is", () => {
     const out = KiloLLM.resolveIdleMs({ options: { chunkTimeout: 15_000 }, fallback: { chunkTimeout: 30_000 } })
@@ -95,6 +119,87 @@ describe("kilocode.session.llm.resolveIdleMs", () => {
         fallback: { chunkTimeout: -5 },
       }),
     ).toBe(60_000)
+  })
+})
+
+// kilocode_change: resolveFirstTokenMs is the new S2 helper for the
+// pre-content (time-to-first-content) budget. Unlike resolveIdleMs it
+// NEVER returns undefined: the pre-content bound is disabled only when
+// the whole watchdog is disabled (idleMs === undefined at the entry
+// point). unset / false / 0 / invalid / non-finite / negative MUST map
+// to DEFAULT_FIRST_TOKEN_MS — leaving a never-first-content hang
+// unbounded when `timeout` is configured as "off" would re-introduce a
+// worse version of #12467 (silent infinite hang instead of a 60s false
+// positive).
+describe("kilocode.session.llm.resolveFirstTokenMs", () => {
+  test("returns prepared positive finite value as-is", () => {
+    const out = KiloLLM.resolveFirstTokenMs({
+      options: { timeout: 90_000 },
+      fallback: { timeout: 30_000 },
+    })
+    expect(out).toBe(90_000)
+  })
+
+  test("falls back to provider value when prepared is missing", () => {
+    const out = KiloLLM.resolveFirstTokenMs({ options: {}, fallback: { timeout: 30_000 } })
+    expect(out).toBe(30_000)
+  })
+
+  test("falls back to provider value when prepared is a non-number string", () => {
+    const out = KiloLLM.resolveFirstTokenMs({
+      options: { timeout: "90_000" },
+      fallback: { timeout: 30_000 },
+    })
+    expect(out).toBe(30_000)
+  })
+
+  test("falls back to provider value when prepared is negative", () => {
+    const out = KiloLLM.resolveFirstTokenMs({
+      options: { timeout: -1 },
+      fallback: { timeout: 30_000 },
+    })
+    expect(out).toBe(30_000)
+  })
+
+  test("falls back to provider value when prepared is non-finite (Infinity, NaN)", () => {
+    expect(
+      KiloLLM.resolveFirstTokenMs({
+        options: { timeout: Number.POSITIVE_INFINITY },
+        fallback: { timeout: 5_000 },
+      }),
+    ).toBe(5_000)
+    expect(
+      KiloLLM.resolveFirstTokenMs({ options: { timeout: Number.NaN }, fallback: { timeout: 5_000 } }),
+    ).toBe(5_000)
+  })
+
+  // Crucial divergence from resolveIdleMs: boolean false must NOT disable
+  // the pre-content bound — it falls back / uses the Kilo default instead.
+  test("treats boolean false as not-configured (falls back, does NOT disable)", () => {
+    expect(
+      KiloLLM.resolveFirstTokenMs({ options: { timeout: false }, fallback: { timeout: 30_000 } }),
+    ).toBe(30_000)
+    expect(KiloLLM.resolveFirstTokenMs({ options: { timeout: false } })).toBe(300_000)
+  })
+
+  test("treats internal 0 as not-configured (falls back, does NOT disable)", () => {
+    expect(
+      KiloLLM.resolveFirstTokenMs({ options: { timeout: 0 }, fallback: { timeout: 30_000 } }),
+    ).toBe(30_000)
+    expect(KiloLLM.resolveFirstTokenMs({ options: { timeout: 0 } })).toBe(300_000)
+  })
+
+  test("uses 300_000 default when nothing valid is configured", () => {
+    expect(KiloLLM.resolveFirstTokenMs({ options: {} })).toBe(300_000)
+  })
+
+  test("uses 300_000 default when both prepared and fallback are invalid", () => {
+    expect(
+      KiloLLM.resolveFirstTokenMs({
+        options: { timeout: "x" },
+        fallback: { timeout: -5 },
+      }),
+    ).toBe(300_000)
   })
 })
 
@@ -285,5 +390,109 @@ describe("kilocode.session.llm.watchdogStream", () => {
     expect(sourceReturnCalled).toBe(true)
     // The abandoned pull is left unresolved; only return() is asserted here.
     void pending
+  })
+
+  // kilocode_change: AC1 (parameterised) — slow time-to-first-content is
+  // bounded by `firstTokenMs`, not `idleMs`. The first content part
+  // (`text-delta`) is delayed 300ms, which is past the 100ms `idleMs` but
+  // within the 1000ms `firstTokenMs` (the request-timeout budget). Without
+  // the fix the per-event idle would fire at t≈100ms and abort a healthy
+  // slow stream (issue #12467). With the fix the pre-content phase is
+  // bounded by the larger `firstTokenMs` and the stream completes.
+  //
+  // Uses `watchdogAsyncIterable` directly (with a raw AsyncIterable) to match
+  // the production call site (`session/llm.ts`), which wraps the AI SDK's
+  // native `fullStream` AsyncIterable. `watchdogStream` would round-trip
+  // through `Stream.toAsyncIterable`, which blocks the event loop on long
+  // stalls and prevents the watchdog's setTimeout from firing.
+  test("AC1 (parameterised): slow time-to-first-content completes when firstTokenMs > idleMs", async () => {
+    // Synthetic structural parts arrive instantly (mirroring the AI SDK's
+    // t+2ms synthetic `start`); the first content part is gated 300ms.
+    const source = iterableFromSchedule(
+      [
+        [0, part("stream-start", { warnings: [] as LanguageModelV2CallWarning[] })],
+        [0, part("start-step", { request: {}, warnings: [] as LanguageModelV2CallWarning[] })],
+        [0, part("text-start", { id: "t1", providerMetadata: undefined })],
+        [300, part("text-delta", { id: "t1", delta: "hi", providerMetadata: undefined })],
+        [310, part("text-delta", { id: "t1", delta: "!", providerMetadata: undefined })],
+        [320, part("finish-step", { finishReason: "stop", usage: undefined, providerMetadata: undefined })],
+        [330, part("finish", { finishReason: "stop", usage: undefined, providerMetadata: undefined })],
+      ],
+      10,
+    )
+    const wrapped = KiloLLM.watchdogAsyncIterable(source, 100, undefined, 1_000)
+    const out = await run(
+      Stream.runCollect(Stream.fromAsyncIterable(wrapped, (e) => (e instanceof Error ? e : new Error(String(e))))),
+    )
+    // 7 raw events must be collected end-to-end — the 300ms wait for the
+    // first content part exceeds idleMs=100 but is well under
+    // firstTokenMs=1000, so the watchdog must NOT abort.
+    expect(out.length).toBe(7)
+  })
+
+  // kilocode_change: AC3 — a never-first-content hang is bounded by
+  // `firstTokenMs` (the request-timeout budget), not by the post-content
+  // `idleMs`. The schedule emits ONLY structural parts and then hangs; the
+  // watchdog must fire at ~firstTokenMs (500ms), not at the much-larger
+  // `idleMs` (5000ms) and not at the Kilo default (300s). This is the
+  // primary direct-unit guard that a `timeout: false` / unset config
+  // still gets a finite bound on time-to-first-content, since the
+  // provider's own request `timeout` signal is cleared once response
+  // headers arrive.
+  //
+  // Uses a hand-rolled `AsyncIterable` rather than an async generator
+  // because the watchdog's catch path calls `safeClose(source.return())`
+  // to clean up the source. On a hand-rolled generator that's suspended
+  // mid-`setTimeout`, `return()` blocks until the pending `next()`
+  // settles (per the async-generator spec), so the timeout would not
+  // appear to fire until the source's setTimeout elapsed. A custom
+  // `AsyncIterable` whose `return()` resolves immediately matches the
+  // behavior of the AI SDK's native `fullStream` consumer in production
+  // and is the same pattern used in the existing "aborts the underlying
+  // source" test in this file.
+  test("AC3: never-first-content hang is bounded by firstTokenMs, not idleMs", async () => {
+    // Yield 3 structural parts instantly, then hang.
+    const parts: FullStreamPart[] = [
+      part("stream-start", { warnings: [] as LanguageModelV2CallWarning[] }),
+      part("start-step", { request: {}, warnings: [] as LanguageModelV2CallWarning[] }),
+      part("text-start", { id: "t1", providerMetadata: undefined }),
+    ]
+    let index = 0
+    let resolveHanging: ((v: IteratorResult<FullStreamPart>) => void) | undefined
+    const source: AsyncIterable<FullStreamPart> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            if (index < parts.length) {
+              return Promise.resolve({ done: false, value: parts[index++]! })
+            }
+            return new Promise<IteratorResult<FullStreamPart>>((resolve) => {
+              resolveHanging = resolve
+            })
+          },
+          return() {
+            if (resolveHanging) resolveHanging({ done: true, value: undefined })
+            return Promise.resolve({ done: true, value: undefined })
+          },
+        }
+      },
+    }
+
+    const start = Date.now()
+    const wrapped = KiloLLM.watchdogAsyncIterable(source, 5_000, undefined, 500)
+    const err = await run(
+      Effect.flip(
+        Stream.runCollect(
+          Stream.fromAsyncIterable(wrapped, (e) => (e instanceof Error ? e : new Error(String(e)))),
+        ),
+      ),
+    )
+    const elapsed = Date.now() - start
+    expect(err).toBeInstanceOf(ProviderError.ResponseStreamError)
+    // Must abort at ~firstTokenMs (500ms), not at ~idleMs (5000ms). The
+    // lower bound allows for setTimeout drift; the upper bound is well
+    // below any reasonable post-content idle window.
+    expect(elapsed).toBeGreaterThanOrEqual(400)
+    expect(elapsed).toBeLessThan(2_000)
   })
 })

--- a/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
@@ -34,14 +34,16 @@ function fromSchedule(events: Array<[number, FullStreamPart]>, end: number): Str
   )
 }
 
-// kilocode_change: raw AsyncIterable version of `fromSchedule` for tests that
-// exercise `watchdogAsyncIterable` directly. The production consumer in
-// `src/session/llm.ts` wraps the AI SDK's native `fullStream` AsyncIterable
-// and uses `watchdogAsyncIterable`, not `watchdogStream`, so the direct-unit
-// AC1/AC3 tests target that same entry point. A hand-rolled AsyncIterable is
-// also used because its `return()` settles promptly on cleanup (the
-// async-generator `return()`-mid-await semantics are described in the AC3
-// test comment).
+// kilocode_change: async-generator version of `fromSchedule` that yields an
+// `AsyncIterable` for tests driving `watchdogAsyncIterable` directly. The
+// production consumer in `src/session/llm.ts` wraps the AI SDK's native
+// `fullStream` AsyncIterable and uses `watchdogAsyncIterable`, not
+// `watchdogStream`, so the direct-unit AC1/AC3 tests target that same entry
+// point. This helper is fine for tests that COMPLETE normally (e.g. AC1). The
+// AC3 test, which must abort during a stall, instead uses a separate
+// hand-rolled `AsyncIterable` (not this generator) because an async
+// generator's `return()` cannot preempt an in-flight internal `await` — see
+// the AC3 test comment for that distinction.
 function iterableFromSchedule(
   events: Array<[number, FullStreamPart]>,
   end: number,

--- a/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
@@ -35,14 +35,13 @@ function fromSchedule(events: Array<[number, FullStreamPart]>, end: number): Str
 }
 
 // kilocode_change: raw AsyncIterable version of `fromSchedule` for tests that
-// exercise `watchdogAsyncIterable` directly (matching the production call
-// site in `session/llm.ts`, which wraps the AI SDK's native `fullStream`
-// AsyncIterable — not a Stream). Going through `Stream.toAsyncIterable` from
-// the `watchdogStream` entry point blocks the Node event loop on long stalls
-// (Effect's Stream round-trip drives the underlying generator synchronously
-// on the consumer's `next()` call), which prevents the watchdog's setTimeout
-// from firing. The production path does not go through that round-trip, so
-// the raw AsyncIterable is the accurate test target.
+// exercise `watchdogAsyncIterable` directly. The production consumer in
+// `src/session/llm.ts` wraps the AI SDK's native `fullStream` AsyncIterable
+// and uses `watchdogAsyncIterable`, not `watchdogStream`, so the direct-unit
+// AC1/AC3 tests target that same entry point. A hand-rolled AsyncIterable is
+// also used because its `return()` settles promptly on cleanup (the
+// async-generator `return()`-mid-await semantics are described in the AC3
+// test comment).
 function iterableFromSchedule(
   events: Array<[number, FullStreamPart]>,
   end: number,

--- a/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
@@ -109,17 +109,17 @@ describe("kilocode.session.llm.resolveIdleMs", () => {
     expect(KiloLLM.resolveIdleMs({ options: {}, fallback: { chunkTimeout: false } })).toBeUndefined()
   })
 
-  test("uses 60_000 default when nothing valid is configured", () => {
-    expect(KiloLLM.resolveIdleMs({ options: {} })).toBe(60_000)
+  test("uses 300_000 default when nothing valid is configured", () => {
+    expect(KiloLLM.resolveIdleMs({ options: {} })).toBe(300_000)
   })
 
-  test("uses 60_000 default when both prepared and fallback are invalid", () => {
+  test("uses 300_000 default when both prepared and fallback are invalid", () => {
     expect(
       KiloLLM.resolveIdleMs({
         options: { chunkTimeout: "x" },
         fallback: { chunkTimeout: -5 },
       }),
-    ).toBe(60_000)
+    ).toBe(300_000)
   })
 })
 

--- a/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
+++ b/packages/opencode/test/kilocode/session/session-stream-watchdog.test.ts
@@ -140,6 +140,13 @@ describe("kilocode.session.llm.watchdogStream", () => {
     expect(out.length).toBe(2)
   })
 
+  test("AC2: mid-response stall after first content is still aborted", async () => {
+    // A content part at t=0, then a long quiet gap that exceeds the idle window.
+    const stream = fromSchedule([[0, part("text-delta", { id: "t1", delta: "hi" })]], 400)
+    const err = await run(Effect.flip(Stream.runCollect(KiloLLM.watchdogStream(stream, 200))))
+    expect(err).toBeInstanceOf(ProviderError.ResponseStreamError)
+  })
+
   test("pending local tool calls suspend the idle timeout until they settle", async () => {
     // tool-call at t=0 (local). 250ms quiet gap then tool-result. A healthy AI
     // SDK run also emits finish-step + finish right after the tool-result, so

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -45,7 +45,7 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
   }),
 )
 
-// kilocode_change - S2b: under the first-content-aware fix, a slow FIRST
+// kilocode_change start - S2b: under the first-content-aware fix, a slow FIRST
 // content chunk is no longer raced against `chunkTimeout`; it is bounded by
 // the request `timeout` (or the Kilo default of 5 min) instead. With no
 // `timeout` configured here, a 250ms first-content delay is comfortably
@@ -124,6 +124,7 @@ it.live("chunkTimeout still aborts a mid-content stall after the first content c
     )
   }),
 )
+// kilocode_change end
 
 it.live("headerTimeout aborts when response headers do not arrive", () =>
   Effect.gen(function* () {

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -70,16 +70,16 @@ it.live("chunkTimeout does NOT abort a slow first content chunk (bounded by time
             messages: [{ role: "user", content: "hello" }],
           })
 
-          const error = yield* Effect.promise(async () => {
+          const { error, text } = yield* Effect.promise(async () => {
             try {
-              for await (const part of result.fullStream) {
-                if (part.type === "error") return part.error
-              }
+              const text = await result.text
+              return { error: undefined, text }
             } catch (error) {
-              return error
+              return { error, text: "" }
             }
           })
           expect(error).toBeUndefined()
+          expect(text).toBe("late")
         }),
       { config: providerConfig(server.url, { chunkTimeout: 50 }) },
     )

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -45,10 +45,56 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
   }),
 )
 
-it.live("chunkTimeout raises a response stream error when SSE body stalls", () =>
+// kilocode_change - S2b: under the first-content-aware fix, a slow FIRST
+// content chunk is no longer raced against `chunkTimeout`; it is bounded by
+// the request `timeout` (or the Kilo default of 5 min) instead. With no
+// `timeout` configured here, a 250ms first-content delay is comfortably
+// within that budget, so the stream completes without error. The previous
+// assertion (that this would raise `ProviderError.ResponseStreamError`) is
+// what the fix removes.
+it.live("chunkTimeout does NOT abort a slow first content chunk (bounded by timeout instead)", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
       Effect.promise(() => delayedBodyServer(250)),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const result = streamText({
+            model: yield* provider.getLanguage(model),
+            onError() {},
+            messages: [{ role: "user", content: "hello" }],
+          })
+
+          const error = yield* Effect.promise(async () => {
+            try {
+              for await (const part of result.fullStream) {
+                if (part.type === "error") return part.error
+              }
+            } catch (error) {
+              return error
+            }
+          })
+          expect(error).toBeUndefined()
+        }),
+      { config: providerConfig(server.url, { chunkTimeout: 50 }) },
+    )
+  }),
+)
+
+// kilocode_change - S2b AC9b: mid-content stall protection is preserved. After
+// the first content-bearing SSE `data:` chunk is observed, `wrapSSE` reverts
+// to racing subsequent reads against `chunkTimeout`; a stall past that window
+// must still raise `ProviderError.ResponseStreamError` (this is the protection
+// the raw-`fullStream` memory/agent consumers rely on — see plan AC9).
+it.live("chunkTimeout still aborts a mid-content stall after the first content chunk", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => contentThenStallServer(5000)),
       (server) => Effect.sync(() => server.server.close()),
     )
 
@@ -205,6 +251,25 @@ async function delayedBodyServer(delay: number, prelude = ""): Promise<{ server:
     setTimeout(() => {
       res.end('data: {"choices":[{"delta":{"content":"late"}}]}\n\ndata: [DONE]\n\n')
     }, delay)
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port")
+  return { server, url: `http://127.0.0.1:${address.port}` }
+}
+
+// Writes a content-bearing SSE `data:` chunk immediately, flushes, then holds
+// the connection open without sending any further bytes. Used to exercise the
+// post-first-content branch of `wrapSSE` (mid-content stall must still be
+// caught by `chunkTimeout`).
+async function contentThenStallServer(stallMs: number): Promise<{ server: Server; url: string }> {
+  const server = createServer((_, res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.flushHeaders()
+    res.write('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n')
+    setTimeout(() => {
+      res.end('data: {"choices":[{"delta":{"content":"there"}}]}\n\ndata: [DONE]\n\n')
+    }, stallMs)
   })
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
   const address = server.address()


### PR DESCRIPTION
## Problem

Users report (prod) that the kilo CLI agent LLM stream "stalls out": a session stops progressing mid-turn and never recovers until CLI restart. The prior per-chunk idle watchdog (#12249, re-landed #12438) masks the symptom but has since caused regression **#12467** — healthy slow streams are killed and retried in a loop.

## Root cause

The idle watchdog arms on the AI SDK's synthetic `start` part (emitted at ~t+2ms, before any provider byte) and then races the pull awaiting the **first content-bearing part** (`text-delta` / `reasoning-delta` / tool input) against the same per-chunk idle window used for inter-chunk gaps. That first wait is the provider's time-to-first-content / prompt-processing phase. On large-context / local / heavy-reasoning models it legitimately exceeds the idle window, so the watchdog aborts a healthy request; because the abort maps to a retryable `ProviderError.ResponseStreamError`, the turn immediately retries from scratch and re-triggers the same slow prompt processing — an endless failed-retry loop (#12467). The idle window also effectively overrode the provider's own request timeout.

A second, lower-level watchdog (`wrapSSE`, raw-fetch/SSE-byte layer) has the same first-content/inter-chunk conflation when a provider-level `chunkTimeout` is configured.

## Fix

Split the two waits the watchdogs conflate, keyed off the **first content-bearing part** (not the first pull):

- **Pre-content wait** (stream open → first content/tool part): no longer bounded by the idle window. Bounded instead by the provider's configured request `timeout` value, falling back to `DEFAULT_FIRST_TOKEN_MS = 300_000` (5 min) when `timeout` is unset/`false`/`0`/invalid — never unbounded while the watchdog is enabled. Structural parts (`start`, `start-step`, `text-start`, `reasoning-start`, `stream-start`) do **not** arm the idle window.
- **Inter-content idle** (after the first content/tool part): keeps the existing per-event idle watchdog (default 60s, still suspended while local tools run), preserving mid-response stall detection.

Applied at both layers:
- `KiloLLM.watchIterator` / `resolveFirstTokenMs` / `trackPart` in `packages/opencode/src/kilocode/session/llm.ts`, threaded into production via `run()` in `packages/opencode/src/session/llm.ts` (`firstTokenMs` travels with the returned stream through both branches and into `watchdogAsyncIterable`).
- `wrapSSE` in `packages/opencode/src/provider/provider.ts` gets an SSE-chunk-level first-content split (bytes are passed through untouched; parsing is observational only for budget selection).

Net effect: #12467's healthy slow streams survive (bounded by the real request timeout, no immediate retry loop); mid-response stalls are still caught in ~60s; a genuine never-first-content hang is bounded by the request `timeout` (or 5 min) instead of hanging forever or firing at 60s.

## Non-goals

- The watchdog is **not** reverted (its stall-detection value is kept); this supersedes the open revert direction.
- No stream reconnect/resume — abort+retry via the existing mapping is sufficient here.
- Does not adopt the `KILO_MAIN_SESSION_RESTART_LIMIT` main-session-restart approach (separate, broader mechanism).

## Behavior states

| State | Behavior | Coverage |
|---|---|---|
| Happy (fast first content, steady chunks) | completes; no watchdog fire | existing A/B/C + suites |
| Slow-but-alive (long time-to-first-content, provider alive within request timeout) | **not** aborted; completes; no retry loop | AC1 (integration `calls===1` + direct-unit) |
| Mid-response stall / dead stream after first content | aborted with `ResponseStreamError`; existing retry recovers | AC2 |
| Never-first-content hang past first-token budget | aborted once budget elapses; terminal error surfaced (no infinite hang, no tight retry loop) | AC3 |

## Test coverage

- **AC1**: slow first content is not aborted or retried — integration (`calls===1`, red on baseline: `calls===2`) + direct-unit parameterised.
- **AC2**: mid-response stall after first content still aborted (new enabled-watchdog coverage).
- **AC3**: never-first-content hang bounded by `firstTokenMs` (not `idleMs`, not never).
- **AC4**: existing local-tool-suspension / disabled-watchdog scenarios A/B/C unchanged.
- **AC9** (`wrapSSE` fetch layer, `test/provider/header-timeout.test.ts`): (a) slow first content no longer aborted by `chunkTimeout` (flipped, baseline-red→fix-green, now asserts content `"late"`); (b) mid-content stall after the first content chunk still raises `ResponseStreamError`.
- `bun run typecheck` and the watchdog + header-timeout suites pass; changeset added.

## Enforcement-layer audit (chunk-idle / stream-idle sites)

1. `opencode/src/kilocode/session/llm.ts` `watchIterator` — **live**; fixed (first-content split).
2. `opencode/src/provider/provider.ts` `wrapSSE` — **live** for provider-level `chunkTimeout`; fixed (first-content split).
3. `packages/core/src/aisdk.ts` `wrapSSE` — **dead for kilocode**: the inlined `provider.ts` custom fetch deletes `chunkTimeout` before SDK construction, and there are no `@opencode-ai/core/aisdk` consumers in `packages/opencode/src`. Left unchanged.
4. `opencode/src/plugin/openai/ws.ts` WS-pool `idleTimer` — **out of scope** (OpenAI Responses over WebSocket, `idleTimeout`, different transport).
5. `opencode/src/kilocode/cloud/websocket-stream.ts` `arm()` — **out of scope** (cloud-agent WS relay, different transport).

## Known limitation (documented)

`wrapSSE`'s first-content detection recognizes OpenAI chat-completions-shaped SSE (`choices[].delta` with `content`/`reasoning_content`/`tool_calls`). For non-chat-completions SSE shapes (Anthropic/Google/OpenAI-Responses) with an explicitly-configured provider-level `chunkTimeout`, mid-content stalls fall back to the `firstTokenMs` budget instead of `chunkTimeout` — still bounded (no hang), and the provider-agnostic session-layer `watchIterator` fully protects the main session path. A naive generalization is intentionally avoided because it would arm on OpenAI's immediate role-delta and reintroduce #12467. Documented in the `wrapSSE` header and the `chunkTimeout` option schema.

Fixes #12467.
