### PR TITLE
fix(cli): flush the session ingest tail on shutdown

### DIFF
--- a/.changeset/ingest-shutdown-flush.md
+++ b/.changeset/ingest-shutdown-flush.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix session transcripts losing their final messages when the CLI exits — pending uploads are now flushed on shutdown and as soon as a session closes.

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -4,6 +4,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { InstanceRuntime } from "../../project/instance-runtime" // kilocode_change
 import { startParentWatchdog } from "../../kilocode/parent-watchdog" // kilocode_change
+import { KiloSessions } from "@/kilo-sessions/kilo-sessions" // kilocode_change
 
 export const ServeCommand = effectCmd({
   command: "serve",
@@ -38,6 +39,7 @@ export const ServeCommand = effectCmd({
           const shutdown = async () => {
             stopWatchdog()
             try {
+              await KiloSessions.drainIngestForShutdown() // kilocode_change
               await InstanceRuntime.disposeAllInstances()
               await server.stop(true)
             } finally {

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -283,6 +283,9 @@ export const TuiThreadCommand = cmd({
       }
       process.once("SIGHUP", () => shutdownAndExit({ reason: "signal", signal: "SIGHUP", code: 129 }))
       process.once("SIGTERM", () => shutdownAndExit({ reason: "signal", signal: "SIGTERM", code: 143 }))
+      // kilocode_change - external kill -INT takes the same graceful path as SIGHUP/SIGTERM.
+      // Interactive Ctrl-C in the TUI is a raw-mode keypress, not a signal.
+      process.once("SIGINT", () => shutdownAndExit({ reason: "signal", signal: "SIGINT", code: 130 }))
       // In some terminal/tab-close paths the parent shell is terminated without
       // forwarding a signal to this process, leaving the TUI orphaned. Detect
       // parent PID re-parenting and exit explicitly.

--- a/packages/opencode/src/cli/tui/worker-shutdown.ts
+++ b/packages/opencode/src/cli/tui/worker-shutdown.ts
@@ -1,0 +1,14 @@
+// kilocode_change - new file
+// Pure shutdown sequence for the embedded TUI worker. Extracted so unit tests can
+// assert drain → dispose → stopServer ordering without loading worker.ts side effects.
+export function createWorkerShutdown(input: {
+  drain: () => Promise<void>
+  dispose: () => Promise<void>
+  stopServer: () => Promise<void>
+}) {
+  return async () => {
+    await input.drain()
+    await input.dispose()
+    await input.stopServer()
+  }
+}

--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -13,6 +13,8 @@ import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecy
 import { KiloLog } from "@/kilocode/log" // kilocode_change
 import { ensureProcessMetadata } from "@opencode-ai/core/util/opencode-process" // kilocode_change
 import { createWorkerRemoteExit } from "@/kilocode/cli/cmd/tui/remote-exit-worker" // kilocode_change
+import { createWorkerShutdown } from "@/cli/tui/worker-shutdown" // kilocode_change
+import { KiloSessions } from "@/kilo-sessions/kilo-sessions" // kilocode_change
 
 ensureProcessMetadata("worker") // kilocode_change - retain worker role and parent run correlation
 await KiloLog.init() // kilocode_change - keep compatibility logs off the TUI terminal
@@ -25,6 +27,15 @@ GlobalBus.on("event", (event) => {
 
 let server: Awaited<ReturnType<typeof Server.listen>> | undefined
 const remoteExit = createWorkerRemoteExit(Rpc.emit) // kilocode_change
+// kilocode_change start - drain ingest before dispose so GlobalBus/remote stay live
+const runShutdown = createWorkerShutdown({
+  drain: () => KiloSessions.drainIngestForShutdown(),
+  dispose: () => InstanceRuntime.disposeAllInstances(),
+  stopServer: async () => {
+    if (server) await server.stop(true)
+  },
+})
+// kilocode_change end
 
 export const rpc = {
   // kilocode_change start - worker lifecycle hooks for remote exit
@@ -78,8 +89,7 @@ export const rpc = {
   },
   async shutdown() {
     remoteExit.shutdown() // kilocode_change
-    await InstanceRuntime.disposeAllInstances()
-    if (server) await server.stop(true)
+    await runShutdown() // kilocode_change - drain → dispose → stopServer
     // kilocode_change start - Clear the Rpc message channel so the worker's event loop can drain and
     // exit naturally. Without this, the active onmessage handle keeps the
     // worker alive even after all async work is done.

--- a/packages/opencode/src/kilo-sessions/ingest-drain.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-drain.ts
@@ -1,10 +1,17 @@
 // Once-per-process guard around the session ingest shutdown drain.
 // Overlapping shutdown paths (worker RPC, KiloShutdown, serve signals) must not double-POST.
+// The guarded call never rejects: a drain failure must not block the remaining shutdown
+// sequence (disposeAllInstances / server.stop). Failures are logged once via the optional
+// onError callback; later callers share the same resolved promise (no retry).
 export namespace IngestDrain {
-  export function create(run: () => Promise<void>) {
+  export function create(run: () => Promise<void>, onError?: (err: unknown) => void) {
     let done: Promise<void> | undefined
     return () => {
-      if (!done) done = run()
+      if (!done) {
+        done = run().catch((err) => {
+          onError?.(err)
+        })
+      }
       return done
     }
   }

--- a/packages/opencode/src/kilo-sessions/ingest-drain.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-drain.ts
@@ -1,0 +1,11 @@
+// Once-per-process guard around the session ingest shutdown drain.
+// Overlapping shutdown paths (worker RPC, KiloShutdown, serve signals) must not double-POST.
+export namespace IngestDrain {
+  export function create(run: () => Promise<void>) {
+    let done: Promise<void> | undefined
+    return () => {
+      if (!done) done = run()
+      return done
+    }
+  }
+}

--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -231,11 +231,26 @@ export namespace IngestQueue {
       }
     }
 
+    async function resolveShare(sessionId: string) {
+      const fresh = await options.getShare(sessionId).catch(() => undefined)
+      if (fresh) shares.set(sessionId, fresh)
+      return fresh ?? (shutting ? shares.get(sessionId) : undefined)
+    }
+
+    async function resolveClient() {
+      // Preserve normal-path throw → outer catch logging; only swallow during shutdown so the
+      // cached client can be used.
+      const fresh = await options.getClient().catch((error) => {
+        if (!shutting) throw error
+        return undefined
+      })
+      if (fresh) cached = fresh
+      return fresh ?? (shutting ? cached : undefined)
+    }
+
     async function run(sessionId: string, items: Data[]) {
       try {
-        const freshShare = await options.getShare(sessionId).catch(() => undefined)
-        if (freshShare) shares.set(sessionId, freshShare)
-        const share = freshShare ?? (shutting ? shares.get(sessionId) : undefined)
+        const share = await resolveShare(sessionId)
         if (!share) {
           if (shutting) {
             options.log.error("ingest drain skipped", { sessionId, reason: "no share" })
@@ -243,14 +258,7 @@ export namespace IngestQueue {
           return
         }
 
-        const freshClient = await options.getClient().catch((error) => {
-          // Preserve normal-path throw → outer catch logging; only swallow during shutdown so the
-          // cached client can be used.
-          if (!shutting) throw error
-          return undefined
-        })
-        if (freshClient) cached = freshClient
-        const client = freshClient ?? (shutting ? cached : undefined)
+        const client = await resolveClient()
         if (!client) {
           if (shutting) {
             options.log.error("ingest drain skipped", { sessionId, reason: "no client" })

--- a/packages/opencode/src/kilo-sessions/ingest-queue.ts
+++ b/packages/opencode/src/kilo-sessions/ingest-queue.ts
@@ -83,7 +83,8 @@ export namespace IngestQueue {
     // To avoid spamming the server, we coalesce updates and flush at most once per ~1s per session.
     //
     // `due` is the earliest time we should flush; it is also used to respect backoff when retries are
-    // active. A later `due` always wins over an earlier one.
+    // active. A later `due` always wins over an earlier one for non-terminal batches. Terminal batches
+    // (`session_close`) may pull the flush earlier.
     const queue = new Map<string, { timeout: Timer; due: number; data: Map<string, Data> }>()
 
     // Per-session retry state.
@@ -93,6 +94,18 @@ export namespace IngestQueue {
     // - Use exponential backoff with a small max budget to prevent infinite loops/log spam
     // - Store `until` so sync() can avoid scheduling a flush before backoff expires
     const retry = new Map<string, { count: number; until: number }>()
+
+    // In-flight flush promises. flush() deletes the queue entry before I/O, so an empty queue is not
+    // quiescence — drain must join these too.
+    const inflight = new Set<Promise<void>>()
+
+    // Last successfully resolved client and per-session share. Drain falls back to these when
+    // getClient/getShare fail during teardown (e.g. authValid HTTP check).
+    let cached: Client | undefined
+    const shares = new Map<string, Share>()
+
+    // Shutdown mode: one attempt per item, no re-enqueue, use cached client/share on resolution failure.
+    let shutting = false
 
     const now = options.now ?? (() => Date.now())
     const set = options.setTimeout ?? ((fn, ms) => setTimeout(fn, ms))
@@ -154,12 +167,12 @@ export namespace IngestQueue {
       return models.length > 0 ? `model:${models}` : ulid()
     }
 
-    function schedule(sessionId: string, due: number, data: Map<string, Data>) {
+    function schedule(sessionId: string, due: number, data: Map<string, Data>, terminal = false) {
       const existing = queue.get(sessionId)
       if (existing) {
-        // Don't reschedule if an earlier flush is already planned.
-        // We only move the flush later (e.g., to respect backoff).
-        if (existing.due >= due) return
+        // Non-terminal: only move the flush later (e.g., to respect backoff).
+        // Terminal (`session_close`): may pull the flush earlier so the tail is not left behind.
+        if (!terminal && existing.due >= due) return
         clear(existing.timeout)
       }
 
@@ -170,7 +183,7 @@ export namespace IngestQueue {
       queue.set(sessionId, { timeout, due, data })
     }
 
-    function enqueue(sessionId: string, items: Data[], mode: "overwrite" | "fill", due: number) {
+    function enqueue(sessionId: string, items: Data[], mode: "overwrite" | "fill", due: number, terminal = false) {
       const existing = queue.get(sessionId)
       if (existing) {
         for (const item of items) {
@@ -180,7 +193,7 @@ export namespace IngestQueue {
           if (mode === "fill" && existing.data.has(k)) continue
           existing.data.set(k, item)
         }
-        schedule(sessionId, due, existing.data)
+        schedule(sessionId, due, existing.data, terminal)
         return
       }
 
@@ -189,7 +202,12 @@ export namespace IngestQueue {
         data.set(key(item), item)
       }
 
-      schedule(sessionId, due, data)
+      schedule(sessionId, due, data, terminal)
+    }
+
+    function requeue(sessionId: string, items: Data[], delay: number) {
+      if (shutting) return
+      enqueue(sessionId, items, "fill", now() + delay)
     }
 
     async function flush(sessionId: string) {
@@ -204,13 +222,41 @@ export namespace IngestQueue {
       queue.delete(sessionId)
 
       const items = Array.from(queued.data.values())
-
+      const done = run(sessionId, items)
+      inflight.add(done)
       try {
-        const share = await options.getShare(sessionId).catch(() => undefined)
-        if (!share) return
+        await done
+      } finally {
+        inflight.delete(done)
+      }
+    }
 
-        const client = await options.getClient()
-        if (!client) return
+    async function run(sessionId: string, items: Data[]) {
+      try {
+        const freshShare = await options.getShare(sessionId).catch(() => undefined)
+        if (freshShare) shares.set(sessionId, freshShare)
+        const share = freshShare ?? (shutting ? shares.get(sessionId) : undefined)
+        if (!share) {
+          if (shutting) {
+            options.log.error("ingest drain skipped", { sessionId, reason: "no share" })
+          }
+          return
+        }
+
+        const freshClient = await options.getClient().catch((error) => {
+          // Preserve normal-path throw → outer catch logging; only swallow during shutdown so the
+          // cached client can be used.
+          if (!shutting) throw error
+          return undefined
+        })
+        if (freshClient) cached = freshClient
+        const client = freshClient ?? (shutting ? cached : undefined)
+        if (!client) {
+          if (shutting) {
+            options.log.error("ingest drain skipped", { sessionId, reason: "no client" })
+          }
+          return
+        }
 
         if (options.log.info) {
           const types = items.map((d) => d.type).join(",")
@@ -233,6 +279,12 @@ export namespace IngestQueue {
 
         if (!response) {
           // Network failures are assumed transient; retry with backoff and a small budget.
+          // Shutdown: one attempt only — log and drop so the process can exit.
+          if (shutting) {
+            options.log.error("share sync failed", { sessionId, error: "network", shutdown: true })
+            return
+          }
+
           const count = (retry.get(sessionId)?.count ?? 0) + 1
           if (count > 6) {
             options.log.error("share sync failed", { sessionId, error: "retry budget exceeded" })
@@ -243,7 +295,7 @@ export namespace IngestQueue {
           const delay = backoff(count)
           retry.set(sessionId, { count, until: now() + delay })
           options.log.error("share sync failed", { sessionId, error: "network", attempt: count, retryInMs: delay })
-          enqueue(sessionId, items, "fill", now() + delay)
+          requeue(sessionId, items, delay)
           return
         }
 
@@ -276,6 +328,16 @@ export namespace IngestQueue {
           return
         }
 
+        if (shutting) {
+          options.log.error("share sync failed", {
+            sessionId,
+            status: response.status,
+            statusText: response.statusText,
+            shutdown: true,
+          })
+          return
+        }
+
         const current = retry.get(sessionId)
         const count = (current?.count ?? 0) + 1
         if (count > 6) {
@@ -293,7 +355,7 @@ export namespace IngestQueue {
           attempt: count,
           retryInMs: delay,
         })
-        enqueue(sessionId, items, "fill", now() + delay)
+        requeue(sessionId, items, delay)
       } catch (error) {
         options.log.error("share sync failed", { sessionId, error })
       }
@@ -305,6 +367,7 @@ export namespace IngestQueue {
       // - Otherwise, merge into the pending queue entry.
       //   The next flush is scheduled ~1s after the first queued event (throttled), but never earlier
       //   than the current backoff window (if retries are active).
+      // - A batch containing session_close is terminal: flush ASAP (respecting backoff only).
       const client = await options.getClient()
       if (!client) return
 
@@ -313,15 +376,54 @@ export namespace IngestQueue {
         options.log.info("ingest sync", { sessionId, types })
       }
 
+      const terminal = data.some((item) => item.type === "session_close")
       const until = retry.get(sessionId)?.until ?? 0
-      const base = queue.get(sessionId)?.due ?? now() + 1000
+      // Terminal batches do not inherit the open debounce window — only backoff.
+      const base = terminal ? now() : (queue.get(sessionId)?.due ?? now() + 1000)
       const due = Math.max(base, until)
-      enqueue(sessionId, data, "overwrite", due)
+      enqueue(sessionId, data, "overwrite", due, terminal)
+    }
+
+    async function drain(bound = 3_000) {
+      // Shutdown drain: one bounded attempt per pending session, join in-flight flushes, no re-enqueue.
+      shutting = true
+      const deadline = now() + bound
+
+      for (const sessionId of Array.from(queue.keys())) {
+        void flush(sessionId)
+      }
+
+      while (queue.size > 0 || inflight.size > 0) {
+        for (const sessionId of Array.from(queue.keys())) {
+          void flush(sessionId)
+        }
+
+        if (now() >= deadline) {
+          options.log.error("ingest drain timed out", {
+            queue: queue.size,
+            inflight: inflight.size,
+            bound,
+          })
+          return
+        }
+
+        if (inflight.size === 0) continue
+
+        const pending = Array.from(inflight)
+        const left = Math.max(0, deadline - now())
+        let timer: Timer | undefined
+        const timeout = new Promise<void>((resolve) => {
+          timer = set(() => resolve(), left)
+        })
+        await Promise.race([Promise.allSettled(pending), timeout])
+        if (timer !== undefined) clear(timer)
+      }
     }
 
     return {
       sync,
       flush,
+      drain,
     } as const
   }
 }

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -13,6 +13,7 @@ import * as Log from "@opencode-ai/core/util/log"
 import { Auth } from "@/auth"
 import { makeRuntime } from "@/effect/run-service"
 import { IngestQueue } from "@/kilo-sessions/ingest-queue"
+import { IngestDrain } from "@/kilo-sessions/ingest-drain"
 import { clearInFlightCache, withInFlightCache } from "@/kilo-sessions/inflight-cache"
 import type * as SDK from "@kilocode/sdk/v2"
 import z from "zod"
@@ -221,6 +222,14 @@ export namespace KiloSessions {
       clearCache()
     },
   })
+
+  // Process-level once-guard: overlapping shutdown paths must not double-POST.
+  // Do not call from per-directory instance finalizers — wrong granularity.
+  const drainIngest = IngestDrain.create(() => ingest.drain())
+
+  export async function drainIngestForShutdown() {
+    await drainIngest()
+  }
 
   const remoteEnabled = process.env["KILO_REMOTE"] === "1"
   let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender } | undefined

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -225,7 +225,11 @@ export namespace KiloSessions {
 
   // Process-level once-guard: overlapping shutdown paths must not double-POST.
   // Do not call from per-directory instance finalizers — wrong granularity.
-  const drainIngest = IngestDrain.create(() => ingest.drain())
+  // Never-reject: serve/worker await this unguarded before dispose/stop.
+  const drainIngest = IngestDrain.create(
+    () => ingest.drain(),
+    (err) => log.warn("ingest drain failed", { err }),
+  )
 
   export async function drainIngestForShutdown() {
     await drainIngest()

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -10,6 +10,7 @@ import { Auth } from "@/auth"
 import { InstanceRuntime } from "@/project/instance-runtime"
 import { SessionExport } from "@/kilocode/session-export"
 import { KiloShutdown } from "@/kilocode/cli/shutdown"
+import { KiloSessions } from "@/kilo-sessions/kilo-sessions"
 import { createHelpCommand } from "@/kilocode/help-command"
 import { KiloConsoleCommand } from "@/kilocode/cli/cmd/console"
 import { CloudCommand } from "@/kilocode/cli/cmd/cloud"
@@ -23,6 +24,11 @@ import { JsonMigration } from "@/kilocode/storage/json-migration"
 import { KiloLog } from "@/kilocode/log"
 
 const log = Log.create({ service: "kilocode.cli" })
+
+// Process-level ingest drain for non-TUI commands (`kilo run`, etc.).
+// KiloCli.shutdown() runs KiloShutdown before disposeAllInstances — preserve that order.
+// Registered at setup load time (not inside shutdown()) so the task is always present.
+KiloShutdown.register(() => KiloSessions.drainIngestForShutdown())
 
 // All Kilo-specific CLI customization lives here so the shared upstream entrypoint
 // (src/index.ts) only needs a handful of thin call-sites behind kilocode_change markers.

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -27,10 +27,12 @@ const log = Log.create({ service: "kilocode.cli" })
 // Process-level ingest drain for non-TUI commands (`kilo run`, etc.).
 // KiloCli.shutdown() runs KiloShutdown before disposeAllInstances — preserve that order.
 // Registered at setup load time (not inside shutdown()) so the task is always present.
-// Lazy-import kilo-sessions deliberately: a static import would pull the provider/plugin
-// graph into every CLI startup (including `kilo --help`). Dynamic import returns the same
-// in-process module singleton, so the drained queue is the one that received events.
-// Task must never reject: a drain failure must not take down the remaining shutdown sequence.
+// Dynamic import keeps setup.ts's own static import graph unchanged: consumers that load
+// setup.ts under partial module mocks (e.g. cli-shutdown tests whose @/auth mock omits
+// OAUTH_DUMMY_KEY) would otherwise fail to link the provider/plugin chain. Dynamic import
+// returns the same in-process module singleton, so the drained queue is the one that
+// received events. Task try/catch covers dynamic-import failure outside the shared drain
+// guard; the drain itself never rejects.
 KiloShutdown.register(async () => {
   try {
     const { KiloSessions } = await import("@/kilo-sessions/kilo-sessions")

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -10,7 +10,6 @@ import { Auth } from "@/auth"
 import { InstanceRuntime } from "@/project/instance-runtime"
 import { SessionExport } from "@/kilocode/session-export"
 import { KiloShutdown } from "@/kilocode/cli/shutdown"
-import { KiloSessions } from "@/kilo-sessions/kilo-sessions"
 import { createHelpCommand } from "@/kilocode/help-command"
 import { KiloConsoleCommand } from "@/kilocode/cli/cmd/console"
 import { CloudCommand } from "@/kilocode/cli/cmd/cloud"
@@ -28,7 +27,13 @@ const log = Log.create({ service: "kilocode.cli" })
 // Process-level ingest drain for non-TUI commands (`kilo run`, etc.).
 // KiloCli.shutdown() runs KiloShutdown before disposeAllInstances — preserve that order.
 // Registered at setup load time (not inside shutdown()) so the task is always present.
-KiloShutdown.register(() => KiloSessions.drainIngestForShutdown())
+// Lazy-import kilo-sessions deliberately: a static import would pull the provider/plugin
+// graph into every CLI startup (including `kilo --help`). Dynamic import returns the same
+// in-process module singleton, so the drained queue is the one that received events.
+KiloShutdown.register(async () => {
+  const { KiloSessions } = await import("@/kilo-sessions/kilo-sessions")
+  await KiloSessions.drainIngestForShutdown()
+})
 
 // All Kilo-specific CLI customization lives here so the shared upstream entrypoint
 // (src/index.ts) only needs a handful of thin call-sites behind kilocode_change markers.

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -30,9 +30,14 @@ const log = Log.create({ service: "kilocode.cli" })
 // Lazy-import kilo-sessions deliberately: a static import would pull the provider/plugin
 // graph into every CLI startup (including `kilo --help`). Dynamic import returns the same
 // in-process module singleton, so the drained queue is the one that received events.
+// Task must never reject: a drain failure must not take down the remaining shutdown sequence.
 KiloShutdown.register(async () => {
-  const { KiloSessions } = await import("@/kilo-sessions/kilo-sessions")
-  await KiloSessions.drainIngestForShutdown()
+  try {
+    const { KiloSessions } = await import("@/kilo-sessions/kilo-sessions")
+    await KiloSessions.drainIngestForShutdown()
+  } catch (err) {
+    log.warn("ingest drain failed", { err })
+  }
 })
 
 // All Kilo-specific CLI customization lives here so the shared upstream entrypoint

--- a/packages/opencode/test/kilocode/cli-shutdown.test.ts
+++ b/packages/opencode/test/kilocode/cli-shutdown.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { KiloShutdown } from "../../src/kilocode/cli/shutdown"
 
 const calls: string[] = []
 const timeouts: Array<number | undefined> = []
@@ -106,6 +107,27 @@ for (const path of [
   }))
 }
 
+/** Same mock body as the kilo-sessions module mock used by setup.ts's drain task. */
+function registerDrain() {
+  KiloShutdown.register(async () => {
+    drainCalls += 1
+    calls.push("drain")
+    if (drainErr) throw drainErr
+  })
+}
+
+/**
+ * Install a drain task for this test only. Clears any leftover registry entries first
+ * (setup.ts's one-time module-scope registration, or a prior test) so assertions do not
+ * depend on declaration order or on whether an earlier test already ran KiloShutdown.run().
+ */
+async function installDrain() {
+  await KiloShutdown.run()
+  calls.length = 0
+  drainCalls = 0
+  registerDrain()
+}
+
 describe("KiloCli.shutdown", () => {
   beforeEach(() => {
     calls.length = 0
@@ -121,8 +143,9 @@ describe("KiloCli.shutdown", () => {
     process.exitCode = exit
   })
 
-  // Runs first: setup registers the drain task once at import; KiloShutdown.run() clears it.
-  // That registration is also what scopes the drain-before-dispose ordering assertion to this test.
+  // Must stay first: setup registers the drain task once at import; KiloShutdown.run() clears it.
+  // Only this test pins that one-time module-scope registration (and the drain-before-dispose
+  // ordering it enables). Later tests call installDrain() so they do not rely on order.
   test("rejects drain without blocking dispose", async () => {
     drainErr = new Error("ingest drain failed")
     process.exitCode = 0
@@ -140,22 +163,24 @@ describe("KiloCli.shutdown", () => {
     err = "Timeout while shutting down PostHog. Some events may not have been sent."
     process.exitCode = 0
     const { KiloCli } = await import("../../src/kilocode/cli/setup")
+    await installDrain()
 
     await expect(KiloCli.shutdown()).resolves.toBeUndefined()
 
     expect(timeouts).toEqual([2000])
-    expect(calls).toEqual(["track:0", "session", "telemetry", "dispose"])
+    expect(calls).toEqual(["track:0", "session", "telemetry", "drain", "dispose"])
     expect(process.exitCode).toBe(0)
   })
 
   test("preserves failing command exit status", async () => {
     process.exitCode = 1
     const { KiloCli } = await import("../../src/kilocode/cli/setup")
+    await installDrain()
 
     await KiloCli.shutdown()
 
     expect(timeouts).toEqual([2000])
-    expect(calls).toEqual(["track:1", "session", "telemetry", "dispose"])
+    expect(calls).toEqual(["track:1", "session", "telemetry", "drain", "dispose"])
     expect(process.exitCode).toBe(1)
   })
 })

--- a/packages/opencode/test/kilocode/cli-shutdown.test.ts
+++ b/packages/opencode/test/kilocode/cli-shutdown.test.ts
@@ -67,6 +67,10 @@ mock.module("@/kilocode/session-export", () => ({
   },
 }))
 
+mock.module("@/kilo-sessions/kilo-sessions", () => ({
+  KiloSessions: { async drainIngestForShutdown() {} },
+}))
+
 mock.module("@/kilocode/help-command", () => ({
   createHelpCommand: () => ({ command: "help", handler() {} }),
 }))

--- a/packages/opencode/test/kilocode/cli-shutdown.test.ts
+++ b/packages/opencode/test/kilocode/cli-shutdown.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 const calls: string[] = []
 const timeouts: Array<number | undefined> = []
 let err: unknown
+let drainErr: unknown
+let drainCalls = 0
 let exit: string | number | null | undefined
 
 mock.module("@opencode-ai/core/global", () => ({
@@ -68,7 +70,12 @@ mock.module("@/kilocode/session-export", () => ({
 }))
 
 mock.module("@/kilo-sessions/kilo-sessions", () => ({
-  KiloSessions: { async drainIngestForShutdown() {} },
+  KiloSessions: {
+    async drainIngestForShutdown() {
+      drainCalls += 1
+      if (drainErr) throw drainErr
+    },
+  },
 }))
 
 mock.module("@/kilocode/help-command", () => ({
@@ -103,12 +110,28 @@ describe("KiloCli.shutdown", () => {
     calls.length = 0
     timeouts.length = 0
     err = undefined
+    drainErr = undefined
+    drainCalls = 0
     exit = process.exitCode
     process.exitCode = undefined
   })
 
   afterEach(() => {
     process.exitCode = exit
+  })
+
+  // Runs first: setup registers the drain task once at import; KiloShutdown.run() clears it.
+  test("rejects drain without blocking dispose", async () => {
+    drainErr = new Error("ingest drain failed")
+    process.exitCode = 0
+    const { KiloCli } = await import("../../src/kilocode/cli/setup")
+
+    await expect(KiloCli.shutdown()).resolves.toBeUndefined()
+
+    expect(drainCalls).toBe(1)
+    expect(timeouts).toEqual([2000])
+    expect(calls).toEqual(["track:0", "session", "telemetry", "dispose"])
+    expect(process.exitCode).toBe(0)
   })
 
   test("keeps telemetry shutdown timeout best-effort and still disposes instances", async () => {

--- a/packages/opencode/test/kilocode/cli-shutdown.test.ts
+++ b/packages/opencode/test/kilocode/cli-shutdown.test.ts
@@ -73,6 +73,7 @@ mock.module("@/kilo-sessions/kilo-sessions", () => ({
   KiloSessions: {
     async drainIngestForShutdown() {
       drainCalls += 1
+      calls.push("drain")
       if (drainErr) throw drainErr
     },
   },
@@ -121,6 +122,7 @@ describe("KiloCli.shutdown", () => {
   })
 
   // Runs first: setup registers the drain task once at import; KiloShutdown.run() clears it.
+  // That registration is also what scopes the drain-before-dispose ordering assertion to this test.
   test("rejects drain without blocking dispose", async () => {
     drainErr = new Error("ingest drain failed")
     process.exitCode = 0
@@ -130,7 +132,7 @@ describe("KiloCli.shutdown", () => {
 
     expect(drainCalls).toBe(1)
     expect(timeouts).toEqual([2000])
-    expect(calls).toEqual(["track:0", "session", "telemetry", "dispose"])
+    expect(calls).toEqual(["track:0", "session", "telemetry", "drain", "dispose"])
     expect(process.exitCode).toBe(0)
   })
 

--- a/packages/opencode/test/kilocode/sessions/ingest-drain.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-drain.test.ts
@@ -37,4 +37,25 @@ describe("IngestDrain once-guard", () => {
     await drain()
     expect(calls).toBe(1)
   })
+
+  test("underlying run() rejection resolves, logs once, and does not retry", async () => {
+    let calls = 0
+    const errors: unknown[] = []
+    const drain = IngestDrain.create(
+      async () => {
+        calls += 1
+        throw new Error("boom")
+      },
+      (err) => {
+        errors.push(err)
+      },
+    )
+
+    await expect(drain()).resolves.toBeUndefined()
+    await expect(drain()).resolves.toBeUndefined()
+    expect(calls).toBe(1)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(Error)
+    expect((errors[0] as Error).message).toBe("boom")
+  })
 })

--- a/packages/opencode/test/kilocode/sessions/ingest-drain.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-drain.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { IngestDrain } from "../../../src/kilo-sessions/ingest-drain"
+
+describe("IngestDrain once-guard", () => {
+  test("overlapping invocations share a single underlying drain call", async () => {
+    let calls = 0
+    let resolveDrain!: () => void
+    const gate = new Promise<void>((resolve) => {
+      resolveDrain = resolve
+    })
+
+    const drain = IngestDrain.create(async () => {
+      calls += 1
+      await gate
+    })
+
+    const first = drain()
+    const second = drain()
+    expect(calls).toBe(1)
+
+    resolveDrain()
+    await Promise.all([first, second])
+    expect(calls).toBe(1)
+
+    await drain()
+    expect(calls).toBe(1)
+  })
+
+  test("sequential calls after completion still run only once", async () => {
+    let calls = 0
+    const drain = IngestDrain.create(async () => {
+      calls += 1
+    })
+
+    await drain()
+    await drain()
+    await drain()
+    expect(calls).toBe(1)
+  })
+})

--- a/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
@@ -517,6 +517,37 @@ describe("share ingest queue", () => {
     expect(sched.size()).toBe(0)
   })
 
+  test("drain does not re-enqueue on retryable HTTP status under shutdown", async () => {
+    const errors: Record<string, unknown>[] = []
+    const sched = scheduler(() => clock.now)
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: {
+        error: (_message, data) => {
+          errors.push(data)
+        },
+      },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async () => new Response("", { status: 429 }),
+      }),
+    })
+
+    await q.sync("s-429", [{ type: "session", data: { id: "s-429", v: 1 } as any }])
+    expect(sched.size()).toBe(1)
+
+    await q.drain()
+    await Bun.sleep(0)
+
+    // Shutdown path logs the retryable status and drops the item (no re-enqueue).
+    expect(errors.some((e) => e.status === 429 && e.shutdown === true)).toBe(true)
+    expect(sched.size()).toBe(0)
+  })
+
   test("drain POSTs using cached client/share when resolution fails at teardown", async () => {
     const urls: string[] = []
     const sched = scheduler(() => clock.now)

--- a/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
@@ -657,6 +657,59 @@ describe("share ingest queue", () => {
     expect(sched.size()).toBe(0)
   })
 
+  test("drain resolves when the bound expires on a never-settling flush", async () => {
+    const errors: { message: string; data: Record<string, unknown> }[] = []
+    const sched = scheduler(() => clock.now)
+    let started = false
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: {
+        error: (message, data) => {
+          errors.push({ message, data })
+        },
+      },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async () => {
+          started = true
+          // Never settles — drain must exit via its bound timeout, not the fetch.
+          return new Promise<Response>(() => {})
+        },
+      }),
+    })
+
+    await q.sync("s-bound", [{ type: "session", data: { id: "s-bound" } as any }])
+    expect(sched.size()).toBe(1)
+
+    const drained = q.drain()
+    let drainDone = false
+    void drained.then(() => {
+      drainDone = true
+    })
+
+    // Drain flushes immediately; fetch hangs and schedules the bound timer.
+    await Bun.sleep(0)
+    expect(started).toBe(true)
+    expect(drainDone).toBe(false)
+    expect(sched.size()).toBe(1)
+    expect(sched.nextAt()).toBe(3000)
+
+    // Advance past the 3s bound and fire the drain's internal timeout.
+    clock.now = 3000
+    sched.run()
+    await drained
+    await Bun.sleep(0)
+
+    expect(drainDone).toBe(true)
+    expect(errors.some((e) => e.message === "ingest drain timed out")).toBe(true)
+    // Bound expiry must not re-enqueue or leave a retry timer.
+    expect(sched.size()).toBe(0)
+  })
+
   test("session_close into open debounce window reschedules flush earlier", async () => {
     const sent: unknown[] = []
     const sched = scheduler(() => clock.now)

--- a/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
+++ b/packages/opencode/test/kilocode/sessions/ingest-queue.test.ts
@@ -467,4 +467,295 @@ describe("share ingest queue", () => {
     expect(payload.data.length).toBe(1)
     expect(payload.data[0].data.message).toBe("second")
   })
+
+  test("drain flushes every pending session and does not re-enqueue on failure", async () => {
+    const sent: { sessionId: string; body: unknown }[] = []
+    const sched = scheduler(() => clock.now)
+    let fail = false
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async (sessionId) => ({ ingestPath: `/ingest/${sessionId}` }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async (input, init) => {
+          const url = String(input)
+          const sessionId = url.includes("/s-a") ? "s-a" : "s-b"
+          sent.push({ sessionId, body: JSON.parse((init?.body as string) ?? "{}") })
+          if (fail) throw new Error("network")
+          return new Response("{}", { status: 200 })
+        },
+      }),
+    })
+
+    await q.sync("s-a", [{ type: "session", data: { id: "s-a", v: 1 } as any }])
+    await q.sync("s-b", [{ type: "session", data: { id: "s-b", v: 1 } as any }])
+    expect(sched.size()).toBe(2)
+
+    await q.drain()
+    await Bun.sleep(0)
+
+    expect(sent.length).toBe(2)
+    expect(sent.map((s) => s.sessionId).sort()).toEqual(["s-a", "s-b"])
+    expect(sched.size()).toBe(0)
+
+    // Failure path: drain POSTs once and does not re-enqueue for retry.
+    fail = true
+    clock.now = 5000
+    await q.sync("s-c", [{ type: "session", data: { id: "s-c", v: 1 } as any }])
+    await q.sync("s-d", [{ type: "session", data: { id: "s-d", v: 1 } as any }])
+    expect(sched.size()).toBe(2)
+
+    const before = sent.length
+    await q.drain()
+    await Bun.sleep(0)
+
+    expect(sent.length).toBe(before + 2)
+    expect(sched.size()).toBe(0)
+  })
+
+  test("drain POSTs using cached client/share when resolution fails at teardown", async () => {
+    const urls: string[] = []
+    const sched = scheduler(() => clock.now)
+    let live = true
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => {
+        if (!live) return undefined
+        return { ingestPath: "/ingest" }
+      },
+      getClient: async () => {
+        if (!live) return undefined
+        return {
+          url: "https://ingest.test",
+          fetch: async (input) => {
+            urls.push(String(input))
+            return new Response("{}", { status: 200 })
+          },
+        }
+      },
+    })
+
+    // Prime cache with a successful flush.
+    await q.sync("s-cache", [{ type: "session", data: { id: "s-cache", v: 1 } as any }])
+    clock.now = 1000
+    sched.run()
+    await Bun.sleep(0)
+    expect(urls).toEqual(["https://ingest.test/ingest?v=2"])
+
+    // Queue a new item, then break resolution so drain must use the cache.
+    clock.now = 2000
+    await q.sync("s-cache", [{ type: "session", data: { id: "s-cache", v: 2 } as any }])
+    live = false
+
+    await q.drain()
+    await Bun.sleep(0)
+
+    expect(urls.length).toBe(2)
+    expect(urls[1]).toBe("https://ingest.test/ingest?v=2")
+    expect(sched.size()).toBe(0)
+  })
+
+  test("drain waits for in-flight flush when queue map is empty", async () => {
+    const sched = scheduler(() => clock.now)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let started = false
+    let finished = false
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async () => {
+          started = true
+          await gate
+          finished = true
+          return new Response("{}", { status: 200 })
+        },
+      }),
+    })
+
+    await q.sync("s-inflight", [{ type: "session", data: { id: "s-inflight" } as any }])
+    clock.now = 1000
+    sched.run()
+    await Bun.sleep(0)
+    expect(started).toBe(true)
+    expect(finished).toBe(false)
+    expect(sched.size()).toBe(0)
+
+    const drained = q.drain()
+    let drainDone = false
+    void drained.then(() => {
+      drainDone = true
+    })
+
+    await Bun.sleep(0)
+    expect(drainDone).toBe(false)
+    expect(finished).toBe(false)
+
+    release()
+    await drained
+    await Bun.sleep(0)
+
+    expect(finished).toBe(true)
+    expect(drainDone).toBe(true)
+  })
+
+  test("drain suppresses re-enqueue when joined in-flight flush fails retryably", async () => {
+    const sched = scheduler(() => clock.now)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let started = false
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async () => {
+          started = true
+          await gate
+          throw new Error("network")
+        },
+      }),
+    })
+
+    await q.sync("s-join-fail", [{ type: "session", data: { id: "s-join-fail" } as any }])
+    clock.now = 1000
+    sched.run()
+    await Bun.sleep(0)
+    expect(started).toBe(true)
+    expect(sched.size()).toBe(0)
+
+    const drained = q.drain()
+    await Bun.sleep(0)
+
+    release()
+    await drained
+    await Bun.sleep(0)
+
+    // Shutdown suppresses re-enqueue; queue and timers must be empty.
+    expect(sched.size()).toBe(0)
+  })
+
+  test("session_close into open debounce window reschedules flush earlier", async () => {
+    const sent: unknown[] = []
+    const sched = scheduler(() => clock.now)
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async (_input, init) => {
+          sent.push(JSON.parse((init?.body as string) ?? "{}"))
+          return new Response("{}", { status: 200 })
+        },
+      }),
+    })
+
+    // Open a normal ~1s debounce window with a part.
+    await q.sync("s-term", [{ type: "part", data: { id: "p1" } as any }])
+    expect(sched.nextAt()).toBe(1000)
+
+    // session_close must pull the flush forward to now (0 wait).
+    clock.now = 200
+    await q.sync("s-term", [{ type: "session_close", data: { reason: "completed" } }])
+    expect(sched.nextAt()).toBe(200)
+
+    sched.run()
+    await Bun.sleep(0)
+    expect(sent.length).toBe(1)
+    const payload = sent[0] as { data: { type: string }[] }
+    expect(payload.data.map((d) => d.type).sort()).toEqual(["part", "session_close"])
+  })
+
+  test("part/message-only batch still schedules at now + 1000", async () => {
+    const sched = scheduler(() => clock.now)
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async () => new Response("{}", { status: 200 }),
+      }),
+    })
+
+    clock.now = 500
+    await q.sync("s-coalesce", [{ type: "part", data: { id: "p1" } as any }])
+    expect(sched.nextAt()).toBe(1500)
+
+    clock.now = 800
+    await q.sync("s-coalesce", [{ type: "message", data: { id: "m1" } as any }])
+    // Later non-terminal sync must not move the flush earlier.
+    expect(sched.nextAt()).toBe(1500)
+  })
+
+  test("terminal batch respects active retry backoff", async () => {
+    const sent: unknown[] = []
+    const sched = scheduler(() => clock.now)
+    let attempt = 0
+
+    const q = IngestQueue.create({
+      now: () => clock.now,
+      setTimeout: sched.setTimeout,
+      clearTimeout: sched.clearTimeout,
+      log: { error: () => {} },
+      getShare: async () => ({ ingestPath: "/ingest" }),
+      getClient: async () => ({
+        url: "https://ingest.test",
+        fetch: async (_input, init) => {
+          attempt += 1
+          if (attempt === 1) throw new Error("network")
+          sent.push(JSON.parse((init?.body as string) ?? "{}"))
+          return new Response("{}", { status: 200 })
+        },
+      }),
+    })
+
+    await q.sync("s-backoff", [{ type: "session", data: { id: "s-backoff", v: 1 } as any }])
+    clock.now = 1000
+    sched.run()
+    await Bun.sleep(0)
+    // Network fail → backoff 1000ms → due at 2000.
+    expect(sched.nextAt()).toBe(2000)
+
+    clock.now = 1200
+    await q.sync("s-backoff", [{ type: "session_close", data: { reason: "completed" } }])
+    // Terminal must still respect retry.until (2000), not fire at now (1200).
+    expect(sched.nextAt()).toBe(2000)
+
+    clock.now = 2000
+    sched.run()
+    await Bun.sleep(0)
+    expect(sent.length).toBe(1)
+    const payload = sent[0] as { data: { type: string }[] }
+    expect(payload.data.map((d) => d.type).sort()).toEqual(["session", "session_close"])
+  })
 })

--- a/packages/opencode/test/kilocode/sessions/worker-shutdown.test.ts
+++ b/packages/opencode/test/kilocode/sessions/worker-shutdown.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import { createWorkerShutdown } from "../../../src/cli/tui/worker-shutdown"
+
+describe("createWorkerShutdown", () => {
+  test("invokes drain before dispose and stopServer", async () => {
+    const order: string[] = []
+    let resolveDrain!: () => void
+    const gate = new Promise<void>((resolve) => {
+      resolveDrain = resolve
+    })
+
+    const run = createWorkerShutdown({
+      drain: async () => {
+        order.push("drain-start")
+        await gate
+        order.push("drain-end")
+      },
+      dispose: async () => {
+        order.push("dispose")
+      },
+      stopServer: async () => {
+        order.push("stopServer")
+      },
+    })
+
+    const pending = run()
+    // dispose must not start while drain is still in flight
+    expect(order).toEqual(["drain-start"])
+
+    resolveDrain()
+    await pending
+    expect(order).toEqual(["drain-start", "drain-end", "dispose", "stopServer"])
+  })
+
+  test("awaits drain fully before dispose even when drain is slow", async () => {
+    const order: string[] = []
+    const run = createWorkerShutdown({
+      drain: async () => {
+        order.push("drain")
+        await Promise.resolve()
+        await Promise.resolve()
+      },
+      dispose: async () => {
+        order.push("dispose")
+      },
+      stopServer: async () => {
+        order.push("stop")
+      },
+    })
+
+    await run()
+    expect(order.indexOf("drain")).toBeLessThan(order.indexOf("dispose"))
+    expect(order.indexOf("dispose")).toBeLessThan(order.indexOf("stop"))
+  })
+})


### PR DESCRIPTION
## Problem

While a Kilo CLI session is live, the mobile session-detail screen streams assistant messages in over the relay. Opening the same session later read-only, the transcript is often **missing the last message(s)** the user watched arrive.

Root cause (CLI-side): the durable transcript depends on a client-side coalescing queue (`IngestQueue`) that flushes at most once per ~1 s per session and was **never flushed on any exit path** — anything still queued when the process ends is lost permanently, even though the cloud already received (and discarded after broadcast) every one of those events over the live relay. Confirmed reproduction rates on the unmodified baseline: clean `/exit` immediate **3/3**, SIGINT **3/3**, SIGHUP **1/1** lost the tail; delayed `/exit` (≥10 s) **0/2**.

## Fix

- **Shutdown drain in `IngestQueue`.** A new `drain()` flushes every pending session concurrently: bounded at 3 s (the TUI parent terminates the worker unconditionally 5 s after asking it to shut down), joins **in-flight** flushes rather than just the queue map (an empty map is not quiescence), suppresses re-enqueue globally once shutdown begins (a joined flush that fails retryably cannot re-queue the tail behind the drain's back), and falls back to the **last-known client/share without re-validating auth** so the tail is actually POSTed at teardown instead of silently dropped on `getClient()`'s HTTP `authValid` check.
- **Wired into the real process shutdown paths** (`K2`), always *before* `disposeAllInstances()` so the GlobalBus handler and remote wiring stay live during the drain:
  - embedded TUI worker `shutdown` RPC — covers the three reproduced endings (`/exit`, SIGHUP, SIGTERM), via a pure `createWorkerShutdown({ drain, dispose, stopServer })` seam;
  - `KiloShutdown` registry for non-TUI commands (`kilo run`, …) reaching the top-level `finally`;
  - the `kilo serve` signal handler, so the daemon child drains when the daemon itself is stopped.
  - A module-level once-guard prevents overlapping paths from double-POSTing. The per-directory instance finalizer is deliberately **not** hooked (wrong granularity for a module-level singleton queue).
- **Terminal batches flush promptly** (`K3`). A batch containing `session_close` no longer inherits the open ~1 s debounce window: `sync()` bases its deadline on `max(now(), retry.until)` and `schedule()` lets terminal batches move a flush *earlier*. Streaming `part`/`message` coalescing is unchanged. This narrows the loss window for endings that cannot be intercepted (`kill -9`, crash, power loss) from ~1 s to a single POST round-trip — it does not close it.
- **SIGINT parity** (`K4`). An external `kill -INT` now takes the same graceful path as SIGHUP/SIGTERM. Interactive Ctrl-C is a raw-mode keypress, not a signal, so interactive behaviour is unchanged.

## Tests

23 unit tests in `packages/opencode/test/kilocode/sessions/`: drain flushes all pending sessions (queue pinned emptied on success, not re-enqueued on failure), drain POSTs via the cached client/share when fresh resolution fails at teardown, drain joins a mid-POST flush and suppresses its re-enqueue on retryable failure, terminal scheduling (close-into-open-window pulls the flush to ~0, non-terminal stays at `now()+1000`, retry backoff still respected), worker-seam ordering (drain before dispose), once-guard. The 12 pre-existing `ingest-queue` tests are unmodified and green. `bun run typecheck` and `oxlint` (0 errors) pass.

## Deliberate two-PR deviation

The confirmed root cause is in the CLI, so the fix ships from this repo. The companion cloud PR **Kilo-Org/cloud#4786** carries **only** the E2E harness change that makes on-device verification of this CLI-side fix possible at all. The batch instruction said one PR from the cloud worktree; the deviation is deliberate and stated in both PR bodies.

## Residuals (documented non-goals)

- `kill -9`, crashes and mid-turn kills keep losing an unflushed tail; the terminal-flush change narrows but cannot close that window.
- A daemon-attached client exit was never reproduced and is not covered by the on-device E2E: the daemon outlives the TUI client, so its ~1 s timer flush still lands — argued unexposed, not measured.
- The `kilo serve` drain is unit-wired with an inspected call site but no daemon-stop E2E (no reproduction exists for that path).

## Verification

- [x] Unit: drain, in-flight join, re-enqueue suppression, cached-client delivery, terminal scheduling, seam ordering, once-guard
- [x] On-device E2E per ending (`/exit`, SIGHUP, SIGINT; delayed-`/exit` control) — ACCEPT 11/11, posted as a `(bot)` comment with the running CLI's version stamp
