### PR TITLE
docs: note that bot-generated PRs are ignored by default in Code Reviews

### DIFF
--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -160,7 +160,7 @@ When a pull request or merge request is opened or updated:
 Reviews are posted directly in your platform (GitHub or GitLab) as if coming from a team reviewer.
 
 {% callout type="info" title="Bot-generated PRs are ignored by default" %}
-Kilo does not automatically review pull or merge requests opened by bots, such as Dependabot, Renovate, or other automation accounts. This keeps review credits and notifications focused on human-authored changes. I
+Kilo does not automatically review pull or merge requests opened by bots, such as Dependabot, Renovate, or other automation accounts. This keeps review credits and notifications focused on human-authored changes.
 {% /callout %}
 
 ## Review Styles

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -160,7 +160,7 @@ When a pull request or merge request is opened or updated:
 Reviews are posted directly in your platform (GitHub or GitLab) as if coming from a team reviewer.
 
 {% callout type="info" title="Bot-generated PRs are ignored by default" %}
-Kilo does not automatically review pull or merge requests opened by bots, such as Dependabot, Renovate, or other automation accounts. This keeps review credits and notifications focused on human-authored changes. If you want bot PRs reviewed, request this on the Code Reviews beta Discord channel.
+Kilo does not automatically review pull or merge requests opened by bots, such as Dependabot, Renovate, or other automation accounts. This keeps review credits and notifications focused on human-authored changes. I
 {% /callout %}
 
 ## Review Styles

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -159,6 +159,10 @@ When a pull request or merge request is opened or updated:
 
 Reviews are posted directly in your platform (GitHub or GitLab) as if coming from a team reviewer.
 
+{% callout type="info" title="Bot-generated PRs are ignored by default" %}
+Kilo does not automatically review pull or merge requests opened by bots, such as Dependabot, Renovate, or other automation accounts. This keeps review credits and notifications focused on human-authored changes. If you want bot PRs reviewed, request this on the Code Reviews beta Discord channel.
+{% /callout %}
+
 ## Review Styles
 
 ### Strict
@@ -236,3 +240,4 @@ The Review Agent is ideal for:
 - Some highly dynamic or domain-specific code may require additional context in `REVIEW.md`.
 - The agent will only run on **selected repositories**.
 - During beta, review capacity may be throttled for extremely large PRs.
+- PRs/MRs opened by bots (e.g. Dependabot, Renovate) are ignored by default.


### PR DESCRIPTION
## What

Documents that the Kilo Code Reviewer ignores pull/merge requests opened by bots (e.g. Dependabot, Renovate) by default.

## Why

This behavior wasn't previously documented, leaving users unsure why automated dependency-update PRs weren't receiving AI reviews.

## Changes

- Added a callout near the "How Code Reviews Work" section in `packages/kilo-docs/pages/automate/code-reviews/overview.md` explaining that bot-authored PRs/MRs are excluded from automatic review by default.
- Added a corresponding bullet under "Limitations and Guidance" for visibility.

---

Built for [Emilie Schario](https://kilo-code.slack.com/archives/D0AAHDZLCBV/p1785168579206629?thread_ts=1780941653.304889&cid=D0AAHDZLCBV) by [Kilo for Slack](https://kilo.ai/slack)