### PR TITLE
fix(vscode): recover Agent Manager terminals after exit

### DIFF
--- a/.changeset/quiet-terminals-recover.md
+++ b/.changeset/quiet-terminals-recover.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start a fresh shell in the same Agent Manager terminal tab when the user types after the terminal ends.

--- a/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
@@ -57,6 +57,7 @@ function makeTerminalId(): string {
 
 export class TerminalManager {
   private readonly entries = new Map<string, Entry>()
+  private readonly restarts = new Map<string, Promise<void>>()
 
   constructor(private readonly deps: TerminalManagerDeps) {}
 
@@ -150,6 +151,24 @@ export class TerminalManager {
     }
   }
 
+  async restart(terminalId: string, cols?: number, rows?: number): Promise<string | undefined> {
+    const entry = this.entries.get(terminalId)
+    if (!entry) return
+    const prior = this.restarts.get(terminalId)
+    if (prior) {
+      await prior
+      const current = this.entries.get(terminalId)
+      return current ? this.deps.buildWsUrl(current.ptyID, current.cwd) : undefined
+    }
+    const task = this.restartEntry(entry, cols, rows)
+    this.restarts.set(terminalId, task)
+    await task.finally(() => {
+      if (this.restarts.get(terminalId) === task) this.restarts.delete(terminalId)
+    })
+    const current = this.entries.get(terminalId)
+    return current ? this.deps.buildWsUrl(current.ptyID, current.cwd) : undefined
+  }
+
   /**
    * Kill every managed terminal. Invoked from AgentManagerProvider.dispose()
    * so PTYs do not outlive a webview drop that bypasses the explicit close
@@ -217,5 +236,36 @@ export class TerminalManager {
       this.deps.log(`Terminal dispose: ${failed}/${snapshot.length} PTYs may linger until kilo serve exits`)
     }
     this.entries.clear()
+  }
+
+  private async restartEntry(entry: Entry, cols?: number, rows?: number): Promise<void> {
+    try {
+      const client = this.deps.getClient()
+      const old = entry.ptyID
+      const created = await client.pty.create({
+        directory: entry.cwd,
+        cwd: entry.cwd,
+        title: entry.title,
+      })
+      const info = created.data
+      if (created.error || !info)
+        throw new Error(created.error ? String(created.error) : "PTY create returned no session")
+      if (cols !== undefined && rows !== undefined) {
+        await client.pty.update({
+          ptyID: info.id,
+          directory: entry.cwd,
+          size: { cols, rows },
+        })
+      }
+      entry.ptyID = info.id
+      await client.pty.remove({ directory: entry.cwd, ptyID: old }).catch((error: unknown) => {
+        this.deps.log(`Failed to remove exited PTY (${old}): ${error instanceof Error ? error.message : String(error)}`)
+      })
+      this.deps.log(`Terminal restarted (${entry.terminalId} pty=${entry.ptyID})`)
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      this.deps.log(`Terminal restart failed (${entry.terminalId}): ${msg}`)
+      throw error
+    }
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/terminal-routing.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-routing.ts
@@ -56,7 +56,8 @@ function isTerminalMessage(
   return (
     m.type === "agentManager.terminal.create" ||
     m.type === "agentManager.terminal.close" ||
-    m.type === "agentManager.terminal.resize"
+    m.type === "agentManager.terminal.resize" ||
+    m.type === "agentManager.terminal.restart"
   )
 }
 
@@ -94,6 +95,22 @@ export class TerminalRouter {
       void this.manager.close(m.terminalId).then(() => {
         this.deps.post({ type: "agentManager.terminal.closed", terminalId: m.terminalId })
       })
+      return true
+    }
+    if (m.type === "agentManager.terminal.restart") {
+      void this.manager
+        .restart(m.terminalId, m.cols, m.rows)
+        .then((wsUrl) => {
+          if (!wsUrl) return
+          this.deps.post({ type: "agentManager.terminal.restarted", terminalId: m.terminalId, wsUrl })
+        })
+        .catch((error: unknown) => {
+          this.deps.post({
+            type: "agentManager.terminal.error",
+            terminalId: m.terminalId,
+            message: error instanceof Error ? error.message : String(error),
+          })
+        })
       return true
     }
     // resize

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -199,6 +199,12 @@ interface TerminalCreatedMessage {
   font: TerminalFont
 }
 
+interface TerminalRestartedMessage {
+  type: "agentManager.terminal.restarted"
+  terminalId: string
+  wsUrl: string
+}
+
 interface TerminalClosedMessage {
   type: "agentManager.terminal.closed"
   terminalId: string
@@ -407,6 +413,7 @@ export type AgentManagerOutMessage =
   | ActionOutMessage
   | RunStatusMessage
   | TerminalCreatedMessage
+  | TerminalRestartedMessage
   | TerminalClosedMessage
   | TerminalErrorMessage
   | TerminalDestinationChangedMessage
@@ -948,6 +955,13 @@ interface TerminalResizeIn {
   rows: number
 }
 
+interface TerminalRestartIn {
+  type: "agentManager.terminal.restart"
+  terminalId: string
+  cols?: number
+  rows?: number
+}
+
 interface TerminalDestinationSelectedIn {
   type: "agentManager.terminal.destinationSelected"
   destination: TerminalDestination
@@ -1035,4 +1049,5 @@ export type AgentManagerInMessage =
   | TerminalCloseIn
   | TerminalStopIn
   | TerminalResizeIn
+  | TerminalRestartIn
   | TerminalDestinationSelectedIn

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
@@ -287,4 +287,49 @@ describe("Agent Manager terminal routing", () => {
     expect(messages[0]).toMatchObject({ type: "agentManager.terminal.created", createId: "real" })
     await router.dispose()
   })
+
+  it("lazily replaces an ended PTY in the same logical terminal", async () => {
+    const messages: AgentManagerOutMessage[] = []
+    let seq = 0
+    const client = {
+      pty: {
+        create: async ({ title }: { title: string }) => {
+          seq++
+          return { data: { id: `pty-${seq}`, title } }
+        },
+        remove: async () => ({ data: true }),
+        update: async () => ({ data: true }),
+      },
+    } as unknown as KiloClient
+    const router = new TerminalRouter({
+      getClient: () => client,
+      getClientAsync: async () => client,
+      getServerConfig: () => ({ baseUrl: "http://127.0.0.1:4096", password: "secret" }),
+      getRoot: () => "/workspace",
+      getWorktreePath: () => undefined,
+      getProjectId: () => "prj-1",
+      log: () => undefined,
+      post: (message) => messages.push(message),
+      getTerminalFont: () => font,
+    })
+
+    router.handle({ type: "agentManager.terminal.create", createId: "one", placement: "tab", worktreeId: null })
+    await wait()
+    const created = messages.find((message) => message.type === "agentManager.terminal.created")
+    if (!created || created.type !== "agentManager.terminal.created") throw new Error("missing terminal")
+
+    router.handle({
+      type: "agentManager.terminal.restart",
+      terminalId: created.terminalId,
+      cols: 80,
+      rows: 24,
+    })
+    await wait()
+    expect(messages.at(-1)).toMatchObject({
+      type: "agentManager.terminal.restarted",
+      terminalId: created.terminalId,
+      wsUrl: expect.stringContaining("pty-2"),
+    })
+    await router.dispose()
+  })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "علامة تبويب جديدة للمحطة الطرفية",
   "agentManager.terminal.ended": "انتهت المحطة الطرفية — أغلق علامة التبويب للإخفاء",
+  "agentManager.terminal.endedRestartable": "انتهت المحطة الطرفية - اكتب لبدء صدفة جديدة أو أغلق علامة التبويب",
   "agentManager.terminal.setupFailed": "فشل البرنامج النصي للإعداد",
   "agentManager.terminal.setupFailedCode": "فشل البرنامج النصي للإعداد برمز الخروج",
   "agentManager.terminal.stopSetup": "إيقاف البرنامج النصي للإعداد",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -64,6 +64,7 @@ export const dict = {
 
   "agentManager.terminal.new": "Nova aba de terminal",
   "agentManager.terminal.ended": "terminal encerrado — feche a aba para dispensar",
+  "agentManager.terminal.endedRestartable": "terminal encerrado - digite para iniciar um novo shell ou feche a aba",
   "agentManager.terminal.setupFailed": "falha no script de configuração",
   "agentManager.terminal.setupFailedCode": "falha no script de configuração com código de saída",
   "agentManager.terminal.stopSetup": "Parar o script de configuração",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "Nova kartica terminala",
   "agentManager.terminal.ended": "terminal je završen — zatvorite karticu da biste odbacili",
+  "agentManager.terminal.endedRestartable": "terminal je završen - kucajte za novu ljusku ili zatvorite karticu",
   "agentManager.terminal.setupFailed": "skripta za postavljanje nije uspjela",
   "agentManager.terminal.setupFailedCode": "skripta za postavljanje nije uspjela s izlaznim kodom",
   "agentManager.terminal.stopSetup": "Zaustavi skriptu za postavljanje",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -65,6 +65,7 @@ export const dict = {
 
   "agentManager.terminal.new": "Ny terminalfane",
   "agentManager.terminal.ended": "terminal afsluttet — luk fanen for at fjerne",
+  "agentManager.terminal.endedRestartable": "terminal afsluttet - skriv for at starte en ny shell, eller luk fanen",
   "agentManager.terminal.setupFailed": "opsætningsscript mislykkedes",
   "agentManager.terminal.setupFailedCode": "opsætningsscript mislykkedes med exitkode",
   "agentManager.terminal.stopSetup": "Stop opsætningsscript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Neuer Terminal-Tab",
   "agentManager.terminal.ended": "Terminal beendet — Tab schließen zum Verwerfen",
+  "agentManager.terminal.endedRestartable":
+    "Terminal beendet - tippen, um eine neue Shell zu starten, oder Tab schließen",
   "agentManager.terminal.setupFailed": "Setup-Skript fehlgeschlagen",
   "agentManager.terminal.setupFailedCode": "Setup-Skript mit Exit-Code fehlgeschlagen",
   "agentManager.terminal.stopSetup": "Setup-Skript stoppen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -68,6 +68,7 @@ export const dict = {
   "agentManager.terminal.new": "New Terminal Tab",
   "agentManager.terminal.add": "New terminal",
   "agentManager.terminal.ended": "terminal ended — close tab to dismiss",
+  "agentManager.terminal.endedRestartable": "terminal ended - type to start a new shell or close tab to dismiss",
   "agentManager.terminal.setupFailed": "setup script failed",
   "agentManager.terminal.setupFailedCode": "setup script failed with exit code",
   "agentManager.terminal.stopSetup": "Stop setup script",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Nueva pestaña de terminal",
   "agentManager.terminal.ended": "terminal finalizado — cierra la pestaña para descartar",
+  "agentManager.terminal.endedRestartable":
+    "terminal finalizado - escribe para iniciar un shell nuevo o cierra la pestaña",
   "agentManager.terminal.setupFailed": "el script de configuración falló",
   "agentManager.terminal.setupFailedCode": "el script de configuración falló con el código de salida",
   "agentManager.terminal.stopSetup": "Detener el script de configuración",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -68,6 +68,7 @@ export const dict = {
   "agentManager.terminal.new": "تب ترمینال جدید",
   "agentManager.terminal.add": "ترمینال جدید",
   "agentManager.terminal.ended": "ترمینال پایان یافت — برای بستن، تب را ببندید",
+  "agentManager.terminal.endedRestartable": "ترمینال پایان یافت - برای شروع پوسته جدید تایپ کنید یا تب را ببندید",
   "agentManager.terminal.setupFailed": "اسکریپت راه‌اندازی ناموفق بود",
   "agentManager.terminal.setupFailedCode": "اسکریپت راه‌اندازی با کد خروجی ناموفق بود",
   "agentManager.terminal.stopSetup": "توقف اسکریپت راه‌اندازی",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Nouvel onglet de terminal",
   "agentManager.terminal.ended": "terminal terminé — fermez l'onglet pour ignorer",
+  "agentManager.terminal.endedRestartable":
+    "terminal terminé - saisissez du texte pour démarrer un nouveau shell ou fermez l'onglet",
   "agentManager.terminal.setupFailed": "échec du script de configuration",
   "agentManager.terminal.setupFailedCode": "échec du script de configuration avec le code de sortie",
   "agentManager.terminal.stopSetup": "Arrêter le script de configuration",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -68,6 +68,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Nuova scheda terminale",
   "agentManager.terminal.ended": "terminale terminato - chiudi la scheda per nasconderlo",
+  "agentManager.terminal.endedRestartable":
+    "terminale terminato - digita per avviare una nuova shell o chiudi la scheda",
   "agentManager.terminal.setupFailed": "script di configurazione non riuscito",
   "agentManager.terminal.setupFailedCode": "script di configurazione non riuscito con codice di uscita",
   "agentManager.terminal.stopSetup": "Interrompi lo script di configurazione",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "新しいターミナルタブ",
   "agentManager.terminal.ended": "ターミナルが終了しました — タブを閉じて破棄",
+  "agentManager.terminal.endedRestartable":
+    "ターミナルが終了しました - 入力して新しいシェルを開始するか、タブを閉じてください",
   "agentManager.terminal.setupFailed": "セットアップスクリプトが失敗しました",
   "agentManager.terminal.setupFailedCode": "セットアップスクリプトが終了コードで失敗しました",
   "agentManager.terminal.stopSetup": "セットアップスクリプトを停止",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "새 터미널 탭",
   "agentManager.terminal.ended": "터미널 종료됨 — 탭을 닫아 해제",
+  "agentManager.terminal.endedRestartable": "터미널 종료됨 - 입력하여 새 셸을 시작하거나 탭을 닫으세요",
   "agentManager.terminal.setupFailed": "설정 스크립트 실패",
   "agentManager.terminal.setupFailedCode": "종료 코드로 설정 스크립트 실패",
   "agentManager.terminal.stopSetup": "설정 스크립트 중지",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -67,6 +67,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Nieuw terminaltabblad",
   "agentManager.terminal.ended": "terminal beëindigd — sluit tabblad om te negeren",
+  "agentManager.terminal.endedRestartable":
+    "terminal beëindigd - typ om een nieuwe shell te starten of sluit het tabblad",
   "agentManager.terminal.setupFailed": "installatiescript mislukt",
   "agentManager.terminal.setupFailedCode": "installatiescript mislukt met exitcode",
   "agentManager.terminal.stopSetup": "Installatiescript stoppen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "Ny terminalfane",
   "agentManager.terminal.ended": "terminal avsluttet — lukk fanen for å avvise",
+  "agentManager.terminal.endedRestartable": "terminal avsluttet - skriv for å starte et nytt skall, eller lukk fanen",
   "agentManager.terminal.setupFailed": "oppsettskript mislyktes",
   "agentManager.terminal.setupFailedCode": "oppsettskript mislyktes med avslutningskode",
   "agentManager.terminal.stopSetup": "Stopp oppsettskriptet",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Nowa karta terminala",
   "agentManager.terminal.ended": "terminal zakończony — zamknij kartę, aby zamknąć",
+  "agentManager.terminal.endedRestartable":
+    "terminal zakończony - wpisz tekst, aby uruchomić nową powłokę, lub zamknij kartę",
   "agentManager.terminal.setupFailed": "skrypt konfiguracji nie powiódł się",
   "agentManager.terminal.setupFailedCode": "skrypt konfiguracji nie powiódł się z kodem wyjścia",
   "agentManager.terminal.stopSetup": "Zatrzymaj skrypt konfiguracji",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -64,6 +64,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Новая вкладка терминала",
   "agentManager.terminal.ended": "терминал завершен — закройте вкладку, чтобы скрыть",
+  "agentManager.terminal.endedRestartable":
+    "терминал завершен - введите текст, чтобы запустить новую оболочку, или закройте вкладку",
   "agentManager.terminal.setupFailed": "сбой скрипта настройки",
   "agentManager.terminal.setupFailedCode": "сбой скрипта настройки с кодом выхода",
   "agentManager.terminal.stopSetup": "Остановить скрипт настройки",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "แท็บเทอร์มินัลใหม่",
   "agentManager.terminal.ended": "เทอร์มินัลสิ้นสุด — ปิดแท็บเพื่อยกเลิก",
+  "agentManager.terminal.endedRestartable": "เทอร์มินัลสิ้นสุด - พิมพ์เพื่อเริ่มเชลล์ใหม่หรือปิดแท็บ",
   "agentManager.terminal.setupFailed": "สคริปต์ติดตั้งล้มเหลว",
   "agentManager.terminal.setupFailedCode": "สคริปต์ติดตั้งล้มเหลวด้วยรหัสออก",
   "agentManager.terminal.stopSetup": "หยุดสคริปต์ติดตั้ง",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -68,6 +68,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Yeni Terminal Sekmesi",
   "agentManager.terminal.ended": "terminal sona erdi — kapatmak için sekmeyi kapatın",
+  "agentManager.terminal.endedRestartable":
+    "terminal sona erdi - yeni bir kabuk başlatmak için yazın veya sekmeyi kapatın",
   "agentManager.terminal.setupFailed": "kurulum betiği başarısız oldu",
   "agentManager.terminal.setupFailedCode": "kurulum betiği çıkış koduyla başarısız oldu",
   "agentManager.terminal.stopSetup": "Kurulum betiğini durdur",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -68,6 +68,8 @@ export const dict = {
 
   "agentManager.terminal.new": "Нова вкладка термінала",
   "agentManager.terminal.ended": "термінал завершено — закрийте вкладку, щоб відхилити",
+  "agentManager.terminal.endedRestartable":
+    "термінал завершено - введіть текст, щоб запустити нову оболонку, або закрийте вкладку",
   "agentManager.terminal.setupFailed": "помилка скрипта налаштування",
   "agentManager.terminal.setupFailedCode": "помилка скрипта налаштування з кодом виходу",
   "agentManager.terminal.stopSetup": "Зупинити скрипт налаштування",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "新建终端标签页",
   "agentManager.terminal.ended": "终端已结束 — 关闭标签页以消除",
+  "agentManager.terminal.endedRestartable": "终端已结束 - 输入以启动新 shell，或关闭标签页",
   "agentManager.terminal.setupFailed": "设置脚本失败",
   "agentManager.terminal.setupFailedCode": "设置脚本失败，退出代码为",
   "agentManager.terminal.stopSetup": "停止设置脚本",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -63,6 +63,7 @@ export const dict = {
 
   "agentManager.terminal.new": "新增終端分頁",
   "agentManager.terminal.ended": "終端已結束 — 關閉分頁以消除",
+  "agentManager.terminal.endedRestartable": "終端已結束 - 輸入以啟動新的 shell，或關閉分頁",
   "agentManager.terminal.setupFailed": "設定腳本失敗",
   "agentManager.terminal.setupFailedCode": "設定腳本失敗，退出代碼為",
   "agentManager.terminal.stopSetup": "停止設定腳本",

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
@@ -284,8 +284,9 @@ export const TerminalTab: Component<Props> = (props) => {
         clearTimeout(fallbackTimer)
         fallbackTimer = undefined
       }
-      if (pending) ws.send(pending)
+      const data = pending
       pending = ""
+      if (data && /[^\r\n]/.test(data)) ws.send(data)
       disconnected = false
       restartRequested = false
     }
@@ -355,7 +356,6 @@ export const TerminalTab: Component<Props> = (props) => {
     const disposeData = term.onData(send)
     open(props.wsUrl)
     const restarted = (url: string) => {
-      term.writeln("\r\n\x1b[90m----------------------------------------\x1b[0m")
       open(url)
     }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
@@ -54,6 +54,7 @@ interface Props {
   /** Provider-owned script status (Run/Setup), used to annotate the
    *  output when a script ends in failure. */
   status?: () => ScriptTerminalStatus | undefined
+  restartable?: boolean
 }
 
 /** How long the ResizeObserver waits after the last size change before
@@ -219,17 +220,22 @@ export const TerminalTab: Component<Props> = (props) => {
     // strips these itself, so this only fires for real title codes.
     const disposeTitle = term.onTitleChange((title) => props.onTitleChange?.(title))
 
-    const ws = new WebSocket(props.wsUrl)
-    ws.binaryType = "arraybuffer"
+    let ws: WebSocket | undefined
     let closed = false
+    let pending = ""
+    let restartRequested = false
+    let disconnected = false
+    let readyTimer: ReturnType<typeof setTimeout> | undefined
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined
     let streamed = false
+    let socketEnded = false
     // The failure line must not depend on event ordering: the stream can
     // close before the exited snapshot lands (fast failures), or stay open
     // when a background child outlives the script. Write it exactly once,
     // from whichever signal arrives first.
     let failureWritten = false
     const noteFailure = () => {
-      if (failureWritten || (!streamed && !closed)) return
+      if (failureWritten || (!streamed && !socketEnded)) return
       const status = props.status?.()
       if (status?.kind !== "setup") return
       if (status.state === "failed") {
@@ -246,32 +252,111 @@ export const TerminalTab: Component<Props> = (props) => {
       props.status?.()
       noteFailure()
     })
-    const disposeData = term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) ws.send(data)
-    })
-    ws.onmessage = (event) => {
-      streamed = true
-      // Text frames carry PTY output; binary frames starting with 0x00
-      // are control metadata (cursor position). See pty/index.ts:46.
-      if (typeof event.data === "string") {
-        term.write(event.data)
+    const requestRestart = () => {
+      if (restartRequested) return
+      restartRequested = true
+      vscode.postMessage({
+        type: "agentManager.terminal.restart",
+        terminalId: props.terminalId,
+        cols: term.cols,
+        rows: term.rows,
+      })
+    }
+    const send = (data: string) => {
+      if (disconnected && props.restartable) {
+        pending += data
+        if (pending.length > 256 * 1024) pending = pending.slice(-256 * 1024)
+        requestRestart()
         return
       }
-      if (event.data instanceof ArrayBuffer) {
-        const bytes = new Uint8Array(event.data)
-        if (bytes.length > 0 && bytes[0] === 0x00) return
-        term.write(bytes)
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(data)
+        return
       }
     }
-    ws.onerror = () => {
-      if (closed) return
-      term.writeln(`\r\n\x1b[90m[${t("agentManager.terminal.connectionError")}]\x1b[0m`)
+    const flush = () => {
+      if (ws?.readyState !== WebSocket.OPEN) return
+      if (readyTimer) {
+        clearTimeout(readyTimer)
+        readyTimer = undefined
+      }
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer)
+        fallbackTimer = undefined
+      }
+      if (pending) ws.send(pending)
+      pending = ""
+      disconnected = false
+      restartRequested = false
     }
-    ws.onclose = () => {
-      if (closed) return
-      closed = true
-      noteFailure()
-      term.writeln(`\r\n\x1b[90m[${t("agentManager.terminal.ended")}]\x1b[0m`)
+    const scheduleFlush = () => {
+      if (!disconnected) return
+      if (readyTimer) clearTimeout(readyTimer)
+      readyTimer = setTimeout(() => {
+        readyTimer = undefined
+        flush()
+      }, 100)
+    }
+    const open = (url: string) => {
+      if (closed || !url) return
+      const next = new WebSocket(url)
+      next.binaryType = "arraybuffer"
+      ws = next
+      next.onopen = () => {
+        if (closed || ws !== next) return
+        socketEnded = false
+        if (props.restartable && disconnected) {
+          fallbackTimer = setTimeout(() => {
+            fallbackTimer = undefined
+            flush()
+          }, 1_000)
+        }
+      }
+      next.onmessage = (event) => {
+        if (closed || ws !== next) return
+        streamed = true
+        if (typeof event.data === "string") {
+          term.write(event.data)
+          scheduleFlush()
+          return
+        }
+        if (event.data instanceof ArrayBuffer) {
+          const bytes = new Uint8Array(event.data)
+          if (bytes.length > 0 && bytes[0] === 0x00) return
+          term.write(bytes)
+          scheduleFlush()
+        }
+      }
+      next.onerror = () => {
+        if (closed || ws !== next) return
+        term.writeln(`\r\n\x1b[90m[${t("agentManager.terminal.connectionError")}]\x1b[0m`)
+      }
+      next.onclose = () => {
+        if (closed || ws !== next) return
+        ws = undefined
+        if (readyTimer) {
+          clearTimeout(readyTimer)
+          readyTimer = undefined
+        }
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+          fallbackTimer = undefined
+        }
+        socketEnded = true
+        noteFailure()
+        if (props.restartable) {
+          disconnected = true
+          restartRequested = false
+        }
+        const key = props.restartable ? "agentManager.terminal.endedRestartable" : "agentManager.terminal.ended"
+        term.writeln(`\r\n\x1b[90m[${t(key)}]\x1b[0m`)
+      }
+    }
+    const disposeData = term.onData(send)
+    open(props.wsUrl)
+    const restarted = (url: string) => {
+      term.writeln("\r\n\x1b[90m----------------------------------------\x1b[0m")
+      open(url)
     }
 
     // Resize: fit on any host size change and forward new cols/rows to
@@ -301,6 +386,8 @@ export const TerminalTab: Component<Props> = (props) => {
         return
       }
       clearTimeout(resizeTimer)
+      if (readyTimer) clearTimeout(readyTimer)
+      if (fallbackTimer) clearTimeout(fallbackTimer)
       resizeTimer = setTimeout(syncSize, RESIZE_DEBOUNCE_MS)
     })
     ro.observe(host)
@@ -354,6 +441,16 @@ export const TerminalTab: Component<Props> = (props) => {
         const comments = message.comments
         if (!Array.isArray(comments) || comments.length === 0) return
         term.paste(`${formatReviewCommentsMarkdown(comments)}\n`)
+        return
+      }
+
+      if (message.type === "agentManager.terminal.restarted") {
+        if (message.terminalId === props.terminalId) restarted(message.wsUrl)
+        return
+      }
+
+      if (message.type === "agentManager.terminal.error" && message.terminalId === props.terminalId) {
+        restartRequested = false
         return
       }
 
@@ -422,6 +519,7 @@ export const TerminalTab: Component<Props> = (props) => {
     themeObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] })
 
     onCleanup(() => {
+      closed = true
       if (pendingFrame !== null) cancelAnimationFrame(pendingFrame)
       document.removeEventListener("visibilitychange", onVisibilityChange)
       window.removeEventListener("focus", onWindowFocus)
@@ -434,7 +532,7 @@ export const TerminalTab: Component<Props> = (props) => {
       disposeData.dispose()
       disposeTitle.dispose()
       try {
-        ws.close()
+        ws?.close()
       } catch (err) {
         // Already closed (ws.close on a closed socket is a no-op in
         // most browsers; the throw is defensive). Logged so unexpected

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
@@ -108,6 +108,7 @@ export function renderTerminalLayer(props: { state: TerminalStateControls }): JS
                 <TerminalTab
                   terminalId={term.id}
                   wsUrl={term.wsUrl}
+                  restartable={term.kind === undefined}
                   active={visible()}
                   focusSerial={focusSerial(props.state, term.id)}
                   font={term.font}
@@ -155,6 +156,7 @@ export function renderSideTerminalLayer(props: {
                 focusSerial={focusSerial(props.state, term.id)}
                 font={term.font}
                 status={() => props.state.scriptStatus(term.id)}
+                restartable={term.kind === undefined}
                 onFocusChange={(focused) => props.state.setFocusedId(focused ? term.id : undefined)}
                 onTitleChange={(title) => props.state.setTitle(term.id, title)}
               />

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -794,6 +794,12 @@ export interface AgentManagerTerminalCreatedMessage {
   font: TerminalFont
 }
 
+export interface AgentManagerTerminalRestartedMessage {
+  type: "agentManager.terminal.restarted"
+  terminalId: string
+  wsUrl: string
+}
+
 export interface AgentManagerTerminalFontChangedMessage {
   type: "agentManager.terminal.fontChanged"
   font: TerminalFont
@@ -1379,6 +1385,7 @@ export type ExtensionMessage =
   | AgentManagerLocalStatsMessage
   | AgentManagerPRStatusMessage
   | AgentManagerTerminalCreatedMessage
+  | AgentManagerTerminalRestartedMessage
   | AgentManagerTerminalFontChangedMessage
   | AgentManagerTerminalClosedMessage
   | AgentManagerTerminalErrorMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -827,6 +827,13 @@ export interface AgentManagerTerminalResizeRequest {
   rows: number
 }
 
+export interface AgentManagerTerminalRestartRequest {
+  type: "agentManager.terminal.restart"
+  terminalId: string
+  cols?: number
+  rows?: number
+}
+
 // Open a file in the selected worktree for a specific session
 export interface AgentManagerOpenFileRequest {
   type: "agentManager.openFile"
@@ -1571,6 +1578,7 @@ export type WebviewMessage =
   | AgentManagerTerminalCreateRequest
   | AgentManagerTerminalCloseRequest
   | AgentManagerTerminalStopRequest
+  | AgentManagerTerminalRestartRequest
   | AgentManagerTerminalDestinationSelectedRequest
   | AgentManagerTerminalResizeRequest
   | RequestImageModelsMessage


### PR DESCRIPTION
Agent Manager terminal tabs can remain on a dead PTY after a shell exits, and the next command may be discarded. This makes the terminal appear available while forcing the user to type again, which is especially disruptive after switching worktrees or using `Cmd+/`.

The terminal now keeps the existing tab and scrollback, clearly advertises that the shell ended, and starts a replacement shell in the same working directory when the user types. Input is buffered while the replacement attaches and delivered once, while a bare Enter only revives the prompt without creating a duplicate empty command. Run and Setup terminals keep their existing close-only behavior and are not rerun automatically.

<img width="700" alt="Agent Manager terminal after the shell ended, with the prompt and previous output preserved" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260803-agent-manager-terminal-ended-final.png?raw=true" />

<img width="700" alt="Agent Manager terminal executing one command after recovery in the same worktree" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260803-agent-manager-terminal-recovered.png?raw=true" />