### PR TITLE
fix(vscode): remove duplicate sidebar border

### DIFF
--- a/.changeset/clean-vscode-sidebar-edge.md
+++ b/.changeset/clean-vscode-sidebar-edge.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the duplicate border along the Kilo Code sidebar edge.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -4797,7 +4797,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       workerUri: webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, "dist", "shiki-worker.js")),
       title: "Kilo Code",
       port: this.connectionService.getServerInfo()?.port,
-      extraStyles: `.container { height: 100%; display: flex; flex-direction: column; height: 100vh; border-right: 1px solid var(--border-weak-base); }`,
+      extraStyles: `.container { height: 100vh; }`,
     })
   }
 


### PR DESCRIPTION
## Summary

Remove the webview-provided right border from the Kilo Code container so VS Code is the sole owner of the sidebar divider. This avoids the doubled vertical edge while retaining the full-height container sizing.

## Visual comparison
<img width="1084" height="1117" alt="view" src="https://github.com/user-attachments/assets/1530e0c7-db41-4edd-bd5d-e1bf9f117b38" />

