### PR TITLE
fix(cli): use system ripgrep in packaged builds

### DIFF
--- a/.changeset/quiet-ripgrep-packaging.md
+++ b/.changeset/quiet-ripgrep-packaging.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Use an installed ripgrep binary for codebase search in packaged Kilo builds.

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -82,6 +82,7 @@ export interface GrepInput {
 }
 
 export interface Interface {
+  readonly filepath: Effect.Effect<string, globalThis.Error> // kilocode_change - share Kilo's managed binary with bundled integrations
   readonly find: (input: FindInput) => Effect.Effect<readonly Entry[], Error>
   readonly glob: (input: GlobInput) => Effect.Effect<SearchResult<Entry>, Error> // kilocode_change
   readonly grep: (input: GrepInput) => Effect.Effect<SearchResult<Match>, Error | InvalidPatternError> // kilocode_change
@@ -176,6 +177,7 @@ export const layer = Layer.effect(
     }
 
     return Service.of({
+      filepath: binary.filepath, // kilocode_change - share Kilo's managed binary with bundled integrations
       glob: (input) =>
         run<string>({
           cwd: input.cwd,

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { $ } from "bun"
+import type { BunPlugin } from "bun" // kilocode_change
 import fs from "fs"
 import os from "os" // kilocode_change
 import path from "path"
@@ -31,6 +32,16 @@ const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const sourcemapsFlag = process.argv.includes("--sourcemaps")
 const plugin = createSolidTransformPlugin()
+// kilocode_change start - packaged CLIs have no node_modules tree for Morph's optional platform package
+const morphRipgrepPlugin: BunPlugin = {
+  name: "kilocode-morph-ripgrep",
+  setup(build) {
+    build.onResolve({ filter: /^@vscode\/ripgrep$/ }, () => ({
+      path: path.join(dir, "src/kilocode/morph-ripgrep.ts"),
+    }))
+  },
+}
+// kilocode_change end
 
 // kilocode_change start - codebase indexing
 async function copyTreeSitterWasms(outputDir: string) {
@@ -267,7 +278,7 @@ for (const item of targets) {
   await Bun.build({
     conditions: ["bun", "node"], // kilocode_change - port anomalyco/opencode#30873; current form from #31566
     tsconfig: "./tsconfig.json",
-    plugins: [plugin],
+    plugins: [plugin, morphRipgrepPlugin], // kilocode_change - use Morph's system-rg fallback in packaged CLIs
     // kilocode_change start - skip sourcemaps for release builds (each .js.map adds ~50 MB per target → ~600 MB total)
     sourcemap: Script.release ? "none" : "external",
     external: ["node-gyp", ...LanceDBRuntime.external],

--- a/packages/opencode/src/kilocode/morph-ripgrep.ts
+++ b/packages/opencode/src/kilocode/morph-ripgrep.ts
@@ -1,4 +1,8 @@
-// Morph's local provider already falls back to this command when its optional
-// @vscode/ripgrep binary cannot run. Compiled Kilo binaries do not ship a
-// node_modules tree, so resolve the provider directly through PATH instead.
-export const rgPath = "rg"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { which } from "@opencode-ai/core/util/which"
+
+// Morph's local provider imports this path directly, but compiled Kilo binaries
+// do not ship its optional @vscode/ripgrep platform package. Prefer a system
+// binary and otherwise point it at the location managed by Kilo's ripgrep layer.
+export const rgPath = which("rg") ?? path.join(Global.Path.bin, process.platform === "win32" ? "rg.exe" : "rg")

--- a/packages/opencode/src/kilocode/morph-ripgrep.ts
+++ b/packages/opencode/src/kilocode/morph-ripgrep.ts
@@ -1,0 +1,4 @@
+// Morph's local provider already falls back to this command when its optional
+// @vscode/ripgrep binary cannot run. Compiled Kilo binaries do not ship a
+// node_modules tree, so resolve the provider directly through PATH instead.
+export const rgPath = "rg"

--- a/packages/opencode/src/kilocode/morph-ripgrep.ts
+++ b/packages/opencode/src/kilocode/morph-ripgrep.ts
@@ -3,6 +3,8 @@ import { Global } from "@opencode-ai/core/global"
 import { which } from "@opencode-ai/core/util/which"
 
 // Morph's local provider imports this path directly, but compiled Kilo binaries
-// do not ship its optional @vscode/ripgrep platform package. Prefer a system
-// binary and otherwise point it at the location managed by Kilo's ripgrep layer.
-export const rgPath = which("rg") ?? path.join(Global.Path.bin, process.platform === "win32" ? "rg.exe" : "rg")
+// do not ship its optional @vscode/ripgrep platform package. Kilo's codebase
+// search preflights its ripgrep layer, so the managed fallback exists before
+// Morph's first spawn. Avoid Git-for-Windows' potentially incompatible MSYS rg.
+const system = process.platform === "win32" ? null : which("rg")
+export const rgPath = system ?? path.join(Global.Path.bin, process.platform === "win32" ? "rg.exe" : "rg")

--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -5,6 +5,7 @@ import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
 import { Instance } from "../kilocode/instance" // kilocode_change
 import { EventV2Bridge } from "@/event-v2-bridge" // kilocode_change
 import { TuiEvent } from "@/server/tui-event" // kilocode_change
+import { Ripgrep } from "@opencode-ai/core/ripgrep" // kilocode_change
 import DESCRIPTION from "./warpgrep.txt"
 
 // FREE_PERIOD_TODO: Remove KILO_WARPGREP_PROXY_URL constant and the proxy
@@ -22,6 +23,7 @@ export const CodebaseSearchTool = Tool.define(
   "codebase_search",
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service // kilocode_change
+    const ripgrep = yield* Ripgrep.Service // kilocode_change - reuse Kilo's managed binary for Morph search
     return {
       description: DESCRIPTION,
       parameters: Parameters,
@@ -45,6 +47,7 @@ export const CodebaseSearchTool = Tool.define(
             timeout: 60_000,
           })
 
+          yield* ripgrep.filepath // kilocode_change - ensure Morph's replacement path exists before its first spawn
           const result = yield* Effect.promise(() =>
             client.execute({
               searchTerm: params.query,


### PR DESCRIPTION
## Summary

- redirect Morph's optional `@vscode/ripgrep` import to its existing PATH-based fallback in compiled CLI builds
- keep normal source and development installs unchanged
- add patch changesets for the CLI and VS Code extension

## Why

The VS Code extension bundles a compiled CLI without a `node_modules` tree. Morph's local code-search provider attempted to resolve a platform-specific optional package before its system-ripgrep fallback could run, producing a runtime error on macOS ARM64.

## Validation

- CLI typecheck passed with the repository-required Bun 1.3.14
- packaged macOS ARM64 CLI build and smoke checks passed
- rebuilt binary no longer contains the missing optional-dependency error path
- annotation guard and lint passed (0 errors)

Fixes #12787