### PR TITLE
fix(vscode): sync mode cycling state

### DIFF
--- a/.changeset/fix-scoped-mode-cycling.md
+++ b/.changeset/fix-scoped-mode-cycling.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Update the visible agent mode when cycling modes in Kilo sidebars and pending session tabs.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -804,13 +804,13 @@
         "command": "kilo-code.new.cycleAgentMode",
         "key": "ctrl+.",
         "mac": "cmd+.",
-        "when": "sideBarFocus && kilo-code.new.sidebarVisible || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
+        "when": "kilo-code.new.sidebarFocused || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
       },
       {
         "command": "kilo-code.new.cyclePreviousAgentMode",
         "key": "ctrl+shift+.",
         "mac": "cmd+shift+.",
-        "when": "sideBarFocus && kilo-code.new.sidebarVisible || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
+        "when": "kilo-code.new.sidebarFocused || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
       },
       {
         "command": "kilo-code.new.autocomplete.cancelSuggestions",

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -741,6 +741,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private setSidebarVisible(visible: boolean): void {
     this.setStreamVisibility(visible)
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)
+    if (!visible && this.opts.focusContext) {
+      void vscode.commands.executeCommand("setContext", this.opts.focusContext, false)
+    }
   }
 
   /** Resolve a WebviewPanel for displaying Kilo in an editor tab. */
@@ -981,6 +984,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         return
       }
       if (await this.handleModelSelectorExpandedMessage(message)) return
+      this.handleWebviewFocusMessage(message)
       this.visibleTaskStreams.handle(message)
       if (await this.handleMemoryMessage(message)) return
       if (this.handleLegacyMigrationMessage(message)) return
@@ -1464,6 +1468,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     })
     this.webviewMessageDisposable = watchFontSizeConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
     this.webviewMessageDisposable = watchWorkStyleConfig((msg) => this.postMessage(msg), this.webviewMessageDisposable)
+  }
+
+  private handleWebviewFocusMessage(message: TypedWebviewMessage & { focused?: unknown }): void {
+    if (message.type !== "webviewFocusChanged") return
+    if (this.opts.focusContext) {
+      void vscode.commands.executeCommand("setContext", this.opts.focusContext, message.focused === true)
+    }
   }
 
   private handleEditorOpenMessage(message: Parameters<typeof handleEditorAction>[0]): boolean {
@@ -4559,6 +4570,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Does NOT kill the server — that's the connection service's job.
    */
   dispose(): void {
+    if (this.opts.focusContext) {
+      void vscode.commands.executeCommand("setContext", this.opts.focusContext, false)
+    }
     this.unsubscribeRemote?.()
     this.streams.focus(undefined)
     this.connectionService.unregisterVisible(this.instanceId)

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -122,7 +122,9 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   // Create the provider with shared service
-  const provider = new KiloProvider(context.extensionUri, connectionService, context)
+  const provider = new KiloProvider(context.extensionUri, connectionService, context, {
+    focusContext: "kilo-code.new.sidebarFocused",
+  })
   provider.setRemoteService(remoteService)
 
   // Register the webview view provider for the sidebar.

--- a/packages/kilo-vscode/src/kilo-provider/options.ts
+++ b/packages/kilo-vscode/src/kilo-provider/options.ts
@@ -1,4 +1,6 @@
 export type KiloProviderOptions = {
+  /** Context key updated from focus events reported by this provider's webview. */
+  focusContext?: string
   projectDirectory?: string | null
   platform?: string
   snapshotInitialization?: "wait"

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -127,6 +127,23 @@ describe("Extension — package.json command sync", () => {
       when: "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'",
     })
   })
+
+  it("scopes agent mode shortcuts to focused Kilo webviews", () => {
+    const bindings = pkg.contributes?.keybindings?.filter(
+      (item: { command: string }) =>
+        item.command === "kilo-code.new.cycleAgentMode" || item.command === "kilo-code.new.cyclePreviousAgentMode",
+    )
+    const when =
+      "kilo-code.new.sidebarFocused || activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' || activeWebviewPanelId == 'kilo-code.new.TabPanel'"
+
+    expect(bindings).toHaveLength(2)
+    expect(bindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "kilo-code.new.cycleAgentMode", when }),
+        expect.objectContaining({ command: "kilo-code.new.cyclePreviousAgentMode", when }),
+      ]),
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/kilo-vscode/tests/unit/session-agent.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-agent.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import {
+  cycleAgent,
   createDraftAgentSeed,
   draftAgentSelection,
   resolveSessionAgent,
@@ -78,6 +79,54 @@ describe("resolveSessionAgent", () => {
     )
 
     expect(result).toBeUndefined()
+  })
+})
+
+describe("cycleAgent", () => {
+  const agents = [
+    { name: "ask", mode: "primary" },
+    { name: "plan", mode: "primary" },
+    { name: "task", mode: "subagent" },
+    { name: "hidden", mode: "primary", hidden: true },
+    { name: "code", mode: "primary" },
+  ]
+
+  function cycle(current: string, direction: 1 | -1, scope = "pending-1") {
+    const calls: Array<[string, string | undefined]> = []
+    const name = cycleAgent({
+      agents,
+      scope,
+      direction,
+      selected: (id) => {
+        expect(id).toBe(scope)
+        return current
+      },
+      select: (agent, id) => calls.push([agent, id]),
+    })
+    return { name, calls }
+  }
+
+  it("cycles the same pending scope read by the visible selector", () => {
+    expect(cycle("ask", 1)).toEqual({ name: "plan", calls: [["plan", "pending-1"]] })
+    expect(cycle("ask", -1)).toEqual({ name: "code", calls: [["code", "pending-1"]] })
+  })
+
+  it("wraps and starts from the first agent when the selection is unknown", () => {
+    expect(cycle("code", 1).name).toBe("ask")
+    expect(cycle("missing", 1).name).toBe("ask")
+  })
+
+  it("does nothing when there is no alternative", () => {
+    const selected: string[] = []
+    expect(
+      cycleAgent({
+        agents: [{ name: "code" }],
+        direction: 1,
+        selected: () => "code",
+        select: (name) => selected.push(name),
+      }),
+    ).toBeUndefined()
+    expect(selected).toEqual([])
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -160,6 +160,7 @@ import { buildShortcutCategories } from "./shortcuts"
 import { tracker } from "./telemetry"
 import "./agent-manager.css"
 import "./agent-manager-review.css"
+import { cycleAgent as cycle } from "../src/context/session-agent"
 const REVIEW_TAB_ID = "review"
 
 interface SetupState {
@@ -1071,14 +1072,14 @@ const AgentManagerContent: Component = () => {
   }
 
   const cycleAgent = (direction: 1 | -1) => {
-    const available = session.agents().filter((a) => a.mode !== "subagent" && !a.hidden)
-    if (available.length <= 1) return
-    const current = session.selectedAgent()
-    const idx = available.findIndex((a) => a.name === current)
-    const raw = idx + direction
-    const next = raw < 0 ? available.length - 1 : raw >= available.length ? 0 : raw
-    const agent = available[next]
-    if (agent) session.selectAgent(agent.name)
+    const id = session.currentSessionID() ?? activePendingId()
+    cycle({
+      agents: session.agents(),
+      scope: id,
+      direction,
+      selected: session.selectedAgent,
+      select: session.selectAgent,
+    })
   }
 
   const syncRunStatuses = (items: RunStatus[] = []) => {

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -42,6 +42,7 @@ import { FeedbackProvider } from "./context/feedback"
 import { KiloEmbeddingModelsProvider } from "./context/kilo-embedding-models"
 import { ImageModelsProvider } from "./context/image-models"
 import type { Message as SDKMessage, Part as SDKPart } from "@kilocode/sdk/v2"
+import { cycleAgent as cycle } from "./context/session-agent"
 import "./styles/chat.css"
 
 type ViewType = "newTask" | "history" | "profile" | "settings" | "subAgentViewer"
@@ -276,14 +277,14 @@ const AppContent: Component = () => {
   }
 
   const cycleAgent = (direction: 1 | -1) => {
-    const available = session.agents().filter((a) => a.mode !== "subagent" && !a.hidden)
-    if (available.length <= 1) return
-    const current = session.selectedAgent()
-    const idx = available.findIndex((a) => a.name === current)
-    const raw = idx + direction
-    const next = raw < 0 ? available.length - 1 : raw >= available.length ? 0 : raw
-    const agent = available[next]
-    if (agent) session.selectAgent(agent.name)
+    const id = session.currentSessionID() ?? tabs?.pending() ?? session.draftSessionID()
+    cycle({
+      agents: session.agents(),
+      scope: id,
+      direction,
+      selected: session.selectedAgent,
+      select: session.selectAgent,
+    })
   }
 
   const handleForked = (message: { type?: string; sessionID?: string; forkedFromID?: string }) => {

--- a/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
@@ -1,5 +1,22 @@
 import type { Message } from "../types/messages"
 
+export function cycleAgent(input: {
+  agents: Array<{ name: string; mode?: string; hidden?: boolean }>
+  scope?: string
+  direction: 1 | -1
+  selected: (scope?: string) => string
+  select: (name: string, scope?: string) => void
+}) {
+  const available = input.agents.filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+  if (available.length <= 1) return
+  const index = available.findIndex((agent) => agent.name === input.selected(input.scope))
+  const raw = index + input.direction
+  const next = raw < 0 ? available.length - 1 : raw >= available.length ? 0 : raw
+  const name = available[next]?.name
+  if (name) input.select(name, input.scope)
+  return name
+}
+
 export function resolveSessionAgent(messages: Message[], names: Set<string>): string | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
     const name = messages[i]?.agent?.trim()

--- a/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/vscode.tsx
@@ -55,6 +55,10 @@ export const VSCodeProvider: ParentComponent = (props) => {
   }
 
   window.addEventListener("message", messageListener)
+  const reportFocus = () => api.postMessage({ type: "webviewFocusChanged", focused: document.hasFocus() })
+  window.addEventListener("focus", reportFocus)
+  window.addEventListener("blur", reportFocus)
+  reportFocus()
   handlers.add((message) => {
     if (message?.type === "modelSelectorExpandedLoaded") setExpanded(message.value)
   })
@@ -62,6 +66,8 @@ export const VSCodeProvider: ParentComponent = (props) => {
 
   onCleanup(() => {
     window.removeEventListener("message", messageListener)
+    window.removeEventListener("focus", reportFocus)
+    window.removeEventListener("blur", reportFocus)
     handlers.clear()
   })
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -175,6 +175,11 @@ export interface WebviewReadyRequest {
   type: "webviewReady"
 }
 
+export interface WebviewFocusChangedRequest {
+  type: "webviewFocusChanged"
+  focused: boolean
+}
+
 export interface SelectSourceRequest {
   type: "selectSource"
   id: string
@@ -1257,6 +1262,7 @@ export type WebviewMessage =
   | CancelLoginRequest
   | SetOrganizationRequest
   | WebviewReadyRequest
+  | WebviewFocusChangedRequest
   | SelectSourceRequest
   | RequestProvidersMessage
   | CompactRequest


### PR DESCRIPTION
The mode-cycling shortcuts were gated by VS Code sidebar focus state, which is not set while focus is inside a webview and prevents the shortcut from dispatching when Kilo is docked in the secondary sidebar. Pending tabs also stored their selected agent under a tab-specific scope, while keyboard cycling updated the unscoped fallback, leaving the visible selector and submitted prompt mode unchanged.

Track focus directly from the sidebar webview and use that context only for sidebar shortcut dispatch. Cycle the same active session, pending-tab, or draft scope consumed by the mode selector and prompt path in both the standard chat and Agent Manager. Editor tabs retain their existing panel scope, and normal editors continue to receive VS Code Quick Fix.

<img width="700" alt="Kilo mode selector updated in the secondary sidebar" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260727-mode-cycling-secondary-sidebar.png?raw=true" />

Fixes #12551.