### PR TITLE
fix(cli): remove arbitrary code execution in debug agent --params parsing

### DIFF
--- a/.changeset/fix-debug-agent-params-code-exec.md
+++ b/.changeset/fix-debug-agent-params-code-exec.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix `kilo debug agent --params` executing arbitrary JavaScript via `new Function()` when the input wasn't strict JSON. Loose object-literal syntax (unquoted keys, single quotes) is now parsed safely with JSON5 instead.

--- a/bun.lock
+++ b/bun.lock
@@ -345,7 +345,7 @@
     },
     "packages/kilo-jetbrains": {
       "name": "@kilocode/kilo-jetbrains",
-      "version": "7.4.17",
+      "version": "7.4.20",
     },
     "packages/kilo-memory": {
       "name": "@kilocode/kilo-memory",
@@ -634,6 +634,7 @@
         "iconv-lite": "0.7.2",
         "ignore": "7.0.5",
         "immer": "11.1.4",
+        "json5": "2.2.3",
         "jsonc-parser": "3.3.1",
         "mammoth": "1.12.0",
         "mime-types": "3.0.2",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -147,6 +147,7 @@
     "iconv-lite": "0.7.2",
     "ignore": "7.0.5",
     "immer": "11.1.4",
+    "json5": "2.2.3",
     "jsonc-parser": "3.3.1",
     "mammoth": "1.12.0",
     "mime-types": "3.0.2",

--- a/packages/opencode/src/cli/cmd/debug/agent.handler.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.handler.ts
@@ -1,4 +1,5 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import JSON5 from "json5" // kilocode_change
 import { EOL } from "os"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { basename } from "path"
@@ -97,7 +98,8 @@ function resolveTools(agent: Agent.Info, availableTools: { id: string }[]) {
   return resolved
 }
 
-function parseToolParams(input?: string) {
+// kilocode_change: exported for unit testing
+export function parseToolParams(input?: string) {
   if (!input) return {}
   const trimmed = input.trim()
   if (trimmed.length === 0) return {}
@@ -107,11 +109,15 @@ function parseToolParams(input?: string) {
       return JSON.parse(trimmed)
     } catch (jsonError) {
       try {
-        return new Function(`return (${trimmed})`)()
-      } catch (evalError) {
+        // kilocode_change start: parse loose object-literal syntax (unquoted keys, single
+        // quotes, trailing commas) with JSON5 instead of `new Function(...)`, which executed
+        // the raw --params string as JavaScript.
+        return JSON5.parse(trimmed)
+        // kilocode_change end
+      } catch (json5Error) {
         throw new Error(
-          `Failed to parse --params. Use JSON or a JS object literal. JSON error: ${jsonError}. Eval error: ${evalError}.`,
-          { cause: evalError },
+          `Failed to parse --params. Use JSON or a JS object literal. JSON error: ${jsonError}. JSON5 error: ${json5Error}.`,
+          { cause: json5Error },
         )
       }
     }

--- a/packages/opencode/test/kilocode/cli/cmd/debug/agent.handler.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/debug/agent.handler.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { parseToolParams } from "../../../../../src/cli/cmd/debug/agent.handler"
+
+describe("parseToolParams", () => {
+  test("returns an empty object for undefined or blank input", () => {
+    expect(parseToolParams(undefined)).toEqual({})
+    expect(parseToolParams("")).toEqual({})
+    expect(parseToolParams("   ")).toEqual({})
+  })
+
+  test("parses strict JSON", () => {
+    expect(parseToolParams('{"path": "foo.ts", "count": 2}')).toEqual({ path: "foo.ts", count: 2 })
+  })
+
+  test("falls back to JSON5 for loose object-literal syntax", () => {
+    expect(parseToolParams("{path: 'foo.ts', count: 2}")).toEqual({ path: "foo.ts", count: 2 })
+    expect(parseToolParams("{trailingComma: 1,}")).toEqual({ trailingComma: 1 })
+  })
+
+  test("rejects non-object results", () => {
+    expect(() => parseToolParams("42")).toThrow("Tool params must be an object.")
+    expect(() => parseToolParams("[1, 2, 3]")).toThrow("Tool params must be an object.")
+    expect(() => parseToolParams('"a string"')).toThrow("Tool params must be an object.")
+  })
+
+  test("fails safely instead of executing arbitrary code", () => {
+    // Simulates an attacker-controlled --params value. If this were still evaluated with
+    // `new Function`, __pwned would be set on globalThis before the throw ran.
+    const payload = "(() => { globalThis.__pwned = true; throw new Error('pwned') })()"
+    expect(() => parseToolParams(payload)).toThrow(/Failed to parse --params/)
+    expect((globalThis as Record<string, unknown>).__pwned).toBeUndefined()
+  })
+
+  test("fails safely on other unparsable code-like input", () => {
+    expect(() => parseToolParams("require('fs').rmSync('/', { recursive: true })")).toThrow(
+      /Failed to parse --params/,
+    )
+    expect(() => parseToolParams("process.exit(1)")).toThrow(/Failed to parse --params/)
+  })
+})


### PR DESCRIPTION
## Summary
- `parseToolParams` in `packages/opencode/src/cli/cmd/debug/agent.handler.ts`
  parses the `--params` value for `kilo debug agent --tool <id> --params <input>`.
  When the input isn't strict JSON, it fell back to
  `new Function(\`return (${trimmed})\`)()`, which compiles and executes the
  raw --params string as JavaScript with the full privileges of the CLI process.
- This is a straightforward code-execution primitive: any `--params` value that
  fails `JSON.parse` gets run as JS. It's currently only reachable through this
  debug flag, but that's exactly the kind of "safe today" assumption that stops
  being true if this parser is reused elsewhere or someone scripts/pastes an
  untrusted params string.
- Replaced the `new Function` fallback with `JSON5.parse`. JSON5 is a small,
  dependency-free, pure parser (no eval anywhere in it) that already supports
  the loose syntax the fallback existed for — unquoted keys, single-quoted
  strings, trailing commas — so `--params` behavior for legitimate inputs is
  unchanged.

## Test plan
- [x] Added `packages/opencode/test/kilocode/cli/cmd/debug/agent.handler.test.ts`
      covering: strict JSON, loose JSON5-style object literals, non-object
      results being rejected, and — most importantly — that a payload like
      `(() => { globalThis.__pwned = true; throw new Error('pwned') })()`
      fails to parse instead of executing.
- [x] `bun test test/kilocode/cli/cmd/debug/agent.handler.test.ts` — 6 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings unrelated to this file)