### PR TITLE
feat: add edit message button to user messages in VS Code extension

### DIFF
--- a/.changeset/edit-message-vscode.md
+++ b/.changeset/edit-message-vscode.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add an "Edit message" button to user messages in the VS Code extension chat. Clicking edit restores the message text into the prompt input and reverts the session to that point, so you can modify a sent message and resend it.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -749,6 +749,7 @@ export function UserMessageDisplay(props: {
   header?: JSX.Element
   onDelete?: () => void
   onFork?: () => void
+  onEdit?: () => void
   onRevert?: () => void
 }) {
   const data = useData()
@@ -932,6 +933,21 @@ export function UserMessageDisplay(props: {
                       props.onFork?.()
                     }}
                     aria-label={i18n.t("ui.message.forkMessage")}
+                  />
+                </Tooltip>
+              </Show>
+              <Show when={props.onEdit}>
+                <Tooltip value={i18n.t("ui.message.editMessage")} placement="right" gutter={4}>
+                  <IconButton
+                    icon="edit"
+                    size="normal"
+                    variant="ghost"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      props.onEdit?.()
+                    }}
+                    aria-label={i18n.t("ui.message.editMessage")}
                   />
                 </Tooltip>
               </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -77,6 +77,14 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
                     }
                   : undefined
               }
+              onEdit={
+                row().answered
+                  ? () => {
+                      if (session.status() !== "idle") return
+                      session.revertSession(row().message.id)
+                    }
+                  : undefined
+              }
             />
           </div>
         )}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeSessionTurn.tsx
@@ -144,6 +144,14 @@ export const VscodeSessionTurn: Component<VscodeSessionTurnProps> = (props) => {
                       }
                     : undefined
                 }
+                onEdit={
+                  assistantMessages().length > 0
+                    ? () => {
+                        if (session.status() !== "idle") return
+                        session.revertSession(msg().id)
+                      }
+                    : undefined
+                }
               />
             </div>
           </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
@@ -11,6 +11,7 @@ interface VscodeUserMessageProps {
   queued?: boolean
   onDelete?: () => void
   onFork?: () => void
+  onEdit?: () => void
   onRevert?: () => void
 }
 
@@ -38,6 +39,7 @@ export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
       queued={props.queued}
       onDelete={props.onDelete}
       onFork={props.onFork}
+      onEdit={props.onEdit}
       onRevert={props.onRevert}
     />
   )

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -171,6 +171,7 @@ export const dict: Record<string, string> = {
   "ui.message.copyMessage": "Copy message",
   "ui.message.deleteQueued": "Delete queued message", // kilocode_change
   "ui.message.forkMessage": "Fork to new session",
+  "ui.message.editMessage": "Edit message",
   "ui.message.revertMessage": "Revert to here",
   "ui.message.copyResponse": "Copy response",
   "ui.message.copied": "Copied",


### PR DESCRIPTION
Adds an 'Edit message' button to user messages in the VS Code extension chat UI.

When clicked, it restores the message text into the prompt input and reverts the session to that point, allowing the user to modify a sent message and resend it.

**Changes:**
- : Add `onEdit` prop to `UserMessageDisplay` with a dedicated edit button (pencil icon)
- : Add `ui.message.editMessage` i18n key
- : Pass through `onEdit` prop
- : Wire `onEdit` to call `revertSession` (same behavior as revert)
- : Wire `onEdit` to call `revertSession`

The edit action uses the existing revert session mechanism (same `POST /session/{id}/revert` endpoint) since the backend doesn't have a dedicated edit endpoint. An edit button provides a clearer UX affordance than the revert button for users who want to modify a sent message.