### PR TITLE
feat(jetbrains): show filenames first in @file mentions

### DIFF
--- a/.changeset/jetbrains-file-suggestions.md
+++ b/.changeset/jetbrains-file-suggestions.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Show file names before their containing folders in JetBrains `@file` suggestions.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/KiloPromptCompletionProvider.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/ui/prompt/KiloPromptCompletionProvider.kt
@@ -252,7 +252,7 @@ class KiloPromptCompletionProvider(
         PrioritizedLookupElement.withGrouping(PrioritizedLookupElement.withPriority(element, 100.0), 100)
 
     private fun file(file: WorkspaceFileDto): LookupElement = LookupElementBuilder.create(file.path)
-        .withPresentableText("@${file.path}")
+        .withPresentableText("@${file.name}")
         .withTailText(parent(file.path), true)
         .withIcon(icon(file))
         .withLookupString(file.name)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/prompt/KiloPromptCompletionProviderTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/ui/prompt/KiloPromptCompletionProviderTest.kt
@@ -211,6 +211,16 @@ class KiloPromptCompletionProviderTest : BasePlatformTestCase() {
         assertSame(AllIcons.Nodes.Folder, icon("src"))
     }
 
+    fun `test mention completion renders filename before parent path`() {
+        rpc.searchResult = FileSearchResultDto(files = listOf(file("src/foo/Bar.kt")))
+
+        complete("@bar<caret>")
+
+        val view = LookupElementPresentation().also { item("src/foo/Bar.kt").renderElement(it) }
+        assertEquals("@Bar.kt", view.itemText)
+        assertEquals("  src/foo", view.tailText)
+    }
+
     fun `test highlights known slash command at start`() {
         assertEquals(
             listOf(KiloPromptCompletionProvider.Highlight(0, 4, KiloPromptCompletionProvider.HighlightKind.COMMAND)),


### PR DESCRIPTION
## Summary

- show the file name first in JetBrains `@file` completion suggestions
- keep the containing path visible as secondary context
- preserve full relative-path matching and insertion behavior
- add a focused regression test for the rendered completion presentation

## Why

JetBrains displayed the full path as the primary suggestion text, unlike the VS Code experience. This makes file names harder to scan when paths are long. The updated presentation puts the file name first while retaining the parent directory for disambiguation.

## Validation

- `./gradlew :frontend:test --tests 'ai.kilocode.client.session.ui.prompt.KiloPromptCompletionProviderTest'`
- `./gradlew typecheck`

Closes #12705
