### PR TITLE
fix: keep slash commands compact in chat

### DIFF
--- a/.changeset/quiet-skill-commands.md
+++ b/.changeset/quiet-skill-commands.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show invoked skill commands and a compact skill indicator instead of expanded skill instructions in session transcripts.

--- a/.changeset/quiet-skill-commands.md
+++ b/.changeset/quiet-skill-commands.md
@@ -3,4 +3,4 @@
 "kilo-code": patch
 ---
 
-Show invoked skill commands and a compact skill indicator instead of expanded skill instructions in session transcripts.
+Show slash commands instead of expanded instructions in session transcripts, with a compact indicator for invoked skills.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -747,6 +747,7 @@ export function UserMessageDisplay(props: {
   text?: string
   copyText?: string
   header?: JSX.Element
+  after?: JSX.Element
   onDelete?: () => void
   onFork?: () => void
   onRevert?: () => void
@@ -899,6 +900,8 @@ export function UserMessageDisplay(props: {
                 </div>
               </GrowBox>
             </div>
+
+            {props.after}
 
             <div data-slot="user-message-copy-wrapper" data-interrupted={props.interrupted ? "" : undefined}>
               <Show when={metaHead() || metaTail()}>

--- a/packages/kilo-vscode/tests/unit/export-transcript.test.ts
+++ b/packages/kilo-vscode/tests/unit/export-transcript.test.ts
@@ -17,7 +17,7 @@ describe("formatTranscript", () => {
         {
           info: { role: "user" },
           parts: [
-            { type: "text", text: "Please export this." },
+            { type: "text", text: "/test-skill", ignored: true },
             { type: "text", text: "hidden", synthetic: true },
           ],
         },
@@ -33,7 +33,7 @@ describe("formatTranscript", () => {
 
     expect(text).toContain("# Export test")
     expect(text).toContain("**Session ID:** ses_123456789")
-    expect(text).toContain("## User\n\nPlease export this.")
+    expect(text).toContain("## User\n\n/test-skill")
     expect(text).toContain("## Assistant\n\n**Tool: read**\n\nSaved as Markdown.")
     expect(text).not.toContain("hidden")
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
@@ -1,5 +1,6 @@
 import { createMemo, type Component } from "solid-js"
-import { UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
+import { Dynamic } from "solid-js/web"
+import { ToolRegistry, UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
 import { partReview } from "../../../../src/shared/review-comments"
 import type { Message, Part, TextPart } from "../../types/messages"
 import { ReviewComments } from "./ReviewComments"
@@ -14,8 +15,20 @@ interface VscodeUserMessageProps {
   onRevert?: () => void
 }
 
+const indicator = ToolRegistry.render("skill")
+
 export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
   const text = createMemo(() => props.parts.find((part): part is TextPart => part.type === "text" && !part.synthetic))
+  const skill = createMemo(() => {
+    for (const part of props.parts) {
+      if (part.type !== "text") continue
+      const value = part.metadata?.skill
+      if (!value || typeof value !== "object") continue
+      const metadata = value as Record<string, unknown>
+      if (metadata.userInitiated !== true || typeof metadata.name !== "string") continue
+      return metadata.name
+    }
+  })
   const review = createMemo(() => {
     const part = text()
     if (!part) return undefined
@@ -32,6 +45,17 @@ export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
       header={
         review() ? (
           <ReviewComments comments={review()!.data.comments} sessionID={props.message.sessionID} variant="message" />
+        ) : undefined
+      }
+      after={
+        skill() && indicator ? (
+          <Dynamic
+            component={indicator}
+            tool="skill"
+            input={{ name: skill() }}
+            metadata={{ userInitiated: true }}
+            status="completed"
+          />
         ) : undefined
       }
       interrupted={props.interrupted}

--- a/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/parts.ts
@@ -23,6 +23,7 @@ export interface TextPart extends BasePart {
   type: "text"
   text: string
   synthetic?: boolean
+  ignored?: boolean
   time?: { start: number; end?: number }
   metadata?: Record<string, unknown>
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -301,7 +301,11 @@ export const layer = Layer.effect(
       const firstInfo = firstUser.info
 
       const subtasks = firstUser.parts.filter((p): p is SessionV1.SubtaskPart => p.type === "subtask")
-      const onlySubtasks = subtasks.length > 0 && firstUser.parts.every((p) => p.type === "subtask")
+      // kilocode_change start - display-only skill text does not change subtask title context
+      const onlySubtasks =
+        subtasks.length > 0 &&
+        firstUser.parts.every((p) => p.type === "subtask" || (p.type === "text" && p.ignored))
+      // kilocode_change end
 
       const ag = yield* agents.get("title")
       if (!ag) return
@@ -1336,7 +1340,7 @@ export const layer = Layer.effect(
         ),
       )
       for (const part of input.parts) {
-        if (part.type !== "text" || part.synthetic) continue
+        if (part.type !== "text" || part.synthetic || part.ignored) continue // kilocode_change - ignored text is display-only
         for (const reference of yield* resolveReferenceParts(part.text, attached)) {
           if (reference.type === "file" && attached.has(reference.url)) continue
           if (reference.type === "file") {
@@ -2411,7 +2415,8 @@ export const layer = Layer.effect(
         (part) => part.type !== "file" || !inputFiles.has(fileURLToPath(part.url)),
       )
       const isSubtask = (agent.mode === "subagent" && cmd.subtask !== false) || cmd.subtask === true
-      const parts = isSubtask
+      // kilocode_change start - preserve the literal skill command while hiding its expanded prompt
+      const commandParts = isSubtask
         ? [
             {
               type: "subtask" as const,
@@ -2424,6 +2429,19 @@ export const layer = Layer.effect(
             },
           ]
         : [...uniqueTemplateParts, ...(input.parts ?? [])]
+      const parts =
+        cmd.source === "skill"
+          ? [
+              {
+                type: "text" as const,
+                text: `/${input.command}${input.arguments ? ` ${input.arguments}` : ""}`,
+                ignored: true,
+                metadata: { skill: { name: cmd.name, userInitiated: true } },
+              },
+              ...commandParts.map((part) => (part.type === "text" ? { ...part, synthetic: true } : part)),
+            ]
+          : commandParts
+      // kilocode_change end
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultInfo()).name) : agent.name
       const userModel = isSubtask

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -375,6 +375,13 @@ export const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const promptOps = yield* ops()
       const { task: taskTool } = yield* registry.named()
+      // kilocode_change start - carry the slash invocation into command-backed child sessions
+      const source = msgs.find((message) => message.info.id === lastUser.id)
+      const invocation = source?.parts.find(
+        (part): part is SessionV1.TextPart =>
+          part.type === "text" && part.ignored === true && typeof part.metadata?.command === "object",
+      )
+      // kilocode_change end
       const taskModel = task.model ? yield* getModel(task.model.providerID, task.model.modelID, sessionID) : model
       const taskVariant = task.variant ?? lastUser.model.variant // kilocode_change
       const assistantMessage: SessionV1.Assistant = yield* sessions.updateMessage({
@@ -464,6 +471,7 @@ export const layer = Layer.effect(
             bypassAgentCheck: true,
             promptOps,
             workflow, // kilocode_change
+            invocation: invocation ? { text: invocation.text, metadata: invocation.metadata } : undefined, // kilocode_change
           },
           // kilocode_change end
           messages: msgs,
@@ -2429,18 +2437,19 @@ export const layer = Layer.effect(
             },
           ]
         : [...uniqueTemplateParts, ...(input.parts ?? [])]
-      const parts =
-        cmd.source === "skill"
-          ? [
-              {
-                type: "text" as const,
-                text: `/${input.command}${input.arguments ? ` ${input.arguments}` : ""}`,
-                ignored: true,
-                metadata: { skill: { name: cmd.name, userInitiated: true } },
-              },
-              ...commandParts.map((part) => (part.type === "text" ? { ...part, synthetic: true } : part)),
-            ]
-          : commandParts
+      const metadata = {
+        command: { name: cmd.name, source: cmd.source ?? "command", userInitiated: true },
+        ...(cmd.source === "skill" ? { skill: { name: cmd.name, userInitiated: true } } : {}),
+      }
+      const parts = [
+        {
+          type: "text" as const,
+          text: `/${input.command}${input.arguments ? ` ${input.arguments}` : ""}`,
+          ignored: true,
+          metadata,
+        },
+        ...commandParts.map((part) => (part.type === "text" ? { ...part, synthetic: true } : part)),
+      ]
       // kilocode_change end
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultInfo()).name) : agent.name

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -237,7 +237,18 @@ export const TaskTool = Tool.define(
 
       const runTask = Effect.fn("TaskTool.runTask")(
         function* () {
-          const parts = yield* ops.resolvePromptParts(params.prompt)
+          // kilocode_change start - keep command-backed child transcripts compact without changing model context
+          const resolved = yield* ops.resolvePromptParts(params.prompt)
+          const invocation = ctx.extra?.invocation as
+            | { text: string; metadata?: Record<string, unknown> }
+            | undefined
+          const parts = invocation
+            ? [
+                { type: "text" as const, text: invocation.text, ignored: true, metadata: invocation.metadata },
+                ...resolved.map((part) => (part.type === "text" ? { ...part, synthetic: true } : part)),
+              ]
+            : resolved
+          // kilocode_change end
           KiloSessionProcessor.markReviewTelemetry(parts, params.command) // kilocode_change - carry review command into child session telemetry
           const result = yield* ops.prompt({
             messageID: MessageID.ascending(),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -3076,9 +3076,21 @@ it.instance(
       yield* prompt.command({
         sessionID: chat.id,
         command: "review",
-        arguments: "",
+        arguments: "uncommitted focus on tests", // kilocode_change
         agent: "general",
       })
+
+      // kilocode_change start - command-backed child sessions preserve the literal invocation
+      const [child] = yield* sessions.children(chat.id)
+      const messages = child ? yield* sessions.messages({ sessionID: child.id }) : []
+      const user = messages.find((message) => message.info.role === "user")
+      expect(
+        user?.parts.some(
+          (part) => part.type === "text" && part.ignored && part.text === "/review uncommitted focus on tests",
+        ),
+      ).toBe(true)
+      expect(user?.parts.some((part) => part.type === "text" && part.synthetic)).toBe(true)
+      // kilocode_change end
 
       const tagged = trackSpy.mock.calls
         .map((args) => args[0] as Parameters<typeof Telemetry.trackLlmCompletion>[0])


### PR DESCRIPTION
Slash commands currently persist expanded command templates as visible user text. This is especially disruptive for skills and subtask commands such as /review, where the child session displays the complete reviewer prompt instead of the command the user entered.

Preserve the literal slash invocation as display-only session text and mark expanded instructions as synthetic model context. Command provenance follows subtask execution into child sessions, while the VS Code client reuses the existing skill renderer only for skill-sourced commands.

Keeping this distinction in persisted session parts makes chat, history, copy, exports, forks, and other clients agree without changing model context. Display-only text is excluded from reference expansion, and subtask-backed commands retain prompt-based title generation.

This follows the core direction proposed in https://github.com/anomalyco/opencode/pull/28239 while preserving arguments and supporting Kilo's existing skill indicator. It is complementary to https://github.com/anomalyco/opencode/pull/40472, which changes model-facing skill argument handling but does not address transcript rendering.