### PR TITLE
fix(jetbrains): use file-based signing secrets for bundled publish workflow

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -142,6 +142,22 @@ jobs:
           JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
 
+      - name: Write signing secrets to temp files
+        run: |
+          dir="$RUNNER_TEMP/jetbrains-signing"
+          mkdir -m 700 -p "$dir"
+          chain="$dir/certificate-chain.pem"
+          key="$dir/private-key.pem"
+          umask 077
+          printf '%s' "$JETBRAINS_CERTIFICATE_CHAIN" > "$chain"
+          printf '%s' "$JETBRAINS_PRIVATE_KEY" > "$key"
+          chmod 600 "$chain" "$key"
+          echo "JETBRAINS_CERTIFICATE_CHAIN_FILE=$chain" >> "$GITHUB_ENV"
+          echo "JETBRAINS_PRIVATE_KEY_FILE=$key" >> "$GITHUB_ENV"
+        env:
+          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
+          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
+
       - name: Build signed bundled plugin
         working-directory: packages/kilo-jetbrains
         run: |
@@ -152,6 +168,9 @@ jobs:
             -Pkilo.cli.bundled=true
           )
 
+          # signPlugin and verifyPluginSignature run as separate Gradle invocations (see #12567)
+          # so the JETBRAINS_CERTIFICATE_CHAIN_FILE / JETBRAINS_PRIVATE_KEY_FILE env vars set in
+          # the previous step (rather than raw multiline secret content) must be present for both.
           ./gradlew clean buildPlugin "${args[@]}"
           ./gradlew signPlugin "${args[@]}"
           ./gradlew verifyPluginSignature "${args[@]}"
@@ -161,9 +180,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           CHANNEL: ${{ needs.validate.outputs.channel }}
-          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
-          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
+
+      - name: Remove signing secret temp files
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/jetbrains-signing"
 
       - name: Resolve bundled archive
         id: archive

--- a/packages/kilo-jetbrains/build.gradle.kts
+++ b/packages/kilo-jetbrains/build.gradle.kts
@@ -207,8 +207,15 @@ intellijPlatform {
     }
 
     signing {
-        certificateChain = providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN")
-        privateKey = providers.environmentVariable("JETBRAINS_PRIVATE_KEY")
+        // File-based inputs are preferred over raw content: certificateChain/privateKey take
+        // precedence over certificateChainFile/privateKeyFile in the IntelliJ Platform Gradle
+        // plugin, and passing multiline PEM content straight through as a certificateChain/
+        // privateKey value can get mishandled as extra CLI arguments by the zip-signer CLI when
+        // signPlugin/verifyPluginSignature run as separate Gradle invocations. Both CI
+        // (.github/workflows/publish-jetbrains-bundled.yml) and local releases
+        // (script/build-version.sh) write the secrets to files and export the *_FILE variables.
+        certificateChainFile.fileProvider(providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN_FILE").map { file(it) })
+        privateKeyFile.fileProvider(providers.environmentVariable("JETBRAINS_PRIVATE_KEY_FILE").map { file(it) })
         password = providers.environmentVariable("JETBRAINS_PRIVATE_KEY_PASSWORD")
     }
 


### PR DESCRIPTION
## Root cause

#12567 (51d660319f) split the JetBrains bundled publish workflow's Gradle build into separate `./gradlew` invocations for `buildPlugin`, `signPlugin`, `verifyPluginSignature`, and `verifyPlugin` to fix a Gradle 9 task-dependency issue between `:signPlugin` and `:verifyPluginSignature`.

After that split, `verifyPluginSignature` started failing in its own invocation with:

```
Task :verifyPluginSignature FAILED
Invalid argument: ***
Usage: org.jetbrains.zip.signer.VerifyOptions
  -cert [String] Certificate file (.../build/tmp/verifyPluginSignature/certificate-chain.pem)
  -in [String] Path to signed plugin zip/jar file (.../build/distributions/kilo.jetbrains-7.0.11-signed.zip)
```

Failed run: https://github.com/Kilo-Org/kilocode/actions/runs/30278909051

The workflow was passing `JETBRAINS_CERTIFICATE_CHAIN` / `JETBRAINS_PRIVATE_KEY` (multiline PEM secrets) directly into the intellij-platform-gradle-plugin's `certificateChain`/`privateKey` `Property<String>` config, which the zip-signer CLI wiring can mishandle — the masked multiline content ends up split into extra CLI arguments — when `verifyPluginSignature` runs as its own Gradle invocation instead of sharing a task graph with `signPlugin`.

`packages/kilo-jetbrains/script/build-version.sh` (used for local releases) avoids this by writing the secrets to temp files and exporting `JETBRAINS_CERTIFICATE_CHAIN_FILE` / `JETBRAINS_PRIVATE_KEY_FILE` / `JETBRAINS_PRIVATE_KEY_PASSWORD` instead, but `build.gradle.kts` never actually wired those `*_FILE` variables into the signing extension — it only read the raw-content `JETBRAINS_CERTIFICATE_CHAIN` / `JETBRAINS_PRIVATE_KEY` env vars.

## Fix

- `packages/kilo-jetbrains/build.gradle.kts`: wire `signing.certificateChainFile` / `signing.privateKeyFile` (file-based, via `fileProvider(...)`) from `JETBRAINS_CERTIFICATE_CHAIN_FILE` / `JETBRAINS_PRIVATE_KEY_FILE` instead of the raw-content `certificateChain` / `privateKey` properties. This makes the local `build-version.sh` flow and CI consistent, and avoids ever passing multiline secret content as a CLI-facing value.
- `.github/workflows/publish-jetbrains-bundled.yml`: write `JETBRAINS_CERTIFICATE_CHAIN` / `JETBRAINS_PRIVATE_KEY` to mode-600 temp files under `$RUNNER_TEMP/jetbrains-signing` (dir mode 700) before the Gradle build step, export the `*_FILE` env vars via `$GITHUB_ENV` so they're available to every subsequent `./gradlew` invocation (`signPlugin`, `verifyPluginSignature`, `verifyPlugin`), and remove the temp files in an `if: always()` cleanup step. No secret values are printed to logs.

## Validation

- `bun run script/check-workflows.ts` — passes
- `git diff --check -- .github/workflows/publish-jetbrains-bundled.yml` — clean
- Verified the `certificateChainFile`/`privateKeyFile`/`fileProvider(Provider<File>)` API against the `org.jetbrains.intellij.platform` Gradle plugin (2.17.0) `Signing` extension source and the Gradle 9 `RegularFileProperty` Javadoc.
- Could not run `./gradlew typecheck` / a full Gradle build in this sandbox — the sandbox's outbound network path fails TLS certificate validation when Gradle tries to download its distribution (`PKIX path building failed`), unrelated to this change. Recommend running `./gradlew typecheck` from `packages/kilo-jetbrains/` in CI/locally before merge as a final check.

## Re-dispatch after merge

```
gh workflow run publish-jetbrains-bundled.yml --ref main -f pr=12563 -f merge_commit=439448291efe1eb648de2481f12923511cbd63ec
```

---

Built for [Kirill Kalishev](https://kilo-code.slack.com/archives/D0ALWEFMAE5/p1785167201643289?thread_ts=1785167184.844549&cid=D0ALWEFMAE5) by [Kilo for Slack](https://kilo.ai/slack)