### PR TITLE
fix(agent-manager): keep detail pane for unassigned sessions

### DIFF
--- a/.changeset/agent-manager-unassigned-detail-pane.md
+++ b/.changeset/agent-manager-unassigned-detail-pane.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the Agent Manager detail pane blanking when an unassigned session is selected. Clicking a session that belongs to no worktree now renders the chat and read-only banner again instead of an empty content area, and live terminal tabs stay mounted across the switch.

--- a/packages/kilo-vscode/tests/unit/agent-manager-ambient-setup.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-ambient-setup.test.ts
@@ -1,8 +1,37 @@
 import { describe, expect, it } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { LOCAL } from "../../webview-ui/agent-manager/navigate"
-import { ambientDecision, createAmbientSetup } from "../../webview-ui/agent-manager/terminal/ambient"
+import { ambientDecision, createAmbientSetup, showTerminalStack } from "../../webview-ui/agent-manager/terminal/ambient"
 import { createTerminalState } from "../../webview-ui/agent-manager/terminal/state"
+
+describe("showTerminalStack", () => {
+  it("hides the detail stack while the history view is open", () => {
+    expect(showTerminalStack(true, "wt-1", false)).toBe(false)
+    expect(showTerminalStack(true, null, false)).toBe(false)
+  })
+
+  it("shows the detail stack for a selected context with sessions", () => {
+    expect(showTerminalStack(false, "wt-1", false)).toBe(true)
+    expect(showTerminalStack(false, LOCAL, false)).toBe(true)
+  })
+
+  it("keeps the detail stack for a provisioning worktree with no sessions", () => {
+    // The side terminal hosts the live Setup tab next to the empty state,
+    // so the stack must render even when the context is empty.
+    expect(showTerminalStack(false, "wt-1", true)).toBe(true)
+  })
+
+  it("shows the detail stack for an unassigned session", () => {
+    // selection === null with a live session: contextEmpty is false, and
+    // the stack hosts the read-only banner / chat. The old gate rendered
+    // here; dropping this case blanks the pane and unmounts live xterms.
+    expect(showTerminalStack(false, null, false)).toBe(true)
+  })
+
+  it("hides the detail stack when nothing is selected and the context is empty", () => {
+    expect(showTerminalStack(false, null, true)).toBe(false)
+  })
+})
 
 describe("ambientDecision", () => {
   it("waits while setup is still running", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -671,7 +671,7 @@ const AgentManagerContent: Component = () => {
     return false
   })
 
-  const showDetailStack = createMemo(() => showTerminalStack(history(), selection()))
+  const showDetailStack = createMemo(() => showTerminalStack(history(), selection(), contextEmpty()))
 
   const overlay = createMemo((): SetupState | null => {
     const state = setup()

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/ambient.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/ambient.ts
@@ -23,9 +23,12 @@ interface AmbientSetupDeps {
 
 export type AmbientDecision = "wait" | "hide" | "keep"
 
-/** Selected contexts own the detail stack; history/unassigned are exclusive. */
-export function showTerminalStack(history: boolean, selection: string | null): boolean {
-  return !history && selection !== null
+/** The detail stack hosts chat, terminals, and the read-only banner.
+ *  It shows for any selected context (local/worktree) and for an
+ *  unassigned session, where `selection` is null but the context is not
+ *  empty (a live session is showing). The history view is exclusive. */
+export function showTerminalStack(history: boolean, selection: string | null, contextEmpty: boolean): boolean {
+  return !history && (selection !== null || !contextEmpty)
 }
 
 /** Setup output owns progress/error presentation when its terminal exists. */


### PR DESCRIPTION
PR #12703 changed the Agent Manager detail-stack gate from `!contextEmpty() && !history()` to `showTerminalStack(history(), selection())`, which resolves to `!history && selection !== null`.

An **unassigned session** (a session that belongs to no worktree and is not the local repo) has `selection === null` but a live session showing, so `contextEmpty()` returns `false`. The old gate rendered the detail stack for that state; the new one does not, because it only checks `selection !== null`.

The result is a regression in an existing, supported flow:

- Clicking an unassigned session **blanks the main pane** — neither the chat/messages nor the read-only banner renders, and the outer `contextEmpty()` empty state does not render either (it is `false` here).
- `readOnly()` (`selection() === null && !!session.currentSessionID()`) becomes **dead code** — the read-only banner with the "Open locally" / "Promote to worktree" actions lives inside the detail stack and is now unreachable.
- `renderTerminalLayer` and the side-terminal host both live inside the same `<Show when={showDetailStack()}>`, so selecting an unassigned session **unmounts every live xterm**, contradicting the "keep terminal tabs mounted so output streams across worktree switches" invariant in the block itself.

## Fix

`showTerminalStack` now takes `contextEmpty` and returns `!history && (selection !== null || !contextEmpty)`. This restores the pre-#12703 semantics for unassigned sessions while preserving the PR's intended provisioning behavior: a worktree with no sessions still renders the stack so the side Setup terminal can sit beside the empty state.

`AgentManagerApp.tsx` passes `contextEmpty()` at the call site.

## Test

Adds a `showTerminalStack` regression suite (`agent-manager-ambient-setup.test.ts`) covering the unassigned case (`selection=null, contextEmpty=false → true`), history exclusivity, selected context, provisioning worktree, and the fully-empty case.