### PR TITLE
fix(vscode): resolve file links against the active session's directory in multi-repo workspaces

### DIFF
--- a/.changeset/vscode-file-links-multi-repo.md
+++ b/.changeset/vscode-file-links-multi-repo.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Resolve clickable file links against the active session's working directory in multi-repo VS Code workspaces, instead of falling back to the workspace root.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1548,7 +1548,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private handleEditorOpenMessage(message: Parameters<typeof handleEditorAction>[0]): boolean {
     return handleEditorAction(message, {
-      dir: () => this.getWorkspaceDirectory(this.currentSession?.id),
+      dir: () => {
+        const session = this.currentSession
+        return session ? this.getSessionDirectory(session.id, session) : this.getWorkspaceDirectory()
+      },
       diff: this.diffVirtualProvider,
       storage: this.extensionContext?.globalStorageUri,
       post: (msg) => this.postMessage(msg),
@@ -4685,10 +4688,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private getWorkspaceDirectory(sessionId?: string): string {
-    const session = this.currentSession
-    if (sessionId && session?.id === sessionId) {
-      return this.getSessionDirectory(sessionId, session)
-    }
     const routed = this.routeSessionDirectory(sessionId ?? undefined)
     // Ambiguous ids degrade to the legacy resolution instead of throwing: this
     // runs eagerly per webview message, where a throw would drop the message.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -4685,6 +4685,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   private getWorkspaceDirectory(sessionId?: string): string {
+    const session = this.currentSession
+    if (sessionId && session?.id === sessionId) {
+      return this.getSessionDirectory(sessionId, session)
+    }
     const routed = this.routeSessionDirectory(sessionId ?? undefined)
     // Ambiguous ids degrade to the legacy resolution instead of throwing: this
     // runs eagerly per webview message, where a throw would drop the message.

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -23,8 +23,16 @@ const mockUri = {
   },
 }
 
+class MockRelativePattern {
+  constructor(
+    public base: { fsPath: string },
+    public pattern: string,
+  ) {}
+}
+
 const mockVscode = {
   Uri: mockUri,
+  RelativePattern: MockRelativePattern,
   extensions: {
     getExtension: (id: string) => {
       if (id === "vscode.git") return undefined
@@ -65,6 +73,7 @@ const mockVscode = {
       const value = typeof pathOrUri === "string" ? pathOrUri : (pathOrUri.fsPath ?? "")
       return value.startsWith("/repo/") ? value.slice("/repo/".length) : value
     },
+    findFiles: async () => [],
     fs: {
       createDirectory: async () => {},
       writeFile: async () => {},

--- a/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
@@ -343,6 +343,8 @@ describe("KiloProvider file link directory resolution", () => {
     time: { created: 1, updated: 1 },
   } as Session
 
+  stat.mockImplementation(async () => ({ type: vscode.FileType.File, ctime: 0, mtime: 0, size: 0 }))
+
   afterEach(() => {
     stat.mockClear()
   })
@@ -359,7 +361,7 @@ describe("KiloProvider file link directory resolution", () => {
     expect(internal.getWorkspaceDirectory("ses-frontend")).toBe("/workspace")
   })
 
-  it("opens relative file links against the current session directory", () => {
+  it("opens relative file links against the current session directory", async () => {
     const { connection } = mockConnection()
     const provider = new KiloProvider({} as never, connection, undefined, {
       rootDirectory: () => "/workspace",
@@ -368,13 +370,14 @@ describe("KiloProvider file link directory resolution", () => {
     internal.currentSession = session
 
     internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb", line: 12 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(stat).toHaveBeenCalledTimes(1)
     const uri = stat.mock.calls[0]![0] as { fsPath: string }
     expect(uri.fsPath).toBe("/workspace/backend/spec/foo_spec.rb")
   })
 
-  it("falls back to the workspace root for relative file links without a current session", () => {
+  it("falls back to the workspace root for relative file links without a current session", async () => {
     const { connection } = mockConnection()
     const provider = new KiloProvider({} as never, connection, undefined, {
       rootDirectory: () => "/workspace",
@@ -383,6 +386,7 @@ describe("KiloProvider file link directory resolution", () => {
     internal.currentSession = null
 
     internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb", line: 12 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(stat).toHaveBeenCalledTimes(1)
     const uri = stat.mock.calls[0]![0] as { fsPath: string }

--- a/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn, afterEach } from "bun:test"
+import * as vscode from "vscode"
+import type { Session } from "@kilocode/sdk/v2/client"
 import { ProjectRouteService } from "../../src/agent-manager/project/route"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
@@ -80,8 +82,11 @@ function mockConnection(getImpl?: (p: SessionGetParams) => Promise<unknown>) {
 type ProviderInternals = {
   client: unknown
   connectionState: "connecting" | "connected" | "disconnected" | "error"
+  currentSession: Session | null
   initConnectionPromise: Promise<void> | null
   webview: { postMessage: (message: unknown) => Promise<unknown> } | null
+  getWorkspaceDirectory: (sessionId?: string) => string
+  handleEditorOpenMessage: (message: unknown) => boolean
   handleSendCommand: (
     command: string,
     args: string,
@@ -323,5 +328,64 @@ describe("KiloProvider route integration", () => {
     expect(commandCalls[0]!.command).toBe("share")
     // No fallback to the active root anywhere.
     expect(calls.every((c) => c.directory !== "/active/root")).toBe(true)
+  })
+})
+
+describe("KiloProvider file link directory resolution", () => {
+  const stat = spyOn(vscode.workspace.fs, "stat")
+  const session = {
+    id: "ses-backend",
+    slug: "ses-backend",
+    projectID: "prj-backend",
+    directory: "/workspace/backend",
+    title: "s",
+    version: "1",
+    time: { created: 1, updated: 1 },
+  } as Session
+
+  afterEach(() => {
+    stat.mockClear()
+  })
+
+  it("resolves getWorkspaceDirectory to the current session's directory", () => {
+    const { connection } = mockConnection()
+    const provider = new KiloProvider({} as never, connection, undefined, {
+      rootDirectory: () => "/workspace",
+    })
+    const internal = provider as unknown as ProviderInternals
+    internal.currentSession = session
+
+    expect(internal.getWorkspaceDirectory("ses-backend")).toBe("/workspace/backend")
+    expect(internal.getWorkspaceDirectory("ses-frontend")).toBe("/workspace")
+  })
+
+  it("opens relative file links against the current session directory", () => {
+    const { connection } = mockConnection()
+    const provider = new KiloProvider({} as never, connection, undefined, {
+      rootDirectory: () => "/workspace",
+    })
+    const internal = provider as unknown as ProviderInternals
+    internal.currentSession = session
+
+    internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb", line: 12 })
+
+    expect(stat).toHaveBeenCalledTimes(1)
+    const uri = stat.mock.calls[0]![0] as { fsPath: string }
+    expect(uri.fsPath).toBe("/workspace/backend/spec/foo_spec.rb")
+  })
+
+  it("falls back to the workspace root for relative file links without a current session", () => {
+    const { connection } = mockConnection()
+    const provider = new KiloProvider({} as never, connection, undefined, {
+      rootDirectory: () => "/workspace",
+    })
+    const internal = provider as unknown as ProviderInternals
+    internal.currentSession = null
+
+    internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb", line: 12 })
+
+    expect(stat).toHaveBeenCalledTimes(1)
+    const uri = stat.mock.calls[0]![0] as { fsPath: string }
+    expect(uri.fsPath).toBe("/workspace/spec/foo_spec.rb")
   })
 })

--- a/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts
@@ -85,7 +85,6 @@ type ProviderInternals = {
   currentSession: Session | null
   initConnectionPromise: Promise<void> | null
   webview: { postMessage: (message: unknown) => Promise<unknown> } | null
-  getWorkspaceDirectory: (sessionId?: string) => string
   handleEditorOpenMessage: (message: unknown) => boolean
   handleSendCommand: (
     command: string,
@@ -347,18 +346,6 @@ describe("KiloProvider file link directory resolution", () => {
 
   afterEach(() => {
     stat.mockClear()
-  })
-
-  it("resolves getWorkspaceDirectory to the current session's directory", () => {
-    const { connection } = mockConnection()
-    const provider = new KiloProvider({} as never, connection, undefined, {
-      rootDirectory: () => "/workspace",
-    })
-    const internal = provider as unknown as ProviderInternals
-    internal.currentSession = session
-
-    expect(internal.getWorkspaceDirectory("ses-backend")).toBe("/workspace/backend")
-    expect(internal.getWorkspaceDirectory("ses-frontend")).toBe("/workspace")
   })
 
   it("opens relative file links against the current session directory", async () => {


### PR DESCRIPTION
## Summary

Fixes #12833.

In multi-repo VS Code workspaces (non-git root containing multiple child repos), clickable relative file links in agent chat (`foo.rb`, `spec/foo_spec.rb:12`) were joined and globbed against the workspace root instead of the session's actual working directory. Absolute paths worked because they short-circuit the relative resolution.

The root cause was that `handleEditorOpenMessage` was passing `getWorkspaceDirectory(currentSession?.id)` as the base directory for `editor-actions.ts`. That helper fell back to `resolveWorkspaceDirectory`, which only consults `sessionDirectories` and then the workspace root, ignoring the active session's own `directory` field.

The fix scopes the change to the file-link path only. `handleEditorOpenMessage` now resolves the base directory through `getSessionDirectory(currentSession.id, currentSession)`, which uses the existing fallback order (Agent Manager routes → tracked `sessionDirectories` → `session.directory` → workspace root). This keeps `getWorkspaceDirectory` and all other call sites unchanged.

## Changes

- `packages/kilo-vscode/src/KiloProvider.ts`: scope file-link directory resolution to `handleEditorOpenMessage`.
- `packages/kilo-vscode/tests/unit/kilo-provider-route-integration.test.ts`: cover relative file link resolution against the session directory and the root fallback.
- `packages/kilo-vscode/tests/setup/vscode-mock.ts`: add `RelativePattern` and `workspace.findFiles` stubs so the `findFallback` path can be unit tested.
- `.changeset/vscode-file-links-multi-repo.md`: patch changeset.

## Test plan

- [x] `bun test tests/unit/kilo-provider-route-integration.test.ts` passes
- [x] `bun run test:unit` in `packages/kilo-vscode/` passes (3697 tests)
- [x] `bun run typecheck` in `packages/kilo-vscode/` passes
- [x] `bun run lint` in `packages/kilo-vscode/` passes
- [x] `bun run bundle` in `packages/kilo-vscode/` completes without errors
- [x] `bun run knip` in `packages/kilo-vscode/` passes
- [x] `bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'` passes