### PR TITLE
fix(cli): bound codebase search on root workspaces

### DIFF
--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { WarpGrepClient } from "@morphllm/morphsdk/tools/warp-grep/client" // kilocode_change
@@ -11,12 +12,59 @@ import DESCRIPTION from "./warpgrep.txt"
 // fallback below. After the free period ends, require MORPH_API_KEY and
 // return an error when it is missing.
 const KILO_WARPGREP_PROXY_URL = "https://api.kilo.ai/api/gateway"
+const CODEBASE_SEARCH_TIMEOUT = "5 minutes"
+
+export type WarpGrepContext = {
+  file: string
+  content: string
+  lines?: Array<[number, number]> | "*"
+}
+
+export type WarpGrepResult = {
+  success: boolean
+  contexts?: WarpGrepContext[]
+  error?: string
+}
 
 const Parameters = Schema.Struct({
   query: Schema.String.annotate({
     description: "Search query describing what code you are looking for. Be specific and descriptive for best results.", // kilocode_change
   }),
 })
+
+export function isWorkspaceRoot(dir: string) {
+  return path.parse(dir).root === dir
+}
+
+export function codebaseSearchTimeoutMessage(repoRoot: string) {
+  return `Codebase search stopped after 5 minutes: the index for this workspace is not ready.\nWorkspace root: ${repoRoot}. Open the concrete project folder or rebuild the index, then retry.`
+}
+
+export function runWarpGrep(
+  query: string,
+  repoRoot: string,
+  execute: (input: { searchTerm: string; repoRoot: string }) => Promise<WarpGrepResult>,
+) {
+  if (isWorkspaceRoot(repoRoot)) {
+    return Effect.succeed<WarpGrepResult>({
+      success: false,
+      error: codebaseSearchTimeoutMessage(repoRoot),
+      contexts: [],
+    })
+  }
+
+  return Effect.promise(() => execute({ searchTerm: query, repoRoot })).pipe(
+    Effect.timeoutOrElse({
+      duration: CODEBASE_SEARCH_TIMEOUT,
+      orElse: () =>
+        Effect.succeed<WarpGrepResult>({
+          success: false,
+          error: codebaseSearchTimeoutMessage(repoRoot),
+          contexts: [],
+        }),
+    }),
+  )
+}
 
 export const CodebaseSearchTool = Tool.define(
   "codebase_search",
@@ -45,12 +93,7 @@ export const CodebaseSearchTool = Tool.define(
             timeout: 60_000,
           })
 
-          const result = yield* Effect.promise(() =>
-            client.execute({
-              searchTerm: params.query,
-              repoRoot: Instance.directory,
-            }),
-          )
+          const result = yield* runWarpGrep(params.query, Instance.directory, (input) => client.execute(input))
 
           if (!result.success || !result.contexts?.length) {
             // FREE_PERIOD_TODO: When the proxy stops serving free requests, errors

--- a/packages/opencode/test/tool/warpgrep.test.ts
+++ b/packages/opencode/test/tool/warpgrep.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect } from "bun:test"
+import { Effect, Fiber } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { codebaseSearchTimeoutMessage, isWorkspaceRoot, runWarpGrep } from "../../src/tool/warpgrep"
+import { it } from "../lib/effect"
+
+describe("tool.codebase_search", () => {
+  it.effect("rejects a workspace root without waiting on search", () =>
+    Effect.gen(function* () {
+      expect(isWorkspaceRoot("/")).toBe(true)
+      expect(codebaseSearchTimeoutMessage("/")).toContain("Open the concrete project folder or rebuild the index")
+
+      const result = yield* runWarpGrep("needle", "/", () => {
+        throw new Error("should not execute for a root workspace")
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain("Codebase search stopped after 5 minutes")
+      expect(result.contexts).toEqual([])
+    }),
+  )
+
+  it.effect("returns a timeout result when the search callback never settles", () =>
+    Effect.gen(function* () {
+      const fiber = yield* runWarpGrep("needle", "/workspace", () => new Promise(() => {})).pipe(Effect.forkChild)
+
+      yield* TestClock.adjust("5 minutes")
+      const result = yield* Fiber.join(fiber)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain("Codebase search stopped after 5 minutes")
+      expect(result.error).toContain("/workspace")
+    }),
+  )
+})


### PR DESCRIPTION
## Issue

Fixes #12707

## Context

Codebase Search could stay running on a broad or unready workspace root without surfacing a useful failure. That left the UI waiting on a local search/index operation that had no meaningful deadline.

## Implementation

- Reject root-only workspace scopes up front and return a clear recovery message that tells the user to open the concrete project folder.
- Wrap the WarpGrep call in a hard five-minute timeout so the tool cannot hang indefinitely when local indexing/search never becomes ready.
- Added a focused unit test for the root guard and the timeout path.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- `PATH=/home/ubuntu/.bun/bin:$PATH /home/ubuntu/.bun/bin/bun test packages/opencode/test/tool/warpgrep.test.ts`
- `PATH=/home/ubuntu/.bun/bin:$PATH /home/ubuntu/.bun/bin/bun test packages/opencode/test/tool/external-directory.test.ts`

### Reviewer test steps

1. Open Kilo Code in a broad workspace root.
2. Trigger Codebase Search.
3. Confirm the tool now returns the root-workspace recovery message instead of waiting indefinitely.

### Blocked checks and substitute verification

- The repo was not preinstalled in this clean worktree, so I used `bun install --ignore-scripts` before running the focused tests.
- No broader suite was needed for this low-risk tool fix.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A