### PR TITLE
docs: fix Fireworks AI pricing link broken by bot detection

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/fireworks.md
+++ b/packages/kilo-docs/pages/ai-providers/fireworks.md
@@ -62,5 +62,5 @@ Then set your default model:
 ## Tips and Notes
 
 - **Performance:** Fireworks AI is optimized for speed and offers excellent performance for both chat and completion tasks.
-- **Pricing:** Refer to the [Fireworks AI Pricing](https://fireworks.ai/pricing) page for current pricing information.
+- **Pricing:** Refer to the [Fireworks AI Pricing](https://docs.fireworks.ai/serverless/pricing) page for current pricing information.
 - **Rate Limits:** Fireworks AI has usage-based rate limits. Monitor your usage in the dashboard and consider upgrading your plan if needed.


### PR DESCRIPTION
## Problem

The lychee link-check CI job (`Kilo-Org/lychee-action`) fails with exit code 2 because `https://fireworks.ai/pricing` returns `500 Internal Server Error` to the link checker. The Fireworks marketing page employs bot detection that rejects non-browser requests, so this URL is unreliable for automated checks and intermittently broken even when fetched from GitHub Actions runners.

## Fix

Point the Fireworks AI provider docs to `https://docs.fireworks.ai/serverless/pricing` instead. This is the stable per-model pricing page that the Fireworks marketing page itself links to as the authoritative source for current model pricing. It returns `200` to link checkers and contains the actual per-token pricing details users are looking for.

## Scope

Single one-line link change in `packages/kilo-docs/pages/ai-providers/fireworks.md`.