### PR TITLE
fix(ci): run docs-sync kilo sessions with --auto

### DIFF
--- a/.github/docs-sync/lib.mjs
+++ b/.github/docs-sync/lib.mjs
@@ -181,9 +181,13 @@ function tailText(text, { lines = STDERR_TAIL_LINES, chars = STDERR_TAIL_CHARS }
  *
  * streamStdout:true → inherit fd 1 (edit live log); false → capture stdout
  * (triage parses it). stderr is always buffered.
+ *
+ * Every call runs with --auto: this bot is headless, so nobody can answer a
+ * permission prompt — without it the CLI auto-rejects asks (e.g. `git log`)
+ * and the chunk/batch burns both retries producing nothing (run 30433266378).
  */
 export function runKilo({ args, timeoutMs, streamStdout = false, label = "kilo" }) {
-  const result = spawnSync("kilo", args, {
+  const result = spawnSync("kilo", [...args, "--auto"], {
     encoding: "utf8",
     maxBuffer: 32 * 1024 * 1024,
     timeout: timeoutMs,

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           set -o pipefail
           kilo run "The docs build or tests failed. Read the attached docs-sync-out/verify.log and fix the packages/kilo-docs changes so they pass. Do not revert doc edits; fix them. Do not modify anything outside packages/kilo-docs." \
-            -m "$EDIT_MODEL" --dir "$GITHUB_WORKSPACE" -f docs-sync-out/verify.log \
+            -m "$EDIT_MODEL" --dir "$GITHUB_WORKSPACE" -f docs-sync-out/verify.log --auto \
             | tee -a docs-sync-out/edit-log.txt
           { bun run --filter @kilocode/kilo-docs build && bun run --filter @kilocode/kilo-docs test; } 2>&1 | tee docs-sync-out/verify2.log
 


### PR DESCRIPTION
## Why

The daily docs-sync run [30433266378](https://github.com/Kilo-Org/kilocode/actions/runs/30433266378/job/90515102484) triaged 293 PRs but chunk 3 failed both attempts: the agent asked to run `git log --oneline -30 ... | head -40`, and headless `kilo run` auto-rejects every permission ask (nobody is there to answer), so the chunk produced no JSON and 25 PRs were degraded to unclassified.

## Fix

Pass `--auto` (auto-approve all permissions, built for autonomous/pipeline usage, CLI ≥ v7.4.0) to every docs-sync `kilo run` invocation:

- `.github/docs-sync/lib.mjs` — appended in the shared `runKilo` helper, covers triage + edit
- `.github/workflows/docs-sync.yml` — the verify-fix step invokes `kilo run` directly

`--auto` also approves tracked Task subagent asks and skips the headless-root mark that denies subagent permissions outright, so agents spawned by the bot get their tools too.

## Test plan

- [ ] Re-run the docs-sync workflow (`gh workflow run docs-sync.yml`) and confirm no `auto-rejecting` lines in the triage/edit steps