### PR TITLE
fix(vscode): avoid Agent Manager terminal logo artifacts

### DIFF
--- a/.changeset/quiet-embedded-logo.md
+++ b/.changeset/quiet-embedded-logo.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use a compatible Kilo wordmark in embedded Agent Manager terminals.

--- a/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
@@ -71,6 +71,9 @@ export class TerminalManager {
       directory: params.cwd,
       cwd: params.cwd,
       title: params.title,
+      // xterm's DOM renderer cannot draw the Unicode sextant glyphs used by
+      // Kilo's modern wordmark, so use the compatible logo in embedded tabs.
+      env: { KILO_UNICODE_LOGO: "0" },
     })
     if (error || !data) {
       const err = error instanceof Error ? error.message : String(error ?? "unknown error")

--- a/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
@@ -15,6 +15,8 @@
 
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 
+const env = { KILO_UNICODE_LOGO: "0" }
+
 /**
  * Everything the manager needs from the surrounding AgentManagerProvider.
  *
@@ -73,7 +75,7 @@ export class TerminalManager {
       title: params.title,
       // xterm's DOM renderer cannot draw the Unicode sextant glyphs used by
       // Kilo's modern wordmark, so use the compatible logo in embedded tabs.
-      env: { KILO_UNICODE_LOGO: "0" },
+      env,
     })
     if (error || !data) {
       const err = error instanceof Error ? error.message : String(error ?? "unknown error")
@@ -240,6 +242,7 @@ export class TerminalManager {
         directory: entry.cwd,
         cwd: entry.cwd,
         title: entry.title,
+        env,
       })
       const info = created.data
       if (created.error || !info)

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
@@ -12,9 +12,13 @@ function wait() {
 describe("Agent Manager terminal routing", () => {
   it("round-trips side placement and rejects missing worktrees", async () => {
     const messages: AgentManagerOutMessage[] = []
+    const envs: Array<Record<string, string> | undefined> = []
     const client = {
       pty: {
-        create: async () => ({ data: { id: "pty-1", title: "Terminal 1" } }),
+        create: async ({ env }: { env?: Record<string, string> }) => {
+          envs.push(env)
+          return { data: { id: "pty-1", title: "Terminal 1" } }
+        },
         remove: async () => ({ data: true }),
         update: async () => ({ data: true }),
       },
@@ -46,6 +50,7 @@ describe("Agent Manager terminal routing", () => {
       worktreeId: "wt-1",
       projectId: "prj-1",
     })
+    expect(envs[0]).toEqual({ KILO_UNICODE_LOGO: "0" })
 
     router.handle({
       type: "agentManager.terminal.create",

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
@@ -51,6 +51,9 @@ describe("Agent Manager terminal routing", () => {
       projectId: "prj-1",
     })
     expect(envs[0]).toEqual({ KILO_UNICODE_LOGO: "0" })
+    router.handle({ type: "agentManager.terminal.restart", terminalId: "side-1" })
+    await wait()
+    expect(envs[1]).toEqual({ KILO_UNICODE_LOGO: "0" })
 
     router.handle({
       type: "agentManager.terminal.create",
@@ -58,7 +61,9 @@ describe("Agent Manager terminal routing", () => {
       placement: "side",
       worktreeId: "missing",
     })
-    expect(messages[1]).toMatchObject({
+    expect(
+      messages.find((message) => message.type === "agentManager.terminal.error" && message.createId === "side-missing"),
+    ).toMatchObject({
       type: "agentManager.terminal.error",
       createId: "side-missing",
     })


### PR DESCRIPTION
The embedded Agent Manager terminal uses xterm.js's DOM renderer, which cannot render the Unicode sextant glyphs in Kilo's modern wordmark. Those glyphs appear as outlined squares and broken blocks when `kilo` is started in an Agent Manager terminal.

Agent Manager-created PTYs now select Kilo's compatible block wordmark by default. Native VS Code terminals and Ghostty keep the modern wordmark, and users can still explicitly opt into the Unicode logo with `KILO_UNICODE_LOGO=1`.

<img width="700" alt="Before: broken sextant glyphs in the Agent Manager terminal" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260806-agent-manager-terminal-before.png?raw=true" />

<img width="700" alt="After: compatible wordmark in the Agent Manager terminal" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260806-agent-manager-terminal-after.png?raw=true" />