### PR TITLE
fix(kilo-docs): close agents callout correctly

### DIFF
--- a/packages/kilo-docs/pages/customize/agents-md.md
+++ b/packages/kilo-docs/pages/customize/agents-md.md
@@ -18,7 +18,7 @@ If you'd like to migrate your memory bank content to AGENTS.md:
 
 1. Examine the contents in `.kilocode/rules/memory-bank/`
 2. Move that content into your project's `AGENTS.md` file (or ask Kilo to do it for you)
-   {% /callout %}
+{% /callout %}
 
 ## What is AGENTS.md?
 


### PR DESCRIPTION
## Issue

Fixes #12788

## Context

The `agents.md` documentation page incorrectly renders all content after the “Memory Bank Deprecation” notice inside the blue callout.

The closing Markdoc tag was indented beneath the notice’s numbered list, causing it to be parsed as list content rather than as the end of the callout.

## Implementation

Move the closing `{% /callout %}` tag out of the numbered-list indentation and return it to the top level. This allows Markdoc to close the callout before the “What is AGENTS.md?” section.

The change is deliberately limited to the malformed markup and does not alter the documentation content.

## Screenshots / Video

Screenshots have not yet been captured.

| before | after |
|---|---|
| The entire page is rendered inside the blue “Memory Bank Deprecation” callout. | Only the deprecation notice is rendered inside the callout. |

## How to Test

### Manual/local verification

- Agent reviewed the rendered Markdoc structure and confirmed the closing callout tag is now at the top level rather than nested beneath the numbered list.
- Agent ran `git diff --check`; it completed successfully with no whitespace errors.
- Agent compared the corrected markup with the documented callout syntax in `packages/kilo-docs/AGENTS.md`.

### Reviewer test steps

1. Start the documentation site with `bun run dev` from `packages/kilo-docs`.
2. Open `/docs/customize/agents-md`.
3. Confirm the blue “Memory Bank Deprecation” callout ends after the two migration steps.
4. Confirm “What is AGENTS.md?” and all subsequent sections render outside the callout.

### Blocked checks and substitute verification

- Agent could not run `bun run lint`, `bun run typecheck`, `bun run test`, or `bun run build` because Bun is not installed or available on `PATH` in the execution environment.
- Substitute verification consisted of `git diff --check`, direct inspection of the final diff, and comparison against the repository’s documented top-level Markdoc callout syntax.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [ ] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

A changeset was considered but not added because this is a documentation-only rendering correction and does not change a released package.

## Get in Touch

@thomasnow
