### PR TITLE
test(cli): disable indexing worker in instance route auth test

### DIFF
--- a/packages/opencode/src/kilocode/indexing.ts
+++ b/packages/opencode/src/kilocode/indexing.ts
@@ -260,6 +260,9 @@ export namespace KiloIndexing {
 
   const boot = async (hit: Cache): Promise<Entry> => {
     const dir = Instance.directory
+    if (process.env["KILO_DISABLE_CODEBASE_INDEXING"] === "vscode-no-workspace") {
+      return track(hit, await inert(() => noWorkspace()))
+    }
     const startup = await AppRuntime.runPromise(
       Effect.gen(function* () {
         const baseline = yield* baselineDirectory(dir)
@@ -269,9 +272,6 @@ export namespace KiloIndexing {
     )
     const baseline = startup.baseline
     const cfg = startup.cfg
-    if (process.env["KILO_DISABLE_CODEBASE_INDEXING"] === "vscode-no-workspace") {
-      return track(hit, await inert(() => noWorkspace()))
-    }
     if (!hasIndexingPlugin(cfg.plugin)) {
       return track(hit, await inert(() => missing()))
     }

--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -20,12 +20,15 @@ export function call(scenario: ActiveScenario, ctx: SeededContext<unknown>, opti
 export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" | "valid" = "missing") {
   return Effect.promise(async () => {
     const controller = new AbortController()
-    return Promise.race([
-      Promise.resolve(
-        app(await runtime(), { auth: { password: "secret" } }).request(
-          toAuthProbeRequest(scenario, credentials, controller.signal),
-        ),
-      ).then((response) => capture(response, scenario.capture)),
+    // kilocode_change start - keep the request so an abandoned capture can be cancelled;
+    // otherwise a never-ending body (SSE event stream) leaks a server fiber that blocks disposeApps
+    const request = Promise.resolve(
+      app(await runtime(), { auth: { password: "secret" } }).request(
+        toAuthProbeRequest(scenario, credentials, controller.signal),
+      ),
+    )
+    const result = await Promise.race([
+      request.then((response) => capture(response, scenario.capture)),
       Bun.sleep(1_000).then(() => {
         controller.abort("auth probe timed out")
         return {
@@ -37,6 +40,9 @@ export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" |
         }
       }),
     ])
+    if (result.timedOut) void request.then((response) => response.body?.cancel().catch(() => undefined))
+    return result
+    // kilocode_change end
   })
 }
 
@@ -47,7 +53,19 @@ const appCache: Partial<Record<string, CachedApp>> = {}
 export async function disposeApps() {
   const apps = Object.values(appCache)
   for (const key of Object.keys(appCache)) delete appCache[key]
-  await Promise.all(apps.flatMap((app) => (app === undefined ? [] : [app.dispose()])))
+  // kilocode_change start - Scope.close can wait forever on request fibers that outlived their
+  // probe (for example a never-ending SSE body whose capture was abandoned). Bound the wait so
+  // teardown and between-scenario resets always continue; the process exit reclaims anything left.
+  let done = false
+  await Promise.race([
+    Promise.all(apps.flatMap((app) => (app === undefined ? [] : [app.dispose()]))).then(() => {
+      done = true
+    }),
+    Bun.sleep(15_000).then(() => {
+      if (!done) console.warn("exerciser disposeApps timed out; continuing")
+    }),
+  ])
+  // kilocode_change end
 }
 
 function app(modules: Runtime, options: CallOptions) {

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1674,7 +1674,24 @@ const main = Effect.gen(function* () {
   yield* Effect.addFinalizer(() =>
     Effect.gen(function* () {
       const modules = yield* Effect.promise(() => runtime())
-      yield* Effect.promise(() => modules.disposeAllInstances())
+      // Teardown must not wait forever on fibers that outlive the run (a reloaded instance can
+      // still be bootstrapping when the finalizer disposes it). Bound the wait with a plain
+      // Promise.race so the process always exits; racing with Effect fibers trips scope-close.
+      const bound = <A>(promise: () => Promise<A>, label: string) =>
+        Effect.promise(() => {
+          let done = false
+          return Promise.race([
+            promise().then((value) => {
+              done = true
+              return value
+            }),
+            Bun.sleep(15_000).then(() => {
+              if (!done) console.warn(`exerciser teardown timed out waiting for ${label}; continuing`)
+              return undefined as A
+            }),
+          ])
+        })
+      yield* bound(() => modules.disposeAllInstances(), "disposeAllInstances")
       yield* Effect.promise(() => disposeApps())
       yield* cleanupExercisePaths
     }),

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -262,7 +262,18 @@ const resetState = Effect.promise(async () => {
   Flag.KILO_SERVER_PASSWORD = original.KILO_SERVER_PASSWORD
   Flag.KILO_SERVER_USERNAME = original.KILO_SERVER_USERNAME
   await disposeApps()
-  await modules.disposeAllInstances()
+  // kilocode_change start - instance disposal can block while a reloaded instance is still
+  // bootstrapping; bound the wait so a reset can never stall the run (same race as teardown)
+  let done = false
+  await Promise.race([
+    modules.disposeAllInstances().then(() => {
+      done = true
+    }),
+    Bun.sleep(15_000).then(() => {
+      if (!done) console.warn("exerciser reset timed out waiting for disposeAllInstances; continuing")
+    }),
+  ])
+  // kilocode_change end
   // kilocode_change - each exerciser process already owns an isolated DB; unlinking it between scenarios races async Kilo callbacks
   await Bun.sleep(25)
 })

--- a/packages/opencode/test/server/httpapi-instance-route-auth.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-route-auth.test.ts
@@ -9,6 +9,11 @@ import { PtyID } from "@opencode-ai/core/pty/schema"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 
+// kilocode_change start - route auth tests do not need an indexing worker per temp project;
+// the worker boot races tmpdir teardown and flakes CI with EBADF/invalid handle errors
+process.env.KILO_DISABLE_CODEBASE_INDEXING = "vscode-no-workspace"
+// kilocode_change end
+
 function app(input: { password?: string; username?: string }) {
   const handler = HttpRouter.toWebHandler(
     HttpApiApp.routes.pipe(

--- a/packages/opencode/test/server/httpapi-instance-route-auth.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-route-auth.test.ts
@@ -12,6 +12,10 @@ import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 // kilocode_change start - route auth tests do not need an indexing worker per temp project;
 // the worker boot races tmpdir teardown and flakes CI with EBADF/invalid handle errors
 process.env.KILO_DISABLE_CODEBASE_INDEXING = "vscode-no-workspace"
+// The PTY connect handler builds the full v2 location stack (FFF native index and git-status
+// watcher threads) just to 404 an unknown session; its native teardown races the tmpdir
+// deletion and flakes CI with EBADF on Linux and invalid handle on Windows.
+process.env.KILO_DISABLE_FFF = "true"
 // kilocode_change end
 
 function app(input: { password?: string; username?: string }) {


### PR DESCRIPTION
Two recurring CI flakes in the CLI test pipeline, both in how tests interact with per-instance async work that outlives the test.

## Route auth test flake (2 of 3 red main runs today)

`server/httpapi-instance-route-auth.test.ts` failed on two platforms, and in both cases the tests themselves passed:

- linux (run 30360322849): `error: Bad file descriptor` raised as an unhandled error between tests
- windows (run 30344932776): `error: Invalid handle` killed the PTY websocket test 43ms in, right as the indexing bootstrap was interrupted

Each request in that test boots a full Kilo instance, and the bootstrap fork-detaches `KiloIndexing.init()`. Since `@kilocode/kilo-indexing` is injected as a default plugin, `boot()` proceeds to real per-tmpdir indexing work: an embedding model catalog fetch, LanceDB init, and a Bun worker that scans the temp project. The tests finish in 1-2.5s, so instance disposal plus the fixture's `rm -rf` of the tmpdir reliably race the worker boot and teardown. The native fd cleanup then surfaces as an unhandled OS error that bun attributes to the test file.

The test only verifies auth gating on two routes; it never needs an indexing worker. Setting `KILO_DISABLE_CODEBASE_INDEXING=vscode-no-workspace` at module scope makes the boot return the inert entry, following the same precedent as the HttpApi exerciser environment (8932a2033b). Test files run in isolated processes, so the env var cannot leak into other files.

The env check also moves to the top of `KiloIndexing.boot()`, before the `AppRuntime.runPromise` config/baseline resolution. Previously the boot did that Effect work first and could be interrupted mid-flight by instance disposal, which is why logs showed a caught but noisy "All fibers interrupted without error" on every disabled-mode boot. Same final status, no intermediate work.

## HttpApi exerciser teardown hang

The HttpApi exerciser job on this PR's first run hung silently for 15 minutes until the job timeout cancelled it. Reproduced locally in auth mode (hangs about every other run) and confirmed on baseline code, so it is pre-existing: after the summary, `web.dispose` closes the router scope, which waits for request fibers. The auth probe race abandons the capture when its 1s timeout wins, so a never-ending body (the SSE event stream opened with valid credentials, whose probe "passes" via the timeout) keeps the server-side fiber alive and blocks `Scope.close` indefinitely. The same block can strike mid-run via `resetState` between scenarios.

Two changes make teardown reliable:

- When an auth probe times out, the response body is cancelled so the abandoned stream releases its server fiber (same pattern the route auth test uses with `cancelBody`).
- `disposeApps` and the teardown/reset `disposeAllInstances` waits are bounded with a plain 15s `Promise.race` so the process always exits even if some future route leaks a fiber. `Effect.timeoutOrElse` was avoided inside the finalizer on purpose: forking fibers while the scope closes trips an Effect internal (`evaluating 'f.length'`) and fails the run.