### PR TITLE
Fix Kimi K3 reasoning effort options

### DIFF
--- a/.changeset/calm-kimis-reason.md
+++ b/.changeset/calm-kimis-reason.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Expose Kimi K3's supported low, high, and max reasoning effort levels.

--- a/packages/opencode/src/kilocode/provider/kimi-k3.ts
+++ b/packages/opencode/src/kilocode/provider/kimi-k3.ts
@@ -2,23 +2,18 @@ import type { Provider } from "@/provider/provider"
 
 const EFFORTS = ["low", "high", "max"] as const
 const MODEL = /(?:^|\/)kimi-k3(?:$|[-/:])/i
-const ROUTERS = new Set(["@kilocode/kilo-gateway", "@openrouter/ai-sdk-provider"])
-const COMPATIBLE = new Set([
-  "@ai-sdk/cerebras",
-  "@ai-sdk/deepinfra",
-  "@ai-sdk/gateway",
-  "@ai-sdk/openai-compatible",
-  "@ai-sdk/togetherai",
-  "@ai-sdk/xai",
-  "ai-gateway-provider",
-  "venice-ai-sdk-provider",
-])
 
-export function kimiK3Variants(model: Provider.Model) {
-  if (![model.id, model.api.id].some((id) => MODEL.test(id))) return
-  if (ROUTERS.has(model.api.npm)) {
-    return Object.fromEntries(EFFORTS.map((effort) => [effort, { reasoning: { enabled: true, effort } }]))
-  }
-  if (!COMPATIBLE.has(model.api.npm)) return
-  return Object.fromEntries(EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+export function kimiK3Variants(model: Provider.Model, variants: Record<string, Record<string, any>>) {
+  if (![model.id, model.api.id].some((id) => MODEL.test(id))) return variants
+
+  const low = variants.low
+  const high = variants.high
+  if (low?.reasoningEffort !== "low" || high?.reasoningEffort !== "high") return variants
+
+  return Object.fromEntries(
+    EFFORTS.map((effort) => [
+      effort,
+      { ...(effort === "low" ? low : (variants[effort] ?? high)), reasoningEffort: effort },
+    ]),
+  )
 }

--- a/packages/opencode/src/kilocode/provider/kimi-k3.ts
+++ b/packages/opencode/src/kilocode/provider/kimi-k3.ts
@@ -1,0 +1,24 @@
+import type { Provider } from "@/provider/provider"
+
+const EFFORTS = ["low", "high", "max"] as const
+const MODEL = /(?:^|\/)kimi-k3(?:$|[-/:])/i
+const ROUTERS = new Set(["@kilocode/kilo-gateway", "@openrouter/ai-sdk-provider"])
+const COMPATIBLE = new Set([
+  "@ai-sdk/cerebras",
+  "@ai-sdk/deepinfra",
+  "@ai-sdk/gateway",
+  "@ai-sdk/openai-compatible",
+  "@ai-sdk/togetherai",
+  "@ai-sdk/xai",
+  "ai-gateway-provider",
+  "venice-ai-sdk-provider",
+])
+
+export function kimiK3Variants(model: Provider.Model) {
+  if (![model.id, model.api.id].some((id) => MODEL.test(id))) return
+  if (ROUTERS.has(model.api.npm)) {
+    return Object.fromEntries(EFFORTS.map((effort) => [effort, { reasoning: { enabled: true, effort } }]))
+  }
+  if (!COMPATIBLE.has(model.api.npm)) return
+  return Object.fromEntries(EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+}

--- a/packages/opencode/src/kilocode/provider/kimi-k3.ts
+++ b/packages/opencode/src/kilocode/provider/kimi-k3.ts
@@ -1,6 +1,5 @@
 import type { Provider } from "@/provider/provider"
 
-const EFFORTS = ["low", "high", "max"] as const
 const MODEL = /(?:^|\/)kimi-k3(?:$|[-/:])/i
 
 export function kimiK3Variants(model: Provider.Model, variants: Record<string, Record<string, any>>) {
@@ -10,10 +9,9 @@ export function kimiK3Variants(model: Provider.Model, variants: Record<string, R
   const high = variants.high
   if (low?.reasoningEffort !== "low" || high?.reasoningEffort !== "high") return variants
 
-  return Object.fromEntries(
-    EFFORTS.map((effort) => [
-      effort,
-      { ...(effort === "low" ? low : (variants[effort] ?? high)), reasoningEffort: effort },
-    ]),
-  )
+  const { medium: _, ...supported } = variants
+  return {
+    ...supported,
+    max: { ...(variants.max ?? high), reasoningEffort: "max" },
+  }
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -7,6 +7,7 @@ import { iife } from "@/util/iife"
 import { kiloProviderOptions } from "@/kilocode/provider-options"
 import { isLing } from "@/kilocode/model-match" // kilocode_change
 import { reasoningSummary } from "@/kilocode/provider/reasoning-summary" // kilocode_change
+import { kimiK3Variants } from "@/kilocode/provider/kimi-k3" // kilocode_change
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -697,6 +698,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   // kilocode_change end
 
   if (!model.capabilities.reasoning) return {}
+
+  const kimi = kimiK3Variants(model) // kilocode_change
+  if (kimi) return kimi // kilocode_change
 
   const id = model.id.toLowerCase()
   const glm52 = ["glm-5.2", "glm-5-2", "glm-5p2"].some(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -686,21 +686,8 @@ function googleThinkingVariants(model: Provider.Model): Record<string, Record<st
   )
 }
 
-export function variants(model: Provider.Model): Record<string, Record<string, any>> {
-  // kilocode_change start
-  if (
-    ["@kilocode/kilo-gateway", "@ai-sdk/openai-compatible"].includes(model.api.npm) &&
-    model.variants &&
-    Object.keys(model.variants).length > 0
-  ) {
-    return model.variants
-  }
-  // kilocode_change end
-
+function defaultVariants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
-
-  const kimi = kimiK3Variants(model) // kilocode_change
-  if (kimi) return kimi // kilocode_change
 
   const id = model.id.toLowerCase()
   const glm52 = ["glm-5.2", "glm-5-2", "glm-5p2"].some(
@@ -1156,6 +1143,20 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     }
   }
   return {}
+}
+
+export function variants(model: Provider.Model): Record<string, Record<string, any>> {
+  // kilocode_change start
+  // Explicit catalog/config variants have higher precedence than inferred Kimi K3 efforts.
+  if (
+    ["@kilocode/kilo-gateway", "@ai-sdk/openai-compatible"].includes(model.api.npm) &&
+    model.variants &&
+    Object.keys(model.variants).length > 0
+  ) {
+    return model.variants
+  }
+  return kimiK3Variants(model, defaultVariants(model))
+  // kilocode_change end
 }
 
 export function options(input: {

--- a/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
+++ b/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../../src/provider/transform"
+import type { Provider } from "../../../src/provider/provider"
+
+function model(api = "moonshotai/kimi-k3", npm = "@ai-sdk/openai-compatible", id = api) {
+  return {
+    id,
+    providerID: "moonshotai",
+    api: { id: api, npm, url: "https://api.moonshot.ai/v1" },
+    name: "Kimi K3",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: { field: "reasoning_content" },
+    },
+    cost: { input: 3, output: 15, cache: { read: 0.3, write: 0 } },
+    limit: { context: 1_048_576, output: 128_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-07-16",
+  } as Provider.Model
+}
+
+describe("Kimi K3 reasoning efforts", () => {
+  test("uses low, high, and max for OpenAI-compatible providers", () => {
+    const item = model()
+    const result = ProviderTransform.variants(item)
+
+    expect(result).toEqual({
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+    expect(ProviderTransform.providerOptions(item, result.max)).toEqual({
+      moonshotai: { reasoningEffort: "max" },
+    })
+  })
+
+  test("uses router reasoning options when catalog variants are unavailable", () => {
+    expect(ProviderTransform.variants(model("moonshotai/kimi-k3", "@kilocode/kilo-gateway"))).toEqual({
+      low: { reasoning: { enabled: true, effort: "low" } },
+      high: { reasoning: { enabled: true, effort: "high" } },
+      max: { reasoning: { enabled: true, effort: "max" } },
+    })
+  })
+
+  test("matches a Kimi K3 API id behind a custom model alias", () => {
+    const item = model("custom/kimi-k3-preview", "@ai-sdk/openai-compatible", "custom/primary")
+
+    expect(Object.keys(ProviderTransform.variants(item))).toEqual(["low", "high", "max"])
+  })
+
+  test("leaves earlier Kimi models on the existing provider defaults", () => {
+    expect(Object.keys(ProviderTransform.variants(model("moonshotai/kimi-k2.5")))).toEqual(["low", "medium", "high"])
+  })
+})

--- a/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
+++ b/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
@@ -52,6 +52,7 @@ describe("Kimi K3 reasoning efforts", () => {
 
   test("rewrites Groq's reasoning-effort variants without a provider allowlist", () => {
     expect(ProviderTransform.variants(model("moonshotai/kimi-k3", "@ai-sdk/groq"))).toEqual({
+      none: { reasoningEffort: "none" },
       low: { reasoningEffort: "low" },
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },

--- a/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
+++ b/packages/opencode/test/kilocode/provider/kimi-k3.test.ts
@@ -41,12 +41,31 @@ describe("Kimi K3 reasoning efforts", () => {
     })
   })
 
-  test("uses router reasoning options when catalog variants are unavailable", () => {
-    expect(ProviderTransform.variants(model("moonshotai/kimi-k3", "@kilocode/kilo-gateway"))).toEqual({
-      low: { reasoning: { enabled: true, effort: "low" } },
-      high: { reasoning: { enabled: true, effort: "high" } },
-      max: { reasoning: { enabled: true, effort: "max" } },
+  test("preserves the existing router thinking toggles", () => {
+    for (const npm of ["@kilocode/kilo-gateway", "@openrouter/ai-sdk-provider"]) {
+      expect(ProviderTransform.variants(model("moonshotai/kimi-k3", npm))).toEqual({
+        instant: { reasoning: { enabled: false } },
+        thinking: { reasoning: { enabled: true } },
+      })
+    }
+  })
+
+  test("rewrites Groq's reasoning-effort variants without a provider allowlist", () => {
+    expect(ProviderTransform.variants(model("moonshotai/kimi-k3", "@ai-sdk/groq"))).toEqual({
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
     })
+  })
+
+  test("preserves explicit catalog variants", () => {
+    const item = model("moonshotai/kimi-k3", "@kilocode/kilo-gateway")
+    item.variants = {
+      instant: { reasoning: { enabled: false } },
+      thinking: { reasoning: { enabled: true } },
+    }
+
+    expect(ProviderTransform.variants(item)).toEqual(item.variants)
   })
 
   test("matches a Kimi K3 API id behind a custom model alias", () => {


### PR DESCRIPTION
Fixes #12780

Kimi K3 supports `low`, `high`, and `max` reasoning effort levels, but inferred variants for OpenAI-compatible/custom model entries fell back to the generic `low`, `medium`, and `high` set.

This adds a narrow Kimi K3 variant fallback that:
- exposes the supported `low`, `high`, and `max` choices
- emits the appropriate option shape for OpenAI-compatible providers and routers
- preserves explicit catalog/config variants and the existing behavior of earlier Kimi models
- includes regression coverage and a patch changeset