### PR TITLE
fix(vscode): translate Agent Manager terminal shortcut

### DIFF
--- a/.changeset/terminal-shortcut-translations.md
+++ b/.changeset/terminal-shortcut-translations.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Translate the Agent Manager terminal focus shortcut label in all supported locales.

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -99,7 +99,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "علامة التبويب التالية",
   "agentManager.shortcuts.newTab": "علامة تبويب جديدة",
   "agentManager.shortcuts.closeTab": "إغلاق علامة التبويب",
-  "agentManager.shortcuts.toggleTerminal": "تبديل الطرفية",
+  "agentManager.shortcuts.toggleTerminal": "التركيز على الطرفية / إخفاء الطرفية",
   "agentManager.shortcuts.runScript": "تشغيل السكربت",
   "agentManager.run.options": "خيارات التشغيل",
   "agentManager.run.configure": "تكوين سكربت التشغيل",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -101,7 +101,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Próxima aba",
   "agentManager.shortcuts.newTab": "Nova aba",
   "agentManager.shortcuts.closeTab": "Fechar aba",
-  "agentManager.shortcuts.toggleTerminal": "Alternar terminal",
+  "agentManager.shortcuts.toggleTerminal": "Focar / ocultar terminal",
   "agentManager.shortcuts.runScript": "Executar script",
   "agentManager.run.options": "Opções de execução",
   "agentManager.run.configure": "Configurar script de execução",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -101,7 +101,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Sljedeća kartica",
   "agentManager.shortcuts.newTab": "Nova kartica",
   "agentManager.shortcuts.closeTab": "Zatvori karticu",
-  "agentManager.shortcuts.toggleTerminal": "Prebaci terminal",
+  "agentManager.shortcuts.toggleTerminal": "Fokusiraj / sakrij terminal",
   "agentManager.shortcuts.runScript": "Pokreni skriptu",
   "agentManager.run.options": "Opcije pokretanja",
   "agentManager.run.configure": "Konfiguriši skriptu za pokretanje",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Næste fane",
   "agentManager.shortcuts.newTab": "Ny fane",
   "agentManager.shortcuts.closeTab": "Luk fane",
-  "agentManager.shortcuts.toggleTerminal": "Skift terminal",
+  "agentManager.shortcuts.toggleTerminal": "Fokusér / skjul terminalen",
   "agentManager.shortcuts.runScript": "Kør script",
   "agentManager.run.options": "Kørselsindstillinger",
   "agentManager.run.configure": "Konfigurer kørselsscript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -103,7 +103,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Nächster Tab",
   "agentManager.shortcuts.newTab": "Neuer Tab",
   "agentManager.shortcuts.closeTab": "Tab schließen",
-  "agentManager.shortcuts.toggleTerminal": "Terminal umschalten",
+  "agentManager.shortcuts.toggleTerminal": "Terminal fokussieren / ausblenden",
   "agentManager.shortcuts.runScript": "Skript ausführen",
   "agentManager.run.options": "Ausführungsoptionen",
   "agentManager.run.configure": "Ausführungsskript konfigurieren",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Siguiente pestaña",
   "agentManager.shortcuts.newTab": "Nueva pestaña",
   "agentManager.shortcuts.closeTab": "Cerrar pestaña",
-  "agentManager.shortcuts.toggleTerminal": "Alternar terminal",
+  "agentManager.shortcuts.toggleTerminal": "Enfocar / ocultar la terminal",
   "agentManager.shortcuts.runScript": "Ejecutar script",
   "agentManager.run.options": "Opciones de ejecución",
   "agentManager.run.configure": "Configurar script de ejecución",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -105,7 +105,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "تب بعدی",
   "agentManager.shortcuts.newTab": "تب جدید",
   "agentManager.shortcuts.closeTab": "بستن تب",
-  "agentManager.shortcuts.toggleTerminal": "نمایش/پنهان کردن ترمینال",
+  "agentManager.shortcuts.toggleTerminal": "تمرکز روی ترمینال / پنهان کردن ترمینال",
   "agentManager.shortcuts.runScript": "اجرای اسکریپت",
   "agentManager.run.options": "گزینه‌های اجرا",
   "agentManager.run.configure": "پیکربندی اسکریپت اجرا",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Onglet suivant",
   "agentManager.shortcuts.newTab": "Nouvel onglet",
   "agentManager.shortcuts.closeTab": "Fermer l'onglet",
-  "agentManager.shortcuts.toggleTerminal": "Basculer le terminal",
+  "agentManager.shortcuts.toggleTerminal": "Focaliser / masquer le terminal",
   "agentManager.shortcuts.runScript": "Exécuter le script",
   "agentManager.run.options": "Options d'exécution",
   "agentManager.run.configure": "Configurer le script d'exécution",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -107,7 +107,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Scheda successiva",
   "agentManager.shortcuts.newTab": "Nuova scheda",
   "agentManager.shortcuts.closeTab": "Chiudi scheda",
-  "agentManager.shortcuts.toggleTerminal": "Mostra/nascondi terminale",
+  "agentManager.shortcuts.toggleTerminal": "Metti a fuoco / nascondi il terminale",
   "agentManager.shortcuts.runScript": "Esegui script",
   "agentManager.run.options": "Opzioni di esecuzione",
   "agentManager.run.configure": "Configura script di esecuzione",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "次のタブ",
   "agentManager.shortcuts.newTab": "新しいタブ",
   "agentManager.shortcuts.closeTab": "タブを閉じる",
-  "agentManager.shortcuts.toggleTerminal": "ターミナルの切り替え",
+  "agentManager.shortcuts.toggleTerminal": "ターミナルにフォーカス / 非表示にする",
   "agentManager.shortcuts.runScript": "スクリプトを実行",
   "agentManager.run.options": "実行オプション",
   "agentManager.run.configure": "実行スクリプトを設定",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -100,7 +100,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "다음 탭",
   "agentManager.shortcuts.newTab": "새 탭",
   "agentManager.shortcuts.closeTab": "탭 닫기",
-  "agentManager.shortcuts.toggleTerminal": "터미널 전환",
+  "agentManager.shortcuts.toggleTerminal": "터미널에 포커스 / 터미널 숨기기",
   "agentManager.shortcuts.runScript": "스크립트 실행",
   "agentManager.run.options": "실행 옵션",
   "agentManager.run.configure": "실행 스크립트 구성",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -106,7 +106,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Volgend tabblad",
   "agentManager.shortcuts.newTab": "Nieuw tabblad",
   "agentManager.shortcuts.closeTab": "Tabblad sluiten",
-  "agentManager.shortcuts.toggleTerminal": "Terminal in-/uitschakelen",
+  "agentManager.shortcuts.toggleTerminal": "Terminal focussen / verbergen",
   "agentManager.shortcuts.runScript": "Script uitvoeren",
   "agentManager.run.options": "Uitvoeropties",
   "agentManager.run.configure": "Uitvoerscript configureren",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -100,7 +100,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Neste fane",
   "agentManager.shortcuts.newTab": "Ny fane",
   "agentManager.shortcuts.closeTab": "Lukk fane",
-  "agentManager.shortcuts.toggleTerminal": "Veksle terminal",
+  "agentManager.shortcuts.toggleTerminal": "Fokuser / skjul terminalen",
   "agentManager.shortcuts.runScript": "Kjør skript",
   "agentManager.run.options": "Kjøringsalternativer",
   "agentManager.run.configure": "Konfigurer kjøreskript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Następna karta",
   "agentManager.shortcuts.newTab": "Nowa karta",
   "agentManager.shortcuts.closeTab": "Zamknij kartę",
-  "agentManager.shortcuts.toggleTerminal": "Przełącz terminal",
+  "agentManager.shortcuts.toggleTerminal": "Przenieś fokus do terminala / ukryj terminal",
   "agentManager.shortcuts.runScript": "Uruchom skrypt",
   "agentManager.run.options": "Opcje uruchamiania",
   "agentManager.run.configure": "Konfiguruj skrypt uruchamiania",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -102,7 +102,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Следующая вкладка",
   "agentManager.shortcuts.newTab": "Новая вкладка",
   "agentManager.shortcuts.closeTab": "Закрыть вкладку",
-  "agentManager.shortcuts.toggleTerminal": "Переключить терминал",
+  "agentManager.shortcuts.toggleTerminal": "Перевести фокус на терминал / скрыть терминал",
   "agentManager.shortcuts.runScript": "Запустить скрипт",
   "agentManager.run.options": "Параметры запуска",
   "agentManager.run.configure": "Настроить скрипт запуска",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -97,7 +97,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "แท็บถัดไป",
   "agentManager.shortcuts.newTab": "แท็บใหม่",
   "agentManager.shortcuts.closeTab": "ปิดแท็บ",
-  "agentManager.shortcuts.toggleTerminal": "สลับเทอร์มินัล",
+  "agentManager.shortcuts.toggleTerminal": "โฟกัสเทอร์มินัล / ซ่อนเทอร์มินัล",
   "agentManager.shortcuts.runScript": "เรียกใช้สคริปต์",
   "agentManager.run.options": "ตัวเลือกการเรียกใช้",
   "agentManager.run.configure": "กำหนดค่าสคริปต์การเรียกใช้",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -107,7 +107,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Sonraki sekme",
   "agentManager.shortcuts.newTab": "Yeni sekme",
   "agentManager.shortcuts.closeTab": "Sekmeyi kapat",
-  "agentManager.shortcuts.toggleTerminal": "Terminali aç/kapat",
+  "agentManager.shortcuts.toggleTerminal": "Terminale odaklan / terminali gizle",
   "agentManager.shortcuts.runScript": "Betiği çalıştır",
   "agentManager.run.options": "Çalıştırma seçenekleri",
   "agentManager.run.configure": "Çalıştırma betiğini yapılandır",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -108,7 +108,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "Наступна вкладка",
   "agentManager.shortcuts.newTab": "Нова вкладка",
   "agentManager.shortcuts.closeTab": "Закрити вкладку",
-  "agentManager.shortcuts.toggleTerminal": "Перемкнути термінал",
+  "agentManager.shortcuts.toggleTerminal": "Перейти до термінала / приховати термінал",
   "agentManager.shortcuts.runScript": "Запустити скрипт",
   "agentManager.run.options": "Параметри запуску",
   "agentManager.run.configure": "Налаштувати скрипт запуску",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -97,7 +97,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "下一个标签页",
   "agentManager.shortcuts.newTab": "新建标签页",
   "agentManager.shortcuts.closeTab": "关闭标签页",
-  "agentManager.shortcuts.toggleTerminal": "切换终端",
+  "agentManager.shortcuts.toggleTerminal": "聚焦终端 / 隐藏终端",
   "agentManager.shortcuts.runScript": "运行脚本",
   "agentManager.run.options": "运行选项",
   "agentManager.run.configure": "配置运行脚本",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -97,7 +97,7 @@ export const dict = {
   "agentManager.shortcuts.nextTab": "下一個分頁",
   "agentManager.shortcuts.newTab": "新建分頁",
   "agentManager.shortcuts.closeTab": "關閉分頁",
-  "agentManager.shortcuts.toggleTerminal": "切換終端機",
+  "agentManager.shortcuts.toggleTerminal": "聚焦終端機 / 隱藏終端機",
   "agentManager.shortcuts.runScript": "執行指令碼",
   "agentManager.run.options": "執行選項",
   "agentManager.run.configure": "設定執行指令碼",


### PR DESCRIPTION
The Agent Manager terminal shortcut now focuses the terminal before hiding it, but only the English label described that behavior. Other supported locales still displayed the old toggle-terminal wording.

Update the existing shortcut translation in every supported locale so the label consistently communicates focusing and hiding the terminal, and add a patch changeset for the localization fix.