### PR TITLE
fix(vscode): make cache hit rate write-aware

### DIFF
--- a/.changeset/write-aware-cache-rate.md
+++ b/.changeset/write-aware-cache-rate.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show a write-aware cache hit rate in the VS Code session usage bar.

--- a/packages/kilo-vscode/tests/unit/model-usage.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Provider, SessionModelUsage } from "../../webview-ui/src/types/messages"
 import {
+  cacheRate,
   groupModelUsage,
   hasModelUsage,
   isSameSessionTree,
@@ -44,6 +45,8 @@ describe("model usage", () => {
       }),
     ).toBeFalse()
     expect(tokenSummary(usage)).toEqual({ input: 10, output: 2, cached: 20 })
+    expect(cacheRate(models[0])).toBe("57.1%")
+    expect(cacheRate({ ...models[0], tokens: { ...tokens, input: 0, cache: { read: 0, write: 0 } } })).toBe("-")
     expect(groupModelUsage(models, providers).map((group) => group.providerName)).toEqual(["Kilo Gateway", "MiniMax"])
     expect(modelUsageName(models[0], providers)).toBe("Qwen 3.7 Plus")
     expect(modelUsageName(models[1], providers)).toBe("MiniMax M3")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskUsage.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@kilocode/kilo-ui/icon"
 import { useLanguage } from "../../context/language"
 import { useProvider } from "../../context/provider"
 import type { SessionModelUsage } from "../../types/messages"
-import { groupModelUsage, modelUsageName, type TokenSummary } from "../../context/model-usage"
+import { cacheRate, groupModelUsage, modelUsageName, type TokenSummary } from "../../context/model-usage"
 import { formatCompactCount } from "../../utils/format"
 
 interface TaskUsageProps {
@@ -35,12 +35,6 @@ export const TaskUsage: Component<TaskUsageProps> = (props) => {
     if (value > 0 && value < 0.000001) return "<$0.000001"
     return money().format(value)
   }
-  const rate = (model: SessionModelUsage["models"][number]) => {
-    const total = model.tokens.input + model.tokens.cache.read
-    if (total === 0) return "-"
-    return `${((model.tokens.cache.read / total) * 100).toFixed(1)}%`
-  }
-
   const Summary = () => (
     <>
       <span class="task-header-tokens-label">Tokens</span>
@@ -102,7 +96,7 @@ export const TaskUsage: Component<TaskUsageProps> = (props) => {
                         </div>
                         <div class="task-header-usage-meta">
                           Cache R {count(model.tokens.cache.read)} · W {count(model.tokens.cache.write)} · Hit Rate{" "}
-                          {rate(model)}
+                          {cacheRate(model)}
                         </div>
                       </div>
                     )}

--- a/packages/kilo-vscode/webview-ui/src/context/model-usage.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/model-usage.ts
@@ -46,6 +46,12 @@ export function tokenSummary(usage: SessionModelUsage): TokenSummary {
   }
 }
 
+export function cacheRate(model: SessionModelUsage["models"][number]) {
+  const total = model.tokens.input + model.tokens.cache.read + model.tokens.cache.write
+  if (total === 0) return "-"
+  return `${((model.tokens.cache.read / total) * 100).toFixed(1)}%`
+}
+
 export function groupModelUsage(models: SessionModelUsage["models"], providers: Record<string, Provider>) {
   const groups = new Map<string, { providerID: string; providerName: string; models: SessionModelUsage["models"] }>()
   for (const model of models) {


### PR DESCRIPTION
The VS Code session usage bar currently calculates cache hit rate as cache reads divided by input plus cache reads. Because cache writes are excluded, sessions with significant write volume can display nearly 100% despite paying for millions of written tokens.

This changes the rate to include cache writes in the denominator, matching the write-aware calculation used by the TUI:

`cache read / (input + cache read + cache write)`

The screenshots below use the exact same persisted session and token counts. The display changes from 100.0% to 49.7%, while `In 6`, `Cache R 19,242`, and `W 19,442` remain unchanged.

Before

<img width="400" alt="VS Code session usage before the write-aware cache rate fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260731-cache-rate-before.png?raw=true" />

After

<img width="400" alt="VS Code session usage after the write-aware cache rate fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260731-cache-rate-after.png?raw=true" />