### PR TITLE
docs: add NVIDIA to BYOK providers

### DIFF
--- a/packages/kilo-docs/pages/gateway/authentication.md
+++ b/packages/kilo-docs/pages/gateway/authentication.md
@@ -97,6 +97,7 @@ BYOK lets you use your own provider API keys with the Kilo AI Gateway. When a BY
 | Kimi Code | `kimi-coding` |
 | Martian | `martian` |
 | Neuralwatt | `neuralwatt` |
+| NVIDIA | `nvidia-byok` |
 | Ollama Cloud | `ollama-cloud` |
 | OpenCode Go | `opencode-go` |
 | OrcaRouter | `orcarouter` |

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -94,10 +94,6 @@ Create an API key in the [NVIDIA API Catalog](https://build.nvidia.com/settings/
 
 Models that do not support tool calling are excluded, as they are unlikely to provide useful results.
 
-{% callout type="warning" title="NVIDIA API Catalog terms" %}
-NVIDIA limits Developer Program endpoints to prototyping, research, development, and testing. Serving production end users may require NVIDIA AI Enterprise licensing. Your prompts and model outputs are sent to NVIDIA under your NVIDIA agreement. Review the [API Catalog quickstart](https://docs.api.nvidia.com/nim/docs/api-quickstart) and the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
-{% /callout %}
-
 ## How Bring Your Own Key works
 
 - When you use the **Kilo Gateway** provider, Kilo checks if there's a BYOK key for the selected model's provider.

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -92,7 +92,7 @@ Your IAM user or role must have the following permissions:
 
 Create an API key in the [NVIDIA API Catalog](https://build.nvidia.com/settings/api-keys), then add it as the NVIDIA provider.
 
-NVIDIA models use their own `nvidia-byok/` prefix, so select a model such as `nvidia-byok/nvidia/nemotron-3-super-120b-a12b` rather than a Kilo Gateway model with the same name. Only NVIDIA-hosted models that support tool calling are available.
+Models that do not support tool calling are excluded, as they are unlikely to be provide useful results.
 
 {% callout type="warning" title="NVIDIA API Catalog terms" %}
 NVIDIA limits Developer Program endpoints to prototyping, research, development, and testing. Serving production end users may require NVIDIA AI Enterprise licensing. Your prompts and model outputs are sent to NVIDIA under your NVIDIA agreement. Review the [API Catalog quickstart](https://docs.api.nvidia.com/nim/docs/api-quickstart) and the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -88,12 +88,6 @@ Your IAM user or role must have the following permissions:
 - `bedrock:InvokeModel`
 - `bedrock:InvokeModelWithResponseStream`
 
-### NVIDIA configuration
-
-Create an API key in the [NVIDIA API Catalog](https://build.nvidia.com/settings/api-keys), then add it as the NVIDIA provider.
-
-Models that do not support tool calling are excluded, as they are unlikely to provide useful results.
-
 ## How Bring Your Own Key works
 
 - When you use the **Kilo Gateway** provider, Kilo checks if there's a BYOK key for the selected model's provider.

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -92,7 +92,7 @@ Your IAM user or role must have the following permissions:
 
 Create an API key in the [NVIDIA API Catalog](https://build.nvidia.com/settings/api-keys), then add it as the NVIDIA provider.
 
-Models that do not support tool calling are excluded, as they are unlikely to be provide useful results.
+Models that do not support tool calling are excluded, as they are unlikely to provide useful results.
 
 {% callout type="warning" title="NVIDIA API Catalog terms" %}
 NVIDIA limits Developer Program endpoints to prototyping, research, development, and testing. Serving production end users may require NVIDIA AI Enterprise licensing. Your prompts and model outputs are sent to NVIDIA under your NVIDIA agreement. Review the [API Catalog quickstart](https://docs.api.nvidia.com/nim/docs/api-quickstart) and the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -49,6 +49,7 @@ These providers offer coding-focused subscriptions or dedicated endpoints. Bring
 - Martian
 - Mistral Codestral
 - Neuralwatt
+- NVIDIA
 - Ollama Cloud
 - OpenCode Go
 - OrcaRouter
@@ -86,6 +87,16 @@ Your IAM user or role must have the following permissions:
 
 - `bedrock:InvokeModel`
 - `bedrock:InvokeModelWithResponseStream`
+
+### NVIDIA configuration
+
+Create an API key in the [NVIDIA API Catalog](https://build.nvidia.com/settings/api-keys), then add it as the NVIDIA provider.
+
+NVIDIA models use their own `nvidia-byok/` prefix, so select a model such as `nvidia-byok/nvidia/nemotron-3-super-120b-a12b` rather than a Kilo Gateway model with the same name. Only NVIDIA-hosted models that support tool calling are available.
+
+{% callout type="warning" title="NVIDIA API Catalog terms" %}
+NVIDIA limits Developer Program endpoints to prototyping, research, development, and testing. Serving production end users may require NVIDIA AI Enterprise licensing. Your prompts and model outputs are sent to NVIDIA under your NVIDIA agreement. Review the [API Catalog quickstart](https://docs.api.nvidia.com/nim/docs/api-quickstart) and the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
+{% /callout %}
 
 ## How Bring Your Own Key works
 


### PR DESCRIPTION
Documents NVIDIA as a direct BYOK provider, matching the cloud-side implementation in Kilo-Org/cloud#4803.

## Changes

- `getting-started/byok.md`: adds NVIDIA to the subscription and direct provider plans list, plus an `### NVIDIA configuration` section covering where to create the key, the required `nvidia-byok/` model prefix, and the tool-calling requirement.
- `gateway/authentication.md`: adds the `nvidia-byok` key ID to the supported BYOK providers table.

NVIDIA is listed under direct provider plans rather than standard API keys because its models are namespaced under `nvidia-byok/` instead of matching existing gateway model IDs, the same as Chutes BYOK and Inceptron BYOK.

The callout states NVIDIA's actual restriction: Developer Program endpoints are limited to prototyping, research, development, and testing, and production use may require NVIDIA AI Enterprise licensing. This matches the notice shown in the cloud BYOK dialog and the existing NVIDIA free-endpoint disclosures elsewhere in the docs.

## Testing

- `bun run script/check-md-table-padding.ts`: 372 files checked, clean.
- `bun test` in `packages/kilo-docs`: 22 passed.
- Docs-only change; `bun.lock` was already modified in my working tree and is deliberately excluded.