### PR TITLE
fix(agent-manager): make Cmd+/ terminal toggle reliable and sidebar-safe

### DIFF
--- a/.changeset/agent-manager-terminal-shortcut-focus.md
+++ b/.changeset/agent-manager-terminal-shortcut-focus.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make Cmd/Ctrl+/ toggle the Agent Manager terminal even when the webview keybinding forwarding drops the key while the prompt input is focused, and stop it from triggering the Agent Manager terminal while the Kilo sidebar is focused.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -678,7 +678,7 @@
         "command": "kilo-code.new.agentManager.showTerminal",
         "key": "ctrl+/",
         "mac": "cmd+/",
-        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+        "when": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' && !kilo-code.new.sidebarFocused"
       },
       {
         "command": "kilo-code.new.agentManager.runScript",

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
@@ -99,6 +99,35 @@ describe("Agent Manager side terminal controller", () => {
     expect(panelFirst.calls.openVscode).toBe(0)
   })
 
+  it("handles Cmd/Ctrl+/ presses locally and dedupes the extension echo", () => {
+    const press = (key: string, opts: Partial<KeyboardEvent> = {}) =>
+      ({ key, metaKey: true, ctrlKey: false, shiftKey: false, altKey: false, ...opts }) as KeyboardEvent
+
+    const item = scene({ destination: "agentManager" })
+    expect(item.ctl.press(press("/"))).toBe(true)
+    expect(item.calls.requestSide).toBe(1)
+    // The extension echoes the same keypress back as an action message;
+    // it must be ignored so the panel does not toggle twice.
+    expect(item.ctl.echo()).toBe(true)
+
+    // Unrelated keys and modifier combinations are not the shortcut.
+    const other = scene({ destination: "agentManager" })
+    expect(other.ctl.press(press("?"))).toBe(false)
+    expect(other.ctl.press(press("/", { shiftKey: true }))).toBe(false)
+    expect(other.ctl.press(press("/", { altKey: true }))).toBe(false)
+    expect(other.ctl.press(press("/", { metaKey: false }))).toBe(false)
+    expect(other.ctl.press(press("/", { metaKey: false, ctrlKey: true }))).toBe(true)
+    expect(other.calls.requestSide).toBe(1)
+  })
+
+  it("stops deduping after the echo window passes", async () => {
+    const item = scene({ destination: "agentManager" })
+    item.ctl.press({ key: "/", metaKey: true } as KeyboardEvent)
+    expect(item.ctl.echo()).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 550))
+    expect(item.ctl.echo()).toBe(false)
+  })
+
   it("persists the picked destination with a section-relative settings key", () => {
     const item = scene()
     item.ctl.choose("agentManager")

--- a/packages/kilo-vscode/tests/unit/extension-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/extension-arch.test.ts
@@ -127,7 +127,7 @@ describe("Extension — package.json command sync", () => {
     expect(terminal).toMatchObject({
       key: "ctrl+/",
       mac: "cmd+/",
-      when: "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'",
+      when: "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel' && !kilo-code.new.sidebarFocused",
     })
     expect(create).toMatchObject({
       key: "ctrl+shift+t",

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -935,7 +935,7 @@ const AgentManagerContent: Component = () => {
           requestAnimationFrame(() => sidebarSearchMenu?.open())
         }
       } else if (msg.action === "showTerminal") {
-        sideCtl.openPreferred("keyboard_shortcut")
+        if (!sideCtl.echo()) sideCtl.openPreferred("keyboard_shortcut")
       } else if (msg.action === "toggleDiff") {
         if (reviewActive()) {
           closeReviewTab()
@@ -992,6 +992,13 @@ const AgentManagerContent: Component = () => {
       }
     }
     window.addEventListener("keydown", preventDefaults, true)
+
+    // Cmd/Ctrl+/ toggles the terminal even when VS Code's webview keybinding
+    // forwarding drops the key before it reaches the workbench (reported with
+    // the prompt input focused). When forwarding does work, the extension
+    // echoes the shortcut back as an action message and sideCtl dedupes it.
+    const shortcut = (e: KeyboardEvent) => sideCtl.press(e)
+    window.addEventListener("keydown", shortcut, true)
 
     // Delete/Backspace on a selected worktree triggers inline delete confirmation.
     // Pressing the key twice in a row (within the 2500ms window) confirms the delete.
@@ -1352,6 +1359,7 @@ const AgentManagerContent: Component = () => {
     onCleanup(() => {
       window.removeEventListener("message", handler)
       window.removeEventListener("keydown", preventDefaults, true)
+      window.removeEventListener("keydown", shortcut, true)
       window.removeEventListener("keydown", deleteKeyHandler)
       window.removeEventListener("keydown", modTrack, true)
       window.removeEventListener("keyup", modTrack, true)

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
@@ -159,5 +159,26 @@ export function createSideTerminal(deps: SideTerminalDeps) {
     setDestination(target)
   }
 
-  return { destination, syncDefault, toggle, close, openPreferred, choose }
+  /**
+   * Cmd/Ctrl+/ pressed while the webview holds DOM focus. VS Code normally
+   * forwards the keybinding to the workbench too, and the extension echoes
+   * it back as a showTerminal action message; `echo()` lets the action
+   * handler skip that duplicate so one keypress never toggles twice.
+   * Handling the key locally keeps the shortcut working when the
+   * forwarding path drops it (e.g. the chat prompt input is focused).
+   */
+  let lastPress = 0
+  const ECHO_MS = 500
+
+  const press = (e: KeyboardEvent): boolean => {
+    if (e.key !== "/" || !(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return false
+    lastPress = Date.now()
+    openPreferred("keyboard_shortcut")
+    return true
+  }
+
+  /** True while an incoming showTerminal action is the echo of `press`. */
+  const echo = () => Date.now() - lastPress < ECHO_MS
+
+  return { destination, syncDefault, toggle, close, openPreferred, choose, press, echo }
 }


### PR DESCRIPTION
Cmd+/ (Agent Manager: Focus Terminal) had two focus-related problems:

1. With the Agent Manager panel open, pressing Cmd+/ while its prompt input was focused could silently do nothing. The shortcut relied solely on VS Code's webview keybinding forwarding (webview keydown -> preload -> emulated dispatch on the workbench), and that chain can drop the key before the `kilo-code.new.agentManager.showTerminal` binding ever fires. The same keypress typed into the Kilo sidebar worked, because that path dispatches at the workbench level, which made the failure look arbitrary.
2. Once the shortcut did fire from the Kilo sidebar, it hijacked the key for the Agent Manager: the binding's `when` clause is true whenever the Agent Manager panel is the active editor, even while typing in the sidebar. With the embedded terminal destination that meant the panel's terminal visibly flickered open/closed on a key that had nothing to do with the Agent Manager.

The Agent Manager webview now handles Cmd/Ctrl+/ itself via a capture-phase keydown listener and routes it through the same `openPreferred("keyboard_shortcut")` path as the toolbar button and the VS Code command. When VS Code's forwarding does work, the extension echoes the shortcut back as a `showTerminal` action message; a short dedup window suppresses that echo so one keypress never toggles twice (which would instantly re-hide the embedded terminal).

The keybinding's `when` clause now additionally requires `!kilo-code.new.sidebarFocused`, the context key the sidebar already maintains for `cycleAgentMode`. Pressing Cmd+/ while the Kilo sidebar is focused no longer touches the Agent Manager, while presses from the Agent Manager panel or a focused integrated terminal (via `terminal.integrated.commandsToSkipShell`) keep working.