### PR TITLE
fix(cli): distinguish MCP header auth from OAuth

### DIFF
--- a/.changeset/tidy-mcp-auth.md
+++ b/.changeset/tidy-mcp-auth.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Distinguish static MCP authorization headers from OAuth authentication.

--- a/.changeset/tidy-mcp-auth.md
+++ b/.changeset/tidy-mcp-auth.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Distinguish static MCP authorization headers from OAuth authentication.
+Distinguish static MCP authorization headers from OAuth authentication. Servers with an `Authorization` header can explicitly opt into OAuth with `"oauth": {}`.

--- a/packages/core/src/v1/config/mcp.ts
+++ b/packages/core/src/v1/config/mcp.ts
@@ -87,7 +87,8 @@ export const Remote = Schema.Struct({
     description: "Headers to send with the request",
   }),
   oauth: Schema.optional(Schema.Union([OAuth, Schema.Literal(false)])).annotate({
-    description: "OAuth authentication configuration for the MCP server. Set to false to disable OAuth auto-detection.",
+    description:
+      "OAuth authentication configuration for the MCP server. OAuth is auto-detected unless an Authorization header is configured; set to {} to opt in with that header, or false to disable OAuth.", // kilocode_change
   }),
   timeout: Schema.optional(PositiveInt).annotate({
     description: "Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.",

--- a/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -71,7 +71,7 @@ MCP servers are configured under the `mcp` key in `kilo.jsonc`:
 }
 ```
 
-Remote servers support OAuth 2.0 authentication. If the server supports it, Kilo Code will automatically start the OAuth flow when you connect. You can also disable OAuth with `"oauth": false`.
+Remote servers support OAuth 2.0 authentication. If the server supports it, Kilo Code automatically starts the OAuth flow when you connect. Configuring an `Authorization` header uses that header without starting OAuth; add `"oauth": {}` to explicitly enable OAuth alongside the header. You can also disable OAuth with `"oauth": false`.
 
 {% /tab %}
 {% tab label="CLI" %}

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -729,7 +729,7 @@ export const McpDebugCommand = effectCmd({
       }
 
       // kilocode_change start - header-auth servers still need the general HTTP diagnostics below
-      if (!McpAuthMode.oauth(serverConfig)) {
+      if (McpAuthMode.header(serverConfig) && !McpAuthMode.oauth(serverConfig)) {
         prompts.log.info(`MCP server ${serverName} uses its configured Authorization header instead of OAuth`)
       }
       // kilocode_change end
@@ -801,10 +801,10 @@ export const McpDebugCommand = effectCmd({
           prompts.log.warn("Server returned 401 Unauthorized")
 
           // kilocode_change start - retain the HTTP probe for header-auth diagnostics without starting OAuth
-          if (!McpAuthMode.oauth(serverConfig)) {
+          if (McpAuthMode.header(serverConfig) && !McpAuthMode.oauth(serverConfig)) {
             prompts.log.warn(McpAuthMode.failure(serverName))
             prompts.log.info('To use OAuth as well, set "oauth": {} for this server.')
-          } else {
+          } else if (McpAuthMode.oauth(serverConfig)) {
             // Try to discover OAuth metadata
             const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
             const authProvider = new McpOAuthProvider(

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -192,7 +192,11 @@ export const McpAuthCommand = effectCmd({
 
     if (servers.length === 0) {
       prompts.log.warn("No OAuth-capable MCP servers configured")
-      prompts.log.info("Remote MCP servers support OAuth by default. Add a remote server in kilo.json:") // kilocode_change
+      // kilocode_change start
+      prompts.log.info(
+        "Remote MCP servers use OAuth automatically unless an Authorization header is configured. Set oauth: {} to opt a header-auth server into OAuth, or add a remote server in kilo.json:",
+      )
+      // kilocode_change end
       prompts.log.info(`
   "mcp": {
     "my-server": {
@@ -724,11 +728,9 @@ export const McpDebugCommand = effectCmd({
         return
       }
 
-      // kilocode_change start
+      // kilocode_change start - header-auth servers still need the general HTTP diagnostics below
       if (!McpAuthMode.oauth(serverConfig)) {
-        prompts.log.warn(`MCP server ${serverName} is not configured to use OAuth`)
-        prompts.outro("Done")
-        return
+        prompts.log.info(`MCP server ${serverName} uses its configured Authorization header instead of OAuth`)
       }
       // kilocode_change end
 
@@ -798,54 +800,61 @@ export const McpDebugCommand = effectCmd({
         if (response.status === 401) {
           prompts.log.warn("Server returned 401 Unauthorized")
 
-          // Try to discover OAuth metadata
-          const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
-          const authProvider = new McpOAuthProvider(
-            serverName,
-            serverConfig.url,
-            {
-              clientId: oauthConfig?.clientId,
-              clientSecret: oauthConfig?.clientSecret,
-              scope: oauthConfig?.scope,
-              redirectUri: oauthConfig?.redirectUri,
-            },
-            {
-              onRedirect: async () => {},
-            },
-            auth,
-          )
+          // kilocode_change start - retain the HTTP probe for header-auth diagnostics without starting OAuth
+          if (!McpAuthMode.oauth(serverConfig)) {
+            prompts.log.warn(McpAuthMode.failure(serverName))
+            prompts.log.info('To use OAuth as well, set "oauth": {} for this server.')
+          } else {
+            // Try to discover OAuth metadata
+            const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
+            const authProvider = new McpOAuthProvider(
+              serverName,
+              serverConfig.url,
+              {
+                clientId: oauthConfig?.clientId,
+                clientSecret: oauthConfig?.clientSecret,
+                scope: oauthConfig?.scope,
+                redirectUri: oauthConfig?.redirectUri,
+              },
+              {
+                onRedirect: async () => {},
+              },
+              auth,
+            )
 
-          prompts.log.info("Testing OAuth flow (without completing authorization)...")
+            prompts.log.info("Testing OAuth flow (without completing authorization)...")
 
-          // Try creating transport with auth provider to trigger discovery
-          const transport = new StreamableHTTPClientTransport(new URL(serverConfig.url), {
-            authProvider,
-            requestInit: serverConfig.headers ? { headers: serverConfig.headers } : undefined,
-          })
-
-          try {
-            const client = new Client({
-              name: "kilo-debug", // kilocode_change
-              version: InstallationVersion,
+            // Try creating transport with auth provider to trigger discovery
+            const transport = new StreamableHTTPClientTransport(new URL(serverConfig.url), {
+              authProvider,
+              requestInit: serverConfig.headers ? { headers: serverConfig.headers } : undefined,
             })
-            await client.connect(transport)
-            prompts.log.success("Connection successful (already authenticated)")
-            await client.close()
-          } catch (error) {
-            if (error instanceof UnauthorizedError) {
-              prompts.log.info(`OAuth flow triggered: ${error.message}`)
 
-              // Check if dynamic registration would be attempted
-              const clientInfo = await authProvider.clientInformation()
-              if (clientInfo) {
-                prompts.log.info(`Client ID available: ${clientInfo.client_id}`)
+            try {
+              const client = new Client({
+                name: "kilo-debug", // kilocode_change
+                version: InstallationVersion,
+              })
+              await client.connect(transport)
+              prompts.log.success("Connection successful (already authenticated)")
+              await client.close()
+            } catch (error) {
+              if (error instanceof UnauthorizedError) {
+                prompts.log.info(`OAuth flow triggered: ${error.message}`)
+
+                // Check if dynamic registration would be attempted
+                const clientInfo = await authProvider.clientInformation()
+                if (clientInfo) {
+                  prompts.log.info(`Client ID available: ${clientInfo.client_id}`)
+                } else {
+                  prompts.log.info("No client ID - dynamic registration will be attempted")
+                }
               } else {
-                prompts.log.info("No client ID - dynamic registration will be attempted")
+                prompts.log.error(`Connection error: ${error instanceof Error ? error.message : String(error)}`)
               }
-            } else {
-              prompts.log.error(`Connection error: ${error instanceof Error ? error.message : String(error)}`)
             }
           }
+          // kilocode_change end
         } else if (response.status >= 200 && response.status < 300) {
           prompts.log.success("Server responded successfully (no auth required or already authenticated)")
           const body = await response.text()

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -731,6 +731,8 @@ export const McpDebugCommand = effectCmd({
       // kilocode_change start - header-auth servers still need the general HTTP diagnostics below
       if (McpAuthMode.header(serverConfig) && !McpAuthMode.oauth(serverConfig)) {
         prompts.log.info(`MCP server ${serverName} uses its configured Authorization header instead of OAuth`)
+      } else if (serverConfig.oauth === false) {
+        prompts.log.warn(`MCP server ${serverName} has OAuth explicitly disabled and no Authorization header configured`)
       }
       // kilocode_change end
 

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -24,6 +24,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Effect } from "effect"
 import { Flag } from "@opencode-ai/core/flag/flag" // kilocode_change
+import { McpAuthMode } from "@/kilocode/mcp/auth-mode" // kilocode_change
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
   switch (status) {
@@ -65,7 +66,7 @@ function configuredServers(config: ConfigV1.Info) {
 
 function oauthServers(config: ConfigV1.Info) {
   return configuredServers(config).filter(
-    (entry): entry is [string, McpRemote] => isMcpRemote(entry[1]) && entry[1].oauth !== false,
+    (entry): entry is [string, McpRemote] => isMcpRemote(entry[1]) && McpAuthMode.oauth(entry[1]), // kilocode_change
   )
 }
 
@@ -235,11 +236,13 @@ export const McpAuthCommand = effectCmd({
       return
     }
 
-    if (!isMcpRemote(serverConfig) || serverConfig.oauth === false) {
+    // kilocode_change start
+    if (!isMcpRemote(serverConfig) || !McpAuthMode.oauth(serverConfig)) {
       prompts.log.error(`MCP server ${serverName} is not an OAuth-capable remote server`)
       prompts.outro("Done")
       return
     }
+    // kilocode_change end
 
     // Check if already authenticated
     const authStatus = auth[serverName] ?? (yield* MCP.Service.use((mcp) => mcp.getAuthStatus(serverName)))
@@ -721,11 +724,13 @@ export const McpDebugCommand = effectCmd({
         return
       }
 
-      if (serverConfig.oauth === false) {
-        prompts.log.warn(`MCP server ${serverName} has OAuth explicitly disabled`)
+      // kilocode_change start
+      if (!McpAuthMode.oauth(serverConfig)) {
+        prompts.log.warn(`MCP server ${serverName} is not configured to use OAuth`)
         prompts.outro("Done")
         return
       }
+      // kilocode_change end
 
       prompts.log.info(`Server: ${serverName}`)
       prompts.log.info(`URL: ${serverConfig.url}`)

--- a/packages/opencode/src/kilocode/mcp/auth-mode.ts
+++ b/packages/opencode/src/kilocode/mcp/auth-mode.ts
@@ -1,0 +1,17 @@
+import type { ConfigMCPV1 } from "@opencode-ai/core/v1/config/mcp"
+
+export namespace McpAuthMode {
+  export function header(config: ConfigMCPV1.Remote) {
+    return Object.keys(config.headers ?? {}).some((name) => name.toLowerCase() === "authorization")
+  }
+
+  export function oauth(config: ConfigMCPV1.Remote) {
+    if (config.oauth === false) return false
+    if (config.oauth) return true
+    return !header(config)
+  }
+
+  export function failure(name: string) {
+    return `Server "${name}" rejected the configured Authorization header. Check its value and any referenced environment variables.`
+  }
+}

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -44,6 +44,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import * as SandboxNetwork from "@/kilocode/sandbox/network" // kilocode_change
+import { McpAuthMode } from "@/kilocode/mcp/auth-mode" // kilocode_change
 import { McpCatalog } from "./catalog"
 
 const DEFAULT_TIMEOUT = 30_000
@@ -248,7 +249,7 @@ export const layer = Layer.effect(
       key: string,
       mcp: ConfigMCPV1.Info & { type: "remote" },
     ) {
-      const oauthDisabled = mcp.oauth === false
+      const oauthDisabled = !McpAuthMode.oauth(mcp) // kilocode_change
       const oauthConfig = typeof mcp.oauth === "object" ? mcp.oauth : undefined
       const url = remoteURL(mcp.url)
       if (!url) {
@@ -304,6 +305,21 @@ export const layer = Layer.effect(
             const lastError = error instanceof Error ? error : new Error(String(error))
             const isAuthError =
               error instanceof UnauthorizedError || (authProvider && lastError.message.includes("OAuth"))
+
+            // kilocode_change start - static Authorization headers are not OAuth credentials
+            if (error instanceof UnauthorizedError && McpAuthMode.header(mcp) && !McpAuthMode.oauth(mcp)) {
+              const message = McpAuthMode.failure(key)
+              lastStatus = { status: "failed" as const, error: message }
+              return events
+                .publish(TuiEvent.ToastShow, {
+                  title: "MCP Header Authentication Failed",
+                  message,
+                  variant: "warning",
+                  duration: 8000,
+                })
+                .pipe(Effect.ignore, Effect.as(undefined))
+            }
+            // kilocode_change end
 
             if (isAuthError) {
               if (lastError.message.includes("registration") || lastError.message.includes("client_id")) {
@@ -786,7 +802,9 @@ export const layer = Layer.effect(
       // kilocode_change end
       const mcpConfig = yield* requireMcpConfig(mcpName)
       if (mcpConfig.type !== "remote") throw new Error(`MCP server ${mcpName} is not a remote server`)
-      if (mcpConfig.oauth === false) throw new Error(`MCP server ${mcpName} has OAuth explicitly disabled`)
+      // kilocode_change start
+      if (!McpAuthMode.oauth(mcpConfig)) throw new Error(`MCP server ${mcpName} is not configured to use OAuth`)
+      // kilocode_change end
       const url = remoteURL(mcpConfig.url)
       if (!url) throw new Error(`Invalid MCP URL for "${mcpName}"`)
 
@@ -973,7 +991,7 @@ export const layer = Layer.effect(
 
     const supportsOAuth = Effect.fn("MCP.supportsOAuth")(function* (mcpName: string) {
       const mcpConfig = yield* requireMcpConfig(mcpName)
-      return mcpConfig.type === "remote" && mcpConfig.oauth !== false
+      return mcpConfig.type === "remote" && McpAuthMode.oauth(mcpConfig) // kilocode_change
     })
 
     const hasStoredTokens = Effect.fn("MCP.hasStoredTokens")(function* (mcpName: string) {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -14,7 +14,7 @@ import { type Tool } from "ai"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js"
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { StreamableHTTPClientTransport, StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js" // kilocode_change
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
@@ -297,6 +297,7 @@ export const layer = Layer.effect(
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       let lastStatus: Status | undefined
+      let stopTransportFallback = false // kilocode_change - avoid retrying rejected header credentials over SSE
 
       for (const { name, transport } of transports) {
         const result = yield* connectTransport(transport, connectTimeout).pipe(
@@ -307,9 +308,14 @@ export const layer = Layer.effect(
               error instanceof UnauthorizedError || (authProvider && lastError.message.includes("OAuth"))
 
             // kilocode_change start - static Authorization headers are not OAuth credentials
-            if (error instanceof UnauthorizedError && McpAuthMode.header(mcp) && !McpAuthMode.oauth(mcp)) {
+            const headerAuthRejected =
+              McpAuthMode.header(mcp) &&
+              !McpAuthMode.oauth(mcp) &&
+              ((error instanceof StreamableHTTPError && error.code === 401) || /\bHTTP 401\b/.test(lastError.message))
+            if (headerAuthRejected) {
               const message = McpAuthMode.failure(key)
               lastStatus = { status: "failed" as const, error: message }
+              stopTransportFallback = true
               return events
                 .publish(TuiEvent.ToastShow, {
                   title: "MCP Header Authentication Failed",
@@ -355,7 +361,14 @@ export const layer = Layer.effect(
         )
         if (result) return { client: result.client, status: { status: "connected" } as Status }
         // If this was an auth error, stop trying other transports
-        if (lastStatus?.status === "needs_auth" || lastStatus?.status === "needs_client_registration") break
+        // kilocode_change start
+        if (
+          stopTransportFallback ||
+          lastStatus?.status === "needs_auth" ||
+          lastStatus?.status === "needs_client_registration"
+        )
+          break
+        // kilocode_change end
       }
 
       return {

--- a/packages/opencode/test/kilocode/mcp-header-auth.test.ts
+++ b/packages/opencode/test/kilocode/mcp-header-auth.test.ts
@@ -15,6 +15,7 @@ it.instance(
       expect(yield* mcp.supportsOAuth("header")).toBe(false)
       expect(yield* mcp.supportsOAuth("oauth")).toBe(true)
       expect(yield* mcp.supportsOAuth("custom")).toBe(true)
+      expect(yield* mcp.supportsOAuth("disabled")).toBe(false)
     }),
   {
     config: {
@@ -37,6 +38,12 @@ it.instance(
           url: "https://mcp.example.com",
           enabled: false,
           headers: { "X-Organization": "example" },
+        },
+        disabled: {
+          type: "remote",
+          url: "https://mcp.example.com",
+          enabled: false,
+          oauth: false,
         },
       },
     },

--- a/packages/opencode/test/kilocode/mcp-header-auth.test.ts
+++ b/packages/opencode/test/kilocode/mcp-header-auth.test.ts
@@ -1,0 +1,54 @@
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { MCP } from "../../src/mcp"
+import { McpAuthMode } from "../../src/kilocode/mcp/auth-mode"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(MCP.defaultLayer)
+
+it.instance(
+  "does not classify static Authorization headers as OAuth",
+  () =>
+    Effect.gen(function* () {
+      const mcp = yield* MCP.Service
+
+      expect(yield* mcp.supportsOAuth("header")).toBe(false)
+      expect(yield* mcp.supportsOAuth("oauth")).toBe(true)
+      expect(yield* mcp.supportsOAuth("custom")).toBe(true)
+    }),
+  {
+    config: {
+      mcp: {
+        header: {
+          type: "remote",
+          url: "https://mcp.example.com",
+          enabled: false,
+          headers: { authorization: "Bearer token" },
+        },
+        oauth: {
+          type: "remote",
+          url: "https://mcp.example.com",
+          enabled: false,
+          headers: { Authorization: "Bearer bootstrap-token" },
+          oauth: {},
+        },
+        custom: {
+          type: "remote",
+          url: "https://mcp.example.com",
+          enabled: false,
+          headers: { "X-Organization": "example" },
+        },
+      },
+    },
+  },
+)
+
+it.effect("describes how to fix rejected header credentials", () =>
+  Effect.sync(() => {
+    const message = McpAuthMode.failure("example")
+
+    expect(message).toContain("configured Authorization header")
+    expect(message).toContain("environment variables")
+    expect(message).not.toContain("mcp auth")
+  }),
+)

--- a/packages/opencode/test/kilocode/mcp-header-auth.test.ts
+++ b/packages/opencode/test/kilocode/mcp-header-auth.test.ts
@@ -52,3 +52,37 @@ it.effect("describes how to fix rejected header credentials", () =>
     expect(message).not.toContain("mcp auth")
   }),
 )
+
+it.instance(
+  "reports a real 401 for a static Authorization header without retrying over SSE",
+  () =>
+    Effect.gen(function* () {
+      const mcp = yield* MCP.Service
+      let requests = 0
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch() {
+          requests++
+          return new Response("Unauthorized", { status: 401 })
+        },
+      })
+
+      yield* Effect.addFinalizer(() => Effect.sync(() => server.stop(true)))
+
+      const result = yield* mcp.add("header", {
+        type: "remote",
+        url: `http://127.0.0.1:${server.port}/mcp`,
+        headers: { Authorization: "Bearer rejected" },
+      })
+      const status = "header" in result.status ? result.status.header : result.status
+
+      expect(status).toEqual({
+        status: "failed",
+        error:
+          'Server "header" rejected the configured Authorization header. Check its value and any referenced environment variables.',
+      })
+      expect(requests).toBe(1)
+    }),
+  { config: { mcp: {} } },
+)

--- a/packages/opencode/test/mcp/headers.test.ts
+++ b/packages/opencode/test/mcp/headers.test.ts
@@ -49,7 +49,9 @@ const { MCP } = await import("../../src/mcp/index")
 const it = testEffect(MCP.defaultLayer)
 
 describe("mcp.headers", () => {
-  it.instance("headers are passed to transports when oauth is enabled (default)", () =>
+  // kilocode_change start
+  it.instance("headers are passed without implicit OAuth for static Authorization", () =>
+    // kilocode_change end
     Effect.gen(function* () {
       const mcp = yield* MCP.Service
       yield* mcp
@@ -72,8 +74,9 @@ describe("mcp.headers", () => {
           Authorization: "Bearer test-token",
           "X-Custom-Header": "custom-value",
         })
-        // OAuth should be enabled by default, so authProvider should exist
-        expect(call.options.authProvider).toBeDefined()
+        // kilocode_change start - static Authorization headers are not OAuth credentials
+        expect(call.options.authProvider).toBeUndefined()
+        // kilocode_change end
       }
     }),
   )


### PR DESCRIPTION
## Summary

Treat remote MCP servers with a configured `Authorization` header as statically authenticated instead of implicitly OAuth-capable. These servers are now omitted from `kilo mcp auth list`, reject direct OAuth commands, and report rejected header credentials with guidance to check the header value and referenced environment variables.

An explicit `oauth: {}` configuration still opts into OAuth when a server intentionally uses both custom headers and OAuth.

## Root cause

OAuth capability was inferred solely from `oauth !== false`, so the CLI and runtime offered OAuth for every remote server even when its credentials came from a static authorization header. A missing environment variable therefore produced an OAuth command that could not fix the configuration.

## Validation

- 12 focused MCP header/OAuth tests
- CLI typecheck
- OpenCode annotation and Promise-facade guards

Closes #12763