### PR TITLE
fix(provider): send enabled thinking for Claude Opus 4.5 across Anthropic, Vertex, Bedrock, and SAP

### DIFF
--- a/.changeset/opus-45-enabled-thinking.md
+++ b/.changeset/opus-45-enabled-thinking.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Send enabled extended thinking for Claude Opus 4.5 across Anthropic, Vertex, Bedrock, and SAP AI Core providers so the reasoning effort picker actually engages Opus 4.5's legacy thinking budget instead of silently no-opping.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -643,7 +643,7 @@ function anthropicOmitsThinking(apiId: string) {
   return anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId) // kilocode_change - include Kilo's fable/sonnet-5 aliases
 }
 
-// kilocode_change start - Opus 4.5 emits enabled extended thinking + bare effort (matches upstream PR #38757)
+// kilocode_change start - Opus 4.5 emits enabled extended thinking + bare effort
 function anthropicOpus45(apiId: string) {
   return ["opus-4-5", "opus-4.5"].some((value) => apiId.includes(value))
 }
@@ -1019,7 +1019,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         )
       }
 
-      // kilocode_change start - Opus 4.5 emits enabled thinking + bare effort (matches upstream PR #38757)
+      // kilocode_change start - Opus 4.5 emits enabled thinking + bare effort
       if (anthropicOpus45(model.api.id)) {
         return Object.fromEntries(
           WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, anthropicOpus45Effort(model, effort)]),
@@ -1058,7 +1058,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           ]),
         )
       }
-      // kilocode_change start - Opus 4.5 on Bedrock uses enabled reasoningConfig + maxReasoningEffort (matches upstream PR #38757)
+      // kilocode_change start - Opus 4.5 on Bedrock uses enabled reasoningConfig + maxReasoningEffort
       if (anthropicOpus45(model.api.id)) {
         return Object.fromEntries(
           WIDELY_SUPPORTED_EFFORTS.map((effort) => [
@@ -1169,6 +1169,24 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             ),
           )
         }
+        // kilocode_change start - Opus 4.5 on SAP emits enabled thinking (snake_case budget_tokens) + bare effort
+        if (anthropicOpus45(model.api.id)) {
+          return wrapInSapModelParams(
+            Object.fromEntries(
+              WIDELY_SUPPORTED_EFFORTS.map((effort) => [
+                effort,
+                {
+                  thinking: {
+                    type: "enabled",
+                    budget_tokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+                  },
+                  effort,
+                },
+              ]),
+            ),
+          )
+        }
+        // kilocode_change end
         return wrapInSapModelParams({
           high: { thinking: { type: "enabled", budget_tokens: 16000 } },
           max: { thinking: { type: "enabled", budget_tokens: 31999 } },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -648,11 +648,15 @@ function anthropicOpus45(apiId: string) {
   return ["opus-4-5", "opus-4.5"].some((value) => apiId.includes(value))
 }
 
+function anthropicOpus45BudgetTokens(model: Provider.Model) {
+  return Math.min(16_000, Math.floor(model.limit.output / 2 - 1))
+}
+
 function anthropicOpus45Effort(model: Provider.Model, effort: string) {
   return {
     thinking: {
       type: "enabled",
-      budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+      budgetTokens: anthropicOpus45BudgetTokens(model),
     },
     effort,
   }
@@ -1066,7 +1070,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             {
               reasoningConfig: {
                 type: "enabled",
-                budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+                budgetTokens: anthropicOpus45BudgetTokens(model),
                 maxReasoningEffort: effort,
               },
             },
@@ -1178,7 +1182,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
                 {
                   thinking: {
                     type: "enabled",
-                    budget_tokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+                    budget_tokens: anthropicOpus45BudgetTokens(model),
                   },
                   effort,
                 },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -643,6 +643,22 @@ function anthropicOmitsThinking(apiId: string) {
   return anthropicOpus47OrLater(apiId) || anthropicClaude5(apiId) // kilocode_change - include Kilo's fable/sonnet-5 aliases
 }
 
+// kilocode_change start - Opus 4.5 emits enabled extended thinking + bare effort (matches upstream PR #38757)
+function anthropicOpus45(apiId: string) {
+  return ["opus-4-5", "opus-4.5"].some((value) => apiId.includes(value))
+}
+
+function anthropicOpus45Effort(model: Provider.Model, effort: string) {
+  return {
+    thinking: {
+      type: "enabled",
+      budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+    },
+    effort,
+  }
+}
+// kilocode_change end
+
 function googleThinkingLevelEfforts(apiId: string) {
   const id = apiId.toLowerCase()
   if (!id.includes("gemini-3")) return ["low", "high"]
@@ -1003,9 +1019,13 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         )
       }
 
-      if (["opus-4-5", "opus-4.5"].some((v) => model.api.id.includes(v))) {
-        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { effort }]))
+      // kilocode_change start - Opus 4.5 emits enabled thinking + bare effort (matches upstream PR #38757)
+      if (anthropicOpus45(model.api.id)) {
+        return Object.fromEntries(
+          WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, anthropicOpus45Effort(model, effort)]),
+        )
       }
+      // kilocode_change end
 
       return {
         high: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1058,6 +1058,22 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           ]),
         )
       }
+      // kilocode_change start - Opus 4.5 on Bedrock uses enabled reasoningConfig + maxReasoningEffort (matches upstream PR #38757)
+      if (anthropicOpus45(model.api.id)) {
+        return Object.fromEntries(
+          WIDELY_SUPPORTED_EFFORTS.map((effort) => [
+            effort,
+            {
+              reasoningConfig: {
+                type: "enabled",
+                budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+                maxReasoningEffort: effort,
+              },
+            },
+          ]),
+        )
+      }
+      // kilocode_change end
       // For Anthropic models on Bedrock, use reasoningConfig with budgetTokens
       if (model.api.id.includes("anthropic")) {
         return {

--- a/packages/opencode/test/kilocode/transform-opus-4.5.test.ts
+++ b/packages/opencode/test/kilocode/transform-opus-4.5.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { ProviderTransform } from "../../src/provider/transform"
+import { Provider } from "../../src/provider/provider"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
 
-function mockModel(overrides: Partial<any> = {}): any {
+function mockModel(overrides: Partial<Provider.Model> = {}): Provider.Model {
   return {
-    id: "test/test-model",
-    providerID: "test",
+    id: ModelV2.ID.make("test/test-model"),
+    providerID: ProviderV2.ID.make("test"),
     api: {
       id: "test-model",
       url: "https://api.test.com",
@@ -65,8 +68,8 @@ describe("ProviderTransform.variants - Claude Opus 4.5 enabled-thinking payload"
 
   test("vertex opus-4-5 emits same shape via google-vertex/anthropic", () => {
     const model = mockModel({
-      id: "google-vertex-anthropic/claude-opus-4-5",
-      providerID: "google-vertex-anthropic",
+      id: ModelV2.ID.make("google-vertex-anthropic/claude-opus-4-5"),
+      providerID: ProviderV2.ID.make("google-vertex-anthropic"),
       api: {
         id: "claude-opus-4-5@default",
         url: "https://us-central1-aiplatform.googleapis.com",
@@ -83,8 +86,8 @@ describe("ProviderTransform.variants - Claude Opus 4.5 enabled-thinking payload"
 
   test("bedrock opus-4-5 emits enabled reasoningConfig + maxReasoningEffort", () => {
     const model = mockModel({
-      id: "bedrock/anthropic-claude-opus-4-5",
-      providerID: "bedrock",
+      id: ModelV2.ID.make("bedrock/anthropic-claude-opus-4-5"),
+      providerID: ProviderV2.ID.make("bedrock"),
       api: {
         id: "us.anthropic.claude-opus-4-5-20251101-v1:0",
         url: "https://bedrock.amazonaws.com",
@@ -104,8 +107,8 @@ describe("ProviderTransform.variants - Claude Opus 4.5 enabled-thinking payload"
 
   test("sap opus-4-5 emits enabled thinking (snake_case) wrapped in modelParams", () => {
     const model = mockModel({
-      id: "sap/anthropic--claude-opus-4-5-20251101",
-      providerID: "sap-ai-core",
+      id: ModelV2.ID.make("sap/anthropic--claude-opus-4-5-20251101"),
+      providerID: ProviderV2.ID.make("sap-ai-core"),
       api: {
         id: "anthropic--claude-opus-4-5-20251101",
         url: "https://api.ai.core.cloud.sap",

--- a/packages/opencode/test/kilocode/transform-opus-4.5.test.ts
+++ b/packages/opencode/test/kilocode/transform-opus-4.5.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../src/provider/transform"
+
+function mockModel(overrides: Partial<any> = {}): any {
+  return {
+    id: "test/test-model",
+    providerID: "test",
+    api: {
+      id: "test-model",
+      url: "https://api.test.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+    limit: { context: 200_000, output: 64_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2024-01-01",
+    ...overrides,
+  }
+}
+
+describe("ProviderTransform.variants - Claude Opus 4.5 enabled-thinking payload", () => {
+  test("anthropic opus-4-5 emits enabled thinking + effort across low/medium/high", () => {
+    const model = mockModel({
+      api: {
+        id: "claude-opus-4-5-20251101",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    expect(result.high).toEqual({
+      thinking: { type: "enabled", budgetTokens: 16000 },
+      effort: "high",
+    })
+  })
+
+  test("anthropic opus-4.5 dotted form emits same enabled thinking shape", () => {
+    const model = mockModel({
+      api: {
+        id: "claude-opus-4.5-20251101",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    expect(result.high).toEqual({
+      thinking: { type: "enabled", budgetTokens: 16000 },
+      effort: "high",
+    })
+  })
+
+  test("vertex opus-4-5 emits same shape via google-vertex/anthropic", () => {
+    const model = mockModel({
+      id: "google-vertex-anthropic/claude-opus-4-5",
+      providerID: "google-vertex-anthropic",
+      api: {
+        id: "claude-opus-4-5@default",
+        url: "https://us-central1-aiplatform.googleapis.com",
+        npm: "@ai-sdk/google-vertex/anthropic",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    expect(result.high).toEqual({
+      thinking: { type: "enabled", budgetTokens: 16000 },
+      effort: "high",
+    })
+  })
+
+  test("bedrock opus-4-5 emits enabled reasoningConfig + maxReasoningEffort", () => {
+    const model = mockModel({
+      id: "bedrock/anthropic-claude-opus-4-5",
+      providerID: "bedrock",
+      api: {
+        id: "us.anthropic.claude-opus-4-5-20251101-v1:0",
+        url: "https://bedrock.amazonaws.com",
+        npm: "@ai-sdk/amazon-bedrock",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    expect(result.high).toEqual({
+      reasoningConfig: {
+        type: "enabled",
+        budgetTokens: 16000,
+        maxReasoningEffort: "high",
+      },
+    })
+  })
+
+  test("sap opus-4-5 emits enabled thinking (snake_case) wrapped in modelParams", () => {
+    const model = mockModel({
+      id: "sap/anthropic--claude-opus-4-5-20251101",
+      providerID: "sap-ai-core",
+      api: {
+        id: "anthropic--claude-opus-4-5-20251101",
+        url: "https://api.ai.core.cloud.sap",
+        npm: "@jerome-benoit/sap-ai-provider-v2",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high"])
+    expect(result.high).toEqual({
+      modelParams: {
+        thinking: { type: "enabled", budget_tokens: 16000 },
+        effort: "high",
+      },
+    })
+  })
+})

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4011,7 +4011,7 @@ describe("ProviderTransform.variants", () => {
         name: "opus 4.5",
         apiIds: ["claude-opus-4-5-20251101", "claude-opus-4.5-20251101"],
         efforts: ["low", "medium", "high"],
-        // kilocode_change - Opus 4.5 emits enabled thinking + bare effort (matches upstream PR #38757)
+        // kilocode_change - Opus 4.5 emits enabled thinking + bare effort
         expectedHigh: { thinking: { type: "enabled", budgetTokens: 16000 }, effort: "high" },
         // kilocode_change end
       },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4011,7 +4011,7 @@ describe("ProviderTransform.variants", () => {
         name: "opus 4.5",
         apiIds: ["claude-opus-4-5-20251101", "claude-opus-4.5-20251101"],
         efforts: ["low", "medium", "high"],
-        // kilocode_change - Opus 4.5 emits enabled thinking + bare effort
+        // kilocode_change start - Opus 4.5 emits enabled thinking + bare effort
         expectedHigh: { thinking: { type: "enabled", budgetTokens: 16000 }, effort: "high" },
         // kilocode_change end
       },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4011,7 +4011,9 @@ describe("ProviderTransform.variants", () => {
         name: "opus 4.5",
         apiIds: ["claude-opus-4-5-20251101", "claude-opus-4.5-20251101"],
         efforts: ["low", "medium", "high"],
-        expectedHigh: { effort: "high" },
+        // kilocode_change - Opus 4.5 emits enabled thinking + bare effort (matches upstream PR #38757)
+        expectedHigh: { thinking: { type: "enabled", budgetTokens: 16000 }, effort: "high" },
+        // kilocode_change end
       },
       {
         name: "sonnet 4.6",


### PR DESCRIPTION
## Issue

Fixes #12546

## Context


 **Why:** KiloCode currently sends only the `effort` parameter for Claude Opus 4.5. Anthropic's adaptive-thinking documentation states that older models such as Claude Opus 4.5 do **not** support adaptive thinking and require `thinking: { type: "enabled", budget_tokens }` alongside `effort`. Sending effort alone does not enable extended thinking on Opus 4.5 because Anthropic requires thinking: { type: "enabled", budget_tokens } alongside effort.

Reference:  
1.https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking

 2.[anomalyco/opencode#38757](https://github.com/anomalyco/opencode/pull/38757) ("fix(provider): generalize Claude adaptive thinking") Thanks to them.

The Opus 5 routing portion of that upstream PR is tracked separately in #12544 and is intentionally not duplicated here.

Scope is restricted to Opus 4.5; no other Claude family is affected.

## Implementation

Added two new helpers in `packages/opencode/src/provider/transform.ts` (after `anthropicOmitsThinking`):

- `anthropicOpus45(apiId)` — matches IDs containing `opus-4-5` or `opus-4.5`.
- `anthropicOpus45Effort(model, effort)` — returns `{ thinking: { type: "enabled", budgetTokens: min(16_000, floor(output / 2 - 1)) }, effort }`.

Then wired the helper into the three provider branches that previously mishandled Opus 4.5:

1. **Anthropic / Vertex** (`case "@ai-sdk/anthropic": case "@ai-sdk/google-vertex/anthropic":`): replaced the bare `{ effort }` literal branch with a call to `anthropicOpus45Effort(model, effort)`.
2. **Bedrock** (`case "@ai-sdk/amazon-bedrock":`): inserted a new branch before the generic `api.id.includes("anthropic")` legacy block. Emits `{ reasoningConfig: { type: "enabled", budgetTokens, maxReasoningEffort: effort } }` to match Bedrock's adaptive-branch shape.
3. **SAP AI Core** (`case "@jerome-benoit/sap-ai-provider-v2":`): inserted a new branch before the generic `{ high, max }` fallback. Uses snake_case `budget_tokens` (SAP's existing convention at that call site) and wraps each variant in `modelParams` via the existing `wrapInSapModelParams` helper.

The budget formula `Math.min(16_000, Math.floor(model.limit.output / 2 - 1))` is identical to upstream PR #38757's `anthropicOpus45Effort`. The default mock model in tests has `output: 64_000`, so `budgetTokens` saturates to `16000` in regression tests.

## Screenshots / Video

N/A — pure backend/provider transform change; no UI diff.

## How to Test

### Manual/local verification

- Select Claude Opus 4.5 and verify requests include the required thinking configuration alongside effort.
- Send a prompt that should trigger extended thinking; observe that thinking summary tokens are now returned and the API request payload contains `thinking: { type: "enabled", budget_tokens }` alongside `effort` (Anthropic/Vertex/SAP) or `reasoningConfig: { type: "enabled", budgetTokens, maxReasoningEffort }` (Bedrock).

### Reviewer test steps

1. `cd packages/opencode && bun test ./test/kilocode/transform-opus-4.5.test.ts` — 5 cases across 4 providers (`claude-opus-4-5-20251101`, `claude-opus-4.5-20251101` on Anthropic; `claude-opus-4-5@default` on Vertex; `us.anthropic.claude-opus-4-5-20251101-v1:0` on Bedrock; `anthropic--claude-opus-4-5-20251101` on SAP).
2. `cd packages/opencode && bun test ./test/provider/transform.test.ts` — confirm the existing `opus 4.5` row in the shared parametrized array now passes with the new `{ thinking: { type: "enabled", budgetTokens: 16000 }, effort: "high" }` shape and that all other rows (Opus 4.7/4.8, Sonnet 4.6, Sonnet 5, Fable 5) are unchanged.
3. `bun run script/check-opencode-annotations.ts --worktree` — confirm all shared-file edits are properly marked.

### Blocked checks and substitute verification

- `bun run typecheck` from `packages/opencode/`: produces pre-existing errors in `src/cli/cmd/run/footer.ts`, `src/cli/cmd/run/runtime.lifecycle.ts`, `src/kilocode/claw/autocomplete.tsx`, `src/kilocode/cli/cmd/tui/context/tui-config.tsx`, etc., all arising from a `@opentui/core` `0.3.2` vs `0.3.4` version skew in `node_modules`. None of the errors touch `packages/opencode/src/provider/transform.ts` or its tests. Substitute verification was targeted typecheck output filtering, which shows zero errors mentioning `transform.ts`.


## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described (new `transform-opus-4.5.test.ts` for 4 providers; existing shared `transform.test.ts` row updated)
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (`.changeset/opus-45-enabled-thinking.md` added)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@TRAVIX26
