### PR TITLE
docs: clarify MiniMax coding plan usage availability

### DIFF
--- a/packages/kilo-docs/pages/gateway/authentication.md
+++ b/packages/kilo-docs/pages/gateway/authentication.md
@@ -97,7 +97,6 @@ BYOK lets you use your own provider API keys with the Kilo AI Gateway. When a BY
 | Kimi Code | `kimi-coding` |
 | Martian | `martian` |
 | MiniMax Coding Plan (minimax.io) | `minimax-coding-plan` |
-| MiniMax Coding Plan (minimaxi.com) | `minimax-cn-coding-plan` |
 | Neuralwatt | `neuralwatt` |
 | Ollama Cloud | `ollama-cloud` |
 | OpenCode Go | `opencode-go` |

--- a/packages/kilo-docs/pages/gateway/authentication.md
+++ b/packages/kilo-docs/pages/gateway/authentication.md
@@ -96,6 +96,8 @@ BYOK lets you use your own provider API keys with the Kilo AI Gateway. When a BY
 | Inceptron BYOK | `inceptron-byok` |
 | Kimi Code | `kimi-coding` |
 | Martian | `martian` |
+| MiniMax Coding Plan (minimax.io) | `minimax-coding-plan` |
+| MiniMax Coding Plan (minimaxi.com) | `minimax-cn-coding-plan` |
 | Neuralwatt | `neuralwatt` |
 | Ollama Cloud | `ollama-cloud` |
 | OpenCode Go | `opencode-go` |
@@ -110,7 +112,7 @@ BYOK lets you use your own provider API keys with the Kilo AI Gateway. When a BY
 1. Add your provider API key in the [Kilo dashboard](https://app.kilo.ai) or through your Kilo Code extension settings
 2. Keys are encrypted at rest using AES-256 encryption
 3. When you make a request for a model from that provider, the gateway automatically uses your key
-4. Usage is tracked but not billed to your Kilo balance (cost is set to $0)
+4. Usage is tracked but not billed to your Kilo balance (cost is set to $0). Usage information for MiniMax Coding Plan requests is unavailable until MiniMax exposes a usage API
 5. If your BYOK key fails, the request will not automatically fall back to Kilo's keys
 
 BYOK keys can be configured at the personal level or at the organization level. Organization-level keys apply to all members of the organization and require owner or billing manager access to manage.

--- a/packages/kilo-docs/pages/gateway/streaming.md
+++ b/packages/kilo-docs/pages/gateway/streaming.md
@@ -20,7 +20,7 @@ Set `stream: true` in your request body to enable streaming:
 ```
 
 {% callout type="info" %}
-The gateway automatically injects `stream_options.include_usage = true` on all streaming requests, so you always receive token usage information in the final chunk.
+The gateway automatically injects `stream_options.include_usage = true` on all streaming requests, so you receive token usage information in the final chunk when the upstream provider returns it. Usage information for MiniMax Coding Plan requests is unavailable until MiniMax exposes a usage API.
 {% /callout %}
 
 ## Streaming with the Vercel AI SDK

--- a/packages/kilo-docs/pages/gateway/usage-and-billing.md
+++ b/packages/kilo-docs/pages/gateway/usage-and-billing.md
@@ -117,6 +117,10 @@ Paid model requests are not rate-limited by the gateway itself, but may be rate-
 
 Usage data is tracked per request and includes:
 
+{% callout type="info" %}
+Usage information for MiniMax Coding Plan requests is unavailable until MiniMax exposes a usage API.
+{% /callout %}
+
 | Field | Description |
 |---|---|
 | `model` | Model ID used |

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -10,7 +10,7 @@ Bring Your Own Key (BYOK) lets you use your own API keys when using the Kilo Gat
 A user or organization may want to use BYOK to:
 
 - Utilize new models quickly, Kilo Gateway supports most new models in minutes
-- Use subscriptions with third-party AI providers, for example the [Z.ai Coding Plan](https://z.ai/subscribe), [Kimi Code](https://platform.moonshot.ai/), or the [BytePlus Coding Plan](https://www.byteplus.com/)
+- Use subscriptions with third-party AI providers, for example the [Z.ai Coding Plan](https://z.ai/subscribe), [Kimi Code](https://platform.moonshot.ai/), the [MiniMax Coding Plan](https://platform.minimax.io/docs/coding-plan/intro), or the [BytePlus Coding Plan](https://www.byteplus.com/)
 - Attribute usage against existing provider commitments or agreements
 - Use existing credits with a provider
 
@@ -28,7 +28,7 @@ Use your provider API key to route matching models through your account:
 - Fireworks
 - Google AI Studio
 - Inception
-- Minimax
+- MiniMax
 - Mistral AI
 - Moonshot AI (Kimi)
 - Novita
@@ -47,6 +47,8 @@ These providers offer coding-focused subscriptions or dedicated endpoints. Bring
 - Inceptron BYOK
 - Kimi Code
 - Martian
+- MiniMax Coding Plan (minimax.io)
+- MiniMax Coding Plan (minimaxi.com)
 - Mistral Codestral
 - Neuralwatt
 - Ollama Cloud
@@ -92,7 +94,8 @@ Your IAM user or role must have the following permissions:
 - When you use the **Kilo Gateway** provider, Kilo checks if there's a BYOK key for the selected model's provider.
 - If a matching BYOK key exists, the request is routed using your key.
 - If the key is invalid, the request fails. It does not fall back to using Kilo's keys.
-- Subscription-based providers (such as the Z.ai Coding Plan or Kimi Code) only expose the models included in that plan. Select one of those models to route traffic through your subscription.
+- Subscription-based providers (such as the Z.ai Coding Plan, Kimi Code, or MiniMax Coding Plan) only expose the models included in that plan. Select one of those models to route traffic through your subscription.
+- Usage information for MiniMax Coding Plan requests is unavailable until MiniMax exposes a usage API.
 
 ## Using BYOK in the Extensions and CLI
 

--- a/packages/kilo-docs/pages/getting-started/byok.md
+++ b/packages/kilo-docs/pages/getting-started/byok.md
@@ -48,7 +48,6 @@ These providers offer coding-focused subscriptions or dedicated endpoints. Bring
 - Kimi Code
 - Martian
 - MiniMax Coding Plan (minimax.io)
-- MiniMax Coding Plan (minimaxi.com)
 - Mistral Codestral
 - Neuralwatt
 - Ollama Cloud


### PR DESCRIPTION
## Issue

No linked issue; docs clarification requested directly.

## Context

MiniMax coding plans were missing from the BYOK coding-plan documentation, and the usage docs implied token usage is always available. This clarifies that MiniMax coding-plan usage information is currently unavailable until MiniMax exposes a usage API.

## Implementation

Updated the BYOK and Gateway docs to list both MiniMax coding-plan variants and added the same usage-availability caveat near existing BYOK, billing, and streaming usage guidance.

<details>
<summary>Pattern followed</summary>

The new entries follow the existing BYOK provider tables and subscription-plan lists, and the caveat uses the existing docs callout style where broader usage data is described.

</details>

## Screenshots / Video

N/A, docs copy only.

## How to Test

### Manual/local verification

- Agent ran `bun run script/check-md-table-padding.ts` and confirmed markdown tables remain unpadded.

### Reviewer test steps

1. Review the updated BYOK and Gateway docs pages.
2. Confirm MiniMax coding-plan entries and the usage-unavailable caveat are present.

### Blocked checks and substitute verification

- No blocked checks.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch