### PR TITLE
fix(cli): support adaptive thinking for Claude 5+

### DIFF
--- a/.changeset/adaptive-opus-five.md
+++ b/.changeset/adaptive-opus-five.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Support adaptive thinking levels for Claude Opus 5.
+Support adaptive thinking levels for Claude Opus and Sonnet 5 and later.

--- a/.changeset/adaptive-opus-five.md
+++ b/.changeset/adaptive-opus-five.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Support adaptive thinking levels for Claude Opus 5.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -616,17 +616,17 @@ function anthropicOpus47OrLater(apiId: string) {
   return major > 4 || (major === 4 && minor >= 7)
 }
 
-// kilocode_change start - Claude 5 aliases and Opus 5+ are adaptive thinking models like opus-4.7/4.8
+// kilocode_change start - Claude 5+ models are adaptive thinking models like opus-4.7/4.8
 function anthropicClaude5(apiId: string) {
   const id = apiId.toLowerCase()
-  if (id.includes("fable") || /sonnet[.-]5/.test(id)) return true
-  const opus = /opus[.-](\d+)(?:[.@-]|$)|claude-(\d+)(?:[.-]\d+)?-opus(?:[.@-]|$)/.exec(id)
-  return Number(opus?.[1] ?? opus?.[2]) >= 5
+  if (id.includes("fable")) return true
+  const version = /(?:opus|sonnet)[.-](\d+)(?:[.@-]|$)|claude-(\d+)(?:[.-]\d+)?-(?:opus|sonnet)(?:[.@-]|$)/.exec(id)
+  return Number(version?.[1] ?? version?.[2]) >= 5
 }
 // kilocode_change end
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  // kilocode_change start - include Claude 5 aliases and future Opus versions
+  // kilocode_change start - include Claude 5+ models
   if (anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId)) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
@@ -979,7 +979,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       if (adaptiveEfforts) {
         let efforts = [...adaptiveEfforts]
         if (model.providerID === "github-copilot") {
-          // kilocode_change start - include Claude 5 aliases and future Opus versions
+          // kilocode_change start - include Claude 5+ models
           if (
             model.api.id.includes("opus-4.7") ||
             model.api.id.includes("opus-4.8") ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -616,10 +616,10 @@ function anthropicOpus47OrLater(apiId: string) {
   return major > 4 || (major === 4 && minor >= 7)
 }
 
-// kilocode_change start - fable and sonnet-5 models are adaptive thinking models like opus-4.7/4.8
+// kilocode_change start - Claude 5 models are adaptive thinking models like opus-4.7/4.8
 function anthropicClaude5(apiId: string) {
   const id = apiId.toLowerCase()
-  return id.includes("fable") || /sonnet[.-]5/.test(id)
+  return id.includes("fable") || /(?:opus|sonnet)[.-]5/.test(id)
 }
 // kilocode_change end
 
@@ -640,7 +640,7 @@ function anthropicAdaptiveEfforts(apiId: string): string[] | null {
 }
 
 function anthropicOmitsThinking(apiId: string) {
-  return anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId) // kilocode_change - include Kilo's fable/sonnet-5 aliases
+  return anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId) // kilocode_change - include Kilo's Claude 5 aliases
 }
 
 function googleThinkingLevelEfforts(apiId: string) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -616,15 +616,17 @@ function anthropicOpus47OrLater(apiId: string) {
   return major > 4 || (major === 4 && minor >= 7)
 }
 
-// kilocode_change start - Claude 5 models are adaptive thinking models like opus-4.7/4.8
+// kilocode_change start - Claude 5 aliases and Opus 5+ are adaptive thinking models like opus-4.7/4.8
 function anthropicClaude5(apiId: string) {
   const id = apiId.toLowerCase()
-  return id.includes("fable") || /(?:opus|sonnet)[.-]5/.test(id)
+  if (id.includes("fable") || /sonnet[.-]5/.test(id)) return true
+  const opus = /opus[.-](\d+)(?:[.@-]|$)|claude-(\d+)(?:[.-]\d+)?-opus(?:[.@-]|$)/.exec(id)
+  return Number(opus?.[1] ?? opus?.[2]) >= 5
 }
 // kilocode_change end
 
 function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  // kilocode_change start - treat opus-4.8 and fable like opus-4.7
+  // kilocode_change start - include Claude 5 aliases and future Opus versions
   if (anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId)) {
     return ["low", "medium", "high", "xhigh", "max"]
   }
@@ -977,7 +979,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       if (adaptiveEfforts) {
         let efforts = [...adaptiveEfforts]
         if (model.providerID === "github-copilot") {
-          // kilocode_change start - treat opus-4.8 and fable like opus-4.7
+          // kilocode_change start - include Claude 5 aliases and future Opus versions
           if (
             model.api.id.includes("opus-4.7") ||
             model.api.id.includes("opus-4.8") ||

--- a/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
+++ b/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
@@ -207,6 +207,50 @@ describe("ProviderTransform.variants - Claude Opus 4.7 / 4.8", () => {
     })
   })
 
+  test("opus-5 returns adaptive thinking variants including xhigh (native anthropic)", () => {
+    const model = mockModel({
+      api: {
+        id: "claude-opus-5",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    expect(result.xhigh).toEqual({
+      thinking: { type: "adaptive", display: "summarized" },
+      effort: "xhigh",
+    })
+  })
+
+  test("opus-5 returns adaptive thinking variants via @ai-sdk/gateway", () => {
+    const model = mockModel({
+      id: "anthropic/claude-opus-5",
+      api: {
+        id: "anthropic/claude-opus-5",
+        url: "https://gateway.ai",
+        npm: "@ai-sdk/gateway",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+  })
+
+  test("opus-5 on bedrock returns adaptive reasoningConfig with xhigh", () => {
+    const model = mockModel({
+      api: {
+        id: "anthropic.claude-opus-5",
+        url: "https://bedrock.amazonaws.com",
+        npm: "@ai-sdk/amazon-bedrock",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    expect(result.xhigh).toEqual({
+      reasoningConfig: { type: "adaptive", maxReasoningEffort: "xhigh", display: "summarized" },
+    })
+  })
+
   test("sonnet-4.6 keeps original adaptive efforts without xhigh", () => {
     const model = mockModel({
       api: {

--- a/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
+++ b/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
@@ -251,7 +251,16 @@ describe("ProviderTransform.variants - Claude Opus 4.7 / 4.8", () => {
     })
   })
 
-  test.each(["claude-opus-5.3", "claude-opus-6", "claude-6-opus", "claude-opus-10"])(
+  test.each([
+    "claude-opus-5.3",
+    "claude-opus-6",
+    "claude-6-opus",
+    "claude-opus-10",
+    "claude-sonnet-5.3",
+    "claude-sonnet-6",
+    "claude-6-sonnet",
+    "claude-sonnet-10",
+  ])(
     "%s is treated as an adaptive thinking model",
     (id) => {
       const model = mockModel({

--- a/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
+++ b/packages/opencode/test/kilocode/transform-opus-4.7.test.ts
@@ -251,6 +251,25 @@ describe("ProviderTransform.variants - Claude Opus 4.7 / 4.8", () => {
     })
   })
 
+  test.each(["claude-opus-5.3", "claude-opus-6", "claude-6-opus", "claude-opus-10"])(
+    "%s is treated as an adaptive thinking model",
+    (id) => {
+      const model = mockModel({
+        api: {
+          id,
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.xhigh).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort: "xhigh",
+      })
+    },
+  )
+
   test("sonnet-4.6 keeps original adaptive efforts without xhigh", () => {
     const model = mockModel({
       api: {


### PR DESCRIPTION
## Summary

Treat Claude Opus and Sonnet model identifiers with major versions 5 and above as adaptive-thinking models across native Anthropic, AI Gateway, and Bedrock providers. This supports minor releases, future major-only identifiers, multi-digit majors, and inverted provider formats.