### PR TITLE
fix(vscode): prevent prompt toolbar height growth when training indicator is visible

### DIFF
--- a/.changeset/prompt-training-indicator-height.md
+++ b/.changeset/prompt-training-indicator-height.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the prompt controls at a consistent height when the model selector shows the prompt-training indicator.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/prompt-input/with-prompt-training-200-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/prompt-input/with-prompt-training-200-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e25bc93fa7d963c9d3a6b71918e623b02ab42a3c638cc2936a02cd2a773e26
+size 5261

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/prompt-input/with-prompt-training-420-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/prompt-input/with-prompt-training-420-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ac5b0f48f483ce5fff844aec9316effb5395ee43740b782ebaa9adab7807f59
+size 5690

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -97,14 +97,20 @@ const MOCK_PROVIDERS = {
 const MOCK_MODELS = flattenModels(MOCK_PROVIDERS as any)
 
 /** A synchronous mock ProviderContext — provides models without waiting for a postMessage round-trip. */
-const MockProviderProvider: ParentComponent<{ kiloAuth?: boolean }> = (props) => {
+const MockProviderProvider: ParentComponent<{ kiloAuth?: boolean; training?: boolean }> = (props) => {
+  const models = createMemo(() =>
+    MOCK_MODELS.map((model) => ({
+      ...model,
+      mayTrainOnYourPrompts: props.training === true,
+    })),
+  )
   const value = {
     providers: () => MOCK_PROVIDERS as any,
     connected: () => ["kilo"],
     defaults: () => ({}),
     defaultSelection: () => ({ providerID: "kilo", modelID: "anthropic/claude-sonnet-4-6" }),
-    models: () => MOCK_MODELS,
-    findModel: (sel: any) => _findModel(MOCK_MODELS, sel),
+    models,
+    findModel: (sel: any) => _findModel(models(), sel),
     authMethods: () => ({}),
     authStates: () => (props.kiloAuth ? { kilo: "oauth" } : {}) as Record<string, ProviderAuthState>,
     isModelValid: () => true,
@@ -303,6 +309,7 @@ interface StoryProvidersProps {
   onOpenDiff?: OpenDiffFn
   onOpenFile?: OpenFileFn
   kiloAuth?: boolean
+  training?: boolean
   /** When true, renders children without the default 12px padding wrapper */
   noPadding?: boolean
 }
@@ -433,7 +440,7 @@ export const StoryProviders: ParentComponent<StoryProvidersProps> = (props) => {
             onProjectConfigChange={props.onProjectConfigChange}
           >
             <DisplayProvider>
-              <MockProviderProvider kiloAuth={props.kiloAuth}>
+              <MockProviderProvider kiloAuth={props.kiloAuth} training={props.training}>
                 <DialogProvider>
                   <LanguageContext.Provider
                     value={{

--- a/packages/kilo-vscode/webview-ui/src/stories/prompt-input.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/prompt-input.stories.tsx
@@ -29,7 +29,9 @@ const agents = [
 
 const noop = () => {}
 
-const PromptProviders: ParentComponent<{ variants?: boolean; modelOverride?: boolean }> = (props) => {
+const PromptProviders: ParentComponent<{ variants?: boolean; modelOverride?: boolean; training?: boolean }> = (
+  props,
+) => {
   const base = mockSessionValue({ status: "idle" })
   const session = {
     ...base,
@@ -42,7 +44,7 @@ const PromptProviders: ParentComponent<{ variants?: boolean; modelOverride?: boo
   }
 
   return (
-    <StoryProviders noPadding>
+    <StoryProviders noPadding training={props.training}>
       {/* overflow:hidden prevents margin-collapse so top/bottom borders are captured in screenshots */}
       <div style={{ overflow: "hidden" }}>
         <SessionContext.Provider value={session as any}>{props.children}</SessionContext.Provider>
@@ -79,6 +81,28 @@ export const Default200: Story = {
   name: "Default — 200px",
   render: () => (
     <PromptProviders>
+      <PromptInput />
+    </PromptProviders>
+  ),
+}
+
+// ---------------------------------------------------------------------------
+// Stories — model whose prompts may be used for training
+// ---------------------------------------------------------------------------
+
+export const WithPromptTraining420: Story = {
+  name: "With prompt training indicator — 420px",
+  render: () => (
+    <PromptProviders training>
+      <PromptInput />
+    </PromptProviders>
+  ),
+}
+
+export const WithPromptTraining200: Story = {
+  name: "With prompt training indicator — 200px",
+  render: () => (
+    <PromptProviders training>
       <PromptInput />
     </PromptProviders>
   ),

--- a/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/model-selector.css
@@ -497,6 +497,11 @@
   flex-shrink: 0;
 }
 
+.model-selector-trigger-free-data [data-component="icon"] {
+  width: 14px;
+  height: 14px;
+}
+
 .model-selector-free-data {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Problem

The prompt training indicator icon (book-open-check) rendered at its default 16px size inside the compact model selector button. This caused the button to grow taller than sibling toolbar buttons (mode switcher, thinking selector), creating visual inconsistency in the prompt input area.

## Solution

Constrain the training indicator icon to 14px when it appears in the model selector trigger button. This keeps all compact toolbar buttons at a consistent 24px height regardless of whether the active model has `mayTrainOnYourPrompts` set.

## Before / After

<img width="600" alt="Before and after: training icon constrained to 14px keeps toolbar buttons at consistent height" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260803-prompt-training-icon-before-after.png?raw=true" />

## Changes

- **CSS** (`model-selector.css`): Added `.model-selector-trigger-free-data [data-component="icon"]` rule to constrain icon size to 14px × 14px
- **Stories** (`prompt-input.stories.tsx`): Added `WithPromptTraining420` and `WithPromptTraining200` stories for visual regression coverage at both sidebar widths
- **StoryProviders**: Added `training` prop to enable `mayTrainOnYourPrompts` on mock models for testing
- **Changeset**: Added patch changeset for `kilo-code`

## Screenshot tests

Two new visual regression stories cover the training indicator at 420px (standard sidebar) and 200px (narrow sidebar). CI will auto-generate baselines on this PR.