### PR TITLE
feat(cli): adopt upstream reasoningVariants from v1.18.11

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -44,6 +44,24 @@ const Cost = Schema.Struct({
   ),
 })
 
+// kilocode_change start - models.dev reasoning_options (snatched from upstream
+// v1.18.11, #36624): effort tiers, thinking toggles, and token budgets.
+const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+// kilocode_change end
+
 export const Model = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
@@ -51,6 +69,7 @@ export const Model = Schema.Struct({
   release_date: Schema.String,
   attachment: Schema.Boolean,
   reasoning: Schema.Boolean,
+  reasoning_options: Schema.optional(Schema.Array(ReasoningOption)), // kilocode_change
   temperature: Schema.Boolean,
   tool_call: Schema.Boolean,
   interleaved: Schema.optional(

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1258,10 +1258,11 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     variants: {},
   }
   Object.assign(base, patchKiloModel(provider.id, model)) // kilocode_change
+  const variants = ProviderTransform.reasoningVariants(model, base) ?? ProviderTransform.variants(base) // kilocode_change
 
   return {
     ...base,
-    variants: mapValues(ProviderTransform.variants(base), (v) => v),
+    variants: mapValues(variants, (v) => v), // kilocode_change
   }
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1154,6 +1154,228 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   return {}
 }
 
+// kilocode_change start - derive variants from models.dev reasoning_options
+// (snatched from upstream v1.18.11, #36624 + follow-up fixes). Takes precedence
+// over the heuristic variants() when the model publishes reasoning_options.
+export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model): Provider.Model["variants"] {
+  const options = model.reasoning_options
+  if (options === undefined) return
+  if (options.length === 0) return {}
+
+  const effort = options.find((option) => option.type === "effort")
+  if (effort) return effortVariants(target, effort.values)
+
+  const toggle = options.some((option) => option.type === "toggle")
+  const budget = options.find((option) => option.type === "budget_tokens")
+  if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
+
+  return nonEmptyVariants({
+    ...(toggle ? reasoningToggle(target) : {}),
+    ...budgetVariants(target, budget.min, budget.max),
+  })
+}
+
+function effortVariants(model: Provider.Model, values: readonly unknown[]) {
+  return Object.fromEntries(
+    values.flatMap((value) => {
+      const id = (() => {
+        if (value === null) return "none"
+        if (typeof value === "string") return value
+      })()
+      if (id === undefined) return []
+      const settings = reasoningEffort(model, id)
+      return settings ? [[id, settings]] : []
+    }),
+  )
+}
+
+function budgetVariants(model: Provider.Model, min?: number, max?: number) {
+  const maximum = Math.min(max ?? OUTPUT_TOKEN_MAX - 1, model.limit.output - 1, OUTPUT_TOKEN_MAX - 1)
+  if (maximum <= 0) return {}
+  const high = Math.min(Math.max(min ?? 0, Math.floor((maximum + 1) / 2)), maximum)
+  return Object.fromEntries(
+    [
+      { id: "high", budget: high },
+      { id: "max", budget: maximum },
+    ].flatMap((item) => {
+      const settings = reasoningBudget(model, item.budget)
+      return settings ? [[item.id, settings]] : []
+    }),
+  )
+}
+
+function nonEmptyVariants(variants: NonNullable<Provider.Model["variants"]>): Provider.Model["variants"] {
+  return Object.keys(variants).length > 0 ? variants : undefined
+}
+
+function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["variants"]> {
+  if (model.api.npm === "@ai-sdk/alibaba")
+    return {
+      none: { enableThinking: false },
+      high: { enableThinking: true },
+    }
+  if (model.api.npm === "@ai-sdk/cohere")
+    return {
+      none: { thinking: { type: "disabled" } },
+      high: { thinking: { type: "enabled" } },
+    }
+  return {}
+}
+
+function reasoningEffort(model: Provider.Model, effort: string) {
+  switch (model.api.npm) {
+    case "@openrouter/ai-sdk-provider":
+      return { reasoning: { effort } }
+    case "@ai-sdk/anthropic":
+    case "@ai-sdk/google-vertex/anthropic":
+      return anthropicEffort(model, effort) ?? { effort }
+    case "@ai-sdk/google":
+    case "@ai-sdk/google-vertex":
+      return { thinkingConfig: { includeThoughts: true, thinkingLevel: effort } }
+    case "@ai-sdk/amazon-bedrock":
+      if (anthropicAdaptiveEfforts(model.api.id))
+        return {
+          reasoningConfig: {
+            type: "adaptive",
+            maxReasoningEffort: effort,
+            ...(anthropicOmitsThinking(model.api.id) ? { display: "summarized" } : {}),
+          },
+        }
+      if (anthropicOpus45(model.api.id))
+        return {
+          reasoningConfig: {
+            type: "enabled",
+            budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+            maxReasoningEffort: effort,
+          },
+        }
+      if (model.api.id.includes("anthropic")) return
+      return { reasoningConfig: { type: "enabled", maxReasoningEffort: effort } }
+    case "@ai-sdk/gateway":
+      if (model.id.includes("anthropic")) return { thinking: { type: "adaptive", display: "summarized" }, effort }
+      if (model.id.includes("google")) return { thinkingConfig: { includeThoughts: true, thinkingLevel: effort } }
+      return { reasoningEffort: effort }
+    case "@ai-sdk/github-copilot":
+      // OAuth discovery replaces these with variants from Copilot's /models capabilities.
+      if (model.id.includes("gemini")) return
+      if (model.id.includes("claude")) return { reasoningEffort: effort }
+      return { reasoningEffort: effort, reasoningSummary: "auto", include: INCLUDE_ENCRYPTED_REASONING }
+    case "@ai-sdk/openai":
+    case "@ai-sdk/amazon-bedrock/mantle":
+      return { reasoningEffort: effort, reasoningSummary: reasoningSummary(model), include: INCLUDE_ENCRYPTED_REASONING } // kilocode_change - keep gpt-5.6 detailed summaries
+    case "@ai-sdk/azure":
+      return { reasoningEffort: effort, reasoningSummary: reasoningSummary(model), include: INCLUDE_ENCRYPTED_REASONING } // kilocode_change
+    case "@jerome-benoit/sap-ai-provider-v2":
+      if (model.id.includes("anthropic"))
+        return { modelParams: { thinking: { type: "adaptive", display: "summarized" }, output_config: { effort } } }
+      return { modelParams: { reasoning_effort: effort } }
+    case "@ai-sdk/openai-compatible":
+    case "@ai-sdk/xai":
+    case "@ai-sdk/mistral":
+    case "@ai-sdk/groq":
+    case "@ai-sdk/cerebras":
+    case "@ai-sdk/deepinfra":
+    case "@ai-sdk/togetherai":
+    case "venice-ai-sdk-provider":
+    case "ai-gateway-provider":
+      return { reasoningEffort: effort }
+    case "@kilocode/kilo-gateway": // kilocode_change - OpenRouter-shaped reasoning effort
+      return { reasoning: { effort } } // kilocode_change
+    case "@ai-sdk/cohere":
+    case "@ai-sdk/perplexity":
+    case "@ai-sdk/vercel":
+    case "@ai-sdk/alibaba":
+    case "gitlab-ai-provider":
+      return
+  }
+}
+
+function anthropicEffort(model: Provider.Model, effort: string) {
+  if (anthropicOpus45(model.api.id)) return anthropicOpus45Effort(model, effort)
+  // Kimi defaults to omitting adaptive thinking text unless summarized display is requested.
+  if (isKimiFamily(model)) return { thinking: { type: "adaptive", display: "summarized" }, effort }
+  if (!anthropicAdaptiveEfforts(model.api.id)) return
+  return {
+    thinking: {
+      type: "adaptive",
+      ...(anthropicOmitsThinking(model.api.id) ? { display: "summarized" } : {}),
+    },
+    effort,
+  }
+}
+
+function anthropicOpus45Effort(model: Provider.Model, effort: string) {
+  return {
+    thinking: {
+      type: "enabled",
+      budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+    },
+    effort,
+  }
+}
+
+function reasoningBudget(model: Provider.Model, budget: number) {
+  switch (model.api.npm) {
+    case "@openrouter/ai-sdk-provider":
+      return { reasoning: { max_tokens: budget } }
+    case "@ai-sdk/anthropic":
+    case "@ai-sdk/google-vertex/anthropic":
+      return { thinking: { type: "enabled", budgetTokens: budget } }
+    case "@ai-sdk/google":
+    case "@ai-sdk/google-vertex":
+      return { thinkingConfig: { includeThoughts: true, thinkingBudget: budget } }
+    case "@ai-sdk/amazon-bedrock":
+      return { reasoningConfig: { type: "enabled", budgetTokens: budget } }
+    case "@ai-sdk/gateway":
+      if (model.id.includes("anthropic")) return { thinking: { type: "enabled", budgetTokens: budget } }
+      if (model.id.includes("google")) return { thinkingConfig: { includeThoughts: true, thinkingBudget: budget } }
+      return
+    case "@ai-sdk/cohere":
+      return { thinking: { type: "enabled", tokenBudget: budget } }
+    case "@ai-sdk/alibaba":
+      return { enableThinking: true, thinkingBudget: budget }
+    case "@jerome-benoit/sap-ai-provider-v2":
+      if (model.id.includes("anthropic")) return { modelParams: { thinking: { type: "enabled", budget_tokens: budget } } }
+      if (model.id.includes("gemini"))
+        return { modelParams: { thinkingConfig: { includeThoughts: true, thinkingBudget: budget } } }
+      return
+    case "@ai-sdk/amazon-bedrock/mantle":
+    case "@ai-sdk/azure":
+    case "@ai-sdk/cerebras":
+    case "@ai-sdk/deepinfra":
+    case "@ai-sdk/github-copilot":
+    case "@ai-sdk/groq":
+    case "@ai-sdk/mistral":
+    case "@ai-sdk/openai":
+    case "@ai-sdk/openai-compatible":
+    case "@ai-sdk/perplexity":
+    case "@ai-sdk/togetherai":
+    case "@ai-sdk/vercel":
+    case "@ai-sdk/xai":
+    case "ai-gateway-provider":
+    case "gitlab-ai-provider":
+    case "venice-ai-sdk-provider":
+      return
+  }
+}
+
+function isKimiFamily(model: Provider.Model) {
+  if (
+    [model.providerID, model.api.id].some((id) => {
+      const value = id.toLowerCase()
+      return value.includes("kimi") || value.includes("moonshot")
+    })
+  )
+    return true
+  const url = model.api.url.toLowerCase()
+  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) => url.includes(host))
+}
+
+function anthropicOpus45(apiId: string) {
+  return ["opus-4-5", "opus-4.5"].some((value) => apiId.includes(value))
+}
+// kilocode_change end
+
 export function options(input: {
   model: Provider.Model
   sessionID: string

--- a/packages/opencode/test/kilocode/provider-reasoning-options.test.ts
+++ b/packages/opencode/test/kilocode/provider-reasoning-options.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../src/provider/transform"
+import { Provider } from "../../src/provider/provider"
+import type * as ModelsDev from "@opencode-ai/core/models-dev"
+
+function mockModel(overrides: Partial<any> = {}): any {
+  return {
+    id: "test/test-model",
+    providerID: "test",
+    api: {
+      id: "test-model",
+      url: "https://api.test.com",
+      npm: "@ai-sdk/openai",
+    },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+    limit: { context: 200_000, output: 64_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2024-01-01",
+    ...overrides,
+  }
+}
+
+function raw(options: ModelsDev.Model["reasoning_options"]): ModelsDev.Model {
+  return { reasoning_options: options } as ModelsDev.Model
+}
+
+describe("ProviderTransform.reasoningVariants - models.dev reasoning_options", () => {
+  test("effort tiers including 'max' and null 'none' on @ai-sdk/openai", () => {
+    const target = mockModel({
+      api: { id: "gpt-5.6", url: "https://api.openai.com", npm: "@ai-sdk/openai" },
+    })
+    const result = ProviderTransform.reasoningVariants(
+      raw([{ type: "effort", values: ["none", null, "low", "medium", "high", "xhigh", "max"] }]),
+      target,
+    )
+    expect(Object.keys(result ?? {})).toEqual(["none", "low", "medium", "high", "xhigh", "max"])
+    expect(result?.none).toEqual({
+      reasoningEffort: "none",
+      reasoningSummary: "detailed",
+      include: ["reasoning.encrypted_content"],
+    })
+    expect(result?.max).toEqual({
+      reasoningEffort: "max",
+      reasoningSummary: "detailed",
+      include: ["reasoning.encrypted_content"],
+    })
+  })
+
+  test("effort tiers on @openrouter/ai-sdk-provider use reasoning object shape", () => {
+    const target = mockModel({
+      providerID: "openrouter",
+      api: { id: "openai/gpt-5.6", url: "https://openrouter.ai", npm: "@openrouter/ai-sdk-provider" },
+    })
+    const result = ProviderTransform.reasoningVariants(
+      raw([{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }]),
+      target,
+    )
+    expect(Object.keys(result ?? {})).toEqual(["none", "low", "medium", "high", "xhigh", "max"])
+    expect(result?.max).toEqual({ reasoning: { effort: "max" } })
+  })
+
+  test("budget_tokens produces high/max budget variants on bedrock", () => {
+    const target = mockModel({
+      api: { id: "anthropic.claude-sonnet-4-5", url: "https://bedrock.amazonaws.com", npm: "@ai-sdk/amazon-bedrock" },
+    })
+    const result = ProviderTransform.reasoningVariants(raw([{ type: "budget_tokens", min: 1024 }]), target)
+    expect(Object.keys(result ?? {})).toEqual(["high", "max"])
+    expect(result?.max).toEqual({ reasoningConfig: { type: "enabled", budgetTokens: 31_999 } })
+  })
+
+  test("explicitly empty reasoning_options means no variants", () => {
+    const target = mockModel()
+    expect(ProviderTransform.reasoningVariants(raw([]), target)).toEqual({})
+  })
+
+  test("missing reasoning_options falls back to heuristics (undefined)", () => {
+    const target = mockModel()
+    expect(ProviderTransform.reasoningVariants(raw(undefined), target)).toBeUndefined()
+  })
+
+  test("models.dev reasoning_options take precedence over heuristic variants in the provider pipeline", () => {
+    const provider = {
+      id: "openai",
+      name: "OpenAI",
+      env: [],
+      npm: "@ai-sdk/openai",
+      models: {
+        "gpt-5.6": {
+          id: "gpt-5.6",
+          name: "GPT-5.6",
+          family: "gpt",
+          release_date: "2025-12-11",
+          attachment: true,
+          reasoning: true,
+          temperature: false,
+          tool_call: true,
+          cost: { input: 1, output: 4, cache_read: 0.5, cache_write: 0 },
+          limit: { context: 400_000, output: 128_000 },
+          reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+        },
+        "gpt-5": {
+          id: "gpt-5",
+          name: "GPT-5",
+          family: "gpt",
+          release_date: "2024-06-01",
+          attachment: true,
+          reasoning: true,
+          temperature: false,
+          tool_call: true,
+          cost: { input: 1, output: 4, cache_read: 0.5, cache_write: 0 },
+          limit: { context: 400_000, output: 128_000 },
+        },
+      },
+    } as unknown as ModelsDev.Provider
+
+    const info = Provider.fromModelsDevProvider(provider)
+    const gpt56 = info.models["gpt-5.6"]
+    expect(Object.keys(gpt56.variants ?? {})).toEqual(["none", "low", "medium", "high", "xhigh", "max"])
+    expect(gpt56.variants?.["max"]).toEqual({
+      reasoningEffort: "max",
+      reasoningSummary: "detailed",
+      include: ["reasoning.encrypted_content"],
+    })
+
+    const gpt5 = info.models["gpt-5"]
+    expect(Object.keys(gpt5.variants ?? {})).toEqual(["minimal", "low", "medium", "high"])
+  })
+})


### PR DESCRIPTION
OpenAI sub-models (gpt-5.6 family) do not expose the `max` reasoning effort tier in the model picker even though models.dev publishes it in the per-model `reasoning_options` field. The CLI previously ignored that field entirely and computed variants from hardcoded version/release-date heuristics, which never emit `max`.

This ports upstream opencode v1.18.11 (#36624 + follow-up fixes through v1.18.11) so that models with `reasoning_options` get their effort/budget/toggle variants directly from models.dev data. Models without the field fall back to the existing heuristic path unchanged.

The port includes the full upstream implementation (`reasoningVariants`, `effortVariants`, `budgetVariants`, `reasoningToggle`, `reasoningEffort`, `reasoningBudget`, `anthropicEffort`, plus helpers like `isKimiFamily` and `anthropicOpus45`) and two fork reconciliations:
- The openai/azure/mantle cases keep the fork's `reasoningSummary(model)` helper so gpt-5.6 retains its `"detailed"` summary instead of upstream's hardcoded `"auto"`.
- A defensive `@kilocode/kilo-gateway` case maps to the OpenRouter-shaped `{ reasoning: { effort } }`.

Verified end-to-end on a live `kilo serve`: gpt-5.6-luna/sol/terra (and their -fast/-pro variants) all surface `[none, low, medium, high, xhigh, max]`, with the `max` variant payload containing `reasoningSummary: "detailed"`. Budget-token models on bedrock produce `[high, max]` budget variants as expected.