### PR TITLE
docs(checkpoints): document revert banner warnings and snapshot restoration

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/checkpoints.md
@@ -100,6 +100,10 @@ Clicking **Revert to here** does two things:
 
 The button is only active when the agent is idle. While the agent is running, the button is disabled to prevent reverting mid-operation.
 
+{% callout type="note" %}
+Workspace restoration requires snapshots. If snapshots are disabled or the reverted range has no stored checkpoint, only the conversation is rewound — the agent's file changes remain on disk, and the revert banner warns you (see below).
+{% /callout %}
+
 ### The Revert Banner
 
 After reverting, a **Revert Banner** appears at the bottom of the chat. The banner shows:
@@ -112,6 +116,11 @@ The banner provides two actions:
 
 - **Redo** — Steps forward one message at a time, re-applying changes from the next reverted message
 - **Redo All** — Restores the workspace to the latest state and un-hides all messages (only shown when more than one message is reverted)
+
+If a revert could not restore your workspace files, the banner warns you that only the conversation was rewound:
+
+- **Snapshots disabled** — the banner explains that file changes were not restored because snapshots are disabled, and offers an **Enable snapshots** button that opens **Settings → Checkpoints**.
+- **No checkpoint available** — the banner explains that no file checkpoint was available, so workspace changes remain on disk (for example, when reverting a range that predates checkpoints).
 
 ### Making a Revert Permanent
 


### PR DESCRIPTION
## What changed

Added two pieces of documentation to the Checkpoints page (`packages/kilo-docs/pages/code-with-ai/features/checkpoints.md`):

1. A **note callout** explaining that workspace restoration requires snapshots. If snapshots are disabled or the reverted range has no stored checkpoint, only the conversation is rewound while the agent's file changes remain on disk.

2. A description of the **revert banner warning states** shown when a revert could not restore workspace files:
   - **Snapshots disabled** — banner explains file changes were not restored and offers an **Enable snapshots** button linking to **Settings → Checkpoints**.
   - **No checkpoint available** — banner explains no file checkpoint was available, so workspace changes remain on disk (e.g. when reverting a range that predates checkpoints).

## Why

These behaviors exist in the extension but were not documented. Users reverting when snapshots are off or for ranges lacking a checkpoint would only have their conversation rewound without the file changes being restored — documenting the banner warning states helps users understand what happened and how to enable snapshots.