### PR TITLE
fix(agent-manager): support llama.cpp tool schema

### DIFF
--- a/.changeset/friendly-llamas-manage.md
+++ b/.changeset/friendly-llamas-manage.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Support the Agent Manager tool with llama.cpp servers that reject prefix-only JSON Schema patterns.

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -117,7 +117,7 @@ const WireParams = Schema.Struct({
   ),
   filter: Schema.optional(ListParams.fields.filter),
   sessionID: Schema.optional(
-    Schema.String.annotate({ description: "For move, use a session ID returned by action=list." }),
+    Schema.String.annotate({ description: "For move, use a session ID returned by action=list (IDs start with ses_)." }),
   ),
   prompt: Schema.optional(PromptParams.fields.prompt),
   sectionID: Schema.optional(MoveParams.fields.sectionID),

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -117,7 +117,7 @@ const WireParams = Schema.Struct({
   ),
   filter: Schema.optional(ListParams.fields.filter),
   sessionID: Schema.optional(
-    SessionID.annotate({ description: "For move, use a session ID returned by action=list." }),
+    Schema.String.annotate({ description: "For move, use a session ID returned by action=list." }),
   ),
   prompt: Schema.optional(PromptParams.fields.prompt),
   sectionID: Schema.optional(MoveParams.fields.sectionID),

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -164,7 +164,7 @@ describe("agent_manager tool", () => {
     expect(action && typeof action === "object" ? action.description : undefined).toContain("Use list first")
     expect(action && typeof action === "object" ? action.description : undefined).toContain("Never edit")
     expect(schema.properties?.sessionID).toEqual(
-      expect.objectContaining({ description: expect.stringContaining("returned by action=list") }),
+      expect.objectContaining({ description: expect.stringContaining("IDs start with ses_") }),
     )
     expect(schema.properties?.sessionID).not.toHaveProperty("pattern")
     expect(schema.properties?.sectionID).toEqual(

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -1,10 +1,10 @@
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer, ManagedRuntime, Queue } from "effect"
+import { Effect, Layer, ManagedRuntime, Queue, Schema } from "effect"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { AgentManagerTool } from "../../src/kilocode/tool/agent-manager"
+import { AgentManagerTool, Params } from "../../src/kilocode/tool/agent-manager"
 import { AgentManagerEvent, type AgentManagerStart } from "../../src/kilocode/agent-manager/event"
 import { AgentManager } from "../../src/kilocode/agent-manager/service"
 import { Bus } from "../../src/bus"
@@ -166,6 +166,7 @@ describe("agent_manager tool", () => {
     expect(schema.properties?.sessionID).toEqual(
       expect.objectContaining({ description: expect.stringContaining("returned by action=list") }),
     )
+    expect(schema.properties?.sessionID).not.toHaveProperty("pattern")
     expect(schema.properties?.sectionID).toEqual(
       expect.objectContaining({ description: expect.stringContaining("Use null to unassign") }),
     )
@@ -184,6 +185,11 @@ describe("agent_manager tool", () => {
       "prompt",
       "sectionID",
     ])
+  })
+
+  test("keeps session ID validation local", () => {
+    expect(Schema.is(Params)({ action: "stop", sessionID: "ses_target" })).toBe(true)
+    expect(Schema.is(Params)({ action: "stop", sessionID: "invalid" })).toBe(false)
   })
 
   test("asks for agent_manager permission", async () => {


### PR DESCRIPTION
The Agent Manager advertises a prefix-only `^ses` pattern for `sessionID`. llama.cpp rejects that tool schema before inference because it requires patterns to be fully anchored.

Expose `sessionID` as a plain string only in the model-facing wire schema while retaining the branded `SessionID` constraint in the local execution schema. This keeps validation intact without applying provider-wide schema rewriting.

Related to #12773.