### PR TITLE
fix(jetbrains): avoid CLI checksum API rate limits

### DIFF
--- a/.changeset/jetbrains-cli-checksums.md
+++ b/.changeset/jetbrains-cli-checksums.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Avoid GitHub API rate-limit failures when the JetBrains plugin downloads the pinned Kilo CLI.

--- a/packages/kilo-jetbrains/backend/build.gradle.kts
+++ b/packages/kilo-jetbrains/backend/build.gradle.kts
@@ -20,9 +20,11 @@ val rawSpec = layout.buildDirectory.file("generated/openapi-spec/openapi.raw.jso
 val generatedSpec = layout.buildDirectory.file("generated/openapi-spec/openapi.json")
 val generatedProps = layout.buildDirectory.dir("generated/kilo-props")
 val generatedCli = layout.buildDirectory.dir("generated/kilo-cli-res")
+val generatedChecksums = layout.buildDirectory.dir("generated/kilo-cli-checksums")
 val pinned = providers.gradleProperty("kilo.cli.pinned").map { it.trim().toBoolean() }.orElse(true)
 val repoCli = pinned.map { !it }
 val bundled = providers.gradleProperty("kilo.cli.bundled").map { it.trim().toBoolean() }.orElse(false)
+val downloadsCli = repoCli.zip(bundled) { repo, bundle -> !repo && !bundle }
 val repoRootDir = rootProject.layout.projectDirectory.dir("../opencode")
 
 val pinnedCliVersion = providers.fileContents(rootProject.layout.projectDirectory.file("package.json")).asText.map { text ->
@@ -33,6 +35,7 @@ val pinnedCliVersion = providers.fileContents(rootProject.layout.projectDirector
 sourceSets {
     main {
         resources.srcDir(generatedProps)
+        if (downloadsCli.get()) resources.srcDir(generatedChecksums)
         if (repoCli.get() || bundled.get()) resources.srcDir(generatedCli)
         kotlin.srcDir(generatedApi)
     }
@@ -104,6 +107,16 @@ val stageBundledCli by tasks.registering(StageBundledCliTask::class) {
     archive.set(generatedCli.map { it.file("kilo-cli.zip") })
 }
 
+val writeCliChecksums by tasks.registering(WriteCliChecksumsTask::class) {
+    description = "Write pinned Kilo CLI checksums"
+    cliVersion.set(pinnedCliVersion)
+    token.set(
+        providers.environmentVariable("GH_TOKEN")
+            .orElse(providers.environmentVariable("GITHUB_TOKEN"))
+    )
+    checksums.set(generatedChecksums.map { it.file("kilo-cli-checksums.properties") })
+}
+
 val normalizeOpenApiSpec by tasks.registering(NormalizeOpenApiSpecTask::class) {
     description = "Normalize upstream CLI OpenAPI metadata before Kotlin client generation"
     dependsOn(generateOpenApiSpec)
@@ -158,6 +171,7 @@ val fixGeneratedApi by tasks.registering(FixGeneratedApiTask::class) {
 
 tasks.named("compileKotlin") {
     dependsOn(fixGeneratedApi, writeKiloProperties)
+    if (downloadsCli.get()) dependsOn(writeCliChecksums)
     if (repoCli.get()) dependsOn(stageRepoCli)
     if (bundled.get()) dependsOn(stageBundledCli)
     inputs.dir(generatedApi)
@@ -165,6 +179,7 @@ tasks.named("compileKotlin") {
 
 tasks.named("processResources") {
     dependsOn(writeKiloProperties)
+    if (downloadsCli.get()) dependsOn(writeCliChecksums)
     if (repoCli.get()) dependsOn(stageRepoCli)
     if (bundled.get()) dependsOn(stageBundledCli)
 }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliChecksums.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliChecksums.kt
@@ -1,0 +1,19 @@
+package ai.kilocode.backend.cli
+
+import java.util.Properties
+
+object KiloCliChecksums {
+    private const val RESOURCE = "kilo-cli-checksums.properties"
+
+    private val values by lazy {
+        val stream = KiloCliChecksums::class.java.classLoader.getResourceAsStream(RESOURCE)
+            ?: return@lazy emptyMap()
+        stream.use {
+            Properties().apply { load(it) }
+                .entries
+                .associate { item -> item.key.toString() to item.value.toString() }
+        }
+    }
+
+    fun load(): Map<String, String> = values
+}

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDownloader.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDownloader.kt
@@ -35,6 +35,7 @@ class KiloCliDownloader(
     private val root: File = File(PathManager.getSystemPath(), "kilo/cli"),
     private val baseUrl: String = "https://github.com/Kilo-Org/kilocode/releases/download",
     private val api: String = "https://api.github.com/repos/Kilo-Org/kilocode/releases/tags",
+    private val digests: Map<String, String> = KiloCliChecksums.load(),
     private val lockTimeoutMs: Long = LOCK_TIMEOUT_MS,
 ) {
     companion object {
@@ -64,7 +65,7 @@ class KiloCliDownloader(
                     cached(version, platform, exe, done)?.let { return@locked it }
                 }
 
-                val digest = asset(version, platform, ext)
+                val digest = digest(version, platform, ext)
                 val stage = stage(version, platform)
                 try {
                     val archive = File(stage, "kilo-$platform.$ext")
@@ -196,6 +197,17 @@ class KiloCliDownloader(
     private fun fail(message: String): Nothing {
         log.warn(message)
         throw IllegalStateException(message)
+    }
+
+    private fun digest(version: String, platform: String, ext: String): String {
+        val digest = digests[platform]
+        if (digest == null) return asset(version, platform, ext)
+        if (digest.matches(DIGEST)) {
+            log.info("Using bundled Kilo CLI checksum for $version $platform")
+            return digest
+        }
+        log.warn("Ignoring malformed bundled Kilo CLI checksum for $platform: $digest")
+        return asset(version, platform, ext)
     }
 
     private fun asset(version: String, platform: String, ext: String): String {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliPlatform.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliPlatform.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.system.CpuArch
 
 internal object KiloCliPlatform {
+    // Keep supported OS/architecture pairs in sync with Gradle CLI staging task platform lists.
     fun current(): String {
         val os = when {
             SystemInfo.isMac -> "darwin"

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
@@ -119,6 +119,33 @@ class KiloCliDownloaderTest {
     }
 
     @Test
+    fun `falls back to github metadata when bundled checksum is malformed`() = runBlocking {
+        MockWebServer().use { server ->
+            val bytes = archive()
+            server.enqueue(metadata(bytes))
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
+            val log = TestLog()
+
+            val cli = KiloCliDownloader(
+                log = log,
+                root = dir,
+                baseUrl = server.url("/release").toString(),
+                api = server.url("/api").toString(),
+                digests = mapOf(KiloCliPlatform.current() to "not-a-digest"),
+            ).resolve("1.2.3")
+
+            assertTrue(cli.isFile)
+            assertContains(
+                log.messages,
+                "WARN: Ignoring malformed bundled Kilo CLI checksum for ${KiloCliPlatform.current()}: not-a-digest"
+            )
+            assertEquals("/api/v1.2.3", server.takeRequest().path)
+            assertEquals("/release/v1.2.3/kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}", server.takeRequest().path)
+            assertEquals(2, server.requestCount)
+        }
+    }
+
+    @Test
     fun `prunes stale versions and removes the extracted archive`() = runBlocking {
         MockWebServer().use { server ->
             val stale = File(File(dir, "0.0.1"), KiloCliPlatform.current())

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
@@ -30,8 +30,8 @@ class KiloCliDownloaderTest {
     fun `downloads extracts and caches pinned cli`() = runBlocking {
         MockWebServer().use { server ->
             val bytes = archive()
-            server.enqueue(metadata(bytes))
             server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
+            val digests = digests(bytes)
             val seen = mutableListOf<CliDownload>()
             val log = TestLog()
             val cli = KiloCliDownloader(
@@ -39,13 +39,13 @@ class KiloCliDownloaderTest {
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = digests,
             ).resolve("1.2.3", onProgress = { seen.add(it) })
 
             assertTrue(cli.isFile)
             assertEquals(File(File(dir, "1.2.3"), KiloCliPlatform.current()).absolutePath, cli.parentFile.parentFile.absolutePath)
             assertEquals("#!/bin/sh\n", cli.readText())
             assertTrue(File(cli.parentFile, "kilo-sandbox-mutation-worker.js").isFile)
-            assertEquals("/api/v1.2.3", server.takeRequest().path)
             assertEquals("/release/v1.2.3/kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}", server.takeRequest().path)
             assertEquals(CliDownload(0, "1.2.3", KiloCliPlatform.current()), seen.first())
             assertTrue(seen.any { it.percent == 100 && it.version == "1.2.3" && it.platform == KiloCliPlatform.current() })
@@ -65,34 +65,56 @@ class KiloCliDownloaderTest {
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = digests,
             ).resolve("1.2.3", onProgress = { cachedProgress.add(it) })
             assertEquals(cli.absolutePath, cached.absolutePath)
-            assertEquals(2, server.requestCount)
+            assertEquals(1, server.requestCount)
             assertTrue(cachedProgress.isEmpty())
             assertContains(log.messages, "INFO: Using cached Kilo CLI 1.2.3 for ${KiloCliPlatform.current()} at ${cli.absolutePath}")
 
             File(cli.parentFile.parentFile, ".complete").writeText("ok\n")
-            server.enqueue(metadata(bytes))
             server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
             val stale = KiloCliDownloader(
                 log = log,
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = digests,
             ).resolve("1.2.3")
             assertEquals(cli.absolutePath, stale.absolutePath)
-            assertEquals(4, server.requestCount)
+            assertEquals(2, server.requestCount)
 
-            server.enqueue(metadata(bytes))
             server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
             val forced = KiloCliDownloader(
                 log = log,
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = digests,
             ).resolve("1.2.3", force = true)
             assertEquals(cli.absolutePath, forced.absolutePath)
-            assertEquals(6, server.requestCount)
+            assertEquals(3, server.requestCount)
+        }
+    }
+
+    @Test
+    fun `falls back to github metadata when bundled checksum is missing`() = runBlocking {
+        MockWebServer().use { server ->
+            val bytes = archive()
+            server.enqueue(metadata(bytes))
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
+
+            val cli = KiloCliDownloader(
+                root = dir,
+                baseUrl = server.url("/release").toString(),
+                api = server.url("/api").toString(),
+                digests = mapOf("other" to "sha256:${"a".repeat(64)}"),
+            ).resolve("1.2.3")
+
+            assertTrue(cli.isFile)
+            assertEquals("/api/v1.2.3", server.takeRequest().path)
+            assertEquals("/release/v1.2.3/kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}", server.takeRequest().path)
+            assertEquals(2, server.requestCount)
         }
     }
 
@@ -110,6 +132,7 @@ class KiloCliDownloaderTest {
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = emptyMap(),
             ).resolve("1.2.3")
 
             assertTrue(cli.isFile)
@@ -132,6 +155,7 @@ class KiloCliDownloaderTest {
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = emptyMap(),
             )
             val old = cli.resolve("1.2.3")
             assertEquals("#!/bin/old\n", old.readText())
@@ -158,12 +182,14 @@ class KiloCliDownloaderTest {
                 root = dir,
                 baseUrl = server.url("/release").toString(),
                 api = server.url("/api").toString(),
+                digests = emptyMap(),
             ).resolve("1.2.3")
             val ex = assertFailsWith<IllegalStateException> {
                 KiloCliDownloader(
                     root = dir,
                     baseUrl = server.url("/release").toString(),
                     api = server.url("/api").toString(),
+                    digests = emptyMap(),
                 ).resolve("1.2.3", force = true)
             }
 
@@ -186,10 +212,33 @@ class KiloCliDownloaderTest {
                     root = dir,
                     baseUrl = server.url("/release").toString(),
                     api = server.url("/api").toString(),
+                    digests = emptyMap(),
                 ).resolve("1.2.3")
             }
 
             assertContains(ex.message.orEmpty(), "digest mismatch")
+            assertFalse(File(File(File(dir, "1.2.3"), KiloCliPlatform.current()), ".complete").exists())
+        }
+    }
+
+    @Test
+    fun `rejects cli archive with mismatched bundled checksum without fetching metadata`() = runBlocking {
+        MockWebServer().use { server ->
+            val bytes = archive()
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
+
+            val ex = assertFailsWith<IllegalStateException> {
+                KiloCliDownloader(
+                    root = dir,
+                    baseUrl = server.url("/release").toString(),
+                    api = server.url("/api").toString(),
+                    digests = mapOf(KiloCliPlatform.current() to "sha256:${sha256("different".toByteArray())}"),
+                ).resolve("1.2.3")
+            }
+
+            assertContains(ex.message.orEmpty(), "digest mismatch")
+            assertEquals("/release/v1.2.3/kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}", server.takeRequest().path)
+            assertEquals(1, server.requestCount)
             assertFalse(File(File(File(dir, "1.2.3"), KiloCliPlatform.current()), ".complete").exists())
         }
     }
@@ -209,6 +258,7 @@ class KiloCliDownloaderTest {
                     root = dir,
                     baseUrl = server.url("/release").toString(),
                     api = server.url("/api").toString(),
+                    digests = emptyMap(),
                 ).resolve("1.2.3")
             }
             val name = "kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}"
@@ -233,6 +283,7 @@ class KiloCliDownloaderTest {
                     root = dir,
                     baseUrl = server.url("/release").toString(),
                     api = server.url("/api").toString(),
+                    digests = emptyMap(),
                 ).resolve("1.2.3")
             }
             assertContains(ex.message.orEmpty(), "has no digest yet")
@@ -261,6 +312,7 @@ class KiloCliDownloaderTest {
                     root = dir,
                     baseUrl = server.url("/release").toString(),
                     api = server.url("/api").toString(),
+                    digests = emptyMap(),
                 ).resolve("1.2.3")
             }
 
@@ -284,6 +336,7 @@ class KiloCliDownloaderTest {
                     KiloCliDownloader(
                         log = log,
                         root = dir,
+                        digests = emptyMap(),
                         lockTimeoutMs = 50,
                     ).resolve("1.2.3")
                 }
@@ -306,6 +359,8 @@ class KiloCliDownloaderTest {
     }
 
     private fun metadata(bytes: ByteArray) = metadata("sha256:${sha256(bytes)}")
+
+    private fun digests(bytes: ByteArray) = mapOf(KiloCliPlatform.current() to "sha256:${sha256(bytes)}")
 
     private fun metadata(digest: String) = MockResponse().setResponseCode(200).setBody(
         """{"assets":[{"name":"kilo-${KiloCliPlatform.current()}.${KiloCliPlatform.archive()}","digest":"$digest"}]}"""

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/BuildTasksPlugin.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/BuildTasksPlugin.kt
@@ -7,8 +7,8 @@ import org.gradle.api.Project
  * `id("build-tasks")` resolves in `backend/build.gradle.kts`.
  *
  * The real value lives in the custom task classes this composite build
- * provides: [NormalizeOpenApiSpecTask], [FixGeneratedApiTask], and
- * [GenerateOpenApiSpecTask].
+ * provides: [NormalizeOpenApiSpecTask], [FixGeneratedApiTask],
+ * [GenerateOpenApiSpecTask], and [WriteCliChecksumsTask].
  */
 class BuildTasksPlugin : Plugin<Project> {
     override fun apply(target: Project) {}

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/WriteCliChecksumsTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/WriteCliChecksumsTask.kt
@@ -20,6 +20,7 @@ abstract class WriteCliChecksumsTask : DefaultTask() {
         private val DIGEST = Regex("^sha256:[a-f0-9]{64}$")
         private val JSON = Json { ignoreUnknownKeys = true }
         private const val API = "https://api.github.com/repos/Kilo-Org/kilocode/releases/tags"
+        // Keep in sync with KiloCliPlatform.current() and StageBundledCliTask.PLATFORMS.
         private val PLATFORMS = listOf(
             "darwin-arm64",
             "darwin-x64",

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/WriteCliChecksumsTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/WriteCliChecksumsTask.kt
@@ -1,0 +1,127 @@
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.net.HttpURLConnection
+import java.net.URI
+import java.time.Instant
+
+abstract class WriteCliChecksumsTask : DefaultTask() {
+    companion object {
+        private val DIGEST = Regex("^sha256:[a-f0-9]{64}$")
+        private val JSON = Json { ignoreUnknownKeys = true }
+        private const val API = "https://api.github.com/repos/Kilo-Org/kilocode/releases/tags"
+        private val PLATFORMS = listOf(
+            "darwin-arm64",
+            "darwin-x64",
+            "linux-arm64",
+            "linux-x64",
+            "windows-arm64",
+            "windows-x64",
+        )
+    }
+
+    @get:Input
+    abstract val cliVersion: Property<String>
+
+    @get:Internal
+    abstract val token: Property<String>
+
+    @get:OutputFile
+    abstract val checksums: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val ver = cliVersion.get()
+        val assets = assets(ver)
+        val values = PLATFORMS.associateWith { platform ->
+            val name = "kilo-$platform.${ext(platform)}"
+            assets[name] ?: throw GradleException("Kilo CLI release $ver did not include $name")
+        }
+
+        val out = checksums.get().asFile
+        out.parentFile.mkdirs()
+        out.writeText(
+            values.entries
+                .sortedBy { it.key }
+                .joinToString(separator = "\n", postfix = "\n") { item -> "${item.key}=${item.value}" }
+        )
+    }
+
+    private fun assets(ver: String): Map<String, String> {
+        val url = "$API/v$ver"
+        logger.lifecycle("Fetching pinned Kilo CLI release checksums from $url")
+        val conn = connect(url)
+        try {
+            val code = conn.responseCode
+            if (code !in 200..299) fail(conn, code, "Failed to fetch pinned Kilo CLI release checksums")
+            val body = conn.inputStream.bufferedReader().use { it.readText() }
+            return JSON.parseToJsonElement(body).jsonObject["assets"]?.jsonArray
+                ?.associate { item ->
+                    val obj = item.jsonObject
+                    val name = obj["name"]?.jsonPrimitive?.contentOrNull
+                    val digest = obj["digest"]?.jsonPrimitive?.contentOrNull
+                    if (name.isNullOrBlank() || digest.isNullOrBlank()) return@associate "" to ""
+                    name to digest
+                }
+                ?.filter { it.key.isNotEmpty() }
+                ?.mapValues { item ->
+                    val digest = item.value
+                    if (!digest.matches(DIGEST)) {
+                        throw GradleException("Pinned Kilo CLI release $ver asset ${item.key} has invalid digest")
+                    }
+                    digest
+                }
+                ?: emptyMap()
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun connect(url: String): HttpURLConnection {
+        val conn = URI(url).toURL().openConnection() as HttpURLConnection
+        conn.connectTimeout = 30_000
+        conn.readTimeout = 120_000
+        conn.instanceFollowRedirects = true
+        conn.setRequestProperty("Accept", "application/vnd.github+json")
+        token.getOrNull()
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { conn.setRequestProperty("Authorization", "Bearer $it") }
+        return conn
+    }
+
+    private fun fail(conn: HttpURLConnection, code: Int, msg: String): Nothing {
+        val info = rate(conn)
+        val body = runCatching { conn.errorStream?.bufferedReader()?.use { it.readText() } }
+            .getOrNull()
+            ?.take(500)
+        val detail = if (body.isNullOrBlank()) "" else ": $body"
+        if (limited(conn, code)) {
+            throw GradleException("GitHub API rate limit exceeded while fetching Kilo CLI checksums ($info)$detail")
+        }
+        throw GradleException("$msg: HTTP $code from ${conn.url} ($info)$detail")
+    }
+
+    private fun rate(conn: HttpURLConnection): String {
+        val reset = conn.getHeaderField("X-RateLimit-Reset")
+            ?.toLongOrNull()
+            ?.let { Instant.ofEpochSecond(it).toString() }
+        return "limit=${conn.getHeaderField("X-RateLimit-Limit")} remaining=${conn.getHeaderField("X-RateLimit-Remaining")} " +
+            "used=${conn.getHeaderField("X-RateLimit-Used")} reset=$reset retryAfter=${conn.getHeaderField("Retry-After")}"
+    }
+
+    private fun limited(conn: HttpURLConnection, code: Int) =
+        code == 429 || (code == 403 && conn.getHeaderField("X-RateLimit-Remaining") == "0")
+
+    private fun ext(platform: String) = if (platform.startsWith("linux-")) "tar.gz" else "zip"
+}


### PR DESCRIPTION
## Issue

No linked issue; this fixes a support-reported JetBrains plugin startup failure where shared/NAT IPs exhaust GitHub's unauthenticated API rate limit while resolving the pinned Kilo CLI checksum.

## Context

The JetBrains plugin downloads the pinned CLI from GitHub Releases on first connect. The binary download itself is CDN-backed, but the plugin made a separate unauthenticated `api.github.com` release metadata call to read the asset SHA-256 digest before verification. Corporate/shared egress IPs can hit GitHub's 60 requests/hour unauthenticated API limit, blocking fresh installs and updates.

## Implementation

- Generate a bundled `kilo-cli-checksums.properties` resource at build time for pinned, non-bundled JetBrains builds.
- Use the build-time GitHub metadata call with `GH_TOKEN`/`GITHUB_TOKEN` support to collect all platform asset digests.
- Load bundled checksums at runtime and verify downloaded archives against them without calling `api.github.com`.
- Keep the existing metadata lookup as a fallback if a platform checksum is missing or malformed.
- Cover the bundled-checksum, fallback, and mismatch paths in `KiloCliDownloaderTest`.

## Screenshots / Video

N/A - backend download/build behavior only.

## How to Test

### Manual/local verification

- Agent ran `./gradlew :backend:test --tests ai.kilocode.backend.cli.KiloCliDownloaderTest` from `packages/kilo-jetbrains/`.
- Agent ran `./gradlew typecheck` from `packages/kilo-jetbrains/`.

### Reviewer test steps

1. From `packages/kilo-jetbrains/`, run `./gradlew :backend:test --tests ai.kilocode.backend.cli.KiloCliDownloaderTest`.
2. From `packages/kilo-jetbrains/`, run `./gradlew typecheck`.
3. Inspect a pinned, non-bundled backend build and confirm `kilo-cli-checksums.properties` is included in backend resources.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A
