### PR TITLE
fix(vscode): list past chats across the worktree family

### DIFF
--- a/.changeset/past-chats-worktree-family.md
+++ b/.changeset/past-chats-worktree-family.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the `@` "Past chats" picker in Agent Manager showing only the current session's directory. It now lists previous sessions across the whole worktree family — the local workspace and every Agent Manager worktree — each labeled with its worktree name, matching the Agent Manager session search. Any listed session can be attached as context, including chats from other worktrees of the same repository.

--- a/packages/kilo-vscode/src/kilo-provider/session-search.ts
+++ b/packages/kilo-vscode/src/kilo-provider/session-search.ts
@@ -4,6 +4,7 @@ type Item = {
   id: string
   title: string
   updated: number
+  worktreeName?: string
 }
 
 type Message = {
@@ -22,11 +23,14 @@ type Input = {
 }
 
 /**
- * Past-chat mention search. Lists root sessions for the directory the current
- * chat runs in (workspace root for the sidebar, the worktree for Agent Manager
- * sessions) — the same directory-scoped `session.list` the session history and
- * Agent Manager search are built on. Fuzzy title filtering happens in the
- * webview (same mechanism as the Agent Manager sidebar search).
+ * Past-chat mention search. Lists root sessions across the current directory's
+ * worktree family (the repo root and its sibling worktrees for git projects,
+ * just the directory itself otherwise) — the same family-wide listing the
+ * Agent Manager session search and the CLI's past-chat picker are built on.
+ * Every session in the family shares the project, so any of them can be
+ * attached regardless of which worktree the current chat runs in. Fuzzy title
+ * filtering happens in the webview (same mechanism as the Agent Manager
+ * sidebar search).
  */
 export async function handleSessionSearch(input: Input): Promise<void> {
   const client = input.client
@@ -39,10 +43,18 @@ export async function handleSessionSearch(input: Input): Promise<void> {
   const dir = input.dir(id)
 
   try {
-    const res = await client.session.list({ directory: dir, roots: true, limit: 50 }, { throwOnError: true })
+    const res = await client.experimental.session.list(
+      { worktrees: true, roots: true, directory: dir, limit: 50 },
+      { throwOnError: true },
+    )
     const sessions: Item[] = res.data
       .filter((session) => session.id !== input.exclude && session.title)
-      .map((session) => ({ id: session.id, title: session.title, updated: session.time.updated }))
+      .map((session) => ({
+        id: session.id,
+        title: session.title,
+        updated: session.time.updated,
+        worktreeName: session.worktreeName,
+      }))
     input.post({ type: "sessionSearchResult", sessions, requestId: input.message.requestId })
   } catch (err) {
     console.error("[Kilo New] Session search failed:", err)

--- a/packages/kilo-vscode/tests/unit/session-search.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-search.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test"
+import { handleSessionSearch } from "../../src/kilo-provider/session-search"
+
+type Query = Record<string, unknown>
+
+function stub(data: Array<Record<string, unknown>> | Error) {
+  const calls: Query[] = []
+  const client = {
+    experimental: {
+      session: {
+        list: async (query: Query) => {
+          calls.push(query)
+          if (data instanceof Error) throw data
+          return { data }
+        },
+      },
+    },
+  }
+  return { calls, client }
+}
+
+function session(id: string, title: string, updated: number, worktreeName?: string) {
+  return { id, title, time: { updated }, worktreeName }
+}
+
+describe("handleSessionSearch", () => {
+  it("lists root sessions across the worktree family for the resolved directory", async () => {
+    const { calls, client } = stub([session("ses_a", "Alpha", 2, "neon-author")])
+    const posted: unknown[] = []
+
+    await handleSessionSearch({
+      client: client as never,
+      message: { requestId: "r1", sessionID: "ses_current" },
+      dir: (id) => (id === "ses_current" ? "/repo/.kilo/worktrees/wt-1" : "/repo"),
+      post: (msg) => posted.push(msg),
+    })
+
+    expect(calls).toEqual([{ worktrees: true, roots: true, directory: "/repo/.kilo/worktrees/wt-1", limit: 50 }])
+    expect(posted).toEqual([
+      {
+        type: "sessionSearchResult",
+        sessions: [{ id: "ses_a", title: "Alpha", updated: 2, worktreeName: "neon-author" }],
+        requestId: "r1",
+      },
+    ])
+  })
+
+  it("falls back to the current and context sessions for directory resolution", async () => {
+    const { calls, client } = stub([])
+
+    await handleSessionSearch({
+      client: client as never,
+      message: { requestId: "r2" },
+      current: "ses_current",
+      context: "ses_context",
+      dir: (id) => `/dir/${id}`,
+      post: () => {},
+    })
+
+    expect(calls[0]?.directory).toBe("/dir/ses_current")
+
+    await handleSessionSearch({
+      client: client as never,
+      message: { requestId: "r3" },
+      context: "ses_context",
+      dir: (id) => `/dir/${id}`,
+      post: () => {},
+    })
+
+    expect(calls[1]?.directory).toBe("/dir/ses_context")
+  })
+
+  it("excludes the given session and sessions without titles", async () => {
+    const { client } = stub([
+      session("ses_keep", "Keep", 3),
+      session("ses_exclude", "Excluded", 2),
+      session("ses_untitled", "", 1),
+    ])
+    const posted: Array<{ sessions: Array<{ id: string }> }> = []
+
+    await handleSessionSearch({
+      client: client as never,
+      message: { requestId: "r4" },
+      dir: () => "/repo",
+      exclude: "ses_exclude",
+      post: (msg) => posted.push(msg as never),
+    })
+
+    expect(posted[0]?.sessions.map((s) => s.id)).toEqual(["ses_keep"])
+  })
+
+  it("posts an empty result when the client is missing or the list fails", async () => {
+    const posted: unknown[] = []
+
+    await handleSessionSearch({
+      client: null,
+      message: { requestId: "r5" },
+      dir: () => "/repo",
+      post: (msg) => posted.push(msg),
+    })
+
+    const failing = stub(new Error("boom"))
+    await handleSessionSearch({
+      client: failing.client as never,
+      message: { requestId: "r6" },
+      dir: () => "/repo",
+      post: (msg) => posted.push(msg),
+    })
+
+    expect(posted).toEqual([
+      { type: "sessionSearchResult", sessions: [], requestId: "r5" },
+      { type: "sessionSearchResult", sessions: [], requestId: "r6" },
+    ])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionMentionPicker.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionMentionPicker.tsx
@@ -42,7 +42,7 @@ export function SessionMentionPicker(props: Props) {
       <List<SessionSearchItem>
         items={props.sessions}
         key={(item) => item.id}
-        filterKeys={["title"]}
+        filterKeys={["title", "worktreeName"]}
         search={{ placeholder: "Search sessions", autofocus: true }}
         onSelect={(item) => {
           if (item) props.onSelect(item)
@@ -52,6 +52,7 @@ export function SessionMentionPicker(props: Props) {
           <span class="session-mention-item">
             <Icon name="history" class="file-mention-icon" />
             <span class="session-mention-title">{item.title}</span>
+            {item.worktreeName && <span class="session-mention-worktree">{item.worktreeName}</span>}
             <span class="session-mention-time">{formatRelativeDate(new Date(item.updated).toISOString())}</span>
           </span>
         )}

--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
@@ -138,6 +138,16 @@
   font-size: var(--kilo-font-size-11);
 }
 
+.session-mention-worktree {
+  flex-shrink: 0;
+  opacity: 0.6;
+  font-size: var(--kilo-font-size-11);
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ============================================
    Slash Command Dropdown
    ============================================ */

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -472,6 +472,8 @@ export interface SessionSearchItem {
   id: string
   title: string
   updated: number
+  /** Name of the worktree the session runs in, when listed across the worktree family. */
+  worktreeName?: string
 }
 
 export interface SessionSearchResultMessage {


### PR DESCRIPTION
In Agent Manager, chats run across many worktree directories of the same repository. The `@` "Past chats" picker fetched candidates with the plain `session.list` endpoint filtered to the chat's exact directory, so a worktree chat's picker showed only that worktree's handful of sessions and looked empty next to the Agent Manager's own session search, which spans all worktrees. The changelog for past chats already promised "searched like the Agent Manager session search", but the implementation scoped to a single directory instead.

The picker now fetches from the same family-wide endpoint the CLI past-chats picker uses: `experimental.session.list` with `worktrees: true`. For git repositories this lists root sessions across the repo's whole worktree family (local workspace plus every linked worktree); for non-git directories the family collapses to the directory itself, so sidebar behavior outside git is unchanged. Every session in the family shares the repository's project server-side, so attaching any of them passes the existing cross-scope validation regardless of which worktree the current chat runs in.

Each picker row is now labeled with the session's worktree name, and the picker's fuzzy search matches on it, mirroring how the Agent Manager sidebar search lets users narrow by worktree.