### PR TITLE
fix(agent-manager): keep terminal cursor visible

### DIFF
--- a/.changeset/calm-cursors-fit.md
+++ b/.changeset/calm-cursors-fit.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the Agent Manager terminal cursor visible on the bottom row.

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+const css = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/agent-manager.css"), "utf8")
+
+test("xterm owns the padding used by FitAddon", () => {
+  const host = css.match(/\.am-terminal-host\s*\{([^}]*)\}/)?.[1]
+  const term = css.match(/\.am-terminal-host \[class~="xterm"\]\s*\{([^}]*)\}/)?.[1]
+
+  expect(host).toBeDefined()
+  expect(term).toBeDefined()
+  expect(host).not.toMatch(/\bpadding\s*:/)
+  expect(term).toMatch(/\bpadding\s*:\s*8px\s*;/)
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -4687,14 +4687,15 @@ body.vscode-high-contrast-light {
   flex: 1;
   min-height: 0;
   min-width: 0;
-  padding: 8px;
   background: var(--vscode-terminal-background, #1e1e1e);
 }
 
 /* Third-party xterm classes — addressed by attribute selector so the
-   agent-manager "am-* prefix" architecture test does not flag them. */
-.am-terminal-host [class="xterm"] {
+   agent-manager "am-* prefix" architecture test does not flag them.
+   FitAddon subtracts padding from xterm itself, not its parent host. */
+.am-terminal-host [class~="xterm"] {
   height: 100%;
+  padding: 8px;
 }
 
 .am-terminal-host [class~="xterm-viewport"] {


### PR DESCRIPTION
Agent Manager applied terminal padding to the host element, while xterm FitAddon only subtracts padding declared on xterm itself. This allowed one extra row to be fitted into the panel and left the bottom cursor pressed against, or clipped by, the panel edge.

Move the existing padding onto the xterm element so FitAddon reserves it when calculating rows. The selector now matches xterm runtime class lists, and a focused contract guard prevents the padding from moving back outside the measured element.

**Before**

<img width="700" alt="Agent Manager terminal cursor touching the bottom edge before the fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260729-agent-manager-terminal-before.png?raw=true" />

**After**

<img width="700" alt="Agent Manager terminal cursor fully visible with bottom spacing after the fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260729-agent-manager-terminal-after.png?raw=true" />