### PR TITLE
fix(jetbrains): avoid writing release signing secrets

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -142,22 +142,6 @@ jobs:
           JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
 
-      - name: Write signing secrets to temp files
-        run: |
-          dir="$RUNNER_TEMP/jetbrains-signing"
-          mkdir -m 700 -p "$dir"
-          chain="$dir/certificate-chain.pem"
-          key="$dir/private-key.pem"
-          umask 077
-          printf '%s' "$JETBRAINS_CERTIFICATE_CHAIN" > "$chain"
-          printf '%s' "$JETBRAINS_PRIVATE_KEY" > "$key"
-          chmod 600 "$chain" "$key"
-          echo "JETBRAINS_CERTIFICATE_CHAIN_FILE=$chain" >> "$GITHUB_ENV"
-          echo "JETBRAINS_PRIVATE_KEY_FILE=$key" >> "$GITHUB_ENV"
-        env:
-          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
-          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
-
       - name: Build signed bundled plugin
         working-directory: packages/kilo-jetbrains
         run: |
@@ -167,24 +151,15 @@ jobs:
             -Pkilo.channel="$CHANNEL"
             -Pkilo.cli.bundled=true
           )
-
-          # signPlugin and verifyPluginSignature run as separate Gradle invocations (see #12567)
-          # so the JETBRAINS_CERTIFICATE_CHAIN_FILE / JETBRAINS_PRIVATE_KEY_FILE env vars set in
-          # the previous step (rather than raw multiline secret content) must be present for both.
-          ./gradlew clean buildPlugin "${args[@]}"
-          ./gradlew signPlugin "${args[@]}"
-          ./gradlew verifyPluginSignature "${args[@]}"
-          ./gradlew verifyPlugin "${args[@]}"
+          ./gradlew clean buildPlugin signPlugin verifyPluginSignature verifyPlugin "${args[@]}"
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           CHANNEL: ${{ needs.validate.outputs.channel }}
+          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
+          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
-
-      - name: Remove signing secret temp files
-        if: always()
-        run: rm -rf "$RUNNER_TEMP/jetbrains-signing"
 
       - name: Resolve bundled archive
         id: archive

--- a/packages/kilo-jetbrains/build.gradle.kts
+++ b/packages/kilo-jetbrains/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.InstrumentCodeTask
 import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
 import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware.PluginInstallationTarget
+import java.io.File
 import java.time.LocalDate
 
 group = "ai.kilocode.jetbrains"
@@ -207,15 +208,12 @@ intellijPlatform {
     }
 
     signing {
-        // File-based inputs are preferred over raw content: certificateChain/privateKey take
-        // precedence over certificateChainFile/privateKeyFile in the IntelliJ Platform Gradle
-        // plugin, and passing multiline PEM content straight through as a certificateChain/
-        // privateKey value can get mishandled as extra CLI arguments by the zip-signer CLI when
-        // signPlugin/verifyPluginSignature run as separate Gradle invocations. Both CI
-        // (.github/workflows/publish-jetbrains-bundled.yml) and local releases
-        // (script/build-version.sh) write the secrets to files and export the *_FILE variables.
-        certificateChainFile.fileProvider(providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN_FILE").map { file(it) })
-        privateKeyFile.fileProvider(providers.environmentVariable("JETBRAINS_PRIVATE_KEY_FILE").map { file(it) })
+        // CI passes raw secret content so signing can run without writing secrets to disk.
+        // Local release builds can still point these properties at pre-existing secret files.
+        certificateChain = providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("JETBRAINS_PRIVATE_KEY")
+        certificateChainFile.fileProvider(providers.environmentVariable("JETBRAINS_CERTIFICATE_CHAIN_FILE").map { File(it) })
+        privateKeyFile.fileProvider(providers.environmentVariable("JETBRAINS_PRIVATE_KEY_FILE").map { File(it) })
         password = providers.environmentVariable("JETBRAINS_PRIVATE_KEY_PASSWORD")
     }
 
@@ -227,6 +225,10 @@ intellijPlatform {
 }
 
 tasks {
+    named("verifyPluginSignature") {
+        dependsOn("signPlugin")
+    }
+
     withType<InstrumentCodeTask> {
         enabled = false
     }


### PR DESCRIPTION
## Summary
- Restore raw-content JetBrains signing inputs for CI so release workflows do not write signing secrets to temp files.
- Keep file-path signing inputs for local release builds that already use pre-existing secret files.
- Run the bundled signing, signature verification, and plugin verification in one Gradle invocation with an explicit `verifyPluginSignature -> signPlugin` dependency.

## Context
The bundled release failure started as a Gradle 9 implicit dependency error between `verifyPluginSignature` and `signPlugin`. Splitting those tasks into separate invocations avoided that error but exposed raw multiline PEM handling in zip-signer, leading to temp-file secret writes. This fixes the original task dependency directly and keeps the Marketplace publish path on the historically working raw-secret `publishPlugin` flow.