### PR TITLE
fix(vscode): accelerate macOS speech capture

### DIFF
--- a/.changeset/faster-macos-speech.md
+++ b/.changeset/faster-macos-speech.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start voice input faster on macOS with native AVFoundation capture.

--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -34,11 +34,32 @@ type Args = {
   input: string[]
 }
 
+const macScript = `
+ObjC.import("AVFoundation")
+ObjC.import("Foundation")
+function run(args) {
+  const settings = $.NSMutableDictionary.alloc.init
+  settings.setObjectForKey($.NSNumber.numberWithUnsignedInt(1819304813), $.AVFormatIDKey)
+  settings.setObjectForKey($.NSNumber.numberWithDouble(16000), $.AVSampleRateKey)
+  settings.setObjectForKey($.NSNumber.numberWithInt(1), $.AVNumberOfChannelsKey)
+  settings.setObjectForKey($.NSNumber.numberWithInt(16), $.AVLinearPCMBitDepthKey)
+  settings.setObjectForKey($.NSNumber.numberWithBool(false), $.AVLinearPCMIsFloatKey)
+  settings.setObjectForKey($.NSNumber.numberWithBool(false), $.AVLinearPCMIsBigEndianKey)
+  const error = Ref()
+  const url = $.NSURL.fileURLWithPath(args[0])
+  const recorder = $.AVAudioRecorder.alloc.initWithURLSettingsError(url, settings, error)
+  if (!recorder || !recorder.prepareToRecord || !recorder.record) throw new Error("Could not start recording")
+  console.log("ready")
+  $.NSFileHandle.fileHandleWithStandardInput.readDataToEndOfFile
+  recorder.stop
+}`
+
 let active: Recording | undefined
 let starting: string | undefined
 let ffmpeg: Promise<string> | undefined
 
 export async function prewarmSpeechCapture(): Promise<void> {
+  if (useMacCapture(process.platform, process.env)) return
   await resolveFFmpeg()
 }
 
@@ -47,8 +68,15 @@ export async function startSpeechCapture(input: Input): Promise<boolean> {
 
   starting = input.requestId
   try {
-    const bin = await resolveFFmpeg()
     const file = path.join(os.tmpdir(), `kilo-stt-${process.pid}-${Date.now()}.wav`)
+    if (useMacCapture(process.platform, process.env)) {
+      const result = await startMac(file, input).catch((err: unknown) => {
+        console.warn("[Kilo New] Native macOS speech capture failed, falling back to FFmpeg", err)
+        return undefined
+      })
+      if (result) return !result.stopped
+    }
+    const bin = await resolveFFmpeg()
     const state = await startWithArgs(bin, file, input, await inputArgSets(bin))
     return !state.stopped
   } finally {
@@ -112,7 +140,7 @@ async function waitForStart(state: Recording): Promise<void> {
       onError(new Error(summary(state, "Could not start microphone recording")))
     }
     const onData = (data: Buffer) => {
-      if (/Output #0|Press \[q\]|size=\s*\d+/i.test(data.toString())) done()
+      if (/^ready$|Output #0|Press \[q\]|size=\s*\d+/im.test(data.toString())) done()
     }
     const timer = setTimeout(() => {
       onError(new Error(summary(state, "Timed out starting microphone recording")))
@@ -129,6 +157,21 @@ async function waitForStart(state: Recording): Promise<void> {
   })
 }
 
+async function startMac(file: string, input: Input): Promise<Recording> {
+  const proc = spawn("/usr/bin/osascript", macCaptureArgs(file), { stdio: ["pipe", "ignore", "pipe"] })
+  const state = createState(input, file, proc)
+  await waitForStart(state)
+  return state
+}
+
+export function macCaptureArgs(file: string): string[] {
+  return ["-l", "JavaScript", "-e", macScript, file]
+}
+
+export function useMacCapture(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): boolean {
+  return platform === "darwin" && !env.KILO_FFMPEG_PATH && !env.FFMPEG_PATH
+}
+
 async function startWithArgs(bin: string, file: string, input: Input, args: Args[]): Promise<Recording> {
   const [first, ...rest] = args
   if (!first) throw new Error(`Unsupported platform for speech input: ${process.platform}`)
@@ -138,6 +181,18 @@ async function startWithArgs(bin: string, file: string, input: Input, args: Args
     : spawn(bin, ["-y", ...first.input, "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", "-f", "wav", file], {
         stdio: ["pipe", "ignore", "pipe"],
       })
+  const state = createState(input, file, proc)
+  try {
+    await waitForStart(state)
+    return state
+  } catch (err) {
+    if (state.stopped) return state
+    if (rest.length === 0) throw err
+    return startWithArgs(bin, file, input, rest)
+  }
+}
+
+function createState(input: Input, file: string, proc: ChildProcess): Recording {
   const state: Recording = { ...input, file, proc, stderr: [], stopped: false }
   active = state
 
@@ -152,15 +207,7 @@ async function startWithArgs(bin: string, file: string, input: Input, args: Args
     state.stderr.push(err.message)
     if (active === state && !state.stopped) active = undefined
   })
-
-  try {
-    await waitForStart(state)
-    return state
-  } catch (err) {
-    if (state.stopped) return state
-    if (rest.length === 0) throw err
-    return startWithArgs(bin, file, input, rest)
-  }
+  return state
 }
 
 function pipeProcess(pipe: string[], bin: string, file: string): ChildProcess {

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "bun:test"
-import { cleanOutput, parseDshowAudioDevices } from "../../src/speech-to-text/capture"
+import { cleanOutput, macCaptureArgs, parseDshowAudioDevices, useMacCapture } from "../../src/speech-to-text/capture"
+
+describe("macCaptureArgs", () => {
+  it("records 16 kHz mono PCM with the built-in AVFoundation bridge", () => {
+    const args = macCaptureArgs("/tmp/speech.wav")
+
+    expect(args.slice(0, 3)).toEqual(["-l", "JavaScript", "-e"])
+    expect(args.at(-1)).toBe("/tmp/speech.wav")
+    expect(args[3]).toContain("AVAudioRecorder")
+    expect(args[3]).toContain("numberWithDouble(16000)")
+    expect(args[3]).toContain("numberWithInt(1), $.AVNumberOfChannelsKey")
+    expect(args[3]).toContain('console.log("ready")')
+  })
+})
+
+describe("useMacCapture", () => {
+  it("preserves explicit FFmpeg overrides", () => {
+    expect(useMacCapture("darwin", {})).toBe(true)
+    expect(useMacCapture("darwin", { KILO_FFMPEG_PATH: "/custom/ffmpeg" })).toBe(false)
+    expect(useMacCapture("darwin", { FFMPEG_PATH: "/custom/ffmpeg" })).toBe(false)
+    expect(useMacCapture("linux", {})).toBe(false)
+    expect(useMacCapture("win32", {})).toBe(false)
+  })
+})
 
 describe("parseDshowAudioDevices", () => {
   it("extracts Windows dshow audio device names", () => {


### PR DESCRIPTION
macOS voice input currently launches FFmpeg for every recording even though the platform already provides AVFoundation. FFmpeg process creation is inexpensive, but its AVFoundation capture path accounts for most of the delay before the UI can safely report that recording has started.

This change records 16 kHz mono PCM WAV audio through AVFoundation using the built-in macOS JavaScript bridge. Readiness is emitted only after `AVAudioRecorder.record()` succeeds, so the UI does not become optimistic and the beginning of speech is not clipped. The microphone remains closed while idle. If native capture fails, Kilo falls back to the existing bundled FFmpeg path. `KILO_FFMPEG_PATH` and `FFMPEG_PATH` continue to force FFmpeg explicitly.

| Trigger-to-recording metric | FFmpeg | Native AVFoundation | Change |
|---|---:|---:|---:|
| Median | 458.8 ms | 222.7 ms | 51.5% faster |
| p95 (nearest rank) | 845.8 ms | 441.9 ms | 47.8% faster |
| Slowest run | 852.2 ms | 442.8 ms | 48.0% faster |

The comparison uses 20 capture-only starts per implementation in the same isolated VS Code environment with microphone permission already granted. Each recording is stopped and cancelled before transcription, so the numbers measure trigger-to-recording readiness rather than network or model latency.

| Overhead | Impact |
|---|---|
| npm/Bun dependency tree | 0% increase. No package manifest or lockfile changes. |
| New binary/framework package | 0. The implementation uses macOS `/usr/bin/osascript`, AVFoundation, and Foundation already provided by the OS. |
| Extension bundle | Approximately 1.1 KB of inline script, about 0.014% of the current 8.47 MB extension bundle. |
| VS Code package size | No increase. The existing FFmpeg fallback remains bundled. |
| Recording CPU | No measurable change, about 0.08 seconds of user/system CPU for a one-second capture in the comparison. |
| Recording memory | Native helper peak RSS is about 40 MB versus 30 MB for FFmpeg, approximately +10 MB or +33% while recording. The process exits after each recording. |

**Platform Scope And Risks**

| Platform | Behavior | Deployment implication |
|---|---|---|
| macOS | Uses native AVFoundation by default, then falls back to FFmpeg if startup fails. | Requires the standard macOS `osascript` and AVFoundation components. TCC, device, format, or managed-device restrictions can reject the native path. A native startup failure can pay the existing five-second readiness timeout before fallback. |
| Windows | Existing FFmpeg capture path is unchanged. | No new Windows dependency or native code path. The macOS speedup does not apply. |
| Linux | Existing FFmpeg, PipeWire, PulseAudio, and ALSA paths are unchanged. | No new Linux dependency or native code path. The macOS speedup does not apply. |

The native script is static and receives the temporary output path as a separate argument. It does not interpolate user input into executable code. The output format remains the existing 16 kHz mono PCM WAV contract used by transcription.

The separate follow-up PR #12821 only improves macOS NSError diagnostics when native startup fails; it does not change capture behavior.