### PR TITLE
fix(core): settle grep processes on exit

### DIFF
--- a/.changeset/calm-subagents-settle.md
+++ b/.changeset/calm-subagents-settle.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent completed grep processes from blocking subagents while inherited output pipes remain open.

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -273,17 +273,16 @@ export const make = Effect.gen(function* () {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
       tapStdio(proc) // kilocode_change - must run in the same tick as spawn
-      let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
       proc.on("exit", (...args) => {
         exit = args
+        Deferred.doneUnsafe(signal, Exit.succeed(args)) // kilocode_change - settle before inherited output pipes close
       })
       proc.on("close", (...args) => {
-        if (end) return
-        end = true
+        // kilocode_change - cross-spawn can suppress `exit` for a Windows ENOENT and only emit `close`
         Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
       })
       proc.on("spawn", () => {
@@ -325,6 +324,18 @@ export const make = Effect.gen(function* () {
       if (proc.kill(signal)) return Effect.void
       return Effect.fail(toPlatformError("kill", new Error("Failed to kill child process"), command))
     })
+
+  // kilocode_change start - detect descendants left in an exited command's owned process group
+  const groupAlive = (proc: NodeChildProcess.ChildProcess) => {
+    if (process.platform === "win32") return false
+    try {
+      process.kill(-proc.pid!, 0)
+      return true
+    } catch {
+      return false
+    }
+  }
+  // kilocode_change end
 
   const timeout =
     (
@@ -409,10 +420,14 @@ export const make = Effect.gen(function* () {
               const done = yield* Deferred.isDone(signal)
               const kill = timeout(proc, command, target.options) // kilocode_change
               if (done) {
-                const [code] = yield* Deferred.await(signal)
+                // kilocode_change start - direct exit can precede descendants and inherited pipe closure
                 if (process.platform === "win32") return yield* Effect.void
-                if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
+                if (!groupAlive(proc)) return yield* Effect.void
+                yield* Effect.ignore(killGroup(command, proc, target.options.killSignal ?? "SIGTERM"))
+                yield* Effect.sleep("100 millis")
+                if (groupAlive(proc)) yield* Effect.ignore(killGroup(command, proc, "SIGKILL"))
                 return yield* Effect.void
+                // kilocode_change end
               }
               const send = (s: NodeJS.Signals) =>
                 Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))

--- a/packages/core/test/kilocode/ripgrep-settlement.test.ts
+++ b/packages/core/test/kilocode/ripgrep-settlement.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Effect, Layer } from "effect"
+import { AppProcess } from "@opencode-ai/core/process"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+import { tmpdir } from "../fixture/tmpdir"
+import { it } from "../lib/effect"
+
+const record = (line: number) =>
+  JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: "fixture.ts" },
+      lines: { text: "needle\n" },
+      line_number: line,
+      absolute_offset: line * 10,
+      submatches: [{ match: { text: "needle" }, start: 0, end: 6 }],
+    },
+  })
+
+const alive = (pid: number) => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const gone = async (pid: number) => {
+  const deadline = Date.now() + 1_000
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return !alive(pid)
+}
+
+describe("Kilo ripgrep settlement", () => {
+  it.live(
+    "settles a bounded grep after its command exits",
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          if (process.platform === "win32") return
+
+          const binary = path.join(tmp.path, "rg")
+          const retained = path.join(tmp.path, "retained.pid")
+          const owned = path.join(tmp.path, "owned.pid")
+          const output = Array.from({ length: 300 }, (_, index) => record(index + 1)).join("\n") + "\n"
+          const source = `#!${process.execPath}
+const { spawn } = require("node:child_process")
+const { writeFileSync } = require("node:fs")
+const retained = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 3_000)"], {
+  detached: true,
+  stdio: ["ignore", "inherit", "inherit"],
+})
+retained.unref()
+const owned = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 10_000)"], {
+  stdio: "ignore",
+})
+owned.unref()
+writeFileSync(${JSON.stringify(retained)}, String(retained.pid))
+writeFileSync(${JSON.stringify(owned)}, String(owned.pid))
+require("node:fs").writeSync(1, ${JSON.stringify(output)})
+`
+          yield* Effect.promise(() => fs.writeFile(binary, source, { mode: 0o755 }))
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(async () => {
+              for (const file of [retained, owned]) {
+                const pid = Number(await fs.readFile(file, "utf8").catch(() => ""))
+                if (!pid || !alive(pid)) continue
+                try {
+                  process.kill(pid, "SIGKILL")
+                } catch {}
+              }
+            }),
+          )
+
+          const fixture = Layer.succeed(
+            RipgrepBinary.Service,
+            RipgrepBinary.Service.of({ filepath: Effect.succeed(binary) }),
+          )
+          const layer = Ripgrep.layer.pipe(Layer.provide(Layer.merge(AppProcess.defaultLayer, fixture)))
+          const started = Date.now()
+          const result = yield* Ripgrep.Service.pipe(
+            Effect.flatMap((ripgrep) =>
+              ripgrep.grep({ cwd: tmp.path, pattern: "needle", limit: 1 }),
+            ),
+            Effect.provide(layer),
+          )
+          const retainedPid = Number(yield* Effect.promise(() => fs.readFile(retained, "utf8")))
+          const ownedPid = Number(yield* Effect.promise(() => fs.readFile(owned, "utf8")))
+
+          expect(result.truncated).toBe(true)
+          expect(Date.now() - started).toBeLessThan(1_000)
+          expect(retainedPid).toBeGreaterThan(0)
+          expect(yield* Effect.promise(() => gone(ownedPid))).toBe(true)
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+    5_000,
+  )
+})


### PR DESCRIPTION
A bounded grep can finish collecting its requested matches while Node still waits for the child process `close` event. `close` is delayed until all inherited output pipes close, so a descendant retaining stdout can leave the grep tool running indefinitely even though the ripgrep command itself has exited. In a subagent, the parent Task then waits forever for that tool result.

The first commit adds a deterministic production-layer regression: fake ripgrep emits enough valid JSON to cross the result limit, exits normally, and leaves one detached descendant retaining the inherited output pipe. It also leaves an owned descendant in ripgrep's process group. Without the fix, the tool waits for the detached pipe owner and fails the one-second settlement assertion.

The process adapter now settles status on the direct `exit` event, while retaining `close` as the Windows failed-spawn fallback. Scope cleanup checks an exited command's process group and terminates remaining owned descendants, escalating to `SIGKILL` after a short grace period. This lets completed grep tools return promptly without leaking processes they still own.

This addresses the underlying cleanup weakness exposed by #12811. The temporary rollback in #12847 remains useful until bounded grep controls are reintroduced with this settlement behavior available.