### PR TITLE
fix(core): include underlying reason in ripgrep execution failures

### DIFF
--- a/.changeset/ripgrep-error-detail.md
+++ b/.changeset/ripgrep-error-detail.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Include the underlying reason in search execution failures instead of showing a bare "ripgrep execution failed" message.

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -165,11 +165,13 @@ export const layer = Layer.effect(
       )
       const abortable = input.signal ? program.pipe(Effect.raceFirst(waitForAbort(input.signal))) : program
       return abortable.pipe(
-        Effect.mapError((cause) =>
-          cause instanceof Error || cause instanceof InvalidPatternError
-            ? cause
-            : failure("ripgrep execution failed", cause),
-        ),
+        // kilocode_change start - surface the underlying reason instead of a bare wrapper message
+        Effect.mapError((cause) => {
+          if (cause instanceof Error || cause instanceof InvalidPatternError) return cause
+          const detail = cause instanceof globalThis.Error && cause.message.trim() ? `: ${cause.message.trim()}` : ""
+          return failure(`ripgrep execution failed${detail}`, cause)
+        }),
+        // kilocode_change end
       )
     }
 

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -61,4 +61,18 @@ describe("Ripgrep", () => {
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
+
+  // kilocode_change start - surfaced error keeps the underlying reason
+  it.live("includes the underlying reason in execution failures", () =>
+    Effect.gen(function* () {
+      const ripgrep = yield* Ripgrep.Service
+      const controller = new AbortController()
+      controller.abort()
+      const error = yield* ripgrep
+        .find({ cwd: process.cwd(), pattern: "*", limit: 1, signal: controller.signal })
+        .pipe(Effect.flip)
+      expect(error.message).toMatch(/^ripgrep execution failed: .+/)
+    }),
+  )
+  // kilocode_change end
 })


### PR DESCRIPTION
## What

Surfaced search errors now include the underlying reason: the catch-all error wrapper in `packages/core/src/ripgrep.ts` appends the cause's message (e.g. `ripgrep execution failed: The operation was aborted.`) instead of the bare `ripgrep execution failed`.

## Why

The wrapper stored the real cause in the error's `cause` field, but every display surface — the VS Code error banner, logs, model-facing tool errors — only propagates `error.message` (via `MessageV2.fromError` → `session.error` SSE event → webview `ErrorDisplay`). Users hitting spawn failures, aborted searches, or spawn-validation rejections saw an opaque message with no actionable detail.

Classified errors (non-zero exit codes with stderr, invalid regex, malformed JSON output) already carry specific messages and pass through unchanged; only the generic wrapper gains the detail.

## Tests

Added a regression test in `packages/core/test/ripgrep.test.ts` asserting the wrapped message keeps the underlying reason.