### PR TITLE
docs: review OpenCode v1.17.9 merge

### DIFF
--- a/BROKEN_PIPELINE_CHAINS.md
+++ b/BROKEN_PIPELINE_CHAINS.md
@@ -1,0 +1,76 @@
+# Broken Pipeline Chains Review
+
+Reviewed PR #12460 at `51d8031c9997bd5478bcde715562169f732d04d4` against `origin/main` (`b367105c8d648c8e05b62c2d27a28a95a4772f61`) and upstream `v1.17.9` (`5c23e88419c4743b9be42cea132f2fb1e6cb63ff`). I traced changed `kilocode_change` behavior and Kilo-owned consumers across the relocated core/server/SDK/HTTP/PTY layers, credential and organization routing, MCP roots, V2 event/UI projection, shell relocation, and markdown worker/theme/Mermaid paths. This review targets broken propagation chains rather than compile-time or style issues.
+
+## Findings
+
+### Resolved, previously high severity: Completed Mermaid fences were passed to Mermaid with their Markdown delimiters
+
+`stream()` correctly separates a code block's Markdown identity from its source: a completed ` ```mermaid ... ``` ` token has `raw` equal to the whole fenced block but `src` equal to `graph TD...` ([`markdown-stream.ts:67-70`](packages/ui/src/components/markdown-stream.ts#L67-L70), [`markdown-stream.ts:81-84`](packages/ui/src/components/markdown-stream.ts#L81-L84)). The new Kilo-specific branch initially carries that source in `unstable` ([`markdown.tsx:378-394`](packages/ui/src/components/markdown.tsx#L378-L394)), but `updateCodeBlock()` drops it and writes `block.raw` into `code[data-lang="mermaid"]` ([`markdown.tsx:709-720`](packages/ui/src/components/markdown.tsx#L709-L720)). `renderMermaid()` then reads that DOM text and passes it directly to `mermaid.parse()`/`render()` ([`markdown-mermaid.ts:398-403`](packages/ui/src/kilocode/markdown-mermaid.ts#L398-L403), [`markdown-mermaid.ts:430-435`](packages/ui/src/kilocode/markdown-mermaid.ts#L430-L435)).
+
+The resulting source begins with ` ```mermaid`, which Mermaid rejects as not having a diagram type. Reproduced from this checkout:
+
+```text
+$ bun -e 'import mermaid from "mermaid"; ...'
+ok "graph TD\n  A-->B"
+fail "```mermaid\ngraph TD\n  A-->B\n```" No diagram type detected matching given configuration for text: ```mermaid
+graph TD
+  A-->B
+```
+```
+
+The merge follow-up now preserves `Block.src` separately from fenced `raw` identity and writes the delimiter-free source into `code[data-lang="mermaid"]`. A real VS Code Storybook/Chromium test renders the completed flowchart SVG and verifies the DOM source contains `flowchart TD` without a Markdown fence.
+
+### Resolved review concern: queued steering remains actionable without restoring the removed wrapper
+
+The Kilo queue intentionally leaves the active prompt's historical messages in the next request and moves the queued target to the end to avoid an invalid assistant prefill ([`prompt-queue.ts:84-119`](packages/opencode/src/kilocode/session/prompt-queue.ts#L84-L119)). Before the merge, when a later LLM step followed a finished assistant, every non-synthetic user text chronologically after that assistant was wrapped as a system reminder requesting the model to address it ([`origin/main:session/prompt.ts:1710-1730`](packages/opencode/src/session/prompt.ts#L1710-L1730)). The PR removes that only conversion and now forwards the same queued/history message content unmodified ([`session/prompt.ts:1698-1707`](packages/opencode/src/session/prompt.ts#L1698-L1707)).
+
+The surrounding queue machinery is still active: `prompt()` serializes a follow-up behind the current loop without cancelling the in-flight stream ([`session/prompt.ts:1406-1429`](packages/opencode/src/session/prompt.ts#L1406-L1429)), and the next loop scopes/reorders the message set ([`session/prompt.ts:1471-1481`](packages/opencode/src/session/prompt.ts#L1471-L1481)). Therefore a user follow-up received while the previous turn is executing tools is still propagated to the continuation request, but it no longer receives the explicit Kilo priority/continuation instruction that made it actionable amid the original task and tool results.
+
+The removed wrapper was an intentional upstream fix: it mutated cached persisted messages into synthetic system reminders and was not part of Kilo's queued-turn request path after `KiloSessionPromptQueue.scope()` hides the later prompt from the active turn. Restoring it would reintroduce the cache mutation bug without improving queue steering. The merge follow-up instead fixes the real race by registering the follow-up slot before dismissing a pending question/suggestion, then adds an isolated real question-tool test. That test proves the dismissed old turn does not make another LLM request, the queued steering prompt is the next user message, and no stale `<system-reminder>` wrapper is injected.
+
+## Verified Chains / Non-Findings
+
+- **PTY self-command and shell environment remain connected; credential stripping is now hardened.** The deleted `PtyPreparation` behavior was moved rather than dropped: `Pty.create()` resolves bare `kilo`/`kilocode`, adopts the location/configured shell, and sets `KILO_TERMINAL`/`KILO_PTY_ID`. The follow-up child-process test exposed that deleting server credential keys was insufficient because node-pty inherited missing keys from the parent environment. Core now passes empty tombstones for both server credentials. The canonical `/api/pty` regression proves caller/plugin precedence, forced terminal identity, and empty credentials inside the spawned shell.
+
+- **Kilo OAuth organization routing reaches the gateway.** The newly explicit credential lookup selects the active integration connection, loads the credential, maps OAuth `metadata.accountID` to `kilocodeOrganizationId`, and removes the legacy `accountID` body field ([`session/runner/model.ts:89-125`](packages/core/src/session/runner/model.ts#L89-L125), [`session/runner/model.ts:146-168`](packages/core/src/session/runner/model.ts#L146-L168)). That request body enters AI SDK options ([`aisdk.ts:60-66`](packages/core/src/aisdk.ts#L60-L66)), Kilo's plugin constructs `createKilo` with those options ([`plugin/provider/kilo.ts:12-42`](packages/core/src/plugin/provider/kilo.ts#L12-L42)), and the gateway uses the organization option to produce request headers ([`kilo-gateway/src/provider.ts:39-70`](packages/kilo-gateway/src/provider.ts#L39-L70)). Targeted credential/provider tests passed.
+
+- **MCP roots propagation is complete.** The new client factory reads the active `InstanceState.directory`, advertises `roots`, and is used for normal transport connects and OAuth authorization connects ([`mcp/index.ts:111-117`](packages/opencode/src/mcp/index.ts#L111-L117), [`mcp/index.ts:231-245`](packages/opencode/src/mcp/index.ts#L231-L245), [`mcp/index.ts:833-840`](packages/opencode/src/mcp/index.ts#L833-L840)). No disconnected `new Client` path remains in the runtime MCP service.
+
+- **Catalog/integration event consumers were updated.** Core replaced model-only catalog events with `catalog.updated` and publishes after catalog finalization ([`core/src/catalog.ts:36-38`](packages/core/src/catalog.ts#L36-L38), [`core/src/catalog.ts:189-199`](packages/core/src/catalog.ts#L189-L199)). The V2 TUI data layer refreshes both models and providers on the new event and refreshes integration/models/providers after integration changes ([`tui/src/context/data.tsx:142-148`](packages/tui/src/context/data.tsx#L142-L148), [`tui/src/context/data.tsx:449-456`](packages/tui/src/context/data.tsx#L449-L456)). Targeted data tests cover the new event path.
+
+- **Kilo theme transfer to the Markdown worker is connected.** The raw Kilo Shiki theme is exported in the marked context, sent during worker initialization, registered by the worker, and used in streaming and completed-token highlighting ([`context/marked.tsx:27-401`](packages/ui/src/context/marked.tsx#L27-L401), [`markdown-worker.ts:66-121`](packages/ui/src/components/markdown-worker.ts#L66-L121), [`markdown-shiki.worker.ts:30-53`](packages/ui/src/components/markdown-shiki.worker.ts#L30-L53)). Pierre registration also retains a synchronous consumer path via `ensureKiloDiffTheme()`.
+
+- **CORS relocation retains Kilo origins.** Shared server CORS imports the Kilo-owned matcher and applies it before configured origins ([`server/src/cors.ts:1-27`](packages/server/src/cors.ts#L1-L27)); the relocated matcher accepts `https://*.kilo.ai` ([`server/src/kilocode/cors.ts:1-5`](packages/server/src/kilocode/cors.ts#L1-L5)). The legacy Kilo server module no longer owns a competing CORS implementation.
+
+## Command Outputs
+
+```text
+HEAD:        51d8031c9997bd5478bcde715562169f732d04d4
+origin/main: b367105c8d648c8e05b62c2d27a28a95a4772f61
+v1.17.9:     5c23e88419c4743b9be42cea132f2fb1e6cb63ff
+
+$ bun test test/server/httpapi-v2-pty.test.ts test/kilocode/provider-saved-auth.test.ts test/provider/provider.test.ts
+95 pass, 0 fail
+
+$ bun test test/kilocode/session-runner-model.test.ts test/plugin/provider-kilo.test.ts
+8 pass, 0 fail
+
+$ bunx playwright test tests/markdown-mermaid.spec.ts --project=chromium
+1 pass, 0 fail; rendered a real flowchart SVG from delimiter-free source
+
+$ bun run script/test-runner.ts kilocode/session-prompt-queue.test.ts kilocode/session-prompt-steering.test.ts --concurrency 1 --retries 0
+2 files passed, 0 failed
+
+$ bun test test/cli/tui/data.test.tsx test/cli/tui/sync.test.tsx test/kilocode/tui-sync-event.test.ts
+10 pass, 0 fail
+```
+
+The TUI command emitted pre-existing/non-fatal missing `/tmp/opencode/state/kv.json` warnings but completed successfully. `git diff --check origin/main...HEAD` reports whitespace warnings in the added Pierre patch; that is outside this behavior-chain review.
+
+## Limitations
+
+- This was a static and targeted-test review of the requested range. It did not launch authenticated Kilo Gateway requests, real MCP servers, or an interactive TUI/VS Code instance.
+- Windows-specific PTY behavior was not exercised on this Darwin host.
+
+Summary: the confirmed Mermaid chain and the real queued-question ordering race are fixed and exercised end to end. The removed legacy steering wrapper remains intentionally absent. Report: `BROKEN_PIPELINE_CHAINS.md`.

--- a/CONFIG_REGRESSION.md
+++ b/CONFIG_REGRESSION.md
@@ -1,0 +1,55 @@
+# Config Regression Review
+
+## Scope and Method
+
+Reviewed PR #12460 at `51d8031c9997bd5478bcde715562169f732d04d4` against `origin/main` (`b367105c8d648c8e05b62c2d27a28a95a4772f61`), with `v1.17.9` as the upstream comparison point. The audit covered changed additions plus executable configuration discovery/loading, directory resolution, TUI configuration, agent/command/skill/plugin discovery, environment overrides, migration behavior, and user-facing help.
+
+I traced path candidates to readers rather than treating package names, test fixtures, `.opencode-version`, or legacy migration inputs as live `.opencode` directory fallback behavior.
+
+## Findings
+
+Finding 1: no configuration fallback regression found. Severity: none. Confidence: high.
+
+The PR does not restore live `.opencode` directory discovery or remove/reorder the Kilo directory lookup. The relevant live-reader paths are unchanged from `origin/main`:
+
+- `packages/core/src/config.ts:177-205` discovers only `.kilo` and legacy `.kilocode` directories, filters directories to those two names, and loads their documents before configuration plugins consume agents, commands, skills, and providers. It does not include `.opencode`.
+- `packages/opencode/src/config/paths.ts:24-40` remains the Kilo override of upstream v1.17.9's `.opencode` path helper: both project and home scans target only `.kilocode` and `.kilo`; explicit directory configuration is only `KILO_CONFIG_DIR`.
+- `packages/opencode/src/config/tui.ts:184-231` continues to resolve TUI configuration from global files, `KILO_TUI_CONFIG`, root `tui.json(c)`, and `.kilo`/`.kilocode` directories. It filters out `.opencode` before reads.
+- `packages/opencode/src/kilocode/config/config.ts:445-448` accepts only `.kilo`, `.kilocode`, or explicit `KILO_CONFIG_DIR` as a configuration directory. `:459-505` probes `.opencode` only to emit the migration notification, and `packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts:325-345` only appends that notification.
+- `packages/core/src/config/plugin/agent.ts:103-114`, `packages/core/src/config/plugin/command.ts:53-68`, and `packages/core/src/config/plugin/skill.ts:20-46` read only directories supplied by the above `Config` service. Therefore none creates an independent `.opencode` agent, command, or skill fallback.
+
+Expected behavior remains: only `.kilo` configuration directories are canonical; `.kilocode` remains the intentional legacy directory fallback; `.opencode` directories are not read as configuration, TUI, agent, command, skill, or plugin sources.
+
+## Notable Non-Findings
+
+- `packages/core/src/plugin/skill/customize-opencode.md` adds OpenCode command-path documentation, and `packages/core/src/plugin/skill.ts:24-29` updates its trigger text. This is an upstream-facing embedded help asset, not a path resolver. More importantly, `packages/core/src/plugin/boot.ts:99-112` does not add `SkillPlugin.Plugin`; only `ConfigSkillPlugin.Plugin` is registered. Its `.opencode` examples cannot activate a live fallback in the current CLI boot path. The separately retained `packages/core/test/plugin/skill.test.ts` exercises manual registration only.
+- The two new `opencode.json` writes in changed HTTP integration tests configure temporary upstream-compatible test fixtures. They do not alter production discovery or add a candidate to a production reader.
+- Root/global `opencode.json(c)` filenames remain intentional legacy compatibility inputs in the Kilo configuration chain. They are distinct from `.opencode` directories and were present before this PR. Existing precedence remains Kilo filenames before legacy OpenCode filenames, including `packages/opencode/src/kilocode/config/config.ts:40-79` and `packages/opencode/src/config/config.ts:191-200, 360-366`.
+- The upstream v1.17.9 baseline scans `.opencode` in `packages/opencode/src/config/paths.ts`; reviewed HEAD preserves Kilo's prior override to `.kilo`/`.kilocode`. No upstream fallback was restored by this merge.
+- The PR does not modify live configuration modules under `packages/opencode/src/kilocode/config/`, `packages/opencode/src/kilocode/tui/`, `packages/core/src/config.ts`, or the Kilo path override in `packages/opencode/src/config/paths.ts`. The only changed file under `packages/core/src/config/` is provider application logic (`packages/core/src/config/plugin/provider.ts`), which consumes already-discovered entries and introduces no filesystem reads.
+
+## Command Outputs
+
+```text
+git merge-base origin/main 51d8031c9997bd5478bcde715562169f732d04d4
+3572898618a5a3082ae5d476e62d1e091e79be62
+
+git diff --quiet origin/main...51d8031c -- [live config/discovery modules]
+config-discovery-diff-exit=0
+
+bun test test/kilocode/config/config.test.ts test/kilocode/server/tui-config.test.ts test/skill/skill.test.ts
+54 pass
+0 fail
+148 expect() calls
+Ran 54 tests across 3 files. [31.39s]
+```
+
+The relevant passing coverage explicitly asserts `.kilo` wins over `.kilocode` and `.opencode` is ignored (`packages/opencode/test/kilocode/config/config.test.ts:551-637`), that TUI config ignores `.opencode` (`packages/opencode/test/kilocode/server/tui-config.test.ts:46-63`), and that skill discovery ignores `.opencode` (`packages/opencode/test/skill/skill.test.ts:197-229`).
+
+## Limitations
+
+- This was a static call-chain audit plus targeted automated tests, not an end-to-end manually launched CLI or extension session with every environment/global configuration combination.
+- Legacy root/global `opencode.json(c)` compatibility is pre-existing, intentional behavior outside the requested `.opencode` directory fallback regression check. It was checked for ordering regressions, not proposed for removal.
+- The inactive `customize-opencode` built-in help asset was assessed from its registration path. If a future boot path registers `SkillPlugin.Plugin`, its upstream-only guidance should be reviewed again separately for product-facing Kilo configuration advice.
+
+Summary: no PR-introduced `.opencode` directory fallback or `.kilo` lookup regression found. Report: `CONFIG_REGRESSION.md`.

--- a/INFRASTRUCTURE_CHANGE.md
+++ b/INFRASTRUCTURE_CHANGE.md
@@ -1,0 +1,50 @@
+# Infrastructure Change Review
+
+## Scope And Methodology
+
+Reviewed the requested merge range `origin/main...HEAD` at reviewed head `51d8031c9997bd5478bcde715562169f732d04d4` (merge base `3572898618a5a3082ae5d476e62d1e091e79be62`). The local upstream reference `v1.17.9` resolves to `5c23e88419c4743b9be42cea132f2fb1e6cb63ff`.
+
+The review classified only infrastructure-related changes: CI/workflows, package-manager and workspace metadata, lockfile and patched dependencies, generated SDK/build artifacts, changesets, and upstream-merge automation. Relevant files were diffed against `origin/main`, and dependency patches, SST declaration file sets, and selected package/build inputs were compared with `v1.17.9`. This is a read-only review; no reviewed source or configuration file was modified.
+
+## Findings
+
+1. **Severity: Medium | Confidence: High**. The reviewed PR made the published `@opencode-ai/http-recorder` package point users to OpenCode instead of Kilo for its homepage and issue tracker. This review branch resolves the finding and extends merge automation to preserve the Kilo values.
+
+   - At the reviewed head, `packages/http-recorder/package.json:13` changed `homepage` from the Kilo repository to the upstream package path.
+   - At the reviewed head, `packages/http-recorder/package.json:14` changed `bugs` from Kilo Issues to the upstream issue tracker.
+   - This is an accidental upstream adoption: the same file retains the Kilo `repository.url` at `packages/http-recorder/package.json:8-12`, producing internally inconsistent npm metadata. `origin/main` had Kilo URLs for all three fields; `v1.17.9` has the adopted OpenCode `homepage` and `bugs` values.
+   - The review follow-up restores the package metadata and extends `script/upstream/transforms/transform-package-json.ts` to preserve `repository`, `homepage`, and `bugs`, with focused regression coverage.
+
+## Expected Or Generated Infrastructure Changes
+
+- `.opencode-version` advances from `v1.17.5` to `v1.17.9`, and `.changeset/opencode-v1-17-5-to-v1-17-9.md` provides the expected Kilo release-note automation for the integrated upstream range.
+- Workspace dependency inputs in `package.json`, `packages/ui/package.json`, and `bun.lock` adopt the v1.17.9 UI stack: `@pierre/diffs` 1.2.10, Shiki 4.2.0, `@shikijs/stream`, and TanStack Solid Virtual. The lockfile changes are consistent with these declarations.
+- `bunfig.toml:3-5` retains Kilo's stricter 410520-second supply-chain quarantine rather than adopting upstream's 259200-second policy. Its only range change adds the required `@pierre` package exclusions.
+- The updated MCP patch and four added patches in `patches/` are all byte-identical to their v1.17.9 counterparts. They are expected dependency inputs for the upstream UI and provider changes, not Kilo-specific substitutions.
+- `packages/sdk/openapi.json` and the v2 TypeScript SDK outputs are generated API artifacts that incorporate the integrated PTY and capability endpoints. The eleven added package-level `sst-env.d.ts` declarations match the upstream v1.17.9 file set. `packages/kilo-docs/source-links.md` is the corresponding source-link generated artifact.
+- `script/upstream/merge.ts` and `script/upstream/utils/git.ts` add a compatibility-tree overlay: unchanged upstream paths retain their prior Kilo content while changed upstream paths are overlaid from the transformed tree. `script/upstream/utils/git.test.ts` covers Kilo-only files, unchanged Kilo content, additions, removals, and `.opencode-version`. This is Kilo-specific merge infrastructure, not upstream workflow adoption.
+
+## Notable Non-Findings
+
+- **No GitHub Actions workflows were added, removed, renamed, or changed in `origin/main...HEAD`.** `git diff --name-status origin/main...HEAD -- .github/workflows` produced no output.
+- The workflow allowlist remains intact. `bun run script/check-workflows.ts` reported `check-workflows: ok (27 workflows).` The allowlist guard was not changed by this range.
+- No changes were made to GitHub Actions composite actions, issue templates, Dependabot configuration, Docker/build-container files, Nix inputs, SST configuration, Turborepo configuration, or release/deploy workflow definitions.
+- The package metadata changes in the remaining workspace packages only reorder existing CI/test scripts or add the upstream-required UI dependency; no package-manager version, workspace membership, root build script behavior, or lockfile integrity policy was unintentionally replaced.
+- `git diff --check` reports the embedded unified-diff syntax in the newly added `patches/@pierre%2Ftrees@1.0.0-beta.4.patch` as space-before-tab and blank-line whitespace. The patch is byte-identical to v1.17.9; these diagnostics are expected when Git checks the outer addition of a patch file containing tab-indented inner context, not an independent patch-format defect.
+
+## Command Outputs
+
+| Command | Relevant output |
+|---|---|
+| `git diff --name-status origin/main...HEAD -- .github/workflows` | No output, therefore no workflow file changes. |
+| `bun run script/check-workflows.ts` | `check-workflows: ok (27 workflows).` |
+| `git diff --check origin/main...HEAD` | Exit code 2. Reports nested unified-diff context in `patches/@pierre%2Ftrees@1.0.0-beta.4.patch`; see the corresponding notable non-finding. |
+| `git diff --check origin/main...HEAD -- ':!patches/@pierre%2Ftrees@1.0.0-beta.4.patch'` | Exit code 0. |
+| Infrastructure-scoped diff stat | 34 relevant files changed, 4,058 insertions and 2,716 deletions, dominated by regenerated OpenAPI/SDK artifacts. |
+| Patch comparison with `v1.17.9` | The updated MCP patch plus the four new dependency patches have identical SHA-256 values at `HEAD` and `v1.17.9`. |
+
+## Limitations
+
+- No `bun install`, build, release/deploy command, or SDK regeneration was run because this was a read-only infrastructure review. A clean frozen-lockfile install should verify that the new `@pierre/trees` patch applies to its installed distribution files.
+- The locally available `v1.17.9` tag was used for upstream comparison; no remote fetch was performed.
+- Generated OpenAPI/SDK content was reviewed as an artifact diff and correlated with the integrated server API changes, but was not independently regenerated in this review.

--- a/KILOCODE_CHANGE_MARKERS.md
+++ b/KILOCODE_CHANGE_MARKERS.md
@@ -1,0 +1,51 @@
+# Kilo Change Marker Review
+
+## Scope And Method
+
+Reviewed `origin/main...HEAD` at `51d8031c9997bd5478bcde715562169f732d04d4`, using `v1.17.9` (`5c23e88419c4743b9be42cea132f2fb1e6cb63ff`) as the upstream-merged release baseline. **208 changed files** were checked, including renames, deletions, generated artifacts, Kilo-owned paths, and shared code. For each changed file, I compared the merge-base PR diff with the final `HEAD` version and, where relevant, the `v1.17.9..HEAD` Kilo delta.
+
+The review focused on every removed or moved `kilocode_change` marker, remaining Kilo-only behavior, marker scope, Kilo helper/test deletions, and package moves. It did not treat the repository checker as sufficient evidence because this range contains an upstream-merge-resolution commit.
+
+## Findings
+
+No confirmed accidentally removed, moved, over-broad, or under-broad `kilocode_change` markers found. **Confidence: high.**
+
+The separate unnecessary-marker audit found 27 surviving annotations whose code matched transformed upstream. The merge follow-up removes those stale annotations while preserving all actual Kilo deltas; see `UNNECESSARY_MARKERS.md`.
+
+## Notable Non-Findings
+
+- **High confidence:** The two removed markers in `packages/core/src/catalog.ts` correctly disappear with the old credential-to-provider projection. Upstream v1.17.9 moves credential selection into integration connections. Kilo's organization routing is preserved, narrowly marked, in `packages/core/src/session/runner/model.ts:99-104`, with dedicated coverage in `packages/core/test/kilocode/session-runner-model.test.ts:10-56`.
+
+- **High confidence:** Deleting `packages/opencode/src/pty-preparation.ts` removes five markers only because PTY setup moved to the shared core service. Kilo self-command resolution, parent PTY identity, and server-credential scrubbing remain marked in `packages/core/src/pty.ts:11`, `packages/core/src/pty.ts:201-225`; the moved helper is Kilo-owned at `packages/core/src/kilocode/pty-self-command.ts`. The legacy handler still applies the plugin `shell.env` hook before invoking core in `packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts:69-82`. The replacement behavior has direct PTY and HTTP API tests.
+
+- **High confidence:** The removed chronology marker in `packages/opencode/src/session/prompt.ts` belongs to upstream's removed steering-wrapper loop. That enclosing behavior is absent from v1.17.9 as well. Kilo chronology protection remains where it is still needed at `packages/opencode/src/session/prompt.ts:1479-1494`, and the queue-specific ordering logic stays in the Kilo-owned `packages/opencode/src/kilocode/session/prompt-queue.ts:99-119`.
+
+- **High confidence:** The deleted Kilo-owned markdown stable-block helper and tests, `packages/ui/src/kilocode/markdown-stable-blocks.ts` and `packages/ui/src/kilocode/markdown-stable-blocks.test.ts`, are superseded by upstream's richer projection model in `packages/ui/src/components/markdown-stream.ts:52-110`. Kilo-only Mermaid rendering, Kilo theme forwarding, directionality, and highlighted-block preservation remain independently marked in `packages/ui/src/components/markdown.tsx:20-23`, `packages/ui/src/components/markdown.tsx:374-383`, `packages/ui/src/components/markdown.tsx:507-545`, and `packages/ui/src/context/marked.tsx:27-31`.
+
+- **High confidence:** Marker movements caused by package extraction are semantically narrow and intact. Examples include PowerShell handling moved to Kilo-owned `packages/core/src/kilocode/powershell.ts` and imported from marked `packages/core/src/shell.ts:11`, plus CORS allowlisting moved from the old server file to the marked call in `packages/server/src/cors.ts:2,24`, with the Kilo regex isolated in `packages/server/src/kilocode/cors.ts`.
+
+- **High confidence:** The 12 files that remove marker text are accounted for by the upstream catalog/PTY/markdown/prompt refactors or marker relocation. No removed marker leaves an unannotated Kilo delta. Some surviving annotations are no longer necessary because the transformed upstream baseline now contains the same code; those maintenance findings are reported separately in `UNNECESSARY_MARKERS.md`. Generated SDK/OpenAPI files and dependency patches do not require source annotation markers.
+
+## Automated Evidence
+
+- `git diff --name-only origin/main...HEAD | wc -l`: `208`, matching the reviewed changed-file count.
+
+- `git diff --name-status --find-renames origin/main...HEAD`: identified 12 rename/delete entries. The only deleted shared file carrying markers was `packages/opencode/src/pty-preparation.ts`; its behavior was traced to the core PTY and handler paths above.
+
+- `git diff --unified=0 origin/main...HEAD | rg '^[+-].*kilocode_change'`: identified marker movements/removals for semantic review. No unexplained marker removal remained after comparison with `v1.17.9` and `HEAD`.
+
+- `bun script/check-opencode-annotations.ts --base origin/main`: output `Skipping shared upstream annotation check - upstream merge detected.` The range includes `a51864cd75d3f6f4785f2b845a268f3fde4bec97 resolve merge conflicts`, so this result is informational only, not a pass.
+
+- Independent release-baseline coverage scan over all changed source files, excluding Kilo-owned, generated, and checker-exempt paths: no changed `v1.17.9..HEAD` source line requiring a marker was left uncovered. This supplements the skipped repository checker and includes the newly extracted `packages/core` and `packages/server` paths that the repository checker does not enumerate in its shared scopes.
+
+- `git diff --check origin/main...HEAD -- ':!patches/@pierre%2Ftrees@1.0.0-beta.4.patch'`: passed with no output.
+
+## Limitations
+
+- The annotation guard intentionally skips upstream merge ranges, including this one, so it cannot independently prove marker correctness. The finding is based on manual three-way semantic review plus the release-baseline coverage scan.
+
+- `git diff --check origin/main...HEAD` reports whitespace in the upstream-added vendored patch `patches/@pierre%2Ftrees@1.0.0-beta.4.patch`. This is unrelated to markers; excluding that patch yields a clean whitespace check.
+
+- No application test or typecheck suite was run. This was a read-only annotation-provenance review; those suites do not validate marker scope or ownership, and the report calls out the directly relevant annotation checks above.
+
+- Existing untracked reports (`CONFIG_REGRESSION.md`, `INFRASTRUCTURE_CHANGE.md`, `OPENCODE_MENTIONS.md`, and `TESTS.md`) were present in the worktree and were not inspected or modified.

--- a/OPENCODE_MENTIONS.md
+++ b/OPENCODE_MENTIONS.md
@@ -1,0 +1,71 @@
+# OpenCode Branding Review
+
+**Scope and methodology**
+
+Reviewed PR #12460 at `51d8031c9997bd5478bcde715562169f732d04d4` over `origin/main...HEAD` (`b367105c8d648c8e05b62c2d27a28a95a4772f61...51d8031c9997bd5478bcde715562169f732d04d4`). Searched added lines and surrounding user-facing UI, CLI/TUI, help, documentation, package metadata, OpenAPI/SDK, prompts, skills, headers, and URLs for `OpenCode`, `opencode`, `opencode.ai`, and `anomalyco/opencode`. Compared ambiguous additions with upstream tag `v1.17.9` (`5c23e88419c4743b9be42cea132f2fb1e6cb63ff`) and traced generated/runtime API rebranding.
+
+**Findings**
+
+1. **Medium severity, high confidence: The reviewed PR routed published `@opencode-ai/http-recorder` metadata users to OpenCode. This review branch resolves the finding.**
+
+   References: `packages/http-recorder/package.json:13-14`.
+
+   At the reviewed head, the user-facing values pointed to the upstream package path and issue tracker. The review follow-up restores the Kilo values:
+
+   ```json
+   "homepage": "https://github.com/Kilo-Org/kilocode/tree/main/packages/http-recorder",
+   "bugs": "https://github.com/Kilo-Org/kilocode/issues"
+   ```
+
+   These fields are exposed by package registries and package tooling, so the reviewed head sent users seeking documentation or support for the Kilo-published package to OpenCode. The package still declared `git+https://github.com/Kilo-Org/kilocode.git` as its repository, and `origin/main` used the matching Kilo homepage and issue tracker. The reviewed values match upstream `v1.17.9`, indicating an upstream metadata import rather than intentional Kilo attribution.
+
+   Resolved values:
+
+   ```json
+   "homepage": "https://github.com/Kilo-Org/kilocode/tree/main/packages/http-recorder",
+   "bugs": "https://github.com/Kilo-Org/kilocode/issues"
+   ```
+
+**Notable Non-Findings**
+
+- The new experimental-capabilities source annotation says `"Get experimental features enabled on the OpenCode server."` in `packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts:140`. This is not an exposed API branding leak: the public OpenAPI transform invokes `matchLegacyKiloOpenApi` (`packages/opencode/src/server/routes/instance/httpapi/public.ts:194`), which recursively replaces `OpenCode` with `Kilo` (`packages/opencode/src/kilocode/server/httpapi/public.ts:131-147`). The committed generated artifact has `"Get experimental features enabled on the Kilo server."` at `packages/sdk/openapi.json:928`; the generated V2 SDK contains no `OpenCode`, `opencode`, `opencode.ai`, or `anomalyco/opencode` hits.
+
+- The merge expands `packages/core/src/plugin/skill/customize-opencode.md` with OpenCode command paths and retains an `https://opencode.ai/config.json` example. This is upstream content, but production boot does not register `SkillPlugin.Plugin`: `packages/core/src/plugin/boot.ts:100-112` registers `ConfigSkillPlugin.Plugin` and deliberately omits the legacy skill. Kilo's registered built-in configuration skill is `kilo-config` (`packages/opencode/src/kilocode/skills/builtin.ts:14-20`), and the Kilo system prompt directs agents to `.kilo/` and `kilo.json` (`packages/opencode/src/kilocode/system-prompt.ts:25`). No current user-facing skill/prompt regression was found. Human verification is warranted only if another shipping client directly registers `SkillPlugin.Plugin` outside the normal boot path.
+
+- Added upstream issue references are source-code comments in `packages/opencode/src/mcp/index.ts` and the generated `packages/kilo-docs/source-links.md` manifest. They are issue provenance, not rendered product documentation or runtime output. The review follow-up retains the issue numbers without forbidden repository URLs.
+
+- Added `@opencode-ai/*` imports, the `opencode` provider ID, legacy `opencode.json` compatibility paths, `.opencode-version`, and upstream merge metadata are technical identifiers or compatibility data. No evidence shows them rendered in the changed UI, CLI/TUI, errors, provider headers, generated SDK, or product help text.
+
+**Command Outputs**
+
+```text
+$ git rev-parse HEAD
+51d8031c9997bd5478bcde715562169f732d04d4
+
+$ git rev-parse origin/main
+b367105c8d648c8e05b62c2d27a28a95a4772f61
+
+$ git show --no-patch --format='%H %s' v1.17.9
+5c23e88419c4743b9be42cea132f2fb1e6cb63ff release: v1.17.9
+
+$ git diff --stat origin/main...HEAD
+208 files changed, 9294 insertions(+), 4906 deletions(-)
+
+$ git show v1.17.9:packages/http-recorder/package.json
+homepage and bugs are the same anomalyco/opencode URLs as HEAD.
+
+$ git show HEAD:packages/sdk/openapi.json | rg -ni 'OpenCode|opencode|anomalyco/opencode|opencode\.ai'
+no matches
+
+$ bun run script/check-forbidden-strings.ts
+passes after the review follow-up restores Kilo package links and sanitizes upstream issue provenance comments.
+```
+
+**Limitations**
+
+- This was a static range review. The local server and package publication flow were not launched, but the `/doc` and SDK conclusions are supported by the explicit runtime transform and committed generated OpenAPI artifact.
+- The inactive `customize-opencode` skill was traced through the normal production boot path. Direct registration by an unreviewed external consumer was not exercised.
+
+**Result**
+
+One medium-severity, high-confidence user-facing branding regression found and resolved on the review branch. Report: `OPENCODE_MENTIONS.md`.

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,61 @@
+# PR #12460 Test-Coverage Review
+
+Reviewed `origin/main...51d8031c9997bd5478bcde715562169f732d04d4` for deleted test files, deleted test blocks, renamed tests, and changed assertions. The audit treated tests in `kilo`/`kilocode` paths and shared tests asserting Kilo behavior, branding, fixtures, or `kilocode_change` behavior as Kilo coverage. I also compared the final runtime shape with upstream `v1.17.9` and inspected the intermediate compatibility-tree repair history.
+
+## Findings
+
+### 1. Resolved: PTY environment coverage moved to the canonical HTTP/core path
+
+`packages/opencode/test/pty/pty-shell.test.ts:75-102` was deleted. Its `pty environment preparation` case proved that plugin environment values were merged and that forced terminal values won, including the Kilo-specific `KILO_TERMINAL="1"` assertion.
+
+HEAD still makes that behavior material: `packages/core/src/pty.ts:212-222` forces `TERM`, `KILO_TERMINAL`, and `KILO_PTY_ID`, and strips `KILO_SERVER_PASSWORD` and `KILO_SERVER_USERNAME`. The replacement HTTP test, `packages/opencode/test/server/httpapi-v2-pty.test.ts:178-249`, covers plugin environment merge, forced `TERM`, and hook cwd, but it does not assert `KILO_TERMINAL`, `KILO_PTY_ID`, or credential stripping. A repository-wide focused search found `KILO_TERMINAL` in tests only as the core PTY fixture input at `packages/core/test/pty/pty-session.test.ts:47`, not as spawned-process output.
+
+Replacement coverage is now complete. The canonical V2 PTY HTTP test inspects a real spawned shell and asserts plugin/caller precedence, forced `TERM`, `KILO_TERMINAL`, `KILO_PTY_ID`, and server-credential stripping. The new assertion exposed and fixed a runtime leak caused by node-pty inheriting omitted parent variables.
+
+### 2. Resolved: Kilo stable-markdown coverage is relocated to the real browser renderer
+
+`packages/ui/src/kilocode/markdown-stable-blocks.test.ts:14-52` was deleted with `markdown-stable-blocks.ts`. The new upstream streaming model intentionally supersedes the helper: `packages/ui/src/components/markdown-stream.ts:61-84` freezes completed top-level tokens and emits completed fences as `mode: "code"`, while `packages/ui/src/components/markdown.tsx:354-411` sends those blocks to the streaming highlighter worker.
+
+`packages/ui/src/components/markdown-stream.test.ts:23-44` replaces the structural portions of the deleted suite: completed fences, completed prose blocks, and a live tail. It also adds delta, replacement, truncation, and fence-splitting coverage through line 193. It does not replace the deleted end-to-end assertion at `markdown-stable-blocks.test.ts:46-52` that the mixed streamed result produces the same final HTML as canonical Markdown. The missing check matters because code fences now bypass `marked.parse(block.src)` and are rendered through a distinct worker/DOM path.
+
+An ad hoc execution of the former mixed-block case confirmed the old helper-level parity assertion cannot simply be restored: parsing the new `mode: "code"` block's raw code with `marked` yields a paragraph rather than a fenced-code element. That is expected from the new architecture, but it demonstrates that the equivalent assertion must move to a `Markdown` renderer integration test with a worker test double or an exercised worker.
+
+Replacement coverage now exercises the actual VS Code Storybook renderer in Chromium. It verifies a completed Mermaid fence becomes a rendered flowchart SVG from delimiter-free source and that surrounding Markdown remains visible.
+
+### 3. Resolved: provider-account removal is intentional and production-path coverage is restored
+
+The removed account-projection blocks in `packages/core/test/catalog.test.ts:28-56`, `packages/core/test/plugin/provider-azure.test.ts:76-104`, `packages/core/test/plugin/provider-cloudflare-workers-ai.test.ts:129-163`, and `packages/core/test/plugin/provider-gitlab.test.ts:166-236` asserted the pre-v2 behavior of projecting active credential secrets and metadata into `Catalog.provider.get()`.
+
+That projection is obsolete in HEAD and conflicts with the upstream v1.17.9 integration model: `packages/core/src/catalog.ts:211-239` now leaves catalog records secret-free and derives availability from `Integration.connection`. Request-time credential projection moved to `packages/core/src/session/runner/model.ts:89-106,163-168`. The Kilo-specific organization mapping has direct replacement coverage at `packages/core/test/kilocode/session-runner-model.test.ts:10-55`, and generic credential precedence plus metadata projection is covered at `packages/core/test/session-runner-model.test.ts:269-296`.
+
+The removed Azure, Cloudflare Workers AI, and GitLab assertions therefore should not be reintroduced at the catalog layer. However, no current focused test exercises their full saved connection -> request/SDK option path after the split. The retained provider tests only cover env/config values or direct plugin options. Human verification is warranted for a saved Azure key with resource metadata, saved Cloudflare key with account metadata, and GitLab PAT/OAuth token selection after this integration migration.
+
+The provider review initially conflated V2 `SessionRunnerModel` with the production legacy provider service. Azure and GitLab do not route through that restricted V2 runner; saved credentials are consumed in `packages/opencode/src/provider/provider.ts`. New Kilo-owned tests exercise the real saved-auth path for Azure resource metadata, GitLab OAuth access, and Cloudflare Workers AI account/key metadata through final provider/SDK URL resolution. Catalog projection remains intentionally secret-free.
+
+## Notable Non-Findings
+
+- The deleted `packages/core/test/pty/input.test.ts` is superseded by `packages/core/test/pty/protocol.test.ts:4-26`, which preserves invalid binary-frame rejection and adds `ArrayBuffer`, control-frame, and replay-chunk coverage.
+- The deleted PTY output-isolation suite is superseded by `packages/core/test/pty/pty-session.test.ts:155-203`, which covers detach behavior, cross-session output isolation, replay, exit notification, and attachment rejection after exit. Socket-object reuse is obsolete because the new attach API owns subscriptions with fresh internal tokens.
+- The shell move is covered rather than lost: `packages/core/test/shell.test.ts:30-107` covers shell selection/login metadata and Windows Git Bash behavior; `packages/core/test/pty/pty-session.test.ts:225-238` covers configured PTY defaults; `packages/opencode/test/kilocode/shell/shell.test.ts:7-47` retains Kilo PowerShell UTF-8 and prologue behavior. The Darwin test profile explicitly replaces the deleted shell suite with `server/httpapi-v2-pty.test.ts`, and `packages/opencode/test/kilocode/test-profile.test.ts:9-50` validates that selection.
+- Kilo branding assertions remain present and were strengthened where behavior changed: `packages/core/test/plugin/provider-kilo.test.ts:20-98` checks the Kilo referer/title headers and provider-id isolation; lines 102-188 verify Kilo Gateway routing, authenticated-token precedence, and anonymous availability. `packages/core/test/plugin/provider-llmgateway.test.ts:38-52` retains the Kilo-branded LLM Gateway headers.
+- The compatibility-tree bug did not ship a mass deletion at the reviewed head. Intermediate compatibility commit `a776bd4d29` removed broad Kilo test trees, but the final `origin/main...HEAD` deleted-test-file list contains only four files: `core/test/pty/input.test.ts`, `core/test/pty/pty-output-isolation.test.ts`, `opencode/test/pty/pty-shell.test.ts`, and `ui/src/kilocode/markdown-stable-blocks.test.ts`. `f1e22ebf21` adds the overlay-preservation logic and its regression test in `script/upstream/utils/git.test.ts`.
+
+## Relevant Commands
+
+| Command | Result |
+|---|---|
+| `git diff --name-status --find-renames origin/main...HEAD` | Final range changes 208 files; four test files are deleted and the shared shell test is renamed to `packages/core/test/shell.test.ts`. |
+| `git diff --find-renames --diff-filter=D --name-only origin/main...HEAD` | Deleted tests are limited to the four files identified above. |
+| `git diff --find-renames -U... origin/main...HEAD` on provider, PTY, shell, profile, and markdown paths | Confirmed the replacement locations and the catalog-to-runtime integration migration. |
+| `bun test test/pty/protocol.test.ts test/pty/pty-session.test.ts test/plugin/provider-kilo.test.ts test/kilocode/session-runner-model.test.ts` in `packages/core` | Passed: 18 tests, 0 failures. |
+| `bun test test/plugin/provider-azure.test.ts test/plugin/provider-cloudflare-workers-ai.test.ts test/plugin/provider-gitlab.test.ts test/plugin/provider-opencode.test.ts test/catalog.test.ts test/session-runner-model.test.ts` in `packages/core` | Passed: 61 tests, 0 failures. |
+| `bun test src/components/markdown-stream.test.ts src/kilocode/markdown-bidi.test.ts` in `packages/ui` | Passed: 23 tests, 0 failures. |
+| `bun test test/server/httpapi-v2-pty.test.ts test/kilocode/test-profile.test.ts test/kilocode/pty-self-command.test.ts test/kilocode/shell/shell.test.ts` in `packages/opencode` | Passed: 13 tests, 0 failures. The suite logged an interrupted indexing bootstrap during cleanup but completed successfully. |
+
+## Limitations
+
+- The review was static plus targeted automated tests. No real external Azure, Cloudflare, or GitLab account was available for the provider-connection manual scenarios in Finding 3.
+- Windows-specific PTY spawning and Git Bash behavior were inspected through platform-guarded tests but could not be executed on this Darwin host.
+- The existing worktree contained unrelated untracked reports, `CONFIG_REGRESSION.md` and `INFRASTRUCTURE_CHANGE.md`; they were not inspected or modified.
+
+Summary: PTY, Markdown/Mermaid, and saved-provider-auth coverage have been relocated to their current production boundaries. The old catalog projection tests remain intentionally removed. Report: `TESTS.md`.

--- a/UNNECESSARY_MARKERS.md
+++ b/UNNECESSARY_MARKERS.md
@@ -1,0 +1,76 @@
+# Unnecessary `kilocode_change` Marker Review
+
+## Scope and Method
+
+- Reviewed PR #12460 at `origin/main...51d8031c9997bd5478bcde715562169f732d04d4` (208 changed paths).
+- Compared shared files at `HEAD` with upstream `v1.17.9` (`5c23e88419c4743b9be42cea132f2fb1e6cb63ff`) after the same branding, package-name, extension, i18n, and web transforms used by `reset-to-upstream.ts`.
+- Excluded Kilo-owned paths, generated artifacts as evidence of marker drift, and upstream-missing paths. Moved paths were evaluated at their current path against the v1.17.9 tree, rather than assuming the PR's rename metadata identifies upstream equivalence.
+- Used line-level comparison after stripping marker syntax. A marker is a finding only where its annotated code is byte-identical to transformed upstream. This catches stale annotations in files that still have other legitimate Kilo changes, which the file-level reset detector intentionally cannot classify as `markers-only`.
+
+## Findings
+
+### Resolved: 27 stale marker annotations removed from 11 changed shared files
+
+The annotated code below was identical to transformed upstream v1.17.9. The merge follow-up removes only these annotations without changing Kilo behavior, reducing future merge-conflict surface.
+
+| File | Stale marker references | Count |
+|---|---|---|
+| `packages/core/src/plugin/provider/llmgateway.ts` | `:20` | 1 |
+| `packages/core/src/plugin/provider/openai-auth.ts` | `:261`, `:263` | 2 |
+| `packages/core/test/plugin/provider-llmgateway.test.ts` | `:53` | 1 |
+| `packages/opencode/src/provider/provider.ts` | `:476`, `:487`, `:497`, `:508`, `:614`, `:814`, `:872`, `:1080` | 8 |
+| `packages/opencode/src/provider/transform.ts` | `:1278` | 1 |
+| `packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts` | `:174`, `:292` | 2 |
+| `packages/opencode/src/session/prompt.ts` | `:757`, `:1089`, `:2052`, `:2182-2186` | 4 |
+| `packages/opencode/test/share/share-next.test.ts` | `:20`, `:307`, `:313` | 3 |
+| `packages/tui/src/context/data.tsx` | `:146`, `:458` | 2 |
+| `packages/tui/src/routes/session/index.tsx` | `:1750`, `:1761` | 2 |
+| `packages/ui/src/components/markdown.tsx` | `:763` | 1 |
+
+The first row includes a transformed branding value (`https://kilo.ai/`), and the provider, prompt, TUI, and markdown rows likewise include values or text produced by the transform pipeline. They are still stale markers because the comparison baseline is the transformed upstream file that `reset-to-upstream.ts` would produce.
+
+## Verified Reset Candidates
+
+No changed PR file is a verified whole-file reset candidate. The required bulk detector found two `markers-only` files, but neither intersects `origin/main...HEAD`:
+
+- `packages/opencode/src/cli/cmd/run/permission.shared.ts`
+- `packages/sdk/js/src/error-interceptor.ts`
+
+The 16 changed-path intersections were all `small-diff`, not `markers-only`. Each has non-marker drift after transforms, so resetting the entire file would discard legitimate Kilo behavior. The stale annotations above are therefore marker-removal candidates, not file-reset candidates.
+
+## False Positives and Non-Findings
+
+- All 16 detector intersections were individually verified with the supported `reset-to-upstream.ts <repo-relative-file> --dry-run` interface. Every command resolved v1.17.9 and printed `[DRY-RUN] Would reset <path> to transformed upstream v1.17.9`; no command reported `already matches`. The verified set was:
+  `packages/core/src/plugin/boot.ts`, `packages/core/src/provider.ts`, `packages/core/src/session/runner/model.ts`, `packages/core/test/plugin/provider-llmgateway.test.ts`, `packages/core/test/session-runner.test.ts`, `packages/opencode/src/mcp/catalog.ts`, `packages/opencode/test/server/httpapi-v2-pty.test.ts`, `packages/opencode/test/tool/shell.test.ts`, `packages/server/src/api.ts`, `packages/server/src/cors.ts`, `packages/server/src/handlers.ts`, `packages/server/src/routes.ts`, `packages/storybook/.storybook/main.ts`, `packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx`, `packages/ui/src/components/markdown-worker.ts`, and `packages/ui/src/pierre/index.ts`.
+- Manual v1.17.9 comparisons confirm those 16 whole files contain actual non-marker differences, including Kilo provider behavior, server wiring, location migration coverage, Kilo-specific tool rendering, and Kilo themes. The detector's low line-count classification is not evidence that the files should be reset.
+- Additional manual suspicious-file dry runs for `packages/core/src/plugin/provider/llmgateway.ts`, `packages/core/src/plugin/provider/openai-auth.ts`, `packages/opencode/src/provider/provider.ts`, `packages/opencode/src/provider/transform.ts`, `packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts`, `packages/opencode/src/session/prompt.ts`, `packages/opencode/test/share/share-next.test.ts`, and `packages/ui/src/components/markdown.tsx` produced the same exact result: `[DRY-RUN] Would reset <path> to transformed upstream v1.17.9`. Line-level comparison shows that each still has legitimate non-marker Kilo drift, alongside the stale markers reported above.
+- `packages/opencode/src/pty-preparation.ts` is deleted locally, so it cannot retain a marker. `packages/ui/src/pierre/kilo-diff-theme.ts` is upstream-missing/Kilo-specific and is not a stale-marker finding.
+- No finding was recorded for generated SDK/OpenAPI output, Kilo-owned paths, or move-only changes. In particular, `packages/opencode/test/server/httpapi-v2-pty.test.ts` exists in upstream v1.17.9 despite its PR-range add status and has real transformed-upstream drift.
+
+## Exact Command Outcomes
+
+`bun run script/upstream/find-reset-candidates.ts --dry-run` completed successfully with no writes:
+
+- Last merged upstream: `v1.17.9` (`5c23e884`).
+- Scope: all shared paths. Review limit: 5 non-marker diff lines. Candidate files: 1011.
+- Skipped: 332 non-code assets and 1793 keep-ours/skip-files-protected paths.
+- Buckets: `markers-only` 2, `cosmetic-only` 1, `small-diff` 198, `large-diff` 423, `identical` 145, `too-large` 1, `upstream-missing` 240, and `local-missing` 1.
+- Both `markers-only` results were reported as `would reset`; neither was changed by this PR. The 16 relevant intersections were verified individually as described above, using only dry-run commands.
+
+`bun run script/upstream/reset-to-upstream.ts --help` documented the supported interface as:
+
+```text
+bun run script/upstream/reset-to-upstream.ts <repo-relative-file> [--dry-run]
+```
+
+No reset, marker-fix, or source-edit command was run without `--dry-run`.
+
+## Limitations
+
+- This review establishes stale annotations relative to the repository's transformed upstream v1.17.9 baseline, not raw upstream bytes. That is the appropriate baseline for this fork and matches both required scripts.
+- `find-reset-candidates.ts` is file-level and deliberately reports small non-marker diffs as reset candidates. It cannot identify stale annotations inside a file that retains unrelated drift; the 27 findings required the additional line-level comparison.
+- The review does not attribute each pre-existing stale annotation to a particular commit in the PR. It establishes that the final merged files in the reviewed range retain the markers.
+
+## Summary
+
+No PR-changed file can be safely reset wholesale based only on markers. The 27 verified unnecessary annotations were removed line by line, while legitimate Kilo deltas remain marked. Report: `UNNECESSARY_MARKERS.md`.


### PR DESCRIPTION
Adds focused human-readable review reports for the OpenCode v1.17.6 through v1.17.9 integration in #12460.

The reports cover marker preservation and reset candidates, infrastructure adoption, user-facing OpenCode branding, cross-layer Kilo behavior chains, configuration fallback behavior, and removed Kilo test coverage. They intentionally contain findings and verification evidence only, without changing the reviewed implementation.