### PR TITLE
fix(jetbrains): split bundled publish Gradle tasks

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -145,11 +145,17 @@ jobs:
       - name: Build signed bundled plugin
         working-directory: packages/kilo-jetbrains
         run: |
-          ./gradlew clean buildPlugin signPlugin verifyPluginSignature verifyPlugin \
-            -Pproduction=true \
-            -Pkilo.version="$VERSION" \
-            -Pkilo.channel="$CHANNEL" \
+          args=(
+            -Pproduction=true
+            -Pkilo.version="$VERSION"
+            -Pkilo.channel="$CHANNEL"
             -Pkilo.cli.bundled=true
+          )
+
+          ./gradlew clean buildPlugin "${args[@]}"
+          ./gradlew signPlugin "${args[@]}"
+          ./gradlew verifyPluginSignature "${args[@]}"
+          ./gradlew verifyPlugin "${args[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Split the bundled JetBrains publish workflow's Gradle build/sign/verify sequence into separate invocations.

## Why

The 7.0.11 bundled publish follow-up failed because Gradle 9 detected that `:verifyPluginSignature` consumes the signed ZIP from `:signPlugin` without an explicit task dependency when both tasks are requested in one graph. Running the same stages sequentially matches the existing JetBrains release script and avoids the implicit dependency validation error.

## Validation

- `bun run script/check-workflows.ts`
- `git diff --check -- .github/workflows/publish-jetbrains-bundled.yml`
- push hook passed:
  - `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains`
  - `bun turbo typecheck --filter=@kilocode/kilo-jetbrains`
