### PR TITLE
fix(vscode): set TZ for gh child processes on Windows

### DIFF
--- a/.changeset/fix-gh-tz-windows-console.md
+++ b/.changeset/fix-gh-tz-windows-console.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Set `TZ` when spawning `gh` on Windows to prevent `tzutil.exe` console windows from flashing over fullscreen applications.

--- a/packages/kilo-vscode/src/agent-manager/shell-env.ts
+++ b/packages/kilo-vscode/src/agent-manager/shell-env.ts
@@ -13,6 +13,7 @@
 
 import { type ExecFileOptionsWithStringEncoding } from "child_process"
 import * as os from "os"
+import * as path from "path"
 import { exec } from "../util/process"
 
 // Environment variable keys match: letters, digits, underscores, starting with a non-digit.
@@ -27,6 +28,43 @@ const FALLBACK_TTL = 10_000
 /** In-flight fix promise so concurrent ENOENT callers wait on the same resolution. */
 let fixing: Promise<boolean> | null = null
 let fixed = false
+
+/** Inferred IANA time zone, cached because Intl resolution is not free. */
+let inferredTz: string | undefined
+
+function isGh(cmd: string): boolean {
+  const ext = path.extname(cmd)
+  const name = ext ? cmd.slice(0, -ext.length) : cmd
+  return path.basename(name) === "gh"
+}
+
+function getTimeZone(): string | undefined {
+  return process.env.TZ || (inferredTz ??= Intl.DateTimeFormat().resolvedOptions().timeZone)
+}
+
+function currentEnv(): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") env[key] = value
+  }
+  return env
+}
+
+function withTzEnv(
+  cmd: string,
+  options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
+): Omit<ExecFileOptionsWithStringEncoding, "encoding"> {
+  if (process.platform !== "win32") return options ?? {}
+  if (!isGh(cmd)) return options ?? {}
+  if (options?.env?.TZ) return options
+
+  const tz = getTimeZone()
+  if (!tz) return options ?? {}
+
+  const env = options?.env ? { ...options.env } : currentEnv()
+  env.TZ = tz
+  return { ...options, env }
+}
 
 /**
  * Parse `env` output, handling multiline variable values correctly.
@@ -133,8 +171,9 @@ export async function execWithShellEnv(
   args: string[],
   options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
 ): Promise<{ stdout: string; stderr: string }> {
+  const opts = withTzEnv(cmd, options)
   try {
-    return await exec(cmd, args, options)
+    return await exec(cmd, args, opts)
   } catch (error) {
     if (
       process.platform !== "darwin" ||
@@ -148,13 +187,13 @@ export async function execWithShellEnv(
     // Already resolved and PATH was actually changed — no point retrying resolution.
     // Just retry with the (already-patched) process.env.
     if (fixed) {
-      return await exec(cmd, args, options)
+      return await exec(cmd, args, opts)
     }
 
     // If another caller is already resolving, wait for it then retry.
     if (fixing) {
       await fixing
-      return await exec(cmd, args, options)
+      return await exec(cmd, args, opts)
     }
 
     console.log(`[shell-env] "${cmd}" not found, resolving shell environment`)
@@ -166,7 +205,7 @@ export async function execWithShellEnv(
       fixing = null
     }
 
-    return await exec(cmd, args, options)
+    return await exec(cmd, args, opts)
   }
 }
 

--- a/packages/kilo-vscode/tests/unit/shell-env.test.ts
+++ b/packages/kilo-vscode/tests/unit/shell-env.test.ts
@@ -1,9 +1,32 @@
 import { afterEach, describe, expect, it } from "bun:test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 import { getShellEnvironment, execWithShellEnv, clearShellEnvCache } from "../../src/agent-manager/shell-env"
+
+let platformDesc: PropertyDescriptor | undefined
+const originalTz = process.env.TZ
 
 afterEach(() => {
   clearShellEnvCache()
+  if (platformDesc) Object.defineProperty(process, "platform", platformDesc)
+  if (originalTz === undefined) delete process.env.TZ
+  else process.env.TZ = originalTz
 })
+
+function setPlatform(value: string) {
+  platformDesc = Object.getOwnPropertyDescriptor(process, "platform")
+  Object.defineProperty(process, "platform", { value, configurable: true })
+}
+
+function fakeGhBin(): { dir: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gh-tz-"))
+  fs.symlinkSync(process.execPath, path.join(dir, "gh"))
+  return {
+    dir,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  }
+}
 
 describe("getShellEnvironment", () => {
   it("returns an object with PATH", async () => {
@@ -72,5 +95,78 @@ describe("clearShellEnvCache", () => {
     // Both should succeed and contain PATH
     expect(first.PATH).toBeDefined()
     expect(second.PATH).toBeDefined()
+  })
+})
+
+describe("execWithShellEnv TZ for gh on Windows", () => {
+  it("injects TZ into gh child processes on Windows", async () => {
+    setPlatform("win32")
+    process.env.TZ = "Test/TZ"
+    const { dir, cleanup } = fakeGhBin()
+    try {
+      const { stdout } = await execWithShellEnv("gh", ["-e", "console.log(process.env.TZ)"], {
+        env: { PATH: dir },
+      })
+      expect(stdout.trim()).toBe("Test/TZ")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("infers a TZ value from the system when process.env.TZ is not set", async () => {
+    setPlatform("win32")
+    delete process.env.TZ
+    const { dir, cleanup } = fakeGhBin()
+    try {
+      const { stdout } = await execWithShellEnv("gh", ["-e", "console.log(process.env.TZ)"], {
+        env: { PATH: dir },
+      })
+      expect(stdout.trim()).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not inject TZ for non-gh commands on Windows", async () => {
+    setPlatform("win32")
+    process.env.TZ = "Test/TZ"
+    const { dir, cleanup } = fakeGhBin()
+    try {
+      fs.symlinkSync(process.execPath, path.join(dir, "git"))
+      const { stdout } = await execWithShellEnv("git", ["-e", "console.log(process.env.TZ)"], {
+        env: { PATH: dir },
+      })
+      expect(stdout.trim()).toBe("undefined")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not inject TZ for gh on non-Windows platforms", async () => {
+    setPlatform("linux")
+    process.env.TZ = "Test/TZ"
+    const { dir, cleanup } = fakeGhBin()
+    try {
+      const { stdout } = await execWithShellEnv("gh", ["-e", "console.log(process.env.TZ)"], {
+        env: { PATH: dir },
+      })
+      expect(stdout.trim()).toBe("undefined")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("preserves an explicit TZ in options.env", async () => {
+    setPlatform("win32")
+    process.env.TZ = "Test/TZ"
+    const { dir, cleanup } = fakeGhBin()
+    try {
+      const { stdout } = await execWithShellEnv("gh", ["-e", "console.log(process.env.TZ)"], {
+        env: { PATH: dir, TZ: "Custom/Zone" },
+      })
+      expect(stdout.trim()).toBe("Custom/Zone")
+    } finally {
+      cleanup()
+    }
   })
 })


### PR DESCRIPTION
## Issue

Fixes #12912

## Context

When `gh` is spawned on Windows without `TZ` in its environment, it calls `tzutil.exe` to resolve the local time zone. When Windows Terminal is the default terminal, that `tzutil` child creates a visible console window that flashes for ~300–500 ms and steals focus from fullscreen games.

The `PRStatusPoller` (and other Agent Manager code) already spawns `gh` through `execWithShellEnv` in `packages/kilo-vscode/src/agent-manager/shell-env.ts`, so this is the single choke-point where we can stop the console flash for every `gh` call.

## Implementation

- Added a `withTzEnv` helper in `shell-env.ts` that:
  - only runs on `process.platform === "win32"`;
  - only applies when the spawned command is `gh` (by base name, stripping `.exe`);
  - uses `process.env.TZ` if set, otherwise falls back to `Intl.DateTimeFormat().resolvedOptions().timeZone` and caches the result;
  - respects an explicit `TZ` already present in the caller-supplied `env`.
- `execWithShellEnv` now wraps every invocation with `withTzEnv` before calling `exec()`, so `PRStatusPoller`, `WorktreeManager`, and any future `gh` callers all get `TZ` automatically.
- `util/process.ts` already forces `windowsHide: true` on every child process, but the visible window comes from the `tzutil` grandchild spawned by `gh`, so hiding the `gh` window alone is not enough. Passing `TZ` prevents `gh` from spawning `tzutil` in the first place.
- Added a focused unit test in `packages/kilo-vscode/tests/unit/shell-env.test.ts` covering: TZ injection, fallback inference, non-gh commands, non-Windows platforms, and explicit `TZ` preservation.
- Added a `.changeset` for the user-facing bug fix.

## Screenshots / Video

N/A — the visible console window is a transient Windows Terminal focus-steal that cannot be captured in a static screenshot, and the fix is verified by the unit tests.

## How to Test

### Manual/local verification

- `bun test tests/unit/shell-env.test.ts` → 15 pass (TZ-specific cases pass)
- `bun run test:unit` → 3732 pass, 0 fail
- `bun run lint` → pass
- `bun run typecheck` → pass
- `bun run format:check` → pass
- `bun run knip` → pass
- `bun run script/check-md-table-padding.ts` → pass

### Reviewer test steps

1. On Windows, set Windows Terminal as the default terminal.
2. Open a workspace where the Agent Manager polls PR status.
3. Observe that `gh` calls from `PRStatusPoller` no longer flash a console window.

### Blocked checks and substitute verification

The local `git push` pre-push hook runs the full `bun turbo typecheck` pipeline. The JetBrains typecheck attempted to download Gradle and failed with a network timeout (`java.net.SocketTimeoutException: Connect timed out` while fetching `gradle-9.4.1-bin.zip`). This is unrelated to the `kilo-vscode` changes. Substitute verification:

- `bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'` completed successfully (28 tasks, all type checks passed).
- `bun run typecheck` in `packages/kilo-vscode/` completed successfully.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.