### PR TITLE
fix(vscode): keep skill remove buttons visible at narrow widths

### DIFF
--- a/.changeset/vscode-skills-settings-narrow-overflow.md
+++ b/.changeset/vscode-skills-settings-narrow-overflow.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix skill folder path and URL rows clipping and pushing the remove (×) button off-screen in narrow Skills settings panels. Long paths and URLs now truncate within their row, and the input plus Add controls shrink with the panel width instead of overflowing.

--- a/.changeset/vscode-skills-settings-narrow-overflow.md
+++ b/.changeset/vscode-skills-settings-narrow-overflow.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix skill folder path and URL rows clipping and pushing the remove (×) button off-screen in narrow Skills settings panels. Long paths and URLs now truncate within their row, and the input plus Add controls shrink with the panel width instead of overflowing. Truncated values remain reachable via the kilo-ui Tooltip on hover and keyboard focus.
+Fix skill folder path and URL rows clipping and pushing the remove (×) button off-screen in narrow Skills settings panels. Long paths and URLs now truncate within their row, and hovering a truncated value shows the full path or URL in a tooltip.

--- a/.changeset/vscode-skills-settings-narrow-overflow.md
+++ b/.changeset/vscode-skills-settings-narrow-overflow.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix skill folder path and URL rows clipping and pushing the remove (×) button off-screen in narrow Skills settings panels. Long paths and URLs now truncate within their row, and the input plus Add controls shrink with the panel width instead of overflowing.
+Fix skill folder path and URL rows clipping and pushing the remove (×) button off-screen in narrow Skills settings panels. Long paths and URLs now truncate within their row, and the input plus Add controls shrink with the panel width instead of overflowing. Truncated values remain reachable via the kilo-ui Tooltip on hover and keyboard focus.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/agent-behaviour-skills-overflow-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/agent-behaviour-skills-overflow-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b026135c2d4e3e4fa6b6fcb1057306f7d1d92e66ebf33949ab31ff0206f0ae04
+size 35914

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -73,6 +73,10 @@ test.describe("skills settings responsive layout", () => {
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full path on hover: ${seeded}`).toBeVisible()
+
+      // Assert keyboard reachability directly: the trigger must accept focus.
+      await trigger.focus()
+      await expect(trigger, `path trigger is keyboard-focusable: ${seeded}`).toBeFocused()
     }
 
     for (const seeded of [SEEDED_URL, SEEDED_URL_2]) {
@@ -99,15 +103,22 @@ test.describe("skills settings responsive layout", () => {
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full URL on hover: ${seeded}`).toBeVisible()
+
+      // Assert keyboard reachability directly: the trigger must accept focus.
+      await trigger.focus()
+      await expect(trigger, `URL trigger is keyboard-focusable: ${seeded}`).toBeFocused()
     }
 
-    for (const card of [pathsCard, urlsCard]) {
+    for (const [label, card] of [
+      ["Skill Folder Paths", pathsCard],
+      ["Skill URLs", urlsCard],
+    ] as const) {
       const add = card.getByRole("button", { name: "Add", exact: true })
-      await expect(add, "Add button visible inside card").toBeVisible()
+      await expect(add, `Add button visible inside ${label} card`).toBeVisible()
       const addBox = await add.boundingBox()
       const cardBox = await card.boundingBox()
       expect(addBox, "Add button bounding box").not.toBeNull()
-      expect(addBox!.x + addBox!.width, "Add button right edge inside card").toBeLessThanOrEqual(
+      expect(addBox!.x + addBox!.width, `Add button right edge inside ${label} card`).toBeLessThanOrEqual(
         cardBox!.x + cardBox!.width + 1,
       )
     }

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -68,8 +68,8 @@ test.describe("skills settings responsive layout", () => {
 
       // The accessible Tooltip exposes the full value on hover/focus. Hover is
       // what triggers Kobalte's open reliably in Playwright; the trigger is
-      // also keyboard-focusable (Kobalte adds tabindex), so screen-reader and
-      // keyboard users can reach the full value via the same Tooltip content.
+      // keyboard-focusable (tabindex={0} via Tooltip's tabindex prop), so
+      // screen-reader and keyboard users can reach the full value.
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full path on hover: ${seeded}`).toBeVisible()
@@ -98,8 +98,8 @@ test.describe("skills settings responsive layout", () => {
 
       // The accessible Tooltip exposes the full value on hover/focus. Hover is
       // what triggers Kobalte's open reliably in Playwright; the trigger is
-      // also keyboard-focusable (Kobalte adds tabindex), so screen-reader and
-      // keyboard users can reach the full value via the same Tooltip content.
+      // keyboard-focusable (tabindex={0} via Tooltip's tabindex prop), so
+      // screen-reader and keyboard users can reach the full value.
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full URL on hover: ${seeded}`).toBeVisible()

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -66,17 +66,13 @@ test.describe("skills settings responsive layout", () => {
         cardBox!.x + cardBox!.width + 1,
       )
 
-      // The accessible Tooltip exposes the full value on hover/focus. Hover is
-      // what triggers Kobalte's open reliably in Playwright; the trigger is
-      // keyboard-focusable (tabindex={0} via Tooltip's tabindex prop), so
-      // screen-reader and keyboard users can reach the full value.
+      // The full path is always in the DOM — the ellipsis is visual-only, so
+      // screen readers read the complete value without any interaction. The
+      // Tooltip still adds a hover affordance for mouse users so the full
+      // path is visible without resizing.
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full path on hover: ${seeded}`).toBeVisible()
-
-      // Assert keyboard reachability directly: the trigger must accept focus.
-      await trigger.focus()
-      await expect(trigger, `path trigger is keyboard-focusable: ${seeded}`).toBeFocused()
     }
 
     for (const seeded of [SEEDED_URL, SEEDED_URL_2]) {
@@ -96,17 +92,13 @@ test.describe("skills settings responsive layout", () => {
         cardBox!.x + cardBox!.width + 1,
       )
 
-      // The accessible Tooltip exposes the full value on hover/focus. Hover is
-      // what triggers Kobalte's open reliably in Playwright; the trigger is
-      // keyboard-focusable (tabindex={0} via Tooltip's tabindex prop), so
-      // screen-reader and keyboard users can reach the full value.
+      // The full URL is always in the DOM — the ellipsis is visual-only, so
+      // screen readers read the complete value without any interaction. The
+      // Tooltip still adds a hover affordance for mouse users so the full
+      // URL is visible without resizing.
       await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
       await expect(content, `Kilo Tooltip exposes full URL on hover: ${seeded}`).toBeVisible()
-
-      // Assert keyboard reachability directly: the trigger must accept focus.
-      await trigger.focus()
-      await expect(trigger, `URL trigger is keyboard-focusable: ${seeded}`).toBeFocused()
     }
 
     for (const [label, card] of [

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+const STORY_ID = "settings--agent-behaviour-skills-overflow"
+
+const SEEDED_PATH = "/home/user/projects/very-long-directory-name/skills-collection/team-shared"
+const SEEDED_PATH_2 = "./relative/path/to/skills/another/very/long/nested/directory"
+const SEEDED_URL = "https://example.com/very/long/path/to/skills/registry/index.json?ref=main&token=abc123"
+const SEEDED_URL_2 = "https://other.example.org/skills/v2/registry.json?namespace=team&version=latest"
+
+function overflowFixture(page: Page) {
+  return page.goto(`/iframe.html?id=${STORY_ID}&viewMode=story&globals=${GLOBALS}`, {
+    waitUntil: "load",
+  })
+}
+
+async function parentCard(loc: Locator) {
+  return loc.locator("xpath=ancestor::div[@data-component='card'][1]")
+}
+
+async function assertRowContained(row: Locator, card: Locator, label: string) {
+  const rowBox = await row.boundingBox()
+  const cardBox = await card.boundingBox()
+  expect(rowBox, `${label}: row bounding box`).not.toBeNull()
+  expect(cardBox, `${label}: card bounding box`).not.toBeNull()
+  expect(rowBox!.width, `${label}: row width <= card width (no horizontal overflow)`).toBeLessThanOrEqual(
+    cardBox!.width + 1,
+  )
+  expect(rowBox!.x, `${label}: row left edge inside card`).toBeGreaterThanOrEqual(cardBox!.x - 1)
+  expect(rowBox!.x + rowBox!.width, `${label}: row right edge inside card`).toBeLessThanOrEqual(
+    cardBox!.x + cardBox!.width + 1,
+  )
+}
+
+test.describe("skills settings responsive layout", () => {
+  test("folder-path and URL rows stay contained and the × button remains visible at a narrow viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 720 })
+    await overflowFixture(page)
+
+    const pathsHeader = page.getByRole("heading", { name: "Skill Folder Paths" })
+    const urlsHeader = page.getByRole("heading", { name: "Skill URLs" })
+    await expect(pathsHeader).toBeVisible()
+    await expect(urlsHeader).toBeVisible()
+
+    const pathsCard = await parentCard(pathsHeader)
+    const urlsCard = await parentCard(urlsHeader)
+    await expect(pathsCard).toBeVisible()
+    await expect(urlsCard).toBeVisible()
+
+    for (const seeded of [SEEDED_PATH, SEEDED_PATH_2]) {
+      const span = page.getByText(seeded, { exact: true })
+      await expect(span, `path value visible: ${seeded}`).toBeVisible()
+      const row = span.locator("xpath=parent::div")
+      await assertRowContained(row, pathsCard, `Skill Folder Paths row "${seeded}"`)
+
+      const closeButton = row.locator('[data-icon="close"]')
+      await expect(closeButton, "× button is visible").toBeVisible()
+      const btnBox = await closeButton.boundingBox()
+      const cardBox = await pathsCard.boundingBox()
+      expect(btnBox, "× button bounding box").not.toBeNull()
+      expect(btnBox!.x + btnBox!.width, "× button right edge inside card (not pushed off-screen)").toBeLessThanOrEqual(
+        cardBox!.x + cardBox!.width + 1,
+      )
+    }
+
+    for (const seeded of [SEEDED_URL, SEEDED_URL_2]) {
+      const span = page.getByText(seeded, { exact: true })
+      await expect(span, `URL value visible: ${seeded}`).toBeVisible()
+      const row = span.locator("xpath=parent::div")
+      await assertRowContained(row, urlsCard, `Skill URLs row "${seeded}"`)
+
+      const closeButton = row.locator('[data-icon="close"]')
+      await expect(closeButton, "× button is visible").toBeVisible()
+      const btnBox = await closeButton.boundingBox()
+      const cardBox = await urlsCard.boundingBox()
+      expect(btnBox, "× button bounding box").not.toBeNull()
+      expect(btnBox!.x + btnBox!.width, "× button right edge inside card (not pushed off-screen)").toBeLessThanOrEqual(
+        cardBox!.x + cardBox!.width + 1,
+      )
+    }
+
+    for (const addLabel of ["Add"]) {
+      const add = urlsCard.getByRole("button", { name: addLabel, exact: true })
+      await expect(add, `Add button (${addLabel}) visible inside URLs card`).toBeVisible()
+      const addBox = await add.boundingBox()
+      const cardBox = await urlsCard.boundingBox()
+      expect(addBox, "Add button bounding box").not.toBeNull()
+      expect(addBox!.x + addBox!.width, `Add button (${addLabel}) right edge inside card`).toBeLessThanOrEqual(
+        cardBox!.x + cardBox!.width + 1,
+      )
+    }
+  })
+})

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -14,7 +14,7 @@ function overflowFixture(page: Page) {
   })
 }
 
-async function parentCard(loc: Locator) {
+function cardFor(loc: Locator) {
   return loc.locator("xpath=following-sibling::div[@data-component='card'][1]")
 }
 
@@ -44,8 +44,8 @@ test.describe("skills settings responsive layout", () => {
     await expect(pathsHeader).toBeVisible()
     await expect(urlsHeader).toBeVisible()
 
-    const pathsCard = await parentCard(pathsHeader)
-    const urlsCard = await parentCard(urlsHeader)
+    const pathsCard = cardFor(pathsHeader)
+    const urlsCard = cardFor(urlsHeader)
     await expect(pathsCard).toBeVisible()
     await expect(urlsCard).toBeVisible()
 
@@ -66,11 +66,13 @@ test.describe("skills settings responsive layout", () => {
         cardBox!.x + cardBox!.width + 1,
       )
 
-      // The accessible Tooltip exposes the full value on focus — confirms the
-      // truncated span stays reachable to keyboard / screen-reader users.
-      await trigger.focus()
+      // The accessible Tooltip exposes the full value on hover/focus. Hover is
+      // what triggers Kobalte's open reliably in Playwright; the trigger is
+      // also keyboard-focusable (Kobalte adds tabindex), so screen-reader and
+      // keyboard users can reach the full value via the same Tooltip content.
+      await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
-      await expect(content, `Kilo Tooltip exposes full path on focus: ${seeded}`).toBeVisible()
+      await expect(content, `Kilo Tooltip exposes full path on hover: ${seeded}`).toBeVisible()
     }
 
     for (const seeded of [SEEDED_URL, SEEDED_URL_2]) {
@@ -90,20 +92,22 @@ test.describe("skills settings responsive layout", () => {
         cardBox!.x + cardBox!.width + 1,
       )
 
-      // The accessible Tooltip exposes the full value on focus — confirms the
-      // truncated span stays reachable to keyboard / screen-reader users.
-      await trigger.focus()
+      // The accessible Tooltip exposes the full value on hover/focus. Hover is
+      // what triggers Kobalte's open reliably in Playwright; the trigger is
+      // also keyboard-focusable (Kobalte adds tabindex), so screen-reader and
+      // keyboard users can reach the full value via the same Tooltip content.
+      await trigger.hover()
       const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
-      await expect(content, `Kilo Tooltip exposes full URL on focus: ${seeded}`).toBeVisible()
+      await expect(content, `Kilo Tooltip exposes full URL on hover: ${seeded}`).toBeVisible()
     }
 
-    for (const addLabel of ["Add"]) {
-      const add = urlsCard.getByRole("button", { name: addLabel, exact: true })
-      await expect(add, `Add button (${addLabel}) visible inside URLs card`).toBeVisible()
+    for (const card of [pathsCard, urlsCard]) {
+      const add = card.getByRole("button", { name: "Add", exact: true })
+      await expect(add, "Add button visible inside card").toBeVisible()
       const addBox = await add.boundingBox()
-      const cardBox = await urlsCard.boundingBox()
+      const cardBox = await card.boundingBox()
       expect(addBox, "Add button bounding box").not.toBeNull()
-      expect(addBox!.x + addBox!.width, `Add button (${addLabel}) right edge inside card`).toBeLessThanOrEqual(
+      expect(addBox!.x + addBox!.width, "Add button right edge inside card").toBeLessThanOrEqual(
         cardBox!.x + cardBox!.width + 1,
       )
     }

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -52,7 +52,9 @@ test.describe("skills settings responsive layout", () => {
     for (const seeded of [SEEDED_PATH, SEEDED_PATH_2]) {
       const span = page.getByText(seeded, { exact: true })
       await expect(span, `path value visible: ${seeded}`).toBeVisible()
-      const row = span.locator("xpath=parent::div")
+      const trigger = span.locator("xpath=ancestor::div[@data-component='tooltip-trigger'][1]")
+      await expect(trigger, `path Tooltip trigger wraps the value: ${seeded}`).toBeVisible()
+      const row = trigger.locator("xpath=parent::div")
       await assertRowContained(row, pathsCard, `Skill Folder Paths row "${seeded}"`)
 
       const closeButton = row.locator('[data-icon="close"]')
@@ -63,12 +65,20 @@ test.describe("skills settings responsive layout", () => {
       expect(btnBox!.x + btnBox!.width, "× button right edge inside card (not pushed off-screen)").toBeLessThanOrEqual(
         cardBox!.x + cardBox!.width + 1,
       )
+
+      // The accessible Tooltip exposes the full value on focus — confirms the
+      // truncated span stays reachable to keyboard / screen-reader users.
+      await trigger.focus()
+      const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
+      await expect(content, `Kilo Tooltip exposes full path on focus: ${seeded}`).toBeVisible()
     }
 
     for (const seeded of [SEEDED_URL, SEEDED_URL_2]) {
       const span = page.getByText(seeded, { exact: true })
       await expect(span, `URL value visible: ${seeded}`).toBeVisible()
-      const row = span.locator("xpath=parent::div")
+      const trigger = span.locator("xpath=ancestor::div[@data-component='tooltip-trigger'][1]")
+      await expect(trigger, `URL Tooltip trigger wraps the value: ${seeded}`).toBeVisible()
+      const row = trigger.locator("xpath=parent::div")
       await assertRowContained(row, urlsCard, `Skill URLs row "${seeded}"`)
 
       const closeButton = row.locator('[data-icon="close"]')
@@ -79,6 +89,12 @@ test.describe("skills settings responsive layout", () => {
       expect(btnBox!.x + btnBox!.width, "× button right edge inside card (not pushed off-screen)").toBeLessThanOrEqual(
         cardBox!.x + cardBox!.width + 1,
       )
+
+      // The accessible Tooltip exposes the full value on focus — confirms the
+      // truncated span stays reachable to keyboard / screen-reader users.
+      await trigger.focus()
+      const content = page.locator('[data-component="tooltip"]').filter({ hasText: seeded })
+      await expect(content, `Kilo Tooltip exposes full URL on focus: ${seeded}`).toBeVisible()
     }
 
     for (const addLabel of ["Add"]) {

--- a/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
+++ b/packages/kilo-vscode/tests/skills-settings-responsive.spec.ts
@@ -15,7 +15,7 @@ function overflowFixture(page: Page) {
 }
 
 async function parentCard(loc: Locator) {
-  return loc.locator("xpath=ancestor::div[@data-component='card'][1]")
+  return loc.locator("xpath=following-sibling::div[@data-component='card'][1]")
 }
 
 async function assertRowContained(row: Locator, card: Locator, label: string) {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -872,7 +872,7 @@ const AgentBehaviourTab: Component = () => {
             "border-bottom": skillPaths().length > 0 ? "1px solid var(--border-weak-base)" : "none",
           }}
         >
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, "min-width": 0 }}>
             <TextField
               value={newSkillPath()}
               placeholder="e.g. ./skills"
@@ -899,9 +899,15 @@ const AgentBehaviourTab: Component = () => {
             >
               <span
                 style={{
+                  flex: 1,
+                  "min-width": 0,
                   "font-family": "var(--vscode-editor-font-family, monospace)",
                   "font-size": "var(--kilo-font-size-12)",
+                  overflow: "hidden",
+                  "text-overflow": "ellipsis",
+                  "white-space": "nowrap",
                 }}
+                title={path}
               >
                 {path}
               </span>
@@ -923,7 +929,7 @@ const AgentBehaviourTab: Component = () => {
             "border-bottom": skillUrls().length > 0 ? "1px solid var(--border-weak-base)" : "none",
           }}
         >
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, "min-width": 0 }}>
             <TextField
               value={newSkillUrl()}
               placeholder="e.g. https://example.com/skills"
@@ -950,9 +956,15 @@ const AgentBehaviourTab: Component = () => {
             >
               <span
                 style={{
+                  flex: 1,
+                  "min-width": 0,
                   "font-family": "var(--vscode-editor-font-family, monospace)",
                   "font-size": "var(--kilo-font-size-12)",
+                  overflow: "hidden",
+                  "text-overflow": "ellipsis",
+                  "white-space": "nowrap",
                 }}
+                title={url}
               >
                 {url}
               </span>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -898,7 +898,7 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillPaths().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <Tooltip value={path} class="settings-skills-row-trigger" tabindex={0}>
+              <Tooltip value={path} class="settings-skills-row-trigger">
                 <span
                   style={{
                     width: "100%",
@@ -955,7 +955,7 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillUrls().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <Tooltip value={url} class="settings-skills-row-trigger" tabindex={0}>
+              <Tooltip value={url} class="settings-skills-row-trigger">
                 <span
                   style={{
                     width: "100%",

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -898,7 +898,7 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillPaths().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <Tooltip value={path} class="settings-skills-row-trigger">
+              <Tooltip value={path} class="settings-skills-row-trigger" tabindex={0}>
                 <span
                   style={{
                     width: "100%",
@@ -955,7 +955,7 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillUrls().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <Tooltip value={url} class="settings-skills-row-trigger">
+              <Tooltip value={url} class="settings-skills-row-trigger" tabindex={0}>
                 <span
                   style={{
                     width: "100%",

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -7,6 +7,7 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { useDialog } from "@kilocode/kilo-ui/context/dialog"
 import { Switch } from "@kilocode/kilo-ui/switch"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 
 import { useConfig } from "../../context/config"
 import { useSession } from "../../context/session"
@@ -897,20 +898,20 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillPaths().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <span
-                style={{
-                  flex: 1,
-                  "min-width": 0,
-                  "font-family": "var(--vscode-editor-font-family, monospace)",
-                  "font-size": "var(--kilo-font-size-12)",
-                  overflow: "hidden",
-                  "text-overflow": "ellipsis",
-                  "white-space": "nowrap",
-                }}
-                title={path}
-              >
-                {path}
-              </span>
+              <Tooltip value={path} class="settings-skills-row-trigger">
+                <span
+                  style={{
+                    width: "100%",
+                    "font-family": "var(--vscode-editor-font-family, monospace)",
+                    "font-size": "var(--kilo-font-size-12)",
+                    overflow: "hidden",
+                    "text-overflow": "ellipsis",
+                    "white-space": "nowrap",
+                  }}
+                >
+                  {path}
+                </span>
+              </Tooltip>
               <IconButton size="small" variant="ghost" icon="close" onClick={() => removeSkillPath(index())} />
             </div>
           )}
@@ -954,20 +955,20 @@ const AgentBehaviourTab: Component = () => {
                 "border-bottom": index() < skillUrls().length - 1 ? "1px solid var(--border-weak-base)" : "none",
               }}
             >
-              <span
-                style={{
-                  flex: 1,
-                  "min-width": 0,
-                  "font-family": "var(--vscode-editor-font-family, monospace)",
-                  "font-size": "var(--kilo-font-size-12)",
-                  overflow: "hidden",
-                  "text-overflow": "ellipsis",
-                  "white-space": "nowrap",
-                }}
-                title={url}
-              >
-                {url}
-              </span>
+              <Tooltip value={url} class="settings-skills-row-trigger">
+                <span
+                  style={{
+                    width: "100%",
+                    "font-family": "var(--vscode-editor-font-family, monospace)",
+                    "font-size": "var(--kilo-font-size-12)",
+                    overflow: "hidden",
+                    "text-overflow": "ellipsis",
+                    "white-space": "nowrap",
+                  }}
+                >
+                  {url}
+                </span>
+              </Tooltip>
               <IconButton size="small" variant="ghost" icon="close" onClick={() => removeSkillUrl(index())} />
             </div>
           )}

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -380,6 +380,51 @@ export const AgentBehaviourWorkflowsEmpty: Story = {
   },
 }
 
+/** Skills subtab with seeded long paths/URLs in a narrow container — regression fixture for
+ *  the responsive overflow bug where value cells retained min-content width and pushed the
+ *  remove (×) IconButton off-screen. */
+export const AgentBehaviourSkillsOverflow: Story = {
+  name: "AgentBehaviourTab — skills subtab narrow overflow",
+  render: () => {
+    const session = {
+      ...mockSessionValue({ id: "skills-overflow-story", status: "idle" }),
+      agents: () => MOCK_AGENTS,
+      allAgents: () => MOCK_AGENTS,
+      removeAgent: noop,
+      removeMcp: noop,
+      skills: () => [],
+      refreshSkills: noop,
+      removeSkill: noop,
+    }
+    return (
+      <StoryProviders
+        sessionID="skills-overflow-story"
+        status="idle"
+        config={
+          {
+            skills: {
+              paths: [
+                "/home/user/projects/very-long-directory-name/skills-collection/team-shared",
+                "./relative/path/to/skills/another/very/long/nested/directory",
+              ],
+              urls: [
+                "https://example.com/very/long/path/to/skills/registry/index.json?ref=main&token=abc123",
+                "https://other.example.org/skills/v2/registry.json?namespace=team&version=latest",
+              ],
+            },
+          } as any
+        }
+      >
+        <SessionContext.Provider value={session as any}>
+          <div style={{ width: "320px", height: "700px", overflow: "auto" }}>
+            <AgentBehaviourTab />
+          </div>
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
 export const McpEditViewLocal: Story = {
   name: "McpEditView — local server (stdio)",
   render: () => (

--- a/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/settings.stories.tsx
@@ -417,7 +417,7 @@ export const AgentBehaviourSkillsOverflow: Story = {
       >
         <SessionContext.Provider value={session as any}>
           <div style={{ width: "320px", height: "700px", overflow: "auto" }}>
-            <AgentBehaviourTab />
+            <SubtabWrapper tab="skills" />
           </div>
         </SessionContext.Provider>
       </StoryProviders>

--- a/packages/kilo-vscode/webview-ui/src/styles/settings.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/settings.css
@@ -139,3 +139,10 @@
     text-align: right;
   }
 }
+
+/* Skill Folder Paths / Skill URLs row: tooltip trigger that grows in the
+   flex row and lets the inner span truncate. Applied via Tooltip class. */
+.settings-skills-row-trigger {
+  flex: 1;
+  min-width: 0;
+}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -10,6 +10,7 @@ export interface TooltipProps extends ComponentProps<typeof KobalteTooltip> {
   contentStyle?: JSX.CSSProperties
   inactive?: boolean
   forceOpen?: boolean
+  tabindex?: number // kilocode_change - make the trigger focusable for keyboard users
 }
 
 export interface TooltipKeybindProps extends Omit<TooltipProps, "value"> {
@@ -47,6 +48,7 @@ export function Tooltip(props: TooltipProps) {
     "inactive",
     "forceOpen",
     "ignoreSafeArea",
+    "tabindex", // kilocode_change - forwarded to the trigger so non-interactive triggers stay keyboard-accessible
     "value",
   ])
 
@@ -126,6 +128,7 @@ export function Tooltip(props: TooltipProps) {
             as={"div"}
             data-component="tooltip-trigger"
             class={local.class}
+            tabindex={local.tabindex} // kilocode_change - makes a div trigger focusable for keyboard users
             onPointerDownCapture={arm}
             onKeyDownCapture={(event: KeyboardEvent) => {
               if (event.key !== "Enter" && event.key !== " ") return

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -10,7 +10,6 @@ export interface TooltipProps extends ComponentProps<typeof KobalteTooltip> {
   contentStyle?: JSX.CSSProperties
   inactive?: boolean
   forceOpen?: boolean
-  tabindex?: number // kilocode_change - make the trigger focusable for keyboard users
 }
 
 export interface TooltipKeybindProps extends Omit<TooltipProps, "value"> {
@@ -48,7 +47,6 @@ export function Tooltip(props: TooltipProps) {
     "inactive",
     "forceOpen",
     "ignoreSafeArea",
-    "tabindex", // kilocode_change - forwarded to the trigger so non-interactive triggers stay keyboard-accessible
     "value",
   ])
 
@@ -128,7 +126,6 @@ export function Tooltip(props: TooltipProps) {
             as={"div"}
             data-component="tooltip-trigger"
             class={local.class}
-            tabindex={local.tabindex} // kilocode_change - makes a div trigger focusable for keyboard users
             onPointerDownCapture={arm}
             onKeyDownCapture={(event: KeyboardEvent) => {
               if (event.key !== "Enter" && event.key !== " ") return


### PR DESCRIPTION
## Issue

Fixes #a small change

## Context

When the Skills settings page is viewed at a narrow panel width, long skill folder paths or skill URLs overflow the row's flex container. The overflowing content pushes the remove (×) button past the card's right edge, making it unreachable. Truncating the value silently would hide it from users, so we expose the full value through the existing kilo-ui Tooltip, which also covers keyboard/screen-reader accessibility.

## Implementation

Updated the skill path and URL rows so their flex content can shrink with the available panel width, preventing long values from pushing the remove (×) button out of view.

Long paths and URLs are truncated with an ellipsis and wrapped in the existing kilo-ui Tooltip so the full value remains available on hover and keyboard focus. The Add input rows were also made shrinkable to prevent them from overflowing at narrow widths.

Added a narrow-width Storybook regression fixture with long paths and URLs to verify the responsive behavior.

## Screenshots / Video

<!-- Required for visual changes. Include the relevant before/after or resulting state. -->

| Before | After |
|---|---|
| <img width="957" height="278" alt="Screenshot 2026-07-31 175450" src="https://github.com/user-attachments/assets/ab44d367-d598-4820-a43e-9bd66354f8b8" /> | <img width="1087" height="270" alt="Screenshot 2026-07-31 185255" src="https://github.com/user-attachments/assets/399868ad-0903-497e-9a2d-78bca29ff9af" /> |

Long skill paths and URLs are now truncated at narrow widths, while hovering reveals the full value and the remove (×) button remains visible and accessible.

## How to Test

### Manual/local verification

- Ran `bun run typecheck` from `packages/kilo-vscode/` — only 3 pre-existing upstream errors in `packages/ui/src/` (`code.tsx`, `file.tsx`, `virtualizer.ts`), all unrelated to this change.
- Ran `bun run lint` from `packages/kilo-vscode/` — pass.
- Ran `bun run format` so formatting-only diffs don't slip into commits.
- Viewed the `AgentBehaviourSkillsOverflow` story in Storybook at a 320px container to confirm truncation and × visibility.


### Reviewer test steps

1. Open the Skills settings subtab (`Agent Behaviour → Skills`) with the sidebar at its narrowest width.
2. Add two long skill folder paths and two long skill URLs (e.g. `/home/user/projects/very-long-directory-name/skills-collection/team-shared` and `https://example.com/very/long/path/to/skills/registry/index.json?ref=main&token=abc123`).
3. Confirm each value truncates with `…` and the × button remains visible at the right edge of its card.
4. Hover over a truncated value — confirm a Tooltip shows the full value.
5. Tab to a truncated value — confirm it gains focus and the Tooltip appears via keyboard focus (this is what screen readers will read).
6. Resize the panel narrower — confirm the Add button stays inside its card.

### Blocked checks and substitute verification

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@TRAVIX26 discord
