### PR TITLE
fix(jetbrains): use file-based bundled signing secrets

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -127,7 +127,7 @@ jobs:
           tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP"
           echo "$RUNNER_TEMP/zig-linux-x86_64-0.14.0" >> "$GITHUB_PATH"
 
-      - name: Validate signing secrets
+      - name: Prepare signing secrets
         run: |
           missing=0
           for name in JETBRAINS_CERTIFICATE_CHAIN JETBRAINS_PRIVATE_KEY JETBRAINS_PRIVATE_KEY_PASSWORD; do
@@ -136,7 +136,19 @@ jobs:
               missing=1
             fi
           done
-          exit "$missing"
+          if [[ "$missing" -ne 0 ]]; then
+            exit "$missing"
+          fi
+
+          chain="$RUNNER_TEMP/jetbrains-certificate-chain.pem"
+          key="$RUNNER_TEMP/jetbrains-private-key.pem"
+          printf '%s' "$JETBRAINS_CERTIFICATE_CHAIN" > "$chain"
+          printf '%s' "$JETBRAINS_PRIVATE_KEY" > "$key"
+          chmod 600 "$chain" "$key"
+          {
+            echo "JETBRAINS_CERTIFICATE_CHAIN_FILE=$chain"
+            echo "JETBRAINS_PRIVATE_KEY_FILE=$key"
+          } >> "$GITHUB_ENV"
         env:
           JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
           JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
@@ -161,8 +173,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           CHANNEL: ${{ needs.validate.outputs.channel }}
-          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
-          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
 
       - name: Resolve bundled archive

--- a/packages/kilo-jetbrains/build.gradle.kts
+++ b/packages/kilo-jetbrains/build.gradle.kts
@@ -89,6 +89,8 @@ val tag = gitTag()?.removePrefix("jetbrains/v")
 val ver = override?.let(::checked) ?: prop?.let(::checked) ?: if (release) checked(
     tag ?: error("Missing JetBrains plugin version. Publish builds must set kilo.jetbrains.version or run from a jetbrains/v<version> tag."),
 ) else checked(tag ?: "0.0.0-dev")
+val chain = providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN_FILE")
+val key = providers.environmentVariable("JETBRAINS_PRIVATE_KEY_FILE")
 
 if (release && !pinned) error(
     "kilo.cli.pinned=false is a dev-only mode and cannot be released. Set kilo.cli.pinned=true before a production/publish build."
@@ -207,8 +209,16 @@ intellijPlatform {
     }
 
     signing {
-        certificateChain = providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN")
-        privateKey = providers.environmentVariable("JETBRAINS_PRIVATE_KEY")
+        if (chain.isPresent) {
+            certificateChainFile = file(chain.get())
+        } else {
+            certificateChain = providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN")
+        }
+        if (key.isPresent) {
+            privateKeyFile = file(key.get())
+        } else {
+            privateKey = providers.environmentVariable("JETBRAINS_PRIVATE_KEY")
+        }
         password = providers.environmentVariable("JETBRAINS_PRIVATE_KEY_PASSWORD")
     }
 


### PR DESCRIPTION
## What
- Write JetBrains signing secrets to runner-temp PEM files in publish-jetbrains-bundled before invoking Gradle.
- Export JETBRAINS_CERTIFICATE_CHAIN_FILE and JETBRAINS_PRIVATE_KEY_FILE, and stop passing multiline certificate/key env vars into the split Gradle invocations.
- Configure the JetBrains Gradle signing block to prefer file-based signing inputs when those env vars are present, while preserving the existing inline-secret fallback for other release paths.

## Why
The 7.0.11 bundled/offline publish still fails after splitting Gradle tasks because verifyPluginSignature receives the multiline certificate content as invalid CLI arguments in a separate Gradle invocation. File-based signing matches packages/kilo-jetbrains/script/build-version.sh and avoids passing multiline secrets through the verifier CLI.

After this merges, retry:
```bash
gh workflow run publish-jetbrains-bundled.yml \
  --ref main \
  -f pr=12563 \
  -f merge_commit=439448291efe1eb648de2481f12923511cbd63ec
```

## Validation
- Not run per request.