### PR TITLE
fix(cli): throttle chunked compaction after rate limits

### DIFF
--- a/.changeset/quiet-compactions-wait.md
+++ b/.changeset/quiet-compactions-wait.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep long-session compaction reliable when providers rate-limit concurrent summary requests.

--- a/packages/opencode/src/kilocode/session/compaction-chunks.ts
+++ b/packages/opencode/src/kilocode/session/compaction-chunks.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Duration, Effect } from "effect"
 import type { Agent } from "@/agent/agent"
 import type { Config } from "@/config/config"
 import type { Provider } from "@/provider/provider"
@@ -7,11 +7,13 @@ import type { LLM } from "@/session/llm"
 import { MessageV2 } from "@/session/message-v2"
 import { usable } from "@/session/overflow"
 import type { SessionProcessor } from "@/session/processor"
+import { SessionRetry } from "@/session/retry"
 import { MessageID, PartID, type SessionID } from "@/session/schema"
 import type { Session } from "@/session/session"
 import { Token } from "@/util/token"
 import * as Log from "@opencode-ai/core/util/log"
 import { Database } from "@opencode-ai/core/database/database"
+import { KiloCompactionThrottle } from "./compaction-throttle"
 
 type Update = <T extends MessageV2.Part>(part: T) => Effect.Effect<T>
 type UpdateMessage = <T extends MessageV2.Info>(msg: T) => Effect.Effect<T>
@@ -22,6 +24,7 @@ const TRANSCRIPT_MAX_CHARS = 16_000
 const RATIO = 0.6
 const CONCURRENCY = 3
 const DEPTH = 3
+const EMPTY_RETRIES = 2
 const OUTPUT = 2_048
 
 export namespace KiloCompactionChunks {
@@ -34,6 +37,10 @@ export namespace KiloCompactionChunks {
     result: SessionProcessor.Result
     output: string | undefined
     error: MessageV2.Assistant["error"]
+  }
+
+  type Work = Input & {
+    throttle?: KiloCompactionThrottle.Control
   }
 
   type Deps = {
@@ -246,11 +253,17 @@ export namespace KiloCompactionChunks {
     } satisfies MessageV2.Assistant
   }
 
-  function run(input: Input & { data: LLM.StreamInput["messages"]; text: string }) {
+  function attempt(input: Work & { data: LLM.StreamInput["messages"]; text: string }) {
     return Effect.gen(function* () {
       const msg = yield* input.session.updateMessage(assistant({ base: input.target, sessionID: input.sessionID }))
       const mdl = model(input.model, input.outputTokenMax)
-      const worker = yield* input.processors.create({ assistantMessage: msg, sessionID: input.sessionID, model: mdl })
+      const worker = yield* input.processors.create({
+        assistantMessage: msg,
+        sessionID: input.sessionID,
+        model: mdl,
+        gate: input.throttle?.gate,
+        retry: input.throttle?.retry,
+      })
       const opts = input.agent.options
       // agent.options feeds into providerOptions; strip maxOutputTokens
       // so it does not leak into the wire body. The output cap is enforced
@@ -280,18 +293,36 @@ export namespace KiloCompactionChunks {
       const result = out.result
       const output = out.output
       if (result !== "continue") return { result, output: undefined, error: out.error }
-      if (!output)
-        return {
-          result: "stop" as const,
-          output: undefined,
-          error:
-            out.error ??
-            new MessageV2.APIError({
-              message: "Compaction worker returned an empty response",
-              isRetryable: true,
-            }).toObject(),
-        }
-      return { result, output, error: undefined }
+      return { result, output, error: out.error }
+    })
+  }
+
+  function empty(error: MessageV2.Assistant["error"]) {
+    return {
+      result: "stop" as const,
+      output: undefined,
+      error:
+        error ??
+        new MessageV2.APIError({
+          message: "Compaction worker returned an empty response",
+          isRetryable: true,
+        }).toObject(),
+    }
+  }
+
+  function run(input: Work & { data: LLM.StreamInput["messages"]; text: string }) {
+    return Effect.gen(function* () {
+      for (const index of Array.from({ length: EMPTY_RETRIES + 1 }, (_, index) => index)) {
+        const output = yield* attempt(input)
+        if (output.result !== "continue" || output.output) return output
+        if (index === EMPTY_RETRIES) return empty(output.error)
+
+        const wait = SessionRetry.delay(index + 1)
+        log.warn("compaction worker returned empty output; retrying", { attempt: index + 1, wait })
+        yield* Effect.sleep(Duration.millis(wait))
+      }
+
+      return empty(undefined)
     })
   }
 
@@ -313,7 +344,7 @@ export namespace KiloCompactionChunks {
     })
   }
 
-  function summarize(input: Input & { chunk: Chunk; total: number }) {
+  function summarize(input: Work & { chunk: Chunk; total: number }) {
     return Effect.gen(function* () {
       const size = budget({ cfg: input.cfg, model: input.model, outputTokenMax: input.outputTokenMax })
       const data = (yield* large({ messages: input.chunk.messages, model: input.model, size }))
@@ -343,7 +374,7 @@ export namespace KiloCompactionChunks {
   }
 
   function reduce(
-    input: Input & { summaries: string[]; depth: number },
+    input: Work & { summaries: string[]; depth: number },
   ): Effect.Effect<Output, never, Database.Service> {
     return Effect.gen(function* () {
       const result = yield* run({ ...input, data: messages({ summaries: input.summaries }), text: input.prompt })
@@ -369,9 +400,11 @@ export namespace KiloCompactionChunks {
     return Effect.gen(function* () {
       const size = budget({ cfg: input.cfg, model: input.model, outputTokenMax: input.outputTokenMax })
       const chunks = yield* split({ messages: input.messages, model: input.model, size })
+      const throttle = yield* KiloCompactionThrottle.make()
+      const work = { ...input, throttle }
       log.info("fallback", { chunks: chunks.length, concurrency: CONCURRENCY })
 
-      const partial = yield* Effect.forEach(chunks, (chunk) => summarize({ ...input, chunk, total: chunks.length }), {
+      const partial = yield* Effect.forEach(chunks, (chunk) => summarize({ ...work, chunk, total: chunks.length }), {
         concurrency: Math.min(CONCURRENCY, chunks.length),
       })
       const failed = partial.find(fatal) ?? partial.find((item) => item.result !== "continue" || !item.output)
@@ -383,7 +416,7 @@ export namespace KiloCompactionChunks {
       const final =
         chunks.length === 1 && (yield* large({ messages: chunks[0].messages, model: input.model, size }))
           ? partial[0]
-          : yield* reduce({ ...input, summaries: partial.map((item) => item.output!), depth: 0 })
+          : yield* reduce({ ...work, summaries: partial.map((item) => item.output!), depth: 0 })
       if (!final || final.result !== "continue" || !final.output) {
         if (yield* fail(input, final)) return "stop" as const
         return "compact" as const

--- a/packages/opencode/src/kilocode/session/compaction-throttle.ts
+++ b/packages/opencode/src/kilocode/session/compaction-throttle.ts
@@ -1,0 +1,94 @@
+import { Clock, Duration, Effect, Ref, Semaphore } from "effect"
+import type { KiloSessionProcessor } from "./processor"
+import type { SessionRetry } from "@/session/retry"
+import { isRecord } from "@/util/record"
+import * as Log from "@opencode-ai/core/util/log"
+
+const log = Log.create({ service: "kilocode.compaction.throttle" })
+
+type State = {
+  slow: boolean
+  next: number
+}
+
+export namespace KiloCompactionThrottle {
+  export type Retry = {
+    error?: SessionRetry.Err
+    next: number
+  }
+
+  export type Control = {
+    gate: KiloSessionProcessor.Gate
+    retry: (input: Retry) => Effect.Effect<void>
+  }
+
+  function text(error: SessionRetry.Err, key: string) {
+    if (!isRecord(error.data)) return ""
+    const value = error.data[key]
+    return typeof value === "string" ? value : ""
+  }
+
+  export function pressure(error: SessionRetry.Err) {
+    if (!isRecord(error.data)) return false
+    if (error.data.statusCode === 429) return true
+
+    const message = text(error, "message").toLowerCase()
+    if (
+      message.includes("rate increased too quickly") ||
+      message.includes("rate limit") ||
+      message.includes("too many requests") ||
+      message.includes("overloaded")
+    )
+      return true
+
+    const structured =
+      /"(?:code|type)"\s*:\s*"[^"]*(?:too_many_requests|rate_limit|resource_exhausted|overloaded|unavailable)[^"]*"/i
+    return structured.test(message) || structured.test(text(error, "responseBody"))
+  }
+
+  /**
+   * Keep the normal three-request fan-out until the provider reports pressure.
+   * Already-running attempts may finish; every later attempt and retry re-enters
+   * the shared serial gate for the remainder of this compaction.
+   */
+  export const make = Effect.fn("KiloCompactionThrottle.make")(function* () {
+    const state = yield* Ref.make<State>({ slow: false, next: 0 })
+    const lock = Semaphore.makeUnsafe(1)
+
+    const gate: KiloSessionProcessor.Gate = (effect) =>
+      Ref.get(state).pipe(
+        Effect.flatMap((current) => {
+          if (!current.slow) return effect
+          return lock.withPermits(1)(
+            Effect.gen(function* () {
+              while (true) {
+                const latest = yield* Ref.get(state)
+                const now = yield* Clock.currentTimeMillis
+                const wait = latest.next - now
+                if (wait <= 0) break
+                yield* Effect.sleep(Duration.millis(wait))
+              }
+              return yield* effect
+            }),
+          )
+        }),
+      )
+
+    const retry = (input: Retry) => {
+      if (!input.error || !pressure(input.error)) return Effect.void
+      const error = input.error
+      return Effect.gen(function* () {
+        yield* Ref.update(state, (current) => ({
+          slow: true,
+          next: Math.max(current.next, input.next),
+        }))
+        log.warn("provider pressure detected; serializing remaining compaction requests", {
+          next: input.next,
+          message: text(error, "message"),
+        })
+      })
+    }
+
+    return { gate, retry }
+  })
+}

--- a/packages/opencode/src/kilocode/session/processor.ts
+++ b/packages/opencode/src/kilocode/session/processor.ts
@@ -24,6 +24,7 @@ export type ReviewTelemetry = {
 
 export namespace KiloSessionProcessor {
   const log = Log.create({ service: "session.processor.kilo" })
+  export type Gate = <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
   export const INCOMPLETE_RESPONSE_RETRIES = 2
   export const INCOMPLETE_RESPONSE_MESSAGE =
     "The provider repeatedly ended the response before returning usable output."
@@ -46,6 +47,10 @@ export namespace KiloSessionProcessor {
     "The model hit its output limit while reasoning and produced no actionable output. Try disabling reasoning or increasing the output limit."
   export const PROVIDER_FINISH_ERROR_MESSAGE =
     "The provider ended the response with an error before returning details. Start a new message to retry; Kilo will compact the oversized conversation first if needed."
+
+  export function gated(gate: Gate | undefined) {
+    return <A, E, R>(effect: Effect.Effect<A, E, R>) => (gate ? gate(effect) : effect)
+  }
 
   export function reviewTelemetry(command: string | undefined): ReviewTelemetry | undefined {
     const cmd = reviewCommandName(command)

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -75,6 +75,8 @@ type Input = {
   // kilocode_change start
   telemetry?: ReviewTelemetry
   snapshotInitialization?: "wait"
+  gate?: KiloSessionProcessor.Gate
+  retry?: (input: { error?: SessionRetry.Err; next: number }) => Effect.Effect<void>
   // kilocode_change end
 }
 
@@ -1315,6 +1317,7 @@ export const layer = Layer.effect(
                 (cause) => !Cause.hasInterruptsOnly(cause),
                 (cause) => Effect.fail(Cause.squash(cause)),
               ),
+              KiloSessionProcessor.gated(input.gate),
               Effect.retry(
                 SessionRetry.policy({
                   provider: input.model.providerID,
@@ -1327,7 +1330,7 @@ export const layer = Layer.effect(
                   }),
                   set: (info) => {
                     if (info.attempt > 0) retries.provider += 1
-                    return setRetry(info)
+                    return (input.retry?.(info) ?? Effect.void).pipe(Effect.andThen(setRetry(info)))
                   },
                 }),
               ),

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -130,7 +130,15 @@ function parseJSON(value: unknown) {
 export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
-  set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
+  // kilocode_change start - expose normalized provider errors to adaptive request controllers
+  set: (input: {
+    attempt: number
+    message: string
+    action?: Retryable["action"]
+    next: number
+    error?: Err
+  }) => Effect.Effect<void>
+  // kilocode_change end
   // kilocode_change start
   limit?: number
   offline?: (input: { error: unknown; message: string }) => Effect.Effect<"retry" | "blocked" | "aborted">
@@ -169,6 +177,7 @@ export function policy(opts: {
           message: retry.message,
           action: retry.action,
           next: now + wait,
+          error, // kilocode_change
         })
         return [meta.attempt, Duration.millis(wait)] as [number, Duration.Duration]
       })

--- a/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
+++ b/packages/opencode/test/kilocode/session-compaction-chunks.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, describe, expect, mock, spyOn, test } from "bun:test"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import fs from "fs/promises"
 import os from "os"
@@ -25,6 +25,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { SessionCompaction } from "../../src/session/compaction"
 import * as SessionProcessorModule from "../../src/session/processor"
 import type { SessionProcessor } from "../../src/session/processor"
+import { SessionRetry } from "../../src/session/retry"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { Session as SessionNs } from "../../src/session/session"
 import { SessionStatus } from "../../src/session/status"
@@ -170,7 +171,7 @@ function reply(text: string, capture?: (input: LLM.StreamInput) => void) {
   }
 }
 
-function fakeRuntime(outputTokenMax?: number, error?: MessageV2.Assistant["error"], empty = false) {
+function fakeRuntime(outputTokenMax?: number, error?: MessageV2.Assistant["error"], empty: boolean | number = false) {
   const calls: string[] = []
   const outputs: number[] = []
   const bus = Bus.layer
@@ -204,7 +205,8 @@ function fakeRuntime(outputTokenMax?: number, error?: MessageV2.Assistant["error
                   : calls.length === 1
                     ? "chunk one"
                     : "chunk two"
-                if (!empty)
+                const missing = empty === true || (typeof empty === "number" && calls.length <= empty)
+                if (!missing)
                   yield* sessions.updatePart({
                     id: PartID.ascending(),
                     messageID: input.assistantMessage.id,
@@ -246,7 +248,7 @@ function fakeRuntime(outputTokenMax?: number, error?: MessageV2.Assistant["error
   }
 }
 
-async function failure(error?: MessageV2.Assistant["error"], empty = false) {
+async function failure(error?: MessageV2.Assistant["error"], empty: boolean | number = false) {
   await using tmp = await tmpdir()
   return provideTestInstance({
     directory: tmp.path,
@@ -263,7 +265,7 @@ async function failure(error?: MessageV2.Assistant["error"], empty = false) {
         }),
       )
 
-      const { rt } = fakeRuntime(undefined, error, empty)
+      const { rt, calls } = fakeRuntime(undefined, error, empty)
       try {
         const msgs = await svc.messages({ sessionID: session.id })
         const parent = msgs.at(-1)?.info.id
@@ -280,7 +282,8 @@ async function failure(error?: MessageV2.Assistant["error"], empty = false) {
         )
         const all = await svc.messages({ sessionID: session.id })
         const summary = all.find((msg) => msg.info.role === "assistant" && msg.info.summary)
-        return { result, summary }
+        const temporary = all.filter((msg) => msg.info.role === "assistant" && !msg.info.summary)
+        return { result, summary, calls, temporary }
       } finally {
         await rt.dispose()
       }
@@ -401,9 +404,12 @@ describe("KiloCompactionChunks", () => {
   })
 
   test("reports empty chunk worker responses as API errors", async () => {
+    const delay = spyOn(SessionRetry, "delay").mockReturnValue(0)
     const result = await failure(undefined, true)
 
     expect(result.result).toBe("stop")
+    expect(result.calls).toHaveLength(3)
+    expect(result.temporary).toHaveLength(0)
     expect(result.summary?.info.role).toBe("assistant")
     if (result.summary?.info.role !== "assistant") return
     expect(result.summary.info.finish).toBe("error")
@@ -411,6 +417,18 @@ describe("KiloCompactionChunks", () => {
     if (result.summary.info.error?.name !== "APIError") return
     expect(result.summary.info.error.data.message).toBe("Compaction worker returned an empty response")
     expect(result.summary.info.error.data.isRetryable).toBe(true)
+    delay.mockRestore()
+  })
+
+  test("retries empty chunk worker responses before failing compaction", async () => {
+    const delay = spyOn(SessionRetry, "delay").mockReturnValue(0)
+    const result = await failure(undefined, 1)
+
+    expect(result.result).toBe("continue")
+    expect(result.calls).toHaveLength(2)
+    expect(result.temporary).toHaveLength(0)
+    expect(result.summary?.parts.find((part) => part.type === "text")?.text).toBe("chunk two")
+    delay.mockRestore()
   })
 
   test("falls back to chunk workers after the first compaction overflows", async () => {

--- a/packages/opencode/test/kilocode/session-compaction-throttle.test.ts
+++ b/packages/opencode/test/kilocode/session-compaction-throttle.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect } from "bun:test"
+import { Clock, Deferred, Effect, Fiber, Ref } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { KiloCompactionThrottle } from "../../src/kilocode/session/compaction-throttle"
+import { MessageV2 } from "../../src/session/message-v2"
+import { it } from "../lib/effect"
+
+function api(input: { message: string; statusCode?: number; responseBody?: string }) {
+  return new MessageV2.APIError({
+    ...input,
+    isRetryable: true,
+  }).toObject()
+}
+
+describe("KiloCompactionThrottle", () => {
+  it.effect("starts concurrently then serializes requests after provider pressure", () =>
+    Effect.gen(function* () {
+      const throttle = yield* KiloCompactionThrottle.make()
+      const active = yield* Ref.make(0)
+      const peak = yield* Ref.make(0)
+      const ready = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const concurrent = throttle.gate(
+        Effect.gen(function* () {
+          const count = yield* Ref.modify(active, (value) => [value + 1, value + 1])
+          yield* Ref.update(peak, (value) => Math.max(value, count))
+          if (count === 3) yield* Deferred.succeed(ready, undefined)
+          yield* Deferred.await(release)
+        }).pipe(Effect.ensuring(Ref.update(active, (value) => value - 1))),
+      )
+      const first = yield* Effect.forEach([0, 1, 2], () => concurrent, { concurrency: 3 }).pipe(Effect.forkChild)
+
+      yield* Deferred.await(ready)
+      expect(yield* Ref.get(peak)).toBe(3)
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(first)
+
+      yield* throttle.retry({
+        error: api({ message: "Too many requests", statusCode: 429 }),
+        next: 0,
+      })
+
+      const order = yield* Ref.make(0)
+      const signals = yield* Effect.forEach([0, 1, 2], () => Deferred.make<void>())
+      const releases = yield* Effect.forEach([0, 1, 2], () => Deferred.make<void>())
+      const serial = throttle.gate(
+        Effect.gen(function* () {
+          const index = yield* Ref.modify(order, (value) => [value, value + 1])
+          yield* Deferred.succeed(signals[index], undefined)
+          yield* Deferred.await(releases[index])
+        }),
+      )
+      const second = yield* Effect.forEach([0, 1, 2], () => serial, { concurrency: 3 }).pipe(Effect.forkChild)
+
+      yield* Deferred.await(signals[0])
+      yield* Effect.yieldNow
+      expect(yield* Ref.get(order)).toBe(1)
+      yield* Deferred.succeed(releases[0], undefined)
+      yield* Deferred.await(signals[1])
+      expect(yield* Ref.get(order)).toBe(2)
+      yield* Deferred.succeed(releases[1], undefined)
+      yield* Deferred.await(signals[2])
+      expect(yield* Ref.get(order)).toBe(3)
+      yield* Deferred.succeed(releases[2], undefined)
+      yield* Fiber.join(second)
+    }),
+  )
+
+  it.effect("holds serialized requests until the shared retry deadline", () =>
+    Effect.gen(function* () {
+      const throttle = yield* KiloCompactionThrottle.make()
+      const done = yield* Deferred.make<void>()
+      const now = yield* Clock.currentTimeMillis
+      yield* throttle.retry({
+        error: api({ message: "Rate limit exceeded", statusCode: 429 }),
+        next: now + 1_000,
+      })
+
+      const fiber = yield* throttle.gate(Deferred.succeed(done, undefined)).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      expect(yield* Deferred.isDone(done)).toBe(false)
+
+      yield* TestClock.adjust("999 millis")
+      expect(yield* Deferred.isDone(done)).toBe(false)
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(fiber)
+      expect(yield* Deferred.isDone(done)).toBe(true)
+    }),
+  )
+
+  it.effect("honors retry deadline extensions while a request is waiting", () =>
+    Effect.gen(function* () {
+      const throttle = yield* KiloCompactionThrottle.make()
+      const done = yield* Deferred.make<void>()
+      const now = yield* Clock.currentTimeMillis
+      const error = api({ message: "Rate limit exceeded", statusCode: 429 })
+      yield* throttle.retry({ error, next: now + 1_000 })
+
+      const fiber = yield* throttle.gate(Deferred.succeed(done, undefined)).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("500 millis")
+      yield* throttle.retry({ error, next: now + 2_000 })
+
+      yield* TestClock.adjust("500 millis")
+      expect(yield* Deferred.isDone(done)).toBe(false)
+      yield* TestClock.adjust("999 millis")
+      expect(yield* Deferred.isDone(done)).toBe(false)
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(fiber)
+      expect(yield* Deferred.isDone(done)).toBe(true)
+    }),
+  )
+
+  it.effect("only treats explicit provider pressure as a throttle signal", () =>
+    Effect.sync(() => {
+      expect(KiloCompactionThrottle.pressure(api({ message: "busy", statusCode: 429 }))).toBe(true)
+      expect(
+        KiloCompactionThrottle.pressure(
+          api({
+            message: "request failed",
+            responseBody: '{"error":{"code":"RESOURCE_EXHAUSTED"}}',
+          }),
+        ),
+      ).toBe(true)
+      expect(
+        KiloCompactionThrottle.pressure(api({ message: '{"type":"error","error":{"type":"too_many_requests"}}' })),
+      ).toBe(true)
+      expect(KiloCompactionThrottle.pressure(api({ message: "Provider is overloaded" }))).toBe(true)
+      expect(KiloCompactionThrottle.pressure(api({ message: "Service unavailable", statusCode: 503 }))).toBe(false)
+      expect(KiloCompactionThrottle.pressure(api({ message: "Network connection reset" }))).toBe(false)
+    }),
+  )
+})

--- a/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
+++ b/packages/opencode/test/kilocode/session-processor-retry-limit.test.ts
@@ -182,10 +182,21 @@ describe("session processor retry limit", () => {
             yield* session.updateMessage(msg)
 
             const mdl = model()
+            const hooks = { gate: 0, retry: 0 }
             const handle = yield* processors.create({
               assistantMessage: msg,
               sessionID: chat.id,
               model: mdl,
+              gate: (effect) =>
+                Effect.sync(() => {
+                  hooks.gate++
+                }).pipe(Effect.andThen(effect)),
+              retry: (info) =>
+                Effect.sync(() => {
+                  expect(info.error && MessageV2.APIError.isInstance(info.error)).toBe(true)
+                  if (info.error && MessageV2.APIError.isInstance(info.error)) expect(info.error.data.statusCode).toBe(429)
+                  hooks.retry++
+                }),
             })
 
             const input: LLM.StreamInput = {
@@ -205,6 +216,7 @@ describe("session processor retry limit", () => {
 
               expect(result).toBe("stop")
               expect(calls).toBe(3)
+              expect(hooks).toEqual({ gate: 3, retry: 2 })
               expect(handle.message.error).toStrictEqual(expected)
             } finally {
               delay.mockRestore()


### PR DESCRIPTION
Fixes #12628.

## What changed

- Keep chunked compaction's normal fan-out at up to three requests.
- When a provider reports explicit pressure (HTTP 429, rate-limit/overload messages, or structured `too_many_requests`, `rate_limit`, `RESOURCE_EXHAUSTED`, or `unavailable` codes), serialize the remaining requests and retries for that compaction.
- Share the provider retry deadline across workers, including `Retry-After`, so they do not wake and retry as another burst.
- Retry successful-but-empty compaction workers twice with fresh temporary messages, cleaning each worker before the next attempt.
- Keep generic 5xx and network failures from lowering concurrency, and preserve all-or-nothing summary assembly.

## Root cause

The chunk fallback used a fixed concurrency of three while each worker owned an independent provider retry loop. On request-limited models, concurrent 429 responses made those workers sleep independently and then retry together, recreating the same burst that triggered the limit. Separately, a worker that completed without text was converted immediately into `Compaction worker returned an empty response`, even though a fresh attempt could recover.

The adaptive controller is scoped to one compaction, so a later compaction starts at normal concurrency again. It is driven by provider pressure rather than free/paid model metadata and adds no new user configuration.

## Validation

- `bun test --timeout 15000 ./test/kilocode/session-compaction-throttle.test.ts ./test/kilocode/session-compaction-chunks.test.ts ./test/kilocode/session-processor-retry-limit.test.ts` (19 passed)
- CLI and monorepo TypeScript checks, including the JetBrains Gradle typecheck
- `bun run lint`
- `bun run script/check-opencode-annotations.ts --worktree`
