### PR TITLE
fix(cli): ignore named provider SSE events

### DIFF
--- a/.changeset/calm-billing-streams.md
+++ b/.changeset/calm-billing-streams.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Ignore unrelated named metadata events in custom OpenAI-compatible and Anthropic streams.

--- a/bun.lock
+++ b/bun.lock
@@ -581,6 +581,7 @@
         "diff": "catalog:",
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
+        "eventsource-parser": "3.1.0",
         "fuzzysort": "3.1.0",
         "gitlab-ai-provider": "6.9.3",
         "glob": "13.0.5",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -139,6 +139,7 @@
     "diff": "catalog:",
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
+    "eventsource-parser": "3.1.0",
     "fuzzysort": "3.1.0",
     "gitlab-ai-provider": "6.9.3",
     "google-auth-library": "10.5.0",

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -14,6 +14,7 @@ import { optionalOmitUndefined } from "@opencode-ai/core/schema"
 import { Effect, Schema } from "effect"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { mapValues, omit, pickBy } from "remeda"
+import { EventSourceParserStream, type EventSourceMessage } from "eventsource-parser/stream"
 
 /** Default timeout (ms) for provider HTTP requests (connection phase). */
 export const REQUEST_TIMEOUT_MS = 300_000 // 5 minutes
@@ -269,4 +270,57 @@ export function buildTimeoutSignal(options: Record<string, any>): {
       clearTimeout(timer)
     },
   }
+}
+
+const ANTHROPIC_EVENTS = new Set([
+  "message_start",
+  "content_block_start",
+  "content_block_delta",
+  "content_block_stop",
+  "message_delta",
+  "message_stop",
+  "ping",
+  "error",
+])
+const OPENAI_EVENTS = new Set<string>()
+
+function encodeSSE(event: EventSourceMessage) {
+  const name = event.event === undefined ? "" : `event: ${event.event}\n`
+  const id = event.id === undefined ? "" : `id: ${event.id}\n`
+  const data = event.data
+    .split("\n")
+    .map((line) => `data: ${line}\n`)
+    .join("")
+  return `${name}${id}${data}\n`
+}
+
+export function filterSSE(res: Response, pkg: string) {
+  if (!res.body) return res
+  if (!res.headers.get("content-type")?.toLowerCase().includes("text/event-stream")) return res
+
+  const names = pkg.includes("@ai-sdk/openai-compatible")
+    ? OPENAI_EVENTS
+    : pkg.includes("@ai-sdk/anthropic")
+      ? ANTHROPIC_EVENTS
+      : undefined
+  if (!names) return res
+
+  const body = res.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(new EventSourceParserStream())
+    .pipeThrough(
+      new TransformStream<EventSourceMessage, string>({
+        transform(event, ctrl) {
+          if (event.event && event.event !== "message" && !names.has(event.event)) return
+          ctrl.enqueue(encodeSSE(event))
+        },
+      }),
+    )
+    .pipeThrough(new TextEncoderStream())
+
+  return new Response(body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  })
 }

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -285,8 +285,8 @@ const ANTHROPIC_EVENTS = new Set([
 const OPENAI_EVENTS = new Set<string>()
 
 function encodeSSE(event: EventSourceMessage) {
-  const name = event.event === undefined ? "" : `event: ${event.event}\n`
-  const id = event.id === undefined ? "" : `id: ${event.id}\n`
+  const name = event.event ? `event: ${event.event}\n` : ""
+  const id = event.id ? `id: ${event.id}\n` : ""
   const data = event.data
     .split("\n")
     .map((line) => `data: ${line}\n`)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -41,6 +41,7 @@ import {
   patchKiloProviderPrivacy,
   kiloSmallModelPriority,
   buildTimeoutSignal,
+  filterSSE,
 } from "@/kilocode/provider/provider"
 import * as ModelsRefresh from "@/kilocode/provider/models-refresh"
 // kilocode_change end
@@ -1783,8 +1784,8 @@ export const layer = Layer.effect(
               timeout: false,
             }).finally(() => headerTimeoutCtl?.clear())
             timeout.clear()
-            if (!chunkAbortCtl) return res
-            return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+            const streamed = chunkAbortCtl ? wrapSSE(res, chunkTimeout, chunkAbortCtl) : res
+            return filterSSE(streamed, model.api.npm)
           } catch (err) {
             timeout.clear()
             throw err

--- a/packages/opencode/test/kilocode/provider/sse.test.ts
+++ b/packages/opencode/test/kilocode/provider/sse.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
+import { streamText } from "ai"
+import { filterSSE } from "@/kilocode/provider/provider"
+
+const encoder = new TextEncoder()
+
+function response(records: string[], type = "text/event-stream") {
+  const bytes = encoder.encode(records.join("\n\n") + "\n\n")
+  const body = new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      for (let offset = 0; offset < bytes.length; offset += 7) {
+        ctrl.enqueue(bytes.slice(offset, offset + 7))
+      }
+      ctrl.close()
+    },
+  })
+  return new Response(body, { headers: { "content-type": type } })
+}
+
+function record(data: unknown, event?: string) {
+  const name = event ? `event: ${event}\n` : ""
+  return `${name}data: ${JSON.stringify(data)}`
+}
+
+describe("provider SSE filtering", () => {
+  test("ignores named metadata in OpenAI-compatible streams", async () => {
+    const records = [
+      record({
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+      }),
+      record({ object: "billing.summary", billing: { cost: "0.01" } }, "billing_summary"),
+      record(
+        {
+          id: "chatcmpl-test",
+          object: "chat.completion.chunk",
+          choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }],
+        },
+        "message",
+      ),
+      record({
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      }),
+      "data: [DONE]",
+    ]
+    const provider = createOpenAICompatible({
+      name: "test",
+      baseURL: "https://example.com/v1",
+      apiKey: "test",
+      fetch: async () => filterSSE(response(records, "Text/Event-Stream; Charset=UTF-8"), "@ai-sdk/openai-compatible"),
+    })
+
+    const result = streamText({ model: provider("test-model"), prompt: "Hi" })
+    expect(await result.text).toBe("Hello")
+    expect(await result.finishReason).toBe("stop")
+  })
+
+  test("ignores named metadata while preserving Anthropic events", async () => {
+    const records = [
+      record(
+        {
+          type: "message_start",
+          message: {
+            id: "msg_test",
+            type: "message",
+            role: "assistant",
+            content: [],
+            model: "test-model",
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 0 },
+          },
+        },
+        "message_start",
+      ),
+      record({ type: "billing_summary", object: "billing.summary", billing: { cost: "0.01" } }, "billing_summary"),
+      record(
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+        "content_block_start",
+      ),
+      record(
+        { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } },
+        "content_block_delta",
+      ),
+      record({ type: "content_block_stop", index: 0 }, "content_block_stop"),
+      record(
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn", stop_sequence: null },
+          usage: { output_tokens: 1 },
+        },
+        "message_delta",
+      ),
+      record({ type: "message_stop" }, "message_stop"),
+    ]
+    const provider = createAnthropic({
+      baseURL: "https://example.com/v1",
+      apiKey: "test",
+      fetch: async () => filterSSE(response(records), "@ai-sdk/anthropic"),
+    })
+
+    const result = streamText({ model: provider("test-model"), prompt: "Hi" })
+    expect(await result.text).toBe("Hello")
+    expect(await result.finishReason).toBe("stop")
+  })
+
+  test("leaves unrelated responses unchanged", () => {
+    const res = Response.json({ ok: true })
+    const stream = response([record({ ok: true }, "metadata")])
+    expect(filterSSE(res, "@ai-sdk/openai-compatible")).toBe(res)
+    expect(filterSSE(res, "@ai-sdk/anthropic")).toBe(res)
+    expect(filterSSE(stream, "@ai-sdk/openai")).toBe(stream)
+  })
+})

--- a/packages/opencode/test/kilocode/provider/sse.test.ts
+++ b/packages/opencode/test/kilocode/provider/sse.test.ts
@@ -24,6 +24,11 @@ function record(data: unknown, event?: string) {
   return `${name}data: ${JSON.stringify(data)}`
 }
 
+function fetcher(records: string[], pkg: string, type?: string) {
+  const run = async () => filterSSE(response(records, type), pkg)
+  return Object.assign(run, { preconnect: fetch.preconnect })
+}
+
 describe("provider SSE filtering", () => {
   test("ignores named metadata in OpenAI-compatible streams", async () => {
     const records = [
@@ -52,7 +57,7 @@ describe("provider SSE filtering", () => {
       name: "test",
       baseURL: "https://example.com/v1",
       apiKey: "test",
-      fetch: async () => filterSSE(response(records, "Text/Event-Stream; Charset=UTF-8"), "@ai-sdk/openai-compatible"),
+      fetch: fetcher(records, "@ai-sdk/openai-compatible", "Text/Event-Stream; Charset=UTF-8"),
     })
 
     const result = streamText({ model: provider("test-model"), prompt: "Hi" })
@@ -101,7 +106,7 @@ describe("provider SSE filtering", () => {
     const provider = createAnthropic({
       baseURL: "https://example.com/v1",
       apiKey: "test",
-      fetch: async () => filterSSE(response(records), "@ai-sdk/anthropic"),
+      fetch: fetcher(records, "@ai-sdk/anthropic"),
     })
 
     const result = streamText({ model: provider("test-model"), prompt: "Hi" })
@@ -115,5 +120,10 @@ describe("provider SSE filtering", () => {
     expect(filterSSE(res, "@ai-sdk/openai-compatible")).toBe(res)
     expect(filterSSE(res, "@ai-sdk/anthropic")).toBe(res)
     expect(filterSSE(stream, "@ai-sdk/openai")).toBe(stream)
+  })
+
+  test("does not add empty event or id fields", async () => {
+    const res = filterSSE(response([record({ ok: true })]), "@ai-sdk/openai-compatible")
+    expect(await res.text()).toBe('data: {"ok":true}\n\n')
   })
 })


### PR DESCRIPTION
Closes #12423
Closes #12541

Custom OpenAI-compatible and Anthropic providers can emit named billing or progress metadata alongside normal SSE messages. The AI SDK discards the SSE event name and validates every payload as a model response, causing `invalid_union` failures and terminating otherwise valid streams.

Filter provider-specific named events before AI SDK validation while preserving default OpenAI-compatible messages and the standard Anthropic event set. The filter operates incrementally across network chunk boundaries and remains compatible with the existing stream timeout wrapper.

Upstream does not currently have a merged equivalent fix. anomalyco/opencode#37030 proposed filtering named events but was closed unmerged and only targeted the native OpenAI-compatible framing path, not the AI SDK custom-provider path used by these reports.