### PR TITLE
fix(tui): suppress expected disposal aborts

### DIFF
--- a/.changeset/quiet-tui-disposal-aborts.md
+++ b/.changeset/quiet-tui-disposal-aborts.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Avoid printing an error when closing the TUI cancels in-flight startup refreshes.

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -62,6 +62,10 @@ export function eventLocation(metadata: { directory: string; workspace?: string 
   if (metadata.directory === "global") return
   return { directory: metadata.directory, workspaceID: metadata.workspace }
 }
+
+export function shouldReportDefaultLocationFailure(reason: unknown, disposed: boolean) {
+  return !disposed || !(reason instanceof Error && reason.name === "AbortError")
+}
 // kilocode_change end
 
 export const { use: useData, provider: DataProvider } = createSimpleContext({
@@ -575,6 +579,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       },
     }
 
+    // kilocode_change start - treat SDK cancellation during normal TUI disposal as expected
+    let disposed = false
+    onCleanup(() => {
+      disposed = true
+    })
     onMount(() => {
       void Promise.allSettled([
         result.location.refresh(),
@@ -586,10 +595,14 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         result.location.command.refresh(),
         result.location.skill.refresh(),
       ]).then((settled) => {
-        for (const failure of settled.filter((item) => item.status === "rejected"))
+        for (const failure of settled) {
+          if (failure.status !== "rejected") continue
+          if (!shouldReportDefaultLocationFailure(failure.reason, disposed)) continue
           console.error("Failed to refresh default location data", failure.reason)
+        }
       })
     })
+    // kilocode_change end
 
     return result
   },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -598,9 +598,9 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       disposed = true
     })
     // kilocode_change end
+    // kilocode_change start
     onMount(() => {
       void Promise.all([
-        // kilocode_change start
         reportDefaultLocationFailure(result.location.refresh(), () => disposed),
         reportDefaultLocationFailure(result.location.agent.refresh(), () => disposed),
         reportDefaultLocationFailure(result.location.integration.refresh(), () => disposed),
@@ -609,9 +609,9 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         reportDefaultLocationFailure(result.location.reference.refresh(), () => disposed),
         reportDefaultLocationFailure(result.location.command.refresh(), () => disposed),
         reportDefaultLocationFailure(result.location.skill.refresh(), () => disposed),
-        // kilocode_change end
       ])
     })
+    // kilocode_change end
 
     return result
   },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -62,9 +62,22 @@ export function eventLocation(metadata: { directory: string; workspace?: string 
   if (metadata.directory === "global") return
   return { directory: metadata.directory, workspaceID: metadata.workspace }
 }
+// kilocode_change end
 
+// kilocode_change start - suppress only refreshes canceled by normal TUI disposal
 export function shouldReportDefaultLocationFailure(reason: unknown, disposed: boolean) {
-  return !disposed || !(reason instanceof Error && reason.name === "AbortError")
+  if (!disposed) return true
+  return !(typeof reason === "object" && reason !== null && "name" in reason && reason.name === "AbortError")
+}
+
+export async function reportDefaultLocationFailure(
+  promise: Promise<void>,
+  disposed: () => boolean,
+  report: (reason: unknown) => void = (reason) => console.error("Failed to refresh default location data", reason),
+) {
+  return promise.catch((reason) => {
+    if (shouldReportDefaultLocationFailure(reason, disposed())) report(reason)
+  })
 }
 // kilocode_change end
 
@@ -579,30 +592,26 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       },
     }
 
-    // kilocode_change start - treat SDK cancellation during normal TUI disposal as expected
+    // kilocode_change start - classify each rejection when it occurs so later disposal cannot hide earlier failures
     let disposed = false
     onCleanup(() => {
       disposed = true
     })
-    onMount(() => {
-      void Promise.allSettled([
-        result.location.refresh(),
-        result.location.agent.refresh(),
-        result.location.integration.refresh(),
-        result.location.model.refresh(),
-        result.location.provider.refresh(),
-        result.location.reference.refresh(),
-        result.location.command.refresh(),
-        result.location.skill.refresh(),
-      ]).then((settled) => {
-        for (const failure of settled) {
-          if (failure.status !== "rejected") continue
-          if (!shouldReportDefaultLocationFailure(failure.reason, disposed)) continue
-          console.error("Failed to refresh default location data", failure.reason)
-        }
-      })
-    })
     // kilocode_change end
+    onMount(() => {
+      void Promise.all([
+        // kilocode_change start
+        reportDefaultLocationFailure(result.location.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.agent.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.integration.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.model.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.provider.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.reference.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.command.refresh(), () => disposed),
+        reportDefaultLocationFailure(result.location.skill.refresh(), () => disposed),
+        // kilocode_change end
+      ])
+    })
 
     return result
   },

--- a/packages/tui/test/kilocode/data.test.ts
+++ b/packages/tui/test/kilocode/data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { eventLocation, shouldReportDefaultLocationFailure } from "../../src/context/data"
+import { eventLocation, reportDefaultLocationFailure, shouldReportDefaultLocationFailure } from "../../src/context/data"
 
 describe("eventLocation", () => {
   test("uses the default location for global events", () => {
@@ -19,11 +19,41 @@ describe("shouldReportDefaultLocationFailure", () => {
     expect(shouldReportDefaultLocationFailure(new DOMException("aborted", "AbortError"), true)).toBe(false)
   })
 
+  test("suppresses cross-realm-shaped lifecycle aborts after disposal", () => {
+    expect(shouldReportDefaultLocationFailure({ name: "AbortError" }, true)).toBe(false)
+  })
+
   test("reports aborts while mounted", () => {
     expect(shouldReportDefaultLocationFailure(new DOMException("aborted", "AbortError"), false)).toBe(true)
   })
 
   test("reports non-abort failures after disposal", () => {
     expect(shouldReportDefaultLocationFailure(new Error("network failed"), true)).toBe(true)
+  })
+})
+
+describe("reportDefaultLocationFailure", () => {
+  test("reports a mounted abort immediately even if disposal happens before other refreshes settle", async () => {
+    let disposed = false
+    const reports: unknown[] = []
+    const abort = Promise.reject(new DOMException("aborted", "AbortError"))
+    const pending = Promise.withResolvers<void>()
+
+    const first = reportDefaultLocationFailure(
+      abort,
+      () => disposed,
+      (reason) => reports.push(reason),
+    )
+    await first
+    disposed = true
+    pending.reject(new DOMException("aborted", "AbortError"))
+    await reportDefaultLocationFailure(
+      pending.promise,
+      () => disposed,
+      (reason) => reports.push(reason),
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0]).toBeInstanceOf(DOMException)
   })
 })

--- a/packages/tui/test/kilocode/data.test.ts
+++ b/packages/tui/test/kilocode/data.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { eventLocation } from "../../src/context/data"
+import { eventLocation, shouldReportDefaultLocationFailure } from "../../src/context/data"
 
 describe("eventLocation", () => {
   test("uses the default location for global events", () => {
@@ -11,5 +11,19 @@ describe("eventLocation", () => {
       directory: "/repo",
       workspaceID: "wsp_test",
     })
+  })
+})
+
+describe("shouldReportDefaultLocationFailure", () => {
+  test("suppresses lifecycle aborts after disposal", () => {
+    expect(shouldReportDefaultLocationFailure(new DOMException("aborted", "AbortError"), true)).toBe(false)
+  })
+
+  test("reports aborts while mounted", () => {
+    expect(shouldReportDefaultLocationFailure(new DOMException("aborted", "AbortError"), false)).toBe(true)
+  })
+
+  test("reports non-abort failures after disposal", () => {
+    expect(shouldReportDefaultLocationFailure(new Error("network failed"), true)).toBe(true)
   })
 })


### PR DESCRIPTION
## What changed

Suppress `AbortError` from default-location refresh requests only when the TUI has already begun normal disposal. Abort failures while mounted and all non-abort failures remain logged.

## Why

`SDKProvider` intentionally aborts in-flight requests during renderer cleanup. `DataProvider` awaited its startup refreshes with `Promise.allSettled()` and logged every rejection, so a normal exit could print a large `Failed to refresh default location data` stack trace.