### PR TITLE
fix(ci): make cancelled/abandoned CI block merge with a clear message

### DIFF
--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -101,13 +101,17 @@ jobs:
     needs:
       - changes
       - unit
-    if: ${{ !cancelled() }}
+    if: always()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Verify JetBrains jobs passed
         run: |
           echo "changes=${{ needs.changes.result }}"
           echo "jetbrains=${{ needs.unit.result }}"
+          case "${{ needs.changes.result }},${{ needs.unit.result }}" in
+            *cancelled* | *abandoned*)
+              echo "::error::JetBrains jobs were cancelled or abandoned (transient/infra, not a test failure). A green re-run is required before merge." ;;
+          esac
           test "${{ needs.changes.result }}" = "success"
           if [ "${{ needs.changes.outputs.jetbrains }}" = "true" ]; then
             test "${{ needs.unit.result }}" = "success"

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -101,7 +101,7 @@ jobs:
     needs:
       - changes
       - unit
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Verify JetBrains jobs passed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,11 +250,16 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - unit
-    if: ${{ !cancelled() }}
+    # kilocode_change - run even on cancel/abandon so the required check is red (blocks merge) instead of skipped/satisfied
+    if: always()
     steps:
       - name: Verify unit matrix passed
         run: |
           echo "unit=${{ needs.unit.result }}"
+          case "${{ needs.unit.result }}" in
+            cancelled | abandoned)
+              echo "::error::Unit jobs were cancelled or abandoned (transient/infra, not a test failure). A green re-run is required before merge." ;;
+          esac
           test "${{ needs.unit.result }}" = "success"
   # kilocode_change end
   # kilocode_change start
@@ -266,13 +271,18 @@ jobs:
       - unit
       - httpapi
       - jetbrains
-    if: ${{ !cancelled() }}
+    # kilocode_change - run even on cancel/abandon so the required check is red (blocks merge) instead of skipped/satisfied
+    if: always()
     steps:
       - name: Verify upstream test jobs passed # kilocode_change
         run: |
           echo "unit=${{ needs.unit.result }}"
           echo "httpapi=${{ needs.httpapi.result }}"
           echo "jetbrains=${{ needs.jetbrains.result }}"
+          case "${{ needs.unit.result }},${{ needs.httpapi.result }},${{ needs.jetbrains.result }},${{ needs.changes.result }}" in
+            *cancelled* | *abandoned*)
+              echo "::error::A test job was cancelled or abandoned (transient/infra, not a test failure). A green re-run is required before merge." ;;
+          esac
           test "${{ needs.unit.result }}" = "success"
           if [ "${{ needs.changes.outputs.general }}" = "true" ]; then
             test "${{ needs.httpapi.result }}" = "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - unit
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Verify unit matrix passed
         run: |
@@ -266,7 +266,7 @@ jobs:
       - unit
       - httpapi
       - jetbrains
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Verify upstream test jobs passed # kilocode_change
         run: |

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -84,13 +84,17 @@ jobs:
       - typecheck-js
       - jetbrains-changes
       - typecheck-jetbrains
-    if: ${{ !cancelled() }}
+    if: always()
     steps:
       - name: Verify typecheck jobs passed
         run: |
           echo "typecheck-js=${{ needs.typecheck-js.result }}"
           echo "jetbrains-changes=${{ needs.jetbrains-changes.result }}"
           echo "typecheck-jetbrains=${{ needs.typecheck-jetbrains.result }}"
+          case "${{ needs.typecheck-js.result }},${{ needs.jetbrains-changes.result }},${{ needs.typecheck-jetbrains.result }}" in
+            *cancelled* | *abandoned*)
+              echo "::error::Typecheck jobs were cancelled or abandoned (transient/infra, not a test failure). A green re-run is required before merge." ;;
+          esac
           test "${{ needs.typecheck-js.result }}" = "success"
           test "${{ needs.jetbrains-changes.result }}" = "success"
           if [ "${{ needs.jetbrains-changes.outputs.jetbrains }}" = "true" ]; then

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -84,7 +84,7 @@ jobs:
       - typecheck-js
       - jetbrains-changes
       - typecheck-jetbrains
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Verify typecheck jobs passed
         run: |


### PR DESCRIPTION
## What changed

The aggregate required gates in `test`, `test-jetbrains`, and `typecheck` (`unit (linux)`, `test (linux)`, `jetbrains / result`, `typecheck`) keep `if: always()` so they still run and conclude **`failure`** when a dependency was cancelled or abandoned. Each gate now prints an explicit `::error::` line explaining that the failure was a transient cancel/abandon (not a test failure) and that a green re-run is required before merge.

## Behavior

- Real test/typecheck failures: unchanged — gate runs and fails with the underlying `needs` result in the log.
- Cancelled or runner-abandoned dependencies: the gate stays **red** (`failure`), so the required check keeps blocking merge and forces a re-run. It no longer shows only the opaque `test "abandoned" = "success"` line — it says why.
- Intentional skips (e.g. JetBrains/HttpApi paths not changed): still accepted exactly as before.

## Why not `!cancelled()`

An earlier revision switched these gates to `if: ${{ !cancelled() }}`. Review correctly flagged that this makes a cancelled final run conclude **`skipped`**, and GitHub branch protection treats a skipped required check as **satisfied** — so a PR could become mergeable without tests ever passing. It also relied on the unverified assumption that a runner `abandoned` state sets `cancelled()`. Keeping `always()` + explicit messaging preserves the merge-blocking "must re-run" guard while removing the confusion.

## Origin

Run https://github.com/Kilo-Org/kilocode/actions/runs/31117751038 failed in `jetbrains / result` because `needs.changes.result` was `abandoned` (transient/infra), producing a cryptic red. This keeps it red (correct — it must be re-run) but makes the reason obvious.

## Verification

- `bun run script/check-workflows.ts`
- `bun run script/check-opencode-annotations.ts --worktree`
- `git diff --check` on the three workflows
- `bash -n` on the `case` guards and Ruby YAML parse of all three files
- Pre-push hook ran JS + JetBrains typechecks successfully
