### PR TITLE
fix(vscode): prevent recursive settings saves

### DIFF
--- a/.changeset/fix-vscode-settings-save.md
+++ b/.changeset/fix-vscode-settings-save.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent settings selects from recursively reapplying unchanged values when saving in VS Code.

--- a/.changeset/fix-vscode-settings-save.md
+++ b/.changeset/fix-vscode-settings-save.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Prevent settings selects from recursively reapplying unchanged values when saving in VS Code.
+Fix settings changes sometimes failing to save and apply in VS Code.

--- a/packages/kilo-ui/src/components/select-change.ts
+++ b/packages/kilo-ui/src/components/select-change.ts
@@ -1,0 +1,4 @@
+export function changed<T>(current: T | undefined, next: T | undefined, key: (item: T) => string) {
+  if (current === undefined || next === undefined) return current !== next
+  return key(current) !== key(next)
+}

--- a/packages/kilo-ui/src/components/select.test.ts
+++ b/packages/kilo-ui/src/components/select.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { changed } from "./select-change"
+
+describe("changed", () => {
+  const key = (item: { value: string }) => item.value
+
+  test("ignores recreated options with the current key", () => {
+    expect(changed({ value: "ollama" }, { value: "ollama" }, key)).toBe(false)
+  })
+
+  test("reports selected and cleared values", () => {
+    expect(changed({ value: "ollama" }, { value: "kilo" }, key)).toBe(true)
+    expect(changed({ value: "ollama" }, undefined, key)).toBe(true)
+    expect(changed(undefined, { value: "ollama" }, key)).toBe(true)
+    expect(changed(undefined, undefined, key)).toBe(false)
+  })
+})

--- a/packages/kilo-ui/src/components/select.tsx
+++ b/packages/kilo-ui/src/components/select.tsx
@@ -1,1 +1,19 @@
+import { Select as Base, type SelectProps } from "@opencode-ai/ui/select"
+import type { ButtonProps } from "@opencode-ai/ui/button"
+import { changed } from "./select-change"
+
 export * from "@opencode-ai/ui/select"
+
+export function Select<T>(props: SelectProps<T> & Omit<ButtonProps, "children">) {
+  const key = (item: T) => (props.value ? props.value(item) : (item as string))
+
+  return (
+    <Base
+      {...props}
+      onSelect={(next) => {
+        if (!changed(props.current, next, key)) return
+        props.onSelect?.(next)
+      }}
+    />
+  )
+}


### PR DESCRIPTION
Settings Save batches edited configuration into a reactive draft. Select options are object-valued, and Kobalte can emit `onChange` when a rerender replaces the selected option object with another object carrying the same logical key. Passing that unchanged selection back into the draft causes another rerender and repeats until the webview overflows its call stack, so no persistence message reaches the extension.

This was introduced by #7312, specifically the batched draft and explicit Save flow. It became visible in the 7.4.15 report tracked by #12523, but the 7.4.15 OpenCode merge did not change the Select callback path.

The Kilo Select boundary now compares the current and next logical keys before forwarding a selection. Real selection and clearing events still propagate, while option-object reconciliation no longer mutates settings.