### PR TITLE
fix(cli): handle missing nested config unsets

### DIFF
--- a/.changeset/quiet-config-unset.md
+++ b/.changeset/quiet-config-unset.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow clearing a nested project setting when no project config file exists yet.

--- a/packages/opencode/src/kilocode/config/writer.ts
+++ b/packages/opencode/src/kilocode/config/writer.ts
@@ -83,6 +83,7 @@ export namespace KilocodeConfigWriter {
   function patchJsonc(input: string, patch: unknown, parts: string[] = []): string {
     if (!isRecord(patch)) {
       if (patch === null) {
+        // jsonc-parser cannot delete a nested path when its parent is absent.
         const tree = parseTree(input)
         if (!tree || !findNodeAtLocation(tree, parts)) return input
       }

--- a/packages/opencode/src/kilocode/config/writer.ts
+++ b/packages/opencode/src/kilocode/config/writer.ts
@@ -82,6 +82,10 @@ export namespace KilocodeConfigWriter {
 
   function patchJsonc(input: string, patch: unknown, parts: string[] = []): string {
     if (!isRecord(patch)) {
+      if (patch === null) {
+        const tree = parseTree(input)
+        if (!tree || !findNodeAtLocation(tree, parts)) return input
+      }
       return applyEdits(
         input,
         modify(input, parts, patch === null ? undefined : patch, {

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -115,6 +115,29 @@ describe("config overlay routes", () => {
     expect(await Bun.file(path.join(project.path, ".kilo", "kilo.jsonc")).exists()).toBe(false)
   })
 
+  test("removes an existing nested unset path", async () => {
+    await using project = await tmpdir()
+    const file = path.join(project.path, ".kilo", "kilo.jsonc")
+    await Filesystem.write(
+      file,
+      '{\n  "$schema": "https://app.kilo.ai/config.json",\n  "indexing": {\n    "enabled": false,\n    "provider": "ollama",\n    "ollama": { "baseUrl": "http://127.0.0.1:11434" }\n  }\n}\n',
+    )
+
+    const response = await req(project.path, "/config/overlay", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "project", unset: [["indexing", "enabled"]] }),
+    })
+    expect(response.status).toBe(200)
+
+    const saved = (await Bun.file(file).json()) as {
+      indexing: { enabled?: boolean; provider: string; ollama: { baseUrl: string } }
+    }
+    expect(saved.indexing.enabled).toBeUndefined()
+    expect(saved.indexing.provider).toBe("ollama")
+    expect(saved.indexing.ollama.baseUrl).toBe("http://127.0.0.1:11434")
+  })
+
   test("returns exact raw target data and a stable missing-file revision", async () => {
     await using project = await tmpdir()
     const first = await KilocodeConfigOverlay.target({ scope: "project", directory: project.path })

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -103,6 +103,18 @@ describe("config overlay routes", () => {
     expect(await Bun.file(target.path).text()).toContain('"model": "test/model"')
   })
 
+  test("ignores a nested unset path when the project target is missing", async () => {
+    await using project = await tmpdir()
+    const response = await req(project.path, "/config/overlay", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ scope: "project", unset: [["agent", "explore", "model"]] }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await Bun.file(path.join(project.path, ".kilo", "kilo.jsonc")).exists()).toBe(false)
+  })
+
   test("returns exact raw target data and a stable missing-file revision", async () => {
     await using project = await tmpdir()
     const first = await KilocodeConfigOverlay.target({ scope: "project", directory: project.path })


### PR DESCRIPTION
The VS Code Settings overlay can represent clearing a nested setting as an unset path, such as `agent.explore.model`. When the project config target does not exist, the overlay writer patches an empty JSON document. jsonc-parser rejects deleting a nested path whose parent is absent with `Can not delete in empty document`, which surfaces in the extension as an opaque `Unexpected server error`.

Apply the same absent-path guard already used by the regular config writer to the overlay writer. Missing delete paths are treated as already unset, while existing paths continue to be removed normally. Add a route regression test for the missing nested project target and include a CLI patch changeset.