### PR TITLE
fix(vscode): restore Markdown comment gutter anchors after renderer wrapper change

### DIFF
--- a/packages/kilo-vscode/tests/unit/markdown-rendered-children.test.ts
+++ b/packages/kilo-vscode/tests/unit/markdown-rendered-children.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test"
+import { Window } from "happy-dom"
+import { markdownRenderedChildren } from "../../webview-ui/diff-viewer/markdown-rendered-children"
+
+const window = new Window()
+
+describe("markdownRenderedChildren", () => {
+  it("flattens the current renderer block wrapper", () => {
+    const root = window.document.createElement("div")
+    root.innerHTML = `
+      <div data-markdown-block>
+        <h1>Heading</h1>
+        <p>Paragraph</p>
+        <ul><li>Item</li></ul>
+        <table><tbody><tr><td>Cell</td></tr></tbody></table>
+      </div>
+    `
+
+    expect(markdownRenderedChildren(root).map((node) => node.tagName)).toEqual(["H1", "P", "UL", "TABLE"])
+  })
+
+  it("preserves legacy top-level blocks and ignores inserted annotations", () => {
+    const root = window.document.createElement("div")
+    root.innerHTML = `
+      <h1>Heading</h1>
+      <div class="am-markdown-inline-annotations"></div>
+      <p>Paragraph</p>
+      <div data-markdown-block>
+        <div class="am-markdown-inline-annotations"></div>
+        <blockquote>Quote</blockquote>
+      </div>
+    `
+
+    expect(markdownRenderedChildren(root).map((node) => node.tagName)).toEqual(["H1", "P", "BLOCKQUOTE"])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
@@ -3,6 +3,7 @@ import type { AnnotationSide, DiffLineAnnotation, SelectedLineRange } from "@pie
 import { markdownCommentBlocks, type MarkdownRange } from "./markdown-comment-ranges"
 import type { AnnotationMeta } from "./review-annotations"
 import { annotationSelector, isAnnotationMutation } from "./markdown-annotation-mutation"
+import { markdownRenderedChildren } from "./markdown-rendered-children"
 
 type Insert = "after" | "list" | "table"
 
@@ -24,16 +25,6 @@ export interface MarkdownAnnotationLayerProps {
   onLineNumberClick: ((event: { annotationSide: AnnotationSide; lineNumber: number }) => void) | undefined
 }
 
-function children(root: HTMLElement): HTMLElement[] {
-  return Array.from(root.children).filter((child): child is HTMLElement => {
-    if (!(child instanceof HTMLElement)) return false
-    if (child.classList.contains("am-markdown-inline-annotations")) return false
-    if (child.classList.contains("am-markdown-list-annotation")) return false
-    if (child.classList.contains("am-markdown-table-annotation")) return false
-    return true
-  })
-}
-
 function listItems(root: HTMLElement): HTMLElement[] {
   return Array.from(root.children).filter((child): child is HTMLElement => {
     if (!(child instanceof HTMLElement)) return false
@@ -49,7 +40,7 @@ function tableRows(root: HTMLElement): HTMLElement[] {
 }
 
 function anchors(root: HTMLElement, source: ReturnType<typeof markdownCommentBlocks>): Anchor[] {
-  const rendered = children(root)
+  const rendered = markdownRenderedChildren(root)
   const result: Anchor[] = []
   let index = 0
 

--- a/packages/kilo-vscode/webview-ui/diff-viewer/markdown-rendered-children.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/markdown-rendered-children.ts
@@ -1,0 +1,18 @@
+const inserted = new Set([
+  "am-markdown-inline-annotations",
+  "am-markdown-list-annotation",
+  "am-markdown-table-annotation",
+])
+
+function isInserted(node: Element): boolean {
+  return Array.from(node.classList).some((name) => inserted.has(name))
+}
+
+export function markdownRenderedChildren(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.children).flatMap((child) => {
+    if (isInserted(child)) return []
+
+    const nodes = child.hasAttribute("data-markdown-block") ? Array.from(child.children) : [child]
+    return nodes.filter((node) => !isInserted(node)).map((node) => node as HTMLElement)
+  })
+}


### PR DESCRIPTION
Commenting on rendered Markdown files in Agent Manager broke after the Markdown renderer started wrapping each rendered block in a `div[data-markdown-block]` container with `display: contents`.

The annotation layer treated those wrappers as the actual Markdown elements, which collapsed the bounding-box lookups and bypassed the list/table special-case comment handling.

**Fix**

- Flatten renderer-owned block wrappers to their actual rendered children in the annotation layer.
- Preserve compatibility with legacy top-level Markdown DOM (no wrapper).
- Keep filtering inserted annotation elements.
- Add regression tests covering wrapped blocks, lists, tables, and legacy rendering.

**Regression**

Introduced in #12460 (`a776bd4d29`, `refactor: kilo compat for v1.17.9`).