### PR TITLE
feat(ui): show line summaries for multi-file patches

### DIFF
--- a/.changeset/bright-files-count.md
+++ b/.changeset/bright-files-count.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show aggregate added and removed line counts for multi-file patch tool calls.

--- a/packages/kilo-ui/src/components/basic-tool.css
+++ b/packages/kilo-ui/src/components/basic-tool.css
@@ -238,6 +238,18 @@ html[data-theme="kilo-vscode"] [data-component="tool-part-wrapper"][data-part-ty
       color: var(--text-weak);
     }
 
+    [data-slot="message-part-tool-changes"] {
+      display: inline-flex;
+      align-items: baseline;
+      flex-shrink: 0;
+    }
+
+    [data-slot="basic-tool-tool-subtitle"] + [data-slot="message-part-tool-changes"]::before {
+      content: "·";
+      margin-right: 6px;
+      color: var(--text-weak);
+    }
+
     [data-slot="basic-tool-tool-title"],
     [data-slot="basic-tool-tool-subtitle"],
     [data-slot="basic-tool-tool-arg"],

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1844,12 +1844,12 @@ function ToolMetaLine(props: {
   )
 }
 
-function ToolChanges(props: { changes: DiffValue; animate?: boolean }) {
+function ToolChanges(props: { changes: DiffValue; animate?: boolean; slot?: string }) {
   let ref: HTMLDivElement | undefined
   useToolFade(() => ref, { delay: 0.04, animate: props.animate })
 
   return (
-    <div ref={ref}>
+    <div ref={ref} data-slot={props.slot}>
       <DiffChanges changes={props.changes} />
     </div>
   )
@@ -2769,9 +2769,7 @@ ToolRegistry.register({
                       <>
                         <ToolText text={text()} animate={reveal()} />
                         <Show when={files().some((file) => file.additions > 0 || file.deletions > 0)}>
-                          <span data-slot="message-part-tool-changes">
-                            <DiffChanges changes={files()} />
-                          </span>
+                          <ToolChanges changes={files()} animate={reveal()} slot="message-part-tool-changes" />
                         </Show>
                       </>
                     )}

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -2764,7 +2764,18 @@ ToolRegistry.register({
                       />
                     )}
                   </Show>
-                  <Show when={!single() && subtitle()}>{(text) => <ToolText text={text()} animate={reveal()} />}</Show>
+                  <Show when={!single() && subtitle()}>
+                    {(text) => (
+                      <>
+                        <ToolText text={text()} animate={reveal()} />
+                        <Show when={files().some((file) => file.additions > 0 || file.deletions > 0)}>
+                          <span data-slot="message-part-tool-changes">
+                            <DiffChanges changes={files()} />
+                          </span>
+                        </Show>
+                      </>
+                    )}
+                  </Show>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Multi-file patch tool calls currently show only the number of affected files in their collapsed header, while the individual file rows expose their own line counts. This makes the overall size of a patch harder to assess without expanding the tool call.

The header now reuses the per-file diff metadata to show aggregate additions and deletions for the current tool call, while preserving the existing single-file presentation and per-file details. The summary is omitted when there are no line changes.

Before:

<img width="754" alt="Multi-file patch header before aggregate line summary" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260731-tool-call-line-summary-before.png?raw=true" />

After:

<img width="754" alt="Multi-file patch header with aggregate line summary" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260731-tool-call-line-summary-after.png?raw=true" />