### PR TITLE
docs(kilo-docs): document kilo cloud CLI usage and skill archives

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -108,7 +108,7 @@ You can customize each Cloud Agent session by also defining env vars and startup
 
 Cloud Agents support project-level [skills](/docs/code-with-ai/platforms/cli#skills) stored in your repository. When your repo is cloned, any skills in `.kilocode/skills/` are automatically available.
 
-- Skills (skill folders uploaded as `.zip` archives, with up to 40 companion files per skill)
+You can also upload skills as `.zip` archives through the Cloud UI. Each skill archive can include up to 40 companion files.
 
 {% callout type="note" %}
 Global skills (`~/.kilocode/skills/`) are not available in Cloud Agents since there is no persistent user home directory.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -106,9 +106,7 @@ You can customize each Cloud Agent session by also defining env vars and startup
 
 ## Skills
 
-Cloud Agents support project-level [skills](/docs/code-with-ai/platforms/cli#skills) stored in your repository. When your repo is cloned, any skills in `.kilocode/skills/` are automatically available.
-
-You can also upload skills as `.zip` archives through the Cloud UI. Each skill archive can include up to 40 companion files.
+Cloud Agents support project-level [skills](/docs/code-with-ai/platforms/cli#skills) stored in your repository. When your repo is cloned, any skills in `.kilocode/skills/` are automatically available. Skill folders are uploaded as `.zip` archives, with up to 40 companion files per skill.
 
 {% callout type="note" %}
 Global skills (`~/.kilocode/skills/`) are not available in Cloud Agents since there is no persistent user home directory.

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -36,6 +36,16 @@ Before using Cloud Agents:
 
 Your work is always pushed to GitHub, ensuring nothing is lost.
 
+## Starting Tasks from the CLI
+
+Use the `kilo cloud` command to run Cloud Agent tasks without opening the browser:
+
+```bash
+kilo cloud start --prompt "Fix the flaky login test" --repo Kilo-Org/kilocode
+```
+
+`kilo cloud` can start tasks, send follow-up prompts, and check task status and results. Repository, branch, model, mode, and organization are inferred from your local checkout and CLI defaults unless you pass the matching flags. Add `--stream` to `kilo cloud start` to print task events as JSONL until the task completes. See the [CLI reference](/docs/code-with-ai/platforms/cli-reference#kilo-cloud) for all commands and options.
+
 ## How Cloud Agents Work
 
 - Each user receives an **isolated Linux container** with common dev tools preinstalled (Node.js, git, gh CLI, glab CLI, etc.).
@@ -97,6 +107,8 @@ You can customize each Cloud Agent session by also defining env vars and startup
 ## Skills
 
 Cloud Agents support project-level [skills](/docs/code-with-ai/platforms/cli#skills) stored in your repository. When your repo is cloned, any skills in `.kilocode/skills/` are automatically available.
+
+- Skills (skill folders uploaded as `.zip` archives, with up to 40 companion files per skill)
 
 {% callout type="note" %}
 Global skills (`~/.kilocode/skills/`) are not available in Cloud Agents since there is no persistent user home directory.


### PR DESCRIPTION
## What

Adds two pieces of content to the Cloud Agents docs page (`packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md`):

- A new **"Starting Tasks from the CLI"** section showing how to launch Cloud Agent tasks with `kilo cloud start`, including how repo/branch/model/mode/org are inferred, the `--stream` flag, and a link to the CLI reference.
- A bullet under **Skills** noting that skill folders are uploaded as `.zip` archives with up to 40 companion files per skill.

## Why

The `kilo cloud` CLI surface for Cloud Agents was undocumented, so users had no path to script or start tasks from the terminal. The Skills section also lacked the upload/archive detail that clarifies how skills are packaged for Cloud Agents.

Built for emilieschario by [Kilo](https://kilo.ai)
