### PR TITLE
fix(agent-manager): align multi-project header actions

### DIFF
--- a/.changeset/align-agent-manager-project-actions.md
+++ b/.changeset/align-agent-manager-project-actions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Align multi-project Agent Manager header actions with the worktree controls.

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
@@ -36,7 +36,6 @@ export const ProjectsSection: Component<ProjectsSectionProps> = (props) => (
       label={<span class="am-section-label">{props.t("agentManager.projects")}</span>}
       actions={
         <div class="am-projects-tools">
-          {props.tools}
           <IconButton
             icon="plus"
             size="small"
@@ -44,6 +43,7 @@ export const ProjectsSection: Component<ProjectsSectionProps> = (props) => (
             label={props.t("agentManager.project.add")}
             onClick={props.onAdd}
           />
+          {props.tools}
         </div>
       }
     />

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -287,6 +287,9 @@ html[data-theme="kilo-vscode"]
    land on the same glyph line as the rows inside the list. */
 .am-projects > .am-section-header {
   padding-left: 2px;
+  /* The project toolbar has one more action than the worktree toolbar. Extend
+     its row so both toolbars start on the same leading action column. */
+  margin-right: -14px;
 }
 
 .am-section-label {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -281,15 +281,14 @@ html[data-theme="kilo-vscode"]
 
 .am-project-body .am-section-header {
   padding-left: 6px;
+  padding-right: 6px;
 }
 
 /* This heading sits outside the projects list, so it needs its own inset to
    land on the same glyph line as the rows inside the list. */
 .am-projects > .am-section-header {
   padding-left: 2px;
-  /* The project toolbar has one more action than the worktree toolbar. Extend
-     its row so both toolbars start on the same leading action column. */
-  margin-right: -14px;
+  padding-right: 2px;
 }
 
 .am-section-label {
@@ -331,7 +330,11 @@ html[data-theme="kilo-vscode"]
 .am-project-actions {
   display: flex;
   align-items: center;
-  gap: 2px;
+  justify-content: space-between;
+  /* The project row needs 20px + 24px + 20px; the worktree row uses the
+     remaining space for its split-button and settings gap. */
+  width: 64px;
+  gap: 0;
 }
 
 .am-project {


### PR DESCRIPTION
Multi-project Agent Manager currently places the add-project control after search and keyboard shortcuts, and its action row starts farther left than the worktree controls. This makes equivalent sidebar actions inconsistent between the project and worktree levels.

Move the add-project control to the leading position and extend the project header action row so its first action aligns with the worktree plus button. The resulting project toolbar uses the same leading action column while retaining the existing sidebar gutter.

<img width="700" alt="Multi-project Agent Manager sidebar with aligned project and worktree actions" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260807-agent-manager-project-actions.png?raw=true" />