### PR TITLE
fix(cli): preserve Kilo prompt cache keys for GPT-5.6

### DIFF
--- a/.changeset/gpt-56-kilo-prompt-cache.md
+++ b/.changeset/gpt-56-kilo-prompt-cache.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve Kilo session prompt cache keys for GPT-5.6 Responses requests.

--- a/packages/opencode/src/kilocode/provider-options.ts
+++ b/packages/opencode/src/kilocode/provider-options.ts
@@ -9,6 +9,7 @@ export function kiloProviderOptions(options: { [x: string]: any }) {
   const result: Record<string, any> = {}
   const openrouter = options as OpenRouterProviderOptions & {
     verbosity?: "high" | "medium" | "low"
+    promptCacheKey?: string
   }
   result.openrouter = openrouter
   result.openai = {
@@ -17,6 +18,7 @@ export function kiloProviderOptions(options: { [x: string]: any }) {
     textVerbosity: openrouter.verbosity,
     store: false,
     forceReasoning: openrouter.reasoning?.enabled,
+    promptCacheKey: openrouter.promptCacheKey,
   } satisfies OpenAIResponsesProviderOptions
   result.anthropic = {
     thinking: { type: openrouter.reasoning?.enabled ? "adaptive" : "disabled" },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1218,6 +1218,7 @@ export function options(input: {
     input.providerOptions?.setCacheKey !== false &&
     (input.model.providerID === "openai" ||
       input.model.api.npm === "@ai-sdk/xai" ||
+      input.model.api.npm === "@kilocode/kilo-gateway" ||
       input.providerOptions?.setCacheKey)
   ) {
     result["promptCacheKey"] = input.sessionID

--- a/packages/opencode/test/kilocode/provider/prompt-cache.test.ts
+++ b/packages/opencode/test/kilocode/provider/prompt-cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { streamText } from "ai"
+import { createKilo } from "@kilocode/kilo-gateway"
+import { ProviderTransform } from "@/provider/transform"
+
+const model = {
+  id: "openai/gpt-5.6-sol",
+  providerID: "kilo",
+  api: {
+    id: "openai/gpt-5.6-sol",
+    url: "https://api.kilo.ai",
+    npm: "@kilocode/kilo-gateway",
+  },
+  capabilities: { reasoning: true },
+  limit: { output: 128_000 },
+} as any
+
+describe("Kilo GPT-5.6 prompt cache options", () => {
+  test("preserves the session key through Kilo provider options", () => {
+    const sessionID = "ses_cache_probe"
+    const options = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    const providerOptions = ProviderTransform.providerOptions(model, options)
+
+    expect(options.promptCacheKey).toBe(sessionID)
+    expect(providerOptions.openai.promptCacheKey).toBe(sessionID)
+  })
+
+  test("allows Kilo provider configuration to disable the session key", () => {
+    const options = ProviderTransform.options({
+      model,
+      sessionID: "ses_cache_probe",
+      providerOptions: { setCacheKey: false },
+    })
+
+    expect(options.promptCacheKey).toBeUndefined()
+  })
+
+  test("sends the session key in the Kilo Responses body", async () => {
+    let body: Record<string, unknown> | undefined
+    const sdk = createKilo({
+      kilocodeToken: "test",
+      fetch: (async (_input, init) => {
+        body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response("data: [DONE]\n\n", { headers: { "content-type": "text/event-stream" } })
+      }) as typeof fetch,
+    })
+    const sessionID = "ses_cache_probe"
+    const options = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    const providerOptions = ProviderTransform.providerOptions(model, options)
+
+    for await (const _ of (
+      await streamText({
+        model: sdk.openai("openai/gpt-5.6-sol"),
+        prompt: "Hi",
+        providerOptions,
+      })
+    ).fullStream) {
+      // Consume the stream so the lazy request executes.
+    }
+
+    expect(body?.prompt_cache_key).toBe(sessionID)
+  })
+})


### PR DESCRIPTION
GPT-5.6 prompt caching was not receiving the session cache key on Kilo Gateway requests, so the Kilo CLI could report cache misses even though the request path was intended to reuse a session prefix.

`ProviderTransform.options(sessionID)` only generated `promptCacheKey` for OpenAI, xAI, or explicitly opted-in providers. Kilo models use `@kilocode/kilo-gateway`, so the default Kilo route produced no key. The Kilo provider adapter then also dropped `promptCacheKey` when translating OpenRouter-shaped options into the OpenAI Responses namespace.

A local request capture confirmed the defect:

- Before: the request to `/api/openrouter/responses` contained no `prompt_cache_key`.
- With the key supplied explicitly: the same gateway emitted `"prompt_cache_key": "ses_cache_probe"`.
- After this change: the full `ProviderTransform` to Kilo Gateway route is covered by a regression test and emits the session key in the captured Responses body.

This is intentionally limited to preserving `prompt_cache_key`. It does not change prompt text, tools, history, pruning, compaction, or output behavior. It also does not add explicit GPT-5.6 cache breakpoints. Those are a separate optimization for stable prefixes and require deliberate input-boundary behavior.

OpenAI documents the relevant GPT-5.6 semantics:

- [Prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching): GPT-5.6 uses `prompt_cache_key` for more reliable matching and reports reads as `cached_tokens` and writes as `cache_write_tokens`.
- [Using GPT-5.6](https://developers.openai.com/api/docs/guides/latest-model): GPT-5.6 supports explicit prompt caching and recommends reviewing cache reads and writes because cache writes cost 1.25x the uncached input rate.

The TUI and VS Code usage surfaces consume the provider-reported cache usage. No UI formula changes are included here.
