### PR TITLE
feat(vscode): render inline chat charts

### DIFF
--- a/.changeset/inline-chat-charts.md
+++ b/.changeset/inline-chat-charts.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Render Chart.js charts from fenced `chart` JSON blocks in chat responses.

--- a/bun.lock
+++ b/bun.lock
@@ -806,6 +806,7 @@
         "@solidjs/meta": "catalog:",
         "@solidjs/router": "catalog:",
         "@typescript/native-preview": "catalog:",
+        "chart.js": "4.5.1",
         "diff": "catalog:",
         "dompurify": "3.4.2",
         "fuzzysort": "catalog:",
@@ -1553,6 +1554,8 @@
     "@kobalte/core": ["@kobalte/core@0.13.11", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@internationalized/date": "^3.4.0", "@internationalized/number": "^3.2.1", "@kobalte/utils": "^0.9.1", "@solid-primitives/props": "^3.1.8", "@solid-primitives/resize-observer": "^2.0.26", "solid-presence": "^0.1.8", "solid-prevent-scroll": "^0.1.4" }, "peerDependencies": { "solid-js": "^1.8.15" } }, "sha512-hK7TYpdib/XDb/r/4XDBFaO9O+3ZHz4ZWryV4/3BfES+tSQVgg2IJupDnztKXB0BqbSRy/aWlHKw1SPtNPYCFQ=="],
 
     "@kobalte/utils": ["@kobalte/utils@0.9.1", "", { "dependencies": { "@solid-primitives/event-listener": "^2.2.14", "@solid-primitives/keyed": "^1.2.0", "@solid-primitives/map": "^0.4.7", "@solid-primitives/media": "^2.2.4", "@solid-primitives/props": "^3.1.8", "@solid-primitives/refs": "^1.0.5", "@solid-primitives/utils": "^6.2.1" }, "peerDependencies": { "solid-js": "^1.8.8" } }, "sha512-eeU60A3kprIiBDAfv9gUJX1tXGLuZiKMajUfSQURAF2pk4ZoMYiqIzmrMBvzcxP39xnYttgTyQEVLwiTZnrV4w=="],
+
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -2855,6 +2858,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 

--- a/packages/kilo-vscode/webview-ui/src/stories/chart.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chart.stories.tsx
@@ -1,0 +1,36 @@
+/** @jsxImportSource solid-js */
+import type { Meta, StoryObj } from "storybook-solidjs-vite"
+import { Markdown } from "@kilocode/kilo-ui/markdown"
+import { StoryProviders } from "./StoryProviders"
+
+const meta: Meta = {
+  title: "Chat/Inline Chart Prototype",
+  parameters: { layout: "padded" },
+}
+
+export default meta
+type Story = StoryObj
+
+const text = `Chart rendered inline from a fenced JSON block:
+
+\`\`\`chart
+{
+  "type": "bar",
+  "data": {
+    "labels": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+    "datasets": [{
+      "label": "Sessions",
+      "data": [12, 19, 8, 15, 23],
+      "backgroundColor": "#5b8def"
+    }]
+  }
+}
+\`\`\``
+
+export const BarChart: Story = {
+  render: () => (
+    <StoryProviders>
+      <Markdown text={text} />
+    </StoryProviders>
+  ),
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,6 +58,7 @@
     "@solid-primitives/resize-observer": "2.1.3",
     "@solidjs/meta": "catalog:",
     "@solidjs/router": "catalog:",
+    "chart.js": "4.5.1",
     "diff": "catalog:",
     "dompurify": "3.4.2",
     "fuzzysort": "catalog:",

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -9,6 +9,7 @@ import { isServer } from "solid-js/web"
 import { stream } from "./markdown-stream"
 import { tryFastRender } from "../kilocode/markdown-fast-path" // kilocode_change
 import { hasMermaid, preserveMermaid, renderMermaid, type MermaidLabels } from "../kilocode/markdown-mermaid" // kilocode_change
+import { hasChart, preserveChart, renderChart } from "../kilocode/markdown-chart" // kilocode_change
 import { preserveStreamingHighlight } from "../kilocode/markdown-stream-highlight" // kilocode_change
 import { createIncrementalMarkdown, type MarkdownBlock } from "../kilocode/markdown-incremental-dom" // kilocode_change
 
@@ -331,6 +332,7 @@ export function Markdown(
     ready: (container, labels, mermaid) => {
       copyCleanup ??= setupCodeCopy(container, () => labels)
       kickMermaid(container, true, mermaid)
+      kickChart(container, true)
       kickHighlight(container, labels)
     },
   })
@@ -398,6 +400,7 @@ export function Markdown(
       incremental.reset() // kilocode_change
       copyCleanup = fast.copyCleanup
       kickMermaid(container, local.streaming ?? false, mermaid)
+      kickChart(container, local.streaming ?? false)
       kickHighlight(container, labels)
       return
     }
@@ -445,6 +448,7 @@ export function Markdown(
           // normal markdown morphdom refreshes so they do not flicker back to
           // their source code while being re-rendered.
           if (preserveMermaid(fromEl, toEl)) return false
+          if (preserveChart(fromEl, toEl)) return false // kilocode_change
           // kilocode_change end
           // Preserve Shiki-highlighted blocks — don't let morphdom revert them
           // to plain <pre><code> during streaming re-renders.
@@ -476,6 +480,7 @@ export function Markdown(
       // kilocode_change end
 
       kickMermaid(container, local.streaming ?? false, mermaid) // kilocode_change
+      kickChart(container, local.streaming ?? false) // kilocode_change
       kickHighlight(container, nextLabels)
     })
     // kilocode_change end
@@ -501,6 +506,13 @@ export function Markdown(
       },
       signal,
     )
+  }
+  // kilocode_change end
+
+  // kilocode_change start: inline chart prototype
+  function kickChart(container: HTMLDivElement, streaming: boolean) {
+    if (streaming || !hasChart(container)) return
+    void renderChart(container).catch((err) => console.warn("Chart render failed", err))
   }
   // kilocode_change end
 

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -193,7 +193,9 @@ export async function deferredHighlight(
   signal?: { aborted: boolean },
 ): Promise<void> {
   const blocks = Array.from(
-    container.querySelectorAll('pre > code[data-lang]:not([data-highlighted]):not([data-lang="mermaid"])'),
+    container.querySelectorAll(
+      'pre > code[data-lang]:not([data-highlighted]):not([data-lang="mermaid"]):not([data-lang="chart"])',
+    ), // kilocode_change
   )
   if (blocks.length === 0) {
     onComplete?.()

--- a/packages/ui/src/kilocode/markdown-chart.css
+++ b/packages/ui/src/kilocode/markdown-chart.css
@@ -1,0 +1,18 @@
+[data-component="markdown"] {
+  [data-component="markdown-code"][data-kind="chart"] {
+    border: 0.5px solid var(--border-weak-base);
+    border-radius: 6px;
+    background: var(--surface-base);
+    overflow: hidden;
+  }
+
+  [data-component="markdown-chart"] {
+    height: 280px;
+    padding: 12px;
+  }
+
+  [data-component="markdown-chart"][data-state="error"] {
+    height: auto;
+    color: var(--text-danger, var(--text-strong));
+  }
+}

--- a/packages/ui/src/kilocode/markdown-chart.ts
+++ b/packages/ui/src/kilocode/markdown-chart.ts
@@ -1,0 +1,49 @@
+import type { Chart as ChartInstance, ChartConfiguration, ChartType } from "chart.js"
+
+const charts = new WeakMap<HTMLElement, ChartInstance>()
+
+export function hasChart(root: HTMLElement) {
+  return root.querySelector('pre > code[data-lang="chart"]') !== null
+}
+
+export function preserveChart(from: Element, to: Element) {
+  if (!(from instanceof HTMLElement) || !(to instanceof HTMLElement)) return false
+  if (from.getAttribute("data-kind") !== "chart" || from.getAttribute("data-chart-state") !== "rendered") return false
+  const before = from.querySelector('pre > code[data-lang="chart"]')?.textContent
+  const after = to.querySelector('pre > code[data-lang="chart"]')?.textContent
+  return !!before && before === after
+}
+
+export async function renderChart(root: HTMLDivElement) {
+  const blocks = Array.from(root.querySelectorAll('pre > code[data-lang="chart"]'))
+  if (blocks.length === 0) return
+  const { default: Chart } = await import("chart.js/auto")
+
+  for (const block of blocks) {
+    const pre = block.parentElement
+    const wrapper = pre?.parentElement
+    if (!(pre instanceof HTMLPreElement) || !(wrapper instanceof HTMLElement)) continue
+    if (wrapper.getAttribute("data-component") !== "markdown-code") continue
+    if (wrapper.getAttribute("data-chart-state") === "rendered") continue
+
+    wrapper.setAttribute("data-kind", "chart")
+    const panel = document.createElement("div")
+    panel.setAttribute("data-component", "markdown-chart")
+    const canvas = document.createElement("canvas")
+    panel.append(canvas)
+    wrapper.insertBefore(panel, pre)
+
+    try {
+      const config = JSON.parse(block.textContent ?? "") as ChartConfiguration<ChartType>
+      config.options = { responsive: true, maintainAspectRatio: false, ...config.options }
+      charts.get(wrapper)?.destroy()
+      charts.set(wrapper, new Chart(canvas, config))
+      wrapper.setAttribute("data-chart-state", "rendered")
+      pre.hidden = true
+    } catch (err) {
+      panel.setAttribute("data-state", "error")
+      panel.textContent = err instanceof Error ? `Chart render failed: ${err.message}` : "Chart render failed."
+      wrapper.setAttribute("data-chart-state", "error")
+    }
+  }
+}

--- a/packages/ui/src/kilocode/markdown-stream-highlight.ts
+++ b/packages/ui/src/kilocode/markdown-stream-highlight.ts
@@ -89,7 +89,7 @@ export function preserveStreamingHighlight(from: Element, to: Element, streaming
   const before = from.querySelector("code")?.textContent ?? ""
   const after = to.querySelector("code")?.textContent ?? ""
   const lang = to.querySelector("code")?.getAttribute("data-lang") || "text"
-  if (!after || lang === "mermaid" || !continues(before, after)) return false
+  if (!after || lang === "mermaid" || lang === "chart" || !continues(before, after)) return false
   queue(from, after, lang)
   return true
 }

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -35,6 +35,7 @@
 @import "../components/logo.css" layer(components);
 @import "../components/markdown.css" layer(components);
 @import "../kilocode/markdown-mermaid.css" layer(components); /* kilocode_change */
+@import "../kilocode/markdown-chart.css" layer(components); /* kilocode_change */
 @import "../components/message-part.css" layer(components);
 @import "../components/message-nav.css" layer(components);
 @import "../components/popover.css" layer(components);


### PR DESCRIPTION
Chat responses can currently render Mermaid diagrams, but they cannot display data visualizations as interactive charts.

This adds a `chart` fenced JSON block backed by locally bundled Chart.js. Completed Markdown responses render the block into a responsive canvas while retaining the source and an error message when parsing or rendering fails. Chart blocks bypass syntax highlighting and preserve their rendered canvas across Markdown refreshes.

<img width="700" alt="Inline bar chart rendered in Kilo chat" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260723-inline-chat-chart.png?raw=true" />