### PR TITLE
fix(tui): silence optional Kilo Pass failures

### DIFF
--- a/.changeset/silent-kilo-pass-refresh.md
+++ b/.changeset/silent-kilo-pass-refresh.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": patch
+---
+
+Prevent optional Kilo Pass refresh failures from disrupting the CLI terminal display.

--- a/packages/kilo-gateway/src/api/kilo-pass.ts
+++ b/packages/kilo-gateway/src/api/kilo-pass.ts
@@ -32,13 +32,9 @@ export async function fetchKiloPassState(token: string): Promise<KiloPassState |
     const response = await fetch(`${KILO_API_BASE}/api/trpc/kiloPass.getState?${params}`, {
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json", ...buildKiloHeaders() },
     })
-    if (!response.ok) {
-      console.warn(`Failed to fetch Kilo Pass: ${response.status}`)
-      return null
-    }
+    if (!response.ok) return null
     return parseKiloPassState(await response.json())
-  } catch (err) {
-    console.warn("Error fetching Kilo Pass:", err)
+  } catch {
     return null
   }
 }

--- a/packages/kilo-gateway/test/api/kilo-pass.test.ts
+++ b/packages/kilo-gateway/test/api/kilo-pass.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test"
-import { parseKiloPassState } from "../../src/api/kilo-pass"
+import { describe, expect, mock, spyOn, test } from "bun:test"
+import { fetchKiloPassState, parseKiloPassState } from "../../src/api/kilo-pass"
 
 describe("parseKiloPassState", () => {
   test("parses batched tRPC subscription data", () => {
@@ -59,5 +59,19 @@ describe("parseKiloPassState", () => {
 
   test("returns null without period amounts", () => {
     expect(parseKiloPassState({ status: "none" })).toBeNull()
+  })
+
+  test("silently ignores transport failures", async () => {
+    const prev = global.fetch
+    const warn = spyOn(console, "warn").mockImplementation(() => undefined)
+    global.fetch = mock(() => Promise.reject(new DOMException("The operation timed out.", "TimeoutError")))
+
+    try {
+      await expect(fetchKiloPassState("token")).resolves.toBeNull()
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+      global.fetch = prev
+    }
   })
 })

--- a/packages/kilo-gateway/test/api/kilo-pass.test.ts
+++ b/packages/kilo-gateway/test/api/kilo-pass.test.ts
@@ -74,4 +74,18 @@ describe("parseKiloPassState", () => {
       global.fetch = prev
     }
   })
+
+  test("silently ignores unsuccessful responses", async () => {
+    const prev = global.fetch
+    const warn = spyOn(console, "warn").mockImplementation(() => undefined)
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 503 })))
+
+    try {
+      await expect(fetchKiloPassState("token")).resolves.toBeNull()
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+      global.fetch = prev
+    }
+  })
 })


### PR DESCRIPTION
## What changed

Treat optional Kilo Pass refresh failures as a silent fallback. Both unsuccessful HTTP responses and transport errors now return `null` without writing to stderr.

## Why

Kilo Pass refreshes are ancillary to the main profile and balance response. Their warnings can either appear beside the prompt (`Failed to fetch Kilo Pass: <status>`) or dump an exception over OpenTUI's terminal buffer, leaving the display corrupted until restart.

Primary profile, balance, authentication, and Gateway failures keep their existing behavior.