### PR TITLE
Update the Cerebras provider example

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/cerebras.md
+++ b/packages/kilo-docs/pages/ai-providers/cerebras.md
@@ -61,7 +61,7 @@ Then set your default model:
 
 ```jsonc
 {
-  "model": "cerebras/llama-4-scout-17b-16e-instruct",
+  "model": "cerebras/gpt-oss-120b",
 }
 ```
 


### PR DESCRIPTION
## Summary

- Replaces the retired Llama 4 Scout model in the provider example with gpt-oss-120b.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

## Validation

- Documentation diff check and comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models