### PR TITLE
refactor(vscode): remove dead code from Agent Manager

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -661,24 +661,12 @@ export class AgentManagerProvider implements Disposable {
       void this.importer.branches()
       return null
     }
-    if (m.type === "agentManager.requestExternalWorktrees") {
-      void this.importer.external()
-      return null
-    }
     if (m.type === "agentManager.importFromBranch") {
       void this.importer.branch(m.branch)
       return null
     }
     if (m.type === "agentManager.importFromPR") {
       void this.importer.pr(m.url)
-      return null
-    }
-    if (m.type === "agentManager.importExternalWorktree") {
-      void this.importer.path(m.path, m.branch)
-      return null
-    }
-    if (m.type === "agentManager.importAllExternalWorktrees") {
-      void this.importer.all()
       return null
     }
   }
@@ -868,7 +856,7 @@ export class AgentManagerProvider implements Disposable {
     }
   }
 
-  /** Send worktreeSetup.ready + sessionMeta + pushState after worktree creation. */
+  /** Send worktreeSetup.ready + pushState after worktree creation. */
   private notifyWorktreeReady(sessionId: string, result: CreateWorktreeResult, worktreeId?: string): void {
     this.pushState()
     this.postToWebview({
@@ -878,14 +866,6 @@ export class AgentManagerProvider implements Disposable {
       sessionId,
       branch: result.branch,
       worktreeId,
-    })
-    this.postToWebview({
-      type: "agentManager.sessionMeta",
-      sessionId,
-      mode: "worktree",
-      branch: result.branch,
-      path: result.path,
-      parentBranch: result.parentBranch,
     })
   }
 
@@ -907,8 +887,6 @@ export class AgentManagerProvider implements Disposable {
       case "agentManager.requestBranches":
       case "agentManager.importFromBranch":
       case "agentManager.importFromPR":
-      case "agentManager.importExternalWorktree":
-      case "agentManager.importAllExternalWorktrees":
       case "agentManager.setTabOrder":
       case "agentManager.setWorktreeOrder":
       case "agentManager.setSessionsCollapsed":

--- a/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
@@ -174,18 +174,6 @@ export class SessionTerminalManager {
     return true
   }
 
-  /**
-   * Check if a session has an active terminal.
-   */
-  hasTerminal(sessionId: string): boolean {
-    const entry = this.terminals.get(sessionId)
-    return entry !== undefined && entry.terminal.exitStatus === undefined
-  }
-
-  hasActiveTerminal(): boolean {
-    return this.host.activeTerminal() !== undefined
-  }
-
   activeSession(): string | undefined {
     const active = this.host.activeTerminal()
     if (!active) return undefined

--- a/packages/kilo-vscode/src/agent-manager/SetupScriptService.ts
+++ b/packages/kilo-vscode/src/agent-manager/SetupScriptService.ts
@@ -66,18 +66,6 @@ export class SetupScriptService {
     return this.resolveScript(platform) !== undefined
   }
 
-  /** Read the setup script content. Returns null if not found or read fails. */
-  async getScript(platform: NodeJS.Platform = process.platform): Promise<string | null> {
-    const script = this.resolveScript(platform)
-    if (!script) return null
-    try {
-      return await fs.promises.readFile(script.path, "utf-8")
-    } catch (error) {
-      this.log(`Failed to read setup script: ${error}`)
-      return null
-    }
-  }
-
   /** Create a default setup script with helpful comments for the current platform. */
   async createDefaultScript(platform: NodeJS.Platform = process.platform): Promise<void> {
     if (!fs.existsSync(this.dir)) {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -67,11 +67,6 @@ export interface CreateWorktreeResult {
   startPointWarning?: string
 }
 
-export interface ExternalWorktreeItem {
-  path: string
-  branch: string
-}
-
 /**
  * Backward compat: split a possibly-prefixed branch like "origin/main" into
  * `{ branch: "main", remote: "origin" }`. If no slash is found, returns bare branch.
@@ -815,7 +810,7 @@ export class WorktreeManager {
 
     // 4. Derived fallback
     if (allowFallback) {
-      const fallbacks = await this.derivedFallbackBranches(branch)
+      const fallbacks = await this.derivedFallbackBranches()
       for (const fallback of fallbacks) {
         if (fallback === branch) continue // already tried
         try {
@@ -863,7 +858,7 @@ export class WorktreeManager {
     }
   }
 
-  async derivedFallbackBranches(requested: string): Promise<string[]> {
+  async derivedFallbackBranches(): Promise<string[]> {
     const defaults = []
     try {
       defaults.push(await this.defaultBranch())
@@ -1012,22 +1007,6 @@ export class WorktreeManager {
         this.log(`Failed to get current branch: ${inner}`)
       }
       return result
-    }
-  }
-
-  async listExternalWorktrees(managedPaths: Set<string>): Promise<ExternalWorktreeItem[]> {
-    try {
-      const raw = await this.git.raw(["worktree", "list", "--porcelain"])
-      const normalizedRoot = normalizePath(this.root)
-      const normalizedManaged = new Set([...managedPaths].map(normalizePath))
-      return parseWorktreeList(raw)
-        .filter(
-          (e) => !e.bare && normalizePath(e.path) !== normalizedRoot && !normalizedManaged.has(normalizePath(e.path)),
-        )
-        .map((e) => ({ path: e.path, branch: e.branch }))
-    } catch (error) {
-      this.log(`Failed to list external worktrees: ${error}`)
-      return []
     }
   }
 

--- a/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -77,7 +77,6 @@ function createMockHost(): Host {
     openFolder: vi.fn(),
     createOutput: () => ({ appendLine: vi.fn(), dispose: vi.fn() }) as OutputHandle,
     extensionKeybindings: () => [],
-    serverPort: () => undefined,
     capture: vi.fn(),
     dispose: vi.fn(),
   }

--- a/packages/kilo-vscode/src/agent-manager/host.ts
+++ b/packages/kilo-vscode/src/agent-manager/host.ts
@@ -125,9 +125,6 @@ export interface Host {
   /** Read extension keybinding metadata. */
   extensionKeybindings(): Array<{ command: string; key?: string; mac?: string }>
 
-  /** Get the CLI server port (for webview CSP). */
-  serverPort(): number | undefined
-
   /** Copy text to the system clipboard. */
   copyToClipboard(text: string): void
 

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -13,7 +13,6 @@ import type { Worktree, ManagedSession, Section } from "./WorktreeStateManager"
 import type { WorktreeStats, LocalStats } from "./GitStatsPoller"
 import type { ApplyConflict } from "./GitOps"
 import type { BranchListItem, WorktreeSetupErrorCode } from "./git-import"
-import type { ExternalWorktreeItem } from "./WorktreeManager"
 import type { RunStatus } from "./run/manager"
 import type { TerminalFont } from "./terminal-font"
 
@@ -22,8 +21,6 @@ export type { TerminalFont }
 // ---------------------------------------------------------------------------
 // Shared payload types
 // ---------------------------------------------------------------------------
-
-type SessionMode = "worktree" | "local"
 
 export type ApplyDiffStatus = "checking" | "applying" | "success" | "conflict" | "error"
 
@@ -112,15 +109,6 @@ interface WorktreeSetupMessage {
   branch?: string
   worktreeId?: string
   errorCode?: WorktreeSetupErrorCode
-}
-
-interface SessionMetaMessage {
-  type: "agentManager.sessionMeta"
-  sessionId: string
-  mode: SessionMode
-  branch?: string
-  path?: string
-  parentBranch?: string
 }
 
 interface StateMessage {
@@ -228,11 +216,6 @@ interface BranchesMessage {
   defaultBranch: string
 }
 
-interface ExternalWorktreesMessage {
-  type: "agentManager.externalWorktrees"
-  worktrees: ExternalWorktreeItem[]
-}
-
 interface ImportResultMessage {
   type: "agentManager.importResult"
   success: boolean
@@ -307,7 +290,6 @@ export type AgentManagerOutMessage =
   | WorktreeStatsMessage
   | LocalStatsMessage
   | WorktreeSetupMessage
-  | SessionMetaMessage
   | StateMessage
   | ErrorOutMessage
   | SessionAddedMessage
@@ -317,7 +299,6 @@ export type AgentManagerOutMessage =
   | SetSessionModelMessage
   | SendInitialMessage
   | BranchesMessage
-  | ExternalWorktreesMessage
   | ImportResultMessage
   | KeybindingsMessage
   | RepoInfoMessage
@@ -500,10 +481,6 @@ interface SetDefaultBaseBranchIn {
   branch?: string
 }
 
-interface RequestExternalWorktreesIn {
-  type: "agentManager.requestExternalWorktrees"
-}
-
 interface ImportFromBranchIn {
   type: "agentManager.importFromBranch"
   branch: string
@@ -512,16 +489,6 @@ interface ImportFromBranchIn {
 interface ImportFromPRIn {
   type: "agentManager.importFromPR"
   url: string
-}
-
-interface ImportExternalWorktreeIn {
-  type: "agentManager.importExternalWorktree"
-  path: string
-  branch: string
-}
-
-interface ImportAllExternalWorktreesIn {
-  type: "agentManager.importAllExternalWorktrees"
 }
 
 interface RequestWorktreeDiffIn {
@@ -807,11 +774,8 @@ export type AgentManagerInMessage =
   | SetReviewDiffStyleIn
   | SetReviewMarkdownRenderIn
   | SetDefaultBaseBranchIn
-  | RequestExternalWorktreesIn
   | ImportFromBranchIn
   | ImportFromPRIn
-  | ImportExternalWorktreeIn
-  | ImportAllExternalWorktreesIn
   | RequestWorktreeDiffIn
   | RequestWorktreeDiffFileIn
   | ApplyWorktreeDiffIn

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -6,7 +6,7 @@
  */
 
 import * as vscode from "vscode"
-import type { Host, PanelContext, OutputHandle, SessionProvider, Disposable } from "./host"
+import type { Host, PanelContext, OutputHandle, SessionProvider } from "./host"
 import type { KiloConnectionService } from "../services/cli-backend"
 import { KiloProvider } from "../KiloProvider"
 import { PLATFORM, SNAPSHOT_INITIALIZATION } from "./constants"
@@ -214,10 +214,6 @@ export class VscodeHost implements Host {
   extensionKeybindings(): Array<{ command: string; key?: string; mac?: string }> {
     const ext = vscode.extensions.getExtension("kilocode.kilo-code")
     return ext?.packageJSON?.contributes?.keybindings ?? []
-  }
-
-  serverPort(): number | undefined {
-    return this.connectionService.getServerInfo()?.port
   }
 
   copyToClipboard(text: string): void {

--- a/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
@@ -2,9 +2,7 @@ import type { Session } from "@kilocode/sdk/v2/client"
 import type { AgentManagerOutMessage } from "./types"
 import type { WorktreeManager, CreateWorktreeResult } from "./WorktreeManager"
 import type { WorktreeStateManager } from "./WorktreeStateManager"
-import { classifyWorktreeError, normalizePath } from "./git-import"
-
-type Worktree = ReturnType<WorktreeStateManager["addWorktree"]>
+import { classifyWorktreeError } from "./git-import"
 
 export interface WorktreeImporterHost {
   manager(): WorktreeManager | undefined
@@ -54,24 +52,6 @@ export class WorktreeImporter {
     } catch (error) {
       this.host.log(`Failed to list branches: ${error}`)
       this.host.post({ type: "agentManager.branches", branches: [], defaultBranch: "main" })
-    }
-  }
-
-  async external(): Promise<void> {
-    const manager = this.host.manager()
-    const state = this.host.state()
-    if (!manager || !state) {
-      this.host.post({ type: "agentManager.externalWorktrees", worktrees: [] })
-      return
-    }
-
-    try {
-      const paths = new Set(state.getWorktrees().map((worktree) => worktree.path))
-      const worktrees = await manager.listExternalWorktrees(paths)
-      this.host.post({ type: "agentManager.externalWorktrees", worktrees })
-    } catch (error) {
-      this.host.log(`Failed to list external worktrees: ${error}`)
-      this.host.post({ type: "agentManager.externalWorktrees", worktrees: [] })
     }
   }
 
@@ -184,136 +164,6 @@ export class WorktreeImporter {
       }
     } catch (error) {
       this.importError(error, "This PR's branch is already checked out in another worktree")
-    } finally {
-      this.importing = false
-    }
-  }
-
-  async path(path: string, branch: string): Promise<void> {
-    const state = this.host.state()
-    const manager = this.host.manager()
-    if (!state || !manager) {
-      this.host.post({ type: "agentManager.importResult", success: false, message: "State not initialized" })
-      return
-    }
-    if (this.busy()) return
-
-    this.importing = true
-    let worktree: Worktree | undefined
-    try {
-      const paths = new Set(state.getWorktrees().map((worktree) => worktree.path))
-      const externals = await manager.listExternalWorktrees(paths)
-      if (!externals.some((worktree) => normalizePath(worktree.path) === normalizePath(path))) {
-        this.host.post({
-          type: "agentManager.importResult",
-          success: false,
-          message: "Path is not a valid worktree for this repository",
-        })
-        return
-      }
-
-      const base = await manager.resolveBaseBranch()
-      worktree = state.addWorktree({ branch, path, parentBranch: base.branch, remote: base.remote, branchOwned: false })
-      this.host.push()
-
-      const session = await this.host.session(path, branch, worktree.id)
-      if (!session) {
-        state.removeWorktree(worktree.id)
-        this.host.push()
-        this.host.post({ type: "agentManager.importResult", success: false, message: "Failed to create session" })
-        return
-      }
-
-      state.addSession(session.id, worktree.id)
-      this.host.register(session.id, path)
-      this.host.push()
-      this.host.post({
-        type: "agentManager.worktreeSetup",
-        status: "ready",
-        message: "Worktree imported",
-        sessionId: session.id,
-        branch,
-        worktreeId: worktree.id,
-      })
-      this.host.post({
-        type: "agentManager.sessionMeta",
-        sessionId: session.id,
-        mode: "worktree",
-        branch,
-        path,
-        parentBranch: base.branch,
-      })
-      this.host.post({ type: "agentManager.importResult", success: true, message: `Imported ${branch}` })
-      this.host.log(`Imported external worktree ${path} (${branch})`)
-    } catch (error) {
-      if (worktree) {
-        state.removeWorktree(worktree.id)
-        this.host.push()
-      }
-      const message = error instanceof Error ? error.message : String(error)
-      this.host.post({ type: "agentManager.importResult", success: false, message })
-    } finally {
-      this.importing = false
-    }
-  }
-
-  async all(): Promise<void> {
-    if (this.busy()) return
-
-    const manager = this.host.manager()
-    const state = this.host.state()
-    if (!manager || !state) {
-      this.host.post({ type: "agentManager.importResult", success: false, message: "Not a git repository" })
-      return
-    }
-    this.importing = true
-
-    try {
-      const paths = new Set(state.getWorktrees().map((worktree) => worktree.path))
-      const externals = await manager.listExternalWorktrees(paths)
-      if (externals.length === 0) {
-        this.host.post({
-          type: "agentManager.importResult",
-          success: true,
-          message: "No external worktrees to import",
-        })
-        return
-      }
-
-      const imported: string[] = []
-      const base = await manager.resolveBaseBranch()
-      for (const external of externals) {
-        try {
-          const worktree = state.addWorktree({
-            branch: external.branch,
-            path: external.path,
-            parentBranch: base.branch,
-            remote: base.remote,
-            branchOwned: false,
-          })
-          const session = await this.host.session(external.path, external.branch, worktree.id)
-          if (session) {
-            state.addSession(session.id, worktree.id)
-            this.host.register(session.id, external.path)
-            imported.push(worktree.id)
-            continue
-          }
-          state.removeWorktree(worktree.id)
-        } catch (error) {
-          this.host.log(`Failed to import external worktree ${external.path}: ${error}`)
-        }
-      }
-
-      this.host.push()
-      this.host.post({
-        type: "agentManager.importResult",
-        success: true,
-        message: `Imported ${imported.length} worktree${imported.length !== 1 ? "s" : ""}`,
-      })
-      this.host.log(`Imported ${imported.length}/${externals.length} external worktrees`)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.host.post({ type: "agentManager.importResult", success: false, message })
     } finally {
       this.importing = false
     }

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -186,8 +186,6 @@ describe("Agent Manager Provider Messages", () => {
       "agentManager.forgetSession",
       "agentManager.importFromBranch",
       "agentManager.importFromPR",
-      "agentManager.importExternalWorktree",
-      "agentManager.importAllExternalWorktrees",
       "agentManager.createSection",
       "agentManager.moveToSection",
     ]
@@ -435,7 +433,6 @@ describe("Agent Manager Provider — onMessage routing", () => {
     const text = body("onSessionMessage")
     const show = text.indexOf("this.terminalManager.prepareContext(m.sessionID)")
     expect(show).toBeGreaterThan(-1)
-    expect(text).not.toContain("!this.terminalManager.hasActiveTerminal()")
     expect(text).toContain('type: "terminalContextError"')
   })
 
@@ -544,8 +541,6 @@ describe("Agent Manager Provider — onMessage routing", () => {
     const pushIdx = text.indexOf("this.pushState()")
     const readyIdx = text.indexOf("agentManager.worktreeSetup")
     expect(pushIdx, "pushState must come before worktreeSetup").toBeLessThan(readyIdx)
-    // Must also send sessionMeta so the webview knows the branch/path
-    expect(text).toContain("agentManager.sessionMeta")
   })
 
   // -- agentManager.requestState in non-git workspace -------------------------
@@ -583,7 +578,6 @@ describe("Agent Manager Provider — onMessage routing", () => {
     const providerText = body("onImportMessage")
     expect(text).toContain("class WorktreeImporter")
     expect(text).toContain("createFromPR")
-    expect(text).toContain("listExternalWorktrees")
     expect(text).toContain("createWorktree")
     expect(providerText).toContain("this.importer")
   })

--- a/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
@@ -130,11 +130,6 @@ describe("SessionTerminalManager structure", () => {
     expect(text).toContain("panel command registration skipped")
   })
 
-  it("exposes active terminal state for terminal context routing", () => {
-    const text = body("hasActiveTerminal")
-    expect(text).toContain("this.host.activeTerminal()")
-  })
-
   it("resolves the session that owns the active managed terminal", () => {
     const text = body("activeSession")
     expect(text).toContain("this.host.activeTerminal()")

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -13,7 +13,6 @@ import {
   type JSX,
 } from "solid-js"
 import type {
-  ExtensionMessage,
   AgentManagerRepoInfoMessage,
   AgentManagerWorktreeSetupMessage,
   AgentManagerStateMessage,
@@ -70,7 +69,6 @@ import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
-import { Popover } from "@kilocode/kilo-ui/popover"
 import { VSCodeProvider, useVSCode } from "../src/context/vscode"
 import { ServerProvider } from "../src/context/server"
 import { ProviderProvider } from "../src/context/provider"

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -117,12 +117,6 @@ export interface BranchInfo {
   isCheckedOut?: boolean
 }
 
-// Agent Manager Import tab: external worktrees (extension → webview)
-export interface ExternalWorktreeInfo {
-  path: string
-  branch: string
-}
-
 export type DiffImageError = "too-large" | "unreadable"
 
 export interface DiffImageSide {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -1,7 +1,6 @@
 import type { ProviderAuthAuthorization, ProviderAuthMethod } from "@kilocode/sdk/v2/client"
 import type { DiffSourceCapabilities, DiffSourceDescriptor } from "../../../../src/diff/sources/types"
 import type { PartBatch, PartRemove, PartUpdate } from "../../../../src/shared/stream-messages"
-import type { SessionMode } from "../../context/worktree-mode"
 import type { MarketplaceItem, MarketplaceInstalledMetadata, MarketplaceRelevanceMetadata } from "../marketplace"
 import type { ConnectionState, ServerInfo, SessionStatus } from "./connection"
 import type { FileAttachment, Part } from "./parts"
@@ -27,7 +26,6 @@ import type {
   AgentManagerApplyWorktreeDiffStatus,
   BranchInfo,
   ContinueInWorktreeStatus,
-  ExternalWorktreeInfo,
   LocalGitStats,
   ManagedSessionState,
   PRStatus,
@@ -632,16 +630,6 @@ export interface NotificationsLoadedMessage {
   dismissedIds: string[]
 }
 
-// Agent Manager worktree session metadata
-export interface AgentManagerSessionMetaMessage {
-  type: "agentManager.sessionMeta"
-  sessionId: string
-  mode: SessionMode
-  branch?: string
-  path?: string
-  parentBranch?: string
-}
-
 // Agent Manager repo info (current branch of the main workspace)
 export interface AgentManagerRepoInfoMessage {
   type: "agentManager.repoInfo"
@@ -817,11 +805,6 @@ export interface AgentManagerBranchesMessage {
   type: "agentManager.branches"
   branches: BranchInfo[]
   defaultBranch: string
-}
-
-export interface AgentManagerExternalWorktreesMessage {
-  type: "agentManager.externalWorktrees"
-  worktrees: ExternalWorktreeInfo[]
 }
 
 // Agent Manager Import tab: result feedback (extension → webview)
@@ -1198,7 +1181,6 @@ export type ExtensionMessage =
   | WorkStyleAppliedMessage
   | WorkStyleApplyFailedMessage
   | NotificationsLoadedMessage
-  | AgentManagerSessionMetaMessage
   | AgentManagerRepoInfoMessage
   | AgentManagerWorktreeSetupMessage
   | AgentManagerSessionAddedMessage
@@ -1226,7 +1208,6 @@ export type ExtensionMessage =
   | OpenCloudSessionMessage
   | SelectKiloModelMessage
   | AgentManagerBranchesMessage
-  | AgentManagerExternalWorktreesMessage
   | AgentManagerImportResultMessage
   | WorkspaceDirectoryChangedMessage
   | AgentManagerWorktreeDiffMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -804,10 +804,6 @@ export interface RequestBranchesMessage {
   type: "agentManager.requestBranches"
 }
 
-export interface RequestExternalWorktreesMessage {
-  type: "agentManager.requestExternalWorktrees"
-}
-
 export interface ImportFromBranchRequest {
   type: "agentManager.importFromBranch"
   branch: string
@@ -816,16 +812,6 @@ export interface ImportFromBranchRequest {
 export interface ImportFromPRRequest {
   type: "agentManager.importFromPR"
   url: string
-}
-
-export interface ImportExternalWorktreeRequest {
-  type: "agentManager.importExternalWorktree"
-  path: string
-  branch: string
-}
-
-export interface ImportAllExternalWorktreesRequest {
-  type: "agentManager.importAllExternalWorktrees"
 }
 
 // Agent Manager: Request one-shot diff fetch (webview → extension)
@@ -1362,11 +1348,8 @@ export type WebviewMessage =
   | RequestCloudSessionDataMessage
   | ImportAndSendMessage
   | RequestBranchesMessage
-  | RequestExternalWorktreesMessage
   | ImportFromBranchRequest
   | ImportFromPRRequest
-  | ImportExternalWorktreeRequest
-  | ImportAllExternalWorktreesRequest
   | RequestWorktreeDiffMessage
   | RequestWorktreeDiffFileMessage
   | StartDiffWatchMessage


### PR DESCRIPTION
Static analysis (tsc unused-locals sweep + protocol message flow tracing) surfaced several Agent Manager code paths that are unreachable in production. This PR deletes them, net -316 lines.

**Dead message flows (never travel the wire):**
- `agentManager.externalWorktrees`: the extension posted it, but the webview has no handler. The webview also never sends `requestExternalWorktrees`, `importExternalWorktree`, or `importAllExternalWorktrees`, so the whole flow is dead: provider handlers, `WorktreeImporter.external()/path()/all()`, `WorktreeManager.listExternalWorktrees()`, `ExternalWorktreeItem`/`ExternalWorktreeInfo`, and the matching message type definitions on both sides of the protocol. Branch/PR import (`importFromBranch`/`importFromPR`) is untouched.
- `agentManager.sessionMeta`: posted after worktree creation but never handled in the webview. The `worktreeSetup` ready message already carries everything the webview consumes.

**Dead interface surface:**
- `Host.serverPort()`: no callers (the panel gets the port through `buildWebviewHtml` directly).
- `SessionTerminalManager.hasTerminal()/hasActiveTerminal()` and `SetupScriptService.getScript()`: no callers and no behavior tests.
- Unused imports (`Disposable`, `ExtensionMessage`, `Popover`) and an unused `derivedFallbackBranches` parameter.

Arch tests that asserted on the removed structure were updated to match.