### PR TITLE
fix(jetbrains): use file signing inputs for bundled publish

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -142,6 +142,22 @@ jobs:
           JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
 
+      - name: Write signing secrets to temp files
+        run: |
+          dir="$RUNNER_TEMP/jetbrains-signing"
+          mkdir -m 700 -p "$dir"
+          chain="$dir/certificate-chain.pem"
+          key="$dir/private-key.pem"
+          umask 077
+          printf '%s' "$JETBRAINS_CERTIFICATE_CHAIN" > "$chain"
+          printf '%s' "$JETBRAINS_PRIVATE_KEY" > "$key"
+          chmod 600 "$chain" "$key"
+          echo "JETBRAINS_CERTIFICATE_CHAIN_FILE=$chain" >> "$GITHUB_ENV"
+          echo "JETBRAINS_PRIVATE_KEY_FILE=$key" >> "$GITHUB_ENV"
+        env:
+          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
+          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
+
       - name: Build signed bundled plugin
         working-directory: packages/kilo-jetbrains
         run: |
@@ -157,9 +173,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           CHANNEL: ${{ needs.validate.outputs.channel }}
-          JETBRAINS_CERTIFICATE_CHAIN: ${{ secrets.JETBRAINS_CERTIFICATE_CHAIN }}
-          JETBRAINS_PRIVATE_KEY: ${{ secrets.JETBRAINS_PRIVATE_KEY }}
           JETBRAINS_PRIVATE_KEY_PASSWORD: ${{ secrets.JETBRAINS_PRIVATE_KEY_PASSWORD }}
+
+      - name: Remove signing secret temp files
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/jetbrains-signing"
 
       - name: Resolve bundled archive
         id: archive


### PR DESCRIPTION
## Summary
- Write JetBrains signing secrets to runner-temp files in the bundled publish workflow.
- Pass only `JETBRAINS_CERTIFICATE_CHAIN_FILE` / `JETBRAINS_PRIVATE_KEY_FILE` to the Gradle signing step.
- Leave Marketplace publish unchanged.

## Why
The `7.0.12-rc.1` Marketplace publish succeeded, but the bundled workflow failed in `verifyPluginSignature` with `Invalid argument: ***`. The signature verifier expects a certificate file path, and raw multiline PEM secrets can be parsed as extra zip-signer CLI arguments.

## Validation
- `git diff --check -- .github/workflows/publish-jetbrains-bundled.yml`
- `bun run script/check-workflows.ts`

## Follow-up after merge
Rerun only the bundled workflow for the already-published release:

```bash
gh workflow run publish-jetbrains-bundled.yml \
  --repo Kilo-Org/kilocode \
  --ref main \
  -f pr=12577 \
  -f merge_commit=7955f645eb811e1d5744d0f2c93c7cf71090505c
```
