### PR TITLE
fix(vscode): remove duplicate Agent Manager empty state

### DIFF
--- a/.changeset/single-agent-manager-empty-state.md
+++ b/.changeset/single-agent-manager-empty-state.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show only one empty-state panel after removing the last Agent Manager worktree.

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2459,20 +2459,6 @@ const AgentManagerContent: Component = () => {
           track={metrics.click}
         />
 
-        {/* Empty worktree state */}
-        <Show when={contextEmpty()}>
-          <div class="am-empty-state">
-            <div class="am-empty-state-icon">
-              <Icon name="branch" size="large" />
-            </div>
-            <div class="am-empty-state-text">{t("agentManager.session.noSessions")}</div>
-            <Button variant="primary" size="small" onClick={handleAddSession}>
-              {t("agentManager.session.new")}
-              <span class="am-shortcut-hint">{kb().newTab ?? ""}</span>
-            </Button>
-          </div>
-        </Show>
-
         <Show when={overlay()}>
           {(state) => (
             <div class="am-setup-overlay">


### PR DESCRIPTION
When the last managed worktree is removed, selection moves to an empty local context. Agent Manager currently renders both the legacy empty-state block and the newer detail-stack empty state, producing duplicate empty-state CTAs.

This removes the obsolete top-level render so the detail stack is the sole owner of session-less selected contexts while preserving setup-terminal layout behavior.

Before and after:

<img width="700" alt="Agent Manager showing duplicate No sessions open templates before the fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-agent-manager-empty-state-repro-before.png?raw=true" />\n\n<img width="700" alt="Agent Manager showing one No sessions open template after the fix" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-agent-manager-empty-state-after.png?raw=true" />

