### PR TITLE
docs: make readme more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,154 +23,42 @@
 
 Kilo Code is an AI coding agent that meets you everywhere you work: [VS Code](https://kilo.ai/landing/vs-code), [JetBrains](https://kilo.ai/features/jetbrains-native), and the [CLI](https://kilo.ai/cli). It's open source with open pricing. You pick from 500+ models, switch between them mid-task, and pay the model provider's rate with zero markup. No API keys required to start.
 
-### Installation
+### Get started
 
-Pick where you want to run Kilo.
-
-<details open>
-<summary><strong>VS Code</strong></summary>
-
-<br>
-
-Install the [Kilo Code extension](vscode:extension/kilocode.kilo-code) directly, or grab it from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code). Create an account and you'll have access to 500+ models including GPT-5.5, Claude Opus 4.7, Claude Sonnet 4.6, and Gemini 3.1 Pro Preview, all at provider pricing.
-
-</details>
-
-<details open>
-<summary><strong>CLI</strong></summary>
-
-<br>
+- **VS Code:** Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=kilocode.Kilo-Code).
+- **JetBrains:** Install from the [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/28350-kilo-code).
+- **Cloud:** Use the [Cloud Agent](https://app.kilo.ai/cloud), set up [Code Reviews](https://app.kilo.ai/code-reviews), or launch an always-on [KiloClaw](https://app.kilo.ai/claw).
+- **CLI:** Install with your preferred package manager:
 
 ```bash
-# npm
 npm install -g @kilocode/cli
-
-# curl
-curl -fsSL https://kilo.ai/cli/install | bash
-
-# pnpm
-pnpm add -g @kilocode/cli
-
-# bun
-bun add -g @kilocode/cli
-
-# Homebrew (macOS / Linux)
-brew install Kilo-Org/tap/kilo
-
-# Arch Linux (AUR)
-paru -S kilo-bin
 ```
 
-Then run `kilo` in any project directory to start.
+Then run `kilo` in a project directory. See the [CLI docs](https://kilo.ai/cli) for other package managers and [GitHub Releases](https://github.com/Kilo-Org/kilocode/releases) for binaries.
 
-</details>
+### Highlights
 
-<details>
-<summary><strong>JetBrains</strong></summary>
-
-<br>
-
-Install the [Kilo Code plugin](https://plugins.jetbrains.com/plugin/28350-kilo-code) from the JetBrains Marketplace, or search "Kilo Code" in `Settings → Plugins` inside any JetBrains IDE.
-
-</details>
-
-<details>
-<summary><strong>Cloud Agent</strong></summary>
-
-<br>
-
-Run Kilo from the web, no local machine needed, at [app.kilo.ai/cloud](https://app.kilo.ai/cloud).
-
-</details>
-
-<details>
-<summary><strong>Code Reviews</strong></summary>
-
-<br>
-
-Set up automated AI code reviews on your pull requests at [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews).
-
-</details>
-
-<details>
-<summary><strong>KiloClaw</strong></summary>
-
-<br>
-
-Spin up your always-on AI agent at [app.kilo.ai/claw](https://app.kilo.ai/claw).
-
-</details>
-
-<details>
-<summary>Install the CLI from GitHub Releases (binaries)</summary>
-
-Download the latest binary from the [Releases page](https://github.com/Kilo-Org/kilocode/releases).
-
-| Platform | Asset |
-|---|---|
-| Windows (most PCs) | `kilo-windows-x64.zip` |
-| macOS (Apple Silicon) | `kilo-darwin-arm64.zip` |
-| macOS (Intel) | `kilo-darwin-x64.zip` |
-| Linux x64 | `kilo-linux-x64.tar.gz` |
-| Linux ARM | `kilo-linux-arm64.tar.gz` |
-
-Notes: `x64-baseline` is a compatibility build for older CPUs without AVX. `musl` is the statically linked build for Alpine or minimal Docker images without glibc. `kilo-vscode-*.vsix` is the VS Code extension package, not the CLI. `Source code` archives are for building from source.
-
-</details>
-
-### Agents
-
-Kilo ships with specialized agents you switch between depending on the task. You can also build your own custom agents.
-
-- **Code** - The default. Implements and edits code from natural language.
-- **Plan** - Designs architecture and writes implementation plans before any code gets written.
-- **Ask** - Answers questions about your codebase without touching any files.
-- **Debug** - Troubleshoots and traces issues.
-- **Review** - Reviews your changes and surfaces issues across performance, security, style, and test coverage.
-
-Learn more about [agents and custom agents](https://kilo.ai/docs/code-with-ai/agents/using-agents).
-
-### What it does
-
-- **Code generation** from natural language, across multiple files.
-- **Inline autocomplete** with ghost-text suggestions and tab to accept.
-- **Self-checking** so the agent reviews and corrects its own work.
-- **Terminal and browser control** to run commands and automate the web.
-- **MCP marketplace** to find and wire up MCP servers that extend what the agent can do.
-- **500+ models** with mid-task switching, so you can match latency, cost, and reasoning to the job.
+- Generate and edit code across multiple files from natural language.
+- Use inline autocomplete, terminal and browser control, and MCP servers.
+- Choose from specialized Code, Plan, Ask, Debug, and Review agents—or [create your own](https://kilo.ai/docs/code-with-ai/agents/using-agents).
+- Switch between 500+ models during a task.
 
 ### Autonomous Mode (CI/CD)
 
-Run `kilo run` with `--auto` for fully autonomous operation with no prompts, built for CI/CD pipelines:
+Use `--auto` to run without permission prompts in trusted CI/CD environments:
 
 ```bash
 kilo run --auto "run tests and fix any failures"
 ```
 
-`--auto` disables all permission prompts and lets the agent execute any action without confirmation. Only use it in trusted environments.
+### Learn more
 
-### Documentation
+- [Documentation](https://kilo.ai/docs)
+- [Contributing guide](/CONTRIBUTING.md) and [Code of Conduct](/CODE_OF_CONDUCT.md)
+- [Release process](RELEASING.md) ([JetBrains](packages/kilo-jetbrains/RELEASING.md))
+- [MIT License](/LICENSE)
 
-For configuration and everything else, [head over to the docs](https://kilo.ai/docs).
-
-### Contributing
-
-Contributions are welcome from developers, writers, and everyone in between. Start with the [Contributing Guide](/CONTRIBUTING.md) for environment setup, coding standards, and how to open a pull request. See [RELEASING.md](RELEASING.md) for the VS Code extension and CLI release process, and [packages/kilo-jetbrains/RELEASING.md](packages/kilo-jetbrains/RELEASING.md) for the JetBrains plugin.
-
-Please review our [Code of Conduct](/CODE_OF_CONDUCT.md) before getting involved.
-
-### License
-
-MIT. You're free to use, modify, and distribute this code, including commercially, as long as you keep the attribution and license notices. See [License](/LICENSE).
-
-### FAQ
-
-<details>
-<summary>Where did Kilo CLI come from?</summary>
-
-Kilo CLI is a fork of [OpenCode](https://github.com/anomalyco/opencode), enhanced to work within the Kilo agentic engineering platform.
-
-</details>
+Kilo CLI is a fork of [OpenCode](https://github.com/anomalyco/opencode), enhanced for the Kilo agentic engineering platform.
 
 ---
 


### PR DESCRIPTION
## Summary

- streamline installation guidance across Kilo surfaces
- combine agent and capability details into a concise highlights section
- consolidate documentation, contribution, release, and license links

The README is reduced from 177 lines to 65 while preserving the main product entry points and safety guidance.