### PR TITLE
fix(cli): promote stable releases to rc

### DIFF
--- a/.changeset/fresh-rc-upgrades.md
+++ b/.changeset/fresh-rc-upgrades.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep RC installations up to date when a newer stable CLI release is published.

--- a/packages/opencode/script/kilocode/npm-publish.ts
+++ b/packages/opencode/script/kilocode/npm-publish.ts
@@ -3,6 +3,10 @@ export namespace NpmPublish {
   const base = 10_000
   const jitter = 5_000
 
+  export function aliases(channel: string) {
+    return channel === "latest" ? ["rc"] : []
+  }
+
   export async function retry(input: {
     name: string
     version: string

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -16,18 +16,21 @@ async function publish(dir: string, name: string, version: string) {
   // GitHub artifact downloads can drop the executable bit, and Docker uses the
   // unpacked dist binaries directly rather than the published tarball.
   if (process.platform !== "win32") await $`chmod -R 755 .`.cwd(dir)
-  if (await published(name, version)) {
-    console.log(`already published ${name}@${version}`)
-    return
-  }
-  await $`bun pm pack`.cwd(dir)
   // kilocode_change start
-  await NpmPublish.retry({
-    name,
-    version,
-    run: () => $`npm publish *.tgz --access public --tag ${Script.channel} --provenance`.cwd(dir),
-    exists: () => published(name, version),
-  })
+  const exists = await published(name, version)
+  if (exists) {
+    console.log(`already published ${name}@${version}`)
+  }
+  if (!exists) {
+    await $`bun pm pack`.cwd(dir)
+    await NpmPublish.retry({
+      name,
+      version,
+      run: () => $`npm publish *.tgz --access public --tag ${Script.channel} --provenance`.cwd(dir),
+      exists: () => published(name, version),
+    })
+  }
+  for (const tag of NpmPublish.aliases(Script.channel)) await $`npm dist-tag add ${name}@${version} ${tag}`
   // kilocode_change end
 }
 

--- a/packages/opencode/test/kilocode/npm-publish.test.ts
+++ b/packages/opencode/test/kilocode/npm-publish.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test"
 import { NpmPublish } from "../../script/kilocode/npm-publish"
 
+describe("npm publish aliases", () => {
+  test("promotes stable releases to the rc channel", () => {
+    expect(NpmPublish.aliases("latest")).toEqual(["rc"])
+  })
+
+  test("does not promote prereleases", () => {
+    expect(NpmPublish.aliases("rc")).toEqual([])
+  })
+})
+
 describe("npm publish retry", () => {
   test("returns after the first successful attempt", async () => {
     const calls = { run: 0, exists: 0, sleep: 0 }


### PR DESCRIPTION
CLI installations built from the `rc` channel resolve upgrades through npm’s `rc` dist-tag. Stable publishes currently update only `latest`, which can leave RC users pinned to an older release even after a newer stable version is available.

Stable CLI publishes now also advance the `rc` alias after publishing, including idempotent workflow reruns where the package version already exists. Prerelease publishes continue to update only their own channel, so stable users remain isolated from prerelease releases.