### PR TITLE
docs(kilo-docs): document JetBrains plugin settings

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/jetbrains.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/jetbrains.md
@@ -8,3 +8,11 @@ description: "Using Kilo Code in JetBrains IDEs"
 ## Installation
 
 {% partial file="install-jetbrains.md" /%}
+
+## Settings
+
+Open **Settings → Tools → Kilo Code** to configure the plugin. The JetBrains plugin reads and writes the same shared `kilo.jsonc` config files as the CLI and the VS Code extension, so changes apply across clients. See [Settings](/docs/getting-started/settings) for config file locations and precedence.
+
+- **Auto-Approve** — set per-tool permission levels (Allow / Ask / Deny) and manage granular command and path exceptions without editing config by hand. Permission prompts offer one-time approvals alongside saved allow/reject rules. See [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions) for the shared permission model.
+- **Context** — toggle auto-compaction, set the auto-compaction limit (the percentage of the model window that triggers compaction), enable pruning of old tool outputs, and manage file watcher ignore patterns. See [Context Condensing](/docs/customize/context/context-condensing) and [.kilocodeignore](/docs/customize/context/kilocodeignore) for what these settings control.
+- **Agent Behavior → Skills** — inspect loaded skills, add extra skill sources (local paths or remote URLs), edit or remove custom skills, and open skill files in the editor. See [Skills](/docs/customize/skills) for the skill format and discovery rules.


### PR DESCRIPTION
## Summary

- Add a Settings section to the JetBrains platform docs covering Auto-Approve, Context, and Agent Behavior → Skills under **Settings → Tools → Kilo Code**
- Link to shared config docs for file locations, permissions, context condensing, and skills

## Test plan

- [ ] Confirm Settings section renders on the JetBrains docs page
- [ ] Verify internal links resolve (settings, auto-approving-actions, context-condensing, kilocodeignore, skills)