### PR TITLE
fix(cli): prevent TUI config logs from corrupting terminal

### DIFF
--- a/.changeset/quiet-tui-config-reloads.md
+++ b/.changeset/quiet-tui-config-reloads.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent TUI config reload logs from corrupting the interactive terminal.

--- a/packages/opencode/src/kilocode/tui/config.ts
+++ b/packages/opencode/src/kilocode/tui/config.ts
@@ -13,6 +13,7 @@ import { isRecord } from "@/util/record"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "@/server/event"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { AppRuntime } from "@/effect/app-runtime"
 
 export namespace KilocodeTuiConfig {
   export const Scope = z.enum(["project", "global"])
@@ -26,7 +27,7 @@ export namespace KilocodeTuiConfig {
   const dirs = [".kilo", ".kilocode"] as const
 
   export async function get(input: { directory: string }) {
-    const cfg = await Effect.runPromise(
+    const cfg = await AppRuntime.runPromise(
       TuiConfig.Service.use((svc) => svc.info()).pipe(
         Effect.provide(
           AppNodeBuilder.build(TuiConfig.node).pipe(

--- a/packages/opencode/test/kilocode/server/tui-config.test.ts
+++ b/packages/opencode/test/kilocode/server/tui-config.test.ts
@@ -43,6 +43,34 @@ describe("TUI config routes", () => {
     expect(body.plugin_origins).toBeUndefined()
   })
 
+  test("does not write TUI config logs to the terminal", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cfg = path.join(dir, ".kilo")
+        await fs.mkdir(cfg, { recursive: true })
+        await Bun.write(path.join(cfg, "tui.json"), JSON.stringify({ theme: "dracula" }))
+      },
+    })
+
+    const output: unknown[][] = []
+    const log = console.log
+    try {
+      console.log = (...args) => output.push(args)
+      const response = await Server.Default().app.request("/tui/config", {
+        headers: { "x-kilo-directory": tmp.path },
+      })
+      expect(response.status).toBe(200)
+    } finally {
+      console.log = log
+    }
+
+    expect(
+      output.some((args) =>
+        args.some((item) => typeof item === "string" && /loading tui config|applying tui config/.test(item)),
+      ),
+    ).toBe(false)
+  })
+
   test("loads legacy .kilocode TUI config and ignores .opencode", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
Global configuration updates trigger a TUI configuration hot reload. The Kilo console endpoint was loading that configuration through a bare Effect runtime, so its INFO logs were rendered by Effect’s default console logger while OpenTUI owned the terminal. This inserted raw loading/applying lines into the prompt and footer.

The endpoint now runs the existing TUI configuration layer through Kilo’s AppRuntime, routing logs through the configured observability sink instead of the shared terminal. A regression test covers non-empty config reloads and prevents those log messages from reaching the terminal.

Fixes #12877