### PR TITLE
fix(vscode): widen settings model selectors

### DIFF
--- a/.changeset/wide-model-settings-selectors.md
+++ b/.changeset/wide-model-settings-selectors.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Widen model selectors in settings so selected model names remain readable

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ModelsTab.tsx
@@ -106,6 +106,7 @@ const ModelsTab: Component = () => {
         <SettingsRow
           title={language.t("settings.providers.defaultModel.title")}
           description={language.t("settings.providers.defaultModel.description")}
+          modelInput
         >
           <ModelSelectorBase
             value={parseModelString(config().model ?? undefined)}
@@ -120,6 +121,7 @@ const ModelsTab: Component = () => {
         <SettingsRow
           title={language.t("settings.providers.smallModel.title")}
           description={language.t("settings.providers.smallModel.description")}
+          modelInput
         >
           <ModelSelectorBase
             value={parseModelString(config().small_model ?? undefined)}
@@ -135,17 +137,23 @@ const ModelsTab: Component = () => {
         <SettingsRow
           title={language.t("settings.providers.subagentModel.title")}
           description={language.t("settings.providers.subagentModel.description")}
+          modelInput
         >
-          <div style={{ display: "flex", "flex-direction": "column", "align-items": "flex-end", gap: "8px" }}>
-            <ModelSelectorBase
-              value={subagentModel()}
-              onSelect={handleSubagentModelSelect}
-              placement="bottom-start"
-              allowClear
-              clearLabel={language.t("settings.providers.notSet")}
-              label={language.t("settings.providers.subagentModel.title")}
-              description={language.t("settings.providers.subagentModel.description")}
-            />
+          <div
+            class="model-settings-control"
+            style={{ display: "flex", "flex-direction": "column", "align-items": "flex-end", gap: "8px" }}
+          >
+            <div class="model-settings-selector">
+              <ModelSelectorBase
+                value={subagentModel()}
+                onSelect={handleSubagentModelSelect}
+                placement="bottom-start"
+                allowClear
+                clearLabel={language.t("settings.providers.notSet")}
+                label={language.t("settings.providers.subagentModel.title")}
+                description={language.t("settings.providers.subagentModel.description")}
+              />
+            </div>
             <Show when={subagentVariants().length > 0}>
               <ThinkingSelectorBase
                 variants={subagentVariants()}
@@ -163,6 +171,7 @@ const ModelsTab: Component = () => {
         <SettingsRow
           title={language.t("settings.autocomplete.model.title")}
           description={language.t("settings.autocomplete.model.description")}
+          modelInput
         >
           <ModelSelectorBase
             value={getAutocompleteSelection(autocompleteProvider(), autocompleteModel())}
@@ -235,6 +244,7 @@ const ModelsTab: Component = () => {
             <SettingsRow
               title={agent.name.charAt(0).toUpperCase() + agent.name.slice(1)}
               last={index() === allAgents().length - 1}
+              modelInput
             >
               <ModelSelectorBase
                 value={parseModelString(config().agent?.[agent.name]?.model ?? undefined)}

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SettingsRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SettingsRow.tsx
@@ -7,10 +7,12 @@ const SettingsRow: Component<{
   descriptionId?: string
   tag?: () => string | undefined
   last?: boolean
+  modelInput?: boolean
   children: JSX.Element
 }> = (props) => (
   <div
     data-slot="settings-row"
+    data-variant={props.modelInput ? "model-input" : undefined}
     style={{
       "margin-bottom": props.last ? "0" : "8px",
       "padding-bottom": props.last ? "0" : "8px",

--- a/packages/kilo-vscode/webview-ui/src/styles/settings.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/settings.css
@@ -121,6 +121,18 @@
   max-width: none;
 }
 
+[data-variant="model-input"] [data-slot="settings-row-input"] {
+  flex: 0 1 350px;
+  max-width: 100%;
+
+  .model-settings-control,
+  .model-settings-selector,
+  .model-settings-selector > [data-component="tooltip-trigger"],
+  [data-slot="popover-trigger"] {
+    width: 100%;
+  }
+}
+
 .settings-font-size-control {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Issue

No linked issue. This is a small, self-contained settings UI improvement.

## Context

Model selectors in the Models settings tab were too narrow for many provider and model names, for example GPT-5... when theres a lot of space available. 

## Implementation

Adds an opt-in model-input layout variant to settings rows. Selected model rows use a 350px flex basis with a 100% maximum width, so they shrink when space is constrained.

The styling is scoped to the Models settings tab rather than changing `ModelSelector` globally. The subagent selector has an explicit full-width wrapper because it shares its control column with the compact reasoning-effort selector.

This was 100% vibe coded by Sol, but the changes make sense to me and this was annoying me. Sorry if there is a more minimal way to fix 😅

## Screenshots / Video

| before | after |
|---|---|
| 
<img width="2206" height="982" alt="Screenshot_20260731_215420" src="https://github.com/user-attachments/assets/7ea6b964-6f30-45bc-ac1b-e95ddf7607e0" />
 | 
<img width="1990" height="1147" alt="Screenshot_20260731_224018" src="https://github.com/user-attachments/assets/c2fd4979-3ab1-42d7-a259-f8fcec139e27" />
|

## How to Test

### Manual/local verification

- Agent: Ran `bun run typecheck` successfully in `packages/kilo-vscode`.
- Agent: Ran `bun run lint` successfully in `packages/kilo-vscode`.
- Agent: Ran 47 focused model-selection tests successfully.
- Agent: Rendered the Models tab with a reasoning-capable subagent model and confirmed the model selector measured 350px while the reasoning selector remained compact.
- Agent: Completed the repository pre-push typecheck successfully.

### Reviewer test steps

1. Build and launch the VS Code extension.
2. Open Kilo Code settings and navigate to the Models tab.
3. Confirm the default, small, autocomplete, and per-agent model selectors have consistent wider controls.
4. Select a reasoning-capable Subagent Model.
5. Confirm the Subagent Model selector matches the other model selector widths.
6. Confirm the reasoning-effort selector remains compact beneath it.
7. Narrow the settings panel and confirm the selectors shrink without horizontal overflow.

### Blocked checks and substitute verification

- None. All relevant checks completed successfully.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
