### PR TITLE
docs: show object-form bash permission example in kilo-config skill

### DIFF
--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -127,7 +127,12 @@ Scalar form applies to all patterns. Object form maps glob patterns to actions. 
 ```jsonc
 {
   "permission": {
-    "bash": "allow", // scalar: allow all bash
+    "bash": {
+      // object form: glob patterns (scalar "allow" also valid)
+      "git push*": "deny",
+      "git reset --hard*": "deny",
+      "*": "ask",
+    },
     "edit": {
       // object: pattern-matched
       "src/**": "allow",


### PR DESCRIPTION
## Context
Fixes #10797. The kilo-config builtin skill showed bash permissions only as a scalar allow example, but the JSON schema (PermissionRuleConfig) supports the same glob-object form as edit.

## Implementation
Updated the Permissions jsonc example in packages/opencode/src/kilocode/skills/kilo-config.md to include a bash object/glob block alongside the existing edit example.

## Screenshots
N/A (docs-only).

## How to Test
- Manual review of the jsonc example against https://app.kilo.ai/config.json PermissionRuleConfig schema
- bun test ./test/kilocode/builtin-skills.test.ts (from packages/opencode/) when Bun is available

## Get in Touch
GitHub: @singhvishalkr

Made with [Cursor](https://cursor.com)