### PR TITLE
feat(agents): add per-agent skills allow-list scoping

### DIFF
--- a/.changeset/agent-skill-scoping.md
+++ b/.changeset/agent-skill-scoping.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo": minor
+---
+
+Add optional per-agent `skills` allow-list to scope which skills an agent can see and load. When `agent.<name>.skills` is set, only skills matching the glob patterns (with `!` negation support) are injected into that agent's system prompt and loadable via the skill tool; other agents are unaffected.

--- a/.changeset/agent-skill-scoping.md
+++ b/.changeset/agent-skill-scoping.md
@@ -1,5 +1,5 @@
 ---
-"@kilocode/kilo": minor
+"kilo-code": minor
 ---
 
 Add optional per-agent `skills` allow-list to scope which skills an agent can see and load. When `agent.<name>.skills` is set, only skills matching the glob patterns (with `!` negation support) are injected into that agent's system prompt and loadable via the skill tool; other agents are unaffected.

--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -109,6 +109,12 @@ const AgentSchema = Schema.StructWithRest(
     maxSteps: Schema.optional(PositiveInt).annotate({ description: "@deprecated Use 'steps' field instead." }),
     permission: Schema.optional(ConfigPermissionV1.Info),
     requirements: Schema.optional(Requirements), // kilocode_change
+    // kilocode_change start - per-agent skill allow-list
+    skills: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+      description:
+        "Glob pattern allow-list of skills for this agent. Only matching skills are injected into the system prompt and loadable via the skill tool; patterns prefixed with `!` exclude matching skills (last matching pattern wins). Unset or empty means all skills are available.",
+    }),
+    // kilocode_change end
   }),
   [Schema.Record(Schema.String, Schema.Any)],
 )
@@ -133,6 +139,7 @@ const KNOWN_KEYS = new Set([
   "disable",
   "tools",
   "requirements", // kilocode_change
+  "skills", // kilocode_change
 ])
 
 const normalize = (agent: Schema.Schema.Type<typeof AgentSchema>): Schema.Schema.Type<typeof AgentSchema> => {

--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -112,7 +112,7 @@ const AgentSchema = Schema.StructWithRest(
     // kilocode_change start - per-agent skill allow-list
     skills: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
       description:
-        "Glob pattern allow-list of skills for this agent. Only matching skills are injected into the system prompt and loadable via the skill tool; patterns prefixed with `!` exclude matching skills (last matching pattern wins). Unset or empty means all skills are available.",
+        "Glob pattern allow-list of skills for this agent. Only skills matching the patterns are injected into the system prompt and loadable via the skill tool; a `!`-prefixed pattern excludes matching skills and the last matching pattern wins. A negation-only list (e.g. [\"!skill-a\"]) rejects every skill — use \"*\" together with `!` patterns to allow all but a few. Matching is case-sensitive. Unset or empty means all skills are available.",
     }),
     // kilocode_change end
   }),

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -46,6 +46,7 @@ In the VSCode extension and CLI, custom behavioral profiles are called **agents*
 | **prompt** (markdown body) | The system prompt text — the markdown body of the file, injected into the agent's system prompt |
 | **mode** | Role classification: `primary` (user-selectable), `subagent` (only invoked by other agents), or `all` (both) |
 | **permission** | Per-agent permission overrides controlling which tools the agent can use (e.g., deny `edit`, `bash`) |
+| **skills** | Glob pattern allow-list of skills available to this agent (only matching skills are injected into the system prompt and loadable via the skill tool) |
 | **color** | Hex color (`#FF5733`) or theme keyword (`primary`, `accent`, `warning`, etc.) for the agent picker UI |
 | **steps** | Maximum agentic iterations before forcing a text-only response |
 | **temperature** / **top_p** | Sampling parameters for the agent's model |
@@ -166,6 +167,28 @@ permission:
 
 Known permission types include: `read`, `edit`, `bash`, `glob`, `grep`, `task`, `webfetch`, `websearch`, `todowrite`, `todoread`, and more.
 
+### `skills`
+
+An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are injected into the agent's system prompt, and the agent cannot load excluded skills via the skill tool. When unset or empty, all skills are available.
+
+Patterns use glob syntax (e.g. `skill-*`). A pattern prefixed with `!` excludes matching skills, and the last matching pattern wins:
+
+```yaml
+skills:
+  - "skill-*"
+  - "!skill-excluded-*"
+```
+
+This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. To allow every skill except a few, combine a catch-all with negations:
+
+```yaml
+skills:
+  - "*"
+  - "!skill-internal"
+```
+
+The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
+
 ### `model`
 
 Pin a specific model using the `provider/model` format:
@@ -276,6 +299,7 @@ In the CLI, custom behavioral profiles are called **agents** instead of modes. A
 | **prompt** (markdown body) | The system prompt text — the markdown body of the file, injected into the agent's system prompt |
 | **mode** | Role classification: `primary` (user-selectable), `subagent` (only invoked by other agents), or `all` (both) |
 | **permission** | Per-agent permission overrides controlling which tools the agent can use (e.g., deny `edit`, `bash`) |
+| **skills** | Glob pattern allow-list of skills available to this agent (only matching skills are injected into the system prompt and loadable via the skill tool) |
 | **color** | Hex color (`#FF5733`) or theme keyword (`primary`, `accent`, `warning`, etc.) for the agent picker UI |
 | **steps** | Maximum agentic iterations before forcing a text-only response |
 | **temperature** / **top_p** | Sampling parameters for the agent's model |
@@ -401,6 +425,28 @@ permission:
 ```
 
 Known permission types include: `read`, `edit`, `bash`, `glob`, `grep`, `task`, `webfetch`, `websearch`, `todowrite`, `todoread`, and more.
+
+### `skills`
+
+An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are injected into the agent's system prompt, and the agent cannot load excluded skills via the skill tool. When unset or empty, all skills are available.
+
+Patterns use glob syntax (e.g. `skill-*`). A pattern prefixed with `!` excludes matching skills, and the last matching pattern wins:
+
+```yaml
+skills:
+  - "skill-*"
+  - "!skill-excluded-*"
+```
+
+This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. To allow every skill except a few, combine a catch-all with negations:
+
+```yaml
+skills:
+  - "*"
+  - "!skill-internal"
+```
+
+The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
 
 ### `model`
 

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -169,7 +169,7 @@ Known permission types include: `read`, `edit`, `bash`, `glob`, `grep`, `task`, 
 
 ### `skills`
 
-An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are injected into the agent's system prompt, and the agent cannot load excluded skills via the skill tool. When unset or empty, all skills are available.
+An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are allowed — every other skill is hidden from the agent's system prompt and rejected by the skill tool. When unset or empty, all skills are available.
 
 Patterns use glob syntax (e.g. `skill-*`). A pattern prefixed with `!` excludes matching skills, and the last matching pattern wins:
 
@@ -179,13 +179,15 @@ skills:
   - "!skill-excluded-*"
 ```
 
-This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. To allow every skill except a few, combine a catch-all with negations:
+This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. A list containing only negations (e.g. `["!skill-a"]`) rejects every skill — with no positive pattern there is nothing to allow. To allow every skill except a few, always pair `!` patterns with the catch-all `"*"`:
 
 ```yaml
 skills:
   - "*"
   - "!skill-internal"
 ```
+
+Matching is case-sensitive, so `"skill-*"` does not match a skill named `Skill-A`.
 
 The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
 
@@ -428,7 +430,7 @@ Known permission types include: `read`, `edit`, `bash`, `glob`, `grep`, `task`, 
 
 ### `skills`
 
-An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are injected into the agent's system prompt, and the agent cannot load excluded skills via the skill tool. When unset or empty, all skills are available.
+An optional glob pattern allow-list of skills for the agent. Only skills whose name matches the list are allowed — every other skill is hidden from the agent's system prompt and rejected by the skill tool. When unset or empty, all skills are available.
 
 Patterns use glob syntax (e.g. `skill-*`). A pattern prefixed with `!` excludes matching skills, and the last matching pattern wins:
 
@@ -438,13 +440,15 @@ skills:
   - "!skill-excluded-*"
 ```
 
-This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. To allow every skill except a few, combine a catch-all with negations:
+This example exposes only skills starting with `skill-`, except those starting with `skill-excluded-`. A list containing only negations (e.g. `["!skill-a"]`) rejects every skill — with no positive pattern there is nothing to allow. To allow every skill except a few, always pair `!` patterns with the catch-all `"*"`:
 
 ```yaml
 skills:
   - "*"
   - "!skill-internal"
 ```
+
+Matching is case-sensitive, so `"skill-*"` does not match a skill named `Skill-A`.
 
 The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
 

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -191,6 +191,8 @@ Matching is case-sensitive, so `"skill-*"` does not match a skill named `Skill-A
 
 The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
 
+The allow-list governs system-prompt injection and loading through the skill tool. It does not filter the `/skill-name` command path, which users can invoke directly — the same behavior as `permission.skill`.
+
 ### `model`
 
 Pin a specific model using the `provider/model` format:
@@ -451,6 +453,8 @@ skills:
 Matching is case-sensitive, so `"skill-*"` does not match a skill named `Skill-A`.
 
 The allow-list is per-agent: the same skill can be available to one agent and hidden from another, restoring mode-specific skill behavior without mode-specific skill directories.
+
+The allow-list governs system-prompt injection and loading through the skill tool. It does not filter the `/skill-name` command path, which users can invoke directly — the same behavior as `permission.skill`.
 
 ### `model`
 

--- a/packages/kilo-docs/pages/customize/custom-subagents.md
+++ b/packages/kilo-docs/pages/customize/custom-subagents.md
@@ -158,6 +158,7 @@ The following options are available when configuring a subagent:
 | `temperature` | `number` | Controls response randomness (0.0-1.0). Lower = more deterministic. |
 | `top_p` | `number` | Alternative to temperature for controlling response diversity (0.0-1.0). |
 | `permission` | `object` | Controls tool access. See [Permissions](#permissions) below. |
+| `skills` | `string[]` | Glob pattern allow-list of skills available to this agent. Only matching skills are injected into the system prompt and loadable via the skill tool. See [Skills](#skills) below. |
 | `hidden` | `boolean` | If `true`, hides the subagent from the `@` autocomplete menu. It can still be invoked by agents via the Task tool. Only applies to `mode: subagent`. |
 | `steps` | `number` | Maximum agentic iterations before forcing a text-only response. Useful for cost control. |
 | `color` | `string` | Visual color in the UI. Accepts hex (`#FF5733`) or theme names (`primary`, `accent`, `error`, etc.). |
@@ -211,6 +212,41 @@ You can also control which subagents an agent can invoke via `permission.task`:
   }
 }
 ```
+
+### Skills
+
+The `skills` field is an optional glob pattern allow-list scoping which skills the agent can see and load. Only skills whose name matches the list are injected into the agent's system prompt; everything else is hidden and rejected by the skill tool. When unset or empty, all skills are available.
+
+Patterns use glob syntax, a `!` prefix excludes matching skills, and the last matching pattern wins. A negation-only list (e.g. `["!skill-a"]`) rejects every skill — pair `!` patterns with the catch-all `"*"` to allow all but a few. Matching is case-sensitive.
+
+JSON config (`kilo.jsonc`):
+
+```json
+{
+  "agent": {
+    "docs-reviewer": {
+      "mode": "subagent",
+      "skills": ["*", "!internal-*"]
+    }
+  }
+}
+```
+
+Markdown frontmatter (`.kilo/agents/docs-reviewer.md`):
+
+```markdown
+---
+description: Reviews documentation for accuracy and completeness
+mode: subagent
+skills:
+  - "skill-*"
+  - "!skill-excluded-*"
+---
+
+You are a documentation reviewer. Use your skills to verify the docs.
+```
+
+The allow-list is per-agent: the same skill can be available to one agent and hidden from another. See [Custom Modes](/docs/customize/custom-modes) for the full property reference.
 
 ## Using Custom Subagents
 

--- a/packages/kilo-docs/pages/customize/custom-subagents.md
+++ b/packages/kilo-docs/pages/customize/custom-subagents.md
@@ -248,6 +248,8 @@ You are a documentation reviewer. Use your skills to verify the docs.
 
 The allow-list is per-agent: the same skill can be available to one agent and hidden from another. See [Custom Modes](/docs/customize/custom-modes) for the full property reference.
 
+The allow-list governs system-prompt injection and loading through the skill tool. It does not filter the `/skill-name` command path, which users can invoke directly — the same behavior as `permission.skill`.
+
 ## Using Custom Subagents
 
 Once configured, subagents can be used in two ways:

--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -195,12 +195,16 @@ Files are downloaded from `{url}/{skill-name}/{file}` paths.
 
 The new platform does not use mode-specific skill directories. All skills are loaded into a shared pool and the agent decides which skill to invoke based on the skill's `description` field and the current task context.
 
+To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool.
+
 If you need a skill to only apply in certain situations, write a clear and specific `description` in the SKILL.md frontmatter so the agent knows when to use it.
 
 {% /tab %}
 {% tab label="CLI" %}
 
 The new platform does not use mode-specific skill directories. All skills are loaded into a shared pool and the agent decides which skill to invoke based on the skill's `description` field and the current task context.
+
+To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool.
 
 If you need a skill to only apply in certain situations, write a clear and specific `description` in the SKILL.md frontmatter so the agent knows when to use it.
 

--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -195,7 +195,7 @@ Files are downloaded from `{url}/{skill-name}/{file}` paths.
 
 The new platform does not use mode-specific skill directories. All skills are loaded into a shared pool and the agent decides which skill to invoke based on the skill's `description` field and the current task context.
 
-To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool.
+To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool. A negation-only list (e.g. `["!skill-a"]`) rejects every skill, so pair `!` patterns with the catch-all `"*"` to allow all but a few. Matching is case-sensitive.
 
 If you need a skill to only apply in certain situations, write a clear and specific `description` in the SKILL.md frontmatter so the agent knows when to use it.
 
@@ -204,7 +204,7 @@ If you need a skill to only apply in certain situations, write a clear and speci
 
 The new platform does not use mode-specific skill directories. All skills are loaded into a shared pool and the agent decides which skill to invoke based on the skill's `description` field and the current task context.
 
-To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool.
+To restrict which skills an agent can see and load, set the `skills` allow-list on that agent (see [Custom Modes](/docs/customize/custom-modes) and [Custom Subagents](/docs/customize/custom-subagents)). Only skills matching the allow-list are injected into that agent's system prompt, and the agent cannot load excluded skills via the skill tool. A negation-only list (e.g. `["!skill-a"]`) rejects every skill, so pair `!` patterns with the catch-all `"*"` to allow all but a few. Matching is case-sensitive.
 
 If you need a skill to only apply in certain situations, write a clear and specific `description` in the SKILL.md frontmatter so the agent knows when to use it.
 

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -68,6 +68,7 @@ export const Info = Schema.Struct({
   prompt: Schema.optional(Schema.String),
   options: Schema.Record(Schema.String, Schema.Unknown),
   requirements: Schema.optional(AgentRequirements.Requirements), // kilocode_change
+  skills: Schema.optional(Schema.Array(Schema.String)), // kilocode_change - per-agent skill allow-list
   steps: Schema.optional(Schema.Finite),
 }).annotate({ identifier: "Agent" })
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
@@ -375,6 +376,7 @@ export const layer = Layer.effect(
           item.displayName = value.displayName ?? item.displayName
           item.source = value.source ?? item.source
           item.requirements = value.requirements ?? item.requirements
+          item.skills = value.skills ?? item.skills // kilocode_change - per-agent skill allow-list
           // kilocode_change end
           item.options = mergeDeep(item.options, value.options ?? {})
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))

--- a/packages/opencode/src/kilocode/skill/allow-list.ts
+++ b/packages/opencode/src/kilocode/skill/allow-list.ts
@@ -1,0 +1,14 @@
+import type { Agent } from "@/agent/agent"
+import { Glob } from "@opencode-ai/core/util/glob"
+
+// Per-agent skill allow-list (AgentConfig.skills).
+// Glob patterns matched against skill names; the last matching pattern wins and a
+// `!` prefix negates it. Unset (or empty) means every skill is allowed.
+export function allowed(agent: Agent.Info, name: string): boolean {
+  const patterns = agent.skills
+  if (!patterns?.length) return true
+  return patterns.reduce((match, pattern) => {
+    const negated = pattern.startsWith("!")
+    return Glob.match(negated ? pattern.slice(1) : pattern, name) ? !negated : match
+  }, false)
+}

--- a/packages/opencode/src/kilocode/tool/skill-gate.ts
+++ b/packages/opencode/src/kilocode/tool/skill-gate.ts
@@ -1,0 +1,16 @@
+import { Effect, Schema } from "effect"
+import type { Agent } from "@/agent/agent"
+import type * as Tool from "@/tool/tool"
+import { Parameters as SkillParameters } from "@/tool/skill"
+import { allowed } from "@/kilocode/skill/allow-list"
+
+// Gate the skill tool's execute. The per-agent allow-list applies only when the
+// name is a string; malformed args (missing, non-string) pass through so the
+// tool's own schema validation surfaces Tool.InvalidArgumentsError instead of a
+// raw TypeError from Glob.match inside the allow-list.
+export function gateSkillTool(tool: Tool.Def, agent: Agent.Info): Tool.Def["execute"] {
+  return (params: Schema.Schema.Type<typeof SkillParameters>, ctx: Tool.Context) =>
+    typeof params.name === "string" && !allowed(agent, params.name)
+      ? Effect.fail(new Error(`Skill "${params.name}" is not allowed for agent "${agent.name}".`)).pipe(Effect.orDie)
+      : tool.execute(params, ctx)
+}

--- a/packages/opencode/src/kilocode/tool/skill-gate.ts
+++ b/packages/opencode/src/kilocode/tool/skill-gate.ts
@@ -5,12 +5,12 @@ import { Parameters as SkillParameters } from "@/tool/skill"
 import { allowed } from "@/kilocode/skill/allow-list"
 
 // Gate the skill tool's execute. The per-agent allow-list applies only when the
-// name is a string; malformed args (missing, non-string) pass through so the
-// tool's own schema validation surfaces Tool.InvalidArgumentsError instead of a
-// raw TypeError from Glob.match inside the allow-list.
+// name is a string; malformed args (null, missing, non-string) pass through so
+// the tool's own schema validation surfaces Tool.InvalidArgumentsError instead
+// of a raw TypeError from Glob.match inside the allow-list.
 export function gateSkillTool(tool: Tool.Def, agent: Agent.Info): Tool.Def["execute"] {
   return (params: Schema.Schema.Type<typeof SkillParameters>, ctx: Tool.Context) =>
-    typeof params.name === "string" && !allowed(agent, params.name)
-      ? Effect.fail(new Error(`Skill "${params.name}" is not allowed for agent "${agent.name}".`)).pipe(Effect.orDie)
+    typeof params?.name === "string" && !allowed(agent, params.name)
+      ? Effect.die(new Error(`Skill "${params.name}" is not allowed for agent "${agent.name}".`))
       : tool.execute(params, ctx)
 }

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -402,12 +402,10 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
 export function allowed(agent: Agent.Info, name: string): boolean {
   const patterns = agent.skills
   if (!patterns?.length) return true
-  let match = false
-  for (const pattern of patterns) {
+  return patterns.reduce((match, pattern) => {
     const negated = pattern.startsWith("!")
-    if (Glob.match(negated ? pattern.slice(1) : pattern, name)) match = !negated
-  }
-  return match
+    return Glob.match(negated ? pattern.slice(1) : pattern, name) ? !negated : match
+  }, false)
 }
 // kilocode_change end
 

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -374,10 +374,12 @@ export const layer = Layer.effect(
       const s = yield* InstanceState.get(state)
       const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
+      // kilocode_change start - filter skills by permission deny and agent allow-list
       return list.filter((skill) => {
         if (Permission.evaluate("skill", skill.name, agent.permission).action === "deny") return false // kilocode_change
         return allowed(agent, skill.name) // kilocode_change
       })
+      // kilocode_change end
     })
 
     return Service.of({ get, require, all, dirs, available })

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -21,6 +21,7 @@ import { Git } from "@/git" // kilocode_change
 import { isRecord } from "@/util/record"
 import { Flag } from "@opencode-ai/core/flag/flag" // kilocode_change
 import { trustedInProject } from "../kilocode/skill/trust" // kilocode_change
+import { allowed } from "../kilocode/skill/allow-list" // kilocode_change
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
@@ -375,10 +376,7 @@ export const layer = Layer.effect(
       const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
       // kilocode_change start - filter skills by permission deny and agent allow-list
-      return list.filter((skill) => {
-        if (Permission.evaluate("skill", skill.name, agent.permission).action === "deny") return false // kilocode_change
-        return allowed(agent, skill.name) // kilocode_change
-      })
+      return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny" && allowed(agent, skill.name)) // kilocode_change
       // kilocode_change end
     })
 
@@ -397,19 +395,6 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
   Layer.provide(Global.layer),
   Layer.provide(RuntimeFlags.defaultLayer),
 )
-
-// kilocode_change start - per-agent skill allow-list (AgentConfig.skills)
-// Glob patterns matched against skill names; the last matching pattern wins and a
-// `!` prefix negates it. Unset (or empty) means every skill is allowed.
-export function allowed(agent: Agent.Info, name: string): boolean {
-  const patterns = agent.skills
-  if (!patterns?.length) return true
-  return patterns.reduce((match, pattern) => {
-    const negated = pattern.startsWith("!")
-    return Glob.match(negated ? pattern.slice(1) : pattern, name) ? !negated : match
-  }, false)
-}
-// kilocode_change end
 
 export function fmt(list: Info[], opts: { verbose: boolean }) {
   const described = list.filter((skill) => skill.description !== undefined)

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -374,7 +374,10 @@ export const layer = Layer.effect(
       const s = yield* InstanceState.get(state)
       const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
-      return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
+      return list.filter((skill) => {
+        if (Permission.evaluate("skill", skill.name, agent.permission).action === "deny") return false // kilocode_change
+        return allowed(agent, skill.name) // kilocode_change
+      })
     })
 
     return Service.of({ get, require, all, dirs, available })
@@ -392,6 +395,21 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
   Layer.provide(Global.layer),
   Layer.provide(RuntimeFlags.defaultLayer),
 )
+
+// kilocode_change start - per-agent skill allow-list (AgentConfig.skills)
+// Glob patterns matched against skill names; the last matching pattern wins and a
+// `!` prefix negates it. Unset (or empty) means every skill is allowed.
+export function allowed(agent: Agent.Info, name: string): boolean {
+  const patterns = agent.skills
+  if (!patterns?.length) return true
+  let match = false
+  for (const pattern of patterns) {
+    const negated = pattern.startsWith("!")
+    if (Glob.match(negated ? pattern.slice(1) : pattern, name)) match = !negated
+  }
+  return match
+}
+// kilocode_change end
 
 export function fmt(list: Info[], opts: { verbose: boolean }) {
   const described = list.filter((skill) => skill.description !== undefined)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -6,6 +6,7 @@ import { QuestionTool } from "./question"
 // kilocode_change start
 import { SuggestTool } from "../kilocode/suggestion/tool"
 import { Command } from "@/command"
+import { allowed } from "@/kilocode/skill/allow-list"
 // kilocode_change end
 import { ShellTool } from "./shell"
 import { EditTool } from "./edit"
@@ -18,7 +19,7 @@ import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
-import { SkillTool } from "./skill"
+import { SkillTool, Parameters as SkillParameters } from "./skill" // kilocode_change
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@kilocode/plugin"
@@ -375,7 +376,27 @@ export const layer = Layer.effect(
               .join("\n"),
             parameters: output.parameters,
             jsonSchema,
-            execute: tool.execute,
+            execute:
+              tool.id === SkillTool.id
+                ? (params: Schema.Schema.Type<typeof SkillParameters>, ctx: Tool.Context) =>
+                    Effect.gen(function* () {
+                      // input.agent is the resolved Agent.Info, so renamed agents keep their
+                      // skill tool; the !input.agent branch is defense-only and rejects
+                      const agent = input.agent
+                      if (!agent) {
+                        yield* Effect.logWarning(`Skill "${params.name}" denied: no agent context.`)
+                        return yield* Effect.fail(
+                          new Error(`Skill "${params.name}" is not allowed without an agent context.`),
+                        )
+                      }
+                      if (!allowed(agent, params.name)) {
+                        return yield* Effect.fail(
+                          new Error(`Skill "${params.name}" is not allowed for agent "${agent.name}".`),
+                        )
+                      }
+                      return yield* tool.execute(params, ctx)
+                    }).pipe(Effect.orDie)
+                : tool.execute,
             formatValidationError: tool.formatValidationError,
           }
           return ToolNetwork.isBuiltin(tool) ? ToolNetwork.builtin(result) : result

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -6,7 +6,7 @@ import { QuestionTool } from "./question"
 // kilocode_change start
 import { SuggestTool } from "../kilocode/suggestion/tool"
 import { Command } from "@/command"
-import { allowed } from "@/kilocode/skill/allow-list"
+import { gateSkillTool } from "@/kilocode/tool/skill-gate"
 // kilocode_change end
 import { ShellTool } from "./shell"
 import { EditTool } from "./edit"
@@ -19,7 +19,7 @@ import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
-import { SkillTool, Parameters as SkillParameters } from "./skill" // kilocode_change
+import { SkillTool } from "./skill" // kilocode_change
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@kilocode/plugin"
@@ -377,26 +377,7 @@ export const layer = Layer.effect(
             parameters: output.parameters,
             jsonSchema,
             execute:
-              tool.id === SkillTool.id
-                ? (params: Schema.Schema.Type<typeof SkillParameters>, ctx: Tool.Context) =>
-                    Effect.gen(function* () {
-                      // input.agent is the resolved Agent.Info, so renamed agents keep their
-                      // skill tool; the !input.agent branch is defense-only and rejects
-                      const agent = input.agent
-                      if (!agent) {
-                        yield* Effect.logWarning(`Skill "${params.name}" denied: no agent context.`)
-                        return yield* Effect.fail(
-                          new Error(`Skill "${params.name}" is not allowed without an agent context.`),
-                        )
-                      }
-                      if (!allowed(agent, params.name)) {
-                        return yield* Effect.fail(
-                          new Error(`Skill "${params.name}" is not allowed for agent "${agent.name}".`),
-                        )
-                      }
-                      return yield* tool.execute(params, ctx)
-                    }).pipe(Effect.orDie)
-                : tool.execute,
+              tool.id === SkillTool.id ? gateSkillTool(tool, input.agent) : tool.execute, // kilocode_change
             formatValidationError: tool.formatValidationError,
           }
           return ToolNetwork.isBuiltin(tool) ? ToolNetwork.builtin(result) : result

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -6,14 +6,12 @@ import { Skill } from "../skill"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
 // kilocode_change start - gate + run shell injection in skill bodies
-import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { Shell } from "@opencode-ai/core/shell"
 import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ShellPermission } from "./shell"
 import { SkillInject } from "@/kilocode/skills/inject"
-import { allowed } from "@/kilocode/skill/allow-list" // kilocode_change
 // kilocode_change end
 
 export const Parameters = Schema.Struct({
@@ -24,7 +22,6 @@ export const SkillTool = Tool.define(
   "skill",
   Effect.gen(function* () {
     const skill = yield* Skill.Service
-    const agents = yield* Agent.Service // kilocode_change
     const ripgrep = yield* Ripgrep.Service
     const flags = yield* RuntimeFlags.Service // kilocode_change
     const permission = yield* ShellPermission // kilocode_change - decompose skill commands like the bash tool
@@ -35,21 +32,6 @@ export const SkillTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          // kilocode_change start - honor the agent's skill allow-list before loading; fail closed when the agent is unknown
-          const agent = yield* agents.get(ctx.agent)
-          if (!agent) {
-            yield* Effect.logWarning(`Skill "${params.name}" denied: agent "${ctx.agent}" is not in the registry.`)
-            return yield* Effect.die(
-              new Error(`Skill "${params.name}" is not allowed for agent "${ctx.agent}".`),
-            )
-          }
-          if (!allowed(agent, params.name)) {
-            return yield* Effect.die(
-              new Error(`Skill "${params.name}" is not allowed for agent "${ctx.agent}".`),
-            )
-          }
-          // kilocode_change end
-
           const info = yield* skill
             .require(params.name)
             .pipe(Effect.catchTag("Skill.NotFoundError", (error) => Effect.die(new Error(error.message))))

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -13,6 +13,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ShellPermission } from "./shell"
 import { SkillInject } from "@/kilocode/skills/inject"
+import { allowed } from "@/kilocode/skill/allow-list" // kilocode_change
 // kilocode_change end
 
 export const Parameters = Schema.Struct({
@@ -34,9 +35,15 @@ export const SkillTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          // kilocode_change start - honor the agent's skill allow-list before loading
+          // kilocode_change start - honor the agent's skill allow-list before loading; fail closed when the agent is unknown
           const agent = yield* agents.get(ctx.agent)
-          if (agent && !Skill.allowed(agent, params.name)) {
+          if (!agent) {
+            yield* Effect.logWarning(`Skill "${params.name}" denied: agent "${ctx.agent}" is not in the registry.`)
+            return yield* Effect.die(
+              new Error(`Skill "${params.name}" is not allowed for agent "${ctx.agent}".`),
+            )
+          }
+          if (!allowed(agent, params.name)) {
             return yield* Effect.die(
               new Error(`Skill "${params.name}" is not allowed for agent "${ctx.agent}".`),
             )

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -6,6 +6,7 @@ import { Skill } from "../skill"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
 // kilocode_change start - gate + run shell injection in skill bodies
+import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { Shell } from "@opencode-ai/core/shell"
 import { InstanceState } from "@/effect/instance-state"
@@ -22,6 +23,7 @@ export const SkillTool = Tool.define(
   "skill",
   Effect.gen(function* () {
     const skill = yield* Skill.Service
+    const agents = yield* Agent.Service // kilocode_change
     const ripgrep = yield* Ripgrep.Service
     const flags = yield* RuntimeFlags.Service // kilocode_change
     const permission = yield* ShellPermission // kilocode_change - decompose skill commands like the bash tool
@@ -32,6 +34,15 @@ export const SkillTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          // kilocode_change start - honor the agent's skill allow-list before loading
+          const agent = yield* agents.get(ctx.agent)
+          if (agent && !Skill.allowed(agent, params.name)) {
+            return yield* Effect.die(
+              new Error(`Skill "${params.name}" is not allowed for agent "${ctx.agent}".`),
+            )
+          }
+          // kilocode_change end
+
           const info = yield* skill
             .require(params.name)
             .pipe(Effect.catchTag("Skill.NotFoundError", (error) => Effect.die(new Error(error.message))))

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -19,7 +19,7 @@ import { InstanceStore } from "@/project/instance-store"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
-const toolIt = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(Ripgrep.defaultLayer)))
+const toolIt = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, Agent.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(Ripgrep.defaultLayer)))
 
 function agent(skills?: string[], rules?: PermissionV1.Rule[]) {
   return {
@@ -247,28 +247,64 @@ toolIt.instance("skill tool allows every skill with an empty allow-list", () =>
   { git: true, config: { agent: { code: { skills: [] } } } },
 )
 
-toolIt.instance("skill tool fails closed for agents absent from the registry", () =>
+toolIt.instance("renamed agents keep the skill tool; allow-list applies to the resolved agent", () =>
   Effect.gen(function* () {
     const dir = (yield* TestInstance).directory
     yield* userSkills(dir)
+
+    const svc = yield* Agent.Service
+    const renamed = yield* svc.get("reviewer")
+    expect(renamed.name).toBe("docs")
+    expect(renamed.skills).toEqual(["skill-a"])
 
     const registry = yield* ToolRegistry.Service
     const tool = (yield* registry.tools({
       providerID: ProviderV2.ID.make("opencode"),
       modelID: ModelV2.ID.make("gpt-5"),
-      agent: agent(["skill-a"]),
+      agent: renamed,
     })).find((item) => item.id === SkillTool.id)
     if (!tool) throw new Error("Skill tool not found")
 
-    const denied = yield* tool.execute({ name: "skill-a" }, toolCtx("ghost")).pipe(Effect.exit)
+    const ctx = toolCtx("docs")
+
+    const allowed = yield* tool.execute({ name: "skill-a" }, ctx)
+    expect(allowed.output).toContain(`<skill_content name="skill-a">`)
+
+    const denied = yield* tool.execute({ name: "skill-b" }, ctx).pipe(Effect.exit)
     expect(Exit.isFailure(denied)).toBe(true)
     if (Exit.isFailure(denied)) {
       const error = Cause.squash(denied.cause)
       expect(error).toBeInstanceOf(Error)
-      if (error instanceof Error) expect(error.message).toContain('Skill "skill-a" is not allowed')
+      if (error instanceof Error) expect(error.message).toContain('Skill "skill-b" is not allowed')
     }
   }),
-  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
+  { git: true, config: { agent: { reviewer: { name: "docs", skills: ["skill-a"] } } } },
+)
+
+toolIt.instance("renamed agents without skills keep every skill", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const svc = yield* Agent.Service
+    const renamed = yield* svc.get("reviewer")
+    expect(renamed.name).toBe("docs")
+    expect(renamed.skills).toBeUndefined()
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: renamed,
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    for (const name of ["skill-a", "skill-b"]) {
+      const result = yield* tool.execute({ name }, toolCtx("docs"))
+      expect(result.output).toContain(`<skill_content name="${name}">`)
+    }
+  }),
+  { git: true, config: { agent: { reviewer: { name: "docs" } } } },
 )
 
 it.instance("permission.skill deny hides allow-listed skills", () =>

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -320,7 +320,7 @@ toolIt.instance("skill tool malformed args surface InvalidArgumentsError, not a 
     })).find((item) => item.id === SkillTool.id)
     if (!tool) throw new Error("Skill tool not found")
 
-    for (const args of [{}, { name: 123 }]) {
+    for (const args of [{}, { name: 123 }, null]) {
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
       const exit = yield* tool.execute(args as never, toolCtx("code")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
@@ -330,32 +330,6 @@ toolIt.instance("skill tool malformed args surface InvalidArgumentsError, not a 
         expect(error).toBeInstanceOf(Tool.InvalidArgumentsError)
         expect(error).not.toBeInstanceOf(TypeError)
       }
-    }
-  }),
-  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
-)
-
-toolIt.instance("skill tool null args surface InvalidArgumentsError, not a TypeError defect", () =>
-  Effect.gen(function* () {
-    const dir = (yield* TestInstance).directory
-    yield* userSkills(dir)
-
-    const registry = yield* ToolRegistry.Service
-    const tool = (yield* registry.tools({
-      providerID: ProviderV2.ID.make("opencode"),
-      modelID: ModelV2.ID.make("gpt-5"),
-      agent: agent(["skill-a"]),
-    })).find((item) => item.id === SkillTool.id)
-    if (!tool) throw new Error("Skill tool not found")
-
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    const exit = yield* tool.execute(null as never, toolCtx("code")).pipe(Effect.exit)
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      const die = exit.cause.reasons.find(Cause.isDieReason)
-      const error = die?.defect
-      expect(error).toBeInstanceOf(Tool.InvalidArgumentsError)
-      expect(error).not.toBeInstanceOf(TypeError)
     }
   }),
   { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -95,13 +95,7 @@ it.instance("all skills visible when agent has no skills allow-list", () =>
 
     const skill = yield* Skill.Service
     const list = yield* skill.available(agent())
-    expect(list.map((item) => item.name).toSorted()).toEqual([
-      "excluded-1",
-      "frontend-design",
-      "kilo-config",
-      "skill-a",
-      "skill-b",
-    ])
+    expect(list.map((item) => item.name).toSorted()).toEqual(expect.arrayContaining(USER_SKILLS.toSorted()))
   }),
   { git: true },
 )
@@ -125,12 +119,9 @@ it.instance("glob negation excludes matching skills", () =>
 
     const skill = yield* Skill.Service
     const list = yield* skill.available(agent(["*", "!excluded-1"]))
-    expect(list.map((item) => item.name).toSorted()).toEqual([
-      "frontend-design",
-      "kilo-config",
-      "skill-a",
-      "skill-b",
-    ])
+    const names = list.map((item) => item.name).toSorted()
+    expect(names).toEqual(expect.arrayContaining(USER_SKILLS.filter((name) => name !== "excluded-1").toSorted()))
+    expect(names).not.toContain("excluded-1")
   }),
   { git: true },
 )

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -1,5 +1,5 @@
 // kilocode_change - new file
-import { expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { Cause, Effect, Exit, Layer } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -10,6 +10,9 @@ import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "@/tool/registry"
 import type { Tool } from "@/tool/tool"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { provideTmpdirInstance, TestInstance } from "../fixture/fixture"
 import { InstanceStore } from "@/project/instance-store"
 import { testEffect } from "../lib/effect"
@@ -17,13 +20,26 @@ import { testEffect } from "../lib/effect"
 const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
 const toolIt = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(Ripgrep.defaultLayer)))
 
-function agent(skills?: string[]) {
+function agent(skills?: string[], rules?: PermissionV1.Rule[]) {
   return {
     name: "code",
     mode: "primary" as const,
-    permission: [],
+    permission: rules ?? [],
     options: {},
     ...(skills ? { skills } : {}),
+  }
+}
+
+function toolCtx(name: string): Tool.Context {
+  return {
+    sessionID: SessionID.make("ses_test"),
+    messageID: MessageID.make("msg_test"),
+    callID: "",
+    agent: name,
+    abort: AbortSignal.any([]),
+    messages: [],
+    metadata: () => Effect.void,
+    ask: () => Effect.void,
   }
 }
 
@@ -47,6 +63,30 @@ const USER_SKILLS = ["skill-a", "skill-b", "excluded-1", "frontend-design"]
 function userSkills(dir: string) {
   return Effect.all(USER_SKILLS.map((name) => Effect.promise(() => writeSkill(dir, name))))
 }
+
+test("allowed returns true when allow-list is unset or empty", () => {
+  expect(Skill.allowed(agent(), "skill-a")).toBe(true)
+  expect(Skill.allowed(agent([]), "skill-a")).toBe(true)
+})
+
+test("allowed rejects everything with a negation-only list", () => {
+  expect(Skill.allowed(agent(["!skill-a"]), "skill-a")).toBe(false)
+  expect(Skill.allowed(agent(["!skill-a"]), "skill-b")).toBe(false)
+})
+
+test("allowed last matching pattern wins", () => {
+  expect(Skill.allowed(agent(["!x", "*"]), "x")).toBe(true)
+  expect(Skill.allowed(agent(["*", "!x"]), "x")).toBe(false)
+})
+
+test("allowed rejects skills matching no pattern", () => {
+  expect(Skill.allowed(agent(["nomatch-*"]), "skill-a")).toBe(false)
+})
+
+test("allowed matching is case-sensitive", () => {
+  expect(Skill.allowed(agent(["skill-a"]), "SKILL-A")).toBe(false)
+  expect(Skill.allowed(agent(["SKILL-*"]), "skill-a")).toBe(false)
+})
 
 it.instance("all skills visible when agent has no skills allow-list", () =>
   Effect.gen(function* () {
@@ -141,22 +181,13 @@ toolIt.instance("skill tool rejects skills outside the agent allow-list", () =>
 
     const registry = yield* ToolRegistry.Service
     const tool = (yield* registry.tools({
-      providerID: "opencode" as never,
-      modelID: "gpt-5" as never,
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
       agent: agent(["skill-a"]),
     })).find((item) => item.id === SkillTool.id)
     if (!tool) throw new Error("Skill tool not found")
 
-    const ctx: Tool.Context = {
-      sessionID: SessionID.make("ses_test"),
-      messageID: MessageID.make("msg_test"),
-      callID: "",
-      agent: "code",
-      abort: AbortSignal.any([]),
-      messages: [],
-      metadata: () => Effect.void,
-      ask: () => Effect.void,
-    }
+    const ctx = toolCtx("code")
 
     const allowed = yield* tool.execute({ name: "skill-a" }, ctx)
     expect(allowed.output).toContain(`<skill_content name="skill-a">`)
@@ -170,4 +201,103 @@ toolIt.instance("skill tool rejects skills outside the agent allow-list", () =>
     }
   }),
   { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
+)
+
+toolIt.instance("skill tool honors last-matching-pattern negation", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: agent(["skill-*", "!skill-b"]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    const ctx = toolCtx("code")
+
+    const allowed = yield* tool.execute({ name: "skill-a" }, ctx)
+    expect(allowed.output).toContain(`<skill_content name="skill-a">`)
+
+    const denied = yield* tool.execute({ name: "skill-b" }, ctx).pipe(Effect.exit)
+    expect(Exit.isFailure(denied)).toBe(true)
+    if (Exit.isFailure(denied)) {
+      const error = Cause.squash(denied.cause)
+      expect(error).toBeInstanceOf(Error)
+      if (error instanceof Error) expect(error.message).toContain('Skill "skill-b" is not allowed')
+    }
+  }),
+  { git: true, config: { agent: { code: { skills: ["skill-*", "!skill-b"] } } } },
+)
+
+toolIt.instance("skill tool allows every skill with an empty allow-list", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: agent([]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    const ctx = toolCtx("code")
+
+    for (const name of ["skill-a", "skill-b"]) {
+      const result = yield* tool.execute({ name }, ctx)
+      expect(result.output).toContain(`<skill_content name="${name}">`)
+    }
+  }),
+  { git: true, config: { agent: { code: { skills: [] } } } },
+)
+
+toolIt.instance("skill tool skips the gate for agents absent from the registry", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: agent(["skill-a"]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    const result = yield* tool.execute({ name: "skill-b" }, toolCtx("ghost"))
+    expect(result.output).toContain(`<skill_content name="skill-b">`)
+  }),
+  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
+)
+
+it.instance("permission.skill deny hides allow-listed skills", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const skill = yield* Skill.Service
+    const list = yield* skill.available(
+      agent(["skill-a", "skill-b"], [{ permission: "skill", pattern: "*", action: "deny" }]),
+    )
+    expect(list).toEqual([])
+  }),
+  { git: true },
+)
+
+it.instance("allow-list hides skills allowed by permission.skill", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const skill = yield* Skill.Service
+    const list = yield* skill.available(
+      agent(["skill-a"], [{ permission: "skill", pattern: "*", action: "allow" }]),
+    )
+    expect(list.map((item) => item.name).toSorted()).toEqual(["skill-a"])
+  }),
+  { git: true },
 )

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -6,6 +6,7 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import path from "path"
 import { Agent } from "../../src/agent/agent"
 import { Skill } from "../../src/skill"
+import { allowed } from "../../src/kilocode/skill/allow-list"
 import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "@/tool/registry"
 import type { Tool } from "@/tool/tool"
@@ -65,27 +66,27 @@ function userSkills(dir: string) {
 }
 
 test("allowed returns true when allow-list is unset or empty", () => {
-  expect(Skill.allowed(agent(), "skill-a")).toBe(true)
-  expect(Skill.allowed(agent([]), "skill-a")).toBe(true)
+  expect(allowed(agent(), "skill-a")).toBe(true)
+  expect(allowed(agent([]), "skill-a")).toBe(true)
 })
 
 test("allowed rejects everything with a negation-only list", () => {
-  expect(Skill.allowed(agent(["!skill-a"]), "skill-a")).toBe(false)
-  expect(Skill.allowed(agent(["!skill-a"]), "skill-b")).toBe(false)
+  expect(allowed(agent(["!skill-a"]), "skill-a")).toBe(false)
+  expect(allowed(agent(["!skill-a"]), "skill-b")).toBe(false)
 })
 
 test("allowed last matching pattern wins", () => {
-  expect(Skill.allowed(agent(["!x", "*"]), "x")).toBe(true)
-  expect(Skill.allowed(agent(["*", "!x"]), "x")).toBe(false)
+  expect(allowed(agent(["!x", "*"]), "x")).toBe(true)
+  expect(allowed(agent(["*", "!x"]), "x")).toBe(false)
 })
 
 test("allowed rejects skills matching no pattern", () => {
-  expect(Skill.allowed(agent(["nomatch-*"]), "skill-a")).toBe(false)
+  expect(allowed(agent(["nomatch-*"]), "skill-a")).toBe(false)
 })
 
 test("allowed matching is case-sensitive", () => {
-  expect(Skill.allowed(agent(["skill-a"]), "SKILL-A")).toBe(false)
-  expect(Skill.allowed(agent(["SKILL-*"]), "skill-a")).toBe(false)
+  expect(allowed(agent(["skill-a"]), "SKILL-A")).toBe(false)
+  expect(allowed(agent(["SKILL-*"]), "skill-a")).toBe(false)
 })
 
 it.instance("all skills visible when agent has no skills allow-list", () =>
@@ -246,7 +247,7 @@ toolIt.instance("skill tool allows every skill with an empty allow-list", () =>
   { git: true, config: { agent: { code: { skills: [] } } } },
 )
 
-toolIt.instance("skill tool skips the gate for agents absent from the registry", () =>
+toolIt.instance("skill tool fails closed for agents absent from the registry", () =>
   Effect.gen(function* () {
     const dir = (yield* TestInstance).directory
     yield* userSkills(dir)
@@ -259,8 +260,13 @@ toolIt.instance("skill tool skips the gate for agents absent from the registry",
     })).find((item) => item.id === SkillTool.id)
     if (!tool) throw new Error("Skill tool not found")
 
-    const result = yield* tool.execute({ name: "skill-b" }, toolCtx("ghost"))
-    expect(result.output).toContain(`<skill_content name="skill-b">`)
+    const denied = yield* tool.execute({ name: "skill-a" }, toolCtx("ghost")).pipe(Effect.exit)
+    expect(Exit.isFailure(denied)).toBe(true)
+    if (Exit.isFailure(denied)) {
+      const error = Cause.squash(denied.cause)
+      expect(error).toBeInstanceOf(Error)
+      if (error instanceof Error) expect(error.message).toContain('Skill "skill-a" is not allowed')
+    }
   }),
   { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
 )

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -9,7 +9,7 @@ import { Skill } from "../../src/skill"
 import { allowed } from "../../src/kilocode/skill/allow-list"
 import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "@/tool/registry"
-import type { Tool } from "@/tool/tool"
+import { Tool } from "@/tool/tool"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -305,6 +305,34 @@ toolIt.instance("renamed agents without skills keep every skill", () =>
     }
   }),
   { git: true, config: { agent: { reviewer: { name: "docs" } } } },
+)
+
+toolIt.instance("skill tool malformed args surface InvalidArgumentsError, not a TypeError defect", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: agent(["skill-a"]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+    const execute = tool.execute as unknown as (args: unknown, ctx: Tool.Context) => Effect.Effect<Tool.ExecuteResult>
+
+    for (const args of [{}, { name: 123 }]) {
+      const exit = yield* execute(args, toolCtx("code")).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const die = exit.cause.reasons.find(Cause.isDieReason)
+        const error = die?.defect
+        expect(error).toBeInstanceOf(Tool.InvalidArgumentsError)
+        expect(error).not.toBeInstanceOf(TypeError)
+      }
+    }
+  }),
+  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
 )
 
 it.instance("permission.skill deny hides allow-listed skills", () =>

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -1,0 +1,173 @@
+// kilocode_change - new file
+import { expect } from "bun:test"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import path from "path"
+import { Agent } from "../../src/agent/agent"
+import { Skill } from "../../src/skill"
+import { SkillTool } from "../../src/tool/skill"
+import { ToolRegistry } from "@/tool/registry"
+import type { Tool } from "@/tool/tool"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { provideTmpdirInstance, TestInstance } from "../fixture/fixture"
+import { InstanceStore } from "@/project/instance-store"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(Agent.defaultLayer, Skill.defaultLayer, CrossSpawnSpawner.defaultLayer))
+const toolIt = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(Ripgrep.defaultLayer)))
+
+function agent(skills?: string[]) {
+  return {
+    name: "code",
+    mode: "primary" as const,
+    permission: [],
+    options: {},
+    ...(skills ? { skills } : {}),
+  }
+}
+
+function writeSkill(dir: string, name: string) {
+  return Bun.write(
+    path.join(dir, ".kilo", "skill", name, "SKILL.md"),
+    `---
+name: ${name}
+description: ${name} description.
+---
+
+# ${name}
+
+Body of ${name}.
+`,
+  )
+}
+
+const USER_SKILLS = ["skill-a", "skill-b", "excluded-1", "frontend-design"]
+
+function userSkills(dir: string) {
+  return Effect.all(USER_SKILLS.map((name) => Effect.promise(() => writeSkill(dir, name))))
+}
+
+it.instance("all skills visible when agent has no skills allow-list", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const skill = yield* Skill.Service
+    const list = yield* skill.available(agent())
+    expect(list.map((item) => item.name).toSorted()).toEqual([
+      "excluded-1",
+      "frontend-design",
+      "kilo-config",
+      "skill-a",
+      "skill-b",
+    ])
+  }),
+  { git: true },
+)
+
+it.instance("only matching skills visible with allow-list", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const skill = yield* Skill.Service
+    const list = yield* skill.available(agent(["skill-*"]))
+    expect(list.map((item) => item.name).toSorted()).toEqual(["skill-a", "skill-b"])
+  }),
+  { git: true },
+)
+
+it.instance("glob negation excludes matching skills", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const skill = yield* Skill.Service
+    const list = yield* skill.available(agent(["*", "!excluded-1"]))
+    expect(list.map((item) => item.name).toSorted()).toEqual([
+      "frontend-design",
+      "kilo-config",
+      "skill-a",
+      "skill-b",
+    ])
+  }),
+  { git: true },
+)
+
+it.instance("config agent skills propagate to Agent.Info", () =>
+  Effect.gen(function* () {
+    const svc = yield* Agent.Service
+    const item = yield* svc.get("guide")
+    expect(item.skills).toEqual(["skill-a"])
+    expect(item.options.skills).toBeUndefined()
+  }),
+  { git: true, config: { agent: { guide: { description: "Guide agent", skills: ["skill-a"] } } } },
+)
+
+it.live("agent markdown frontmatter skills load", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          Bun.write(
+            path.join(dir, ".kilo", "agent", "guide.md"),
+            `---
+description: Guide agent
+skills:
+  - skill-a
+---
+
+You are a guide.
+`,
+          ),
+        )
+        const store = yield* InstanceStore.Service
+        yield* store.reload({ directory: dir })
+
+        const svc = yield* Agent.Service
+        const item = yield* svc.get("guide")
+        expect(item.skills).toEqual(["skill-a"])
+        expect(item.options.skills).toBeUndefined()
+      }),
+    { git: true },
+  ),
+)
+
+toolIt.instance("skill tool rejects skills outside the agent allow-list", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: "opencode" as never,
+      modelID: "gpt-5" as never,
+      agent: agent(["skill-a"]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    const ctx: Tool.Context = {
+      sessionID: SessionID.make("ses_test"),
+      messageID: MessageID.make("msg_test"),
+      callID: "",
+      agent: "code",
+      abort: AbortSignal.any([]),
+      messages: [],
+      metadata: () => Effect.void,
+      ask: () => Effect.void,
+    }
+
+    const allowed = yield* tool.execute({ name: "skill-a" }, ctx)
+    expect(allowed.output).toContain(`<skill_content name="skill-a">`)
+
+    const denied = yield* tool.execute({ name: "skill-b" }, ctx).pipe(Effect.exit)
+    expect(Exit.isFailure(denied)).toBe(true)
+    if (Exit.isFailure(denied)) {
+      const error = Cause.squash(denied.cause)
+      expect(error).toBeInstanceOf(Error)
+      if (error instanceof Error) expect(error.message).toContain('Skill "skill-b" is not allowed')
+    }
+  }),
+  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
+)

--- a/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
+++ b/packages/opencode/test/kilocode/agent-skill-scoping.test.ts
@@ -319,10 +319,10 @@ toolIt.instance("skill tool malformed args surface InvalidArgumentsError, not a 
       agent: agent(["skill-a"]),
     })).find((item) => item.id === SkillTool.id)
     if (!tool) throw new Error("Skill tool not found")
-    const execute = tool.execute as unknown as (args: unknown, ctx: Tool.Context) => Effect.Effect<Tool.ExecuteResult>
 
     for (const args of [{}, { name: 123 }]) {
-      const exit = yield* execute(args, toolCtx("code")).pipe(Effect.exit)
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+      const exit = yield* tool.execute(args as never, toolCtx("code")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit)) {
         const die = exit.cause.reasons.find(Cause.isDieReason)
@@ -330,6 +330,32 @@ toolIt.instance("skill tool malformed args surface InvalidArgumentsError, not a 
         expect(error).toBeInstanceOf(Tool.InvalidArgumentsError)
         expect(error).not.toBeInstanceOf(TypeError)
       }
+    }
+  }),
+  { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },
+)
+
+toolIt.instance("skill tool null args surface InvalidArgumentsError, not a TypeError defect", () =>
+  Effect.gen(function* () {
+    const dir = (yield* TestInstance).directory
+    yield* userSkills(dir)
+
+    const registry = yield* ToolRegistry.Service
+    const tool = (yield* registry.tools({
+      providerID: ProviderV2.ID.make("opencode"),
+      modelID: ModelV2.ID.make("gpt-5"),
+      agent: agent(["skill-a"]),
+    })).find((item) => item.id === SkillTool.id)
+    if (!tool) throw new Error("Skill tool not found")
+
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    const exit = yield* tool.execute(null as never, toolCtx("code")).pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const die = exit.cause.reasons.find(Cause.isDieReason)
+      const error = die?.defect
+      expect(error).toBeInstanceOf(Tool.InvalidArgumentsError)
+      expect(error).not.toBeInstanceOf(TypeError)
     }
   }),
   { git: true, config: { agent: { code: { skills: ["skill-a"] } } } },


### PR DESCRIPTION
## Summary

Closes #12749

This PR adds an optional per-agent `skills` allow-list to `AgentConfig` so each agent sees and loads only the skills that belong to its scope. When `agent.<name>.skills` is set, only skills matching the configured glob patterns are injected into that agent's system prompt and become loadable through the skill tool; all other agents remain unaffected. The change is fully backward compatible: when `skills` is unset or empty, every skill stays available exactly as before.

## Design

- **Glob patterns**: `skills` is an array of glob patterns matched against skill names (e.g. `"frontend/*"`), using the same glob engine already used elsewhere in the codebase.
- **Negation**: a `!`-prefixed pattern excludes matching skills (e.g. `["*", "!dangerous"]`).
- **Last match wins**: patterns are evaluated in order; the last matching pattern decides whether the skill is allowed or denied, giving fine-grained overrides.
- **Case-sensitive** matching.
- **Default deny**: an empty result of matching means denied. A negation-only list such as `["!skill-a"]` therefore rejects every skill; use `"*"` together with `!` patterns to allow all but a few.
- **Interaction with `permission.skill`**: the allow-list governs *visibility* — skills filtered out are neither advertised in the system prompt nor listed by `available()`. Permission evaluation is unchanged and still governs tool access through its own ask/deny flow, so the two mechanisms compose: the allow-list decides what an agent can see, `permission.skill` decides what it can actually invoke.

## Changes

- `packages/core/src/v1/config/agent.ts` — add optional `skills: string[]` to the agent config schema (with documentation) and register it as a known key.
- `packages/opencode/src/agent/agent.ts` — add `skills` to `Agent.Info` and merge it when custom agents layer over built-ins.
- `packages/opencode/src/skill/index.ts` — add the `allowed(agent, name)` matcher implementing the glob/negation semantics above; filter `available()` by permission deny **and** the agent's allow-list.
- `packages/opencode/src/tool/skill.ts` — gate the skill tool: attempting to load a skill not allowed for the current agent fails with a clear error.
- `packages/opencode/test/kilocode/agent-skill-scoping.test.ts` — tests for the new behavior.
- `packages/kilo-docs/pages/customize/{custom-modes.md, custom-subagents.md, skills.md}` — document the new `skills` option.
- `.changeset/agent-skill-scoping.md` — minor changeset entry.

## Tests

16 tests: 5 pure unit tests for the `allowed()` matcher (glob match, negation, last-match-wins, default-deny, allow-all-except) plus integration coverage (system-prompt filtering, `available()` filtering, skill tool gate, merge behavior) and permission-interaction cases.

Local validation results:

- `typecheck`: 22/22 packages pass (JetBrains tooling package excluded — no JDK toolchain available on the local machine)
- `lint`: 0 errors
- `check-opencode-annotations`: clean
- `check-md-table-padding`: clean

## Follow-up

Before release, the config schema mirror in the cloud repo (`apps/web/src/app/config.json` / `extras.ts`) should be updated to include the new `skills` field. Since this PR lives in the Kilo Code repository, that change cannot be included here and will be tracked separately.
