### PR TITLE
feat(vscode): show sandbox toggle by default on supported platforms

### DIFF
--- a/.changeset/sandbox-default-on.md
+++ b/.changeset/sandbox-default-on.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Show the sandbox toggle for all users on supported platforms by default. The sandbox itself remains off until toggled on; users opt in via the prompt toggle or Settings. Setting `sandbox.enabled: false` hides the toggle entirely.

--- a/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
+++ b/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
@@ -20,7 +20,7 @@ describe("NewWorktreeDialog sandbox toggle", () => {
     expect(src).toContain("sandbox: sandboxVisible() ? sandboxOverride() : undefined")
     expect(src).toContain("const { config, globalConfig, features, settings } = useConfig()")
     expect(src).toContain(
-      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true",
+      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled !== false",
     )
     expect(provider).toContain("await this.fetchAndSendSandboxDefault(message.contextDirectory, message.requestID)")
     expect(src).not.toContain("createSignal(config().sandbox?.enabled === true)")

--- a/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-input-connection-guard.test.ts
@@ -83,9 +83,9 @@ describe("PromptInput sandbox toggle", () => {
     expect(src).not.toContain("setSandboxTarget")
   })
 
-  it("shows sandbox controls only when the global sandbox setting is enabled", () => {
+  it("shows sandbox controls unless the global sandbox setting is explicitly disabled", () => {
     expect(src).toContain(
-      'globalConfig().sandbox?.enabled === true &&\n    !session.currentSessionID()?.startsWith("cloud:")',
+      'globalConfig().sandbox?.enabled !== false &&\n    !session.currentSessionID()?.startsWith("cloud:")',
     )
     expect(src).toContain("features().sandboxControls &&")
     expect(src).toContain("<Show when={sandboxVisible()}>")

--- a/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
@@ -125,7 +125,7 @@ describe("Agent Manager sandbox startup", () => {
 
   test("uses the persisted sandbox default for UI and only sends explicit overrides", () => {
     expect(dialog).toContain(
-      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true",
+      "const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled !== false",
     )
     expect(dialog).toContain('vscode.postMessage({ type: "requestSandboxDefault", requestID: sandboxRequestID })')
     expect(dialog).toContain(

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -119,7 +119,7 @@ export const NewWorktreeDialog: Component<{ onClose: () => void; defaultBaseBran
   const [sandboxReason, setSandboxReason] = createSignal<string | undefined>()
   const [sandboxRevision, setSandboxRevision] = createSignal(-1)
   const sandboxRequestID = crypto.randomUUID()
-  const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled === true
+  const sandboxVisible = () => features().sandboxControls && globalConfig().sandbox?.enabled !== false
   const speech = useSpeechToText(vscode, server, { t })
   const canUseSpeech = () => canUseSpeechToText(config(), provider.authStates())
   const speechModel = () => selectedSpeechToTextModel(config())

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -243,7 +243,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
   const sandboxVisible = () =>
     features().sandboxControls &&
-    globalConfig().sandbox?.enabled === true &&
+    globalConfig().sandbox?.enabled !== false &&
     !session.currentSessionID()?.startsWith("cloud:")
   const sandbox = () => {
     const id = sandboxID()


### PR DESCRIPTION
The sandbox toggle (prompt button and Agent Manager worktree dialog) was hidden unless the user had already set `sandbox.enabled: true` in global settings. This made the feature invisible to most users, who would never discover it existed.

## What changed

Flip the visibility gate from opt-in (`=== true`) to opt-out (`!== false`) in two places:

- `PromptInput.tsx` — the prompt sandbox button
- `NewWorktreeDialog.tsx` — the Agent Manager worktree dialog sandbox toggle

The sandbox confinement itself is **not** enabled by default. It remains off until the user explicitly toggles it on. This change only makes the toggle visible so users can discover and opt into the feature.

## Opt-out

Setting `sandbox.enabled: false` in global settings hides the toggle entirely. Windows users never see it (`sandboxControls` is `false` on `win32`).

## Scope

This is an extension-only change. The backend sandbox config default and the TUI are untouched.