### PR TITLE
feat(cli): support silent agent-switch commands

### DIFF
--- a/.changeset/silent-agent-switches.md
+++ b/.changeset/silent-agent-switches.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Support silent agent-switch slash commands with `silent: true` frontmatter.

--- a/.changeset/silent-agent-switches.md
+++ b/.changeset/silent-agent-switches.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": minor
 ---
 
-Support silent agent-switch slash commands with `silent: true` frontmatter.
+Support terminal TUI silent agent-switch slash commands with `agent` and `silent: true` frontmatter.

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -12,6 +12,7 @@ export class Info extends Schema.Class<Info>("CommandV2.Info")({
   agent: Schema.String.pipe(Schema.optional),
   model: ModelV2.Ref.pipe(Schema.optional),
   subtask: Schema.Boolean.pipe(Schema.optional),
+  silent: Schema.Boolean.pipe(Schema.optional), // kilocode_change
 }) {}
 
 export type Data = {

--- a/packages/core/src/config/command.ts
+++ b/packages/core/src/config/command.ts
@@ -9,4 +9,5 @@ export class Info extends Schema.Class<Info>("ConfigV2.Command")({
   model: Schema.String.pipe(Schema.optional),
   variant: Schema.String.pipe(Schema.optional),
   subtask: Schema.Boolean.pipe(Schema.optional),
+  silent: Schema.Boolean.pipe(Schema.optional), // kilocode_change
 }) {}

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -43,6 +43,7 @@ export const Plugin = PluginV2.define({
               item.model.variant = ModelV2.VariantID.make(command.variant)
             }
             if (command.subtask !== undefined) item.subtask = command.subtask
+            if (command.silent !== undefined) item.silent = command.silent // kilocode_change
           })
         }
       }

--- a/packages/core/src/v1/config/command.ts
+++ b/packages/core/src/v1/config/command.ts
@@ -9,5 +9,6 @@ export const Info = Schema.Struct({
   model: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),
   subtask: Schema.optional(Schema.Boolean),
+  silent: Schema.optional(Schema.Boolean), // kilocode_change
 })
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -33,6 +33,7 @@ agent: reviewer
 model: anthropic/claude
 variant: high
 subtask: true
+silent: true # kilocode_change
 ---
 Review files`,
             )
@@ -70,6 +71,7 @@ Review files`,
                 variant: ModelV2.VariantID.make("high"),
               },
               subtask: true,
+              silent: true, // kilocode_change
             }),
             new CommandV2.Info({ name: "empty", template: "" }),
             new CommandV2.Info({ name: "nested/docs", template: "Write docs" }),

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -37,6 +37,7 @@ export const Info = Schema.Struct({
   // Some command templates are lazy promises from MCP prompt resolution.
   template: Schema.Unknown,
   subtask: Schema.optional(Schema.Boolean),
+  silent: Schema.optional(Schema.Boolean), // kilocode_change
   hints: Schema.Array(Schema.String),
 }).annotate({ identifier: "Command" })
 
@@ -125,6 +126,7 @@ export const layer = Layer.effect(
             return command.template
           },
           subtask: command.subtask,
+          silent: command.silent, // kilocode_change
           hints: hints(command.template),
         }
       }

--- a/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
@@ -1,0 +1,16 @@
+import { slashMatches } from "./command-display"
+
+type Command = {
+  name: string
+  source?: "command" | "mcp" | "skill"
+  agent?: string
+  silent?: boolean
+}
+
+export function silentAgent(text: string, commands: readonly Command[]) {
+  if (!text.startsWith("/")) return
+  const name = text.split("\n")[0].split(" ")[0].slice(1)
+  const command = commands.find((item) => slashMatches(item, name))
+  if (command?.source !== "command" || command.silent !== true) return
+  return command.agent
+}

--- a/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
@@ -7,8 +7,16 @@ type Command = {
   silent?: boolean
 }
 
-export function silentAgent(text: string, commands: readonly Command[]) {
-  const match = text.match(/^\/([^\s]+)[ \t]*$/)
+type Input = {
+  text: string
+  mode: "normal" | "shell"
+  parts: number
+  editor: "none" | "pending" | "sent"
+}
+
+export function silentAgent(input: Input, commands: readonly Command[]) {
+  if (input.mode !== "normal" || input.parts > 0 || input.editor === "pending") return
+  const match = input.text.match(/^\/([^\s]+)[ \t]*$/)
   if (!match) return
   const name = match[1]
   const command = commands.find((item) => slashMatches(item, name))

--- a/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/silent-command.ts
@@ -8,8 +8,9 @@ type Command = {
 }
 
 export function silentAgent(text: string, commands: readonly Command[]) {
-  if (!text.startsWith("/")) return
-  const name = text.split("\n")[0].split(" ")[0].slice(1)
+  const match = text.match(/^\/([^\s]+)[ \t]*$/)
+  if (!match) return
+  const name = match[1]
   const command = commands.find((item) => slashMatches(item, name))
   if (command?.source !== "command" || command.silent !== true) return
   return command.agent

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -14,6 +14,7 @@ description: Run tests # optional, shown in command list
 agent: code # optional, route to a specific agent
 model: anthropic/claude-sonnet # optional, override model
 subtask: true # optional, run as subtask
+silent: true # optional, switch to agent without sending a prompt
 ---
 Run all tests in $1 and fix failures.
 Use $ARGUMENTS for the full arg string.

--- a/packages/opencode/src/kilocode/skills/kilo-config.md
+++ b/packages/opencode/src/kilocode/skills/kilo-config.md
@@ -14,7 +14,7 @@ description: Run tests # optional, shown in command list
 agent: code # optional, route to a specific agent
 model: anthropic/claude-sonnet # optional, override model
 subtask: true # optional, run as subtask
-silent: true # optional, switch to agent without sending a prompt
+silent: true # optional in terminal TUI; requires agent
 ---
 Run all tests in $1 and fix failures.
 Use $ARGUMENTS for the full arg string.
@@ -22,6 +22,8 @@ Reference files with @file and shell output with !`cmd`.
 ```
 
 Template variables: `$1`-`$N` (positional args), `$ARGUMENTS` (full string), `@file` (file contents), `` !`cmd` `` (shell output).
+
+`silent: true` switches agents without sending a prompt only in the terminal TUI and only when `agent` is also configured. The input must be the exact slash command with no arguments, additional lines, attached parts, or pending editor context. Other inputs and clients execute the command template normally.
 
 ### Finding a named command
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1019,6 +1019,8 @@ it.instance("loads commands from .kilo/command (singular)", () =>
       path.join(test.directory, ".kilo", "command", "hello.md"), // kilocode_change
       `---
 description: Test command
+agent: code
+silent: true
 ---
 Hello from singular command`,
     )
@@ -1035,6 +1037,8 @@ Nested command template`,
 
     expect(config.command?.["hello"]).toEqual({
       description: "Test command",
+      agent: "code",
+      silent: true,
       template: "Hello from singular command",
     })
 

--- a/packages/opencode/test/kilocode/silent-command.test.ts
+++ b/packages/opencode/test/kilocode/silent-command.test.ts
@@ -17,16 +17,29 @@ describe("silent agent-switch commands", () => {
       silent: true,
     },
   ]
+  const input = {
+    text: "/code",
+    mode: "normal" as const,
+    parts: 0,
+    editor: "none" as const,
+  }
 
   test("resolves an exact silent agent-switch command", () => {
-    expect(silentAgent("/code", commands)).toBe("code")
-    expect(silentAgent("/code  ", commands)).toBe("code")
+    expect(silentAgent(input, commands)).toBe("code")
+    expect(silentAgent({ ...input, text: "/code  " }, commands)).toBe("code")
+    expect(silentAgent({ ...input, editor: "sent" }, commands)).toBe("code")
   })
 
   test("preserves commands with arguments or multiple lines for normal submission", () => {
-    expect(silentAgent("/code fix the login bug", commands)).toBeUndefined()
-    expect(silentAgent("/code\nfix the login bug", commands)).toBeUndefined()
-    expect(silentAgent("/code\n", commands)).toBeUndefined()
+    expect(silentAgent({ ...input, text: "/code fix the login bug" }, commands)).toBeUndefined()
+    expect(silentAgent({ ...input, text: "/code\nfix the login bug" }, commands)).toBeUndefined()
+    expect(silentAgent({ ...input, text: "/code\n" }, commands)).toBeUndefined()
+  })
+
+  test("preserves ineligible prompt states for normal submission", () => {
+    expect(silentAgent({ ...input, mode: "shell" }, commands)).toBeUndefined()
+    expect(silentAgent({ ...input, parts: 1 }, commands)).toBeUndefined()
+    expect(silentAgent({ ...input, editor: "pending" }, commands)).toBeUndefined()
   })
 
   it.live("exposes silent command frontmatter to clients", () =>
@@ -42,7 +55,7 @@ describe("silent agent-switch commands", () => {
             silent: true,
             source: "command",
           })
-          expect(silentAgent("/code", command ? [command] : [])).toBe("code")
+          expect(silentAgent(input, command ? [command] : [])).toBe("code")
         }),
       {
         git: true,
@@ -60,10 +73,10 @@ describe("silent agent-switch commands", () => {
   )
 
   test("ignores commands that are not explicit silent agent switches", () => {
-    expect(silentAgent("code", commands)).toBeUndefined()
-    expect(silentAgent("/plan", commands)).toBeUndefined()
-    expect(silentAgent("/code", [{ ...commands[0], silent: false }])).toBeUndefined()
-    expect(silentAgent("/code", [{ ...commands[0], agent: undefined }])).toBeUndefined()
-    expect(silentAgent("/code", [{ ...commands[0], source: "mcp" }])).toBeUndefined()
+    expect(silentAgent({ ...input, text: "code" }, commands)).toBeUndefined()
+    expect(silentAgent({ ...input, text: "/plan" }, commands)).toBeUndefined()
+    expect(silentAgent(input, [{ ...commands[0], silent: false }])).toBeUndefined()
+    expect(silentAgent(input, [{ ...commands[0], agent: undefined }])).toBeUndefined()
+    expect(silentAgent(input, [{ ...commands[0], source: "mcp" }])).toBeUndefined()
   })
 })

--- a/packages/opencode/test/kilocode/silent-command.test.ts
+++ b/packages/opencode/test/kilocode/silent-command.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { Command } from "../../src/command"
+import { silentAgent } from "../../src/kilocode/cli/cmd/silent-command"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(Command.defaultLayer, CrossSpawnSpawner.defaultLayer))
+
+describe("silent agent-switch commands", () => {
+  const commands = [
+    {
+      name: "code",
+      source: "command" as const,
+      agent: "code",
+      silent: true,
+    },
+  ]
+
+  test("resolves the configured agent without using the command body", () => {
+    expect(silentAgent("/code", commands)).toBe("code")
+    expect(silentAgent("/code ignored arguments", commands)).toBe("code")
+  })
+
+  it.live("exposes silent command frontmatter to clients", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const service = yield* Command.Service
+          const command = yield* service.get("code")
+
+          expect(command).toMatchObject({
+            name: "code",
+            agent: "code",
+            silent: true,
+            source: "command",
+          })
+          expect(silentAgent("/code", command ? [command] : [])).toBe("code")
+        }),
+      {
+        git: true,
+        config: {
+          command: {
+            code: {
+              template: "This body must not be sent.",
+              agent: "code",
+              silent: true,
+            },
+          },
+        },
+      },
+    ),
+  )
+
+  test("ignores commands that are not explicit silent agent switches", () => {
+    expect(silentAgent("code", commands)).toBeUndefined()
+    expect(silentAgent("/plan", commands)).toBeUndefined()
+    expect(silentAgent("/code", [{ ...commands[0], silent: false }])).toBeUndefined()
+    expect(silentAgent("/code", [{ ...commands[0], agent: undefined }])).toBeUndefined()
+    expect(silentAgent("/code", [{ ...commands[0], source: "mcp" }])).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/kilocode/silent-command.test.ts
+++ b/packages/opencode/test/kilocode/silent-command.test.ts
@@ -18,9 +18,15 @@ describe("silent agent-switch commands", () => {
     },
   ]
 
-  test("resolves the configured agent without using the command body", () => {
+  test("resolves an exact silent agent-switch command", () => {
     expect(silentAgent("/code", commands)).toBe("code")
-    expect(silentAgent("/code ignored arguments", commands)).toBe("code")
+    expect(silentAgent("/code  ", commands)).toBe("code")
+  })
+
+  test("preserves commands with arguments or multiple lines for normal submission", () => {
+    expect(silentAgent("/code fix the login bug", commands)).toBeUndefined()
+    expect(silentAgent("/code\nfix the login bug", commands)).toBeUndefined()
+    expect(silentAgent("/code\n", commands)).toBeUndefined()
   })
 
   it.live("exposes silent command frontmatter to clients", () =>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1549,6 +1549,7 @@ export type Config = {
       model?: string
       variant?: string
       subtask?: boolean
+      silent?: boolean
     }
   }
   skills?: {
@@ -2106,6 +2107,7 @@ export type Command = {
   trusted?: boolean
   template: string
   subtask?: boolean
+  silent?: boolean
   hints: Array<string>
 }
 
@@ -6181,6 +6183,7 @@ export type CommandV2Info = {
     variant?: string
   }
   subtask?: boolean
+  silent?: boolean
 }
 
 export type SkillV2Info = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -29132,6 +29132,9 @@
                 },
                 "subtask": {
                   "type": "boolean"
+                },
+                "silent": {
+                  "type": "boolean"
                 }
               },
               "required": ["template"],
@@ -30791,6 +30794,9 @@
             "type": "string"
           },
           "subtask": {
+            "type": "boolean"
+          },
+          "silent": {
             "type": "boolean"
           },
           "hints": {
@@ -44358,6 +44364,9 @@
             "additionalProperties": false
           },
           "subtask": {
+            "type": "boolean"
+          },
+          "silent": {
             "type": "boolean"
           }
         },

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1047,10 +1047,15 @@ export function Prompt(props: PromptProps) {
     if (costAlert.handle(store.prompt.input.trim())) return true
     // kilocode_change end
     // kilocode_change start - switch agents without sending a command prompt
-    const target =
-      store.mode === "normal" && store.prompt.parts.length === 0 && editorContextLabelState() !== "pending"
-        ? silentAgent(store.prompt.input, sync.data.command)
-        : undefined
+    const target = silentAgent(
+      {
+        text: store.prompt.input,
+        mode: store.mode,
+        parts: store.prompt.parts.length,
+        editor: editorContextLabelState(),
+      },
+      sync.data.command,
+    )
     if (target) {
       local.agent.set(target)
       if (local.agent.current()?.name !== target) return false

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1047,7 +1047,10 @@ export function Prompt(props: PromptProps) {
     if (costAlert.handle(store.prompt.input.trim())) return true
     // kilocode_change end
     // kilocode_change start - switch agents without sending a command prompt
-    const target = silentAgent(store.prompt.input, sync.data.command)
+    const target =
+      store.mode === "normal" && store.prompt.parts.length === 0 && editorContextLabelState() !== "pending"
+        ? silentAgent(store.prompt.input, sync.data.command)
+        : undefined
     if (target) {
       local.agent.set(target)
       if (local.agent.current()?.name !== target) return false

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -58,6 +58,7 @@ import { slashMatches } from "@/kilocode/cli/cmd/command-display"
 import * as AgentRequirements from "@/kilocode/cli/agent-requirements"
 import { createCostAlertController } from "@/kilocode/cli/cmd/tui/cost-alert"
 import { MemoryPrompt } from "@/kilocode/cli/cmd/tui/component/memory-prompt"
+import { silentAgent } from "@/kilocode/cli/cmd/silent-command"
 // kilocode_change end
 import { KILO_BASE_MODE, useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
 import { useTuiConfig } from "../../config"
@@ -1044,6 +1045,15 @@ export function Prompt(props: PromptProps) {
     if (!store.prompt.input) return false
     // kilocode_change start - in-memory cost alert command
     if (costAlert.handle(store.prompt.input.trim())) return true
+    // kilocode_change end
+    // kilocode_change start - switch agents without sending a command prompt
+    const target = silentAgent(store.prompt.input, sync.data.command)
+    if (target) {
+      local.agent.set(target)
+      if (local.agent.current()?.name !== target) return false
+      clearPrompt()
+      return true
+    }
     // kilocode_change end
     const agent = local.agent.current()
     if (!agent) return false


### PR DESCRIPTION
## Summary

- add optional `silent: true` frontmatter for custom commands with an `agent`
- propagate the metadata through the command schemas and generated SDK types
- switch the CLI TUI agent locally without sending a chat message or invoking the command template
- document the option and add focused regression coverage plus a changeset

## Verification

- `bun test test/kilocode/silent-command.test.ts` (`packages/opencode`)
- `bun test test/config/config.test.ts -t "loads commands from .kilo/command"` (`packages/opencode`)
- `bun test test/config/command.test.ts` (`packages/core`)
- package typechecks for `packages/core`, `packages/opencode`, and `packages/tui`
- repository pre-push typecheck: 22 non-JetBrains packages passed
- `bun run lint`
- `bun run script/check-opencode-annotations.ts --worktree`
- `bun run script/check-md-table-padding.ts`

Closes #12710