### PR TITLE
docs: add v1.17.13 merge review reports

### DIFF
--- a/BROKEN_PIPELINE_CHAINS.md
+++ b/BROKEN_PIPELINE_CHAINS.md
@@ -1,0 +1,93 @@
+# Broken Pipeline Chains
+
+## Scope And Methodology
+
+- Reviewed PR #12695 at exact head `054ee594915b93546d0613a45e0671edd43905ee` against base and merge-base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`. The range contains 1,237 changed files, 101,898 insertions, and 41,085 deletions.
+- Read root `AGENTS.md`, `REVIEW.md`, `packages/opencode/AGENTS.md`, `packages/core/src/tool/AGENTS.md`, `packages/schema/AGENTS.md`, `packages/opencode/src/session/llm/AGENTS.md`, server/test package instructions, `packages/kilo-vscode/AGENTS.md`, `kilo-steer`, and merge-review/merge-minimizer guidance.
+- Enumerated marker changes with the full base-to-head diff, not only head grep results. `git diff -G'kilocode_change'` identified 175 touched files and 659 changed marker lines: 381 additions and 278 deletions. Across all 1,237 changed paths, base contained 3,311 marker occurrences in 265 files and head contains 3,416 in 301 files. Repository-wide non-Markdown totals are 5,750 at base and 5,853 at head. Deleted/moved marker regions were included through `git diff` and base-side `git grep`.
+- Grouped the changed marker regions into behavior chains, then followed Kilo introduction points through schema/type/config/state, event storage and projection, route assembly, IPC/SSE, OpenAPI/SDK, and final CLI/TUI/VS Code consumers. The principal groups were: durable/session events and legacy projection; production listener/API/SDK composition; config hot reload; question localization/blocking and permission interactivity; editor context; worktree/session metadata; interactive terminal and PTY association; plugin/provider/auth bootstrap; tool registry/sandbox/network policy; snapshot/revert/compaction compatibility; CLI/TUI lifecycle and auto-approval; and UI branding/rendering.
+- Compared base and head definitions, registrations, senders/receivers, and generated boundaries. Passing compilation or generated SDK presence was not treated as behavioral proof. Targeted tests and direct schema/manifest probes were run where practical.
+
+## Findings
+
+### P1 High: the native `/api/event` stream terminates on normal Kilo/legacy events
+
+**Broken links:** `packages/server/src/handlers/event.ts:2,11-17,30-36`; contract mismatch introduced at `packages/opencode/src/server/routes/instance/httpapi/api.ts:70-74`; omitted definitions are selected at `packages/protocol/src/groups/event.ts:52-55` and `packages/schema/src/event-manifest.ts:57-61,63-82`.
+
+**Expected chain:** a producer such as `packages/opencode/src/session/status.ts:39-44` publishes `SessionStatusEvent.Status` through the shared `EventV2Bridge` -> `EventManifest.Latest` contains `session.status` -> Kilo constructs `ServerApi` with all `EventManifest.Latest` definitions -> `EventHandler` subscribes to the shared `EventV2` bus -> the handler encodes against the same API-specific event union -> SSE -> generated SDK Next/client consumers receive the event.
+
+**Actual head chain and silent failure:** Kilo correctly builds `ServerApi` with 89 latest definitions, but the moved shared handler hard-codes `OpenCodeEvent`, whose schema is built from only 58 `ServerDefinitions`. Thirty-one events emitted by this Kilo listener are excluded, including `session.status`, `session.error`, `permission.asked`, `question.asked`, `global.config.updated`, and `global.disposed`. `Schema.encodeUnknownSync(OpenCodeEvent)` throws inside `Stream.map` when the first omitted event arrives, terminating the SSE response after it opened successfully. This is a common server event: `SessionStatus.set` emits `session.status` on busy/idle transitions. A generated current-API client can therefore connect successfully and then lose the stream during an ordinary session turn. Kilo's shipped legacy global SSE path is separate and was not shown to fail from this mismatch.
+
+**Base/head evidence:** base `packages/server/src/handlers/event.ts` serialized `JSON.stringify(data)` without narrowing the event union and filtered/resolved location before forwarding. Head changed this to `Schema.encodeUnknownSync(OpenCodeEvent)` while Kilo's API assembly changed independently to `makeApi({ definitions: EventManifest.Latest.values().toArray() })`. The direct probe returned:
+
+```text
+session.status REJECTED SchemaError(Expected V2Event, got {"id":"evt_status","type":"session.status","data":{"sessionID":"ses_test","status":{"type":"idle"}}})
+global.config.updated REJECTED SchemaError(Expected V2Event, got {"id":"evt_cfg","type":"global.config.updated","data":{}})
+```
+
+The manifest probe returned `latest: 89`, `server: 58`, `omitted: 31`; a second control confirmed `session.status` is present in `Latest`, absent from `ServerDefinitions`, and rejected by the encoder. Existing `httpapi-v2-location.test.ts` now positively expects cross-location native events, and its targeted suite passes, but it only emits `session.created`, which belongs to both unions, so it does not exercise the broken branch.
+
+**Repair/verification direction:** make the handler encoder derive from the same definitions used to construct its `Api` (for example, an API-specific handler factory or injected event schema), or retain a schema that covers `EventManifest.Latest` for the Kilo assembly. Add a production-listener test that opens `/api/event`, causes actual `session.status`, `permission.asked`, and `global.config.updated` emissions, asserts the stream remains open, and verifies generated SDK decoding. Also decide and test the intended cross-location policy separately; the merge deliberately removed base's subscriber-location filtering.
+
+### P2 Medium: released `session.next.prompt.promoted.1` rows are no longer readable or replayable
+
+**Broken links:** removed durable definition between base `packages/core/src/session/event.ts` and head `packages/schema/src/session-event.ts:445-478`; absent from `packages/schema/src/durable-event-manifest.ts:7-15`; hard failure at `packages/core/src/event.ts:51-60,544-565`; silent omission at `packages/core/src/event.ts:64-109`; downstream compatibility comment without decoder at `packages/opencode/src/kilocode/plugins/sync-v2.tsx:162-165`.
+
+**Expected chain:** released base writes `session.next.prompt.promoted.1` into `event` -> durable manifest retains a decoder for the released key -> SQL durable stream/history or workspace `/sync/history` reads it -> decoder maps it to a current prompt-visible event or a retained compatibility event -> projector marks the admitted input promoted and materializes the user message -> sync/TUI consumers display it -> replay into another workspace remains contiguous and succeeds.
+
+**Actual head chain and silent failure:** base explicitly defined `PromptLifecycle.Promoted`, included it in durable definitions, generated it into OpenAPI/SDK, projected it into a user message, and persisted it as version 1. Head removes the definition and every generated type, with only a comment saying new promotion now emits `session.next.prompted`. No migration or storage decoder maps already-persisted `session.next.prompt.promoted.1` rows. Consequently:
+
+- `EventV2.durable()` reads raw rows and `decodeSerializedEvent` throws `Unknown durable event type session.next.prompt.promoted.1`, terminating `/api/session/{id}/event` and any in-process durable subscriber when that historical row is reached.
+- `EventV2.readAggregate()` uses `inArray(EventTable.type, SessionDurable.definitions.keys())`; the removed row is silently filtered out of `/api/session/{id}/history`. Pagination can therefore omit the promotion while advancing around later rows.
+- `/sync/history` still sends raw rows, and `/sync/replay` calls `replayAll`; replay defects on the unknown type, so moving/warping a released session across Kilo workspaces can fail despite current event tests being green.
+
+**Base/head evidence:** base grep found the definition, projector/message-updater cases, SDK/OpenAPI variants, and TUI consumers. Head grep finds only the explanatory comment. A manifest probe at head returned:
+
+```json
+{"global":false,"session":false}
+```
+
+for `Durable.has("session.next.prompt.promoted.1")` and `SessionDurable.definitions.has(...)`. Head's event tests explicitly assert unknown replay types defect, confirming the failure mode rather than providing fallback behavior. The existing `event-storage-compat` tests cover released tool-content shapes but not removed durable event keys.
+
+**Repair/verification direction:** retain a storage/replay-only compatibility definition for `session.next.prompt.promoted.1` and translate its payload (`timeCreated`) to the current `Prompted` semantics (`timestamp`, `delivery`) before projection, without re-exposing an obsolete current producer unless required. Alternatively migrate every persisted row atomically and idempotently before any reader starts. Add old-database controls for `durable()`, finite `history()`, `/sync/history -> /sync/replay`, and old -> head -> old behavior.
+
+## Notable Non-Findings
+
+- **Question and permission chain preserved:** `labelKey`, `descriptionKey`, `mode`, `questionKey`, `headerKey`, and `blocking` moved to `packages/schema/src/v1/question.ts`, survive OpenAPI and generated SDK, pass through `Question.ask`, and are consumed by TUI and VS Code. The `interactive` permission flag is present in schema, route payload, handler, ACP/TUI/direct-mode/VS Code senders, and the skill-shell human-only guard.
+- **Editor context chain preserved:** VS Code gathers and sends `editorContext`; generated request types include it; prompt input persists it on user messages; compaction retains it; system/environment prompt consumers read it.
+- **Config hot-reload chain preserved on the legacy global stream:** config/TUI writers emit `global.config.updated` through `GlobalBus`; TUI and VS Code receive and refetch config. The event is also in the generated manifest. This does not mitigate finding 1 for the new `/api/event` route.
+- **Interactive terminal and PTY chain preserved:** tool registration and primary-agent gating, session association, events, typed routes, handlers, OpenAPI/SDK, TUI/direct-mode state reducers, and write/resize/close consumers are all present at head.
+- **Worktree labels and session search preserved:** experimental session listing sets `worktreeName`; schema/OpenAPI/SDK retain it; TUI and VS Code search/display consumers read it.
+- **Compaction/tool storage compatibility preserved:** current writers retain released `include` and stored tool-content shapes, with SQL-boundary codecs and targeted compatibility tests.
+- **Production listener service graph repaired:** Kilo listener composition now provides the moved location/session middleware, `SessionV2`, local execution, `MoveSession`, and shared app services. The route graph itself is present; finding 1 is a handler-schema mismatch after route construction.
+- **Plugin/bootstrap registration preserved:** the removed `PluginBoot` marker migrated to `PluginInternal`, which remains included via location services. The Kilo rule suppressing redundant `customize-opencode` registration remains in the internal boot sequence, while Kilo provider hooks and Kilo bootstrap/tool registries remain reachable.
+
+## Command Results
+
+```text
+$ git rev-parse HEAD
+054ee594915b93546d0613a45e0671edd43905ee
+$ git merge-base 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee
+0b8f749ae13388cf7a38ea7fb9183acaac99eef8
+$ git diff --shortstat BASE..HEAD
+1237 files changed, 101898 insertions(+), 41085 deletions(-)
+$ marker diff counts
+659 changed marker lines; 381 added; 278 removed; 175 files matched -G
+$ changed-path marker inventory
+base: 3311 occurrences / 265 files; head: 3416 occurrences / 301 files
+```
+
+```text
+$ bun test test/event-manifest.test.ts test/kilocode/sync-event-encoding.test.ts test/server/httpapi-v2-location.test.ts  # packages/opencode
+10 pass; 0 fail; 35 expect() calls; 3 files; 3.55s
+$ bun test test/kilocode/event-storage-compat.test.ts test/session-history.test.ts  # packages/core
+9 pass; 0 fail; 23 expect() calls; 2 files; 657ms
+```
+
+The passing tests are controls and demonstrate why compilation/CI remains green; none injects an omitted Kilo event through `packages/server/src/handlers/event.ts`, and none seeds a released `session.next.prompt.promoted.1` row.
+
+## Limitations
+
+- This was a focused broken-chain audit, not a full verdict on all 1,237 files. Marker occurrences were exhaustively enumerated and grouped, but the report intentionally omits a per-file/per-marker checklist.
+- No real user database, credentials, remote workspace, browser, VS Code host, or production server was used. The durable-row finding is static proof plus manifest/runtime probes; a disposable old-version database smoke test remains advisable.
+- The worktree initially contained unrelated untracked `vscode-self-test.config.json`; parallel reviewer reports appeared while this audit was running. None was read, changed, or removed. This audit wrote only this report. No commit, push, or GitHub mutation was performed.

--- a/CONFIG_REGRESSION.md
+++ b/CONFIG_REGRESSION.md
@@ -1,0 +1,44 @@
+# Config Regression Audit
+
+## Scope and methodology
+
+Reviewed PR #12695 at head `054ee594915b93546d0613a45e0671edd43905ee` against base/merge-base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`, with pristine upstream v1.17.13 parent `10c894bdeef3618f5666fb506ef7f9491bb964d8` as the third comparison. The range contains 525 commits (6 merges) and changes 1,237 files (`101898` insertions, `41085` deletions), so this audit was bounded to config discovery/loading/path resolution, related docs/specs and tests, and downstream directory consumers for agents, commands, skills, plugins, TUI config, migrations, and global/XDG paths.
+
+I compared the lookup predicates and order in `packages/core/src/config.ts`, `packages/opencode/src/config/{config,paths,tui,tui-migrate}.ts`, Kilo config helpers/overlays/source reporting, `Global.Path`, config environment flags, and resource-directory consumers. I also searched the three revisions for `.opencode`, `opencode.json`, config aliases, and path construction, separating provider/package/protocol identifiers and migration detection from active filesystem fallback.
+
+## Findings
+
+### P3: The newly restored v2 config spec documents the forbidden upstream `.opencode` lookup
+
+- **Path/line:** `specs/v2/config.md:16`, with related stale statements at `specs/v2/config.md:110` and `specs/v2/config.md:204`.
+- **Violated invariant:** Kilo intentionally does not read project `.opencode` or the sibling global opencode config directory; Kilo config directories are `.kilo` and legacy `.kilocode` only.
+- **Candidate flow claimed by the spec:** global config directory -> ancestor `opencode.json[c]` -> ancestor `.opencode/opencode.json[c]`, with `.opencode` plugin directories and policy precedence treated as active/open behavior.
+- **Actual head flow:** `packages/core/src/config.ts:143,178-206` uses filenames `config.json`, `kilo.json[c]`, and `opencode.json[c]`, but directory targets are only `.kilo` and `.kilocode`; `packages/opencode/src/config/paths.ts:23-40` has the same directory restriction. `packages/core/test/config/config.test.ts` creates `.opencode` and expects its config to be ignored; `packages/opencode/test/kilocode/config/config.test.ts:694-781` additionally proves config, commands, agents, and plugins under `.opencode` are ignored.
+- **Base/head/upstream evidence:** base already had the Kilo-only runtime predicates and did not contain the line at `specs/v2/config.md:16`. Head adds that sentence in commit `898f0dc40b` while retaining the base predicates. Pristine upstream `10c894b...` is the source of the claimed behavior: its `packages/core/src/config.ts` searches `targets: [".opencode", ...]`. This is therefore a conflict-adaptation documentation regression, not an active runtime fallback regression.
+- **Affected users/platforms:** contributors implementing v2 config and any future Kilo client/runtime wired to the spec, on macOS, Linux, and Windows. Following the spec would reintroduce loading repository-controlled `.opencode` agents, commands, skills, plugins, and policy/config values.
+- **Fix/verification:** rewrite the three statements to name `.kilo` and legacy `.kilocode`, state that `.opencode` is deliberately excluded, and describe Kilo's accepted legacy filenames separately from directory fallback. Keep the existing core and opencode negative controls; a reviewer should also verify future v2 config work against `packages/kilo-docs/pages/getting-started/settings/index.md:30-35` rather than importing these upstream statements.
+
+## Notable non-findings
+
+- No PR-introduced active `.opencode` fallback was found. Base and head have identical lookup roots in both config implementations. The static control `git diff --exit-code 0b8f749ae13388cf7a38ea7fb9183acaac99eef8..054ee594915b93546d0613a45e0671edd43905ee -G'\.opencode|targets:|directories|const names' -- packages/core/src/config.ts packages/opencode/src/config/paths.ts packages/opencode/src/kilocode/config/config.ts` returned `exit=0`.
+- Kilo-only global path selection remains intact. `packages/core/src/global.ts:12-25` resolves XDG/AppData locations under `kilo`, and `Global.make()` uses `KILO_CONFIG_DIR` or that Kilo path. Head config flags expose `KILO_CONFIG`, `KILO_CONFIG_CONTENT`, and `KILO_CONFIG_DIR`; no `OPENCODE_CONFIG*` filesystem alias was found in the audited flag/load path.
+- Legacy filenames remain intentionally accepted only inside Kilo-selected locations. Both loaders may read `opencode.json[c]` from the project ancestry, `.kilo`/`.kilocode`, `KILO_CONFIG_DIR`, or `${XDG_CONFIG_HOME}/kilo`; docs explicitly distinguish this filename compatibility from the removed `.opencode` directory fallback. This is not a read from `${XDG_CONFIG_HOME}/opencode`.
+- `packages/opencode/src/kilocode/config/config.ts:562-574` reads filesystem existence for `${XDG_CONFIG_HOME}/opencode` and project `.opencode` solely to build a migration notification. It does not parse or merge their contents. The one-time TOML/bash/auth/data migration paths found likewise do not add an active opencode config fallback.
+- V2 directory consumers receive only the `Config.Directory` entries produced from global Kilo config plus `.kilo`/`.kilocode`, so agents, commands, skills, local plugins, references, and policy configuration do not gain an indirect `.opencode` path through generic helpers. The v1 TUI filter also explicitly accepts only `.kilo`, `.kilocode`, or `KILO_CONFIG_DIR`.
+- Remaining `opencode` strings in provider IDs, npm package names, `@opencode-ai/*` imports, `.well-known/opencode`, plugin engine metadata, install/uninstall detection, plan compatibility permissions, and `.opencode-version` cache markers are not config-directory fallback candidates. The embedded upstream `customize-opencode` skill text is stale but pre-existing at the base and is not registered by Kilo's internal v2 plugin boot (`packages/core/src/plugin/internal.ts` skips that skill), so it is not a PR regression in this range.
+
+## Exact commands and results
+
+- `git merge-base 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee` -> `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`.
+- `git diff --shortstat 0b8f749ae13388cf7a38ea7fb9183acaac99eef8..054ee594915b93546d0613a45e0671edd43905ee` -> `1237 files changed, 101898 insertions(+), 41085 deletions(-)`.
+- `git rev-list --count 0b8f749ae13388cf7a38ea7fb9183acaac99eef8..054ee594915b93546d0613a45e0671edd43905ee` -> `525`; the same command with `--merges --count` -> `6`.
+- Three-revision `git grep` control for config targets showed base/head `.kilo` + `.kilocode`, while upstream `10c894b...` showed `.opencode` in core, opencode config paths, and TUI filtering.
+- From `packages/core`: `bun test test/config/config.test.ts test/config/plugin.test.ts` -> `21 pass, 0 fail`, 87 expectations, 2 files.
+- From `packages/opencode`: `bun test test/kilocode/config/config.test.ts test/skill/skill.test.ts` -> `55 pass, 0 fail`, 146 expectations, 2 files.
+- From `packages/opencode`: `bun test test/config/tui.test.ts test/kilocode/server/tui-config.test.ts test/kilocode/server/config-sources.test.ts test/kilocode/server/config-overlay.test.ts` -> `74 pass, 3 skip, 0 fail`, 227 expectations, 4 files.
+
+## Limitations
+
+- Tests ran on macOS; Windows AppData path behavior was verified statically, not executed on Windows. XDG behavior was exercised through existing isolated test environments.
+- I did not run the complete monorepo suite or manually launch every client. The focused tests cover both config implementations and downstream v1 TUI/config-source/overlay behavior; v2 server reachability was traced statically through `LocationServiceMap` and internal config plugins.
+- The worktree began with unrelated untracked `vscode-self-test.config.json`; concurrent reviewers may create or remove other report files. I did not read or modify them. This audit creates only `CONFIG_REGRESSION.md` and does not mutate GitHub, commit, or push.

--- a/INFRASTRUCTURE_CHANGE.md
+++ b/INFRASTRUCTURE_CHANGE.md
@@ -1,0 +1,129 @@
+# Infrastructure Change Review
+
+## Scope And Methodology
+
+Infrastructure verdict: **not safe to merge until the release publisher and CI test coverage findings are fixed; the Effect override also needs an explicit compatibility decision.**
+
+This review is limited to infrastructure changes in PR #12695 at head `054ee594915b93546d0613a45e0671edd43905ee`, against base and merge base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`. I compared `base..head`, partitioned the imported upstream range from Kilo adaptations using pristine upstream `10c894bdeef3618f5666fb506ef7f9491bb964d8` (`v1.17.13`), inspected the active and disabled GitHub Actions changes, release/build scripts, workspace manifests, Turbo configuration, dependency patches, lockfile resolution, changeset input, and generated SDK/OpenAPI machinery. I then exercised the resolved Turbo task graph and targeted package checks without publishing, committing, pushing, or changing GitHub.
+
+The reviewed PR is large (`1237 files changed, 101898 insertions(+), 41085 deletions(-)`), but the infrastructure-relevant flattened delta is concentrated in `.github`, root workspace/lock/Turbo files, package manifests and scripts, three dependency patches, release automation, generated clients, and `packages/sdk/openapi.json`. Product source under the newly imported Schema, Protocol, Core, Client, SDK Next, and Session UI packages was considered only where it activates CI, generation, packaging, or release behavior.
+
+## Findings
+
+### P1/high: Kilo CI silently skips newly imported package tests, including one that currently fails
+
+- **Paths:** `.github/workflows/test.yml:144-160`, `packages/client/package.json:11-15`, `packages/client/test/contract-identity.test.ts:40-44`, `turbo.json`
+- **Provenance:** Introduced by the merge adaptation. Upstream `v1.17.13` runs `GITHUB_ACTIONS=false bun turbo test`, while Kilo preserves its `bun turbo test:ci` orchestration. The imported packages define `test`, not `test:ci`.
+- **Exact evidence:** The active Kilo unit workflow invokes only `bun turbo test:ci` for non-CLI packages. `bun turbo run test:ci --dry=json` reports all of the following as `<NONEXISTENT>`: `@opencode-ai/client#test:ci`, `@opencode-ai/httpapi-codegen#test:ci`, `@opencode-ai/sdk-next#test:ci`, and `@opencode-ai/session-ui#test:ci`. Their manifests expose `test` scripts instead. The generated-client freshness command added at `.github/workflows/test.yml:224-227` runs generation plus `git diff`; it does not run the package's contract tests.
+- **Concrete failure:** Running `bun test` in `packages/client` produced:
+
+  ```text
+  (fail) client and Server contracts generate identically
+
+   15 pass
+   1 fail
+   75 expect() calls
+  Ran 16 tests across 4 files. [1020.00ms]
+  ```
+
+  The assertion at `packages/client/test/contract-identity.test.ts:44` found different generated contracts because middleware errors are emitted in different orders, for example `[401, 400]` versus `[400, 401]`. Even if error ordering is ultimately judged semantically irrelevant, the imported upstream invariant explicitly requires client and server generation to be identical, and the current Kilo CI never executes it.
+- **Risk to Kilo infrastructure:** Required checks can pass while generator, protocol/client identity, embedded SDK, and extracted Session UI tests are not scheduled. This already conceals a red test at the reviewed head and creates a durable blind spot for future upstream imports.
+- **Human action:** Add `test:ci` scripts for every imported package that has tests, or add an explicit CI step that runs their existing `test` scripts. Confirm `bun turbo test:ci` schedules non-zero commands, fix or deliberately revise the client/server identity invariant, and make the required job depend on the resulting checks.
+
+### P1/high: Kilo's release job now attempts to publish the upstream-owned `@opencode-ai/ui` npm package
+
+- **Paths:** `script/publish.ts:125-126`, `packages/ui/package.json:2-12`, `packages/ui/script/publish.ts:11-23`, `.github/workflows/publish.yml:469-478`
+- **Provenance:** The UI package publisher is introduced by upstream `v1.17.10-v1.17.13`; the Kilo merge retained the upstream package name and publisher, changed its repository metadata/version to Kilo, and wired it into Kilo's existing release driver.
+- **Exact evidence:** `script/publish.ts` now unconditionally runs `bun ./packages/ui/script/publish.ts`. That script reads `name: "@opencode-ai/ui"`, checks `npm view`, and then executes `npm publish ... --access public --tag ${Script.channel}`. The Kilo release workflow invokes the driver with npm provenance enabled. The live read-only registry query returned:
+
+  ```json
+  {
+    "version": "1.18.13",
+    "dist-tags": {
+      "tui-v2": "0.0.0-tui-v2-202606261840",
+      "next": "0.0.0-next-16741",
+      "latest": "1.18.13",
+      "beta": "0.0.0-beta-202608041253",
+      "dev": "0.0.0-dev-202608041225"
+    },
+    "repository": {
+      "url": "git+https://github.com/anomalyco/opencode.git",
+      "type": "git",
+      "directory": "packages/ui"
+    }
+  }
+  ```
+
+  The reviewed package instead has version `7.4.20` and repository `Kilo-Org/kilocode`. The PR changeset versions only `@kilocode/cli` and `kilo-code`; it does not establish ownership or release intent for `@opencode-ai/ui`.
+- **Risk to Kilo infrastructure:** A Kilo release can fail at npm authorization/provenance before the VS Code publish step, or, if credentials unexpectedly have access, publish Kilo-modified artifacts into OpenCode's namespace with Kilo's unrelated `7.x` version line. Either outcome violates the requirement that repository/release machinery remain Kilo-owned.
+- **Human action:** Remove the UI publish call from Kilo's release driver unless Kilo has an explicit package ownership agreement. If Kilo intends to distribute this UI independently, rename it to a Kilo-owned npm scope, define versioning/changeset policy, and validate trusted-publisher provenance from `Kilo-Org/kilocode` in a dry-run release.
+
+### P2/medium, human verification: the Effect beta.83 upgrade retains a beta.74 platform override
+
+- **Paths:** `package.json:58`, `package.json:87`, `package.json:138-142`, `bun.lock:1425-1429`, `patches/effect@4.0.0-beta.83.patch`
+- **Provenance:** Merge-resolution/adaptation issue. Base consistently used Effect beta.74 and the beta.74 override. Pristine upstream `v1.17.13` upgrades Effect and `@effect/platform-node` to beta.83 and has no `@effect/platform-node-shared` override. Head imports the beta.83 catalog and patch but retains Kilo's old beta.74 override.
+- **Exact evidence:** The reviewed root catalog contains `effect: 4.0.0-beta.83`, `@effect/platform-node: 4.0.0-beta.83`, and `@effect/sql-sqlite-bun: 4.0.0-beta.83`, while `overrides` forces `@effect/platform-node-shared: 4.0.0-beta.74`. The lockfile records `@effect/platform-node@4.0.0-beta.83` requesting `@effect/platform-node-shared: ^4.0.0-beta.83`, but resolves the shared package to beta.74 with peer dependency `effect: ^4.0.0-beta.74`. `bun pm ls --all` confirms:
+
+  ```text
+  ├── @effect/platform-node@4.0.0-beta.83
+  ├── @effect/platform-node-shared@4.0.0-beta.74
+  ├── effect@4.0.0-beta.83
+  ```
+
+- **Risk to Kilo infrastructure:** Bun is forced outside `@effect/platform-node`'s declared dependency range and across an Effect beta API boundary. Typecheck and selected layer tests passed, but platform-specific file, socket, worker, or runtime behavior can fail outside those tests; subsequent lockfile regeneration will preserve the unsupported split.
+- **Human action:** Establish why the beta.74 override still exists. Prefer removing it or updating it to beta.83, regenerate `bun.lock`, and rerun cross-platform Core/CLI tests. If it must remain, document the compatibility rationale and add a guard that proves the mixed versions are intentional.
+
+## Notable Non-Findings
+
+- The only active workflow changed in `base..head` is `.github/workflows/test.yml`. The PR does not change `.github/workflows/publish.yml`, `.github/workflows/beta.yml`, `.github/workflows/containers.yml`, `.github/workflows/generate.yml`, reusable actions, Dockerfiles, Compose files, Nix files, or container build scripts.
+- Changes to `.github/workflows/disabled/compliance-close.yml.disabled`, `duplicate-issues.yml.disabled`, `storybook.yml.disabled`, and `triage.yml.disabled` remain inert because their filenames still end in `.disabled`. They import upstream team-author exemptions and Session UI path coverage without activating upstream automation in Kilo.
+- `script/github/close-issues.ts` still targets `anomalyco/opencode`, but its only workflow caller found in this repository is `.github/workflows/disabled/close-issues.yml.disabled`; the PR does not activate it. Human review is still advisable before ever re-enabling that workflow.
+- `.github/ISSUE_TEMPLATE/config.yml` only changes the Discord contact description. It does not enable blank issues or redirect the link away from `https://kilo.ai/discord`.
+- The imported `packages/client` generation machinery is explicitly gated by `bun run check:generated` in the active HTTP API job. Generated-output scope is substantial but expected: `packages/client/src/generated*` is new, `packages/sdk/js/src/v2/gen` changes, and `packages/sdk/openapi.json` changes by `27550` additions and `14963` deletions. Targeted OpenAPI/SDK tests passed; the separate skipped client contract test is the finding above.
+- The dependency patch changes are infrastructure-relevant but did not expose a separate verified defect: the MCP SDK patch expands OAuth/session-retry behavior, the TanStack patch adds virtual-range clamping, and the new Effect patch gives SSE wrapper schemas distinct OpenAPI identifiers. The version-resolution concern is limited to the stale Effect platform override described above.
+- `script/check-opencode-annotations.ts` expands coverage to newly upstream-owned packages (`core`, `llm`, `schema`, `protocol`, `server`, and `tui`), and `script/check-model-tool-network.ts` adapts its network-layer check to the new LayerNode graph. No weakening of their intended checks was identified in this infrastructure pass.
+
+## Commands And Results
+
+- Revision verification:
+
+  ```text
+  $ git rev-parse HEAD
+  054ee594915b93546d0613a45e0671edd43905ee
+  $ git merge-base 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee
+  0b8f749ae13388cf7a38ea7fb9183acaac99eef8
+  $ git diff --shortstat 0b8f749ae13388cf7a38ea7fb9183acaac99eef8..054ee594915b93546d0613a45e0671edd43905ee
+   1237 files changed, 101898 insertions(+), 41085 deletions(-)
+  ```
+
+- Infrastructure guards:
+
+  ```text
+  $ bun run script/check-workflows.ts
+  check-workflows: ok (29 workflows).
+  $ bun run script/check-md-table-padding.ts
+  check-md-table-padding: 385 file(s) checked, no padded tables found.
+  $ git diff --check BASE..HEAD -- <infrastructure paths>
+  [no output; exit 0]
+  ```
+
+- Turbo coverage proof: `bun turbo run test:ci --dry=json` exited `0`, but reported `<NONEXISTENT>` commands for the four imported packages named in finding 1. Direct package results were:
+
+  ```text
+  packages/client:          15 pass, 1 fail, 16 tests across 4 files
+  packages/httpapi-codegen: 66 pass, 0 fail, 66 tests across 2 files
+  packages/sdk-next:         5 pass, 0 fail, 5 tests across 2 files
+  packages/session-ui:      57 pass, 0 fail, 57 tests across 11 files
+  ```
+
+- Generated API integration: `bun test ./test/server/httpapi-public-openapi.test.ts ./test/server/httpapi-sdk.test.ts` from `packages/opencode` passed `39` tests across `2` files with `0` failures.
+- Effect integration: `bun run --cwd packages/core typecheck` exited `0`; `bun test ./test/effect/layer-node/layer-node.test.ts ./test/effect/layer-node/node-build.test.ts` from `packages/core` passed `17` tests across `2` files with `0` failures.
+- Client typecheck: `bun run typecheck` from `packages/client` exited `0`. Its direct test failure is therefore behavioral/contract-level rather than a TypeScript compile failure.
+- Worktree integrity before writing this report: `git status --short` showed only the pre-existing untracked `vscode-self-test.config.json`; diagnostics left no tracked changes. GitHub was not queried or mutated through `gh`, and no commit, push, tag, release, package publish, or other external mutation was performed.
+
+## Limitations
+
+- I did not execute `script/publish.ts`, `npm publish`, changeset versioning, release tagging, or any GitHub Actions workflow because those paths mutate package registries, Git history, releases, marketplaces, or GitHub state. The npm package check was read-only.
+- I did not run the full monorepo suite or all cross-platform jobs. Targeted checks covered the changed CI graph, imported package tests, Core Effect layers, and generated OpenAPI/SDK integration; Windows/Linux-only runtime behavior for the mixed Effect versions remains a human-verification item.
+- I did not regenerate tracked SDK/OpenAPI artifacts in-place because the assignment permits writing only this report. Freshness was assessed from the committed generation gate, diffs, targeted tests, and the clean tracked worktree after diagnostics.
+- Disabled workflows were reviewed as dormant repository machinery, not executed. Their behavior could differ if renamed back to `.yml` in a later change.

--- a/KILOCODE_CHANGE_MARKERS.md
+++ b/KILOCODE_CHANGE_MARKERS.md
@@ -1,0 +1,95 @@
+# `kilocode_change` Marker Audit
+
+## Scope and methodology
+
+- Reviewed exact head `054ee594915b93546d0613a45e0671edd43905ee` against base and merge base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8` for PR #12695 (`johnnyeric/kilo-opencode-v1.17.13`). Verified recorded upstream merge `db1eae3583535d9b7a61ec8af9702e1580471056` has upstream parent `10c894bdeef3618f5666fb506ef7f9491bb964d8`, and conflict-resolution merge `518501a994bcd660e8c6d061b450c32412104004` has second parent `898f0dc40b4549bb4160ed3cb53d19a6a39243dc`.
+- Checked all **1,237 changed files** from `git diff --name-only <base> <head>`. The inventory was traversed file by file to compare marker counts and marker-bearing lines at base/head; shared source candidates were also compared with pristine upstream v1.17.13 after the repository's branding/package transforms. Deleted and renamed paths were separately inventoried, and surviving base-marked code was searched by normalized content when line positions moved.
+- Focused semantic review covered all 175 files whose marker lines changed, all 265 changed files that contained a marker at base, every file with a removed marker line, all 48 files with a net marker-count decrease, and concept/symbol moves implicated by those removals. A removal was accepted only when the final file matched upstream, the marked construct disappeared with an upstream deletion/refactor, or equivalent Kilo behavior remained marked at its new location.
+- The audit concerns accidental marker loss. It does not claim that every pre-existing marker is ideally narrow or that every unrelated Kilo divergence introduced by concurrent `main` merges is annotated.
+
+## Findings
+
+### P3: Kilo credential compatibility dependencies lost their block marker
+
+- **Path/symbol:** `packages/core/src/credential.ts:206-207`, optional `FSUtil.Service` and `Global.Service` acquisition inside `Credential.layer`.
+- **Evidence:** Base lines 218-221 wrapped these two acquisitions in `// kilocode_change start` / `end`. Reviewed head retains the same Kilo-only acquisitions at lines 206-207 but removes both boundaries. Pristine upstream `10c894b...` has neither acquisition and its credential layer depends only on the database. Head still needs these services for Kilo's isolated `KILO_AUTH_CONTENT` handling and legacy `auth.json` synchronization; the new node wiring at lines 423-424 is marked, but it does not annotate the separate service acquisitions. The marker fixer reports `[DRY-RUN] Would update packages/core/src/credential.ts`. `git blame` attributes removal of the boundaries to conflict resolution `518501a994`.
+- **Risk:** No runtime behavior is lost, but future upstream comparisons and conflict resolution can misclassify these optional Kilo dependencies as upstream code and drop or incorrectly simplify them. The inline marker on `export const layer` at line 201 covers only that declaration under the repository checker semantics, not lines 206-207.
+- **Verification/fix direction:** Restore a narrow start/end block around lines 206-207, then dry-run `script/upstream/fix-kilocode-markers.ts` and confirm those lines are covered against transformed v1.17.13.
+
+### P3: The Kilo model-footer sort marker moved onto the upstream release-date sort
+
+- **Path/symbol:** `packages/tui/src/component/dialog-model.tsx:297-298`, non-`newestFirst` branch of `sortModelOptions`.
+- **Evidence:** Base line 297 was `(option) => option.footer === undefined, // kilocode_change - free model footers include Kilo disclosure labels`. Reviewed head leaves that Kilo-specific predicate unmarked at line 297 and puts the same explanatory marker on `[(option) => option.releaseDate, "desc"]` at line 298. Pristine upstream `10c894b...` already contains release-date descending sort there, while its footer predicate is `(option) => option.footer !== "Free"`. Thus the marker now marks upstream behavior and no longer marks the actual Kilo divergence. The repository marker fixer reports that it would update the file, but direct line/symbol comparison is required to identify the ownership error. `git blame` attributes the misplaced marker to `518501a994`.
+- **Risk:** No current sorting behavior is lost, but the marker gives the next merge the opposite guidance: it encourages retaining a stale marker on upstream code while leaving the Kilo disclosure-label ordering vulnerable to reset.
+- **Verification/fix direction:** Move the existing inline marker/comment from line 298 back to the footer predicate at line 297; leave the upstream release-date line unmarked.
+
+## Notable non-findings
+
+- No removed marker corresponded to a confirmed loss of Kilo runtime behavior. Concept searches found the reviewed branch's explicit restoration commit `a606a91e69` retained the previously dropped processor tool settlement, compaction overflow accounting/system instructions, snapshot ignore cleanup, shell metadata/output draining, Snowflake OAuth branding, worker logging, and TUI rendering deltas with markers at their final locations.
+- Fourteen net-loss files were justified exact upstream reverts: ten final blobs exactly match pristine upstream (`packages/core/src/command.ts`, `packages/core/src/session/event.ts`, `packages/core/src/v1/permission.ts`, `packages/core/src/v1/session.ts`, three Core provider tests, `packages/opencode/src/server/event.ts`, `packages/server/src/api.ts`, and `packages/server/src/handlers/event.ts`), while four marked files were deleted along with their upstream counterparts (`packages/core/src/plugin/boot.ts`, `packages/core/src/plugin/provider/openai-auth.ts`, `packages/server/src/groups/location.ts`, and `packages/server/src/groups/session.ts`). The latter functionality was moved into upstream's new plugin/protocol/location structure rather than silently discarded.
+- Marker-count decreases caused by the Layer-to-`LayerNode` refactor were generally justified. Broad marked `defaultLayer`/dependency blocks disappeared, while surviving Kilo dependencies were represented by narrow markers on node dependencies or Kilo-owned nodes. Examples checked include `packages/opencode/src/effect/app-runtime.ts`, `agent/agent.ts`, `config/config.ts`, `provider/auth.ts`, `session/revert.ts`, `session/summary.ts`, `skill/index.ts`, and `tool/registry.ts`.
+- `packages/core/src/tool/read-filesystem.ts` retained the filesystem-identity invariant: `Target`, `inspect`, `verify`, descriptor verification in `read`, and directory verification in `list` remain marked. Removed markers around pagination code accompanied an upstream rewrite to typed errors/chunk handling rather than a loss of the Kilo permission-to-use race protection.
+- `packages/opencode/src/session/compaction.ts` retained Kilo compaction queue/recovery/chunk/export logic and marked Kilo dependencies. The unmarked `SessionEvent.Compaction.Started` publication is unchanged upstream behavior; the old marker was associated with the earlier event bridge shape, not a surviving Kilo-only line.
+- `packages/opencode/src/cli/cmd/tui.ts` retained marked Kilo cloud-fork ordering, internal authenticated transport, worker lifecycle, and graceful shutdown behavior. Removed inline markers were either absorbed by surrounding Kilo blocks or matched upstream transport/validation behavior. `packages/opencode/src/tool/shell.ts` moved the output-reader marker from the call line to the immediately adjacent explanatory line; coverage remains clear.
+- All 12 detected renames were upstream server-group moves into `packages/protocol/src/groups/*`; the renamed `fs` path retained its marker, and no other renamed source had a base marker to lose.
+
+## Exact command outputs and results
+
+```text
+$ git rev-parse HEAD
+054ee594915b93546d0613a45e0671edd43905ee
+
+$ git merge-base 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee
+0b8f749ae13388cf7a38ea7fb9183acaac99eef8
+
+$ git rev-list --parents -n 1 db1eae3583
+db1eae3583535d9b7a61ec8af9702e1580471056 f844790ed7e0220146d0b5d650a57fce6ecc79d5 10c894bdeef3618f5666fb506ef7f9491bb964d8
+
+$ git rev-list --parents -n 1 518501a994
+518501a994bcd660e8c6d061b450c32412104004 db1eae3583535d9b7a61ec8af9702e1580471056 898f0dc40b4549bb4160ed3cb53d19a6a39243dc
+
+$ git diff --name-only <base> <head> | wc -l
+1237
+
+$ git diff --shortstat <base> <head>
+1237 files changed, 101898 insertions(+), 41085 deletions(-)
+
+$ git diff --name-status <base> <head> | status-count
+A 334
+D 31
+M 860
+R 12
+
+$ git diff --name-only <base> <head> | shasum -a 256
+8b58590320954afdc63188e6bb204c79411f79ea375442c75a2c2e224ded7ceb  -
+
+$ git grep -I -n -e kilocode_change <base> -- | wc -l
+5817
+$ git grep -I -n -e kilocode_change <head> -- | wc -l
+5920
+
+$ git diff --name-only -Gkilocode_change <base> <head> | wc -l
+175
+
+base_marked_changed_files=265 head_marked_changed_files=301
+
+$ bun run script/check-opencode-annotations.ts --base <base>
+Skipping shared upstream annotation check — upstream merge detected.
+
+$ bun run script/upstream/fix-kilocode-markers.ts packages/core/src/credential.ts --dry-run
+[OK] Last merged upstream: v1.17.13 (10c894bd)
+[INFO] [DRY-RUN] Would update packages/core/src/credential.ts
+
+$ bun run script/upstream/fix-kilocode-markers.ts packages/tui/src/component/dialog-model.tsx --dry-run
+[OK] Last merged upstream: v1.17.13 (10c894bd)
+[WARN] 1 upstream-only deleted line(s) cannot be annotated in the current file
+[INFO] [DRY-RUN] Would update packages/tui/src/component/dialog-model.tsx
+```
+
+## Limitations
+
+- The normal annotation guard deliberately skips upstream-merge ranges, so it cannot validate this PR; the audit used direct base/head/upstream comparisons and the repository marker utilities instead.
+- The marker fixer identifies changed ranges, not semantic ownership within a multi-line range. That is why it misses the misplaced `dialog-model.tsx` inline marker and why every candidate required direct evidence rather than treating dry-run output as a finding.
+- Transformed-upstream comparison over-reports files changed by later `main` merges and Kilo adaptations. Findings were retained only where a marker-covered base construct demonstrably survives as unmarked Kilo-only code at reviewed head.
+- One generated file was present in the 1,237-file inventory; generated and binary files were included in path/status/count checks, but marker semantics apply only to comment-capable source files.
+- Other reviewers had untracked report/config files in the shared worktree during this audit. They were not part of the pinned Git comparisons and were not modified. No GitHub state was read or mutated, and no commit or push was performed.

--- a/OPENCODE_MENTIONS.md
+++ b/OPENCODE_MENTIONS.md
@@ -1,0 +1,101 @@
+# OpenCode Naming Audit
+
+## Scope And Methodology
+
+Reviewed Kilo-Org/kilocode PR #12695 at exact head `054ee594915b93546d0613a45e0671edd43905ee`, branch `johnnyeric/kilo-opencode-v1.17.13`, against exact base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`. The merge base is the stated base. The local `v1.17.13` tag resolves to `10c894bdeef3618f5666fb506ef7f9491bb964d8`; merge commit `db1eae3583535d9b7a61ec8af9702e1580471056` has parents `f844790ed7e0220146d0b5d650a57fce6ecc79d5` and that upstream commit, and the reviewed head contains it.
+
+Read root `AGENTS.md`, `REVIEW.md`, `packages/opencode/AGENTS.md`, `packages/opencode/test/AGENTS.md`, `packages/schema/AGENTS.md`, `packages/llm/AGENTS.md`, `packages/core/src/tool/AGENTS.md`, `packages/kilo-docs/AGENTS.md`, `kilo-steer`, `merge-review-johnny`, and `kilocode-merge-minimizer`.
+
+Searched the complete base-to-head diff case-insensitively for `opencode`, `open-code`, `open code`, OpenCode web domains, and the known upstream GitHub repositories. I then inspected production strings, UI and Storybook text, docs, package metadata, CLI help snapshots, generated OpenAPI/SDK descriptions, model-facing text, and URLs in context. Candidates were compared with base, pristine local upstream `v1.17.13`, merge/adaptation commits, final-head callers, and final rendered output where possible.
+
+## Findings
+
+### 1. P2 Medium: Kilo OAuth callbacks render the OpenCode wordmark
+
+**Location:** `packages/core/src/oauth/page.ts:252-270`, adapted by `packages/core/src/kilocode/oauth/page.ts:5-14`; active callers include `packages/core/src/plugin/provider/openai.ts:60-84` and `packages/opencode/src/plugin/snowflake-cortex.ts:184-212`.
+
+**Introduced surface:** The upstream renderer introduces `const WORDMARK = \`<svg ... viewBox="0 0 234 42" ... aria-label="OpenCode" ...>\`` followed by the 19 paths of the OpenCode wordmark. The Kilo adapter only performs `page.replaceAll("OpenCode", "Kilo")`.
+
+**Why user-facing:** ChatGPT and Snowflake sign-in success/error pages are opened in the user's browser. The replacement correctly changes text such as `OpenCode is now connected to ...`, the title, and the SVG accessibility label, but it cannot change SVG path geometry. The resulting page therefore labels an OpenCode-shaped wordmark as “Kilo” and visibly presents upstream branding during a Kilo authorization flow.
+
+**Proof and provenance:** `packages/core/src/oauth/page.ts` is inherited from pristine upstream `v1.17.13`; the string-only Kilo wrapper was added during merge resolution (`518501a994b...`). Rendering the active wrapper produced:
+
+```text
+contains_OpenCode=false
+contains_Kilo_copy=true
+aria=aria-label="Kilo"
+wordmark_viewbox=true
+wordmark_paths=19
+```
+
+**Suggested fix:** Do not use global text replacement as the complete branding adapter. Supply the actual Kilo wordmark from a Kilo-owned renderer/parameter, or replace the full upstream `<svg>` block as well as textual branding. Human-verify the rendered ChatGPT and Snowflake success and error pages after the change.
+
+### 2. P3 Low: Public Kilo plugin source documentation names the API and host OpenCode
+
+**Locations:** `packages/plugin/src/v2/effect/README.md:1,5,48` and `packages/plugin/src/v2/promise/README.md:1,5`.
+
+**Exact introduced text:** `# OpenCode V2 Effect Plugin API`, `# OpenCode V2 Promise Plugin API`, ``hook` installs behavior at an OpenCode extension point.`, and `OpenCode rebuilds the domain ...`.
+
+**Why user-facing:** These are developer-facing guides colocated with newly exported `@kilocode/plugin/v2/effect` and `@kilocode/plugin/v2/promise` entrypoints. The adaptation changed the examples from `@opencode-ai/plugin` to `@kilocode/plugin` but retained upstream product naming in the headings and explanatory copy, so users reading Kilo's source documentation are told that the Kilo package exposes an OpenCode API/host.
+
+**Provenance:** The wording is unchanged from pristine upstream `v1.17.13` and entered the Kilo tree through merge adaptation commit `898f0dc40b...`; it did not exist at the reviewed base.
+
+**Suggested wording:** `# Kilo V2 Effect Plugin API`, `# Kilo V2 Promise Plugin API`, `a Kilo extension point`, and `Kilo rebuilds the domain ...`. If product intends “OpenCode V2” as a formal compatibility API name, human-verify and document that exception explicitly; current `@kilocode/plugin` imports and Kilo repository location suggest Kilo wording is intended.
+
+## Notable Non-Findings
+
+- Generated public artifacts are clean at final head: `packages/sdk/openapi.json`, `packages/sdk/js/src/v2/gen/types.gen.ts`, `packages/sdk/js/src/v2/gen/sdk.gen.ts`, and the CLI help snapshot contain no case-insensitive `OpenCode`, `opencode.ai`, or `open-code` match. Commit `61b2f1d0cb...` explicitly changed generated OpenAPI tags/names from `opencode HttpApi` to `Kilo HttpApi`.
+- No added OpenCode match was found in the reviewed diff under Kilo-owned product surfaces `packages/kilo-docs`, `packages/kilo-vscode`, `packages/kilo-ui`, or `packages/kilo-console`. The changed CLI reference also uses Kilo branding.
+- The OAuth wrapper successfully removes literal OpenCode text and accessibility naming for current ChatGPT and Snowflake callers. The remaining issue is the unchanged visual path geometry. The upstream `bootstrap()` renderer has no production caller at final head, so its literal OpenCode output is not reported separately.
+- `@opencode-ai/*` imports/package names, `OpenCode` SDK namespace/type names, `@opencode/*` Effect service identifiers, `opencode.json`/`.opencode` compatibility paths, `OPENCODE_*` compatibility environment variables, server username `opencode`, and provider ID/name `opencode` were excluded as internal/source/compatibility identifiers rather than user-facing branding regressions.
+- Newly added `@opencode-ai/client`, `@opencode-ai/sdk-next`, `@opencode-ai/schema`, `@opencode-ai/protocol`, and `@opencode-ai/session-ui` metadata/READMEs retain upstream naming, but all corresponding package manifests are `private: true`. Their current names and `OpenCode` API symbols are upstream architecture/source identities, not shipped Kilo package metadata; no finding was raised.
+- `packages/session-ui/src/components/timeline-playground.stories.tsx` says ``opencode export` JSON file`, and Storybook autodocs mention the OpenCode design system. These are upstream test/development fixtures in a private package, not shipped runtime UI, and were excluded under the requested fixture exception.
+- OpenCode domains in provider fixtures, recorded cassettes, URL-classification tests, config compatibility tests, upstream provider catalog data, and comments explaining why Kilo disables OpenCode Console integration were excluded as fixtures, provider identities, compatibility coverage, or internal rationale.
+- `.changeset/opencode-v1-17-9-to-v1-17-13.md:6` says `Changes from opencode v1.17.9 to v1.17.13 upstream:`. This is intentional release-note attribution generated by the established upstream changeset workflow, consistent with earlier Kilo releases, and not accidental product renaming.
+- OpenCode links already present in Kilo documentation for explicit fork attribution, upstream behavior references, or the Kilo Cloud schema-overlay architecture were not introduced by this PR and are legitimate attribution/reference links.
+
+## Exact Command Results
+
+```text
+$ git rev-parse HEAD
+054ee594915b93546d0613a45e0671edd43905ee
+
+$ git merge-base 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee
+0b8f749ae13388cf7a38ea7fb9183acaac99eef8
+
+$ git show -s --format='%H%n%P%n%s' 10c894bdeef3618f5666fb506ef7f9491bb964d8
+10c894bdeef3618f5666fb506ef7f9491bb964d8
+6697cf3fd81d44fc8c3f72d32edb0e2549d24003
+release: v1.17.13
+
+$ git merge-base --is-ancestor 10c894bdeef3618f5666fb506ef7f9491bb964d8 054ee594915b93546d0613a45e0671edd43905ee
+upstream_ancestor_exit=0
+
+$ git diff --shortstat 0b8f749ae13388cf7a38ea7fb9183acaac99eef8 054ee594915b93546d0613a45e0671edd43905ee
+1237 files changed, 101898 insertions(+), 41085 deletions(-)
+
+$ git diff --unified=0 BASE HEAD | rg -i '^\+[^+].*(opencode|open[- ]code)' | wc -l
+1583
+
+$ git diff --unified=0 BASE HEAD | rg -i '^-[^-].*(opencode|open[- ]code)' | wc -l
+382
+
+$ git grep -n -i -E 'OpenCode|opencode\.ai|open-code' HEAD -- packages/sdk/openapi.json packages/sdk/js/src/v2/gen/types.gen.ts packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+head_scan_exit=1
+
+$ git diff --unified=0 BASE HEAD -- packages/kilo-docs packages/kilo-vscode packages/kilo-ui packages/kilo-console | rg -n -i -C 2 '^\+[^+].*(OpenCode|opencode\.ai|console\.opencode|open-code)'
+(no output)
+
+$ git status --short
+?? vscode-self-test.config.json
+```
+
+The unrelated untracked `vscode-self-test.config.json` existed before this audit and was not modified. Other parallel reviewer reports may appear concurrently and were not modified.
+
+## Limitations
+
+- This was a focused naming/link audit, not a complete behavioral or visual review of the 1,237-file merge.
+- The repository only has the Kilo `origin` remote configured in this worktree. Upstream provenance was verified against the local signed-by-history tag/commit graph and pristine `v1.17.13` commit already merged into the reviewed head; no authoritative upstream remote fetch was performed.
+- OAuth HTML was rendered and inspected structurally, but no browser screenshot comparison was run. The SVG source comment, unchanged 19-path geometry, and upstream comparison establish that it remains the OpenCode wordmark; final visual acceptance should still be human-verified.
+- Source-document visibility can differ between GitHub, package build, and npm publication. The plugin README finding is scoped to Kilo's developer-facing source documentation; the manifest's `files: ["dist"]` may prevent those nested README files from appearing in the packed npm artifact.
+- No files other than this report were edited; no commit, push, or GitHub mutation was performed.

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,59 @@
+# Kilo Test Coverage Preservation Audit
+
+## Scope And Methodology
+
+- Reviewed Kilo-Org/kilocode PR #12695 at exact head `054ee594915b93546d0613a45e0671edd43905ee` against base and merge base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8` on macOS, branch `johnnyeric/kilo-opencode-v1.17.13`.
+- Read root `AGENTS.md`, `REVIEW.md`, `packages/opencode/AGENTS.md`, `packages/opencode/test/AGENTS.md`, relevant package guidance for `packages/llm`, `packages/schema`, and `packages/kilo-vscode`, plus `kilo-steer` and the read-only review procedure.
+- Inventoried test/spec paths, test directories, fixtures, recordings, snapshots, package scripts, Turbo scheduling, and `.github/workflows/test.yml` with Git rename/copy detection. Compared deleted files, removed declarations/assertions, and Kilo-related concepts between base and final head.
+- Treated paths containing `kilo`/`kilocode` as Kilo-owned, then searched changed shared tests for `kilocode_change`, `KILO_*`, Kilo branding, `@kilocode`, `api.kilo`, providers, Kilo APIs, and Kilo fixtures.
+- Compared extracted test names in Kilo-owned suites at both revisions and traced unmatched names and assertions into final-head tests and implementations. Running tests was limited to targeted controls because this is a coverage-preservation audit.
+
+## Findings
+
+### P3: Direct coverage for replacing stale Kilo references was removed
+
+- **Old path/test:** `packages/core/test/reference.test.ts`, `replaces sources without a scoped transform`.
+- **Removed Kilo invariant:** `Reference.Service.replace(...)`, a Kilo-specific API, must remove stale effective references and install the new set without relying on a request-scoped transform slot.
+- **Equivalent final-head coverage:** No. `packages/opencode/test/kilocode/reference.test.ts` still exercises `KiloReference.sync(...)` and proves metadata is installed from an initially empty service, but it does not seed a stale source and prove it is removed. The final-head test `sync does not publish an update for equivalent references` covers the no-op branch, not replacement of a differing set.
+- **Evidence:** Final head still declares the Kilo-only API at `packages/core/src/reference.ts:38` and implements it at lines 116-124. Its production caller remains `packages/opencode/src/kilocode/reference.ts:153-190`, ending in `yield* service.replace(sources)`. The base test seeded `stale`, invoked `replace([["current", current]])`, and asserted that only `current` remained; that test block is absent at head. A concept search found no other final-head test of `Reference.Service.replace`.
+- **Direction:** Restore a focused Kilo test, preferably under `packages/core/test/kilocode/` or `packages/opencode/test/kilocode/`, that seeds stale and retained/replacement entries, invokes the real `replace` or `KiloReference.sync` path, and asserts the exact final list. Human verification should also confirm that repeated reconciliation cannot retain references removed from effective Kilo config.
+
+### P3: OpenAI OAuth page branding coverage was weakened from rendered output to source text
+
+- **Old path/test:** `packages/opencode/test/kilocode/oauth-branding.test.ts`, `extracted core OAuth browser flow uses Kilo branding` (renamed at head to `core OAuth browser flow uses Kilo branding`).
+- **Removed Kilo invariant:** The HTML actually served by the OpenAI OAuth callback must contain Kilo branding and no OpenCode branding, including the document title.
+- **Equivalent final-head coverage:** Partial only. The renamed test checks that `openai.ts` mentions `KiloOauthCallbackPage` and that the wrapper source contains `.replaceAll("OpenCode", "Kilo")`; it no longer calls the wrapper or asserts rendered HTML. `packages/core/test/oauth-page.test.ts` executes only the unbranded upstream `OauthCallbackPage.bootstrap` escaping path.
+- **Evidence:** Base assertions required `<title>Kilo</title>` and rejected `<title>OpenCode</title>`. Head replaced them with source-text assertions. `git grep` found no test invoking `KiloOauthCallbackPage.success` or `.error`. A diagnostic execution at the pinned head currently produced `Authorization successful · Kilo` and `Authorization failed · Kilo`, with `hasOpenCode: false`, so this is lost regression detection rather than a current runtime defect.
+- **Direction:** Execute `KiloOauthCallbackPage.success()` and `.error()` in the Kilo branding test and assert representative visible text/title contains `Kilo` and excludes `OpenCode`. Retain the OpenAI call-site assertion if desired, but do not use source inspection as the only branding contract.
+
+## Notable Non-Findings
+
+- No Kilo-owned test file was deleted or renamed. Across `packages/opencode/test/kilocode` and `packages/core/test/kilocode`, the reviewed diff contains 127 changed files: 124 modified and 3 added, with 1,746 added and 1,528 deleted lines. Test-name extraction found 3,017 distinct names at base and 3,021 at head; the only unmatched Kilo-suite name was the OAuth test renamed above. The apparent removed compaction and `maxOutputTokens` declarations were formatting changes; their cases and assertions remain.
+- The seven deleted test files are shared upstream architecture tests, not Kilo-specific files: `packages/core/test/model-request.test.ts`, `packages/core/test/plugin/provider-helper.ts`, `packages/core/test/public-opencode.test.ts`, `packages/core/test/public-tool.test.ts`, `packages/core/test/session-logging.test.ts`, `packages/opencode/test/effect/app-graph-types.test.ts`, and `packages/opencode/test/effect/app-graph.test.ts`. No file contains Kilo branding, Kilo providers, custom Kilo APIs, or `kilocode_change` markers at base.
+- The deleted app-graph tests moved conceptually to final-head layer-node tests in `packages/core/test/effect/layer-node/`; replacement propagation, unused replacements, dependency replacement, graph compilation, and type exploration remain covered. The old public API was replaced by the Protocol/Client/SDK Next architecture, with real embedded session/tool coverage in `packages/sdk-next/test/embedded.test.ts` and contract identity/generation coverage in `packages/client/test/contract-identity.test.ts`. `ModelRequest.normalizeAiSdkOptions` and its source module no longer exist, so its dedicated tests are obsolete rather than silently dropped.
+- The base Kilo assertions that interruption did not create a durable `session.next.interrupt.requested` record became obsolete with the upstream architecture. Head removed that event contract and sequence-aware coordinator API and directly delegates process-local interruption; `packages/core/test/session-prompt.test.ts` retains delegation and empty-transcript checks. There is no final-head interrupt event to preserve coverage for.
+- The removed direct reference replacement case is the only Kilo-specific shared test block found without equivalent final-head coverage. Renamed RuntimeFlags cases retain the same `KILO_*` inputs and assertions. The modified TUI prompt, ACP resume, location-event, provider, config, compaction, and Kilo fixture cases retain or strengthen their applicable invariants.
+- No deleted or renamed fixture, recording, cassette, snapshot, or other coverage-data file was found. Modified Kilo recordings preserve Kilo system branding and update request shape for `strict: false`; no scenario interaction was removed.
+- Test scheduling was not reduced. The non-CLI and sharded CLI commands in `.github/workflows/test.yml` are unchanged, including the Darwin Kilo profile gate and `KILO_TEST_SHARD`. The PR adds a generated-client check, adds `packages/sdk/js`'s `test` script, and adds Turbo test dependencies for Core and Session UI. No package or Kilo test path was newly excluded.
+
+## Commands And Results
+
+- `git rev-parse HEAD`, base/head validation, and `git merge-base BASE HEAD` returned head `054ee594915b93546d0613a45e0671edd43905ee`, base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`, and merge base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`.
+- `git diff --shortstat BASE HEAD` returned `1237 files changed, 101898 insertions(+), 41085 deletions(-)`.
+- `git diff --name-status --find-renames=40% BASE HEAD -- <test patterns> | cut -f1 | sort | uniq -c` returned `65 A`, `7 D`, `405 M`, and no rename status.
+- `git diff --name-only --diff-filter=D BASE HEAD -- <test patterns>` returned exactly the seven shared deleted files listed above.
+- `git diff --name-status --find-renames=1% BASE HEAD -- <fixture/snapshot patterns> | rg '^(D|R)'` and the deleted fixture/recording concept search returned no output.
+- Kilo-owned test diff aggregation returned `files=127 added=1746 deleted=1528` and statuses `3 A`, `124 M`.
+- The base/head Kilo test-name comparison returned `base test names 3017 head test names 3021` and one unmatched name: `extracted core OAuth browser flow uses Kilo branding` in `packages/opencode/test/kilocode/oauth-branding.test.ts`; final head contains its renamed partial replacement.
+- `bun test test/kilocode/oauth-branding.test.ts test/kilocode/compaction-payload-recovery.test.ts` from `packages/opencode` returned `6 pass`, `0 fail`, `33 expect() calls`, across 2 files in 5.33s.
+- `bun test test/kilocode/reference.test.ts` from `packages/opencode` returned `4 pass`, `0 fail`, `5 expect() calls`, in 1.475s. This confirms retained tests pass but does not fill the stale-source replacement gap.
+- `bun test test/reference.test.ts test/oauth-page.test.ts` from `packages/core` returned `4 pass`, `0 fail`, `7 expect() calls`, across 2 files in 354ms.
+- Direct final-head evaluation of `KiloOauthCallbackPage.success/error` returned titles `Authorization successful · Kilo` and `Authorization failed · Kilo`; both had `hasKilo: true` and `hasOpenCode: false`.
+- `git status --short` before report writing showed only the pre-existing untracked `vscode-self-test.config.json`. Final verification also showed the parallel reviewers' report files; this audit did not modify those files or the pre-existing config.
+
+## Limitations
+
+- This audit did not execute all 405 modified test files or the full package/CI matrix. It used static base/head comparison, declaration/assertion and concept searches, architecture tracing, and targeted controls.
+- Test-name extraction is regex-based and can miss dynamically generated names; removed assertions and Kilo concepts were searched separately to reduce that risk.
+- Git similarity-based rename detection is unreliable for heavily rewritten files. Low-threshold results produced false pairings among unrelated small tests, so conclusions about moved coverage are based on symbols, invariants, implementation removal, and final-head concept searches rather than rename scores alone.
+- No GitHub state was read or mutated for this coverage audit, and no commit or push was performed.

--- a/UNNECESSARY_MARKERS.md
+++ b/UNNECESSARY_MARKERS.md
@@ -1,0 +1,74 @@
+# Unnecessary `kilocode_change` Markers
+
+## Scope And Methodology
+
+- Reviewed PR #12695 at exact head `054ee594915b93546d0613a45e0671edd43905ee` against requested base `0b8f749ae13388cf7a38ea7fb9183acaac99eef8`; `git merge-base` returned the same base. The PR range contains 525 commits and 1,237 changed files (334 added, 860 modified, 31 deleted, 12 renamed).
+- Verified the recorded and resolved upstream version is `v1.17.13` at `10c894bdeef3618f5666fb506ef7f9491bb964d8`, that this commit is an ancestor of the reviewed head, and that `.opencode-version` at the head contains `v1.17.13`.
+- Read the required root/package review instructions and marker-minimization guidance. Limited findings to files changed in `0b8f749a..054ee594`; repository-wide candidates outside that range were treated only as non-findings.
+- Ran the required bulk candidate command, then successful narrower dry runs over the shared packages containing the PR-relevant marker-only files. Independently scanned all 1,237 PR-touched files using the repository's own `translate()`, `clean()`, and `join()` functions. Of 301 PR-touched files containing `kilocode_change`, only the two findings below were marker-only relative to transformed upstream.
+- For each relevant candidate, ran the single-file reset script with its supported invocation, `bun run script/upstream/reset-to-upstream.ts <repo-relative-file> --dry-run`. No reset was applied.
+
+## Findings
+
+### P3: stale marker in the merged core prompt test
+
+- **Path / marker:** `packages/core/test/session-prompt.test.ts:101`, standalone comment `// kilocode_change - no durable interrupt lookup: released database readers cannot decode that event type.` immediately before `describe("SessionV2.prompt", ...)`.
+- **Evidence:** `find-reset-candidates.ts packages/core --dry-run --concurrency 1` classified this file as `markers-only`. Compared with pristine upstream merge parent `10c894bd`, the sole final-head difference is that comment. Upstream blob hash is `c6bc9430b3ac0467db3e00d437d2b321ad963e47`; head blob hash is `4389eaf90e68dbc5636b16b700dd579efdc3f3fd`. Transform-aware verification returned `rawEqual=false`, `transformedEqual=false`, `markerCleanedEqual=true`; upstream/transformed/cleaned size is 19,669 bytes while head is 19,776 bytes.
+- **Reset verification:** `[OK] Last merged upstream: v1.17.13 (10c894bd)` followed by `[INFO] [DRY-RUN] Would reset packages/core/test/session-prompt.test.ts to transformed upstream v1.17.13`.
+- **Cleanup:** reset this file to transformed upstream or remove the standalone marker comment. There is no Kilo code attached to preserve.
+
+### P3: stale inline marker in the merged account service test
+
+- **Path / marker:** `packages/opencode/test/account/service.test.ts:39`, trailing `// kilocode_change` on the `LayerNode.compile(Account.node, ...)` line.
+- **Evidence:** `find-reset-candidates.ts packages/opencode/test --dry-run --concurrency 1` classified this file as `markers-only`. Compared with pristine upstream merge parent `10c894bd`, the sole final-head difference is the trailing marker. Upstream blob hash is `0ebe69c2394b6b5028acd45e32132d5df41251ea`; head blob hash is `eb246cfe824158108a114af2b6e97135719a4367`. Transform-aware verification returned `rawEqual=false`, `transformedEqual=false`, `markerCleanedEqual=true`; upstream/transformed/cleaned size is 14,032 bytes while head is 14,051 bytes.
+- **Reset verification:** `[OK] Last merged upstream: v1.17.13 (10c894bd)` followed by `[INFO] [DRY-RUN] Would reset packages/opencode/test/account/service.test.ts to transformed upstream v1.17.13`.
+- **Cleanup:** reset this file to transformed upstream or remove the trailing marker. The `LayerNode.compile(...)` implementation itself is pristine upstream code.
+
+## Notable Non-Findings
+
+- The source-scope run also classified `packages/opencode/src/cli/cmd/run/demo.ts` and `packages/opencode/src/cli/cmd/run/subagent-data.ts` as marker-only, but neither file changed in the reviewed PR range; they are excluded from findings.
+- No other PR-touched marker file became identical to transformed `v1.17.13` after marker removal. This statement is limited to marker-only identity, not whether other small Kilo diffs remain desirable.
+- Branding/package transforms did not affect either finding: for both candidates the transformed upstream byte count equals the raw upstream byte count.
+
+## Command Results
+
+`bun run script/upstream/find-reset-candidates.ts --dry-run`:
+
+```text
+[OK] Last merged upstream: v1.17.13 (10c894bd)
+[INFO] Scope: (all shared paths)
+[INFO] Review limit: 5 non-marker diff line(s)
+[INFO] Mode: dry-run
+[INFO] Skipping 332 non-code asset(s)
+[INFO] Skipping 1879 file(s) protected by keepOurs/skipFiles config
+[INFO] Candidate files: 1198
+[INFO] Checking upstream blob sizes...
+[INFO] Pre-bucketed 359 (missing or too-large)
+[INFO] Classifying 839 file(s)...
+[INFO] Classified 839/839
+shell tool terminated command after exceeding timeout 600000 ms
+```
+
+The same exact command first timed out after 120,000 ms at the same point. It made no writes because `--dry-run` was set.
+
+Successful scoped candidate results relevant to this report:
+
+```text
+packages/core: 135 candidates; markers-only 1
+  packages/core/test/session-prompt.test.ts
+
+packages/opencode/test: 175 candidates; markers-only 1
+  packages/opencode/test/account/service.test.ts
+
+packages/opencode/src: 255 candidates; markers-only 2
+  packages/opencode/src/cli/cmd/run/demo.ts
+  packages/opencode/src/cli/cmd/run/subagent-data.ts
+```
+
+The two `packages/opencode/src` candidates are outside the PR range. Both PR-relevant single-file reset dry runs exited successfully and reported that they would reset to transformed upstream `v1.17.13`; neither wrote a file.
+
+## Limitations
+
+- The required all-shared-path bulk command reproducibly hung after printing `Classified 839/839` and never emitted its markdown summary, even with a 600-second timeout. Static inspection shows report generation should follow classification directly, but the exact post-classification blocking cause was not established. Successful package-scoped executions plus the independent transform-aware scan supplied the missing PR-scoped classification.
+- The bulk finder intentionally excludes 332 non-code assets and 1,879 config-protected files and pre-buckets missing/oversized files. The independent scan considered PR-touched text blobs that contain marker text and exist at both upstream and head, so this report does not claim marker-only verification for binary, deleted, upstream-missing, or marker-free files.
+- Existing untracked reviewer artifacts were present and were not read, edited, deleted, or included in this report. No GitHub state was queried or mutated, and no commit, push, reset, or source edit was performed.


### PR DESCRIPTION
## What

Add seven focused local review reports for #12695 covering marker preservation, infrastructure, OpenCode branding, unnecessary markers, pipeline chains, config fallback behavior, and Kilo-specific test coverage.

## Why

The upstream merge is large enough that these fork-specific risks need an explicit human-readable audit. The reports preserve exact commands, evidence, notable non-findings, and limitations without changing the reviewed code.