### PR TITLE
revert(cli): stop promoting stable releases to rc

### DIFF
--- a/packages/opencode/script/kilocode/npm-publish.ts
+++ b/packages/opencode/script/kilocode/npm-publish.ts
@@ -3,10 +3,6 @@ export namespace NpmPublish {
   const base = 10_000
   const jitter = 5_000
 
-  export function aliases(channel: string) {
-    return channel === "latest" ? ["rc"] : []
-  }
-
   export async function retry(input: {
     name: string
     version: string

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -16,21 +16,18 @@ async function publish(dir: string, name: string, version: string) {
   // GitHub artifact downloads can drop the executable bit, and Docker uses the
   // unpacked dist binaries directly rather than the published tarball.
   if (process.platform !== "win32") await $`chmod -R 755 .`.cwd(dir)
-  // kilocode_change start
-  const exists = await published(name, version)
-  if (exists) {
+  if (await published(name, version)) {
     console.log(`already published ${name}@${version}`)
+    return
   }
-  if (!exists) {
-    await $`bun pm pack`.cwd(dir)
-    await NpmPublish.retry({
-      name,
-      version,
-      run: () => $`npm publish *.tgz --access public --tag ${Script.channel} --provenance`.cwd(dir),
-      exists: () => published(name, version),
-    })
-  }
-  for (const tag of NpmPublish.aliases(Script.channel)) await $`npm dist-tag add ${name}@${version} ${tag}`
+  await $`bun pm pack`.cwd(dir)
+  // kilocode_change start
+  await NpmPublish.retry({
+    name,
+    version,
+    run: () => $`npm publish *.tgz --access public --tag ${Script.channel} --provenance`.cwd(dir),
+    exists: () => published(name, version),
+  })
   // kilocode_change end
 }
 

--- a/packages/opencode/test/kilocode/npm-publish.test.ts
+++ b/packages/opencode/test/kilocode/npm-publish.test.ts
@@ -1,16 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { NpmPublish } from "../../script/kilocode/npm-publish"
 
-describe("npm publish aliases", () => {
-  test("promotes stable releases to the rc channel", () => {
-    expect(NpmPublish.aliases("latest")).toEqual(["rc"])
-  })
-
-  test("does not promote prereleases", () => {
-    expect(NpmPublish.aliases("rc")).toEqual([])
-  })
-})
-
 describe("npm publish retry", () => {
   test("returns after the first successful attempt", async () => {
     const calls = { run: 0, exists: 0, sleep: 0 }


### PR DESCRIPTION
Reverts #12647.

Stable CLI releases publish through npm trusted publishing, but the added `npm dist-tag add ... rc` operation is not supported by npm OIDC authentication. It falls back to token authentication and caused the v7.4.18 release job to fail after partially publishing the platform packages.

This restores the previous OIDC-only release path by removing automatic stable-to-`rc` promotion. The `rc` tag will remain on the most recent actual release candidate until npm supports dist-tag operations through trusted publishing or promotion is performed interactively.