### PR TITLE
fix(ci): pass KILO_ORG_ID to docs-sync LLM steps

### DIFF
--- a/.github/docs-sync/edit.mjs
+++ b/.github/docs-sync/edit.mjs
@@ -10,7 +10,7 @@
  * warning — its PRs show up in the rolling PR body as skipped, so nothing
  * fails silently.
  *
- * Env: EDIT_MODEL (provider/model), KILO_API_KEY (set by workflow; read natively by the kilo provider).
+ * Env: EDIT_MODEL (provider/model), KILO_API_KEY + KILO_ORG_ID (set by workflow; read natively by the kilo provider).
  */
 
 import { execFileSync } from "node:child_process"

--- a/.github/docs-sync/triage.mjs
+++ b/.github/docs-sync/triage.mjs
@@ -10,8 +10,8 @@
  * "unclassified" entries (docs_worthy=false) instead of failing the run —
  * the PR body then shows those PRs as skipped, visible to reviewers.
  *
- * Env: TRIAGE_MODEL (provider/model), KILO_API_KEY (gateway auth, set by the workflow;
- * the kilo provider reads it natively). Reads the prompt from triage-prompt.md next to this script.
+ * Env: TRIAGE_MODEL (provider/model), KILO_API_KEY + KILO_ORG_ID (gateway auth, set by
+ * the workflow; the kilo provider reads them natively). Reads the prompt from triage-prompt.md next to this script.
  */
 
 import { execFileSync } from "node:child_process"

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -41,6 +41,11 @@ jobs:
     if: github.repository == 'Kilo-Org/kilocode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 120
+    env:
+      # Both are required: without KILO_ORG_ID the gateway bills the key
+      # owner's personal balance (402 "Add credits") instead of the org.
+      KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
+      KILO_ORG_ID: ${{ secrets.KILO_ORG_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -74,8 +79,6 @@ jobs:
       - name: Triage merged PRs (LLM, chunked)
         id: triage
         if: steps.collect.outputs.count != '0'
-        env:
-          KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
         run: node .github/docs-sync/triage.mjs
 
       - name: Filter docs-worthy PRs
@@ -103,8 +106,6 @@ jobs:
 
       - name: Update docs (Kilo CLI, batched)
         if: (steps.worthy.outputs.count || '0') != '0' && inputs.dry_run != true
-        env:
-          KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
         run: node .github/docs-sync/edit.mjs
 
       - name: Verify docs build and tests
@@ -122,7 +123,6 @@ jobs:
         if: steps.verify.outcome == 'failure'
         continue-on-error: true
         env:
-          KILO_API_KEY: ${{ secrets.KILO_API_KEY }}
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_API_KEY }}
         run: |
           set -o pipefail


### PR DESCRIPTION
## Issue

Follow-up to #12512 (docs-sync bot). No tracking issue — exception: this fixes a defect found in the first dry run after that PR merged.

Failed dry run: https://github.com/Kilo-Org/kilocode/actions/runs/30107542234/job/89528563405

## Context

The docs-sync dry run went green but every LLM call failed: all 8 triage chunks 402'd with `Add credits to continue, or switch to a free model`, so 187/187 PRs were degraded to "unclassified" and triage reported 0 docs-worthy.

Root cause: the workflow passed `KILO_API_KEY` to the LLM steps but not `KILO_ORG_ID`. Without the org ID the CLI's kilo provider sends no `X-KiloCode-OrganizationId` header (`packages/core/src/plugin/provider/kilo.ts`), so the gateway falls back to the key owner's personal balance (`getBalanceAndOrgSettings` in kilocode-backend) instead of the organization balance. The personal balance is empty → HTTP 402 on a paid model.

Evidence the key itself is fine: the same `KILO_API_KEY` + `KILO_ORG_ID` pair ran the paid smoke-test gate successfully in the publish run ~12 minutes before the docs-sync dry run (run 30106281647). Same secret, same day — works with the org ID, 402s without.

## Implementation

- Hoisted `KILO_API_KEY` + `KILO_ORG_ID` to job-level `env:` in `docs-sync.yml`, matching the existing pattern in `smoke-test.yml` (and the CLI's own generated GitHub workflow template, which emits both). This covers the triage, edit, and fix-verify steps and any future CLI-invoking steps.
- Updated the `Env:` doc comments in `triage.mjs` / `edit.mjs` to name both variables.

## Screenshots / Video

N/A — CI-only change.

## How to Test

### Manual/local verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on the edited workflow — valid (agent-executed).
- Full monorepo typecheck ran green via the pre-push hook (agent-executed).

### Reviewer test steps

1. Trigger a dry run from this branch: `gh workflow run docs-sync.yml --ref fix/docs-sync-kilo-org-id -f dry_run=true`
2. Confirm the "Triage merged PRs" step no longer logs `Add credits to continue` and chunks produce real classifications (not all "triage failed to classify this PR").

### Blocked checks and substitute verification

- Cannot exercise the paid gateway path locally; substitute verification is the branch dry run above, plus the same-day smoke-test success cited as evidence the key+org pair bills correctly.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (CI-only; none needed)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
