### PR TITLE
docs(kilo-docs): document upstream v1.17.13 behavior

### DIFF
--- a/.changeset/opencode-v1-17-9-to-v1-17-13.md
+++ b/.changeset/opencode-v1-17-9-to-v1-17-13.md
@@ -5,11 +5,7 @@
 
 Changes from opencode v1.17.9 to v1.17.13 upstream:
 
-- Core Improvements: Sessions gain a snapshot and revert system for staging, clearing and committing file reverts.
-- Core Improvements: Durable session history is served in finite pages and exposed through the SDK.
 - Core Improvements: MCP servers can append their instructions to the model context, and MCP resources are available as tools with template listing.
-- Core Improvements: MCP tools use the `mcp__server__tool` naming convention, with legacy names still accepted.
-- Core Improvements: Plugins can use the v2 effect host and a namespaced hook API.
 - Core Improvements: Model variants are generated from models.dev data, including modes exposed as models.
 - Core Improvements: Tool definitions pass `strict` through for Codex parity, and Gemini requests support video and audio media.
 - Core Bugfixes: Interrupted assistant steps settle instead of leaving sessions stuck busy.
@@ -18,8 +14,8 @@ Changes from opencode v1.17.9 to v1.17.13 upstream:
 - Core Bugfixes: Stale GitHub Copilot Responses item IDs are no longer replayed, and OpenAI reasoning variants are forced where required.
 - Core Bugfixes: Adaptive thinking is enabled for Claude Sonnet 5, and expired promos were removed from the zen catalog.
 - Core Bugfixes: Preserve released prompt history during database replay and keep native event streams connected for all supported Kilo events.
-- Core Bugfixes: Remote skills refresh atomically with version pinning, and skill base directories are emitted as filesystem paths.
-- CLI Improvements: `kilo run --mini` provides a compact interactive mode, and ports increment from the default when busy.
+- Core Bugfixes: Remote skill manifests support optional per-skill versions; changing a version refreshes the cached skill atomically, and skill base directories are emitted as filesystem paths.
+- CLI Improvements: Ports increment from the default when busy.
 - CLI Improvements: Use `--auto` to start the TUI in a run-scoped auto-approve mode, and leave the mode mid-session from the command palette.
-- TUI Improvements: Redesigned crash screen, model picker sorted by release date, a diff viewer keybind, main-branch diff source, bindable move-session command, and inline skill load errors.
+- TUI Improvements: Redesigned crash screen, model picker sorted by release date, bindable diff viewer and Move Session commands, main-branch diff source, and inline skill load errors.
 - TUI Bugfixes: File autocomplete is scoped to the session, multi-day durations format correctly, and root sessions load in the session switcher.

--- a/packages/kilo-docs/pages/automate/mcp/using-in-cli.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-cli.md
@@ -165,6 +165,8 @@ MCP tools use the same permission system as built-in tools (`allow`, `ask`, `den
 
 For full details and examples, see [MCP Tool Permissions](/docs/automate/mcp/using-in-kilo-code#auto-approve-tools).
 
+Connected servers can also add usage instructions to the model context and expose resources, including parameterized resource templates. See [Server instructions and resources](/docs/automate/mcp/using-in-kilo-code#server-instructions-and-resources).
+
 ## Environment Variables
 
 Use `{env:VARIABLE_NAME}` syntax in config files to reference environment variables:

--- a/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
+++ b/packages/kilo-docs/pages/automate/mcp/using-in-kilo-code.md
@@ -513,6 +513,12 @@ After configuring an MCP server, Kilo Code will automatically detect available t
 
 Example: "Analyze the performance of my API" might use an MCP tool that tests API endpoints.
 
+### Server instructions and resources
+
+When a connected MCP server provides instructions, Kilo adds them to the model context so the agent can follow the server's usage guidance. Kilo omits those instructions when every tool from that server is denied.
+
+Resource-capable servers also make the `list_mcp_resources`, `list_mcp_resource_templates`, and `read_mcp_resource` tools available to the agent. Resource templates describe parameterized URIs; the agent fills in a template, then reads the resulting resource URI. Resource listing and reads use Kilo's normal read approval flow.
+
 ## Troubleshooting MCP Servers
 
 {% tabs %}

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -97,6 +97,8 @@ The `kilo console` command and its browser interface are deprecated and will be 
 | `/copy` | - | Copy latest agent response |
 | `/copy-session` | - | Copy session transcript |
 | `/export` | - | Export session transcript |
+| `/move` | - | Move the current session to another project directory |
+| `/diff` | - | Open the diff viewer |
 | `/timestamps` | `/toggle-timestamps` | Show/hide timestamps |
 | `/thinking` | `/toggle-thinking` | Show/hide thinking blocks |
 
@@ -218,6 +220,19 @@ There is no notification slash command or command-palette toggle. Use `tui.json`
 ## Slash Commands
 
 The CLI's interactive mode supports slash commands for common operations. The main commands are documented above in the [Interactive Slash Commands](#interactive-slash-commands) section.
+
+Use `/diff` to review working-tree changes. From the diff viewer, switch the source to the current branch compared with the main branch or to changes from the last assistant turn. Use `/move` to move the current session to another project directory.
+
+The `diff_open` and `session_move` TUI keybindings run the same actions and are unbound by default. Set them under `keybinds` in `tui.jsonc`:
+
+```jsonc
+{
+  "keybinds": {
+    "diff_open": "<leader>d",
+    "session_move": "<leader>o",
+  },
+}
+```
 
 ## Permissions
 

--- a/packages/kilo-docs/pages/customize/skills.md
+++ b/packages/kilo-docs/pages/customize/skills.md
@@ -105,16 +105,19 @@ The remote server must serve an `index.json` file at the URL path with the follo
 ```json
 {
   "skills": [
-    { "name": "skill-name", "files": ["SKILL.md", "references/file.md"] }
+    { "name": "skill-name", "version": "2", "files": ["SKILL.md", "references/file.md"] }
   ]
 }
 ```
 
 Each skill object contains:
 - `name`: The skill name (must match the directory name)
+- `version`: Optional version string for refreshing cached skill files
 - `files`: Array of files to fetch for this skill (must include `SKILL.md`)
 
 Files are downloaded from `{url}/{skill-name}/{file}` paths.
+
+When you change a remote skill's contents or file list, also change its `version`. On the next skill rediscovery (`/reload` or a new session), Kilo downloads the complete new version before atomically replacing the cached directory. If any download fails, Kilo keeps the previous cached version.
 
 {% /tab %}
 {% tab label="CLI" %}
@@ -174,16 +177,19 @@ The remote server must serve an `index.json` file at the URL path with the follo
 ```json
 {
   "skills": [
-    { "name": "skill-name", "files": ["SKILL.md", "references/file.md"] }
+    { "name": "skill-name", "version": "2", "files": ["SKILL.md", "references/file.md"] }
   ]
 }
 ```
 
 Each skill object contains:
 - `name`: The skill name (must match the directory name)
+- `version`: Optional version string for refreshing cached skill files
 - `files`: Array of files to fetch for this skill (must include `SKILL.md`)
 
 Files are downloaded from `{url}/{skill-name}/{file}` paths.
+
+When you change a remote skill's contents or file list, also change its `version`. On the next skill rediscovery (`/reload` or a new session), Kilo downloads the complete new version before atomically replacing the cached directory. If any download fails, Kilo keeps the previous cached version.
 
 {% /tab %}
 {% /tabs %}


### PR DESCRIPTION
## Issue

Related to #12695. This is a documentation follow-up for the user-facing changes imported by that upstream merge; there is no standalone issue.

## Context

Audit and align Kilo's documentation and merge changeset with the behavior that actually shipped from OpenCode v1.17.9 through v1.17.13. The documentation must not present upstream-only v2 infrastructure, transparent fixes, existing Kilo checkpoint behavior, or unsupported interfaces as new public features.

## Implementation

Document the bindable Move Session and diff viewer actions, remote skill versioning and atomic refresh semantics, and MCP server instructions and resources. Preserve Kilo's underscore MCP tool naming and correct the merge changeset to exclude the pre-existing snapshot/revert flow and unsupported `kilo run --mini` interface.

## Screenshots / Video

N/A — documentation-only changes.

## How to Test

### Manual/local verification

- Agent: ran `bun run lint` in `packages/kilo-docs` (0 errors; existing warnings remain).
- Agent: ran `bun run typecheck` in `packages/kilo-docs`.
- Agent: ran `bun run test` in `packages/kilo-docs` (22 tests passed).
- Agent: ran the Markdown table-padding guard for the four touched documentation pages and `git diff --check`.
- Agent: the pre-push repository typecheck completed successfully (28/28 tasks).

### Reviewer test steps

1. Compare the changeset and updated pages with the Kilo behavior imported by #12695.
2. Confirm the pages document only shipped user-facing behavior and retain Kilo's underscore MCP tool naming.
3. Confirm the generated CLI reference still does not expose `kilo run --mini`.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
