### PR TITLE
fix(vscode): stop flashing interruption warning on queued follow-up handoff

### DIFF
--- a/.changeset/superseded-turn-close.md
+++ b/.changeset/superseded-turn-close.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Stop flashing a "Turn interrupted" warning when a follow-up message is queued while the assistant is still working. The running turn now closes with a dedicated "superseded" reason instead of "interrupted" when it hands off to the queued prompt, so the premature-stop warning only appears for real interruptions.

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -408,7 +408,7 @@ export type WebviewMessage =
       message: Record<string, unknown>
     }
   | { type: "sessionStatus"; sessionID: string; status: string; attempt?: number; message?: string; next?: number }
-  | { type: "sessionTurnClosed"; sessionID: string; reason: "completed" | "error" | "interrupted" }
+  | { type: "sessionTurnClosed"; sessionID: string; reason: "completed" | "error" | "interrupted" | "superseded" }
   | {
       type: "permissionRequest"
       permission: {

--- a/packages/kilo-vscode/tests/unit/session-outcome.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-outcome.test.ts
@@ -138,6 +138,13 @@ describe("terminal", () => {
     ).toBe("error")
   })
 
+  it("hides superseded turns that handed off to a queued follow-up", () => {
+    expect(
+      terminal({ reason: "superseded", messages: [message("tool-calls")], todos: [todo("pending")] }),
+    ).toBeUndefined()
+    expect(terminal({ reason: "superseded", messages: [message("unknown")], todos: [] })).toBeUndefined()
+  })
+
   it("reports only the latest assistant finish reason", () => {
     const user: Message = { id: "u1", sessionID: "s1", role: "user", createdAt: new Date(1).toISOString() }
     expect(terminal({ reason: "completed", messages: [message("length"), user], todos: [] })?.finish).toBeUndefined()

--- a/packages/kilo-vscode/webview-ui/src/context/session-outcome.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-outcome.ts
@@ -41,6 +41,9 @@ function identifiers(
 
 export function terminal(input: Input): TerminalState | undefined {
   if (!input.reason) return undefined
+  // A superseded turn handed off to a queued follow-up; it is not a premature
+  // stop, and the follow-up turn closes with its own reason afterwards.
+  if (input.reason === "superseded") return undefined
   const last = input.messages[input.messages.length - 1]
   const finish = last?.role === "assistant" ? last.finish : undefined
   const ids = identifiers(last, input.parts)

--- a/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
@@ -3,7 +3,7 @@ import type { Part, TokenUsage } from "./parts"
 
 export type SessionModelUsage = KilocodeSessionModelUsageResponse
 
-export type SessionCloseReason = "completed" | "error" | "interrupted"
+export type SessionCloseReason = "completed" | "error" | "interrupted" | "superseded"
 
 // Message structure (simplified for webview)
 export interface Message {

--- a/packages/opencode/src/kilocode/memory/turn.ts
+++ b/packages/opencode/src/kilocode/memory/turn.ts
@@ -78,7 +78,9 @@ export namespace MemoryLifecycle {
           if (!enabled) return
           yield* MemoryTurn.close({
             sessionID: evt.properties.sessionID,
-            reason: evt.properties.reason,
+            // A superseded turn handed off to a queued follow-up after draining
+            // its step; for digest purposes it was cut short like an interrupt.
+            reason: evt.properties.reason === "superseded" ? "interrupted" : evt.properties.reason,
             sessions: input.sessions,
             summary: input.summary,
             provider: input.provider,

--- a/packages/opencode/src/kilocode/session/event.ts
+++ b/packages/opencode/src/kilocode/session/event.ts
@@ -2,7 +2,10 @@ import { BusEvent } from "@/bus/bus-event"
 import { MessageID, SessionID } from "@/session/schema"
 import { Schema } from "effect"
 
-const CloseReason = Schema.Literals(["completed", "error", "interrupted"])
+// "superseded": the turn handed off to a queued follow-up after draining its
+// current step. Distinct from "interrupted" so clients do not surface a
+// premature-stop warning for a deliberate queue handoff.
+const CloseReason = Schema.Literals(["completed", "error", "interrupted", "superseded"])
 
 export const KiloSessionEvent = {
   TurnOpen: BusEvent.define(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1848,9 +1848,11 @@ export const layer = Layer.effect(
           // kilocode_change start — break out so a newer queued prompt can take over
           // instead of starting another LLM step for the now-superseded turn. The
           // current handle.process has fully drained (tokens + inline tool calls) by
-          // the time we get here, so nothing is cut off.
+          // the time we get here, so nothing is cut off. The close reason is
+          // "superseded", not "interrupted": this is a deliberate queue handoff,
+          // not a premature stop, so clients must not flash an interruption warning.
           if (KiloSessionPromptQueue.hasFollowup(sessionID)) {
-            closeReasons.set(sessionID, "interrupted")
+            closeReasons.set(sessionID, "superseded")
             return "break" as const
           }
           // kilocode_change end

--- a/packages/opencode/test/kilocode/session-prompt-queue.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-queue.test.ts
@@ -549,6 +549,96 @@ describe("session prompt queue", () => {
     }
   })
 
+  test("closes a queued-handoff turn as superseded, not interrupted", async () => {
+    const ready = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) return new Response("not found", { status: 404 })
+
+        // Hold every stream open until the follow-up prompt is queued, so
+        // runLoop deterministically takes the hasFollowup break once its
+        // current step drains. Forked title/summary calls get held too; they
+        // are Effect.ignore'd and drain once released.
+        ready.resolve()
+        const stream = reply({ text: "reply", wait: release.promise })
+        return new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "opencode.json"), JSON.stringify(providerCfg(server.url.origin)))
+        },
+      })
+
+      await provideTestInstance({
+        directory: tmp.path,
+        fn: async () =>
+          scoped(tmp.path, async (prompt) => {
+            const closed: KiloSession.CloseReason[] = []
+            const unsubscribe = Bus.subscribe(KiloSession.Event.TurnClose, (event) => {
+              closed.push(event.properties.reason)
+            })
+
+            const session = await sessions.create({ title: "Superseded close reason" })
+            const first = Effect.runPromise(
+              prompt.prompt({
+                sessionID: session.id,
+                agent: "code",
+                parts: [{ type: "text", text: "first prompt" }],
+              }),
+            )
+
+            // A request reaching the mock implies the turn loop is running
+            // (forked title/summary calls fire from step 1 of the loop).
+            await ready.promise
+            const second = Effect.runPromise(
+              prompt.prompt({
+                sessionID: session.id,
+                agent: "code",
+                parts: [{ type: "text", text: "second prompt" }],
+              }),
+            )
+
+            // Wait until the follow-up is actually queued behind the in-flight
+            // turn, then let the first stream drain so runLoop hands off.
+            await Effect.runPromise(
+              pollWithTimeout(
+                Effect.sync(() => (KiloSessionPromptQueue.hasFollowup(session.id) ? (true as const) : undefined)),
+                "follow-up prompt never queued behind the in-flight turn",
+                "3 seconds",
+              ),
+            )
+            release.resolve()
+
+            expect((await first).info.role).toBe("assistant")
+            expect((await second).info.role).toBe("assistant")
+            // Bus delivery is a microtask chain; flush a macrotask so the last
+            // TurnClose callback lands before asserting.
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            unsubscribe()
+
+            expect(closed).toHaveLength(2)
+            // The first turn drained its stream cleanly and handed off to the
+            // queued follow-up; it must not look like a user interruption to
+            // clients (they flash a "Turn interrupted" warning on that reason).
+            expect(closed[0]).toBe("superseded")
+            expect(closed[1]).toBe("completed")
+          }),
+      })
+    } finally {
+      server.stop(true)
+    }
+  }, 20_000)
+
   test("bridges legacy instance context for prompts after a completed turn", async () => {
     const calls: number[] = []
     const server = Bun.serve({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3557,7 +3557,7 @@ export type EventSessionTurnClose = {
   properties: {
     sessionID: string
     parentID?: string
-    reason: "completed" | "error" | "interrupted"
+    reason: "completed" | "error" | "interrupted" | "superseded"
   }
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -24497,6 +24497,15 @@
             "$ref": "#/components/schemas/EventServerInstanceDisposed"
           },
           {
+            "$ref": "#/components/schemas/EventSessionTurnOpen"
+          },
+          {
+            "$ref": "#/components/schemas/EventSessionTurnClose"
+          },
+          {
+            "$ref": "#/components/schemas/EventSessionQueueChanged"
+          },
+          {
             "$ref": "#/components/schemas/EventSessionNetworkAsked"
           },
           {
@@ -24522,12 +24531,6 @@
           },
           {
             "$ref": "#/components/schemas/EventInteractive_terminalDeleted"
-          },
-          {
-            "$ref": "#/components/schemas/EventSessionTurnOpen"
-          },
-          {
-            "$ref": "#/components/schemas/EventSessionTurnClose"
           },
           {
             "$ref": "#/components/schemas/EventSandboxStatusChanged"
@@ -24557,10 +24560,10 @@
             "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
           },
           {
-            "$ref": "#/components/schemas/EventLspClientDiagnostics"
+            "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
           },
           {
-            "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
+            "$ref": "#/components/schemas/EventLspClientDiagnostics"
           },
           {
             "$ref": "#/components/schemas/EventMemoryStatus1"
@@ -24818,10 +24821,10 @@
             "$ref": "#/components/schemas/EventProjectUpdated"
           },
           {
-            "$ref": "#/components/schemas/EventLspUpdated"
+            "$ref": "#/components/schemas/EventVcsBranchUpdated"
           },
           {
-            "$ref": "#/components/schemas/EventVcsBranchUpdated"
+            "$ref": "#/components/schemas/EventLspUpdated"
           },
           {
             "$ref": "#/components/schemas/EventWorkspaceReady"
@@ -26838,7 +26841,7 @@
             "type": "object",
             "properties": {
               "start": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               }
             },
@@ -26914,11 +26917,11 @@
             "type": "object",
             "properties": {
               "start": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "end": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
               },
               "elapsed": {
@@ -27687,6 +27690,15 @@
                 "$ref": "#/components/schemas/EventServerInstanceDisposed"
               },
               {
+                "$ref": "#/components/schemas/EventSessionTurnOpen"
+              },
+              {
+                "$ref": "#/components/schemas/EventSessionTurnClose"
+              },
+              {
+                "$ref": "#/components/schemas/EventSessionQueueChanged"
+              },
+              {
                 "$ref": "#/components/schemas/EventSessionNetworkAsked"
               },
               {
@@ -27712,12 +27724,6 @@
               },
               {
                 "$ref": "#/components/schemas/EventInteractive_terminalDeleted"
-              },
-              {
-                "$ref": "#/components/schemas/EventSessionTurnOpen"
-              },
-              {
-                "$ref": "#/components/schemas/EventSessionTurnClose"
               },
               {
                 "$ref": "#/components/schemas/EventSandboxStatusChanged"
@@ -27747,10 +27753,10 @@
                 "$ref": "#/components/schemas/EventKilocodeNotebookCancelled"
               },
               {
-                "$ref": "#/components/schemas/EventLspClientDiagnostics"
+                "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
               },
               {
-                "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
+                "$ref": "#/components/schemas/EventLspClientDiagnostics"
               },
               {
                 "$ref": "#/components/schemas/EventMemoryStatus"
@@ -28008,10 +28014,10 @@
                 "$ref": "#/components/schemas/EventProjectUpdated"
               },
               {
-                "$ref": "#/components/schemas/EventLspUpdated"
+                "$ref": "#/components/schemas/EventVcsBranchUpdated"
               },
               {
-                "$ref": "#/components/schemas/EventVcsBranchUpdated"
+                "$ref": "#/components/schemas/EventLspUpdated"
               },
               {
                 "$ref": "#/components/schemas/EventWorkspaceReady"
@@ -35218,6 +35224,96 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
+      "EventSessionTurnOpen": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.turn.open"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              }
+            },
+            "required": ["sessionID"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventSessionTurnClose": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.turn.close"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "parentID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "reason": {
+                "type": "string",
+                "enum": ["completed", "error", "interrupted", "superseded"]
+              }
+            },
+            "required": ["sessionID", "reason"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventSessionQueueChanged": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.queue.changed"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "queued": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^msg"
+                }
+              }
+            },
+            "required": ["sessionID", "queued"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
       "EventSessionNetworkAsked": {
         "type": "object",
         "properties": {
@@ -35464,64 +35560,6 @@
               }
             },
             "required": ["terminalID", "sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventSessionTurnOpen": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.turn.open"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              }
-            },
-            "required": ["sessionID"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventSessionTurnClose": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.turn.close"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "parentID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "reason": {
-                "type": "string",
-                "enum": ["completed", "error", "interrupted"]
-              }
-            },
-            "required": ["sessionID", "reason"],
             "additionalProperties": false
           }
         },
@@ -35837,33 +35875,6 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
-      "EventLspClientDiagnostics": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["lsp.client.diagnostics"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "serverID": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              }
-            },
-            "required": ["serverID", "path"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
       "EventKilo-sessionsRemote-status-changed": {
         "type": "object",
         "properties": {
@@ -35885,6 +35896,33 @@
               }
             },
             "required": ["enabled", "connected"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventLspClientDiagnostics": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["lsp.client.diagnostics"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "serverID": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": ["serverID", "path"],
             "additionalProperties": false
           }
         },
@@ -39854,24 +39892,6 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
-      "EventLspUpdated": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["lsp.updated"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
       "EventVcsBranchUpdated": {
         "type": "object",
         "properties": {
@@ -39890,6 +39910,24 @@
               }
             },
             "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventLspUpdated": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["lsp.updated"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
           }
         },
         "required": ["id", "type", "properties"],


### PR DESCRIPTION
Sending a follow-up message while a session is still running queues the prompt behind the active turn. The active turn then breaks out of its loop after the current LLM step drains so the queued prompt can take over. That deliberate handoff was recorded with the turn close reason "interrupted", and the webview renders a yellow "Turn interrupted." warning card whenever a session sits idle with that close reason. Between the old turn closing and the queued turn starting there is a brief idle window, so the card flashed on screen and vanished again, suggesting a premature stop that never happened.

The queue handoff now publishes a dedicated "superseded" close reason instead of "interrupted":

- The turn-close event schema gains the new literal and the prompt loop records it on the handoff break. Memory digests still treat the cut-short turn as interrupted, and attention sounds plus the TUI indicator are unaffected (they key off "completed" and MessageAbortedError respectively).
- The extension and webview extend their close-reason unions, and the webview terminal-state logic returns no warning for superseded turns. The follow-up turn closes with its own reason right after, so no state lingers.
- Real interruptions (Esc, cancel) still close as "interrupted" and still surface the warning.

Covered by a new backend integration test that queues a follow-up mid-turn against a held-open mock LLM stream and asserts both close reasons, plus a webview unit test for the superseded terminal state.