### PR TITLE
fix(vscode): show prompt input toggle tooltips instantly

### DIFF
--- a/.changeset/instant-prompt-tooltips.md
+++ b/.changeset/instant-prompt-tooltips.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show prompt input toggle tooltips instantly on hover instead of after a delay.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1433,7 +1433,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           <ModelSelector sessionID={sid} />
           <ThinkingSelector sessionID={sid} />
           <Show when={session.hasModelOverride(sid())}>
-            <Tooltip value={language.t("prompt.action.resetModel")} placement="top">
+            <Tooltip value={language.t("prompt.action.resetModel")} placement="top" openDelay={0}>
               <Button
                 variant="ghost"
                 size="small"
@@ -1449,7 +1449,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         </div>
         <div class="prompt-input-hint-actions">
           <Show when={showIndexing()}>
-            <Tooltip value={indexing.status().message || indexing.label()} placement="top">
+            <Tooltip value={indexing.status().message || indexing.label()} placement="top" openDelay={0}>
               <Button
                 variant="ghost"
                 size="small"
@@ -1481,6 +1481,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 : language.t("prompt.action.autoApprove.disabled")
             }
             placement="top"
+            openDelay={0}
           >
             <Button
               variant="ghost"
@@ -1508,7 +1509,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               onToggle={toggleSandbox}
             />
           </Show>
-          <Tooltip value={language.t("prompt.action.enhance")} placement="top">
+          <Tooltip value={language.t("prompt.action.enhance")} placement="top" openDelay={0}>
             <Button
               variant="ghost"
               size="small"
@@ -1525,7 +1526,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           <Show
             when={showStop()}
             fallback={
-              <Tooltip value={sendLabel()} placement="top">
+              <Tooltip value={sendLabel()} placement="top" openDelay={0}>
                 <Button
                   variant="ghost"
                   size="small"
@@ -1541,7 +1542,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               </Tooltip>
             }
           >
-            <Tooltip value={language.t("prompt.action.stop")} placement="top">
+            <Tooltip value={language.t("prompt.action.stop")} placement="top" openDelay={0}>
               <Button
                 variant="ghost"
                 size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -726,334 +726,339 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
           {props.description}
         </span>
       </Show>
-      <PopupSelector
-        expanded={expanded()}
-        preferredWidth={350}
-        preferredExpandedWidth={450}
-        preferredHeight={300}
-        preferredExpandedHeight={800}
-        minHeight={200}
-        placement={props.placement ?? "top-start"}
-        deferDismiss={props.deferDismiss}
-        portal={props.portal}
-        open={open()}
-        onOpenChange={setOpen}
-        triggerAs={Button}
-        triggerProps={{
-          variant: "secondary",
-          size: "normal",
-          get disabled() {
-            return !canOpen()
-          },
-          get title() {
-            return activeModel()?.id
-          },
-          get ["aria-label"]() {
-            return controlLabel()
-          },
-          get ["aria-describedby"]() {
-            return describedBy()
-          },
-        }}
-        trigger={
-          <>
-            <span class="model-selector-trigger-label">{triggerLabel()}</span>
-            <Show when={activeCollectsData()}>
-              <Tooltip value={dataLabel()} placement="top">
-                <span class="model-selector-trigger-free-data" aria-label={dataLabel()}>
-                  <Icon name="book-open-check" size="small" />
-                </span>
-              </Tooltip>
-            </Show>
-            <svg class="model-selector-trigger-chevron" width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M8 4l4 5H4l4-5z" />
-            </svg>
-          </>
-        }
-        class={`model-selector-popover${expanded() ? " model-selector-popover--expanded" : ""}`}
-      >
-        {(bodyH) => {
-          createEffect(() => {
-            if (!expanded()) return
-            const h = bodyH()
-            if (h === undefined) return
-            const chrome = (searchWrapperRef?.offsetHeight ?? 0) + (splitterRef?.offsetHeight ?? 0)
-            setPreviewHeight((h - chrome) / 2)
-          })
-          return (
-            <div
-              onKeyDown={handleKeyDown}
-              class={`model-selector-body${expanded() ? " model-selector-body--expanded" : ""}`}
-              style={{ height: `${bodyH()}px` }}
-              ref={bodyRef}
-            >
-              <div class="model-selector-search-wrapper" ref={searchWrapperRef}>
-                <input
-                  ref={searchRef}
-                  data-autofocus
-                  class="model-selector-search"
-                  type="text"
-                  role="combobox"
-                  aria-label={searchLabel()}
-                  aria-describedby={describedBy()}
-                  aria-autocomplete="list"
-                  aria-haspopup="tree"
-                  aria-expanded={open()}
-                  aria-controls={listID}
-                  aria-activedescendant={activeOptionID()}
-                  placeholder={language.t("dialog.model.search.placeholder")}
-                  value={search()}
-                  onInput={(e) => {
-                    setBrowsing(false)
-                    setNavigating(false)
-                    setSearch(e.currentTarget.value)
-                  }}
-                  onMouseDown={(e) => {
-                    const input = e.currentTarget
-                    if (input.selectionStart !== input.selectionEnd || input.selectionStart !== input.value.length) {
+      <Tooltip value={activeModel()?.id ?? ""} placement="top" openDelay={0} inactive={!activeModel()}>
+        <PopupSelector
+          expanded={expanded()}
+          preferredWidth={350}
+          preferredExpandedWidth={450}
+          preferredHeight={300}
+          preferredExpandedHeight={800}
+          minHeight={200}
+          placement={props.placement ?? "top-start"}
+          deferDismiss={props.deferDismiss}
+          portal={props.portal}
+          open={open()}
+          onOpenChange={setOpen}
+          triggerAs={Button}
+          triggerProps={{
+            variant: "secondary",
+            size: "normal",
+            get disabled() {
+              return !canOpen()
+            },
+            get ["aria-label"]() {
+              return controlLabel()
+            },
+            get ["aria-describedby"]() {
+              return describedBy()
+            },
+          }}
+          trigger={
+            <>
+              <span class="model-selector-trigger-label">{triggerLabel()}</span>
+              <Show when={activeCollectsData()}>
+                <Tooltip value={dataLabel()} placement="top" openDelay={0}>
+                  <span class="model-selector-trigger-free-data" aria-label={dataLabel()}>
+                    <Icon name="book-open-check" size="small" />
+                  </span>
+                </Tooltip>
+              </Show>
+              <svg
+                class="model-selector-trigger-chevron"
+                width="10"
+                height="10"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+              >
+                <path d="M8 4l4 5H4l4-5z" />
+              </svg>
+            </>
+          }
+          class={`model-selector-popover${expanded() ? " model-selector-popover--expanded" : ""}`}
+        >
+          {(bodyH) => {
+            createEffect(() => {
+              if (!expanded()) return
+              const h = bodyH()
+              if (h === undefined) return
+              const chrome = (searchWrapperRef?.offsetHeight ?? 0) + (splitterRef?.offsetHeight ?? 0)
+              setPreviewHeight((h - chrome) / 2)
+            })
+            return (
+              <div
+                onKeyDown={handleKeyDown}
+                class={`model-selector-body${expanded() ? " model-selector-body--expanded" : ""}`}
+                style={{ height: `${bodyH()}px` }}
+                ref={bodyRef}
+              >
+                <div class="model-selector-search-wrapper" ref={searchWrapperRef}>
+                  <input
+                    ref={searchRef}
+                    data-autofocus
+                    class="model-selector-search"
+                    type="text"
+                    role="combobox"
+                    aria-label={searchLabel()}
+                    aria-describedby={describedBy()}
+                    aria-autocomplete="list"
+                    aria-haspopup="tree"
+                    aria-expanded={open()}
+                    aria-controls={listID}
+                    aria-activedescendant={activeOptionID()}
+                    placeholder={language.t("dialog.model.search.placeholder")}
+                    value={search()}
+                    onInput={(e) => {
                       setBrowsing(false)
                       setNavigating(false)
-                    }
-                  }}
-                />
-                <Tooltip
-                  value={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
-                  placement="top"
-                >
-                  <IconButton
-                    icon={expanded() ? "collapse" : "expand"}
-                    size="small"
-                    variant="ghost"
-                    aria-label={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
-                    aria-expanded={expanded()}
-                    aria-controls={previewID}
-                    onClick={() => {
-                      if (expanded()) {
-                        setPreActiveKey(null)
-                        setPreviewKey(null)
+                      setSearch(e.currentTarget.value)
+                    }}
+                    onMouseDown={(e) => {
+                      const input = e.currentTarget
+                      if (input.selectionStart !== input.selectionEnd || input.selectionStart !== input.value.length) {
+                        setBrowsing(false)
+                        setNavigating(false)
                       }
-                      setExpanded(!expanded())
-                      requestAnimationFrame(() => {
-                        searchRef?.focus()
-                        scrollRow(preActiveKey() ?? selectedKey(), "nearest")
-                      })
                     }}
                   />
-                </Tooltip>
-              </div>
-
-              <div id={listID} class="model-selector-list" role="tree" aria-label={label()} ref={listRef}>
-                <Show when={groups().length === 0}>
-                  <div class="model-selector-empty" role="status" aria-live="polite">
-                    {language.t("dialog.model.empty")}
-                  </div>
-                </Show>
-
-                <Show when={nodes().length > 0}>
-                  <Virtualizer
-                    ref={setVirtualizer}
-                    data={nodes()}
-                    keepMounted={mounted()}
-                    bufferSize={120}
-                    itemSize={30}
+                  <Tooltip
+                    value={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
+                    placement="top"
                   >
-                    {
-                      // eslint-disable-next-line complexity
-                      (node) => {
-                        if (node.kind === "group" && node.group) {
-                          const group = node.group
-                          const key = groupKey(group.key)
-                          const shown = () => isGroupOpen(group.key)
+                    <IconButton
+                      icon={expanded() ? "collapse" : "expand"}
+                      size="small"
+                      variant="ghost"
+                      aria-label={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
+                      aria-expanded={expanded()}
+                      aria-controls={previewID}
+                      onClick={() => {
+                        if (expanded()) {
+                          setPreActiveKey(null)
+                          setPreviewKey(null)
+                        }
+                        setExpanded(!expanded())
+                        requestAnimationFrame(() => {
+                          searchRef?.focus()
+                          scrollRow(preActiveKey() ?? selectedKey(), "nearest")
+                        })
+                      }}
+                    />
+                  </Tooltip>
+                </div>
+
+                <div id={listID} class="model-selector-list" role="tree" aria-label={label()} ref={listRef}>
+                  <Show when={groups().length === 0}>
+                    <div class="model-selector-empty" role="status" aria-live="polite">
+                      {language.t("dialog.model.empty")}
+                    </div>
+                  </Show>
+
+                  <Show when={nodes().length > 0}>
+                    <Virtualizer
+                      ref={setVirtualizer}
+                      data={nodes()}
+                      keepMounted={mounted()}
+                      bufferSize={120}
+                      itemSize={30}
+                    >
+                      {
+                        // eslint-disable-next-line complexity
+                        (node) => {
+                          if (node.kind === "group" && node.group) {
+                            const group = node.group
+                            const key = groupKey(group.key)
+                            const shown = () => isGroupOpen(group.key)
+                            return (
+                              <div
+                                id={optionID(key)}
+                                class={`model-selector-group-label${props.allowClear || group.key !== groups()[0]?.key ? " model-selector-group-label--divided" : ""}${isSelected(key) ? " selected" : ""}${isSelected(key) && !pointer() ? " keyboard-focused" : ""}`}
+                                role="treeitem"
+                                aria-level={1}
+                                aria-expanded={shown()}
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => toggleGroup(group.key)}
+                                onMouseMove={() => setPointer(true)}
+                                onMouseEnter={() => {
+                                  if (pointer()) setSelectedKey(key)
+                                }}
+                              >
+                                <svg
+                                  class={`model-selector-group-chevron${shown() ? "" : " model-selector-group-chevron--collapsed"}`}
+                                  width="10"
+                                  height="10"
+                                  viewBox="0 0 16 16"
+                                  fill="currentColor"
+                                  aria-hidden="true"
+                                >
+                                  <path d="M4 6l4 5 4-5H4z" />
+                                </svg>
+                                <span>{group.label}</span>
+                                <Show when={!shown() && !!debouncedSearch()}>
+                                  <span class="model-selector-group-match-dot" aria-hidden="true" />
+                                </Show>
+                              </div>
+                            )
+                          }
+
+                          const row = node.row
+                          if (!row) return null
+                          if (row.kind === "clear") {
+                            return (
+                              <div
+                                id={optionID(CLEAR_KEY)}
+                                class={`model-selector-item${isSelected(CLEAR_KEY) && !pointer() ? " keyboard-focused" : ""}${isSelected(CLEAR_KEY) ? " selected" : ""}${!props.value?.providerID ? " active" : ""}`}
+                                role="treeitem"
+                                aria-level={1}
+                                aria-selected={!props.value?.providerID}
+                                onClick={() => pickClear()}
+                                onMouseMove={() => setPointer(true)}
+                                onMouseEnter={() => {
+                                  if (pointer()) setSelectedKey(CLEAR_KEY)
+                                }}
+                              >
+                                <span class="model-selector-item-name" style={{ "font-style": "italic", opacity: 0.7 }}>
+                                  {props.clearLabel ?? language.t("dialog.model.notSet")}
+                                </span>
+                              </div>
+                            )
+                          }
+                          if (!row.model) return null
+
+                          const model = row.model
+                          const hovered = () => isSelected(row.key)
+                          const preActive = () => isPreActive(row.key)
+                          const starred = () => favoriteKeys().has(modelKey(model.providerID, model.id))
+                          const showProvider = () => row.kind === "favorite"
+                          const showSelect = () => expanded() && preActive() && !isActive(model)
+                          const starLabel = () =>
+                            `${starred() ? language.t("model.favorite.remove") : language.t("model.favorite.add")}: ${sanitizeName(model.name)}`
                           return (
                             <div
-                              id={optionID(key)}
-                              class={`model-selector-group-label${props.allowClear || group.key !== groups()[0]?.key ? " model-selector-group-label--divided" : ""}${isSelected(key) ? " selected" : ""}${isSelected(key) && !pointer() ? " keyboard-focused" : ""}`}
-                              role="treeitem"
-                              aria-level={1}
-                              aria-expanded={shown()}
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={() => toggleGroup(group.key)}
-                              onMouseMove={() => setPointer(true)}
-                              onMouseEnter={() => {
-                                if (pointer()) setSelectedKey(key)
-                              }}
+                              role="presentation"
+                              class={`model-selector-row${hovered() || preActive() ? " selected" : ""}`}
                             >
-                              <svg
-                                class={`model-selector-group-chevron${shown() ? "" : " model-selector-group-chevron--collapsed"}`}
-                                width="10"
-                                height="10"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                                aria-hidden="true"
+                              <div
+                                id={optionID(row.key)}
+                                class={`model-selector-item${(hovered() && !pointer()) || preActive() ? " keyboard-focused" : ""}${hovered() || preActive() ? " selected" : ""}${chosen(row) ? " active" : ""}`}
+                                role="treeitem"
+                                aria-level={2}
+                                aria-selected={chosen(row)}
+                                onClick={() => {
+                                  if (!expanded()) {
+                                    selectRow(row)
+                                    return
+                                  }
+                                  setRow(row.key)
+                                  setPreviewKey(row.key)
+                                  searchRef?.focus()
+                                }}
+                                onDblClick={() => {
+                                  if (expanded()) selectRow(row)
+                                }}
+                                onMouseMove={() => setPointer(true)}
+                                onMouseEnter={() => {
+                                  if (pointer()) setSelectedKey(row.key)
+                                }}
                               >
-                                <path d="M4 6l4 5 4-5H4z" />
-                              </svg>
-                              <span>{group.label}</span>
-                              <Show when={!shown() && !!debouncedSearch()}>
-                                <span class="model-selector-group-match-dot" aria-hidden="true" />
+                                <div class="model-selector-item-left">
+                                  <span class="model-selector-item-name">
+                                    {(() => {
+                                      const full = sanitizeName(model.name)
+                                      const sep = full.indexOf(": ")
+                                      if (sep < 0) return <span class="model-selector-item-name-main">{full}</span>
+                                      return (
+                                        <>
+                                          <span class="model-selector-item-name-provider">{full.slice(0, sep)}</span>
+                                          <span class="model-selector-item-name-main">{full.slice(sep + 2)}</span>
+                                        </>
+                                      )
+                                    })()}
+                                  </span>
+                                  <Show when={isAuto(model)}>
+                                    <Tooltip value={autoLabel(model)} placement="top">
+                                      <span class="model-selector-auto-icon" aria-label={autoLabel(model)}>
+                                        <Icon name="models" size="small" />
+                                      </span>
+                                    </Tooltip>
+                                  </Show>
+                                  <Show when={isFree(model) || hasByok(model) || isDataCollectedModel(model)}>
+                                    <span class="model-selector-free-data">
+                                      <Show when={isFree(model) && !hasByok(model)}>
+                                        <span class="model-selector-data-badge">
+                                          <Tag data-variant="member">{freeLabel()}</Tag>
+                                        </span>
+                                      </Show>
+                                      <Show when={hasByok(model)}>
+                                        <span class="model-selector-data-badge model-selector-data-badge--byok">
+                                          <Tag data-variant="member">BYOK</Tag>
+                                        </span>
+                                      </Show>
+                                      <Show when={isDataCollectedModel(model)}>
+                                        <Tooltip value={dataLabel()} placement="top">
+                                          <span class="model-selector-free-data-icon" aria-label={dataLabel()}>
+                                            <Icon name="book-open-check" size="small" />
+                                          </span>
+                                        </Tooltip>
+                                      </Show>
+                                    </span>
+                                  </Show>
+                                  <Show when={showProvider()}>
+                                    <span class="model-selector-item-provider-tag">{model.providerName}</span>
+                                  </Show>
+                                </div>
+                              </div>
+                              <Show when={session && props.favorites !== false}>
+                                <button
+                                  type="button"
+                                  class={`model-selector-star${starred() ? " model-selector-star--active" : ""}`}
+                                  aria-label={starLabel()}
+                                  aria-pressed={starred()}
+                                  onMouseDown={(e) => e.preventDefault()}
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    toggleFavorite(model, row)
+                                    searchRef?.focus()
+                                  }}
+                                >
+                                  <Icon name={starred() ? "star-filled" : "star"} size="small" />
+                                </button>
+                              </Show>
+                              <Show when={showSelect()}>
+                                <button
+                                  type="button"
+                                  class="model-selector-item-select-btn"
+                                  aria-label={`${language.t("dialog.model.select")}: ${sanitizeName(model.name)}`}
+                                  onClick={() => selectRow(row)}
+                                >
+                                  {language.t("dialog.model.select")}
+                                </button>
                               </Show>
                             </div>
                           )
                         }
-
-                        const row = node.row
-                        if (!row) return null
-                        if (row.kind === "clear") {
-                          return (
-                            <div
-                              id={optionID(CLEAR_KEY)}
-                              class={`model-selector-item${isSelected(CLEAR_KEY) && !pointer() ? " keyboard-focused" : ""}${isSelected(CLEAR_KEY) ? " selected" : ""}${!props.value?.providerID ? " active" : ""}`}
-                              role="treeitem"
-                              aria-level={1}
-                              aria-selected={!props.value?.providerID}
-                              onClick={() => pickClear()}
-                              onMouseMove={() => setPointer(true)}
-                              onMouseEnter={() => {
-                                if (pointer()) setSelectedKey(CLEAR_KEY)
-                              }}
-                            >
-                              <span class="model-selector-item-name" style={{ "font-style": "italic", opacity: 0.7 }}>
-                                {props.clearLabel ?? language.t("dialog.model.notSet")}
-                              </span>
-                            </div>
-                          )
-                        }
-                        if (!row.model) return null
-
-                        const model = row.model
-                        const hovered = () => isSelected(row.key)
-                        const preActive = () => isPreActive(row.key)
-                        const starred = () => favoriteKeys().has(modelKey(model.providerID, model.id))
-                        const showProvider = () => row.kind === "favorite"
-                        const showSelect = () => expanded() && preActive() && !isActive(model)
-                        const starLabel = () =>
-                          `${starred() ? language.t("model.favorite.remove") : language.t("model.favorite.add")}: ${sanitizeName(model.name)}`
-                        return (
-                          <div
-                            role="presentation"
-                            class={`model-selector-row${hovered() || preActive() ? " selected" : ""}`}
-                          >
-                            <div
-                              id={optionID(row.key)}
-                              class={`model-selector-item${(hovered() && !pointer()) || preActive() ? " keyboard-focused" : ""}${hovered() || preActive() ? " selected" : ""}${chosen(row) ? " active" : ""}`}
-                              role="treeitem"
-                              aria-level={2}
-                              aria-selected={chosen(row)}
-                              onClick={() => {
-                                if (!expanded()) {
-                                  selectRow(row)
-                                  return
-                                }
-                                setRow(row.key)
-                                setPreviewKey(row.key)
-                                searchRef?.focus()
-                              }}
-                              onDblClick={() => {
-                                if (expanded()) selectRow(row)
-                              }}
-                              onMouseMove={() => setPointer(true)}
-                              onMouseEnter={() => {
-                                if (pointer()) setSelectedKey(row.key)
-                              }}
-                            >
-                              <div class="model-selector-item-left">
-                                <span class="model-selector-item-name">
-                                  {(() => {
-                                    const full = sanitizeName(model.name)
-                                    const sep = full.indexOf(": ")
-                                    if (sep < 0) return <span class="model-selector-item-name-main">{full}</span>
-                                    return (
-                                      <>
-                                        <span class="model-selector-item-name-provider">{full.slice(0, sep)}</span>
-                                        <span class="model-selector-item-name-main">{full.slice(sep + 2)}</span>
-                                      </>
-                                    )
-                                  })()}
-                                </span>
-                                <Show when={isAuto(model)}>
-                                  <Tooltip value={autoLabel(model)} placement="top">
-                                    <span class="model-selector-auto-icon" aria-label={autoLabel(model)}>
-                                      <Icon name="models" size="small" />
-                                    </span>
-                                  </Tooltip>
-                                </Show>
-                                <Show when={isFree(model) || hasByok(model) || isDataCollectedModel(model)}>
-                                  <span class="model-selector-free-data">
-                                    <Show when={isFree(model) && !hasByok(model)}>
-                                      <span class="model-selector-data-badge">
-                                        <Tag data-variant="member">{freeLabel()}</Tag>
-                                      </span>
-                                    </Show>
-                                    <Show when={hasByok(model)}>
-                                      <span class="model-selector-data-badge model-selector-data-badge--byok">
-                                        <Tag data-variant="member">BYOK</Tag>
-                                      </span>
-                                    </Show>
-                                    <Show when={isDataCollectedModel(model)}>
-                                      <Tooltip value={dataLabel()} placement="top">
-                                        <span class="model-selector-free-data-icon" aria-label={dataLabel()}>
-                                          <Icon name="book-open-check" size="small" />
-                                        </span>
-                                      </Tooltip>
-                                    </Show>
-                                  </span>
-                                </Show>
-                                <Show when={showProvider()}>
-                                  <span class="model-selector-item-provider-tag">{model.providerName}</span>
-                                </Show>
-                              </div>
-                            </div>
-                            <Show when={session && props.favorites !== false}>
-                              <button
-                                type="button"
-                                class={`model-selector-star${starred() ? " model-selector-star--active" : ""}`}
-                                aria-label={starLabel()}
-                                aria-pressed={starred()}
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  toggleFavorite(model, row)
-                                  searchRef?.focus()
-                                }}
-                              >
-                                <Icon name={starred() ? "star-filled" : "star"} size="small" />
-                              </button>
-                            </Show>
-                            <Show when={showSelect()}>
-                              <button
-                                type="button"
-                                class="model-selector-item-select-btn"
-                                aria-label={`${language.t("dialog.model.select")}: ${sanitizeName(model.name)}`}
-                                onClick={() => selectRow(row)}
-                              >
-                                {language.t("dialog.model.select")}
-                              </button>
-                            </Show>
-                          </div>
-                        )
                       }
-                    }
-                  </Virtualizer>
-                </Show>
-              </div>
+                    </Virtualizer>
+                  </Show>
+                </div>
 
-              <Show when={expanded()}>
-                <div class="model-selector-splitter" ref={splitterRef} onMouseDown={onSplitterMouseDown} />
-              </Show>
-              <div
-                id={previewID}
-                aria-hidden={!expanded()}
-                class={`model-selector-preview${expanded() ? " model-selector-preview--visible" : ""}`}
-                style={expanded() ? { height: `${previewHeight()}px` } : {}}
-              >
                 <Show when={expanded()}>
-                  <ModelPreview model={previewModel() ?? activeModel() ?? null} models={visibleModels()} />
+                  <div class="model-selector-splitter" ref={splitterRef} onMouseDown={onSplitterMouseDown} />
                 </Show>
+                <div
+                  id={previewID}
+                  aria-hidden={!expanded()}
+                  class={`model-selector-preview${expanded() ? " model-selector-preview--visible" : ""}`}
+                  style={expanded() ? { height: `${previewHeight()}px` } : {}}
+                >
+                  <Show when={expanded()}>
+                    <ModelPreview model={previewModel() ?? activeModel() ?? null} models={visibleModels()} />
+                  </Show>
+                </div>
               </div>
-            </div>
-          )
-        }}
-      </PopupSelector>
+            )
+          }}
+        </PopupSelector>
+      </Tooltip>
     </>
   )
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -151,6 +151,7 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
           </div>
         }
         placement="top"
+        openDelay={0}
       >
         <PopupSelector
           expanded={false}

--- a/packages/kilo-vscode/webview-ui/src/components/speech-to-text/SpeechToTextButton.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/speech-to-text/SpeechToTextButton.tsx
@@ -46,7 +46,7 @@ export const SpeechToTextButton: Component<Props> = (props) => {
   })
 
   return (
-    <Tooltip value={label()} placement="top">
+    <Tooltip value={label()} placement="top" openDelay={0}>
       <Button
         variant="ghost"
         size="small"

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -160,7 +160,7 @@ export function Popover<T extends ValidComponent = "div">(props: PopoverProps<T>
         focus(node)
       }}
       onCloseAutoFocus={(event: Event) => {
-        if (state.dismiss === "outside") event.preventDefault()
+        if (opened() || state.dismiss === "outside") event.preventDefault() // kilocode_change
         setState("dismiss", null)
       }}
     >


### PR DESCRIPTION
Hovering any button in the prompt input footer (mode/model/thinking selectors, reset model, indexing, auto-approve, enhance, voice input, send/stop) waited ~700ms before its tooltip appeared, because the kilo-ui `Tooltip` wrapper only zeroed Kobalte's `closeDelay` and left the default `openDelay`. The sandbox toggle had already opted out with an explicit `openDelay={0}`.

This extends the same pattern to every remaining prompt input control:

- Passes `openDelay={0}` on all `Tooltip` instances in `PromptInput`, `SpeechToTextButton`, and `ThinkingSelector`
- Replaces the model selector trigger's native `title` attribute (which also has an OS-level hover delay and cannot be styled) with the standard kilo-ui `Tooltip`, matching how `ThinkingSelector` already wraps its selector; the tooltip stays suppressed while the popup is open via the wrapper's existing `aria-expanded` tracking
- Removes the now-redundant native `title` so the two tooltips never stack