### PR TITLE
fix(ui): align queued message remove button with message action buttons

### DIFF
--- a/.changeset/queued-remove-button-size.md
+++ b/.changeset/queued-remove-button-size.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-ui": patch
+---
+
+Align the queued message remove button with the other message action buttons: it now shares the same 20px style as the copy, fork, and revert buttons and shows a "Delete queued message" tooltip on hover.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -1,5 +1,17 @@
 /* Kilo Message Part overrides */
 
+/* Message action rows (copy, fork, revert, feedback, delete queued)
+   share one compact icon-button size. */
+[data-component="text-part"] [data-slot="text-part-copy-wrapper"][data-is-turn-copy],
+[data-component="text-part"] [data-slot="assistant-copy-wrapper"],
+[data-component="user-message"] [data-slot="user-message-copy-wrapper"],
+[data-component="user-message"] [data-slot="user-message-queued-indicator"] {
+  [data-component="icon-button"] {
+    width: 20px;
+    height: 20px;
+  }
+}
+
 [data-component="text-part"] {
   margin-top: 8px;
 
@@ -13,11 +25,6 @@
 
   [data-slot="text-part-copy-wrapper"][data-is-turn-copy] {
     display: flex;
-
-    [data-component="icon-button"] {
-      width: 20px;
-      height: 20px;
-    }
   }
 
   [data-slot="assistant-copy-wrapper"] {
@@ -26,11 +33,6 @@
     justify-content: flex-start;
     gap: 2px;
     margin-top: 2px;
-
-    [data-component="icon-button"] {
-      width: 20px;
-      height: 20px;
-    }
 
     /* Thumbs up/down: fill the outline on hover to preview the rated state. */
     [data-component="icon-button"][data-icon="thumbs-up"]:hover [data-slot="icon-svg"] path,
@@ -512,11 +514,6 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
 
     [data-slot="user-message-meta-wrap"] {
       display: none;
-    }
-
-    [data-component="icon-button"] {
-      width: 20px;
-      height: 20px;
     }
   }
 }

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -820,18 +820,20 @@ export function UserMessageDisplay(props: {
 
   const Delete = () => (
     <Show when={props.onDelete}>
-      <IconButton
-        data-slot="user-message-delete"
-        icon="close-small"
-        size="normal"
-        variant="ghost"
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={(event) => {
-          event.stopPropagation()
-          props.onDelete?.()
-        }}
-        aria-label={i18n.t("ui.message.deleteQueued")}
-      />
+      <Tooltip value={i18n.t("ui.message.deleteQueued")} placement="right" gutter={4}>
+        <IconButton
+          data-slot="user-message-delete"
+          icon="close-small"
+          size="normal"
+          variant="ghost"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(event) => {
+            event.stopPropagation()
+            props.onDelete?.()
+          }}
+          aria-label={i18n.t("ui.message.deleteQueued")}
+        />
+      </Tooltip>
     </Show>
   )
 


### PR DESCRIPTION
The remove button on queued messages rendered at the default icon-button size (24px) while every other message action button (copy, fork, revert, feedback) is compact (20px). The compact sizing was applied through three separate CSS overrides, one per action row, so any new button had to remember to opt in. That is how the queued remove button drifted, and it also had no tooltip, unlike all its siblings.

The compact sizing now lives in one shared rule covering every message action row, including the queued indicator, so the remove button matches the copy button exactly and future action buttons inherit the same dimensions. The remove button is also wrapped in the same Tooltip pattern as the copy, fork, and revert buttons and shows "Delete queued message" on hover.

Follow-up to #12370.

Before (remove button visibly larger than the copy button below it):

<img width="700" alt="Queued message with oversized remove button next to the smaller copy button" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260724-queued-message-remove-btn-before.png?raw=true" />

After (remove button hovered, now the same size as the other action buttons):

<img width="700" alt="Queued message with compact remove button in hover state" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260724-queued-message-remove-btn-after-hover.png?raw=true" />

After (remove button at rest next to the hovered copy button, matching dimensions):

<img width="700" alt="Queued message remove button at rest matching the copy button size" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260724-queued-message-remove-btn-after.png?raw=true" />