### PR TITLE
fix(cli): avoid startup database lock crashes

### DIFF
--- a/.changeset/safe-credential-reconciliation.md
+++ b/.changeset/safe-credential-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent concurrent Kilo startups from rewriting unchanged credentials, retry transient database locks, and redact bound values from database errors.

--- a/packages/core/src/credential.ts
+++ b/packages/core/src/credential.ts
@@ -15,6 +15,7 @@ import { Global } from "./global"
 import { DataMigrationTable } from "./data-migration.sql"
 import path from "path"
 import { parse as parseKiloAccounts } from "./kilocode/credential-migration"
+import { isBusy } from "./kilocode/sqlite-error"
 import { NonNegativeInt } from "./schema"
 // kilocode_change end
 
@@ -170,6 +171,17 @@ export const legacyImportLayer = Layer.effectDiscard(
       const integration = Integration.ID.make(integrationID.replace(/\/+$/, ""))
       return [{ integration, value: legacyValue(integration, decoded.value) }]
     })
+    const migrated = yield* db.select().from(DataMigrationTable).where(eq(DataMigrationTable.name, name)).get()
+    const existing = yield* db.select().from(CredentialTable).orderBy(desc(CredentialTable.time_created)).all()
+    const same = (left: Value, right: Value) => JSON.stringify(left) === JSON.stringify(right)
+    if (
+      migrated &&
+      values.every((item) => {
+        const current = existing.find((row) => row.integration_id === item.integration)
+        return current !== undefined && same(current.value, item.value)
+      })
+    )
+      return
     yield* db.transaction((tx) =>
       Effect.gen(function* () {
         for (const item of values) {
@@ -181,7 +193,12 @@ export const legacyImportLayer = Layer.effectDiscard(
             .orderBy(desc(CredentialTable.time_created)) // kilocode_change - reconcile the active imported account
             .get()
           if (current) {
-            yield* tx.update(CredentialTable).set({ value: item.value }).where(eq(CredentialTable.id, current.id)).run()
+            if (!same(current.value, item.value))
+              yield* tx
+                .update(CredentialTable)
+                .set({ value: item.value })
+                .where(eq(CredentialTable.id, current.id))
+                .run()
             continue
           }
           yield* tx.insert(CredentialTable).values({
@@ -194,7 +211,15 @@ export const legacyImportLayer = Layer.effectDiscard(
         yield* tx.insert(DataMigrationTable).values({ name, time_completed: Date.now() }).onConflictDoNothing().run()
       }),
     )
-  }).pipe(Effect.orDie),
+  }).pipe(
+    Effect.retry({ while: isBusy, times: 2 }),
+    Effect.catch((error) =>
+      isBusy(error)
+        ? Effect.logWarning("legacy credential reconciliation deferred because the database is busy")
+        : Effect.fail(error),
+    ),
+    Effect.orDie,
+  ),
 )
 // kilocode_change end
 

--- a/packages/core/src/kilocode/database-compat.ts
+++ b/packages/core/src/kilocode/database-compat.ts
@@ -4,19 +4,29 @@ import type { Database } from "../database/database"
 type Db = Database.Interface["db"]
 
 export function ensure(db: Db) {
-  return db.transaction(
-    (tx) =>
-      Effect.gen(function* () {
-        const rows = yield* tx.all<{ name: string }>("PRAGMA table_info('session_context_epoch')")
-        const names = new Set(rows.map((row) => row.name))
+  const load = db.all<{ name: string }>("PRAGMA table_info('session_context_epoch')")
+  const ready = (rows: { name: string }[]) => {
+    const names = new Set(rows.map((row) => row.name))
+    return ["agent", "replacement_seq", "revision"].every((name) => names.has(name))
+  }
+  return load.pipe(
+    Effect.flatMap((rows) => {
+      if (ready(rows)) return Effect.void
+      return db.transaction(
+        (tx) =>
+          Effect.gen(function* () {
+            const current = yield* tx.all<{ name: string }>("PRAGMA table_info('session_context_epoch')")
+            const names = new Set(current.map((row) => row.name))
 
-        if (!names.has("agent"))
-          yield* tx.run("ALTER TABLE `session_context_epoch` ADD `agent` text DEFAULT 'build' NOT NULL")
-        if (!names.has("replacement_seq"))
-          yield* tx.run("ALTER TABLE `session_context_epoch` ADD `replacement_seq` integer")
-        if (!names.has("revision"))
-          yield* tx.run("ALTER TABLE `session_context_epoch` ADD `revision` integer DEFAULT 0 NOT NULL")
-      }),
-    { behavior: "immediate" },
+            if (!names.has("agent"))
+              yield* tx.run("ALTER TABLE `session_context_epoch` ADD `agent` text DEFAULT 'build' NOT NULL")
+            if (!names.has("replacement_seq"))
+              yield* tx.run("ALTER TABLE `session_context_epoch` ADD `replacement_seq` integer")
+            if (!names.has("revision"))
+              yield* tx.run("ALTER TABLE `session_context_epoch` ADD `revision` integer DEFAULT 0 NOT NULL")
+          }),
+        { behavior: "immediate" },
+      )
+    }),
   )
 }

--- a/packages/core/src/kilocode/sqlite-error.ts
+++ b/packages/core/src/kilocode/sqlite-error.ts
@@ -1,0 +1,10 @@
+import { Cause, Option } from "effect"
+import { isSqlError } from "effect/unstable/sql/SqlError"
+
+export function isBusy(error: unknown): boolean {
+  if (isSqlError(error)) return error.reason._tag === "LockTimeoutError"
+  if (typeof error !== "object" || error === null || !("cause" in error) || error.cause === error) return false
+  if (!Cause.isCause(error.cause)) return isBusy(error.cause)
+  const failure = Cause.findErrorOption(error.cause)
+  return Option.isSome(failure) && isBusy(failure.value)
+}

--- a/packages/core/test/credential.test.ts
+++ b/packages/core/test/credential.test.ts
@@ -1,11 +1,15 @@
 import path from "path"
+import { Database as SQLite } from "bun:sqlite" // kilocode_change
 import { describe, expect } from "bun:test"
+import { eq } from "drizzle-orm" // kilocode_change
 import { Effect, Layer } from "effect"
 import { Credential } from "@opencode-ai/core/credential"
+import { CredentialTable } from "@opencode-ai/core/credential/sql" // kilocode_change
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Integration } from "@opencode-ai/core/integration"
 // kilocode_change start
 import { Database } from "@opencode-ai/core/database/database"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 // kilocode_change end
 import { tmpdir } from "./fixture/tmpdir"
@@ -19,6 +23,16 @@ function localLayer(directory: string) {
     Layer.fresh, // kilocode_change - rebuild so process-local credentials are re-read
   )
 }
+
+// kilocode_change start
+function importer(dir: string, store: Database.Interface) {
+  return Credential.legacyImportLayer.pipe(
+    Layer.provide(Layer.succeed(Database.Service, store)),
+    Layer.provide(FSUtil.defaultLayer),
+    Layer.provide(Global.layerWith({ data: dir })),
+  )
+}
+// kilocode_change end
 
 describe("Credential", () => {
   it.live("stores, updates, lists, and removes credentials", () =>
@@ -193,6 +207,70 @@ describe("Credential", () => {
           expect(after.azure[0]?.value).toMatchObject({ type: "key", key: "updated" })
         }),
       ),
+    ),
+  )
+
+  it.live("skips unchanged legacy writes and defers locked reconciliation", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        const file = path.join(tmp.path, "credential.db")
+        const auth = path.join(tmp.path, "auth.json")
+        const write = (key: string) =>
+          Effect.promise(() => Bun.write(auth, JSON.stringify({ kilo: { type: "api", key } })))
+        return Effect.gen(function* () {
+          yield* write("first")
+          const store = yield* Database.Service
+          const layer = importer(tmp.path, store)
+          yield* Layer.build(Layer.fresh(layer))
+
+          const before = yield* store.db
+            .select()
+            .from(CredentialTable)
+            .where(eq(CredentialTable.integration_id, Integration.ID.make("kilo")))
+            .get()
+          yield* Layer.build(Layer.fresh(layer))
+          const unchanged = yield* store.db
+            .select()
+            .from(CredentialTable)
+            .where(eq(CredentialTable.integration_id, Integration.ID.make("kilo")))
+            .get()
+          expect(unchanged?.time_updated).toBe(before?.time_updated)
+
+          yield* write("second")
+          yield* store.db.run("PRAGMA busy_timeout = 0")
+          yield* Effect.acquireUseRelease(
+            Effect.sync(() => {
+              const holder = new SQLite(file)
+              holder.run("PRAGMA busy_timeout = 0")
+              holder.run("BEGIN IMMEDIATE")
+              return holder
+            }),
+            () => Layer.build(Layer.fresh(layer)),
+            (holder) =>
+              Effect.sync(() => {
+                if (holder.inTransaction) holder.run("ROLLBACK")
+                holder.close()
+              }),
+          )
+
+          const stale = yield* store.db
+            .select()
+            .from(CredentialTable)
+            .where(eq(CredentialTable.integration_id, Integration.ID.make("kilo")))
+            .get()
+          expect(stale?.value).toMatchObject({ type: "key", key: "first" })
+
+          yield* Layer.build(Layer.fresh(layer))
+          const reconciled = yield* store.db
+            .select()
+            .from(CredentialTable)
+            .where(eq(CredentialTable.integration_id, Integration.ID.make("kilo")))
+            .get()
+          expect(reconciled?.value).toMatchObject({ type: "key", key: "second" })
+        }).pipe(Effect.provide(Database.layerFromPath(file)), Effect.scoped)
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
 

--- a/packages/core/test/kilocode/database-migration-compat.test.ts
+++ b/packages/core/test/kilocode/database-migration-compat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Database as SQLite } from "bun:sqlite"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
@@ -159,6 +160,22 @@ describe("database migration compatibility", () => {
               sql`SELECT agent, replacement_seq AS replacementSeq, revision FROM session_context_epoch WHERE session_id = 'session'`,
             ),
           ).toEqual({ agent: "build", replacementSeq: 4, revision: 1 })
+
+          yield* db.run("PRAGMA busy_timeout = 0")
+          yield* Effect.acquireUseRelease(
+            Effect.sync(() => {
+              const holder = new SQLite(filename)
+              holder.run("PRAGMA busy_timeout = 0")
+              holder.run("BEGIN IMMEDIATE")
+              return holder
+            }),
+            () => ensure(db),
+            (holder) =>
+              Effect.sync(() => {
+                if (holder.inTransaction) holder.run("ROLLBACK")
+                holder.close()
+              }),
+          )
         }),
       ).pipe(Effect.provide(Database.layerFromPath(filename)), Effect.scoped),
     )

--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
@@ -279,7 +279,13 @@ export class SQLiteEffectPreparedQuery<
       assertUnreachable(cacheStrat)
     }).pipe(
       Effect.catch((e) => {
-        return Effect.fail(new EffectDrizzleQueryError({ query: queryString, params, cause: Cause.fail(e) }))
+        return Effect.fail(
+          new EffectDrizzleQueryError({
+            query: queryString,
+            params: params.map(() => "<redacted>"), // kilocode_change - bound values may contain credentials
+            cause: Cause.fail(e),
+          }),
+        )
       }),
     )
   }

--- a/packages/effect-drizzle-sqlite/test/sqlite.test.ts
+++ b/packages/effect-drizzle-sqlite/test/sqlite.test.ts
@@ -130,6 +130,24 @@ test("preserves failed transaction begin errors", async () => {
   }
 })
 
+// kilocode_change start - query errors must never expose bound credential values
+test("redacts bound values from query errors", async () => {
+  await run(
+    Effect.gen(function* () {
+      const db = yield* makeDb
+      const secret = "must-not-leak"
+      yield* db.insert(users).values({ id: 1, name: "Ada" })
+
+      const error = yield* db.insert(users).values({ id: 1, name: secret }).pipe(Effect.flip)
+
+      expect(error.message).not.toContain(secret)
+      expect(error.params).not.toContain(secret)
+      expect(error.params.every((param) => param === "<redacted>")).toBe(true)
+    }),
+  )
+})
+// kilocode_change end
+
 test("supports returning and rejects empty update sets", async () => {
   await run(
     Effect.gen(function* () {

--- a/packages/opencode/src/kilocode/database/sqlite-error.ts
+++ b/packages/opencode/src/kilocode/database/sqlite-error.ts
@@ -1,7 +1,5 @@
-import { isSqlError } from "effect/unstable/sql/SqlError"
+import { isBusy } from "@opencode-ai/core/kilocode/sqlite-error"
+
+export { isBusy }
 
 export const busyMessage = "Database is busy. Please try again in a moment."
-
-export function isBusy(error: unknown) {
-  return isSqlError(error) && error.reason._tag === "LockTimeoutError"
-}

--- a/packages/opencode/test/kilocode/database/sqlite-error.test.ts
+++ b/packages/opencode/test/kilocode/database/sqlite-error.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
+import { Cause } from "effect"
 import { LockTimeoutError, SqlError, UnknownError } from "effect/unstable/sql/SqlError"
+import { EffectDrizzleQueryError } from "drizzle-orm/effect-core/errors"
 import { busyMessage, isBusy } from "@/kilocode/database/sqlite-error"
 
 describe("SQLite errors", () => {
@@ -26,5 +28,23 @@ describe("SQLite errors", () => {
     })
 
     expect(isBusy(error)).toBe(false)
+  })
+
+  test("recognizes lock timeouts wrapped by Drizzle", () => {
+    const error = new EffectDrizzleQueryError({
+      query: "update credential set value = ?",
+      params: ["<redacted>"],
+      cause: Cause.fail(
+        new SqlError({
+          reason: new LockTimeoutError({
+            cause: new Error("database is locked"),
+            message: "Failed to execute statement",
+            operation: "execute",
+          }),
+        }),
+      ),
+    })
+
+    expect(isBusy(error)).toBe(true)
   })
 })


### PR DESCRIPTION
## Issue

No linked issue — this PR follows a locally reproduced CLI startup crash caused by concurrent Kilo processes sharing the same SQLite database.

## Context

Kilo reconciles credentials from the legacy `auth.json` store during startup. It previously rewrote an unchanged credential on every launch and also opened an immediate compatibility transaction even when no schema repair was needed. With another Kilo process holding SQLite's writer lock, startup could fail before the CLI or server became usable.

The Drizzle error wrapper also included every bound SQL parameter in the error message, causing OAuth credentials to appear in stderr when the update failed.

## Implementation

Make steady-state startup read-only in both affected compatibility paths:

- Skip legacy credential reconciliation when the newest stored values already match `auth.json`.
- Read compatibility columns before opening an immediate transaction, while retaining the transaction and an in-transaction re-check when an actual repair is required.
- Retry transient lock failures during legacy reconciliation and defer that compatibility sync if the database remains busy.
- Recognize lock timeouts nested inside Drizzle's Effect cause.
- Replace bound query values with `<redacted>` before constructing query errors.

A first startup after an upgrade that genuinely requires schema repair still waits for the writer lock and fails if it remains unavailable; that repair cannot safely be deferred because later code requires those columns.

## Screenshots / Video

Error:
<img width="813" height="72" alt="Screenshot 2026-08-06 at 15 26 20" src="https://github.com/user-attachments/assets/4dcef84f-33d6-49a2-94a6-0bda8400b903" />

## How to Test

### Manual/local verification

Agent-executed deterministic verification used disposable `XDG_DATA_HOME` and `KILO_DB` directories with dummy credentials:

- Initialized equivalent pre-fix and patched databases.
- Changed each legacy `auth.json` credential.
- Held `BEGIN IMMEDIATE` from a second SQLite connection for 18 seconds.
- Confirmed installed CLI 7.4.19 exited 1 at credential reconciliation and printed the dummy bound value.
- Confirmed patched `bun run dev -- auth list --pure` exited 0 under the same lock without a secret-bearing query error.
- Confirmed the next unlocked startup reconciled the deferred dummy credential.

Automated checks executed by agents:

- `bun test ./test/credential.test.ts ./test/kilocode/database-migration-compat.test.ts` from `packages/core`: 9 passed.
- `bun test ./test/sqlite.test.ts` from `packages/effect-drizzle-sqlite`: 8 passed.
- `bun test ./test/kilocode/database/sqlite-error.test.ts` from `packages/opencode`: 3 passed.
- `bun run typecheck` in all three affected packages.
- Repository pre-push monorepo typecheck.
- `bun run lint`: zero errors.
- Annotation, Promise-facade, Markdown-table, formatting, and diff guards.
- Independent Fable review also ran the full core suite: 1,215 passed, 0 failed.

### Reviewer test steps

1. Point `XDG_DATA_HOME` and `KILO_DB` at a disposable directory and create a dummy Kilo API credential in `auth.json`.
2. Run `bun run dev -- auth list --pure` once to initialize the database.
3. Change the dummy credential in `auth.json`.
4. From a second process, open the database and hold `BEGIN IMMEDIATE`.
5. Run `bun run dev -- auth list --pure` and confirm it exits successfully without printing the credential.
6. Release the lock, run the command again, and confirm the updated credential was reconciled.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.