### PR TITLE
feat(config): add option to disable file safety guards

### DIFF
--- a/.changeset/disable-file-safety-guards.md
+++ b/.changeset/disable-file-safety-guards.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Allow trusted global config to disable built-in `.env` read and Kilo config-edit permission guards.
+`dangerously_disable_file_safety_guards`: Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option. This covers `.env` reads and Kilo config edits.

--- a/.changeset/disable-file-safety-guards.md
+++ b/.changeset/disable-file-safety-guards.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow trusted global config to disable built-in `.env` read and Kilo config-edit permission guards.

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -129,12 +129,16 @@ export const Info = Schema.Struct({
   hide_prompt_training_models: Schema.optional(Schema.Boolean).annotate({
     description: "Hide Kilo Gateway models that may train on your prompts from model listings",
   }),
+  // kilocode_change end
+  // kilocode_change start
   dangerously_disable_file_safety_guards: Schema.optional(
     Schema.Boolean.annotate({
       description:
         "Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.",
     }),
   ),
+  // kilocode_change end
+  // kilocode_change start
   sandbox: Schema.optional(
     Schema.Struct({
       enabled: Schema.optional(

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -129,10 +129,12 @@ export const Info = Schema.Struct({
   hide_prompt_training_models: Schema.optional(Schema.Boolean).annotate({
     description: "Hide Kilo Gateway models that may train on your prompts from model listings",
   }),
-  dangerously_disable_file_safety_guards: Schema.optional(Schema.Boolean).annotate({
-    description:
-      "Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.",
-  }),
+  dangerously_disable_file_safety_guards: Schema.optional(
+    Schema.Boolean.annotate({
+      description:
+        "Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.",
+    }),
+  ),
   sandbox: Schema.optional(
     Schema.Struct({
       enabled: Schema.optional(

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -129,6 +129,10 @@ export const Info = Schema.Struct({
   hide_prompt_training_models: Schema.optional(Schema.Boolean).annotate({
     description: "Hide Kilo Gateway models that may train on your prompts from model listings",
   }),
+  dangerously_disable_file_safety_guards: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.",
+  }),
   sandbox: Schema.optional(
     Schema.Struct({
       enabled: Schema.optional(

--- a/packages/kilo-docs/pages/customize/agent-permissions.md
+++ b/packages/kilo-docs/pages/customize/agent-permissions.md
@@ -148,6 +148,25 @@ permission:
 
 Kilo treats `.env` and `.env.*` reads as sensitive. Broad read approvals, such as `read: allow`, `read: { "*": allow }`, saved wildcard approvals, or allow-everything mode do not bypass the built-in prompt for these files. `.env.example` is treated as safe documentation and can be allowed by default.
 
+{% callout type="danger" title="Disable built-in file guards" %}
+Set `dangerously_disable_file_safety_guards` to `true` only in global config when you intentionally want ordinary permission rules, saved approvals, and allow-everything mode to cover `.env` files and Kilo config files such as root `AGENTS.md`.
+
+Project config cannot enable this option, but it can set the option to `false` to re-enable the guards. Explicit `ask` and `deny` permission rules still apply.
+{% /callout %}
+
+```jsonc
+{
+  "$schema": "https://app.kilo.ai/config.json",
+  "dangerously_disable_file_safety_guards": true,
+  "permission": {
+    "read": "allow",
+    "edit": "allow"
+  }
+}
+```
+
+Enabling this option can expose secrets and allow silent changes to agent instructions or configuration. Keep the explicit sensitive-file rules below as the safe recommendation.
+
 Use explicit sensitive-file rules only when you intentionally want that behavior for a specific agent:
 
 ```yaml

--- a/packages/kilo-docs/pages/customize/agent-permissions.md
+++ b/packages/kilo-docs/pages/customize/agent-permissions.md
@@ -149,7 +149,9 @@ permission:
 Kilo treats `.env` and `.env.*` reads as sensitive. Broad read approvals, such as `read: allow`, `read: { "*": allow }`, saved wildcard approvals, or allow-everything mode do not bypass the built-in prompt for these files. `.env.example` is treated as safe documentation and can be allowed by default.
 
 {% callout type="danger" title="Disable built-in file guards" %}
-Set `dangerously_disable_file_safety_guards` to `true` only in global config when you intentionally want ordinary permission rules, saved approvals, and allow-everything mode to cover `.env` files and Kilo config files such as root `AGENTS.md`.
+`dangerously_disable_file_safety_guards`: Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.
+
+Set it to `true` only in global config when you intentionally want ordinary permission rules, saved approvals, and allow-everything mode to cover `.env` files and Kilo config files such as root `AGENTS.md`.
 
 Project config cannot enable this option, but it can set the option to `false` to re-enable the guards. Explicit `ask` and `deny` permission rules still apply.
 {% /callout %}

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -29,6 +29,7 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer"
 import { AbsolutePath, type DeepMutable } from "@opencode-ai/core/schema"
 // kilocode_change start
 import * as KiloAgent from "@/kilocode/agent"
+import { FileSafety } from "@/kilocode/permission/file-safety" // kilocode_change
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import * as AgentRequirements from "@/kilocode/agent-requirements"
 import * as KiloReference from "@/kilocode/reference"
@@ -146,6 +147,7 @@ export const layer = Layer.effect(
           ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),
         } satisfies Record<string, "allow" | "ask" | "deny">
 
+        const guards = FileSafety.enabled(cfg) // kilocode_change
         const baseDefaults = Permission.fromConfig({ // kilocode_change
           "*": "allow",
           doom_loop: "ask",
@@ -162,13 +164,7 @@ export const layer = Layer.effect(
           repo_clone: "deny",
           repo_overview: "deny",
           // kilocode_change end
-          // mirrors github.com/github/gitignore Node.gitignore pattern for .env files
-          read: {
-            "*": "allow",
-            "*.env": "ask",
-            "*.env.*": "ask",
-            "*.env.example": "allow",
-          },
+          read: FileSafety.read(guards), // kilocode_change
         })
 
         // kilocode_change start - patch defaults with bash allowlist and recall permission

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -46,6 +46,7 @@ import { primaryPaths } from "../kilocode/primary-worktree"
 import { Git } from "@/git"
 import { KilocodeDefaultPlugins } from "@/kilocode/config/default-plugins"
 import { KilocodeGlobalConfigStamp } from "@/kilocode/config/global-stamp"
+import { FileSafety } from "@/kilocode/permission/file-safety"
 import { SandboxConfig } from "@/kilocode/sandbox/config"
 import type { KilocodeMarkdown } from "@/kilocode/config/markdown"
 import {
@@ -540,7 +541,7 @@ export const layer = Layer.effect(
         ) {
           const scope = kind ?? (yield* pluginScopeForSource(source))
           const trusted = sourceTrusted ?? scope === "global"
-          const scoped = KilocodeConfig.scopeIndexing(SandboxConfig.scope(next, scope), scope)
+          const scoped = KilocodeConfig.scopeIndexing(SandboxConfig.scope(FileSafety.scope(next, scope), scope), scope)
           result = mergeConfigConcatArrays(result, scoped)
           if (next.instructions?.length) {
             result.instruction_origins = origins(result.instruction_origins, next.instructions, trusted, source)

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -1,5 +1,6 @@
 // kilocode_change - new file
 import { Permission } from "@/permission"
+import { FileSafety } from "@/kilocode/permission/file-safety"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Glob } from "@opencode-ai/core/util/glob"
 import * as Truncate from "../../tool/truncate"
@@ -143,16 +144,11 @@ export const readOnlyBash: Record<string, "allow" | "ask" | "deny"> = {
   "man *-H*": "deny",
 }
 
-function askGuard(mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
+function askGuard(guards: boolean, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
   return Permission.fromConfig({
     "*": "deny",
     bash: readOnlyBash,
-    read: {
-      "*": "allow",
-      "*.env": "ask",
-      "*.env.*": "ask",
-      "*.env.example": "allow",
-    },
+    read: FileSafety.read(guards),
     grep: "allow",
     glob: "allow",
     list: "allow",
@@ -224,7 +220,7 @@ export function hardenPlan(
   item.permission = Permission.merge(item.permission, planEditGuard(worktree), ...edit)
 }
 
-function planGuard(worktree: string, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
+function planGuard(worktree: string, guards: boolean, mcp: Record<string, "allow" | "ask" | "deny"> = {}) {
   return Permission.fromConfig({
     "*": "deny",
     question: "allow",
@@ -236,12 +232,7 @@ function planGuard(worktree: string, mcp: Record<string, "allow" | "ask" | "deny
       general: "deny",
     },
     bash: readOnlyBash,
-    read: {
-      "*": "allow",
-      "*.env": "ask",
-      "*.env.*": "ask",
-      "*.env.example": "allow",
-    },
+    read: FileSafety.read(guards),
     grep: "allow",
     glob: "allow",
     list: "allow",
@@ -295,6 +286,7 @@ export function cacheKey(cfg: Config.Info) {
     mcp: cfg.mcp,
     mode: cfg.mode,
     permission: cfg.permission,
+    dangerously_disable_file_safety_guards: cfg.dangerously_disable_file_safety_guards,
     native_notebook_tools: cfg.experimental?.native_notebook_tools,
     references: cfg.references,
     reference: cfg.reference,
@@ -406,6 +398,7 @@ export function patchAgents(
   worktree: string,
   whitelistedDirs: string[],
 ) {
+  const guards = FileSafety.enabled(cfg)
   // Rename "build" → "code" for backward compatibility
   if (agents.build) {
     agents.code = {
@@ -428,7 +421,7 @@ export function patchAgents(
       description: "Plan mode. Can only edit plan files; all other filesystem mutations are denied.",
       permission: Permission.merge(
         defaults,
-        planGuard(worktree, kilo.mcpRules),
+        planGuard(worktree, guards, kilo.mcpRules),
         user,
         planEditGuard(worktree),
         restrictions(user),
@@ -536,7 +529,7 @@ export function patchAgents(
     description: "Get answers and explanations without making changes to the codebase.",
     prompt: PROMPT_ASK,
     options: {},
-    permission: Permission.merge(defaults, askGuard(kilo.mcpRules), user, askEditGuard(), denies(user)),
+    permission: Permission.merge(defaults, askGuard(guards, kilo.mcpRules), user, askEditGuard(), denies(user)),
     mode: "primary",
     native: true,
   }

--- a/packages/opencode/src/kilocode/permission/drain.ts
+++ b/packages/opencode/src/kilocode/permission/drain.ts
@@ -1,11 +1,12 @@
 import { Deferred, Effect } from "effect"
 import { Permission } from "@/permission"
-import { ConfigProtection } from "@/kilocode/permission/config-paths"
+import { FileSafety } from "@/kilocode/permission/file-safety"
 
 interface PendingEntry {
   info: Permission.Request
   ruleset: Permission.Ruleset
   hardRuleset?: Permission.Ruleset
+  fileGuards: boolean
   deferred: Deferred.Deferred<void, Permission.RejectedError | Permission.CorrectedError>
 }
 
@@ -31,12 +32,15 @@ export function drainCovered(
     for (const [id, entry] of pending) {
       if (id === exclude) continue
       // Never auto-resolve config file edit permissions
-      const skill = ConfigProtection.globalSkillPattern(entry.info)
-      if (ConfigProtection.isRequest(entry.info) && !skill) continue
+      const skill = FileSafety.skill(entry.fileGuards, entry.info)
+      if (FileSafety.protected(entry.fileGuards, entry.info) && !skill) continue
       const actions = entry.info.patterns.map((pattern: string) => {
         const rule = skill
           ? Permission.evaluate(entry.info.permission, skill, approved)
-          : Permission.resolve(entry.info.permission, pattern, entry.ruleset, approved)
+          : Permission.resolve(entry.info.permission, pattern, entry.ruleset, {
+              overrides: [approved],
+              fileGuards: entry.fileGuards,
+            })
         const hard = entry.hardRuleset
           ? Permission.evaluate(entry.info.permission, pattern, entry.hardRuleset)
           : undefined

--- a/packages/opencode/src/kilocode/permission/file-safety.ts
+++ b/packages/opencode/src/kilocode/permission/file-safety.ts
@@ -1,20 +1,27 @@
 import type { Rule } from "@/kilocode/permission/rule"
+import { ConfigProtection } from "@/kilocode/permission/config-paths"
+import { ReadPermission } from "@/kilocode/permission/read"
 
 type Config = { dangerously_disable_file_safety_guards?: boolean }
+type Request = {
+  permission: string
+  patterns: readonly string[]
+  metadata?: Record<string, unknown>
+}
 
-export namespace FileSafety {
-  export function enabled(config: Config) {
+export const FileSafety = {
+  enabled(config: Config) {
     return config.dangerously_disable_file_safety_guards !== true
-  }
+  },
 
-  export function scope<T extends Config>(config: T, source: "global" | "local"): T {
+  scope<T extends Config>(config: T, source: "global" | "local"): T {
     if (source === "global" || config.dangerously_disable_file_safety_guards !== true) return config
     const scoped = { ...config }
     delete scoped.dangerously_disable_file_safety_guards
     return scoped
-  }
+  },
 
-  export function read(active: boolean) {
+  read(active: boolean) {
     if (!active) return "allow" as const
     return {
       "*": "allow",
@@ -22,5 +29,17 @@ export namespace FileSafety {
       "*.env.*": "ask",
       "*.env.example": "allow",
     } as const satisfies Record<string, Rule["action"]>
-  }
+  },
+
+  harden(active: boolean, permission: string, pattern: string, rule: Rule): Rule {
+    return active ? ReadPermission.harden(permission, pattern, rule) : rule
+  },
+
+  protected(active: boolean, request: Request) {
+    return active && ConfigProtection.isRequest(request)
+  },
+
+  skill(active: boolean, request: Request) {
+    return active ? ConfigProtection.globalSkillPattern(request) : undefined
+  },
 }

--- a/packages/opencode/src/kilocode/permission/file-safety.ts
+++ b/packages/opencode/src/kilocode/permission/file-safety.ts
@@ -1,0 +1,26 @@
+import type { Rule } from "@/kilocode/permission/rule"
+
+type Config = { dangerously_disable_file_safety_guards?: boolean }
+
+export namespace FileSafety {
+  export function enabled(config: Config) {
+    return config.dangerously_disable_file_safety_guards !== true
+  }
+
+  export function scope<T extends Config>(config: T, source: "global" | "local"): T {
+    if (source === "global" || config.dangerously_disable_file_safety_guards !== true) return config
+    const scoped = { ...config }
+    delete scoped.dangerously_disable_file_safety_guards
+    return scoped
+  }
+
+  export function read(active: boolean) {
+    if (!active) return "allow" as const
+    return {
+      "*": "allow",
+      "*.env": "ask",
+      "*.env.*": "ask",
+      "*.env.example": "allow",
+    } as const satisfies Record<string, Rule["action"]>
+  }
+}

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -145,6 +145,18 @@ Actions: `"allow"`, `"ask"`, `"deny"`. Set `null` to delete an inherited key.
 
 Tool permissions: `read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `webfetch`, `websearch`, `semantic_search`, `kilo_memory_save`, `kilo_memory_recall`, `lsp`, `skill`, `external_directory`, `todowrite`, `todoread`, `question`, `doom_loop`.
 
+### File safety escape hatch
+
+`dangerously_disable_file_safety_guards: true` may be set only by trusted global config. It lets normal permission rules, saved approvals, and allow-everything mode cover `.env` reads and protected Kilo config edits. Project config cannot enable it, but may set it to `false` to re-enable the guards. Explicit `ask` and `deny` rules and agent-mode restrictions still apply.
+
+```jsonc
+{
+  "dangerously_disable_file_safety_guards": true
+}
+```
+
+This can expose secrets and permit silent edits to configuration or agent instructions. Keep the guards enabled unless the user has deliberately accepted that risk.
+
 ## MCP Servers
 
 ```jsonc

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -147,7 +147,9 @@ Tool permissions: `read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `webfe
 
 ### File safety escape hatch
 
-`dangerously_disable_file_safety_guards: true` may be set only by trusted global config. It lets normal permission rules, saved approvals, and allow-everything mode cover `.env` reads and protected Kilo config edits. Project config cannot enable it, but may set it to `false` to re-enable the guards. Explicit `ask` and `deny` rules and agent-mode restrictions still apply.
+`dangerously_disable_file_safety_guards`: Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.
+
+Set it to `true` only in trusted global config to let normal permission rules, saved approvals, and allow-everything mode cover `.env` reads and protected Kilo config edits. Project config cannot enable it, but may set it to `false` to re-enable the guards. Explicit `ask` and `deny` rules and agent-mode restrictions still apply.
 
 ```jsonc
 {

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -16,7 +16,7 @@ import { SessionID } from "@/session/schema" // kilocode_change - used by AllowE
 import { ConfigProtection } from "@/kilocode/permission/config-paths"
 import { KiloHeadless } from "@/kilocode/permission/headless"
 import { drainCovered } from "@/kilocode/permission/drain"
-import { ReadPermission } from "@/kilocode/permission/read"
+import { FileSafety } from "@/kilocode/permission/file-safety"
 import { AgentManagerPermission } from "@/kilocode/permission/agent-manager" // kilocode_change
 import { ExternalDirectoryPermission } from "@/kilocode/permission/external-directory"
 // kilocode_change end
@@ -99,6 +99,7 @@ interface PendingEntry {
   ruleset: Ruleset
   hardRuleset?: Ruleset
   saved?: boolean
+  fileGuards: boolean
   // kilocode_change end
   deferred: Deferred.Deferred<void, RejectedError | CorrectedError>
 }
@@ -122,18 +123,28 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Permi
 }
 
 // kilocode_change start
-export function resolve(permission: string, pattern: string, ruleset: Ruleset, ...overrides: Ruleset[]): Rule {
+export function resolve(
+  permission: string,
+  pattern: string,
+  ruleset: Ruleset,
+  options: { overrides?: Ruleset[]; fileGuards?: boolean } = {},
+): Rule {
   const evalFn =
     permission === "external_directory"
       ? (permission: string, pattern: string, ...sets: Ruleset[]) =>
           ExternalDirectoryPermission.evaluate(permission, pattern, ...sets)
       : evaluate
+  const active = options.fileGuards !== false
   const base = AgentManagerPermission.harden(
     permission,
     pattern,
-    ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ruleset)),
+    FileSafety.harden(active, permission, pattern, evalFn(permission, pattern, ruleset)),
   ) // kilocode_change
-  const saved = AgentManagerPermission.harden(permission, pattern, evalFn(permission, pattern, ...overrides)) // kilocode_change
+  const saved = AgentManagerPermission.harden(
+    permission,
+    pattern,
+    evalFn(permission, pattern, ...(options.overrides ?? [])),
+  ) // kilocode_change
   if (base.action === "deny") return base
   if (saved.action === "deny") return saved
   if (base.action === "ask") {
@@ -154,10 +165,15 @@ function subset(permission: string, ruleset: Ruleset) {
 }
 
 function covered(entry: PendingEntry, approved: Ruleset, local: Ruleset) {
-  if (ConfigProtection.isRequest(entry.info)) return false
+  if (FileSafety.protected(entry.fileGuards, entry.info)) return false
   return entry.info.patterns.every((pattern) => {
     if (veto(entry.info.permission, pattern, entry.hardRuleset)) return false
-    return resolve(entry.info.permission, pattern, entry.ruleset, approved, local).action === "allow"
+    return (
+      resolve(entry.info.permission, pattern, entry.ruleset, {
+        overrides: [approved, local],
+        fileGuards: entry.fileGuards,
+      }).action === "allow"
+    )
   })
 }
 // kilocode_change end
@@ -194,6 +210,7 @@ export const layer = Layer.effect(
 
     const ask = Effect.fn("Permission.ask")(function* (input: AskInput) {
       const { approved, pending } = yield* InstanceState.get(state)
+      const fileGuards = FileSafety.enabled(yield* config.get()) // kilocode_change
       // kilocode_change start
       const { ruleset, hardRuleset, ...request } = input
       const s = yield* InstanceState.get(state)
@@ -203,8 +220,8 @@ export const layer = Layer.effect(
       let approvedRule: Rule | undefined // kilocode_change - remember the rule that auto-approved
 
       // kilocode_change start - protect config access while honoring explicit global skill trust
-      const isProtected = ConfigProtection.isRequest(request)
-      const skill = ConfigProtection.globalSkillPattern(request)
+      const isProtected = FileSafety.protected(fileGuards, request)
+      const skill = FileSafety.skill(fileGuards, request)
       const trusted = skill
         ? (() => {
             const rule = ExternalDirectoryPermission.evaluate(request.permission, skill, approved)
@@ -222,7 +239,10 @@ export const layer = Layer.effect(
       // kilocode_change end
 
       for (const pattern of request.patterns) {
-        const rule = resolve(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
+        const rule = resolve(request.permission, pattern, ruleset, {
+          overrides: [approved, local],
+          fileGuards,
+        }) // kilocode_change — include session-scoped rules
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
         // kilocode_change start — saved/session approvals cannot override hard Ask/Plan denials
         if (veto(request.permission, pattern, hardRuleset)) {
@@ -272,7 +292,7 @@ export const layer = Layer.effect(
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()
-      pending.set(id, { info, ruleset, hardRuleset, deferred }) // kilocode_change
+      pending.set(id, { info, ruleset, hardRuleset, deferred, fileGuards }) // kilocode_change
       yield* events.publish(Event.Asked, info) // kilocode_change - was bus.publish
       // kilocode_change start - was `return yield* Effect.ensuring(...)`; report the manual decision to callers
       yield* Effect.ensuring(
@@ -322,7 +342,11 @@ export const layer = Layer.effect(
       if (input.reply === "once") return
 
       // kilocode_change start - downgrade "always" to "once" for protected config paths
-      if (ConfigProtection.isRequest(existing.info) && !ConfigProtection.isGlobalSkillRequest(existing.info)) return
+      if (
+        FileSafety.protected(existing.fileGuards, existing.info) &&
+        FileSafety.skill(existing.fileGuards, existing.info) === undefined
+      )
+        return
       // kilocode_change end
 
       for (const pattern of existing.info.always) {
@@ -366,9 +390,9 @@ export const layer = Layer.effect(
       const existing = s.pending.get(input.requestID)
       if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
 
-      if (ConfigProtection.isRequest(existing.info) && !ConfigProtection.isGlobalSkillRequest(existing.info)) return
-
-      const skill = ConfigProtection.globalSkillPattern(existing.info)
+      const isProtected = FileSafety.protected(existing.fileGuards, existing.info)
+      const skill = FileSafety.skill(existing.fileGuards, existing.info)
+      if (isProtected && skill === undefined) return
       const validRules = new Set(
         skill ? [skill] : [...((existing.info.metadata?.rules as string[] | undefined) ?? []), ...existing.info.always],
       )

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1574,6 +1574,18 @@ test("config parser preserves permission order while rejecting unknown top-level
   }
 })
 
+// kilocode_change start
+test("parses the file safety guard escape hatch", () => {
+  const config = ConfigParse.schema(
+    ConfigV1.Info,
+    { dangerously_disable_file_safety_guards: true },
+    "test:file-safety",
+  )
+
+  expect(config.dangerously_disable_file_safety_guards).toBe(true)
+})
+// kilocode_change end
+
 // MCP config merging tests
 
 // kilocode_change start - regression for `env` alias on local MCP entries

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, expect, test } from "bun:test"
 import type { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { Global } from "@opencode-ai/core/global"
 import { Effect } from "effect"
+import path from "path"
 import { Agent } from "../../src/agent/agent"
+import * as KiloAgent from "../../src/kilocode/agent"
 import { Permission } from "../../src/permission"
+import { Filesystem } from "../../src/util/filesystem"
 import { provideTestInstance } from "../fixture/fixture"
 import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 
@@ -22,6 +26,22 @@ async function get(config: Partial<ConfigV1.Info>, name = "plan") {
     fn: () => load(tmp.path, (svc) => svc.get(name)),
   })
   return item
+}
+
+async function configured(config: Partial<ConfigV1.Info>, run: (dir: string) => Promise<void>) {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir({ git: true })
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await Filesystem.write(path.join(globalTmp.path, "kilo.json"), JSON.stringify(config))
+  await disposeAllInstances()
+
+  try {
+    await provideTestInstance({ directory: tmp.path, fn: () => run(tmp.path) })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await disposeAllInstances()
+  }
 }
 
 function expectPlan(item: Agent.Info | undefined, action: Permission.Action = "allow") {
@@ -73,6 +93,44 @@ test("plan agent honors user bash allow over read-only deny default", async () =
       expect(Permission.evaluate("bash", "cargo search serde", plan!.permission).action).toBe("allow")
     },
   })
+})
+
+test(
+  "trusted config removes built-in env asks without weakening plan edits",
+  async () => {
+    await configured({ dangerously_disable_file_safety_guards: true }, async (dir) => {
+      for (const name of ["code", "ask", "plan"]) {
+        const item = await load(dir, (svc) => svc.get(name))
+        expect(Permission.evaluate("read", ".env", item!.permission).action).toBe("allow")
+      }
+      const plan = await load(dir, (svc) => svc.get("plan"))
+      expect(Permission.evaluate("edit", "src/output.log", plan!.permission).action).toBe("deny")
+    })
+  },
+  { timeout: 30_000 },
+)
+
+test(
+  "explicit env restrictions still override disabled built-in guards",
+  async () => {
+    await configured(
+      {
+        dangerously_disable_file_safety_guards: true,
+        permission: { read: { "*": "allow", "*.env": "deny" } },
+      },
+      async (dir) => {
+        const code = await load(dir, (svc) => svc.get("code"))
+        expect(Permission.evaluate("read", ".env", code!.permission).action).toBe("deny")
+      },
+    )
+  },
+  { timeout: 30_000 },
+)
+
+test("file safety config participates in the agent cache key", () => {
+  expect(KiloAgent.cacheKey({ dangerously_disable_file_safety_guards: true })).not.toBe(
+    KiloAgent.cacheKey({ dangerously_disable_file_safety_guards: false }),
+  )
 })
 
 test("plan agent still hard-denies non-plan edits after user edit allow", async () => {

--- a/packages/opencode/test/kilocode/config/config.test.ts
+++ b/packages/opencode/test/kilocode/config/config.test.ts
@@ -376,6 +376,48 @@ describe("kilocode sandbox config", () => {
   })
 })
 
+async function scoped(global: object | undefined, local: object) {
+  await using globalTmp = await tmpdir()
+  await using tmp = await tmpdir({ git: true })
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  await clear()
+  await disposeAllInstances()
+
+  try {
+    if (global) await writeConfig(globalTmp.path, global)
+    await writeConfig(tmp.path, local)
+    return await provideTestInstance({ directory: tmp.path, fn: load })
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    await clear()
+    await disposeAllInstances()
+  }
+}
+
+describe("file safety guard config", () => {
+  test("prevents project config from disabling file safety guards", async () => {
+    const config = await scoped(undefined, { dangerously_disable_file_safety_guards: true })
+
+    expect(config.dangerously_disable_file_safety_guards).toBeUndefined()
+  })
+
+  test("allows project config to re-enable globally disabled file safety guards", async () => {
+    const config = await scoped(
+      { dangerously_disable_file_safety_guards: true },
+      { dangerously_disable_file_safety_guards: false },
+    )
+
+    expect(config.dangerously_disable_file_safety_guards).toBe(false)
+  })
+
+  test("keeps trusted global file safety configuration", async () => {
+    const config = await scoped({ dangerously_disable_file_safety_guards: true }, {})
+
+    expect(config.dangerously_disable_file_safety_guards).toBe(true)
+  })
+})
+
 describe("custom provider model config", () => {
   test("persists and removes reasoning across a global config reload", async () => {
     await using globalTmp = await tmpdir()

--- a/packages/opencode/test/kilocode/permission/agent-manager-prompt.test.ts
+++ b/packages/opencode/test/kilocode/permission/agent-manager-prompt.test.ts
@@ -20,8 +20,13 @@ describe("Agent Manager side-effect permissions", () => {
   test("requires consent despite a saved wildcard approval", () => {
     const rules = Permission.fromConfig({ agent_manager: "ask" })
     const saved = [{ permission: "agent_manager", pattern: "*", action: "allow" as const }]
-    expect(Permission.resolve("agent_manager", "prompt", rules, saved).action).toBe("ask")
-    expect(Permission.resolve("agent_manager", "stop", rules, saved).action).toBe("ask")
+    expect(Permission.resolve("agent_manager", "prompt", rules, { overrides: [saved] }).action).toBe("ask")
+    expect(Permission.resolve("agent_manager", "stop", rules, { overrides: [saved] }).action).toBe("ask")
+  })
+
+  test("requires consent when file guards are disabled", () => {
+    expect(Permission.resolve("agent_manager", "prompt", broad, { fileGuards: false }).action).toBe("ask")
+    expect(Permission.resolve("agent_manager", "stop", broad, { fileGuards: false }).action).toBe("ask")
   })
 
   test("allows only explicit side-effect approvals", () => {

--- a/packages/opencode/test/kilocode/permission/env-read.test.ts
+++ b/packages/opencode/test/kilocode/permission/env-read.test.ts
@@ -99,6 +99,23 @@ describe("env read permissions", () => {
     }),
   )
 
+  it.live("disabled file guards let broad read approval cover env files", () =>
+    Effect.sync(() => {
+      const set = Permission.merge(rules(), Permission.fromConfig({ read: { "*": "allow" } }))
+      expect(Permission.resolve("read", "project/.env", set, { fileGuards: false }).action).toBe("allow")
+      expect(Permission.resolve("read", "project/.env.local", set, { fileGuards: false }).action).toBe("allow")
+    }),
+  )
+
+  it.live("disabled file guards preserve explicit env ask and deny", () =>
+    Effect.sync(() => {
+      const ask = Permission.fromConfig({ read: { "*": "allow", "*.env": "ask" } })
+      const deny = Permission.fromConfig({ read: { "*": "allow", "*.env": "deny" } })
+      expect(Permission.resolve("read", ".env", ask, { fileGuards: false }).action).toBe("ask")
+      expect(Permission.resolve("read", ".env", deny, { fileGuards: false }).action).toBe("deny")
+    }),
+  )
+
   it.live("saved wildcard read approval does not bypass env ask", () =>
     withDir(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/kilocode/permission/file-safety.test.ts
+++ b/packages/opencode/test/kilocode/permission/file-safety.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "bun:test"
+import { Effect, Exit, Fiber, Layer, Ref } from "effect"
+import { Bus } from "../../../src/bus"
+import * as Config from "../../../src/config/config"
+import { EventV2Bridge } from "../../../src/event-v2-bridge"
+import { Permission } from "../../../src/permission"
+import { SessionID } from "../../../src/session/schema"
+import { Database } from "@opencode-ai/core/database/database"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { TestConfig } from "../../fixture/config"
+import { provideTmpdirInstance } from "../../fixture/fixture"
+
+function env(get: Config.Interface["get"]) {
+  return Layer.mergeAll(
+    Permission.layer.pipe(
+      Layer.provide(EventV2Bridge.defaultLayer),
+      Layer.provide(TestConfig.layer({ get })),
+      Layer.provide(Database.defaultLayer),
+    ),
+    Bus.layer,
+    CrossSpawnSpawner.defaultLayer,
+  )
+}
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask(input)
+  })
+
+const reply = (input: Parameters<Permission.Interface["reply"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.reply(input)
+  })
+
+const allow = (input: Parameters<Permission.Interface["allowEverything"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.allowEverything(input)
+  })
+
+const list = () =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.list()
+  })
+
+const wait = (count: number) =>
+  Effect.gen(function* () {
+    for (const _ of Array.from({ length: 100 })) {
+      const requests = yield* list()
+      if (requests.length >= count) return requests
+      yield* Effect.sleep("10 millis")
+    }
+    return yield* Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`))
+  })
+
+test("unguarded config edits can persist ordinary approvals", async () => {
+  const get = () => Effect.succeed({ dangerously_disable_file_safety_guards: true })
+  await Effect.runPromise(
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const ruleset = Permission.fromConfig({ edit: "ask" })
+        const first = PermissionV1.ID.make("permission_file_safety_first")
+        const pending = yield* ask({
+          id: first,
+          sessionID: SessionID.make("session_file_safety"),
+          permission: "edit",
+          patterns: ["AGENTS.md"],
+          metadata: {},
+          always: ["AGENTS.md"],
+          ruleset,
+        }).pipe(Effect.forkScoped)
+
+        const requests = yield* wait(1)
+        expect(requests[0].metadata).not.toMatchObject({ disableAlways: true, configProtected: true })
+        yield* reply({ requestID: first, reply: "always" })
+        yield* Fiber.join(pending)
+
+        const outcome = yield* ask({
+          id: PermissionV1.ID.make("permission_file_safety_second"),
+          sessionID: SessionID.make("session_file_safety"),
+          permission: "edit",
+          patterns: ["AGENTS.md"],
+          metadata: {},
+          always: ["AGENTS.md"],
+          ruleset,
+        })
+        expect(outcome.manual).toBe(false)
+        expect(yield* list()).toHaveLength(0)
+      }),
+    ).pipe(Effect.scoped, Effect.provide(env(get))),
+  )
+})
+
+test("unguarded config edits are covered by allow everything", async () => {
+  const get = () => Effect.succeed({ dangerously_disable_file_safety_guards: true })
+  await Effect.runPromise(
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const id = PermissionV1.ID.make("permission_file_safety_everything")
+        const pending = yield* ask({
+          id,
+          sessionID: SessionID.make("session_file_safety_everything"),
+          permission: "edit",
+          patterns: ["AGENTS.md"],
+          metadata: {},
+          always: ["AGENTS.md"],
+          ruleset: Permission.fromConfig({ edit: "ask" }),
+        }).pipe(Effect.forkScoped)
+
+        yield* wait(1)
+        yield* allow({ enable: true, requestID: id })
+        yield* Fiber.join(pending)
+        expect(yield* list()).toHaveLength(0)
+      }),
+    ).pipe(Effect.scoped, Effect.provide(env(get))),
+  )
+})
+
+test("pending config edits keep their file guard policy", async () => {
+  const config = await Effect.runPromise(Ref.make({}))
+  await Effect.runPromise(
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const id = PermissionV1.ID.make("permission_file_safety_stable")
+        const pending = yield* ask({
+          id,
+          sessionID: SessionID.make("session_file_safety_stable"),
+          permission: "edit",
+          patterns: ["AGENTS.md"],
+          metadata: {},
+          always: ["AGENTS.md"],
+          ruleset: Permission.fromConfig({ edit: "ask" }),
+        }).pipe(Effect.forkScoped)
+
+        yield* wait(1)
+        yield* Ref.set(config, { dangerously_disable_file_safety_guards: true })
+        yield* allow({ enable: true, requestID: id })
+        expect((yield* list()).map((item) => item.id)).toContain(id)
+        yield* reply({ requestID: id, reply: "reject" })
+        expect(Exit.isFailure(yield* Fiber.await(pending))).toBe(true)
+      }),
+    ).pipe(Effect.scoped, Effect.provide(env(() => Ref.get(config)))),
+  )
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1595,6 +1595,7 @@ export type Config = {
   terminal_command_display?: "expanded" | "collapsed"
   code_edit_display?: "expanded" | "collapsed"
   hide_prompt_training_models?: boolean
+  dangerously_disable_file_safety_guards?: boolean
   /**
    * Sandbox configuration for agent tools
    */

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1595,6 +1595,9 @@ export type Config = {
   terminal_command_display?: "expanded" | "collapsed"
   code_edit_display?: "expanded" | "collapsed"
   hide_prompt_training_models?: boolean
+  /**
+   * Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option.
+   */
   dangerously_disable_file_safety_guards?: boolean
   /**
    * Sandbox configuration for agent tools

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -29195,7 +29195,8 @@
             "type": "boolean"
           },
           "dangerously_disable_file_safety_guards": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Disable built-in safety guards for sensitive file reads and Kilo config edits so normal permission rules and approvals apply. Only trusted global config may enable this option."
           },
           "sandbox": {
             "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -29194,6 +29194,9 @@
           "hide_prompt_training_models": {
             "type": "boolean"
           },
+          "dangerously_disable_file_safety_guards": {
+            "type": "boolean"
+          },
           "sandbox": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Issue

Fixes #12609

## Context

Currently there is no way to disable permissions prompts for edits to the root AGENTS.md in a project.

## Implementation

Adds a `dangerously_disable_file_safety_guards` config option to allow users to disable this and other hardcoded project-level protections.

Important considerations:
- Only the user-level config can set this to `true`. Projects can override it to `false` to reenable the checks, but for safety, projects setting it to `true` will be ignored.
- System-level and agent-level permissions checks are still respected. For example, if an agent forbids all edits, enabling this config option will not override that for that agent.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Enable this config option in global config file
- Ask your agent to create or edit an AGENTS.md file
- Should not see a permissions prompt, AGENTS.md file should be written automatically by the agent.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
