### PR TITLE
fix(vscode): prevent Agent Manager overview timeouts

### DIFF
--- a/.changeset/quiet-worktrees-list.md
+++ b/.changeset/quiet-worktrees-list.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent Agent Manager overview requests from timing out while refreshing Git statistics across many worktrees.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -240,7 +240,7 @@ export class AgentManagerProvider implements Disposable {
         await this.stateReady
         return this.state
       },
-      stats: (refresh) => this.statsPoller.snapshot(refresh),
+      stats: () => this.statsPoller.snapshot(),
       prs: () => this.prBridge.snapshot(),
       push: () => this.pushState(),
       managed: (id) => this.panelSessions.has(id) || !!this.state?.getSession(id),

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -164,10 +164,10 @@ export class GitStatsPoller {
   }
 
   private async fetch(generation = this.generation): Promise<void> {
-    await Promise.all([this.fetchWorktreeStats(false, generation), this.fetchLocalStats(generation)])
+    await Promise.all([this.fetchWorktreeStats(generation), this.fetchLocalStats(generation)])
   }
 
-  private async fetchWorktreeStats(includeSkipped = false, generation = this.generation): Promise<void> {
+  private async fetchWorktreeStats(generation = this.generation): Promise<void> {
     const worktrees = this.options.getWorktrees()
     if (worktrees.length === 0) return
 
@@ -183,7 +183,7 @@ export class GitStatsPoller {
     for (const id of Object.keys(this.lastStats)) {
       if (!ids.has(id)) delete this.lastStats[id]
     }
-    const active = includeSkipped ? available : available.filter((wt) => !this.skipWorktreeIds.has(wt.id))
+    const active = available.filter((wt) => !this.skipWorktreeIds.has(wt.id))
     if (active.length === 0) {
       if (available.length > 0) return
       if (this.lastHash === "") return

--- a/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitStatsPoller.ts
@@ -131,13 +131,7 @@ export class GitStatsPoller {
     this.lastStats = {}
   }
 
-  async snapshot(refresh = false): Promise<{ worktrees: WorktreeStats[]; local?: LocalStats }> {
-    if (refresh && !this.busy) {
-      this.busy = true
-      await Promise.all([this.fetchWorktreeStats(true), this.fetchLocalStats()]).finally(() => {
-        this.busy = false
-      })
-    }
+  async snapshot(): Promise<{ worktrees: WorktreeStats[]; local?: LocalStats }> {
     return {
       worktrees: Object.values(this.lastStats),
       ...(this.lastLocalStats ? { local: this.lastLocalStats } : {}),

--- a/packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts
@@ -257,7 +257,10 @@ export class AgentManagerOrchestrationBridge {
       if (this.disposed || active.cancelled) return
       const client = this.connection.getClient()
       if (request.operation === "overview") {
-        const stats = await this.options.stats(true)
+        // Git stats are refreshed by the poller independently. A forced refresh
+        // here can spawn one diff/ahead-behind pair per worktree and exceed the
+        // host request timeout before the overview can return its IDs.
+        const stats = await this.options.stats()
         if (this.disposed || active.cancelled) return
         const result = await overview({
           client,

--- a/packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts
@@ -44,7 +44,7 @@ interface Options {
   root(): string | undefined
   ready(): Promise<WorktreeStateManager | undefined>
   state(): WorktreeStateManager | undefined
-  stats(refresh?: boolean): Promise<{ worktrees: WorktreeStats[]; local?: LocalStats }>
+  stats(): Promise<{ worktrees: WorktreeStats[]; local?: LocalStats }>
   prs(): Map<string, PRStatus>
   push(): void
   managed(sessionID: string): boolean

--- a/packages/kilo-vscode/tests/unit/agent-manager-orchestration-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-orchestration-bridge.test.ts
@@ -37,6 +37,7 @@ describe("AgentManagerOrchestrationBridge", () => {
     const replies: unknown[] = []
     const rejections: unknown[] = []
     const lists = new Map<string, AgentManagerRequest[]>()
+    const statsCalls: Array<boolean | undefined> = []
     const handlers: {
       event?: (event: SSEPayload, directory?: string) => void
       state?: (state: "connecting" | "connected" | "disconnected" | "error") => void
@@ -53,6 +54,12 @@ describe("AgentManagerOrchestrationBridge", () => {
         })),
         status: mock(async () => ({ data: {} })),
         promptAsync,
+      },
+      permission: {
+        list: mock(async () => ({ data: [] })),
+      },
+      question: {
+        list: mock(async () => ({ data: [] })),
       },
       kilocode: {
         agentManager: {
@@ -96,7 +103,11 @@ describe("AgentManagerOrchestrationBridge", () => {
       root: () => root,
       ready: async () => state,
       state: () => state,
-      stats: async () => ({ worktrees: [] }),
+      stats: async (refresh) => {
+        statsCalls.push(refresh)
+        if (refresh) return new Promise(() => undefined)
+        return { worktrees: [] }
+      },
       prs: () => new Map(),
       push,
       managed: (id) => managed.has(id),
@@ -108,7 +119,21 @@ describe("AgentManagerOrchestrationBridge", () => {
         { id: `event-${value.id}`, type: "kilocode.agent_manager.requested", properties: value } as SSEPayload,
         directory,
       )
-    return { bridge, client, close, handlers, lists, managed, promptAsync, push, rejections, replies, request, status }
+    return {
+      bridge,
+      client,
+      close,
+      handlers,
+      lists,
+      managed,
+      promptAsync,
+      push,
+      rejections,
+      replies,
+      request,
+      statsCalls,
+      status,
+    }
   }
 
   const request: AgentManagerRequest = {
@@ -229,6 +254,30 @@ describe("AgentManagerOrchestrationBridge", () => {
       requestID: "amr_ungroup",
       directory: dir,
       result: { operation: "move", sessionID: "ses_target", sectionID: null, moved: true },
+    })
+    test.bridge.dispose()
+  })
+
+  it("returns an overview without waiting for a forced git refresh", async () => {
+    const test = harness()
+    test.request({
+      id: "amr_overview",
+      sessionID: "ses_caller",
+      operation: "overview",
+    })
+    await waitFor(() => test.replies.length === 1)
+
+    expect(test.statsCalls).toEqual([undefined])
+    expect(test.replies[0]).toEqual({
+      requestID: "amr_overview",
+      directory: root,
+      result: {
+        operation: "overview",
+        overview: expect.objectContaining({
+          ungrouped: [expect.objectContaining({ id: expect.any(String) })],
+          sections: [],
+        }),
+      },
     })
     test.bridge.dispose()
   })

--- a/packages/kilo-vscode/tests/unit/agent-manager-orchestration-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-orchestration-bridge.test.ts
@@ -37,7 +37,7 @@ describe("AgentManagerOrchestrationBridge", () => {
     const replies: unknown[] = []
     const rejections: unknown[] = []
     const lists = new Map<string, AgentManagerRequest[]>()
-    const statsCalls: Array<boolean | undefined> = []
+    const statsCalls: number[] = []
     const handlers: {
       event?: (event: SSEPayload, directory?: string) => void
       state?: (state: "connecting" | "connected" | "disconnected" | "error") => void
@@ -103,9 +103,8 @@ describe("AgentManagerOrchestrationBridge", () => {
       root: () => root,
       ready: async () => state,
       state: () => state,
-      stats: async (refresh) => {
-        statsCalls.push(refresh)
-        if (refresh) return new Promise(() => undefined)
+      stats: async () => {
+        statsCalls.push(1)
         return { worktrees: [] }
       },
       prs: () => new Map(),
@@ -258,7 +257,7 @@ describe("AgentManagerOrchestrationBridge", () => {
     test.bridge.dispose()
   })
 
-  it("returns an overview without waiting for a forced git refresh", async () => {
+  it("returns an overview with cached git stats", async () => {
     const test = harness()
     test.request({
       id: "amr_overview",
@@ -267,7 +266,7 @@ describe("AgentManagerOrchestrationBridge", () => {
     })
     await waitFor(() => test.replies.length === 1)
 
-    expect(test.statsCalls).toEqual([undefined])
+    expect(test.statsCalls).toEqual([1])
     expect(test.replies[0]).toEqual({
       requestID: "amr_overview",
       directory: root,


### PR DESCRIPTION
Agent Manager overview requests currently force a Git statistics refresh before returning. With many managed worktrees, that refresh launches diff and ahead/behind operations for every worktree and can exceed the orchestration host timeout, leaving session-management tools unavailable.

The overview now uses the poller’s cached statistics while background polling continues to refresh them. This keeps worktree and session IDs available without coupling the orchestration response to repository-wide Git work, with regression coverage for a stalled refresh.