### PR TITLE
fix(kilo-vscode): await saveFile in VS Code test harness and add regression test

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde.ts
@@ -71,13 +71,7 @@ export class VsCodeIde implements IDE {
   }
 
   async fileExists(fileUri: string): Promise<boolean> {
-    try {
-      await stat(vscode.Uri.file(fileUri))
-      return true
-    } catch {
-      console.error(`File does not exist: ${fileUri}`)
-      return false
-    }
+    return (await stat(vscode.Uri.file(fileUri))) !== null
   }
 
   async writeFile(path: string, contents: string): Promise<void> {
@@ -85,13 +79,12 @@ export class VsCodeIde implements IDE {
   }
 
   async saveFile(fileUri: string): Promise<void> {
-    console.log(`Saving file: ${fileUri}`)
     const uri = vscode.Uri.parse(fileUri)
-    vscode.window.visibleTextEditors.forEach(async (editor) => {
-      if (areEqualURIs(uri, editor.document.uri)) {
-        await editor.document.save()
-      }
-    })
+    const savePromises = vscode.window.visibleTextEditors
+      .filter((editor) => areEqualURIs(uri, editor.document.uri))
+      .map((editor) => editor.document.save())
+
+    await Promise.all(savePromises)
   }
 
   async readFile(fileUri: string): Promise<string> {

--- a/packages/kilo-vscode/tests/unit/vscodeide-savefile.test.ts
+++ b/packages/kilo-vscode/tests/unit/vscodeide-savefile.test.ts
@@ -1,36 +1,6 @@
 import { describe, it, expect, vi } from "bun:test"
-import { VsCodeIde } from "../src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde"
+import { VsCodeIde } from "../../src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde"
 import * as vscode from "vscode"
-
-vi.mock("vscode", () => ({
-  Uri: {
-    parse: (fileUri: string) => ({
-      toString: () => fileUri,
-    }),
-    file: (path: string) => ({
-      toString: () => `file://${path}`,
-    }),
-  },
-  workspace: {
-    fs: {
-      stat: vi.fn().mockResolvedValue({} as any),
-      readFile: vi.fn(),
-    },
-    textDocuments: [],
-    notebookDocuments: [],
-    workspaceFolders: [],
-  },
-  window: {
-    visibleTextEditors: [],
-    activeTextEditor: undefined,
-  },
-  env: {
-    clipboard: {
-      readText: vi.fn().mockResolvedValue("")
-    },
-    machineId: "test-machine",
-  },
-}))
 
 describe("VsCodeIde", () => {
   it("awaits save on visible editor matching the URI", async () => {

--- a/packages/kilo-vscode/tests/unit/vscodeide-savefile.test.ts
+++ b/packages/kilo-vscode/tests/unit/vscodeide-savefile.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "bun:test"
+import { VsCodeIde } from "../src/services/autocomplete/continuedev/core/vscode-test-harness/src/VSCodeIde"
+import * as vscode from "vscode"
+
+vi.mock("vscode", () => ({
+  Uri: {
+    parse: (fileUri: string) => ({
+      toString: () => fileUri,
+    }),
+    file: (path: string) => ({
+      toString: () => `file://${path}`,
+    }),
+  },
+  workspace: {
+    fs: {
+      stat: vi.fn().mockResolvedValue({} as any),
+      readFile: vi.fn(),
+    },
+    textDocuments: [],
+    notebookDocuments: [],
+    workspaceFolders: [],
+  },
+  window: {
+    visibleTextEditors: [],
+    activeTextEditor: undefined,
+  },
+  env: {
+    clipboard: {
+      readText: vi.fn().mockResolvedValue("")
+    },
+    machineId: "test-machine",
+  },
+}))
+
+describe("VsCodeIde", () => {
+  it("awaits save on visible editor matching the URI", async () => {
+    const saveMock = vi.fn().mockResolvedValue(true)
+    const editor = {
+      document: {
+        uri: { toString: () => "file:///test.ts" },
+        save: saveMock,
+      },
+    }
+
+    vscode.window.visibleTextEditors = [editor]
+
+    const ide = new VsCodeIde({} as any)
+    await ide.saveFile("file:///test.ts")
+
+    expect(saveMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("completes without error when no visible editor matches", async () => {
+    vscode.window.visibleTextEditors = []
+
+    const ide = new VsCodeIde({} as any)
+    await expect(ide.saveFile("file:///nonexistent.ts")).resolves.toBeUndefined()
+  })
+
+  it("returns false when the file does not exist", async () => {
+    vi.mocked(vscode.workspace.fs.stat).mockResolvedValueOnce(null)
+
+    const ide = new VsCodeIde({} as any)
+    await expect(ide.fileExists("/missing.ts")).resolves.toBe(false)
+  })
+
+  it("returns true when the file exists", async () => {
+    vi.mocked(vscode.workspace.fs.stat).mockResolvedValueOnce({} as any)
+
+    const ide = new VsCodeIde({} as any)
+    await expect(ide.fileExists("/exists.ts")).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
Fix the VS Code autocomplete test harness so [VsCodeIde.saveFile](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) properly waits for editor saves instead of triggering them in an unawaited forEach callback.

Changes
[VSCodeIde.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[saveFile](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now collects matching [editor.document.save()](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) promises and awaits them with [Promise.all](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[fileExists](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now returns false when [stat()](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns null, instead of duplicating its own try/catch flow
[vscodeide-savefile.test.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added regression coverage for:
[saveFile](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) awaiting a visible editor's save
[saveFile](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) completing successfully when no matching editor exists
[fileExists](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returning false when the file is missing
[fileExists](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returning true when the file exists
Updated the import path to ../../src/...
Removed the local conflicting [vscode](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html) mock and now rely on the shared preload mock
Testing
Run locally in the extension package:

cd packages/kilo-vscode
bun test tests/unit/vscodeide-savefile.test.ts --dots