### PR TITLE
fix(vscode): persist Agent Manager dialog selections

### DIFF
--- a/.changeset/cache-worktree-dialog-selections.md
+++ b/.changeset/cache-worktree-dialog-selections.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember Agent Manager worktree dialog model, variant, mode, and sandbox selections when reopened.

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -56,10 +56,11 @@ const WORKTREE_PROMPT_COMMANDS = new Set(["models", "agents", "variant", "sandbo
 const WORKTREE_PROMPT_SCOPE = "agent-manager-worktree-prompt"
 
 type DialogTab = "new" | "import"
+type Model = { providerID: string; modelID: string }
 
 type DialogSelections = {
   agent?: string
-  model?: { providerID: string; modelID: string }
+  model?: Model
   variant?: string
   sandbox?: boolean
 }
@@ -79,6 +80,18 @@ function readDialogSelections(value: unknown): DialogSelections {
     variant: typeof data.variant === "string" ? data.variant : undefined,
     sandbox: typeof data.sandbox === "boolean" ? data.sandbox : undefined,
   }
+}
+
+function restoreAgent(value: string | undefined, list: Array<{ name: string }>, base: string): string {
+  if (!value) return base
+  if (list.length === 0) return value
+  return list.some((item) => item.name === value) ? value : base
+}
+
+function restoreModel(value: Model | undefined, providers: Record<string, unknown>, valid: (value: Model) => boolean) {
+  if (!value) return undefined
+  if (Object.keys(providers).length === 0) return value
+  return valid(value) ? value : undefined
 }
 
 function fallback<T>(value: T | undefined, get: () => T): T {
@@ -140,9 +153,12 @@ export const NewWorktreeDialog: Component<{
   const [prompt, setPrompt] = createSignal((cached?.advancedDialogPrompt as string) ?? "")
   const saved = readDialogSelections(cached?.advancedDialogSelections)
   const [versions, setVersions] = createSignal<VersionCount>(1)
-  const initialAgent = fallback(saved.agent, () => session.selectedAgent())
-  const initialModel = fallback(saved.model, () => session.modelForAgent(initialAgent))
-  const [model, setModel] = createSignal<{ providerID: string; modelID: string } | null>(initialModel)
+  const initialAgent = restoreAgent(saved.agent, session.agents(), session.selectedAgent())
+  const initialModel = fallback(
+    restoreModel(saved.model, provider.providers(), (value) => provider.isModelValid(value)),
+    () => session.modelForAgent(initialAgent),
+  )
+  const [model, setModel] = createSignal<Model | null>(initialModel)
   const [compareMode, setCompareMode] = createSignal(false)
   const [modelAllocations, setModelAllocations] = createSignal<ModelAllocations>(new Map())
   const [agent, setAgent] = createSignal(initialAgent)

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -57,6 +57,34 @@ const WORKTREE_PROMPT_SCOPE = "agent-manager-worktree-prompt"
 
 type DialogTab = "new" | "import"
 
+type DialogSelections = {
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+  sandbox?: boolean
+}
+
+function readDialogSelections(value: unknown): DialogSelections {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+  const data = value as Record<string, unknown>
+  const raw = data.model
+  const model = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : undefined
+
+  return {
+    agent: typeof data.agent === "string" ? data.agent : undefined,
+    model:
+      typeof model?.providerID === "string" && typeof model.modelID === "string"
+        ? { providerID: model.providerID, modelID: model.modelID }
+        : undefined,
+    variant: typeof data.variant === "string" ? data.variant : undefined,
+    sandbox: typeof data.sandbox === "boolean" ? data.sandbox : undefined,
+  }
+}
+
+function fallback<T>(value: T | undefined, get: () => T): T {
+  return value === undefined ? get() : value
+}
+
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
 
 function sanitizeSegment(text: string, maxLength = 50): string {
@@ -110,9 +138,10 @@ export const NewWorktreeDialog: Component<{
   const [name, setName] = createSignal("")
   const cached = vscode.getState<Record<string, unknown>>()
   const [prompt, setPrompt] = createSignal((cached?.advancedDialogPrompt as string) ?? "")
+  const saved = readDialogSelections(cached?.advancedDialogSelections)
   const [versions, setVersions] = createSignal<VersionCount>(1)
-  const initialAgent = session.selectedAgent()
-  const initialModel = session.modelForAgent(initialAgent)
+  const initialAgent = fallback(saved.agent, () => session.selectedAgent())
+  const initialModel = fallback(saved.model, () => session.modelForAgent(initialAgent))
   const [model, setModel] = createSignal<{ providerID: string; modelID: string } | null>(initialModel)
   const [compareMode, setCompareMode] = createSignal(false)
   const [modelAllocations, setModelAllocations] = createSignal<ModelAllocations>(new Map())
@@ -125,8 +154,10 @@ export const NewWorktreeDialog: Component<{
   const [baseBranchOpen, setBaseBranchOpen] = createSignal(false)
   const [compareOpen, setCompareOpen] = createSignal(false)
   const [highlightedIndex, setHighlightedIndex] = createSignal(0)
-  const [variant, setVariant] = createSignal<string | undefined>(session.variantForAgent(initialAgent, initialModel))
-  const [sandbox, setSandbox] = createSignal<boolean | undefined>()
+  const [variant, setVariant] = createSignal<string | undefined>(
+    fallback(saved.variant, () => session.variantForAgent(initialAgent, initialModel)),
+  )
+  const [sandbox, setSandbox] = createSignal<boolean | undefined>(saved.sandbox)
   const [sandboxDefault, setSandboxDefault] = createSignal<boolean | undefined>()
   const [sandboxOverride, setSandboxOverride] = createSignal<boolean | undefined>()
   const [sandboxAvailable, setSandboxAvailable] = createSignal(true)
@@ -284,6 +315,19 @@ export const NewWorktreeDialog: Component<{
     const state = vscode.getState<Record<string, unknown>>() ?? {}
     vscode.setState({ ...state, advancedDialogImages: imgs.length > 0 ? imgs : undefined })
   }
+
+  createEffect(() => {
+    const state = vscode.getState<Record<string, unknown>>() ?? {}
+    vscode.setState({
+      ...state,
+      advancedDialogSelections: {
+        agent: agent(),
+        model: model(),
+        variant: variant(),
+        sandbox: sandbox(),
+      },
+    })
+  })
 
   // Auto-persist images to webview state on any change
   createEffect(() => persistImages(imageAttach.images()))


### PR DESCRIPTION
The Agent Manager New Worktree dialog reset model, variant, mode, and sandbox selections whenever it closed, forcing repeated setup while the prompt draft remained. Persist these selections in webview state and restore them on the next open. Stored values are validated before use, and the server sandbox response remains authoritative. This includes a patch changeset for the user-facing fix.