### PR TITLE
fix(vscode): open files from read tool headers

### DIFF
--- a/.changeset/open-read-tool-files.md
+++ b/.changeset/open-read-tool-files.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open files by clicking their names in read tool headers.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -1737,12 +1737,17 @@ function TaskLink(props: { href: string; text: string; onClick: (e: MouseEvent) 
   )
 }
 
-function ToolText(props: { text: string; delay?: number; animate?: boolean }) {
+function ToolText(props: { text: string; delay?: number; animate?: boolean; onClick?: (event: MouseEvent) => void }) {
   let ref: HTMLSpanElement | undefined
   useToolFade(() => ref, { delay: props.delay, wipe: true, animate: props.animate })
 
   return (
-    <span ref={ref} data-slot="basic-tool-tool-subtitle">
+    <span
+      ref={ref}
+      data-slot="basic-tool-tool-subtitle"
+      classList={{ clickable: !!props.onClick }}
+      onClick={props.onClick}
+    >
       {props.text}
     </span>
   )
@@ -1783,6 +1788,7 @@ function ToolTriggerRow(props: {
   action?: JSX.Element
   animate?: boolean
   revealOnMount?: boolean
+  onClick?: (event: MouseEvent) => void
 }) {
   const reveal = useToolReveal(
     () => props.pending,
@@ -1802,7 +1808,9 @@ function ToolTriggerRow(props: {
         <span data-slot="basic-tool-tool-title">
           <TextShimmer text={props.title} active={props.pending} />
         </span>
-        <Show when={detail()}>{(text) => <ToolText text={text()} animate={detailAnimate()} />}</Show>
+        <Show when={detail()}>
+          {(text) => <ToolText text={text()} animate={detailAnimate()} onClick={props.onClick} />}
+        </Show>
       </div>
       <Show when={props.action}>{props.action}</Show>
     </div>
@@ -1894,9 +1902,6 @@ ToolRegistry.register({
           hideDetails
           {...props}
           icon="glasses"
-          onSubtitleClick={
-            data.openFile && props.input.filePath ? () => data.openFile!(props.input.filePath) : undefined
-          }
           trigger={
             <ToolTriggerRow
               title={i18n.t("ui.tool.read")}
@@ -1904,6 +1909,14 @@ ToolRegistry.register({
               subtitle={props.input.filePath ? getFilename(props.input.filePath) : ""}
               args={args}
               animate={props.reveal}
+              onClick={
+                data.openFile && props.input.filePath
+                  ? (event) => {
+                      event.stopPropagation()
+                      data.openFile!(props.input.filePath)
+                    }
+                  : undefined
+              }
             />
           }
         />

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -426,6 +426,15 @@ describe("BasicTool export contract (runtime)", () => {
   })
 })
 
+describe("Read tool file link contract (source)", () => {
+  const message = fs.readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")
+
+  it("opens the input file from the custom trigger detail", () => {
+    expect(message).toMatch(/name:\s*"read"[\s\S]*?<ToolTriggerRow[\s\S]*?onClick=/)
+    expect(message).toMatch(/event\.stopPropagation\(\)[\s\S]*?data\.openFile!\(props\.input\.filePath\)/)
+  })
+})
+
 describe("Collapsed deferred tool details contract (source)", () => {
   const basic = fs.readFileSync(BASIC_TOOL_FILE, "utf-8")
   const message = fs.readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")


### PR DESCRIPTION
## Issue

Fixes #12791

## Context

Read tool headers display the file name, but clicking it does not open the file. The renderer passed `onSubtitleClick` to `BasicTool` while also supplying a custom trigger element; `BasicTool` only applies that callback to structured trigger objects, so the handler was never attached to the rendered subtitle.

## Implementation

Route an optional click handler through the custom `ToolTriggerRow` and its detail text. The read renderer stops event propagation and calls `openFile` with the original absolute `input.filePath`, while retaining the compact filename and offset/limit display. A focused source-contract regression test protects this wiring, and a patch changeset records the user-facing fix.

## Screenshots / Video

N/A — this changes click behavior without changing the rendered appearance.

## How to Test

### Manual/local verification

Executed by the agent:

- `bun run typecheck` — passed.
- `bun run lint` — passed.
- `bun run knip` — passed.
- `bun run build:check` — passed, including extension and webview bundles.
- `bun test tests/unit/kilo-ui-contract.test.ts` — 46 passed, 0 failed.
- `bun run check-kilocode-change` — passed.
- `git diff --check` — passed.
- Repository formatter — passed.

### Reviewer test steps

1. Ask Kilo to read a file with the read tool.
2. Click the filename in the resulting read tool header.
3. Confirm VS Code opens that file in the editor.
4. Repeat with a file outside the workspace root and confirm the absolute input path still resolves.

### Blocked checks and substitute verification

- `bun run test:unit` ran all 3,689 tests and reported 3,687 passing, two failures, and one follow-on error. Both failures are unrelated Agent Manager git/worktree tests. `continue-in-worktree.test.ts` passed completely on rerun (10 passed). `worktree-manager.test.ts` still has one unrelated failure: `WorktreeManager.resolveStartPoint > returns bare branch + remote when remote exists` receives `local-tracking` instead of `remote`. The affected Kilo UI contract suite passed completely (46/46).
- `bun run compile` completed dependency preparation and the console web build, then stopped while generating the bundled Linux CLI because Zig is not installed. As substitute verification, `bun run build:check` passed in full, including typechecks, lint, and all extension/webview bundles.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.