### PR TITLE
fix(agent-manager): keep terminal destination consistent across windows

### DIFF
--- a/.changeset/agent-manager-terminal-destination-consistency.md
+++ b/.changeset/agent-manager-terminal-destination-consistency.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep each Agent Manager panel's terminal destination consistent. A dropdown pick is now remembered per panel and no longer flips when another window rewrites the shared terminal destination setting, so the terminal shortcut keeps opening the terminal type that panel is actually using. The shortcut also no longer dead-ends on worktrees without an active session, and terminals left over from a reloaded webview are cleaned up instead of leaking.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1028,7 +1028,7 @@
             "Open or focus the VS Code integrated terminal.",
             "Open or focus an embedded terminal in the Agent Manager side panel."
           ],
-          "description": "Choose where the Agent Manager terminal button and Focus Terminal keyboard shortcut open a terminal."
+          "description": "Default destination for the Agent Manager terminal button and Focus Terminal keyboard shortcut. The terminal button's dropdown remembers its own choice per Agent Manager panel; this setting only applies to panels that never picked one."
         },
         "kilo-code.new.indexing.showButtonWhenDisabled": {
           "type": "boolean",

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -593,6 +593,10 @@ export class AgentManagerProvider implements Disposable {
       this.terminalManager.showLocalTerminal()
       return null
     }
+    if (m.type === "agentManager.showWorktreeTerminal") {
+      this.terminalManager.showWorktreeTerminal(m.worktreeId, this.state)
+      return null
+    }
     if (m.type === "agentManager.openWorktree") {
       this.openWorktreeDirectory(m.worktreeId)
       return null
@@ -720,6 +724,13 @@ export class AgentManagerProvider implements Disposable {
   }
 
   private onRequestState(): void {
+    // requestState fires from the webview's onMount, and a freshly mounted
+    // webview has no terminal records — any PTYs the router still tracks
+    // belong to a previous webview instance (reload or crash) and are
+    // unreachable orphans. Kill them here rather than leaking shells until
+    // the panel itself is disposed. In-flight creates from the dying
+    // instance are reaped by the router's generation guard.
+    void this.terminalRouter.dispose()
     void this.stateReady
       ?.then(() => {
         // When the folder is not a git repo (or has no folder open),

--- a/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/SessionTerminalManager.ts
@@ -123,6 +123,27 @@ export class SessionTerminalManager {
   }
 
   /**
+   * Show (or create) a terminal rooted at a worktree directory. Used when
+   * the worktree has no session to key the terminal off (e.g. all of its
+   * sessions were closed) so the shortcut never dead-ends on a sessionless
+   * worktree.
+   */
+  showWorktreeTerminal(worktreeId: string, state: WorktreeStateManager | undefined): void {
+    const key = `worktree:${worktreeId}`
+    if (this.showExisting(key, false)) return
+
+    const worktree = state?.getWorktree(worktreeId)
+    const cwd = worktree?.path ?? this.host.repoPath()
+    if (!cwd) {
+      this.log(`showWorktreeTerminal: no cwd resolved for worktree ${worktreeId}`)
+      this.host.showWarning("Open a folder that contains a git repository to use worktrees")
+      return
+    }
+
+    this.showOrCreate(key, cwd, worktree ? `Agent: ${worktree.branch}` : "Agent: worktree")
+  }
+
+  /**
    * Show the existing local terminal if one was previously created (used on context switch).
    */
   showExistingLocal(): boolean {

--- a/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
+++ b/packages/kilo-vscode/src/agent-manager/__tests__/AgentManagerProvider.spec.ts
@@ -39,6 +39,7 @@ vi.mock("../SessionTerminalManager", () => ({
   SessionTerminalManager: class {
     showTerminal() {}
     showLocalTerminal() {}
+    showWorktreeTerminal() {}
     syncLocalOnSessionSwitch() {}
     syncOnSessionSwitch() {
       return false
@@ -214,6 +215,20 @@ describe("AgentManagerProvider worktree creation", () => {
     await pending
 
     expect(manager.createWorktreeOnDisk).toHaveBeenCalledTimes(1)
+  })
+
+  it("disposes orphaned terminals when a freshly mounted webview requests state", async () => {
+    const manager = createHarness()
+    const dispose = vi.fn().mockResolvedValue(undefined)
+    manager.terminalRouter = { handle: vi.fn().mockReturnValue(false), dispose } as unknown as {
+      handle: ReturnType<typeof vi.fn>
+    }
+    // Avoid the vscode-backed pushEmptyState; the disposal under test is synchronous.
+    ;(manager as unknown as Record<string, unknown>).pushEmptyState = vi.fn()
+
+    await manager.onMessage({ type: "agentManager.requestState" })
+
+    expect(dispose).toHaveBeenCalledTimes(1)
   })
 
   it("routes file search through the active worktree session", async () => {

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -414,6 +414,11 @@ interface ShowLocalTerminalIn {
   type: "agentManager.showLocalTerminal"
 }
 
+interface ShowWorktreeTerminalIn {
+  type: "agentManager.showWorktreeTerminal"
+  worktreeId: string
+}
+
 interface OpenWorktreeIn {
   type: "agentManager.openWorktree"
   worktreeId: string
@@ -780,6 +785,7 @@ export type AgentManagerInMessage =
   | StopRunScriptIn
   | ShowTerminalIn
   | ShowLocalTerminalIn
+  | ShowWorktreeTerminalIn
   | OpenWorktreeIn
   | CopyToClipboardIn
   | ShowExistingLocalTerminalIn

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -411,6 +411,7 @@ describe("Agent Manager Provider — onMessage routing", () => {
       "agentManager.stopRunScript",
       "agentManager.showTerminal",
       "agentManager.showLocalTerminal",
+      "agentManager.showWorktreeTerminal",
       "agentManager.showExistingLocalTerminal",
       "agentManager.requestRepoInfo",
       "agentManager.requestState",

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
@@ -1,13 +1,25 @@
 import { describe, expect, it } from "bun:test"
-import { createSideTerminal } from "../../webview-ui/agent-manager/terminal/side"
+import {
+  createSideTerminal,
+  readSavedDestination,
+  resolveVscodeTerminalRequest,
+} from "../../webview-ui/agent-manager/terminal/side"
 
-function scene(opts: { destination?: "vscode" | "agentManager"; visible?: boolean; focused?: boolean } = {}) {
+function scene(
+  opts: {
+    destination?: "vscode" | "agentManager"
+    saved?: "vscode" | "agentManager"
+    visible?: boolean
+    focused?: boolean
+  } = {},
+) {
   const calls = {
     requestSide: 0,
     closeSide: 0,
     hide: 0,
     refocus: 0,
     openVscode: 0,
+    persisted: [] as string[],
     posted: [] as Array<Record<string, unknown>>,
     tracked: [] as string[],
   }
@@ -35,8 +47,10 @@ function scene(opts: { destination?: "vscode" | "agentManager"; visible?: boolea
     postMessage: (msg) => calls.posted.push(msg as Record<string, unknown>),
     track: (button) => calls.tracked.push(button),
     openVscode: () => calls.openVscode++,
+    saved: opts.saved,
+    save: (destination) => calls.persisted.push(destination),
   })
-  if (opts.destination) ctl.setDestination(opts.destination)
+  if (opts.destination) ctl.syncDefault(opts.destination)
   return { ctl, calls }
 }
 
@@ -88,5 +102,84 @@ describe("Agent Manager side terminal controller", () => {
     expect(item.calls.posted).toEqual([
       { type: "updateSetting", key: "agentManager.terminalButtonDestination", value: "agentManager" },
     ])
+    expect(item.calls.persisted).toEqual(["agentManager"])
+  })
+
+  it("follows the remote default while the panel has no explicit choice", () => {
+    const item = scene()
+    item.ctl.syncDefault("agentManager")
+    expect(item.ctl.destination()).toBe("agentManager")
+    item.ctl.syncDefault("vscode")
+    expect(item.ctl.destination()).toBe("vscode")
+  })
+
+  it("keeps the panel's explicit choice when another window rewrites the shared setting", () => {
+    const item = scene()
+    item.ctl.choose("agentManager")
+    // Echo of the application-scoped setting being rewritten elsewhere:
+    // worktree window B picked the VS Code terminal, which must not flip
+    // this panel's routing.
+    item.ctl.syncDefault("vscode")
+    expect(item.ctl.destination()).toBe("agentManager")
+    item.ctl.openPreferred("keyboard_shortcut")
+    expect(item.calls.requestSide).toBe(1)
+    expect(item.calls.openVscode).toBe(0)
+  })
+
+  it("restores a saved panel choice and ignores remote defaults", () => {
+    const item = scene({ saved: "agentManager" })
+    expect(item.ctl.destination()).toBe("agentManager")
+    item.ctl.syncDefault("vscode")
+    expect(item.ctl.destination()).toBe("agentManager")
+  })
+})
+
+describe("readSavedDestination", () => {
+  it("reads a valid choice and rejects anything else", () => {
+    expect(readSavedDestination({ terminalDestination: "agentManager" })).toBe("agentManager")
+    expect(readSavedDestination({ terminalDestination: "vscode" })).toBe("vscode")
+    expect(readSavedDestination({ terminalDestination: "bogus" })).toBeUndefined()
+    expect(readSavedDestination({})).toBeUndefined()
+    expect(readSavedDestination(undefined)).toBeUndefined()
+  })
+})
+
+describe("resolveVscodeTerminalRequest", () => {
+  const sessions = new Map([
+    ["wt-1", "session-a"],
+    ["wt-2", "session-b"],
+  ])
+  const forWorktree = (id: string) => sessions.get(id)
+
+  it("prefers the current session", () => {
+    expect(resolveVscodeTerminalRequest("wt-1", "session-current", forWorktree)).toEqual({
+      type: "agentManager.showTerminal",
+      sessionId: "session-current",
+    })
+  })
+
+  it("falls back to a session of the selected worktree when the current session is cleared", () => {
+    // Terminal tab activation clears the current session; the shortcut
+    // must still open a terminal for the worktree, not dead-end.
+    expect(resolveVscodeTerminalRequest("wt-2", undefined, forWorktree)).toEqual({
+      type: "agentManager.showTerminal",
+      sessionId: "session-b",
+    })
+  })
+
+  it("opens a worktree-rooted terminal for sessionless worktrees", () => {
+    expect(resolveVscodeTerminalRequest("wt-3", undefined, forWorktree)).toEqual({
+      type: "agentManager.showWorktreeTerminal",
+      worktreeId: "wt-3",
+    })
+  })
+
+  it("opens the local terminal for the local context and unassigned selections", () => {
+    expect(resolveVscodeTerminalRequest("local", undefined, forWorktree)).toEqual({
+      type: "agentManager.showLocalTerminal",
+    })
+    expect(resolveVscodeTerminalRequest(null, undefined, forWorktree)).toEqual({
+      type: "agentManager.showLocalTerminal",
+    })
   })
 })

--- a/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-terminal-manager.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from "bun:test"
 import path from "node:path"
 import { Project, SyntaxKind } from "ts-morph"
 import { SessionTerminalManager, type TerminalHost } from "../../src/agent-manager/SessionTerminalManager"
+import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 
 const ROOT = path.resolve(import.meta.dir, "../..")
 const FILE = path.join(ROOT, "src/agent-manager/SessionTerminalManager.ts")
@@ -160,5 +161,65 @@ describe("SessionTerminalManager command restoration", () => {
 
     await expect(state.handler()).rejects.toBe(expected)
     state.manager.dispose()
+  })
+})
+
+describe("SessionTerminalManager worktree terminals", () => {
+  function scene(opts: { worktreePath?: string; repoPath?: string } = {}) {
+    const created: Array<{ cwd: string; name: string }> = []
+    const warnings: string[] = []
+    let shown = 0
+    const host: TerminalHost = {
+      createTerminal(o) {
+        created.push(o)
+        return {
+          show: () => shown++,
+          dispose() {},
+          exitStatus: undefined,
+        }
+      },
+      activeTerminal: () => undefined,
+      repoPath: () => opts.repoPath,
+      showWarning: (msg) => warnings.push(msg),
+      setContext() {},
+      onTerminalClosed: () => ({ dispose() {} }),
+      onActiveTerminalChanged: () => ({ dispose() {} }),
+      registerCommand: () => ({ dispose() {} }),
+      executeCommand: () => Promise.resolve(),
+    }
+    const state = {
+      getWorktree: (id: string) =>
+        opts.worktreePath ? { id, path: opts.worktreePath, branch: "feature/x" } : undefined,
+    } as unknown as WorktreeStateManager
+    const manager = new SessionTerminalManager(() => {}, host)
+    return { manager, state, created, warnings, shown: () => shown }
+  }
+
+  it("creates a terminal rooted at the worktree path", () => {
+    const s = scene({ worktreePath: "/repo/.kilo/worktrees/wt-1", repoPath: "/repo" })
+    s.manager.showWorktreeTerminal("wt-1", s.state)
+    expect(s.created).toEqual([{ cwd: "/repo/.kilo/worktrees/wt-1", name: "Agent: feature/x" }])
+    expect(s.shown()).toBe(1)
+  })
+
+  it("reuses the live terminal on repeat calls", () => {
+    const s = scene({ worktreePath: "/repo/.kilo/worktrees/wt-1" })
+    s.manager.showWorktreeTerminal("wt-1", s.state)
+    s.manager.showWorktreeTerminal("wt-1", s.state)
+    expect(s.created).toHaveLength(1)
+    expect(s.shown()).toBe(2)
+  })
+
+  it("falls back to the repo root when the worktree is unknown", () => {
+    const s = scene({ repoPath: "/repo" })
+    s.manager.showWorktreeTerminal("gone", s.state)
+    expect(s.created).toEqual([{ cwd: "/repo", name: "Agent: worktree" }])
+  })
+
+  it("warns and creates nothing when no cwd resolves", () => {
+    const s = scene({})
+    s.manager.showWorktreeTerminal("gone", s.state)
+    expect(s.created).toHaveLength(0)
+    expect(s.warnings).toHaveLength(1)
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -126,6 +126,8 @@ import {
   createTerminalHandlers,
   createTerminalMessageHandler,
   createSideTerminal,
+  readSavedDestination,
+  resolveVscodeTerminalRequest,
 } from "./terminal"
 import { focusCurrentTab, renderTab, renderTerminalLayer, renderNewTabButton } from "./tab-rendering"
 import { useTabScroll } from "./tab-scroll"
@@ -1283,7 +1285,7 @@ const AgentManagerContent: Component = () => {
         // a slow create landing after a mode switch must not steal it.
         if (sidePanel() === "terminal" && terms.sideKey() === contextKey) terms.requestFocus(terminalId)
       },
-      onDestinationChanged: (destination) => sideCtl.setDestination(destination),
+      onDestinationChanged: (destination) => sideCtl.syncDefault(destination),
     })
     const unsubTerminals = vscode.onMessage((msg) => {
       terminalDispatch(msg)
@@ -2108,11 +2110,17 @@ const AgentManagerContent: Component = () => {
     refocus: () => window.dispatchEvent(new Event("focusPrompt")),
     postMessage: (msg) => vscode.postMessage(msg as never),
     track: (button, surface, properties) => metrics.track(button, surface, properties),
-    openVscode: () => {
-      const id = session.currentSessionID()
-      if (id) vscode.postMessage({ type: "agentManager.showTerminal", sessionId: id })
-      else if (selection() === LOCAL) vscode.postMessage({ type: "agentManager.showLocalTerminal" })
-    },
+    // Panel-local pick, immune to cross-window setting echoes (see side.ts).
+    saved: readSavedDestination(vscode.getState<Record<string, unknown>>()),
+    save: (d) => vscode.setState({ ...vscode.getState<Record<string, unknown>>(), terminalDestination: d }),
+    openVscode: () =>
+      vscode.postMessage(
+        resolveVscodeTerminalRequest(
+          selection(),
+          session.currentSessionID(),
+          (wt) => managedSessions().find((ms) => ms.worktreeId === wt)?.id,
+        ) as never,
+      ),
   })
 
   const handleReviewTabMouseDown = (e: MouseEvent) => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/index.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/index.ts
@@ -23,6 +23,6 @@ export type { TerminalTabState, TerminalStateControls, TerminalHandlerDeps } fro
 export { renderTerminalTab, renderTerminalLayer, renderSideTerminalLayer } from "./render"
 export { SideTerminalPanel } from "./SideTerminalPanel"
 export { TerminalDestinationButton } from "./TerminalDestinationButton"
-export { createSideTerminal } from "./side"
+export { createSideTerminal, readSavedDestination, resolveVscodeTerminalRequest } from "./side"
 export { TerminalTab } from "./TerminalTab"
 export { SortableTerminalTab } from "./SortableTerminalTab"

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
@@ -7,11 +7,52 @@
  * embedded terminal behaves like the diff panel: press once to reveal,
  * press again to hide. Hiding never kills the terminal — only the
  * explicit close action (or `Cmd+W` while it holds focus) does.
+ *
+ * ## Destination state ownership
+ *
+ * The VS Code setting is application-scoped, so one value is shared by
+ * every window and echoed back via `terminal.destinationChanged`
+ * whenever ANY window rewrites it. Two windows can therefore fight:
+ * picking "VS Code terminal" in worktree window B would silently flip
+ * the routing of the panel in window A. To keep each panel consistent,
+ * an explicit dropdown pick is stored per panel (webview state) and
+ * wins over remote echoes; the setting only drives panels that never
+ * picked a destination themselves (it stays the default for new ones).
  */
 
 import { createSignal } from "solid-js"
 import type { Accessor } from "solid-js"
 import type { TerminalDestination } from "../../src/types/messages/agent-manager"
+import { LOCAL } from "../navigate"
+
+/** Read the panel-local destination choice from raw webview state. */
+export function readSavedDestination(state: Record<string, unknown> | undefined): TerminalDestination | undefined {
+  const value = state?.terminalDestination
+  return value === "agentManager" || value === "vscode" ? value : undefined
+}
+
+export type VscodeTerminalRequest =
+  | { type: "agentManager.showTerminal"; sessionId: string }
+  | { type: "agentManager.showWorktreeTerminal"; worktreeId: string }
+  | { type: "agentManager.showLocalTerminal" }
+
+/**
+ * Pick the message the terminal button / Focus Terminal shortcut sends
+ * when the destination is the VS Code integrated terminal. The fallback
+ * chain exists so the shortcut never dead-ends: activating a terminal
+ * tab clears the current session, and a worktree may have no sessions
+ * at all. Extracted from AgentManagerApp.tsx (max-lines cap).
+ */
+export function resolveVscodeTerminalRequest(
+  selection: string | null,
+  currentSessionID: string | undefined,
+  sessionForWorktree: (worktreeId: string) => string | undefined,
+): VscodeTerminalRequest {
+  const id = currentSessionID ?? (selection && selection !== LOCAL ? sessionForWorktree(selection) : undefined)
+  if (id) return { type: "agentManager.showTerminal", sessionId: id }
+  if (selection && selection !== LOCAL) return { type: "agentManager.showWorktreeTerminal", worktreeId: selection }
+  return { type: "agentManager.showLocalTerminal" }
+}
 
 interface Handlers {
   requestSide(): void
@@ -32,10 +73,16 @@ export interface SideTerminalDeps {
   track: (button: string, surface: string, properties: Record<string, string>) => void
   /** Open or focus the VS Code integrated terminal for the active context. */
   openVscode: () => void
+  /** Panel-local choice restored from webview state, if the user ever
+   *  picked one in this panel. */
+  saved: TerminalDestination | undefined
+  /** Persist the panel-local choice so it survives webview reloads. */
+  save: (destination: TerminalDestination) => void
 }
 
 export function createSideTerminal(deps: SideTerminalDeps) {
-  const [destination, setDestination] = createSignal<TerminalDestination>("vscode")
+  const [local, setLocal] = createSignal<TerminalDestination | undefined>(deps.saved)
+  const [destination, setDestination] = createSignal<TerminalDestination>(deps.saved ?? "vscode")
 
   /**
    * Hiding while the terminal holds focus would strand the cursor on
@@ -78,17 +125,32 @@ export function createSideTerminal(deps: SideTerminalDeps) {
   }
 
   /**
-   * Dropdown pick. Applied locally right away so the button reacts
-   * without a round trip, then persisted as a VS Code setting; the
-   * extension echoes it back via `terminal.destinationChanged`.
+   * Dropdown pick. The choice is panel-local and sticky: it is kept in
+   * webview state and beats later `terminal.destinationChanged` echoes
+   * caused by other windows rewriting the shared application-scoped
+   * setting. The setting is still written so it stays the default for
+   * panels that never picked a destination (and new panels).
    * The key is relative to the `kilo-code.new` section, matching every
    * other `updateSetting` sender.
    */
   const choose = (target: TerminalDestination) => {
     deps.track("terminal_destination", "tab_toolbar", { destination: target })
+    setLocal(target)
     setDestination(target)
+    deps.save(target)
     deps.postMessage({ type: "updateSetting", key: "agentManager.terminalButtonDestination", value: target })
   }
 
-  return { destination, setDestination, toggle, close, openPreferred, choose }
+  /**
+   * Apply a remote default (initial `agentManager.state` payload or a
+   * live `terminal.destinationChanged` echo). Ignored once the user
+   * picked a destination in this panel — their choice wins over every
+   * echo, including ones triggered by this panel's own `choose` write.
+   */
+  const syncDefault = (target: TerminalDestination) => {
+    if (local()) return
+    setDestination(target)
+  }
+
+  return { destination, syncDefault, toggle, close, openPreferred, choose }
 }

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -695,6 +695,12 @@ export interface ShowLocalTerminalRequest {
   type: "agentManager.showLocalTerminal"
 }
 
+// Show a terminal rooted at a worktree directory (worktree has no session)
+export interface ShowWorktreeTerminalRequest {
+  type: "agentManager.showWorktreeTerminal"
+  worktreeId: string
+}
+
 // Open a worktree directory in VS Code
 export interface OpenWorktreeRequest {
   type: "agentManager.openWorktree"
@@ -1336,6 +1342,7 @@ export type WebviewMessage =
   | StopRunScriptRequest
   | ShowTerminalRequest
   | ShowLocalTerminalRequest
+  | ShowWorktreeTerminalRequest
   | OpenWorktreeRequest
   | CopyToClipboardRequest
   | ShowExistingLocalTerminalRequest


### PR DESCRIPTION
The Agent Manager terminal destination (`kilo-code.new.agentManager.terminalButtonDestination`) is an application-scoped setting, but the toolbar dropdown behaved as if each window owned its value. Picking a destination in one worktree window rewrote the shared setting, and every other window's panel followed the echo within a second. Repro: enable the embedded panel terminal in window A, pick the VS Code terminal in window B, return to A and press `Cmd/Ctrl+/`. The shortcut now opens the integrated terminal instead of the embedded one, while the embedded terminal keeps running invisibly in the background with no way to reach it via the keybind. To the user the terminal looks broken.

An explicit dropdown pick is now panel-local state (webview state, survives reloads) and wins over any later setting echo, so each Agent Manager panel keeps the routing it was actually configured with. The setting is still written and serves as the default for panels that never picked a destination, so single-window behavior is unchanged.

Two neighboring state consistency problems in the same flow are fixed along the way:

- The shortcut could dead-end. Activating a terminal tab clears the current session, and the VS Code destination path required a current session, so `Cmd/Ctrl+/` on a worktree selection silently did nothing. The request now falls back from the current session to any session of the selected worktree, then to a worktree-rooted integrated terminal (new `agentManager.showWorktreeTerminal` message), then to the local terminal.
- A reloaded or crashed webview forgot all terminals while their PTYs kept running as unreachable orphans on the backend until the panel was closed. The provider now disposes the terminal router when a freshly mounted webview requests state, matching the deliberate kill-on-panel-close behavior. In-flight creates from the dying instance are reaped by the router's existing generation guard.

Restart semantics are unchanged and remain intentionally ephemeral: closing the panel or reloading the window kills every embedded terminal, terminal ids are never persisted into the durable tab order, and scrollback does not survive. VS Code integrated terminals are owned by VS Code and survive independently.

<img width="500" alt="Terminal destination dropdown with VS Code terminal and Agent Manager panel options" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260729-agent-manager-terminal-destination-menu.png?raw=true" />

<img width="700" alt="Embedded side terminal running a command in the Agent Manager inspector" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260729-agent-manager-side-terminal.png?raw=true" />

<img width="700" alt="Embedded side terminal and VS Code integrated terminal coexisting after switching destinations" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260729-agent-manager-terminal-destinations.png?raw=true" />
