### PR TITLE
fix(agent-manager): improve inspector resize performance

### DIFF
--- a/.changeset/sync-inspector-width.md
+++ b/.changeset/sync-inspector-width.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Persist the Agent Manager inspector width and share it between the terminal and diff viewer.
+Persist the Agent Manager inspector width, share it between the terminal and diff viewer, and keep resizing responsive.

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -5,6 +5,10 @@ import { clampPanelWidth, maxPanelWidth, minPanelWidth } from "../../webview-ui/
 
 const css = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/agent-manager.css"), "utf8")
 const app = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/AgentManagerApp.tsx"), "utf8")
+const terminal = readFileSync(
+  resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/TerminalTab.tsx"),
+  "utf8",
+)
 
 test("xterm owns the padding used by FitAddon", () => {
   const host = css.match(/\.am-terminal-host\s*\{([^}]*)\}/)?.[1]
@@ -21,6 +25,18 @@ test("uses one persisted width for the diff and terminal inspector", () => {
   expect(app).toContain("setPanelWidth(pendingSideWidth!)")
   expect(app).not.toContain("diffWidth")
   expect(app).not.toContain("terminalWidth")
+})
+
+test("limits inspector layout updates during resize", () => {
+  expect(app).toContain("SIDE_RESIZE_INTERVAL_MS = 32")
+  expect(app).toContain("time - sideResizeTime < SIDE_RESIZE_INTERVAL_MS")
+})
+
+test("does not refit hidden terminal buffers during resize", () => {
+  const callback = terminal.match(/const ro = new ResizeObserver\(\(\) => \{([\s\S]*?)\n    \}\)/)?.[1]
+  expect(callback).toBeDefined()
+  expect(callback).toContain("if (!props.active) return")
+  expect(callback!.indexOf("if (!props.active) return")).toBeLessThan(callback!.indexOf("fit.fit()"))
 })
 
 test("clamps the restored inspector width to the shared layout bounds", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -200,6 +200,7 @@ type SidePanel = "diff" | "pr" | "terminal" | null
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
 // Fallback keybindings before extension sends resolved ones
 const MAX_JUMP_INDEX = 9
+const SIDE_RESIZE_INTERVAL_MS = 32
 
 const defaultBindings: Record<string, string> = {
   previousSession: isMac ? "⌘⌥↑" : "Ctrl+Alt+↑",
@@ -308,6 +309,7 @@ const AgentManagerContent: Component = () => {
   let pendingSidebarWidth: number | undefined
   let sideRaf: number | undefined
   let pendingSideWidth: number | undefined
+  let sideResizeTime = 0
 
   const [history, setHistory] = createSignal(false)
   const [sidePanel, setSidePanel] = createSignal<SidePanel>(null)
@@ -323,10 +325,16 @@ const AgentManagerContent: Component = () => {
   const resizeSide = (width: number) => {
     pendingSideWidth = clampPanelWidth(width, window.innerWidth)
     if (sideRaf !== undefined) return
-    sideRaf = requestAnimationFrame(() => {
+    const flush = (time: number) => {
+      if (time - sideResizeTime < SIDE_RESIZE_INTERVAL_MS) {
+        sideRaf = requestAnimationFrame(flush)
+        return
+      }
       sideRaf = undefined
+      sideResizeTime = time
       setPanelWidth(pendingSideWidth!)
-    })
+    }
+    sideRaf = requestAnimationFrame(flush)
   }
   const showSideTerminal = () => {
     setHistory(false)

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
@@ -377,9 +377,9 @@ export const TerminalTab: Component<Props> = (props) => {
       open(url)
     }
 
-    // Resize: fit on any host size change and forward new cols/rows to
-    // the backend PTY. Debounced because a user drag can fire dozens of
-    // resize events per second.
+    // Resize the visible terminal and forward new cols/rows to the backend
+    // PTY. Hidden terminals refit when activated, avoiding scrollback reflow
+    // for every mounted terminal during an inspector drag.
     let resizeTimer: ReturnType<typeof setTimeout> | undefined
     let lastCols = term.cols
     let lastRows = term.rows
@@ -395,6 +395,7 @@ export const TerminalTab: Component<Props> = (props) => {
       })
     }
     const ro = new ResizeObserver(() => {
+      if (!props.active) return
       try {
         fit.fit()
       } catch (err) {


### PR DESCRIPTION
## Problem

Resizing the Agent Manager inspector repeatedly committed layout changes while the diff viewer and mounted xterm instances reflowed. Large diffs and terminal scrollback could produce visible stalls during a drag.

## Change

- Limit inspector width commits to approximately 30 FPS while preserving the latest width for a trailing update.
- Skip ResizeObserver-driven xterm refits for hidden terminal tabs. Hidden terminals refit when activated at their current dimensions.
- Add regression coverage for both resize invariants.

## Measured Improvement

Measured with the VS Code self-test profiler using the same 1.46-second divider drag, 90 synthetic pointer updates, and the same Agent Manager webview scenario. Diff and terminal runs were captured separately. The terminal scenario used 5,000 lines of scrollback.

### Inline Diff Resize

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Total RunTask time | 583.72 ms | 395.38 ms | -32.3% |
| Longest task | 69.74 ms | 14.60 ms | -79.1% |
| Tasks over 16 ms | 2 | 0 | -100% |
| Tasks over 50 ms | 1 | 0 | -100% |
| UpdateLayoutTree | 124.33 ms | 77.60 ms | -37.6% |
| Layout | 40.86 ms | 31.88 ms | -22.0% |
| Paint | 46.57 ms | 32.40 ms | -30.4% |

### Inline Terminal Resize

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Total RunTask time | 480.59 ms | 288.42 ms | -40.0% |
| Longest task | 7.65 ms | 9.96 ms | +30.3% |
| Tasks over 16 ms | 0 | 0 | unchanged |
| Tasks over 50 ms | 0 | 0 | unchanged |
| UpdateLayoutTree | 53.99 ms | 23.20 ms | -57.0% |
| Layout | 37.70 ms | 22.80 ms | -39.5% |
| Paint | 27.16 ms | 17.11 ms | -37.0% |
| FunctionCall | 103.13 ms | 47.10 ms | -54.3% |

The terminal after-run longest task remained below 10 ms. The one-time post-build capture was discarded from the comparison because it included an unrelated outer VS Code terminal-panel height transition.

## User-visible Result

- Diff resizing no longer produces the measured long main-thread stalls.
- Terminal scrollback remains responsive while the inspector is dragged.
- Inactive terminal tabs avoid unnecessary scrollback reflow and still fit correctly when selected.