### PR TITLE
fix(agent-manager): make worktree hover cards instant

### DIFF
--- a/.changeset/instant-worktree-hover.md
+++ b/.changeset/instant-worktree-hover.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show and hide Agent Manager worktree hover cards instantly.

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -187,8 +187,8 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
       <ContextMenu>
         <HoverCard
           class="am-worktree-hover-card"
-          openDelay={50}
-          closeDelay={50}
+          openDelay={0}
+          closeDelay={0}
           placement="right-start"
           gutter={8}
           open={hovered() && !overClose() && !props.pendingDelete}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -3283,11 +3283,11 @@ body.am-wt-dragging-active * {
 /* HoverCard popover for worktree items */
 
 .am-worktree-hover-card[data-expanded] {
-  animation-duration: 0ms;
+  animation: none;
 }
 
 .am-worktree-hover-card[data-closed] {
-  animation-duration: 0ms;
+  animation: none;
 }
 
 .am-hover-card {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -3283,11 +3283,11 @@ body.am-wt-dragging-active * {
 /* HoverCard popover for worktree items */
 
 .am-worktree-hover-card[data-expanded] {
-  animation-duration: 80ms;
+  animation-duration: 0ms;
 }
 
 .am-worktree-hover-card[data-closed] {
-  animation-duration: 60ms;
+  animation-duration: 0ms;
 }
 
 .am-hover-card {


### PR DESCRIPTION
Worktree hover cards regressed to delayed open and close behavior after the prior speed-up fix. Restore zero-delay open and close behavior and remove the scoped worktree-card animations so hover details respond immediately again. The change is limited to Agent Manager worktree hover cards and includes a patch changeset.