### PR TITLE
fix(vscode): remove selected project indicator

### DIFF
--- a/.changeset/remove-project-selection-indicator.md
+++ b/.changeset/remove-project-selection-indicator.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the redundant selected-project indicator from Agent Manager.

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
@@ -48,7 +48,7 @@ export const ProjectsSection: Component<ProjectsSectionProps> = (props) => (
         {(id) => {
           const project = () => props.projects.find((item) => item.id === id)!
           return (
-            <div class="am-project" classList={{ "am-project-active": project().active }}>
+            <div class="am-project">
               <div class="am-project-item" data-project-id={project().id}>
                 <button
                   class="am-project-main"

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -241,25 +241,12 @@ html[data-theme="kilo-vscode"]
   border-bottom: 0;
 }
 
-.am-project::before {
-  content: "";
-  position: absolute;
-  inset: 6px auto 6px 0;
-  width: 2px;
-  border-radius: 0 2px 2px 0;
-  background: transparent;
-}
-
-.am-project-active::before {
-  background: var(--border-interactive-base);
-}
-
 .am-project-item {
   display: flex;
   align-items: center;
   gap: 2px;
   min-height: 34px;
-  padding: 6px 8px 6px 12px;
+  padding: 6px 8px;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Agent Manager added a blue vertical marker and extra left inset to the active project row. The marker is redundant with the selected project content and makes the project list feel unnecessarily indented.

This removes the decorative marker and restores the row to the standard horizontal padding while preserving project activation, restoration, and expansion behavior.

Before:
<img width="700" alt="Agent Manager project row with the selected-project indicator" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-agent-manager-project-indicator-before.png?raw=true" />

After:
<img width="700" alt="Agent Manager project row without the selected-project indicator" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-agent-manager-project-indicator-after.png?raw=true" />