### PR TITLE
fix(cli): keep built-in skill examples inert

### DIFF
--- a/.changeset/calm-skill-examples.md
+++ b/.changeset/calm-skill-examples.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent built-in skill documentation examples from triggering shell permission prompts.

--- a/packages/opencode/src/kilocode/skills/builtin.ts
+++ b/packages/opencode/src/kilocode/skills/builtin.ts
@@ -3,7 +3,7 @@
 // Content is inlined at compile time via Bun's static import of .md files.
 // Registered before all discovery phases so user skills with the same name override.
 
-import KILO_CONFIG from "./kilo-config.md"
+import KILO_CONFIG from "./kilo-config.md" with { type: "text" }
 
 export interface BuiltinSkill {
   name: string

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -136,7 +136,7 @@ Use this skill.
   )
 
   // kilocode_change start
-  it.live("built-in kilo-config includes named command lookup guidance", () =>
+  it.live("built-in kilo-config keeps rendered shell examples inert", () =>
     provideTmpdirInstance(
       (dir) =>
         Effect.gen(function* () {
@@ -157,9 +157,13 @@ Use this skill.
           })).find((t) => t.id === SkillTool.id)
           if (!tool) throw new Error("Skill tool not found")
 
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
           const ctx: Tool.Context = {
             ...baseCtx,
-            ask: () => Effect.void,
+            ask: (req) =>
+              Effect.sync(() => {
+                requests.push(req)
+              }),
           }
 
           const result = yield* tool.execute({ name: "kilo-config" }, ctx)
@@ -170,6 +174,9 @@ Use this skill.
           expect(result.output).toContain("~/.kilocode/")
           expect(result.output).toContain("**/command/")
           expect(result.output).toContain("explicit search")
+          expect(result.output).toContain("`` !`cmd` ``")
+          expect(result.output).not.toContain("[skill shell command failed]")
+          expect(requests.map((request) => request.permission)).toEqual(["skill"])
         }),
       { git: true },
     ),


### PR DESCRIPTION
## Problem
Built-in skills can contain documentation examples using the shell placeholder syntax `!`cmd``. Loading the built-in `kilo-config` skill incorrectly treated the documented placeholder as a live shell command and requested permission to run `cmd`.

The failure was especially confusing with auto-approve enabled because genuine model-triggered skill shell commands intentionally require an interactive human approval. The permission card was caused by a false-positive command match, not by the PR workflow prompt or a broken auto-approve setting.

## Reproduction
In a fresh Agent Manager session, send:

```text
Load the built-in kilo-config skill, then reply with exactly LOADED. Do not use any other tools.
```

Before this change, loading the skill displayed:

```text
Run shell commands from skill "kilo-config"?
cmd
```

Approving the request then produced:

```text
zsh:1: command not found: cmd
```

## Cause
The existing skill-shell protection correctly recognizes Markdown fenced blocks and inline code spans for filesystem-backed `SKILL.md` files. The built-in `kilo-config.md` file was imported through Bun's default Markdown loader, which converted it to HTML before shell-placeholder scanning. The inert Markdown delimiters were therefore gone, while the placeholder text remained, so the scanner saw `cmd` as executable.

The prior regression coverage used raw filesystem Markdown and did not exercise the built-in import representation.

## Fix
Import the built-in skill as raw text so it reaches the existing inert-range scanner as Markdown. The scanner can then preserve both fenced examples and inline examples while continuing to execute genuine live `!`command`` placeholders under the existing human approval policy.

The built-in skill integration test now verifies that the literal example remains unchanged, no shell failure is inserted, and loading the skill requests only the normal skill permission, never bash permission.

## User-visible result
The reproduction prompt now completes with:

```text
Skill kilo-config
LOADED
```

No shell permission card is shown and `cmd` is not executed.