### PR TITLE
refactor(vscode): deduplicate config snapshots

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -161,6 +161,7 @@ import { AnacondaDesktopBridge } from "./anaconda-desktop/bridge"
 import { fetchOpenAIModels, FetchModelsError } from "./shared/fetch-models"
 import type { Agent } from "@kilocode/sdk/v2/client"
 import { configFeatures } from "./features"
+import { fetchSnapshot } from "./kilo-provider/config-snapshot"
 import { createAutoApproveBridge } from "./kilo-provider/auto-approve"
 import type { KiloProviderOptions } from "./kilo-provider/options"
 import { fetchKiloEmbeddingModelCatalog } from "@kilocode/kilo-gateway"
@@ -2562,24 +2563,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const workspaceDir = this.getWorkspaceDirectory()
-      const [{ data: config }, { data: global }, { data: overlay }] = await Promise.all([
-        retry(() => this.client!.config.get({ directory: workspaceDir }, { throwOnError: true })),
-        this.client.global.config.get({ throwOnError: true }),
-        this.client.config.overlay({ directory: workspaceDir, scope: "project" }, { throwOnError: true }),
-      ])
-      this.cachedGlobalConfig = global ?? null
-
-      const message = {
-        type: "configLoaded",
-        config,
-        globalConfig: global,
-        projectConfig: overlay?.project,
-        settings: { maxCost: this.maxCostSetting(), languageCommitMessage: this.commitMessageLanguageSetting() },
-        features: configFeatures(config),
-      }
-      this.cachedConfigMessage = message
-      this.postMessage(message)
+      await this.refreshConfig("configLoaded")
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch config:", error)
     }
@@ -2673,29 +2657,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async fetchAndSendConfigUpdated(): Promise<void> {
     if (!this.client || this.connectionState !== "connected") return
     try {
-      const dir = this.getWorkspaceDirectory()
-      const [{ data: config }, { data: global }, { data: overlay }] = await Promise.all([
-        retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true })),
-        this.client.global.config.get({ throwOnError: true }),
-        this.client.config.overlay({ directory: dir, scope: "project" }, { throwOnError: true }),
-      ])
-      this.cachedGlobalConfig = global ?? null
-      this.cachedConfigMessage = {
-        type: "configLoaded",
-        config,
-        globalConfig: global,
-        projectConfig: overlay?.project,
-        settings: { maxCost: this.maxCostSetting(), languageCommitMessage: this.commitMessageLanguageSetting() },
-        features: configFeatures(config),
-      }
-      this.postMessage({
-        type: "configUpdated",
-        config,
-        globalConfig: global,
-        projectConfig: overlay?.project,
-        settings: { maxCost: this.maxCostSetting(), languageCommitMessage: this.commitMessageLanguageSetting() },
-        features: configFeatures(config),
-      })
+      await this.refreshConfig("configUpdated")
     } catch (error) {
       console.error("[Kilo New] KiloProvider: Failed to fetch config after update:", error)
     }
@@ -3064,28 +3026,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
 
     try {
-      const [{ data: merged }, { data: global }, { data: overlay }] = await Promise.all([
-        retry(() => this.client!.config.get({ directory: dir }, { throwOnError: true })),
-        this.client.global.config.get({ throwOnError: true }),
-        this.client.config.overlay({ directory: dir, scope: "project" }, { throwOnError: true }),
-      ])
-      this.cachedGlobalConfig = global ?? null
-      this.cachedConfigMessage = {
-        type: "configLoaded",
-        config: merged,
-        globalConfig: global,
-        projectConfig: overlay?.project,
-        settings: { maxCost: this.maxCostSetting(), languageCommitMessage: this.commitMessageLanguageSetting() },
-        features: configFeatures(merged),
-      }
-      this.postMessage({
-        type: "configUpdated",
-        config: merged,
-        globalConfig: global,
-        projectConfig: overlay?.project,
-        settings: { maxCost: this.maxCostSetting(), languageCommitMessage: this.commitMessageLanguageSetting() },
-        features: configFeatures(merged),
-      })
+      await this.refreshConfig("configUpdated", dir)
       this.requirements.clear()
       await Promise.all([
         refreshProviders ? this.fetchAndSendProviders() : Promise.resolve(),
@@ -3113,6 +3054,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       this.pending--
     }
   }
+
+  private async refreshConfig(type: "configLoaded" | "configUpdated", dir = this.getWorkspaceDirectory()) {
+    const snapshot = await fetchSnapshot(this.client!, dir, () => ({
+      maxCost: this.maxCostSetting(),
+      languageCommitMessage: this.commitMessageLanguageSetting(),
+    }))
+    this.cachedGlobalConfig = snapshot.globalConfig ?? null
+    this.cachedConfigMessage = { type: "configLoaded", ...snapshot }
+    this.postMessage({ type, ...snapshot })
+  }
+
   private postConfigFailure(error: unknown): void {
     console.error("[Kilo New] KiloProvider: Failed to update config:", error)
     this.postMessage({

--- a/packages/kilo-vscode/src/kilo-provider/config-snapshot.ts
+++ b/packages/kilo-vscode/src/kilo-provider/config-snapshot.ts
@@ -1,0 +1,20 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+import { configFeatures } from "../features"
+import { retry } from "../services/cli-backend/retry"
+
+type Client = Pick<KiloClient, "config" | "global">
+type Settings = { maxCost: number; languageCommitMessage: string }
+export async function fetchSnapshot(client: Client, dir: string, settings: () => Settings) {
+  const [{ data: config }, { data: global }, { data: overlay }] = await Promise.all([
+    retry(() => client.config.get({ directory: dir }, { throwOnError: true })),
+    client.global.config.get({ throwOnError: true }),
+    client.config.overlay({ directory: dir, scope: "project" }, { throwOnError: true }),
+  ])
+  return {
+    config,
+    globalConfig: global,
+    projectConfig: overlay?.project,
+    settings: settings(),
+    features: configFeatures(config),
+  }
+}

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import type { Config } from "@kilocode/sdk/v2/client"
+import { fetchSnapshot } from "../../src/kilo-provider/config-snapshot"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
 const { KiloProvider } = await import("../../src/KiloProvider")
@@ -17,6 +18,7 @@ type Internals = {
     projectUnset?: string[][],
   ) => Promise<void>
   fetchAndSendConfig: () => Promise<void>
+  fetchAndSendConfigUpdated: () => Promise<void>
   fetchAndSendProviders: () => Promise<void>
   fetchAndSendAgents: () => Promise<void>
   fetchAndSendSkills: () => Promise<void>
@@ -28,17 +30,18 @@ type Internals = {
 function createConnection() {
   let drains = 0
   const patches: unknown[] = []
+  const config = { snapshot: true }
+  const global = { snapshot: false }
+  const project = { default_agent: "code" }
   const client = {
     global: {
       config: {
-        get: async () => ({ data: {} }),
-        update: async () => ({ data: {} }),
+        get: async () => ({ data: global }),
       },
     },
     config: {
-      get: async () => ({ data: {} }),
-      update: async () => ({ data: {} }),
-      overlay: async () => ({ data: { project: {} } }),
+      get: async () => ({ data: config }),
+      overlay: async () => ({ data: { project } }),
       overlayUpdate: async (patch: unknown) => {
         patches.push(patch)
         return { data: {} }
@@ -47,6 +50,7 @@ function createConnection() {
   }
 
   return {
+    client,
     drains: () => drains,
     patches: () => patches,
     service: {
@@ -59,6 +63,29 @@ function createConnection() {
 }
 
 describe("KiloProvider indexing refresh", () => {
+  it("shares snapshot payloads across load, SSE refresh, and post-save refresh", async () => {
+    const conn = createConnection()
+    const settings = () => ({ maxCost: 0, languageCommitMessage: "sync" })
+    const snapshot = await fetchSnapshot(conn.client as never, "/repo", settings)
+    const provider = new KiloProvider({} as never, conn.service as never)
+    const internal = provider as unknown as Internals
+    const sent: unknown[] = []
+    provider.postMessage = (message) => void sent.push(message)
+    internal.connectionState = "connected"
+    await internal.fetchAndSendConfig()
+    await internal.fetchAndSendConfigUpdated()
+    await internal.handleUpdateConfig({})
+
+    expect(sent).toEqual([
+      { type: "configLoaded", ...snapshot },
+      { type: "configUpdated", ...snapshot },
+      { type: "configUpdated", ...snapshot },
+    ])
+    sent.length = 0
+    internal.connectionState = "disconnected"
+    await internal.fetchAndSendConfig()
+    expect(sent).toEqual([{ type: "configLoaded", ...snapshot }])
+  })
   it("reloadAfterAuthChange fetches config first, then indexing status", async () => {
     const provider = new KiloProvider({} as never, {} as never)
     const internal = provider as unknown as Internals

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -71,7 +71,7 @@ describe("KiloProvider indexing refresh", () => {
     const internal = provider as unknown as Internals
     const sent: unknown[] = []
     provider.postMessage = (message) => void sent.push(message)
-    internal.connectionState = "connected"
+    Object.assign(internal, { connectionState: "connected", commitMessageLanguageSetting: () => "sync" })
     await internal.fetchAndSendConfig()
     await internal.fetchAndSendConfigUpdated()
     await internal.handleUpdateConfig({})


### PR DESCRIPTION
KiloProvider independently fetched and assembled the same merged, global, and project configuration payload for initial loading, backend update events, and post-save refreshes. Maintaining those copies separately made it easy for message shape, feature derivation, or cache behavior to drift between paths.\n\nCentralize snapshot fetching and derivation behind a focused helper while leaving each caller's guards, logging, cache semantics, update type, fallback behavior, and refresh ordering intact. The shared behavioral coverage verifies that all three paths produce the same payload and that disconnected loads continue to replay the cached configLoaded message.