### PR TITLE
fix(cli): safely restore grep signal controls

### DIFF
--- a/.changeset/green-greps-settle.md
+++ b/.changeset/green-greps-settle.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add bounded, context-aware grep controls without leaving agents waiting on completed searches.

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -269,7 +269,11 @@ export const make = Effect.gen(function* () {
     return { stdout, stderr, all: Stream.merge(stdout, stderr) }
   }
 
-  const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions, settle: boolean) =>
+  const spawn = (
+    command: ChildProcess.StandardCommand,
+    opts: NodeChildProcess.SpawnOptions,
+    direct: boolean, // kilocode_change - avoid shadowing settle
+  ) =>
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
@@ -281,7 +285,7 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
-        if (settle) Deferred.doneUnsafe(signal, Exit.succeed(args)) // kilocode_change - bounded grep must not await inherited pipes
+        if (direct) Deferred.doneUnsafe(signal, Exit.succeed(args)) // kilocode_change - bounded grep must not await inherited pipes
       })
       proc.on("close", (...args) => {
         if (end) return

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -3,6 +3,7 @@ import { NodeFileSystem, NodeSink, NodeStream } from "@effect/platform-node"
 import * as NodePath from "@effect/platform-node/NodePath"
 import { prepareCommand as prepareSandbox } from "@kilocode/sandbox" // kilocode_change
 import { tap as tapStdio, tapped } from "./kilocode/stdio-tap" // kilocode_change - Bun drops buffered stdio on close
+import * as SpawnExit from "./kilocode/spawn-exit" // kilocode_change
 import * as SpawnValidation from "./kilocode/spawn-validation" // kilocode_change
 import { settle } from "./kilocode/exit-code" // kilocode_change - settle signal termination as 128 + signum
 import * as Deferred from "effect/Deferred"
@@ -268,7 +269,7 @@ export const make = Effect.gen(function* () {
     return { stdout, stderr, all: Stream.merge(stdout, stderr) }
   }
 
-  const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
+  const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions, settle: boolean) =>
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
@@ -280,6 +281,7 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        if (settle) Deferred.doneUnsafe(signal, Exit.succeed(args)) // kilocode_change - bounded grep must not await inherited pipes
       })
       proc.on("close", (...args) => {
         if (end) return
@@ -326,6 +328,18 @@ export const make = Effect.gen(function* () {
       return Effect.fail(toPlatformError("kill", new Error("Failed to kill child process"), command))
     })
 
+  // kilocode_change start - inspect descendants owned by commands that settle on direct exit
+  const groupAlive = (proc: NodeChildProcess.ChildProcess) => {
+    if (process.platform === "win32") return false
+    try {
+      process.kill(-proc.pid!, 0)
+      return true
+    } catch {
+      return false
+    }
+  }
+  // kilocode_change end
+
   const timeout =
     (
       proc: NodeChildProcess.ChildProcess,
@@ -370,6 +384,7 @@ export const make = Effect.gen(function* () {
       switch (command._tag) {
         case "StandardCommand": {
           const validation = SpawnValidation.take(command) // kilocode_change - retain target validation through preparation
+          const direct = SpawnExit.take(command) // kilocode_change - opt selected commands into direct-exit settlement
           const dir = yield* cwd(command.options)
           // kilocode_change start - prepare agent-scoped commands through the selected sandbox backend
           const target = yield* prepareSandbox(command, dir, env(command.options))
@@ -396,21 +411,33 @@ export const make = Effect.gen(function* () {
 
           const [proc, signal] = yield* Effect.acquireRelease(
             // kilocode_change start - spawn the prepared command and options
-            spawn(target, {
-              cwd: dir,
-              env: env(target.options),
-              stdio: stdios(sin, sout, serr, extra),
-              detached: target.options.detached ?? process.platform !== "win32",
-              shell: target.options.shell,
-              // kilocode_change end
-              windowsHide: process.platform === "win32",
-            }),
+            spawn(
+              target,
+              {
+                cwd: dir,
+                env: env(target.options),
+                stdio: stdios(sin, sout, serr, extra),
+                detached: target.options.detached ?? process.platform !== "win32",
+                shell: target.options.shell,
+                // kilocode_change end
+                windowsHide: process.platform === "win32",
+              },
+              direct, // kilocode_change
+            ),
             Effect.fnUntraced(function* ([proc, signal]) {
               const done = yield* Deferred.isDone(signal)
               const kill = timeout(proc, command, target.options) // kilocode_change
               if (done) {
                 const [code] = yield* Deferred.await(signal)
                 if (process.platform === "win32") return yield* Effect.void
+                // kilocode_change start - clean up only descendants owned by direct-settling commands
+                if (direct && groupAlive(proc)) {
+                  yield* Effect.ignore(killGroup(command, proc, target.options.killSignal ?? "SIGTERM"))
+                  yield* Effect.sleep("100 millis")
+                  if (groupAlive(proc)) yield* Effect.ignore(killGroup(command, proc, "SIGKILL"))
+                  return yield* Effect.void
+                }
+                // kilocode_change end
                 if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
                 return yield* Effect.void
               }

--- a/packages/core/src/kilocode/ripgrep-grep.ts
+++ b/packages/core/src/kilocode/ripgrep-grep.ts
@@ -1,0 +1,50 @@
+import type { Match } from "@opencode-ai/schema/filesystem"
+
+export interface Options {
+  readonly context?: number
+  readonly literal?: boolean
+  readonly ignoreCase?: boolean
+}
+
+export type GrepMatch = Match & {
+  readonly context: boolean
+  readonly textTruncated: boolean
+}
+
+export const flags = (input: Options) => [
+  ...(input.literal ? ["--fixed-strings"] : []),
+  ...(input.ignoreCase ? ["--ignore-case"] : []),
+  ...(input.context ? [`--context=${input.context}`] : []),
+]
+
+export const stop = (limit: number) => {
+  let matches = 0
+  return (row: { readonly context: boolean }) => !row.context && ++matches > limit
+}
+
+export const select = <
+  A extends {
+    readonly context: boolean
+    readonly path: { readonly text: string }
+    readonly line_number: number
+  },
+>(
+  input: { readonly limit: number; readonly context?: number },
+  items: readonly A[],
+) => {
+  let count = 0
+  const overflow = items.findIndex((row) => !row.context && ++count > input.limit)
+  const selected = items.slice(0, overflow === -1 ? items.length : overflow)
+  const matches = selected.filter((row) => !row.context)
+  return selected.filter(
+    (row) =>
+      !row.context ||
+      matches.some(
+        (match) =>
+          match.path.text === row.path.text && Math.abs(match.line_number - row.line_number) <= (input.context ?? 0),
+      ),
+  )
+}
+
+export const decorate = (match: Match, context: boolean, textTruncated: boolean): GrepMatch =>
+  Object.assign(match, { context, textTruncated })

--- a/packages/core/src/kilocode/spawn-exit.ts
+++ b/packages/core/src/kilocode/spawn-exit.ts
@@ -1,0 +1,14 @@
+import type { ChildProcess } from "effect/unstable/process"
+
+const commands = new WeakSet<object>()
+
+export function attach(command: ChildProcess.StandardCommand) {
+  commands.add(command)
+  return command
+}
+
+export function take(command: ChildProcess.StandardCommand) {
+  const found = commands.has(command)
+  commands.delete(command)
+  return found
+}

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -1,9 +1,11 @@
 export * as Ripgrep from "./ripgrep"
 
-import { Context, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Context, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { makeGlobalNode } from "./effect/app-node"
 import { Entry, Match } from "@opencode-ai/schema/filesystem"
+import * as KiloGrep from "./kilocode/ripgrep-grep" // kilocode_change
+import * as SpawnExit from "./kilocode/spawn-exit" // kilocode_change
 import * as SpawnValidation from "./kilocode/spawn-validation" // kilocode_change
 import { AppProcess, collectStream, waitForAbort } from "./process"
 import { NonNegativeInt, PositiveInt, RelativePath } from "./schema"
@@ -21,7 +23,7 @@ const MAX_RECORD_BYTES = 64 * 1024
 const MAX_SUBMATCHES = 100
 
 const RawMatch = Schema.Struct({
-  type: Schema.Literal("match"),
+  type: Schema.Literals(["match", "context"]), // kilocode_change - retain requested context records
   data: Schema.Struct({
     path: Schema.Struct({ text: Schema.String }),
     lines: Schema.Struct({ text: Schema.String }),
@@ -37,7 +39,7 @@ const RawMatch = Schema.Struct({
   }),
 })
 
-type RawMatchData = (typeof RawMatch.Type)["data"]
+type RawMatchData = (typeof RawMatch.Type)["data"] & { readonly context: boolean } // kilocode_change
 
 export class Error extends Schema.TaggedErrorClass<Error>()("Ripgrep.Error", {
   message: Schema.String,
@@ -69,7 +71,8 @@ export interface GlobInput {
   readonly validate?: Effect.Effect<void, unknown> // kilocode_change - bind approved searches at spawn
 }
 
-export interface GrepInput {
+export interface GrepInput extends KiloGrep.Options {
+  // kilocode_change
   readonly cwd: string
   readonly pattern: string
   readonly file?: string
@@ -82,7 +85,7 @@ export interface GrepInput {
 export interface Interface {
   readonly find: (input: FindInput) => Effect.Effect<readonly Entry[], Error>
   readonly glob: (input: GlobInput) => Effect.Effect<SearchResult<Entry>, Error> // kilocode_change
-  readonly grep: (input: GrepInput) => Effect.Effect<SearchResult<Match>, Error | InvalidPatternError> // kilocode_change
+  readonly grep: (input: GrepInput) => Effect.Effect<SearchResult<KiloGrep.GrepMatch>, Error | InvalidPatternError> // kilocode_change
 }
 
 // kilocode_change start - retain truncation state through model-facing tools
@@ -114,6 +117,7 @@ const layer = Layer.effect(
       readonly parse: (line: string) => Effect.Effect<A | undefined, Error>
       readonly pattern?: string
       readonly onItem?: (item: A) => Effect.Effect<void>
+      readonly stop?: (item: A) => boolean // kilocode_change - stop bounded searches at the overflow match
       readonly validate?: Effect.Effect<void, unknown> // kilocode_change - spawn-bound target validation
     }) => {
       const program = Effect.scoped(
@@ -124,16 +128,24 @@ const layer = Layer.effect(
             cwd: input.cwd,
             extendEnv: true,
             stdin: "ignore",
+            forceKillAfter: input.stop ? Duration.seconds(1) : undefined, // kilocode_change - bound grep interruption
           })
-          const handle = yield* process.spawn(
-            input.validate ? SpawnValidation.attach(command, input.validate) : command,
-          )
+          const validated = input.validate ? SpawnValidation.attach(command, input.validate) : command
+          const spawned = input.stop ? SpawnExit.attach(validated) : validated // kilocode_change
+          const handle = yield* process.spawn(spawned)
           // kilocode_change end
           const stderrFiber = yield* collectStream(handle.stderr, ERROR_BYTES).pipe(
             Effect.map((output) => output.buffer.toString("utf8")),
             Effect.forkScoped,
           )
           let observed = 0
+          let stopped = false // kilocode_change
+          const take = input.stop // kilocode_change start
+            ? Stream.takeUntil<A>((row) => {
+                stopped = input.stop?.(row) ?? false
+                return stopped
+              })
+            : Stream.take(input.limit + 1) // kilocode_change end
           const rows = yield* Stream.decodeText(handle.stdout).pipe(
             Stream.splitLines,
             Stream.filter((line) => line.length > 0),
@@ -143,11 +155,12 @@ const layer = Layer.effect(
               if (!input.onItem || observed++ >= input.limit) return Effect.void
               return input.onItem(row)
             }),
-            Stream.take(input.limit + 1),
+            take, // kilocode_change
             Stream.runCollect,
             Effect.map((chunk) => [...chunk]),
           )
-          const truncated = rows.length > input.limit
+          if (stopped) return { items: rows, truncated: true, partial: false } // kilocode_change
+          const truncated = input.stop ? false : rows.length > input.limit // kilocode_change - custom stop owns truncation
           if (truncated) return { items: rows.slice(0, input.limit), truncated, partial: false }
 
           const code = yield* handle.exitCode
@@ -244,11 +257,13 @@ const layer = Layer.effect(
       grep: (input) =>
         run<RawMatchData>({
           ...input,
+          stop: KiloGrep.stop(input.limit), // kilocode_change
           args: [
             "--no-config",
             "--json",
             "--hidden",
             "--no-messages",
+            ...KiloGrep.flags(input), // kilocode_change
             ...(input.include ? [`--glob=${input.include}`] : []),
             "--glob=!**/.git/**",
             "--",
@@ -264,13 +279,19 @@ const layer = Layer.effect(
                 })
             ).pipe(
               Effect.flatMap((json) => {
-                if (!json || typeof json !== "object" || !("type" in json) || json.type !== "match")
+                if (
+                  !json ||
+                  typeof json !== "object" ||
+                  !("type" in json) ||
+                  (json.type !== "match" && json.type !== "context") // kilocode_change
+                )
                   return Effect.succeed(undefined)
                 return Schema.decodeUnknownEffect(RawMatch)(json).pipe(
                   Effect.map((match) => ({
                     ...match.data,
                     path: { text: match.data.path.text.replace(/^\.[\\/]/, "") },
                     submatches: match.data.submatches.slice(0, MAX_SUBMATCHES),
+                    context: match.type === "context", // kilocode_change
                   })),
                   Effect.mapError((cause) => failure("Invalid ripgrep match output", cause)),
                 )
@@ -280,12 +301,12 @@ const layer = Layer.effect(
           // kilocode_change start - retain spawn metadata after mapping matches
           Effect.map((result) => ({
             ...result,
-            items: result.items.map((match) => {
+            items: KiloGrep.select(input, result.items).map((match) => {
               const relative = match.path.text
                 .replace(/^(?:\.[\\/])+/u, "")
                 .replace(/^[\\/]+/u, "")
                 .replaceAll("\\", "/")
-              return Match.make({
+              const item = Match.make({
                 entry: Entry.make({
                   path: RelativePath.make(relative),
                   type: "file",
@@ -299,6 +320,7 @@ const layer = Layer.effect(
                   end: submatch.end,
                 })),
               })
+              return KiloGrep.decorate(item, match.context, match.lines.text.length > 2_000)
             }),
           })),
           // kilocode_change end

--- a/packages/core/test/kilocode/ripgrep-settlement.test.ts
+++ b/packages/core/test/kilocode/ripgrep-settlement.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect } from "bun:test"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Effect, Fiber, Layer } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+import { tmpdir } from "../fixture/tmpdir"
+import { it } from "../lib/effect"
+
+const record = (type: "match" | "context", line: number, text: string) =>
+  JSON.stringify({
+    type,
+    data: {
+      path: { text: "fixture.ts" },
+      lines: { text: `${text}\n` },
+      line_number: line,
+      absolute_offset: line * 10,
+      submatches: type === "match" ? [{ match: { text: "NEEDLE.*" }, start: 0, end: 8 }] : [],
+    },
+  })
+
+const alive = (pid: number) => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const read = async (file: string) => {
+  const deadline = Date.now() + 1_000
+  while (Date.now() < deadline) {
+    const value = await fs.readFile(file, "utf8").catch(() => undefined)
+    if (value) return value
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${file}`)
+}
+
+const cleanup = async (file: string) => {
+  const pid = Number(await fs.readFile(file, "utf8").catch(() => ""))
+  if (!pid || !alive(pid)) return
+  try {
+    process.kill(pid, "SIGKILL")
+  } catch (err) {
+    if (alive(pid)) throw err
+  }
+}
+
+const gone = async (pid: number) => {
+  const deadline = Date.now() + 1_000
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true
+    await Bun.sleep(10)
+  }
+  return !alive(pid)
+}
+
+const fixture = async (dir: string, source: string) => {
+  if (process.platform !== "win32") {
+    const binary = path.join(dir, "rg")
+    await fs.writeFile(binary, `#!${process.execPath}\n${source}`, { mode: 0o755 })
+    return binary
+  }
+
+  const script = path.join(dir, "fake-rg.cjs")
+  const binary = path.join(dir, "rg.cmd")
+  await fs.writeFile(script, source)
+  await fs.writeFile(binary, `@echo off\r\n"${process.execPath}" "%~dp0fake-rg.cjs" %*\r\n`)
+  return binary
+}
+
+const layer = (binary: string) =>
+  LayerNode.compile(Ripgrep.node, [
+    [
+      RipgrepBinary.node,
+      Layer.succeed(RipgrepBinary.Service, RipgrepBinary.Service.of({ filepath: Effect.succeed(binary) })),
+    ],
+  ] as const)
+
+describe("Kilo ripgrep settlement", () => {
+  it.live(
+    "settles a bounded parameterized grep when inherited output stays open",
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const retained = path.join(tmp.path, "retained.pid")
+          const owned = path.join(tmp.path, "owned.pid")
+          const args = path.join(tmp.path, "args.json")
+          const output =
+            [
+              record("context", 1, "before"),
+              record("match", 2, "NEEDLE.*"),
+              record("context", 3, "after"),
+              record("context", 5, "later before"),
+              record("match", 6, "NEEDLE.*"),
+            ].join("\n") + "\n"
+          const source = `const { spawn } = require("node:child_process")
+const { writeFileSync, writeSync } = require("node:fs")
+const retained = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 30_000)"], {
+  detached: true,
+  stdio: ["ignore", "inherit", "inherit"],
+})
+retained.unref()
+${
+  process.platform === "win32"
+    ? ""
+    : `const owned = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 30_000)"], {
+  stdio: "ignore",
+})
+owned.unref()`
+}
+writeFileSync(${JSON.stringify(retained)}, String(retained.pid))
+${process.platform === "win32" ? "" : `writeFileSync(${JSON.stringify(owned)}, String(owned.pid))`}
+writeFileSync(${JSON.stringify(args)}, JSON.stringify(process.argv.slice(2)))
+writeSync(1, ${JSON.stringify(output)})
+`
+          const binary = yield* Effect.promise(() => fixture(tmp.path, source))
+
+          const result = yield* Ripgrep.Service.pipe(
+            Effect.flatMap((ripgrep) =>
+              ripgrep.grep({
+                cwd: tmp.path,
+                pattern: "NEEDLE.*",
+                include: "*.ts",
+                context: 1,
+                limit: 1,
+                literal: true,
+                ignoreCase: true,
+              }),
+            ),
+            Effect.provide(layer(binary)),
+            Effect.timeout("5 seconds"),
+          )
+          const pid = Number(yield* Effect.promise(() => read(retained)))
+          const passed: unknown = JSON.parse(yield* Effect.promise(() => read(args)))
+          if (!Array.isArray(passed) || !passed.every((arg) => typeof arg === "string")) {
+            throw new Error("Fake ripgrep did not capture string arguments")
+          }
+
+          expect(result.truncated).toBe(true)
+          expect(result.items.map((item) => [item.context, item.line, item.text.trim()])).toEqual([
+            [true, 1, "before"],
+            [false, 2, "NEEDLE.*"],
+            [true, 3, "after"],
+          ])
+          expect(passed).toContain("--fixed-strings")
+          expect(passed).toContain("--ignore-case")
+          expect(passed).toContain("--context=1")
+          expect(passed).toContain("--glob=*.ts")
+          expect(alive(pid)).toBe(true)
+          if (process.platform !== "win32") {
+            const child = Number(yield* Effect.promise(() => read(owned)))
+            expect(yield* Effect.promise(() => gone(child))).toBe(true)
+          }
+        }),
+      (tmp) =>
+        Effect.promise(async () => {
+          await cleanup(path.join(tmp.path, "retained.pid"))
+          await cleanup(path.join(tmp.path, "owned.pid"))
+          await tmp[Symbol.asyncDispose]()
+        }),
+    ),
+    10_000,
+  )
+
+  it.live(
+    "force kills a bounded grep that does not exit after cancellation",
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const ready = path.join(tmp.path, "ready.pid")
+          const source = `const { writeFileSync } = require("node:fs")
+if (process.platform !== "win32") process.on("SIGTERM", () => {})
+writeFileSync(${JSON.stringify(ready)}, String(process.pid))
+setInterval(() => {}, 10_000)
+`
+          const binary = yield* Effect.promise(() => fixture(tmp.path, source))
+
+          const controller = new AbortController()
+          const fiber = yield* Ripgrep.Service.pipe(
+            Effect.flatMap((ripgrep) =>
+              ripgrep.grep({ cwd: tmp.path, pattern: "needle", context: 1, limit: 1, signal: controller.signal }),
+            ),
+            Effect.provide(layer(binary)),
+            Effect.exit,
+            Effect.forkScoped,
+          )
+          const pid = Number(yield* Effect.promise(() => read(ready)))
+          controller.abort()
+          const exit = yield* Fiber.join(fiber).pipe(Effect.timeout("5 seconds"))
+
+          expect(exit._tag).toBe("Failure")
+          expect(alive(pid)).toBe(false)
+        }),
+      (tmp) =>
+        Effect.promise(async () => {
+          await cleanup(path.join(tmp.path, "ready.pid"))
+          await tmp[Symbol.asyncDispose]()
+        }),
+    ),
+    10_000,
+  )
+})

--- a/packages/opencode/src/kilocode/tool/grep-signal-controls.ts
+++ b/packages/opencode/src/kilocode/tool/grep-signal-controls.ts
@@ -1,0 +1,64 @@
+import { NonNegativeInt, PositiveInt } from "@opencode-ai/core/schema"
+import { Schema } from "effect"
+
+export const DEFAULT_LIMIT = 100
+
+export const fields = {
+  context: Schema.optional(NonNegativeInt).annotate({
+    description: "Number of context lines to show before and after each match (default 0)",
+  }),
+  limit: Schema.optional(PositiveInt).annotate({
+    description: "Maximum matching lines to return (default 100)",
+  }),
+  literal: Schema.optional(Schema.Boolean).annotate({
+    description: "Treat pattern as plain text instead of a regex (default false)",
+  }),
+  ignoreCase: Schema.optional(Schema.Boolean).annotate({
+    description: "Match without regard to letter case (default false)",
+  }),
+}
+
+type Input = {
+  readonly context?: number
+  readonly limit?: number
+  readonly literal?: boolean
+  readonly ignoreCase?: boolean
+}
+
+export const metadata = (input: Input, limit: number, context: number) => ({
+  context,
+  limit,
+  literal: input.literal,
+  ignoreCase: input.ignoreCase,
+})
+
+export const options = (input: Input, limit: number, context: number) => ({
+  limit,
+  context,
+  literal: input.literal,
+  ignoreCase: input.ignoreCase,
+})
+
+export const describe = (description: string) => `${description}
+- Searches file contents using regular expressions by default; use literal=true for plain-text patterns
+- Use ignoreCase=true for case-insensitive matching, context=N for surrounding lines, and limit=N to bound matches (default 100)
+- Context lines are explicitly labeled when requested`
+
+export const line = (
+  row: { readonly line: number; readonly text: string; readonly context: boolean },
+  context: number,
+) => {
+  const label = context === 0 ? `Line ${row.line}` : `${row.context ? "[context]" : "[match]"} Line ${row.line}`
+  return `  ${label}: ${row.text}`
+}
+
+export const limitNotice = (limit: number) =>
+  `${limit} matches limit reached. Use limit=${Math.min(Number.MAX_SAFE_INTEGER, limit * 2)} for more, or refine pattern.`
+
+export const notices = (rows: readonly { readonly textTruncated: boolean }[]) => {
+  const output: string[] = []
+  if (rows.some((row) => row.textTruncated)) {
+    output.push("", "Some matching or context lines were truncated. Use read for full lines.")
+  }
+  return output
+}

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -3,18 +3,20 @@ import { Effect, Schema } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import * as KiloGrep from "@/kilocode/tool/grep-signal-controls" // kilocode_change
 import { assertExternalDirectoryEffect } from "./external-directory"
 import DESCRIPTION from "./grep.txt"
 import * as Tool from "./tool"
 
 export const Parameters = Schema.Struct({
-  pattern: Schema.String.annotate({ description: "The regex pattern to search for in file contents" }),
+  pattern: Schema.String.annotate({ description: "Pattern to search for in file contents (regex by default)" }), // kilocode_change
   path: Schema.optional(Schema.String).annotate({
     description: "The directory to search in. Defaults to the current working directory.",
   }),
   include: Schema.optional(Schema.String).annotate({
     description: 'File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")',
   }),
+  ...KiloGrep.fields, // kilocode_change
 })
 
 export const GrepTool = Tool.define(
@@ -23,10 +25,12 @@ export const GrepTool = Tool.define(
     const fs = yield* FSUtil.Service
     const ripgrep = yield* Ripgrep.Service
     return {
-      description: DESCRIPTION,
+      description: KiloGrep.describe(DESCRIPTION), // kilocode_change
       parameters: Parameters,
-      execute: (params: { pattern: string; path?: string; include?: string }, ctx: Tool.Context) =>
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          const limit = params.limit ?? KiloGrep.DEFAULT_LIMIT // kilocode_change
+          const context = params.context ?? 0 // kilocode_change
           const empty = {
             title: params.pattern,
             metadata: { matches: 0, truncated: false },
@@ -44,6 +48,7 @@ export const GrepTool = Tool.define(
               pattern: params.pattern,
               path: params.path,
               include: params.include,
+              ...KiloGrep.metadata(params, limit, context), // kilocode_change
             },
           })
 
@@ -66,7 +71,7 @@ export const GrepTool = Tool.define(
             file: info?.type === "File" ? path.basename(search) : undefined, // kilocode_change - constrain exact-file searches
             pattern: params.pattern,
             include: params.include,
-            limit: 100,
+            ...KiloGrep.options(params, limit, context), // kilocode_change
             signal: ctx.abort, // kilocode_change - stop ripgrep when the tool call is cancelled
           })
           // kilocode_change start
@@ -74,18 +79,20 @@ export const GrepTool = Tool.define(
           if (matches.length === 0) return empty
           // kilocode_change end
 
-          const rows = matches.map((item) => ({ // kilocode_change
+          const rows = matches.map((item) => ({
+            // kilocode_change
             path: path.resolve(cwd, item.entry.path),
             line: item.line,
             text: item.text,
+            context: item.context, // kilocode_change
+            textTruncated: item.textTruncated, // kilocode_change
           }))
 
-          const limit = 100
           const truncated = result.truncated // kilocode_change
           const final = rows
           if (final.length === 0) return empty
 
-          const total = rows.length
+          const total = rows.filter((row) => !row.context).length // kilocode_change
           const hasMore = truncated // kilocode_change
           const output = [`Found ${total} matches${hasMore ? " (more matches available)" : ""}`]
 
@@ -96,13 +103,14 @@ export const GrepTool = Tool.define(
               current = match.path
               output.push(`${match.path}:`)
             }
-            output.push(`  Line ${match.line}: ${match.text}`)
+            output.push(KiloGrep.line(match, context)) // kilocode_change
           }
 
           if (truncated) {
             output.push("")
-            output.push("(Results truncated. Consider using a more specific path or pattern.)")
+            output.push(KiloGrep.limitNotice(limit)) // kilocode_change
           }
+          output.push(...KiloGrep.notices(rows)) // kilocode_change
           if (result.partial) output.push("", "(Some paths were inaccessible.)") // kilocode_change
 
           return {

--- a/packages/opencode/test/kilocode/tool/grep-signal-controls.test.ts
+++ b/packages/opencode/test/kilocode/tool/grep-signal-controls.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect } from "bun:test"
 import path from "path"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Agent } from "../../../src/agent/agent"
@@ -13,13 +14,8 @@ import { TestInstance } from "../../fixture/fixture"
 import { testEffect } from "../../lib/effect"
 
 const it = testEffect(
-  Layer.mergeAll(
-    CrossSpawnSpawner.defaultLayer,
-    FSUtil.defaultLayer,
-    Ripgrep.defaultLayer,
-    Truncate.defaultLayer,
-    Agent.defaultLayer,
-    Git.defaultLayer,
+  LayerNode.compile(
+    LayerNode.group([CrossSpawnSpawner.node, FSUtil.node, Ripgrep.node, Truncate.node, Agent.node, Git.node]),
   ),
 )
 

--- a/packages/opencode/test/kilocode/tool/grep-signal-controls.test.ts
+++ b/packages/opencode/test/kilocode/tool/grep-signal-controls.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { Agent } from "../../../src/agent/agent"
+import { Git } from "../../../src/git"
+import { GrepTool } from "../../../src/tool/grep"
+import { Truncate } from "../../../src/tool/truncate"
+import { MessageID, SessionID } from "../../../src/session/schema"
+import { TestInstance } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(
+    CrossSpawnSpawner.defaultLayer,
+    FSUtil.defaultLayer,
+    Ripgrep.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+    Git.defaultLayer,
+  ),
+)
+
+const ctx = {
+  sessionID: SessionID.make("ses_grep_signal_controls"),
+  messageID: MessageID.make("msg_grep_signal_controls"),
+  callID: "",
+  agent: "code",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const file = (test: { readonly directory: string }, name: string) => path.join(test.directory, name)
+
+const init = Effect.gen(function* () {
+  const info = yield* GrepTool
+  return yield* info.init()
+})
+
+describe("Kilo grep signal-to-noise controls", () => {
+  it.instance("preserves the default match output", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(file(test, "default.txt"), "before\nneedle\nafter\n"))
+      const grep = yield* init
+      const result = yield* grep
+        .execute({ pattern: "needle", path: test.directory }, ctx)
+        .pipe(Effect.timeout("2 seconds"))
+
+      expect(result.metadata.matches).toBe(1)
+      expect(result.output).toContain("Line 2: needle")
+      expect(result.output).not.toContain("[match]")
+    }),
+  )
+
+  it.instance("executes all signal controls and settles at the custom limit", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        Bun.write(
+          file(test, "controls.txt"),
+          ["regex before", "NEEDLEzzz", "regex after", "before", "NEEDLE.*", "after", "far", "needle.*"].join("\n") +
+            "\n",
+        ),
+      )
+      const grep = yield* init
+      const result = yield* grep
+        .execute(
+          {
+            pattern: "needle.*",
+            path: test.directory,
+            include: "*.txt",
+            context: 1,
+            limit: 1,
+            literal: true,
+            ignoreCase: true,
+          },
+          ctx,
+        )
+        .pipe(Effect.timeout("2 seconds"))
+
+      expect(result.metadata).toEqual({ matches: 1, truncated: true })
+      expect(result.output).toContain("[context] Line 4: before")
+      expect(result.output).toContain("[match] Line 5: NEEDLE.*")
+      expect(result.output).toContain("[context] Line 6: after")
+      expect(result.output).not.toContain("NEEDLEzzz")
+      expect(result.output).not.toContain("Line 7: far")
+      expect(result.output).not.toContain("Line 8: needle.*")
+      expect(result.output).toContain("1 matches limit reached. Use limit=2 for more, or refine pattern.")
+    }),
+  )
+
+  it.instance("does not count context lines toward the match limit", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const content = Array.from(
+        { length: 35 },
+        (_, index) => `before-${index}\nneedle-${index}\nafter-${index}\ngap-${index}`,
+      ).join("\n")
+      yield* Effect.promise(() => Bun.write(file(test, "context-limit.txt"), `${content}\n`))
+      const grep = yield* init
+      const result = yield* grep
+        .execute({ pattern: "needle", path: test.directory, context: 1, limit: 100 }, ctx)
+        .pipe(Effect.timeout("2 seconds"))
+
+      expect(result.metadata.matches).toBe(35)
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.output).toContain("needle-34")
+      expect(result.output).not.toContain("matches limit reached")
+    }),
+  )
+
+  it.instance("guides the model to read truncated lines", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(file(test, "long.txt"), `${"x".repeat(2_100)}needle\n`))
+      const grep = yield* init
+      const result = yield* grep.execute({ pattern: "needle", path: test.directory }, ctx)
+
+      expect(result.metadata.matches).toBe(1)
+      expect(result.output).toContain("Some matching or context lines were truncated. Use read for full lines.")
+    }),
+  )
+})

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -114,16 +114,37 @@ exports[`tool parameters JSON Schema (wire shape) grep 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
+    "context": {
+      "description": "Number of context lines to show before and after each match (default 0)",
+      "maximum": 9007199254740991,
+      "minimum": 0,
+      "type": "integer",
+    },
+    "ignoreCase": {
+      "description": "Match without regard to letter case (default false)",
+      "type": "boolean",
+    },
     "include": {
       "description": "File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")",
       "type": "string",
+    },
+    "limit": {
+      "description": "Maximum matching lines to return (default 100)",
+      "exclusiveMinimum": 0,
+      "maximum": 9007199254740991,
+      "minimum": -9007199254740991,
+      "type": "integer",
+    },
+    "literal": {
+      "description": "Treat pattern as plain text instead of a regex (default false)",
+      "type": "boolean",
     },
     "path": {
       "description": "The directory to search in. Defaults to the current working directory.",
       "type": "string",
     },
     "pattern": {
-      "description": "The regex pattern to search for in file contents",
+      "description": "Pattern to search for in file contents (regex by default)",
       "type": "string",
     },
   },

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -145,7 +145,7 @@ describe("tool.grep", () => {
       const grep = yield* info.init()
       const result = yield* grep.execute({ pattern: "needle", path: test.directory, include: "*.txt" }, ctx)
 
-      expect(result.output).toContain("(Results truncated. Consider using a more specific path or pattern.)")
+      expect(result.output).toContain("100 matches limit reached. Use limit=200 for more, or refine pattern.") // kilocode_change
       expect(result.output).not.toMatch(/showing \d+ of \d+ matches/)
     }),
   )

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -163,6 +163,21 @@ describe("tool parameters", () => {
       expect(parsed.path).toBe("/tmp")
       expect(parsed.include).toBe("*.ts")
     })
+    // kilocode_change start - configurable grep signal controls
+    test("accepts signal controls", () => {
+      expect(parse(Grep, { pattern: "TODO", context: 0, limit: 1, literal: true, ignoreCase: true })).toMatchObject({
+        context: 0,
+        limit: 1,
+        literal: true,
+        ignoreCase: true,
+      })
+    })
+    test("rejects invalid signal controls", () => {
+      expect(accepts(Grep, { pattern: "TODO", context: -1 })).toBe(false)
+      expect(accepts(Grep, { pattern: "TODO", limit: 0 })).toBe(false)
+      expect(accepts(Grep, { pattern: "TODO", limit: 1.5 })).toBe(false)
+    })
+    // kilocode_change end
     test("rejects missing pattern", () => {
       expect(accepts(Grep, {})).toBe(false)
     })


### PR DESCRIPTION
PR #12811 added configurable grep context, limits, literal matching, and case-insensitive matching, but bounded searches could leave an agent waiting after the direct ripgrep process had already exited. PR #12847 reverted the controls because descendants retaining inherited output pipes could delay Node's `close` event indefinitely.

This restores the signal controls while making early settlement an explicit ripgrep-only process policy. Bounded ripgrep commands settle on direct process exit, clean up owned process-group descendants on POSIX, and retain force-kill escalation for cancellation. Other commands keep the existing close-based lifecycle, so ordinary background shell processes are not pulled into this behavior.

The regression coverage recreates the inherited-pipe condition with a platform-specific fake ripgrep executable. The existing unit matrix exercises settlement and cancellation on Linux, macOS, and Windows; POSIX jobs additionally assert owned process-group cleanup while detached descendants remain untouched.