### PR TITLE
fix(ui): preserve parenthesized tildes in markdown

### DIFF
--- a/.changeset/fuzzy-tildes-smile.md
+++ b/.changeset/fuzzy-tildes-smile.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve parenthesized tilde expressions as literal text in rendered chat messages.

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -321,6 +321,17 @@ export const createMarkedParser = (props: { nativeParser?: NativeMarkdownParser 
         },
         // kilocode_change end
       },
+      // kilocode_change start: Marked accepts a tilde preceded by an opening
+      // parenthesis as the closing delimiter. It is left-flanking there, so
+      // preserve it literally instead of corrupting text such as "(~1 GB)".
+      tokenizer: {
+        del(src) {
+          const match = this.rules.inline.del.exec(src)
+          if (match?.[0].at(-2) === "(") return
+          return false
+        },
+      },
+      // kilocode_change end
     },
     // kilocode_change start: enable only double-dollar math.
     // Single $ is far more common as a currency symbol in agent responses

--- a/packages/ui/src/kilocode/markdown-strikethrough.test.ts
+++ b/packages/ui/src/kilocode/markdown-strikethrough.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { createMarkedParser } from "../context/marked"
+
+describe("Markdown strikethrough boundaries", () => {
+  test.each(["(~a (~b", "~a (~b", "(~24 GB) and (~5.7 GB)", "(~/.config) and (~/.cache)"])(
+    "preserves parenthesized tildes in %s",
+    async (text) => {
+      const parser = createMarkedParser({})
+      const html = await Promise.resolve(parser.parse(text))
+
+      expect(html).not.toContain("<del>")
+      expect(html).toContain(text)
+    },
+  )
+
+  test.each([
+    ["~removed~", "<del>removed</del>"],
+    ["~~removed~~", "<del>removed</del>"],
+    ["(~removed~)", "(<del>removed</del>)"],
+  ])("keeps valid strikethrough syntax in %s", async (text, expected) => {
+    const parser = createMarkedParser({})
+    const html = await Promise.resolve(parser.parse(text))
+
+    expect(html).toContain(expected)
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #12530

## Context

Marked treats a tilde immediately preceded by `(` as a closing strikethrough delimiter. As a result, ordinary expressions such as `(~24 GB)` and `(~5.7 GB)` can form an unintended strikethrough span in rendered chat messages.

## Implementation

Reject the invalid closing delimiter at the existing Marked tokenizer boundary while preserving valid single- and double-tilde strikethrough syntax. Regression coverage includes the minimal issue reproduction, the reported size example, tilde paths, and valid strikethrough forms.

## Screenshots / Video

Before:

<img width="1443" height="835" alt="image" src="https://github.com/user-attachments/assets/ebc280b6-e115-42ad-8235-10fd7c74f530" />

After:

<img width="257" height="192" alt="Scherm­afbeelding 2026-07-26 om 16 30 04" src="https://github.com/user-attachments/assets/cf086c67-6809-42fe-89de-b0bd3f668378" />

## How to Test

### Manual/local verification

- Agent ran the full `@opencode-ai/ui` test suite: 90 passed, 0 failed.
- Agent ran the UI package typecheck, repository lint, Prettier check, annotation guard, markdown-table guard, and `git diff --check`; all passed.
- The pre-push hook ran the cross-package typecheck successfully.

### Reviewer test steps

1. Render `(~a (~b` or `(~24 GB) and (~5.7 GB)` in a chat message.
2. Confirm the text remains literal and contains no strikethrough.
3. Render `~removed~`, `~~removed~~`, and `(~removed~)`.
4. Confirm valid strikethrough syntax still renders with a line through `removed`.

### Blocked checks and substitute verification

- None. All relevant checks completed successfully.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

thomas07374