### PR TITLE
fix(cli): disable interactive tools in headless runs

### DIFF
--- a/.changeset/headless-suggestions-exit.md
+++ b/.changeset/headless-suggestions-exit.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent non-interactive `kilo run` sessions from waiting for unavailable question or suggestion input.

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -958,6 +958,7 @@ export const RunCommand = effectCmd({
         await share(client, sessionID)
 
         if (!args.interactive) {
+          const disabled = { question: false, suggest: false } // kilocode_change - headless runs cannot answer UI tools
           const events = await client.event.subscribe()
           const completed = loop(client, events).catch((e) => {
             console.error(e)
@@ -988,6 +989,7 @@ export const RunCommand = effectCmd({
               command: args.command,
               arguments: message,
               variant: args.variant,
+              ephemeralTools: disabled, // kilocode_change
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
@@ -1004,6 +1006,7 @@ export const RunCommand = effectCmd({
             agent,
             model,
             variant: args.variant,
+            ephemeralTools: disabled, // kilocode_change
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -44,7 +44,10 @@ export namespace KiloTask {
 
   /** Carry request-scoped tool denials into child and follow-up prompts. */
   export function restrictions(tools?: Record<string, boolean>) {
-    return Object.fromEntries(Object.entries(tools ?? {}).filter(([, enabled]) => !enabled))
+    return {
+      ...(tools?.question === false ? { question: false } : {}),
+      ...(tools?.suggest === false ? { suggest: false } : {}),
+    }
   }
 
   /**

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -42,6 +42,11 @@ export namespace KiloTask {
     return false
   }
 
+  /** Carry request-scoped tool denials into child and follow-up prompts. */
+  export function restrictions(tools?: Record<string, boolean>) {
+    return Object.fromEntries(Object.entries(tools ?? {}).filter(([, enabled]) => !enabled))
+  }
+
   /**
    * Build inherited permission ceilings from the calling agent.
    * Merges the static agent definition with the session's accumulated permissions

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2122,6 +2122,7 @@ export const layer = Layer.effect(
         agent: userAgent,
         parts,
         variant: input.variant,
+        ephemeralTools: input.ephemeralTools, // kilocode_change - retain non-persistent caller restrictions
         snapshotInitialization: input.snapshotInitialization, // kilocode_change
       })
       yield* events.publish(Command.Event.Executed, {
@@ -2200,6 +2201,11 @@ export const PromptInput = Schema.Struct({
     description:
       "@deprecated tools and permissions have been merged, you can set permissions on the session itself now",
   }),
+  // kilocode_change start - expose non-persistent tool restrictions to SDK callers
+  ephemeralTools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
+    description: "Tool availability overrides for this prompt only; these do not update session permissions.",
+  }),
+  // kilocode_change end
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),
@@ -2233,7 +2239,6 @@ type PartInputUnion =
 export type PromptInput = Omit<Schema.Schema.Type<typeof PromptInput>, "parts" | "editorContext"> & {
   parts: PartInputUnion[]
   editorContext?: MessageV2.EditorContext
-  ephemeralTools?: Record<string, boolean>
 }
 // kilocode_change end
 
@@ -2261,6 +2266,11 @@ export const CommandInput = Schema.Struct({
   arguments: Schema.String,
   command: Schema.String,
   variant: Schema.optional(Schema.String),
+  // kilocode_change start - expose non-persistent tool restrictions to SDK callers
+  ephemeralTools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
+    description: "Tool availability overrides for this command only; these do not update session permissions.",
+  }),
+  // kilocode_change end
   // kilocode_change start - managed product slow-snapshot policy
   snapshotInitialization: Schema.optional(Schema.Literal("wait")).annotate({
     description: "Wait silently if snapshot initialization is slow instead of asking the user.",

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -202,6 +202,13 @@ export const TaskTool = Tool.define(
         Effect.orDie,
       )
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
+      // kilocode_change start - retain headless tool restrictions in subagent turns and background follow-ups
+      const user = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: msg.info.parentID }).pipe(
+        Effect.provideService(Database.Service, database),
+        Effect.orDie,
+      )
+      const restrictions = KiloTask.restrictions(user.info.role === "user" ? user.info.tools : undefined)
+      // kilocode_change end
 
       // kilocode_change start — prefer valid subagent overrides, safely inheriting when overrides go stale
       const selected = yield* KiloTask.resolveModel({
@@ -247,6 +254,7 @@ export const TaskTool = Tool.define(
             },
             variant, // kilocode_change
             agent: next.name,
+            ephemeralTools: restrictions, // kilocode_change - inherit request-scoped tool denials
             tools: {
               question: false, // kilocode_change - subagents cannot prompt the user directly
               interactive_terminal: false, // kilocode_change - subagents cannot take over the user's terminal
@@ -278,6 +286,7 @@ export const TaskTool = Tool.define(
             sessionID: ctx.sessionID,
             agent: currentParent.agent ?? ctx.agent,
             variant,
+            ephemeralTools: restrictions, // kilocode_change - keep headless background follow-ups non-interactive
             parts: [
               {
                 type: "text",

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -203,11 +203,8 @@ export const TaskTool = Tool.define(
       )
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
       // kilocode_change start - retain headless tool restrictions in subagent turns and background follow-ups
-      const user = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: msg.info.parentID }).pipe(
-        Effect.provideService(Database.Service, database),
-        Effect.orDie,
-      )
-      const restrictions = KiloTask.restrictions(user.info.role === "user" ? user.info.tools : undefined)
+      const user = ctx.messages.findLast((item) => item.info.role === "user")
+      const restrictions = KiloTask.restrictions(user?.info.role === "user" ? user.info.tools : undefined)
       // kilocode_change end
 
       // kilocode_change start — prefer valid subagent overrides, safely inheriting when overrides go stale

--- a/packages/opencode/test/kilocode/run-auto.test.ts
+++ b/packages/opencode/test/kilocode/run-auto.test.ts
@@ -140,6 +140,7 @@ describe("cli run auto permissions", () => {
   test("auto approves tracked subagent permissions and ignores unrelated sessions", async () => {
     const q = feed<Event>()
     const calls: Array<{ requestID: string; reply: string }> = []
+    const prompts: Array<Record<string, unknown>> = []
     const done = Promise.withResolvers<void>()
 
     const sdk = {
@@ -160,7 +161,8 @@ describe("cli run auto permissions", () => {
         get: async (input: { sessionID: string }) => ({
           data: { id: input.sessionID, directory: "/tmp/project" },
         }),
-        prompt: async () => {
+        prompt: async (input: Record<string, unknown>) => {
+          prompts.push(input)
           q.push(task("ses_child"))
           q.push(permission("perm_other", "ses_other"))
           q.push(permission("perm_child", "ses_child"))
@@ -175,5 +177,6 @@ describe("cli run auto permissions", () => {
     await run(sdk)
 
     expect(calls).toEqual([{ requestID: "perm_child", reply: "once" }])
+    expect(prompts[0]?.ephemeralTools).toEqual({ question: false, suggest: false })
   })
 })

--- a/packages/opencode/test/kilocode/run-headless-tools.test.ts
+++ b/packages/opencode/test/kilocode/run-headless-tools.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../lib/cli-process"
+
+describe("kilo run headless tools", () => {
+  cliIt.live(
+    "omits UI tools and exits when the model still calls suggest",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.tool("suggest", {
+          suggest: "Review the result",
+          actions: [{ label: "Review", description: "Review the changes", prompt: "/review uncommitted" }],
+        })
+        yield* llm.text("finished without waiting for input")
+
+        const result = yield* opencode.run("call suggest, then finish", {
+          format: "json",
+          extraArgs: ["--auto"],
+          timeoutMs: 30_000,
+        })
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("finished without waiting for input")
+
+        const inputs = yield* llm.inputs
+        const names = inputs.flatMap((input) =>
+          ((input.tools ?? []) as Array<{ function?: { name?: string } }>).flatMap((item) =>
+            item.function?.name ? [item.function.name] : [],
+          ),
+        )
+        expect(names).toContain("glob")
+        expect(names).not.toContain("question")
+        expect(names).not.toContain("suggest")
+      }),
+    60_000,
+  )
+})

--- a/packages/opencode/test/kilocode/run-network.test.ts
+++ b/packages/opencode/test/kilocode/run-network.test.ts
@@ -320,6 +320,7 @@ describe("cli run network retries", () => {
         command: "compact",
         arguments: "argument\nfrom stdin",
         variant: undefined,
+        ephemeralTools: { question: false, suggest: false },
       },
     ])
   })

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -262,6 +262,31 @@ function providerCfg(url: string) {
   }
 }
 
+it.live("ephemeral prompt tools do not persist session restrictions", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "Ephemeral prompt tools" })
+
+      const message = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        ephemeralTools: { question: false, suggest: false },
+        parts: [{ type: "text", text: "headless" }],
+      })
+
+      expect(message.info.role).toBe("user")
+      if (message.info.role !== "user") throw new Error("expected a user message")
+      expect(message.info.tools).toEqual({ question: false, suggest: false })
+      const reloaded = yield* sessions.get(session.id)
+      expect(reloaded.permission).toBeUndefined()
+    }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live(
   "blocks @file content denied by .kilocodeignore",
   () =>

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -55,7 +55,7 @@ afterEach(async () => {
   await disposeAllInstances()
 })
 
-const seed = Effect.fn("NestedTaskToolTest.seed")(function* () {
+const seed = Effect.fn("NestedTaskToolTest.seed")(function* (tools?: Record<string, boolean>) {
   const sessions = yield* Session.Service
   const chat = yield* sessions.create({ title: "Parent" })
   const user = yield* sessions.updateMessage({
@@ -64,6 +64,7 @@ const seed = Effect.fn("NestedTaskToolTest.seed")(function* () {
     sessionID: chat.id,
     agent: "build",
     model: ref,
+    tools,
     time: { created: Date.now() },
   })
   const assistant: MessageV2.Assistant = {
@@ -172,6 +173,37 @@ describe("Kilo task nesting", () => {
         expect(kids[0]?.parentID).toBe(chat.id)
         expect(seen?.sessionID).toBe(result.metadata.sessionId)
         expect(seen?.agent).toBe("explore")
+      }),
+    ),
+  )
+
+  it.live("propagates request-scoped tool restrictions to subagents", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed({ question: false, suggest: false })
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+
+        yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "explore",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps({ onPrompt: (input) => (seen = input) }) },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.ephemeralTools).toEqual({ question: false, suggest: false })
       }),
     ),
   )

--- a/packages/opencode/test/kilocode/task-nesting.test.ts
+++ b/packages/opencode/test/kilocode/task-nesting.test.ts
@@ -180,9 +180,11 @@ describe("Kilo task nesting", () => {
   it.live("propagates request-scoped tool restrictions to subagents", () =>
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
-        const { chat, assistant } = yield* seed({ question: false, suggest: false })
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed({ question: false, suggest: false, read: false })
         const tool = yield* TaskTool
         const def = yield* tool.init()
+        const messages = yield* sessions.messages({ sessionID: chat.id })
         let seen: SessionPrompt.PromptInput | undefined
 
         yield* def.execute(
@@ -197,7 +199,7 @@ describe("Kilo task nesting", () => {
             agent: "build",
             abort: new AbortController().signal,
             extra: { promptOps: stubOps({ onPrompt: (input) => (seen = input) }) },
-            messages: [],
+            messages,
             metadata: () => Effect.void,
             ask: () => Effect.void,
           },

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4484,6 +4484,9 @@ export class Session2 extends HeyApiClient {
       tools?: {
         [key: string]: boolean
       }
+      ephemeralTools?: {
+        [key: string]: boolean
+      }
       format?: OutputFormat
       system?: string
       variant?: string
@@ -4511,6 +4514,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agent" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
+            { in: "body", key: "ephemeralTools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
@@ -4846,6 +4850,9 @@ export class Session2 extends HeyApiClient {
       tools?: {
         [key: string]: boolean
       }
+      ephemeralTools?: {
+        [key: string]: boolean
+      }
       format?: OutputFormat
       system?: string
       variant?: string
@@ -4873,6 +4880,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "agent" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
+            { in: "body", key: "ephemeralTools" },
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
@@ -4911,6 +4919,9 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      ephemeralTools?: {
+        [key: string]: boolean
+      }
       snapshotInitialization?: "wait"
       parts?: Array<{
         id?: string
@@ -4937,6 +4948,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "ephemeralTools" },
             { in: "body", key: "snapshotInitialization" },
             { in: "body", key: "parts" },
           ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -9290,6 +9290,9 @@ export type SessionPromptData = {
     tools?: {
       [key: string]: boolean
     }
+    ephemeralTools?: {
+      [key: string]: boolean
+    }
     format?: OutputFormat
     system?: string
     variant?: string
@@ -9644,6 +9647,9 @@ export type SessionPromptAsyncData = {
     tools?: {
       [key: string]: boolean
     }
+    ephemeralTools?: {
+      [key: string]: boolean
+    }
     format?: OutputFormat
     system?: string
     variant?: string
@@ -9696,6 +9702,9 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    ephemeralTools?: {
+      [key: string]: boolean
+    }
     snapshotInitialization?: "wait"
     parts?: Array<{
       id?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -7819,12 +7819,6 @@
                   "variant": {
                     "type": "string"
                   },
-                  "ephemeralTools": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
-                  },
                   "snapshotInitialization": {
                     "type": "string",
                     "enum": ["wait"]
@@ -7995,6 +7989,12 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "ephemeralTools": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
                   },
                   "snapshotInitialization": {
                     "type": "string",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6888,6 +6888,12 @@
                       "type": "boolean"
                     }
                   },
+                  "ephemeralTools": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  },
                   "format": {
                     "$ref": "#/components/schemas/OutputFormat"
                   },
@@ -7798,6 +7804,12 @@
                       "type": "boolean"
                     }
                   },
+                  "ephemeralTools": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  },
                   "format": {
                     "$ref": "#/components/schemas/OutputFormat"
                   },
@@ -7806,6 +7818,12 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "ephemeralTools": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
                   },
                   "snapshotInitialization": {
                     "type": "string",


### PR DESCRIPTION
## What

Exclude `suggest` and `question` from model tool lists for non-interactive `kilo run` requests, including resumed sessions, commands, subagents, and background follow-up turns. The restriction is request-scoped and does not alter session permissions, so later interactive TUI turns retain their existing behavior.

## Why

These tools wait for UI responses that headless clients cannot provide. If a model selected either tool, benchmark and automation processes could remain blocked indefinitely instead of completing the agent loop and exiting.