### PR TITLE
fix(cli): isolate model snapshot smoke auth

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -88,6 +88,7 @@ function smokeEnv(root: string) {
     XDG_STATE_HOME: path.join(root, "state"),
     KILO_DISABLE_MODELS_FETCH: "1",
     KILO_DISABLE_PROJECT_CONFIG: "1",
+    KILO_AUTH_CONTENT: "{}",
     KILO_CONFIG_CONTENT: JSON.stringify({ enabled_providers: ["anthropic"] }),
     ANTHROPIC_API_KEY: "dummy",
   }


### PR DESCRIPTION
## Summary

Set `KILO_AUTH_CONTENT` to an empty object in the compiled model snapshot smoke-test environment.

The smoke test isolates XDG data and config paths, but CLI startup also checks the real home directory for legacy auth at `~/.kilocode/cli/config.json` and migrates it into the temporary auth store. Developers with a legacy Kilo credential could therefore initialize the Kilo auth plugin while the smoke configuration enabled only Anthropic, causing provider serialization to receive an absent catalog entry and fail with `JSON Parse error: Unexpected identifier "undefined"`. Developers without that legacy file do not reproduce the failure. Explicit empty auth content keeps the smoke assertion independent of migrated developer credentials.