### PR TITLE
fix(vscode): defer unused worktree watchers

### DIFF
--- a/.changeset/calm-location-watchers.md
+++ b/.changeset/calm-location-watchers.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Prevent VS Code sessions and Agent Manager worktrees from starting unused file watchers and defer file indexing until search is used.

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -166,22 +166,33 @@ export const fffLayer = Layer.effect(
       return real !== undefined && FSUtil.contains(root.path, real)
     })
     // kilocode_change end
-    const result = yield* Effect.try({
-      try: () =>
-        Fff.create({
-          basePath: location.directory,
-          aiMode: true,
-          ...scanning(location.directory), // kilocode_change - permit broad scanning only at the exact boundary.
-        }),
-      catch: (cause) => cause,
-    }).pipe(Effect.orDie)
-    if (!result.ok) return yield* Effect.die(result.error)
-    yield* Effect.addFinalizer(() => Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
+    // kilocode_change start - defer FFF until search because other location consumers do not need its native index.
+    const scope = yield* Scope.Scope
+    const load = yield* Effect.cached(
+      Effect.gen(function* () {
+        const result = yield* Effect.try({
+          try: () =>
+            Fff.create({
+              basePath: location.directory,
+              aiMode: true,
+              disableMmapCache: true,
+              disableContentIndexing: true,
+              ...scanning(location.directory),
+            }),
+          catch: (cause) => cause,
+        }).pipe(Effect.orDie)
+        if (!result.ok) return yield* Effect.die(result.error)
+        yield* Scope.addFinalizer(scope, Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
+        return result
+      }),
+    )
+    // kilocode_change end
     return Service.of({
       glob: (input) =>
         // kilocode_change start
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
+          const result = yield* load
         // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
@@ -210,6 +221,7 @@ export const fffLayer = Layer.effect(
         // kilocode_change start
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
+          const result = yield* load
         // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
@@ -247,7 +259,8 @@ export const fffLayer = Layer.effect(
           })
         }),
       find: (input) =>
-        Effect.sync(() => {
+        Effect.gen(function* () { // kilocode_change - load the native index only for an actual search.
+          const result = yield* load // kilocode_change
           const options = { pageIndex: 0, pageSize: input.limit ?? 50 }
           const items = (() => {
             if (input.type === "file") {

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -1,7 +1,7 @@
 export * as FileSystemSearch from "./search"
 
 import path from "path"
-import { Context, Effect, Layer, Scope } from "effect"
+import { Context, Duration, Effect, Layer, Scope } from "effect"
 import { Fff } from "#fff"
 import fuzzysort from "fuzzysort"
 import { FileSystem } from "../filesystem"
@@ -170,38 +170,61 @@ export const fffLayer = Layer.effect(
     // kilocode_change end
     // kilocode_change start - defer FFF until search because other location consumers do not need its native index.
     const scope = yield* Scope.Scope
-    const load = yield* Effect.cached(
-      Effect.gen(function* () {
-        const result = yield* Effect.try({
-          try: () =>
-            Fff.create({
-              basePath: location.directory,
-              aiMode: true,
-              disableMmapCache: true,
-              disableContentIndexing: true,
-              ...scanning(location.directory),
-            }),
-          catch: (cause) => cause,
-        }).pipe(Effect.orDie)
-        if (!result.ok) return yield* Effect.die(result.error)
-        const scan = yield* Effect.promise(() => result.value.waitForScan()).pipe(Effect.orDie)
-        if (!scan.ok || !scan.value) return yield* Effect.die(new Error("FFF initial scan did not complete"))
-        yield* Scope.addFinalizer(scope, Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
-        return result
-      }),
+    const release = (entry: { finder: { destroy(): void }; closed: boolean }) =>
+      Effect.sync(() => {
+        if (entry.closed) return
+        entry.closed = true
+        entry.finder.destroy()
+      }).pipe(Effect.ignore)
+    const make = Effect.gen(function* () {
+      const result = yield* Effect.try({
+        try: () =>
+          Fff.create({
+            basePath: location.directory,
+            aiMode: true,
+            disableMmapCache: true,
+            disableContentIndexing: true,
+            ...scanning(location.directory),
+          }),
+        catch: (cause) => cause,
+      }).pipe(Effect.orDie)
+      if (!result.ok) return yield* Effect.die(result.error)
+      const entry = { finder: result.value, closed: false }
+      yield* Scope.addFinalizer(scope, release(entry))
+      return entry
+    })
+    const [load, invalidate] = yield* Effect.cachedInvalidateWithTTL(
+      make.pipe(
+        Effect.flatMap((entry) =>
+          Effect.promise(() => entry.finder.waitForScan())
+            .pipe(
+              Effect.orDie,
+              Effect.onError(() => release(entry)),
+            )
+            .pipe(
+              Effect.flatMap((scan) => {
+                if (!scan.ok || !scan.value) return Effect.die(new Error("FFF initial scan did not complete"))
+                return Effect.succeed(entry)
+              }),
+            ),
+        ),
+      ),
+      Duration.infinity,
     )
+    const get = load.pipe(Effect.onError(() => invalidate))
+    yield* Scope.addFinalizer(scope, invalidate)
     // kilocode_change end
     return Service.of({
       glob: (input) =>
         // kilocode_change start
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
-          const result = yield* load
+          const result = yield* get
           // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
           const found = yield* Effect.sync(() =>
-            result.value.glob(prefix ? `${prefix}/${input.pattern}` : input.pattern, {
+            result.finder.glob(prefix ? `${prefix}/${input.pattern}` : input.pattern, {
               pageIndex: 0,
               pageSize: input.limit,
             }),
@@ -225,13 +248,13 @@ export const fffLayer = Layer.effect(
         // kilocode_change start
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
-          const result = yield* load
+          const result = yield* get
           // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
           const found = yield* Effect.sync(
             () =>
-              result.value.grep(
+              result.finder.grep(
                 [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
                   .filter((value) => value !== undefined)
                   .join(" "),
@@ -266,11 +289,11 @@ export const fffLayer = Layer.effect(
       find: (input) =>
         Effect.gen(function* () {
           // kilocode_change - load the native index only for an actual search.
-          const result = yield* load // kilocode_change
+          const result = yield* get // kilocode_change
           const options = { pageIndex: 0, pageSize: input.limit ?? 50 }
           const items = (() => {
             if (input.type === "file") {
-              const found = result.value.fileSearch(input.query.trim(), options)
+              const found = result.finder.fileSearch(input.query.trim(), options)
               if (!found.ok) throw found.error
               return found.value.items.map((item, index) => ({
                 path: item.relativePath,
@@ -279,7 +302,7 @@ export const fffLayer = Layer.effect(
               }))
             }
             if (input.type === "directory") {
-              const found = result.value.directorySearch(input.query.trim(), options)
+              const found = result.finder.directorySearch(input.query.trim(), options)
               if (!found.ok) throw found.error
               return found.value.items.map((item, index) => ({
                 path: item.relativePath,
@@ -287,7 +310,7 @@ export const fffLayer = Layer.effect(
                 score: found.value.scores[index]?.total ?? 0,
               }))
             }
-            const found = result.value.mixedSearch(input.query.trim(), options)
+            const found = result.finder.mixedSearch(input.query.trim(), options)
             if (!found.ok) throw found.error
             return found.value.items.map((item, index) => ({
               path: item.item.relativePath,

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -176,23 +176,25 @@ export const fffLayer = Layer.effect(
         entry.closed = true
         entry.finder.destroy()
       }).pipe(Effect.ignore)
-    const make = Effect.gen(function* () {
-      const result = yield* Effect.try({
-        try: () =>
-          Fff.create({
-            basePath: location.directory,
-            aiMode: true,
-            disableMmapCache: true,
-            disableContentIndexing: true,
-            ...scanning(location.directory),
-          }),
-        catch: (cause) => cause,
-      }).pipe(Effect.orDie)
-      if (!result.ok) return yield* Effect.die(result.error)
-      const entry = { finder: result.value, closed: false }
-      yield* Scope.addFinalizer(scope, release(entry))
-      return entry
-    })
+    const make = Effect.uninterruptible(
+      Effect.gen(function* () {
+        const result = yield* Effect.try({
+          try: () =>
+            Fff.create({
+              basePath: location.directory,
+              aiMode: true,
+              disableMmapCache: true,
+              disableContentIndexing: true,
+              ...scanning(location.directory),
+            }),
+          catch: (cause) => cause,
+        }).pipe(Effect.orDie)
+        if (!result.ok) return yield* Effect.die(result.error)
+        const entry = { finder: result.value, closed: false }
+        yield* Scope.addFinalizer(scope, release(entry))
+        return entry
+      }),
+    )
     const [load, invalidate] = yield* Effect.cachedInvalidateWithTTL(
       make.pipe(
         Effect.flatMap((entry) =>

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -77,7 +77,8 @@ export const ripgrepLayer = Layer.effect(
             })
             .pipe(
               Effect.map((result) =>
-                result.items.map( // kilocode_change
+                result.items.map(
+                  // kilocode_change
                   (entry) =>
                     new FileSystem.Entry({
                       ...entry,
@@ -105,7 +106,8 @@ export const ripgrepLayer = Layer.effect(
             })
             .pipe(
               Effect.map((result) =>
-                result.items.map( // kilocode_change
+                result.items.map(
+                  // kilocode_change
                   (match) =>
                     new FileSystem.Match({
                       ...match,
@@ -182,6 +184,8 @@ export const fffLayer = Layer.effect(
           catch: (cause) => cause,
         }).pipe(Effect.orDie)
         if (!result.ok) return yield* Effect.die(result.error)
+        const scan = yield* Effect.promise(() => result.value.waitForScan()).pipe(Effect.orDie)
+        if (!scan.ok || !scan.value) return yield* Effect.die(new Error("FFF initial scan did not complete"))
         yield* Scope.addFinalizer(scope, Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
         return result
       }),
@@ -193,7 +197,7 @@ export const fffLayer = Layer.effect(
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
           const result = yield* load
-        // kilocode_change end
+          // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
           const found = yield* Effect.sync(() =>
@@ -208,7 +212,7 @@ export const fffLayer = Layer.effect(
           yield* SearchTarget.validate(fs, target).pipe(Effect.orDie)
           const items = yield* Effect.filter(found.value.items, (item) => safe(root, item.relativePath))
           return items.map((item) => {
-          // kilocode_change end
+            // kilocode_change end
             const absolute = path.resolve(location.directory, item.relativePath)
             return new FileSystem.Entry({
               path: RelativePath.make(item.relativePath.replaceAll("\\", "/")),
@@ -222,24 +226,25 @@ export const fffLayer = Layer.effect(
         Effect.gen(function* () {
           const { root, target } = yield* inspect(input.path)
           const result = yield* load
-        // kilocode_change end
+          // kilocode_change end
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           // kilocode_change start
-          const found = yield* Effect.sync(() =>
-            result.value.grep(
-              [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
-                .filter((value) => value !== undefined)
-                .join(" "),
-              { mode: "regex", pageSize: input.limit, timeBudgetMs: 1_500 },
-            ),
-          // kilocode_change end
+          const found = yield* Effect.sync(
+            () =>
+              result.value.grep(
+                [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
+                  .filter((value) => value !== undefined)
+                  .join(" "),
+                { mode: "regex", pageSize: input.limit, timeBudgetMs: 1_500 },
+              ),
+            // kilocode_change end
           )
           if (!found.ok) throw found.error
           // kilocode_change start
           yield* SearchTarget.validate(fs, target).pipe(Effect.orDie)
           const items = yield* Effect.filter(found.value.items, (item) => safe(root, item.relativePath))
           return items.map((match) => {
-          // kilocode_change end
+            // kilocode_change end
             const bytes = Buffer.from(match.lineContent)
             return new FileSystem.Match({
               entry: new FileSystem.Entry({
@@ -259,7 +264,8 @@ export const fffLayer = Layer.effect(
           })
         }),
       find: (input) =>
-        Effect.gen(function* () { // kilocode_change - load the native index only for an actual search.
+        Effect.gen(function* () {
+          // kilocode_change - load the native index only for an actual search.
           const result = yield* load // kilocode_change
           const options = { pageIndex: 0, pageSize: input.limit ?? 50 }
           const items = (() => {

--- a/packages/core/test/kilocode/fff.test.ts
+++ b/packages/core/test/kilocode/fff.test.ts
@@ -36,7 +36,7 @@ describe("FFF scanning boundaries", () => {
 })
 
 describe("FFF lifecycle", () => {
-  test("initializes on the first search and reuses one picker", async () => {
+  test("retries a failed first search and reuses one picker", async () => {
     if (!Fff.available()) return
 
     const dir = await tmpdir()
@@ -45,6 +45,7 @@ describe("FFF lifecycle", () => {
     try {
       FileFinder.create = (opts) => {
         calls.create++
+        if (calls.create === 1) return { ok: false, error: "transient failure" }
         calls.opts = opts
         const result = create(opts)
         if (!result.ok) return result
@@ -80,19 +81,25 @@ describe("FFF lifecycle", () => {
               const service = Context.get(context, FileSystemSearch.Service)
               expect(calls.create).toBe(0)
 
-              yield* Effect.all(
-                [
-                  service.find({ query: "", type: "file", limit: 1 }),
-                  service.find({ query: "", type: "file", limit: 1 }),
-                ],
-                { concurrency: "unbounded" },
+              const first = yield* Effect.exit(
+                Effect.all(
+                  [
+                    service.find({ query: "", type: "file", limit: 1 }),
+                    service.find({ query: "", type: "file", limit: 1 }),
+                  ],
+                  { concurrency: "unbounded" },
+                ),
               )
+              expect(first._tag).toBe("Failure")
               expect(calls.create).toBe(1)
+
+              yield* service.find({ query: "", type: "file", limit: 1 })
+              expect(calls.create).toBe(2)
               expect(calls.opts?.disableMmapCache).toBe(true)
               expect(calls.opts?.disableContentIndexing).toBe(true)
 
               yield* service.find({ query: "", type: "file", limit: 1 })
-              expect(calls.create).toBe(1)
+              expect(calls.create).toBe(2)
               expect(calls.destroy).toBe(0)
             }),
           (scope, exit) => Scope.close(scope, exit),

--- a/packages/core/test/kilocode/fff.test.ts
+++ b/packages/core/test/kilocode/fff.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test"
+import { FileFinder, type InitOptions } from "@ff-labs/fff-bun"
+import "@opencode-ai/core/filesystem"
+import { Fff } from "@opencode-ai/core/filesystem/fff.bun"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import os from "os"
 import path from "path"
+import { Context, Effect, Layer, Scope } from "effect"
 import { scanning } from "@opencode-ai/core/kilocode/fff"
+import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
+import { tmpdir } from "../fixture/tmpdir"
 
 describe("FFF scanning boundaries", () => {
   test("enables filesystem-root scanning only at the exact root", () => {
@@ -23,5 +32,76 @@ describe("FFF scanning boundaries", () => {
       enableFsRootScanning: false,
       enableHomeDirScanning: false,
     })
+  })
+})
+
+describe("FFF lifecycle", () => {
+  test("initializes on the first search and reuses one picker", async () => {
+    if (!Fff.available()) return
+
+    const dir = await tmpdir()
+    const create = FileFinder.create
+    const calls = { create: 0, destroy: 0, opts: undefined as InitOptions | undefined }
+    try {
+      FileFinder.create = (opts) => {
+        calls.create++
+        calls.opts = opts
+        const result = create(opts)
+        if (!result.ok) return result
+        const destroy = result.value.destroy.bind(result.value)
+        result.value.destroy = () => {
+          calls.destroy++
+          destroy()
+        }
+        return result
+      }
+
+      await Effect.runPromise(
+        Effect.acquireUseRelease(
+          Scope.make(),
+          (scope) =>
+            Effect.gen(function* () {
+              const { FileSystemSearch } = yield* Effect.promise(() => import("@opencode-ai/core/filesystem/search"))
+              const layer = FileSystemSearch.fffLayer.pipe(
+                Layer.provide(FSUtil.defaultLayer),
+                Layer.provide(
+                  Layer.succeed(
+                    Location.Service,
+                    Location.Service.of(
+                      location(
+                        { directory: AbsolutePath.make(dir.path) },
+                        { vcs: { type: "git", store: AbsolutePath.make(path.join(dir.path, ".git")) } },
+                      ),
+                    ),
+                  ),
+                ),
+              )
+              const context = yield* Layer.buildWithScope(layer, scope)
+              const service = Context.get(context, FileSystemSearch.Service)
+              expect(calls.create).toBe(0)
+
+              yield* Effect.all(
+                [
+                  service.find({ query: "", type: "file", limit: 1 }),
+                  service.find({ query: "", type: "file", limit: 1 }),
+                ],
+                { concurrency: "unbounded" },
+              )
+              expect(calls.create).toBe(1)
+              expect(calls.opts?.disableMmapCache).toBe(true)
+              expect(calls.opts?.disableContentIndexing).toBe(true)
+
+              yield* service.find({ query: "", type: "file", limit: 1 })
+              expect(calls.create).toBe(1)
+              expect(calls.destroy).toBe(0)
+            }),
+          (scope, exit) => Scope.close(scope, exit),
+        ),
+      )
+      expect(calls.destroy).toBe(1)
+    } finally {
+      FileFinder.create = create
+      await dir[Symbol.asyncDispose]()
+    }
   })
 })

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -29,7 +29,12 @@ export function resolveIndexingEnv(folders: readonly WorkspaceFolderLike[] | und
 }
 
 export function resolveManagedServerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  return { ...env, KILO_DISABLE_CHANNEL_DB: "true" }
+  return {
+    ...env,
+    KILO_DISABLE_CHANNEL_DB: "true",
+    // VS Code does not consume the backend's file.watcher.updated events.
+    KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+  }
 }
 
 export class ServerManager {

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -315,10 +315,17 @@ describe("server workspace helpers", () => {
     expect(resolveIndexingEnv([{ uri: { fsPath: "/repo" } }])).toEqual({})
   })
 
-  it("uses the shared database for the managed backend while preserving the environment", () => {
-    expect(resolveManagedServerEnv({ PATH: "/usr/bin", KILO_DISABLE_CHANNEL_DB: "false" })).toEqual({
+  it("disables unused managed-backend services while preserving the environment", () => {
+    expect(
+      resolveManagedServerEnv({
+        PATH: "/usr/bin",
+        KILO_DISABLE_CHANNEL_DB: "false",
+        KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: "false",
+      }),
+    ).toEqual({
       PATH: "/usr/bin",
       KILO_DISABLE_CHANNEL_DB: "true",
+      KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
     })
   })
 })


### PR DESCRIPTION
## Problem

Agent Manager creates location-scoped services for sessions, PTYs, references, and file operations across many worktrees. The FFF search layer eagerly initialized a native index and filesystem watcher for every location, even when no file search was requested. Managed VS Code backends also retained a Core file watcher whose events are not consumed by the extension.

The previous watcher change, [#12593](https://github.com/Kilo-Org/kilocode/pull/12593), stopped Kilo bootstrap warmup but did not stop FFF from initializing inside each location scope. A later upstream refactor restored that eager FFF path.

## Exact Fix

- Defer FFF construction until `find`, `glob`, or `grep` is actually called.
- Share the first FFF initialization within a location scope.
- Await the initial scan before returning search results.
- Invalidate failed or interrupted loads so a transient failure can retry.
- Register an idempotent finalizer immediately after native picker creation and destroy it when the location scope closes.
- Disable unused FFF mmap and content-index caches.
- Force managed VS Code servers to set `KILO_EXPERIMENTAL_DISABLE_FILEWATCHER=true`.
- Add lifecycle coverage for eager creation, concurrent initialization, initial-scan completion, retry behavior, cache settings, and cleanup.

## Measured Result

These measurements compare the live Kilo backend before and after reloading the packaged fix while multiple Agent Manager agents were active. CPU is workload-dependent, so the CPU values are sampled ranges rather than a controlled benchmark.

| Resource | Before | After | Improvement |
|---|---:|---:|---|
| FFF native watcher instances | 24-33 | 0 during normal Agent Manager use | No idle per-worktree FFF watchers |
| Core file watcher instances | 1 | 0 | Removed unused VS Code watcher |
| Kilo server threads | About 141 | 23-28 | Removed watcher worker pools |
| Kilo resident memory | About 2.2 GB | 1.15-1.3 GB | Roughly 40-48% lower |
| Kilo CPU | 47-187% with bursts | 18-62%, about 39% average while agents remained active | Much lower idle/background overhead |

The remaining CPU is workload-driven agent execution, SQLite/event processing, and session handling. Codebase indexing is separate, consent-gated, and was not part of the 24-33 watcher fanout.

## Merge Protection

The lifecycle tests fail if a future merge makes FFF eager again, creates duplicate concurrent pickers, skips the initial scan, or drops cleanup. The managed-backend test also verifies that VS Code always disables the unused Core watcher.