### PR TITLE
fix(vscode): improve narrow recent sessions layout

### DIFF
--- a/.changeset/narrow-sidebar-recent.md
+++ b/.changeset/narrow-sidebar-recent.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep recent sessions and the Show History action inset and usable in narrow VS Code sidebars.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/work-style-onboarding-default-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/settings/work-style-onboarding-default-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3f86dabc39700b3a86508c1e6499a546eeabf720832b62c9ce12f2d97378ebd
-size 34649
+oid sha256:00092414080e2f70fb9b3166e8d06a1692af93e33717d0ab8fea5fe96e6a6982
+size 34468

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -122,6 +122,7 @@
   color: var(--vscode-descriptionForeground);
   text-align: center;
   padding: 20px;
+  padding-inline: 12px;
   gap: 20px;
 }
 

--- a/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/chat-layout.css
@@ -115,7 +115,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   height: 100%;
+  width: 100%;
+  min-width: 0;
   color: var(--vscode-descriptionForeground);
   text-align: center;
   padding: 20px;

--- a/packages/kilo-vscode/webview-ui/src/styles/welcome.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/welcome.css
@@ -210,6 +210,7 @@
   font-family: inherit;
   font-size: var(--kilo-font-size-12);
   font-weight: 500;
+  white-space: nowrap;
   cursor: pointer;
   transition:
     background-color 0.15s,


### PR DESCRIPTION
The recent-session empty state could grow wider than the available VS Code sidebar because its padding was added outside the intrinsic content width. In narrow sidebars, the session rows and Show History action therefore reached the panel edges and clipped surrounding content.\n\nThe empty-state container now uses border-box sizing, fills the available width, allows its contents to shrink, and uses a smaller 12px horizontal inset. The Feedback & Support label also stays on one line at narrow widths. The existing 300px recent-session cap is unchanged for wider sidebars.\n\nThe comparison below uses a 220px sidebar viewport to make the original overflow visible.\n\nBefore:\n\n<img width="440" alt="At 220px, the original recent empty state overflows and clips text and the Show History control" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-recent-sidebar-narrow-before.png?raw=true" />\n\nAfter:\n\n<img width="440" alt="At 220px, the recent empty state stays within the viewport and keeps Feedback and Support on one line" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-recent-sidebar-narrow-text-after.png?raw=true" />