### PR TITLE
fix(ci): authenticate JetBrains OpenAPI codegen GitHub API calls

### DIFF
--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Run JetBrains unit tests
         run: bun script/test-ci.ts
         working-directory: packages/kilo-jetbrains
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish JetBrains unit reports
         if: always()


### PR DESCRIPTION
## What

Pass `GITHUB_TOKEN` to the "Run JetBrains unit tests" step in `test-jetbrains.yml`.

## Why

The `:backend:generateOpenApiSpec` Gradle task (a codegen prerequisite for compiling the backend module and its serialization tests) fetches pinned Kilo CLI release metadata from the GitHub REST API to resolve the release asset digest. The task authenticates via `GH_TOKEN`/`GITHUB_TOKEN`, but the workflow step never exposed one, so the calls ran unauthenticated against GitHub's **60 requests/hour per-IP** limit.

On shared Blacksmith runners that budget is consumed across the concurrent matrix jobs, so the build intermittently fails with:

```
> Task :backend:generateOpenApiSpec FAILED
Caused by: GradleException: GitHub API rate limit exceeded while fetching pinned Kilo CLI
release metadata (limit=60 remaining=0 used=60 ...)
```

Exposing `secrets.GITHUB_TOKEN` moves these calls to the authenticated, repo-scoped 1000/hour limit, which is per-token rather than per-IP and eliminates the shared-runner contention. `test-ci.ts` spawns Gradle with the inherited environment, so no further plumbing is needed. `permissions: contents: read` is already sufficient to read public release metadata.