### PR TITLE
fix(cli): settle signal-terminated bash commands

### DIFF
--- a/.changeset/swift-shells-settle.md
+++ b/.changeset/swift-shells-settle.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Return promptly with a failed exit status when Bash commands terminate from a signal.

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -626,7 +626,13 @@ export const ShellTool = Tool.define(
           const timeout = Effect.sleep(`${CommandTimeout.duration(input.timeout)} millis`) // kilocode_change
 
           const exit = yield* Effect.raceAll([
-            handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
+            // kilocode_change start - signal termination has no numeric exit code; settle it as failure
+            // instead of leaving raceAll waiting for the abort or timeout branches.
+            handle.exitCode.pipe(
+              Effect.catch(() => Effect.succeed(1)),
+              Effect.map((code) => ({ kind: "exit" as const, code })),
+            ),
+            // kilocode_change end
             abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
             timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
           ])

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -629,6 +629,7 @@ export const ShellTool = Tool.define(
             // kilocode_change start - signal termination has no numeric exit code; settle it as failure
             // instead of leaving raceAll waiting for the abort or timeout branches.
             handle.exitCode.pipe(
+              Effect.tapError((error) => Effect.logWarning("failed to read shell exit code", { error })),
               Effect.catch(() => Effect.succeed(1)),
               Effect.map((code) => ({ kind: "exit" as const, code })),
             ),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -190,6 +190,25 @@ describe("tool.shell", () => {
     ),
   )
 
+  // kilocode_change start
+  if (process.platform !== "win32") {
+    it.live("settles when the shell exits from a signal", () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          const result = yield* run({
+            command: "kill -SEGV $$",
+            description: "Terminate the shell with SIGSEGV",
+            timeout: 60_000,
+          }).pipe(Effect.timeout("5 seconds"))
+          expect(result.metadata.exit).toBeGreaterThan(0)
+          expect(result.output).not.toContain("exceeding timeout")
+        }),
+      ),
+    )
+  }
+  // kilocode_change end
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
## Issue

Fixes #12677

## Context

When a command terminated the shell with a signal such as `SIGSEGV`, the process exit effect failed without producing a numeric exit code. The Bash tool passed that effect directly to `Effect.raceAll`, which continued waiting for the abort or timeout branches after the exit branch failed. As a result, the tool appeared to hang instead of reporting command failure.

## Implementation

Convert expected exit-code lookup failures into a non-zero command status before entering the race. This lets signal-terminated commands settle immediately while preserving the existing abort, timeout, output-drain, and process-cleanup behavior.

A regression test terminates the real shell with `SIGSEGV` and verifies that the tool completes with a failed status instead of waiting for its configured timeout.

## Screenshots / Video

N/A — this is a non-visual CLI process-lifecycle fix.

## How to Test

### Manual/local verification

- Agent-executed: `bun test test/tool/shell.test.ts` in `packages/opencode` — 24 passed.
- Agent-executed: `bun run typecheck` in `packages/opencode` — passed.
- Agent-executed: repository pre-push type-check — all 22 non-JetBrains packages and the JetBrains package passed.
- Agent-executed: `bun run lint` at the repository root — completed with 0 errors and existing warnings only.
- Agent-executed: `bun run script/check-opencode-annotations.ts --worktree` — passed.

### Reviewer test steps

1. Invoke the Bash tool with `kill -SEGV $$` on Linux or macOS.
2. Confirm the tool returns promptly with a non-zero exit status.
3. Confirm it does not wait for the configured Bash timeout.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Please reach out through GitHub on this PR.
