### PR TITLE
fix(core): strict OpenAI-compatible compaction failure caused by maxOutputTokens leak into provider options

### DIFF
--- a/.changeset/compaction-maxoutputtokens-leak.md
+++ b/.changeset/compaction-maxoutputtokens-leak.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix compilation failure against strict OpenAI-compatible providers during context compaction. The compaction path no longer leaks `maxOutputTokens` into provider options, which was rejected by strict upstreams with "Unsupported parameter(s)".

--- a/.changeset/compaction-maxoutputtokens-leak.md
+++ b/.changeset/compaction-maxoutputtokens-leak.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Fix compilation failure against strict OpenAI-compatible providers during context compaction. The compaction path no longer leaks `maxOutputTokens` into provider options, which was rejected by strict upstreams with "Unsupported parameter(s)".
+Fix compaction failure against strict OpenAI-compatible providers during context compaction. The compaction path no longer leaks `maxOutputTokens` into provider options, which was rejected by strict upstreams with "Unsupported parameter(s)".

--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -252,16 +252,10 @@ export namespace KiloCompactionChunks {
       const mdl = model(input.model, input.outputTokenMax)
       const worker = yield* input.processors.create({ assistantMessage: msg, sessionID: input.sessionID, model: mdl })
       const opts = input.agent.options
-      const agent = {
-        ...input.agent,
-        options: {
-          ...opts,
-          maxOutputTokens: Math.min(
-            mdl.limit.output,
-            typeof opts?.maxOutputTokens === "number" ? opts.maxOutputTokens : mdl.limit.output,
-          ),
-        },
-      }
+      // agent.options feeds into providerOptions; strip maxOutputTokens
+      // so it does not leak into the wire body. The output cap is enforced
+      // independently via the constrained model and llm.ts re-cap.
+      const agent = { ...input.agent, options: opts ?? {} }
       const out = yield* Effect.gen(function* () {
         const result = yield* worker.process({
           user: input.user,

--- a/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
+++ b/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
@@ -710,4 +710,137 @@ describe("KiloCompactionChunks", () => {
       },
     })
   })
+
+  test(
+    "compaction must not leak maxOutputTokens into agent options",
+    async () => {
+      await using tmp = await tmpdir()
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await svc.create({})
+          const first = await user(session.id, "first " + "a".repeat(20_000))
+          await assistant(session.id, first.id, tmp.path, "reply " + "b".repeat(20_000))
+          const second = await user(session.id, "second " + "c".repeat(20_000))
+          await assistant(session.id, second.id, tmp.path, "reply " + "d".repeat(20_000))
+          await Effect.runPromise(
+            KiloSessionCompaction.create({
+              session: store,
+              sessionID: session.id,
+              agent: "build",
+              model: ref,
+              auto: false,
+            }),
+          )
+
+          const captured: Array<{ opts: Record<string, unknown>; modelLimitOutput: number }> = []
+          const bus = Bus.layer
+          const processor = Layer.effect(
+            SessionProcessorModule.SessionProcessor.Service,
+            Effect.gen(function* () {
+              const sessions = yield* SessionNs.Service
+              return SessionProcessorModule.SessionProcessor.Service.of({
+                create: Effect.fn("TestSessionProcessorLeak.create")((input) =>
+                  Effect.succeed({
+                    get message() {
+                      return input.assistantMessage
+                    },
+                    updateToolCall: Effect.fn("TestSessionProcessorLeak.updateToolCall")(() =>
+                      Effect.succeed(undefined),
+                    ),
+                    metadata: Effect.fn("TestSessionProcessorLeak.metadata")(() => Effect.void),
+                    completeToolCall: Effect.fn("TestSessionProcessorLeak.completeToolCall")(() => Effect.void),
+                    process: Effect.fn("TestSessionProcessorLeak.process")((stream: LLM.StreamInput) =>
+                      Effect.gen(function* () {
+                        captured.push({
+                          opts: stream.agent.options as Record<string, unknown>,
+                          modelLimitOutput: stream.model.limit.output,
+                        })
+                        const text = stream.messages.some((msg) =>
+                          JSON.stringify(msg).includes("Create a new anchored summary"),
+                        )
+                          ? "final summary"
+                          : "chunk summary"
+                        yield* sessions.updatePart({
+                          id: PartID.ascending(),
+                          messageID: input.assistantMessage.id,
+                          sessionID: input.sessionID,
+                          type: "text",
+                          text,
+                        })
+                        input.assistantMessage.finish = "stop"
+                        return "continue" as const
+                      }),
+                    ),
+                  } satisfies SessionProcessor.Handle),
+                ),
+              })
+            }),
+          )
+
+          const model = ProviderTest.model({
+            providerID,
+            id: modelID,
+            limit: { context: 10_000, output: 1_000 },
+          })
+          const outputTokenMax = 512
+          const rt = ManagedRuntime.make(
+            Layer.mergeAll(SessionCompaction.layer.pipe(Layer.provide(processor)), processor, bus).pipe(
+              Layer.provide(ProviderTest.fake({ model }).layer),
+              Layer.provide(SessionNs.defaultLayer),
+              Layer.provide(agents),
+              Layer.provide(Plugin.defaultLayer),
+              Layer.provide(SyncEvent.defaultLayer),
+              Layer.provide(EventV2Bridge.defaultLayer),
+              Layer.provide(Database.defaultLayer),
+              Layer.provide(RuntimeFlags.layer({ outputTokenMax })),
+              Layer.provide(bus),
+              Layer.provide(
+                Layer.mock(Config.Service)({
+                  get: () => Effect.succeed({ ...{}, compaction: { reserved: 1_000 } }),
+                }),
+              ),
+            ),
+          )
+
+          try {
+            const msgs = await svc.messages({ sessionID: session.id })
+            const parent = msgs.at(-1)?.info.id
+            expect(parent).toBeTruthy()
+            const result = await rt.runPromise(
+              SessionCompaction.Service.use((svc) =>
+                svc.process({
+                  parentID: parent!,
+                  messages: msgs,
+                  sessionID: session.id,
+                  auto: false,
+                }),
+              ),
+            )
+
+            expect(result).toBe("continue")
+            expect(captured.length).toBeGreaterThan(0)
+            // Negative assertion (the bug surfacing):
+            // maxOutputTokens must not appear in agent.options that the
+            // worker hands to the LLM. Today a strict OpenAI-compatible
+            // upstream rejects that field with
+            // Unsupported parameter(s): maxOutputTokens`.
+            for (const c of captured) {
+              expect(c.opts.maxOutputTokens).toBeUndefined()
+            }
+            // Positive assertion (budget preserved through an independent path):
+            // the constrained model still threads a tightened output limit
+            // through to every worker. If a future "fix" accidentally severs
+            // the only budget source along with the leak, this fails.
+            for (const c of captured) {
+              expect(c.modelLimitOutput).toBeLessThanOrEqual(outputTokenMax)
+            }
+          } finally {
+            await rt.dispose()
+          }
+        },
+      })
+    },
+    30_000,
+  )
 })


### PR DESCRIPTION
## Issue

Fixes #12477

## Context

Compaction from the VS Code extension could fail with `upstream_error: ... "Unsupported parameter(s): 'maxOutputTokens'"` against strict OpenAI-compatible upstreams.

The bug is a provider-options leakage: `KiloCompactionChunks.run()` wrote the compaction output budget into `agent.options.maxOutputTokens` because `agent.options` was the path of least resistance that already flowed into the LLM. `LLMRequestPrep.prepare` then merges that bag into `providerOptions`, and the AI SDK serializes it verbatim into the request body. `maxOutputTokens` is an AI SDK option name, not an OpenAI wire field, so strict providers reject it.

The compaction budget is still enforced through the normal generation-parameter path. llm.ts computes and caps prepared.params.maxOutputTokens, then passes it to streamText as the top-level maxOutputTokens parameter. The AI SDK translates that into the provider-specific wire field (OpenAI → max_tokens/max_completion_tokens, Anthropic → max_tokens, etc.). The agent.options injection was therefore redundant and only caused the provider-options leak.

## Implementation

Single-site strip in `packages/opencode/src/kilocode/session/compaction-chunks.ts:run()` — drop the `maxOutputTokens` write into `agent.options` while preserving the rest of the user's options verbatim via spread. No call-site or type changes. Mirrors the existing `stripInternalOptions` pattern used for sibling leaks (`id`, `displayName`, `source`, `reference`, `resolved` per kilo PRs https://github.com/Kilo-Org/kilocode/commit/c94a097758 and https://github.com/Kilo-Org/kilocode/commit/275af49905).

Deliberate non-fix in `request.ts`: extending `stripInternalOptions` to denylist `maxOutputTokens` would also strip values users explicitly configure on non-compaction turns. Out of scope here — the issue is about compaction, built-in agents default `options: {}`, and the user-facing question is its own PR.

The fix follows the same leak-class precedent as `plugin/github-copilot`, `plugin/cloudflare`, and `session/llm/request.ts` (`gpt-5` openai-compatible), all of which strip `maxOutputTokens` for the same upstream schema reasons.

## Screenshots / Video

N/A — internal provider-options reshaping, no visual change.

| before | after |
|---|---|
|  |  |

## How to Test

### Manual/local verification

- Targeted regression test: `bun test ./packages/opencode/test/kilocode/session-compaction-chunks.test.ts -t "must not leak"` — captures every worker invocation, asserts `agent.options.maxOutputTokens === undefined` and `model.limit.output <= outputTokenMax` (budget preserved on independent path).

### Reviewer test steps

1. Run `bun test ./packages/opencode/test/kilocode/session-compaction-chunks.test.ts -t "must not leak"` from `packages/opencode/`. Expect 1 pass, 0 fail.
2. To verify negative: temporarily revert the source change in `run()`, rerun the test, expect fail at `expect(c.opts.maxOutputTokens).toBeUndefined()` with `Received: 512`.
3. To verify the existing adjacent tests still cover the budget, run `bun test ./packages/opencode/test/kilocode/session-compaction-chunks.test.ts -t "caps worker output budget"` — passes both before and after the fix, confirming the cap path is independent of the stripped injection.

### Blocked checks and substitute verification

- Two pre-existing tests in the same file (`preserves gateway errors from chunk workers`, `compacts oversized replay turns after overflow compaction`) time out under bun:test's 5000ms default. Verified by running them on unmodified `main` with my change stashed — they fail identically there. Unrelated to this PR. Suggested follow-up: raise the per-test timeout on those cases.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (user-facing impact: contexts that previously failed outline compaction against strict providers now succeed; no API/CLI surface change)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@TRAVIX26 Discord
