### PR TITLE
feat(agent-manager): support worktree slash commands

### DIFF
--- a/.changeset/worktree-slash-commands.md
+++ b/.changeset/worktree-slash-commands.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Support model, agent, variant, and sandbox slash commands in Agent Manager worktree prompts.

--- a/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
@@ -3,7 +3,10 @@ import { createRoot } from "solid-js"
 import { useSlashCommand } from "../../webview-ui/src/hooks/useSlashCommand"
 import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/types/messages"
 
-function setup(sandbox: () => void, options: { enabled?: () => boolean; exclude?: () => Set<string> } = {}) {
+function setup(
+  sandbox: () => void,
+  options: { enabled?: () => boolean; exclude?: () => Set<string>; include?: Set<string> } = {},
+) {
   const sent: WebviewMessage[] = []
   const handlers = new Set<(message: ExtensionMessage) => void>()
   const root = createRoot((dispose) => ({
@@ -18,6 +21,7 @@ function setup(sandbox: () => void, options: { enabled?: () => boolean; exclude?
       },
       { action: sandbox, enabled: options.enabled ?? (() => true) },
       options.exclude,
+      options.include,
     ),
   }))
   const fire = (message: ExtensionMessage) => {
@@ -27,6 +31,33 @@ function setup(sandbox: () => void, options: { enabled?: () => boolean; exclude?
 }
 
 describe("useSlashCommand sandbox action", () => {
+  it("supports the singular model alias", () => {
+    const ctx = setup(() => {})
+
+    ctx.slash.onInput("/model", 6)
+
+    expect(ctx.slash.results()[0]).toEqual(expect.objectContaining({ name: "models", hints: ["model"] }))
+    ctx.dispose()
+  })
+
+  it("can restrict the menu to worktree configuration commands", () => {
+    const ctx = setup(() => {}, { include: new Set(["models", "agents", "variant", "sandbox"]) })
+
+    ctx.fire({
+      type: "commandsLoaded",
+      commands: [
+        { name: "merge", description: "Merge changes", hints: [] },
+        { name: "models", description: "Server model command", hints: [] },
+      ],
+    })
+    ctx.slash.onInput("/merge", 6)
+    expect(ctx.slash.results()).toEqual([])
+
+    ctx.slash.onInput("/models", 7)
+    expect(ctx.slash.results().map((command) => command.name)).toEqual(["models"])
+    ctx.dispose()
+  })
+
   it("opens project memory actions from the top-level command", () => {
     const ctx = setup(() => {})
     const state = { text: "/memory" }

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -53,6 +53,7 @@ import type { ModeRouter } from "./mode-router"
 type VersionCount = 1 | 2 | 3 | 4
 const VERSION_OPTIONS: VersionCount[] = [1, 2, 3, 4]
 const WORKTREE_PROMPT_COMMANDS = new Set(["models", "agents", "variant", "sandbox"])
+const WORKTREE_PROMPT_SCOPE = "agent-manager-worktree-prompt"
 
 type DialogTab = "new" | "import"
 
@@ -289,7 +290,6 @@ export const NewWorktreeDialog: Component<{
 
   let textareaRef: HTMLTextAreaElement | undefined
   let containerRef: HTMLDivElement | undefined
-  let slashDropdownRef: HTMLDivElement | undefined
 
   const setPromptValue = (value: string) => {
     setPrompt(value)
@@ -310,6 +310,7 @@ export const NewWorktreeDialog: Component<{
       return hidden
     },
     WORKTREE_PROMPT_COMMANDS,
+    WORKTREE_PROMPT_SCOPE,
   )
   const onFocusPrompt = () => restorePrompt()
   window.addEventListener("focusPrompt", onFocusPrompt)
@@ -616,7 +617,7 @@ export const NewWorktreeDialog: Component<{
               onDrop={imageAttach.handleDrop}
             >
               <Show when={slash.show()}>
-                <div class="slash-command-dropdown am-slash-command-dropdown" ref={slashDropdownRef}>
+                <div class="slash-command-dropdown am-slash-command-dropdown" data-component="popover-content">
                   <Show
                     when={slash.results().length > 0}
                     fallback={<div class="slash-command-empty">No commands found</div>}
@@ -702,6 +703,7 @@ export const NewWorktreeDialog: Component<{
                       agents={session.agents()}
                       value={agent()}
                       onSelect={selectAgent}
+                      trigger={WORKTREE_PROMPT_SCOPE}
                       portal={false}
                       deferDismiss
                     />
@@ -714,6 +716,7 @@ export const NewWorktreeDialog: Component<{
                       }}
                       onPick={restorePrompt}
                       onCancel={restorePrompt}
+                      trigger={WORKTREE_PROMPT_SCOPE}
                       placement="top-start"
                       portal={false}
                       deferDismiss
@@ -722,6 +725,7 @@ export const NewWorktreeDialog: Component<{
                       variants={variants()}
                       value={effectiveVariant()}
                       onSelect={setVariant}
+                      trigger={WORKTREE_PROMPT_SCOPE}
                       portal={false}
                       deferDismiss
                       cycleHint={settings()["chat.shiftTabCyclesVariant"] !== false}

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -43,6 +43,7 @@ import { useSpeechToTextModels } from "../src/context/speech-to-text-models"
 import { createSpeechShortcut } from "../src/components/speech-to-text/shortcut"
 import { convertToMentionPath } from "../src/utils/path-mentions"
 import { insertSpacedText } from "../src/components/chat/prompt-input-utils"
+import { useSlashCommand } from "../src/hooks/useSlashCommand"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
 import { BranchSelect, BranchSelectPopover } from "../src/components/shared/BranchSelect"
 import { tracker } from "./telemetry"
@@ -51,6 +52,7 @@ import type { ModeRouter } from "./mode-router"
 
 type VersionCount = 1 | 2 | 3 | 4
 const VERSION_OPTIONS: VersionCount[] = [1, 2, 3, 4]
+const WORKTREE_PROMPT_COMMANDS = new Set(["models", "agents", "variant", "sandbox"])
 
 type DialogTab = "new" | "import"
 
@@ -287,6 +289,31 @@ export const NewWorktreeDialog: Component<{
 
   let textareaRef: HTMLTextAreaElement | undefined
   let containerRef: HTMLDivElement | undefined
+  let slashDropdownRef: HTMLDivElement | undefined
+
+  const setPromptValue = (value: string) => {
+    setPrompt(value)
+    persistPrompt(value)
+    adjustHeight()
+  }
+  const restorePrompt = () => {
+    requestAnimationFrame(() => textareaRef?.focus({ preventScroll: true }))
+  }
+  const slash = useSlashCommand(
+    vscode,
+    { action: toggleSandbox, enabled: () => sandboxVisible() && sandbox() !== undefined && sandboxAvailable() },
+    () => {
+      const hidden = new Set<string>()
+      if (session.agents().length < 2) hidden.add("agents")
+      if (variants().length === 0) hidden.add("variant")
+      if (!sandboxVisible()) hidden.add("sandbox")
+      return hidden
+    },
+    WORKTREE_PROMPT_COMMANDS,
+  )
+  const onFocusPrompt = () => restorePrompt()
+  window.addEventListener("focusPrompt", onFocusPrompt)
+  onCleanup(() => window.removeEventListener("focusPrompt", onFocusPrompt))
 
   onMount(() => {
     setBranchesLoading(true)
@@ -385,6 +412,11 @@ export const NewWorktreeDialog: Component<{
   const onKey = (e: KeyboardEvent) => {
     if (shortcut.down(e)) {
       e.preventDefault()
+      e.stopPropagation()
+      return
+    }
+
+    if (slash.onKeyDown(e, textareaRef, setPromptValue, restorePrompt)) {
       e.stopPropagation()
       return
     }
@@ -583,6 +615,33 @@ export const NewWorktreeDialog: Component<{
               onDragLeave={imageAttach.handleDragLeave}
               onDrop={imageAttach.handleDrop}
             >
+              <Show when={slash.show()}>
+                <div class="slash-command-dropdown am-slash-command-dropdown" ref={slashDropdownRef}>
+                  <Show
+                    when={slash.results().length > 0}
+                    fallback={<div class="slash-command-empty">No commands found</div>}
+                  >
+                    <For each={slash.results()}>
+                      {(cmd, index) => (
+                        <div
+                          class="slash-command-item"
+                          classList={{ "slash-command-item--active": index() === slash.index() }}
+                          onMouseDown={(e) => {
+                            e.preventDefault()
+                            if (textareaRef) slash.select(cmd, textareaRef, setPromptValue, restorePrompt)
+                          }}
+                          onMouseEnter={() => slash.setIndex(index())}
+                        >
+                          <span class="slash-command-name">/{cmd.name}</span>
+                          <Show when={cmd.description}>
+                            <span class="slash-command-desc">{cmd.description}</span>
+                          </Show>
+                        </div>
+                      )}
+                    </For>
+                  </Show>
+                </div>
+              </Show>
               <Show when={imageAttach.images().length > 0}>
                 <div class="image-attachments">
                   <For each={imageAttach.images()}>
@@ -626,6 +685,7 @@ export const NewWorktreeDialog: Component<{
                       setPrompt(val)
                       persistPrompt(val)
                       adjustHeight()
+                      slash.onInput(val, e.currentTarget.selectionStart ?? val.length)
                     }}
                     onKeyDown={onKey}
                     onKeyUp={speechUp}
@@ -652,6 +712,8 @@ export const NewWorktreeDialog: Component<{
                       onSelect={(pid, mid) => {
                         if (pid && mid) setModel({ providerID: pid, modelID: mid })
                       }}
+                      onPick={restorePrompt}
+                      onCancel={restorePrompt}
                       placement="top-start"
                       portal={false}
                       deferDismiss

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2822,8 +2822,11 @@ body.am-wt-dragging-active * {
 /* While any inline (non-portaled) selector popover is open, let it escape the
    dialog's scroll containers. Covers model, thinking-variant, and mode pickers. */
 .am-nv-dialog .am-prompt-input-container:has([data-component="popover-content"]),
+.am-nv-dialog .am-prompt-input-container:has(.am-slash-command-dropdown),
 .am-nv-dialog-content:has([data-component="popover-content"]),
-[data-component="dialog"]:has(.am-nv-dialog [data-component="popover-content"]) [data-slot="dialog-body"] {
+.am-nv-dialog-content:has(.am-slash-command-dropdown),
+[data-component="dialog"]:has(.am-nv-dialog [data-component="popover-content"]) [data-slot="dialog-body"],
+[data-component="dialog"]:has(.am-nv-dialog .am-slash-command-dropdown) [data-slot="dialog-body"] {
   overflow: visible;
 }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2830,6 +2830,11 @@ body.am-wt-dragging-active * {
   overflow: visible;
 }
 
+.am-slash-command-dropdown {
+  min-width: 0;
+  max-width: none;
+}
+
 .am-nv-dialog .am-prompt-input-ghost-wrapper {
   height: 100%;
 }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModeSwitcher.tsx
@@ -39,6 +39,8 @@ export interface ModeSwitcherBaseProps {
   portal?: boolean
   /** Delay outside dismissal while the popover opens inside a dialog. */
   deferDismiss?: boolean
+  /** Only respond to picker events from this prompt scope. */
+  trigger?: string
 }
 
 export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
@@ -51,7 +53,9 @@ export const ModeSwitcherBase: Component<ModeSwitcherBaseProps> = (props) => {
   let slash = false
 
   // Listen for slash command trigger
-  const onTrigger = () => {
+  const onTrigger = (event: Event) => {
+    const source = (event as CustomEvent<{ source?: string }>).detail?.source
+    if (source !== props.trigger) return
     slash = true
     openSelected()
   }

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -134,6 +134,8 @@ export interface ModelSelectorBaseProps {
   label?: string
   /** Additional accessible context for this model setting. */
   description?: string
+  /** Only respond to picker events from this prompt scope. */
+  trigger?: string
 }
 
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
@@ -512,7 +514,11 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
 
   // Register before the popover mounts so programmatic slash-command opens
   // always restore the prompt before the popover's own Escape handler runs.
-  const onTrigger = () => setOpen(true)
+  const onTrigger = (event: Event) => {
+    const source = (event as CustomEvent<{ source?: string }>).detail?.source
+    if (source !== props.trigger) return
+    setOpen(true)
+  }
   const onEscape = (e: KeyboardEvent) => {
     if (!open() || e.key !== "Escape") return
     e.preventDefault()

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ThinkingSelector.tsx
@@ -41,6 +41,8 @@ export interface ThinkingSelectorBaseProps {
   deferDismiss?: boolean
   /** Listen for the global prompt trigger event. Defaults to true. */
   globalTrigger?: boolean
+  /** Only respond to picker events from this prompt scope. */
+  trigger?: string
   /** Show the Shift+Tab cycle hint in the trigger tooltip. */
   cycleHint?: boolean
   /** Accessible name for the selector trigger. */
@@ -85,7 +87,9 @@ export const ThinkingSelectorBase: Component<ThinkingSelectorBaseProps> = (props
     refocus()
   }
 
-  const onTrigger = () => {
+  const onTrigger = (event: Event) => {
+    const source = (event as CustomEvent<{ source?: string }>).detail?.source
+    if (source !== props.trigger) return
     if (rows().length === 0) return
     onOpen(true)
   }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -56,6 +56,7 @@ export function useSlashCommand(
   vscode: VSCodeContext,
   sandbox: { action: () => void; enabled: Accessor<boolean> },
   exclude?: Set<string> | Accessor<Set<string>>,
+  include?: Set<string> | Accessor<Set<string>>,
 ): SlashCommand {
   const [server, setServer] = createSignal<SlashCommandInfo[]>([])
   const [query, setQuery] = createSignal<string | null>(null)
@@ -83,7 +84,7 @@ export function useSlashCommand(
     {
       name: "models",
       description: "Switch the AI model",
-      hints: [],
+      hints: ["model"],
       action: () => {
         window.dispatchEvent(new CustomEvent("openModelPicker"))
       },
@@ -192,17 +193,23 @@ export function useSlashCommand(
     return exclude
   }
 
+  const included = () => {
+    if (typeof include === "function") return include()
+    return include
+  }
+
   const client = () => {
     const set = excluded()
-    if (!set) return all
-    return all.filter((c) => !set.has(c.name))
+    const only = included()
+    return all.filter((c) => !set?.has(c.name) && (!only || only.has(c.name)))
   }
 
   const commands = (): SlashCommandEntry[] => {
     const list = client()
     const names = new Set(list.map((c) => c.name))
     const set = excluded()
-    const filtered = server().filter((c) => !names.has(c.name) && !set?.has(c.name))
+    const only = included()
+    const filtered = server().filter((c) => !names.has(c.name) && !set?.has(c.name) && (!only || only.has(c.name)))
     return [...list, ...filtered]
   }
 

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -57,11 +57,15 @@ export function useSlashCommand(
   sandbox: { action: () => void; enabled: Accessor<boolean> },
   exclude?: Set<string> | Accessor<Set<string>>,
   include?: Set<string> | Accessor<Set<string>>,
+  scope?: string,
 ): SlashCommand {
   const [server, setServer] = createSignal<SlashCommandInfo[]>([])
   const [query, setQuery] = createSignal<string | null>(null)
   const [index, setIndex] = createSignal(0)
   const [requested, setRequested] = createSignal(false)
+  const open = (name: string) => {
+    window.dispatchEvent(new CustomEvent(name, { detail: { source: scope } }))
+  }
 
   const all: SlashCommandEntry[] = [
     {
@@ -86,7 +90,7 @@ export function useSlashCommand(
       description: "Switch the AI model",
       hints: ["model"],
       action: () => {
-        window.dispatchEvent(new CustomEvent("openModelPicker"))
+        open("openModelPicker")
       },
     },
     {
@@ -94,7 +98,7 @@ export function useSlashCommand(
       description: "Switch the agent mode",
       hints: ["modes"],
       action: () => {
-        window.dispatchEvent(new CustomEvent("openModePicker"))
+        open("openModePicker")
       },
     },
     {
@@ -102,7 +106,7 @@ export function useSlashCommand(
       description: "Switch the reasoning effort",
       hints: ["variants", "reasoning", "thinking"],
       action: () => {
-        window.dispatchEvent(new CustomEvent("openVariantPicker"))
+        open("openVariantPicker")
       },
     },
     {


### PR DESCRIPTION
The Agent Manager New Worktree dialog uses a separate prompt input from normal session chats, which made model and variant selection require mouse interaction through the controls below the prompt.

This adds the relevant configuration slash commands to the worktree prompt: `/models` and `/model`, `/agents` and `/modes`, `/variant` and its reasoning aliases, and `/sandbox` when available. The menu uses the normal keyboard navigation behavior, opens the existing selectors, restores prompt focus after selection or cancellation, and excludes session-only commands such as merge.

<img width="900" alt="Agent Manager worktree slash command menu" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260804-agent-manager-worktree-slash-commands.png?raw=true" />
