### PR TITLE
fix(tui): prevent TUI config logs from leaking into the terminal

### DIFF
--- a/.changeset/fix-tui-config-log-leak.md
+++ b/.changeset/fix-tui-config-log-leak.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix the CLI prompt and footer glitching with raw log output after running `/auto-approve` or saving an "Allow always" permission. The terminal now stays clean during config updates.

--- a/packages/opencode/src/kilocode/tui/config.ts
+++ b/packages/opencode/src/kilocode/tui/config.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, Schema } from "effect"
 import { applyEdits, modify } from "jsonc-parser"
 import { mergeDeep } from "remeda"
 import { Global } from "@opencode-ai/core/global"
+import * as Observability from "@opencode-ai/core/observability"
 import { ConfigParse } from "@/config/parse"
 import { CurrentWorkingDirectory } from "@/config/tui-cwd"
 import { TuiConfig } from "@/config/tui"
@@ -26,11 +27,13 @@ export namespace KilocodeTuiConfig {
   const dirs = [".kilo", ".kilocode"] as const
 
   export async function get(input: { directory: string }) {
+    // kilocode_change - provide Observability.layer so Effect logs route to Kilo's log sink, not the shared TTY
     const cfg = await Effect.runPromise(
       TuiConfig.Service.use((svc) => svc.info()).pipe(
         Effect.provide(
           AppNodeBuilder.build(TuiConfig.node).pipe(
             Layer.provide(Layer.succeed(CurrentWorkingDirectory, input.directory)),
+            Layer.provideMerge(Observability.layer),
           ),
         ),
       ),

--- a/packages/opencode/src/kilocode/tui/config.ts
+++ b/packages/opencode/src/kilocode/tui/config.ts
@@ -27,7 +27,6 @@ export namespace KilocodeTuiConfig {
   const dirs = [".kilo", ".kilocode"] as const
 
   export async function get(input: { directory: string }) {
-    // kilocode_change - provide Observability.layer so Effect logs route to Kilo's log sink, not the shared TTY
     const cfg = await Effect.runPromise(
       TuiConfig.Service.use((svc) => svc.info()).pipe(
         Effect.provide(

--- a/packages/opencode/test/kilocode/server/tui-config.test.ts
+++ b/packages/opencode/test/kilocode/server/tui-config.test.ts
@@ -175,7 +175,6 @@ describe("TUI config routes", () => {
     expect(events.some((event) => event.payload?.type === "global.config.updated")).toBe(true)
   })
 
-  // kilocode_change start - regression test: internal Effect logs from TUI config must not leak to the shared TTY
   const LEAKED = ["loading tui config", "applying tui config", "skipping invalid tui config", "failed to read tui config"]
 
   async function withConsoleCapture<T>(fn: () => Promise<T>): Promise<{ stdout: string; result: T }> {
@@ -240,5 +239,4 @@ describe("TUI config routes", () => {
       expect(stdout).not.toContain(message)
     }
   })
-  // kilocode_change end
 })

--- a/packages/opencode/test/kilocode/server/tui-config.test.ts
+++ b/packages/opencode/test/kilocode/server/tui-config.test.ts
@@ -174,4 +174,71 @@ describe("TUI config routes", () => {
 
     expect(events.some((event) => event.payload?.type === "global.config.updated")).toBe(true)
   })
+
+  // kilocode_change start - regression test: internal Effect logs from TUI config must not leak to the shared TTY
+  const LEAKED = ["loading tui config", "applying tui config", "skipping invalid tui config", "failed to read tui config"]
+
+  async function withConsoleCapture<T>(fn: () => Promise<T>): Promise<{ stdout: string; result: T }> {
+    const original = console.log
+    let captured = ""
+    console.log = (...args: unknown[]) => {
+      captured += args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n"
+    }
+    try {
+      const result = await fn()
+      return { stdout: captured, result }
+    } finally {
+      console.log = original
+    }
+  }
+
+  test("GET /tui/config does not leak internal Effect logs to the terminal", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(path.join(cfg, "tui.json"), JSON.stringify({ theme: "dracula" }, null, 2))
+      },
+    })
+
+    const { stdout } = await withConsoleCapture(async () => {
+      const response = await Server.Default().app.request("/tui/config", {
+        headers: { "x-kilo-directory": tmp.path },
+      })
+      expect(response.status).toBe(200)
+      return response
+    })
+
+    for (const message of LEAKED) {
+      expect(stdout).not.toContain(message)
+    }
+  })
+
+  test("PATCH /tui/config does not leak internal Effect logs during hot-reload", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(path.join(cfg, "tui.json"), JSON.stringify({ theme: "dracula" }, null, 2))
+      },
+    })
+
+    const { stdout } = await withConsoleCapture(async () => {
+      const response = await Server.Default().app.request("/tui/config?scope=project", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          "x-kilo-directory": tmp.path,
+        },
+        body: JSON.stringify({ theme: "nord" }),
+      })
+      expect(response.status).toBe(200)
+      return response
+    })
+
+    for (const message of LEAKED) {
+      expect(stdout).not.toContain(message)
+    }
+  })
+  // kilocode_change end
 })

--- a/packages/opencode/test/kilocode/tui-config-logger-routing.test.ts
+++ b/packages/opencode/test/kilocode/tui-config-logger-routing.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import * as Log from "@opencode-ai/core/util/log"
+import { KilocodeTuiConfig } from "@/kilocode/tui/config"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+
+void Log.init({ print: false })
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+// kilocode_change - regression test: direct calls must not leak Effect logs to the shared TTY
+const LEAKED = ["loading tui config", "applying tui config", "skipping invalid tui config", "failed to read tui config"]
+
+async function withConsoleCapture<T>(fn: () => Promise<T>): Promise<{ stdout: string; result: T }> {
+  const original = console.log
+  let captured = ""
+  console.log = (...args: unknown[]) => {
+    captured += args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n"
+  }
+  try {
+    const result = await fn()
+    return { stdout: captured, result }
+  } finally {
+    console.log = original
+  }
+}
+
+describe("KilocodeTuiConfig.get logger routing", () => {
+  test("does not leak internal Effect logs through Effect's default logger", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(path.join(cfg, "tui.json"), JSON.stringify({ theme: "dracula" }, null, 2))
+      },
+    })
+
+    const { stdout, result } = await withConsoleCapture(() => KilocodeTuiConfig.get({ directory: tmp.path }))
+    expect(result.theme).toBe("dracula")
+    for (const message of LEAKED) {
+      expect(stdout).not.toContain(message)
+    }
+  })
+
+  test("does not leak warnings from invalid config files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(path.join(cfg, "tui.json"), "{ this is not valid jsonc }")
+      },
+    })
+
+    const { stdout, result } = await withConsoleCapture(() => KilocodeTuiConfig.get({ directory: tmp.path }))
+    expect(result).toBeTypeOf("object")
+    for (const message of LEAKED) {
+      expect(stdout).not.toContain(message)
+    }
+  })
+})

--- a/packages/opencode/test/kilocode/tui-config-logger-routing.test.ts
+++ b/packages/opencode/test/kilocode/tui-config-logger-routing.test.ts
@@ -13,7 +13,6 @@ afterEach(async () => {
   await resetDatabase()
 })
 
-// kilocode_change - regression test: direct calls must not leak Effect logs to the shared TTY
 const LEAKED = ["loading tui config", "applying tui config", "skipping invalid tui config", "failed to read tui config"]
 
 async function withConsoleCapture<T>(fn: () => Promise<T>): Promise<{ stdout: string; result: T }> {


### PR DESCRIPTION
## Issue

<!-- Reference an existing issue with `Fixes #123`, `Closes #123`, or equivalent linked issue wording. -->

Fixes #12877

## Context

Commands that persist global TUI configuration (for example /auto-approve or selecting Allow always in a permission prompt) trigger a TUI config hot reload. During that reload, KilocodeTuiConfig.get() executed via a bare Effect.runPromise() without Observability.layer, causing Effect's default logger to write internal messages such as loading tui config and applying tui config directly to the shared terminal. Because OpenTUI owns a diff-rendered screen, these writes corrupted the prompt and footer.

Elsewhere in Kilo, Effect-based services execute through the application's observability runtime, which replaces Effect's default logger with Kilo's configured logging pipeline. KilocodeTuiConfig.get() bypassed that runtime, making it the exception rather than the norm.

This PR closes the runtime boundary by routing the effect through `Observability.layer` so logs go to Kilo's configured log sink rather than stdout. It addresses every log level (INFO/WARN/ERROR), not just the two messages that another pr mentioned in the above issue downgrades to DEBUG.

## Implementation

Single source change in `packages/opencode/src/kilocode/tui/config.ts` — the `get()` function now provides `Observability.layer` alongside the per-request `CurrentWorkingDirectory:


```ts
Effect.runPromise(
  TuiConfig.Service.use((svc) => svc.info()).pipe(
    Effect.provide(
      AppNodeBuilder.build(TuiConfig.node).pipe(
        Layer.provide(Layer.succeed(CurrentWorkingDirectory, input.directory)),
        Layer.provideMerge(Observability.layer),
      ),
    ),
  ),
)
```

`KilocodeTuiConfig.update()` calls `get()` at the end of every save, so the PATCH path is fixed transitively.

## Screenshots / Video

<!-- Required for visual changes. Include the relevant before/after or resulting state. -->

### BEFORE

https://github.com/user-attachments/assets/e79183d6-fa13-448e-be39-e4a31a97d38b 

### AFTER

https://github.com/user-attachments/assets/2ce389b7-7bce-4786-a0e9-064d9006e1a2 

## How to Test

### Manual/local verification

- Start `kilo --pure` or `kilo` whatever with a non-empty `~/.config/kilo/tui.jsonc` (e.g. `{"theme":"kilo"}`).
- Run `/auto-approve`. Confirm the prompt, footer, and separator remain intact — no `loading tui config` / `applying tui config` lines appear in the live TUI.
- Repeat after selecting `Allow always` on a Bash permission prompt.

### Reviewer test steps

1. From `packages/opencode/`, run `bun test ./test/kilocode/server/tui-config.test.ts ./test/kilocode/tui-config-logger-routing.test.ts`.
2. All 10 tests pass.
3. To confirm the tests are meaningful, revert the `Observability.layer` line in `get()`, re-run, and watch the two new `does not leak` tests fail with the exact Effect default-logger output.

### Blocked checks and substitute verification

- `bun run typecheck` reports one unrelated pre-existing error in `test/mcp/oauth-provider.test.ts`

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@TRAVIX26 discord
