### PR TITLE
fix(vscode): surface macOS speech capture errors

### DIFF
--- a/packages/kilo-vscode/src/speech-to-text/capture.ts
+++ b/packages/kilo-vscode/src/speech-to-text/capture.ts
@@ -46,7 +46,10 @@ function run(args) {
   const error = Ref()
   const url = $.NSURL.fileURLWithPath(args[0])
   const recorder = $.AVAudioRecorder.alloc.initWithURLSettingsError(url, settings, error)
-  if (!recorder || !recorder.prepareToRecord || !recorder.record) throw new Error("Could not start recording")
+  if (!recorder || !recorder.prepareToRecord || !recorder.record) {
+    const description = error[0] && error[0].localizedDescription
+    throw new Error(description ? description.js : "Could not start recording")
+  }
   console.log("ready")
   $.NSFileHandle.fileHandleWithStandardInput.readDataToEndOfFile
   recorder.stop

--- a/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-capture.test.ts
@@ -19,6 +19,7 @@ describe("macCaptureArgs", () => {
     expect(args[3]).toContain("numberWithDouble(16000), $.AVSampleRateKey")
     expect(args[3]).toContain("numberWithInt(1), $.AVNumberOfChannelsKey")
     expect(args[3]).toContain("numberWithInt(24000), $.AVEncoderBitRateKey")
+    expect(args[3]).toContain("error[0] && error[0].localizedDescription")
     expect(args[3]).toContain('console.log("ready")')
   })
 })


### PR DESCRIPTION
Follow-up to #12814. The native macOS speech bridge already captures an NSError when AVAudioRecorder initialization fails, but discarded it and reported only a generic startup error.

Include the NSError localized description when available, while retaining the generic fallback when macOS does not populate the reference. This makes microphone permission, device, and format failures actionable in the existing speech-capture diagnostics without changing the recording lifecycle.