### PR TITLE
fix(cli): suppress AI SDK system message warning in TUI

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -395,6 +395,7 @@ const live: Layer.Layer<
         ...KiloLLM.timeout({ options: prepared.params.options, fallback: item.options, log: l }), // kilocode_change
         headers: prepared.headers,
         maxRetries: input.retries ?? 0,
+        allowSystemInMessages: true, // kilocode_change - system prompts are trusted and intentionally included in messages
         messages: prepared.messages,
         model: wrapLanguageModel({
           model: language,


### PR DESCRIPTION
## Problem

AI SDK 6.0.235 logs a `console.warn` when system messages appear in the `messages` array:

```
AI SDK Warning: System messages in the prompt or messages fields can be a security risk...
```

OpenCode prepends trusted system prompts to `messages` in `session/llm/request.ts`, so this warning fires on every turn and bleeds directly into the TUI frame, corrupting the terminal UI.

The existing `globalThis.AI_SDK_LOG_WARNINGS = false` suppression in `session/prompt.ts` and `server/server.ts` only disables AI SDK's internal warning logger. The prompt-level system-message warning is emitted via raw `console.warn` from `standardizePrompt`, bypassing that global.

## Fix

Set `allowSystemInMessages: true` on the `streamText` call in `packages/opencode/src/session/llm.ts`. This tells AI SDK that the `role: "system"` messages in `messages` are intentional and trusted, so the warning path is never entered.

## Why this shape

- OpenCode upstream intentionally prepends system prompts into `messages` rather than using the top-level `system` option.
- Moving to `system` would require changes to provider transforms and risk breaking provider-specific behavior.
- `allowSystemInMessages: true` is per-call, does not disable unrelated AI SDK warnings, and future-proofs against AI SDK 7 which rejects system messages by default instead of merely warning.

## Validation

- `bun run script/check-opencode-annotations.ts --worktree` passed.
- `git diff --check` passed.
- AI SDK source inspection confirmed `true` suppresses the warning, `false` throws, `undefined` warns.
- One shared file changed with a narrow `kilocode_change` marker.