### PR TITLE
perf(agent-manager): speed up worktree session startup

### DIFF
--- a/.changeset/faster-agent-manager-worktrees.md
+++ b/.changeset/faster-agent-manager-worktrees.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Start Agent Manager worktree sessions faster by prefetching base branches, reducing workspace file-watcher load, and overlapping independent multi-session setup.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -59,6 +59,12 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "files.watcherExclude": {
+        "**/.kilo/worktrees/**": true,
+        "**/.kilocode/worktrees/**": true
+      }
+    },
     "taskDefinitions": [
       {
         "type": "kilo-worktree-setup",

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -121,6 +121,8 @@ export class WorktreeManager {
   // Key: `${root}:${remote}:${branch}`, Value: timestamp when fetch was done
   private static fetchCache = new Map<string, number>()
   private static readonly FETCH_CACHE_TTL = 60_000 // 1 minute
+  private static gitAvailable = false
+  private static lfsAvailable: boolean | undefined
 
   private withGitLock<T>(fn: () => Promise<T>): Promise<T> {
     const key = this.root
@@ -183,9 +185,12 @@ export class WorktreeManager {
   }
 
   private async ensureGitAvailable(): Promise<void> {
+    if (WorktreeManager.gitAvailable) return
     try {
       await execWithShellEnv("git", ["--version"])
+      WorktreeManager.gitAvailable = true
     } catch (error) {
+      WorktreeManager.gitAvailable = false
       if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
         throw new Error(
           "Git is not installed or not found in PATH. Please install Git (https://git-scm.com) and restart VS Code.",
@@ -912,10 +917,13 @@ export class WorktreeManager {
   }
 
   async checkLfsAvailable(): Promise<boolean> {
+    if (WorktreeManager.lfsAvailable) return true
     try {
       await execWithShellEnv("git", ["lfs", "version"], { cwd: this.root, timeout: 5000 })
+      WorktreeManager.lfsAvailable = true
       return true
     } catch {
+      WorktreeManager.lfsAvailable = false
       // git-lfs not installed
       return false
     }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -150,6 +150,13 @@ export class WorktreeManager {
     return this.withGitLock(() => this.createWorktreeImpl(params))
   }
 
+  /** Start the remote base refresh before creation reaches the git mutex. */
+  async prefetchBase(branch?: string): Promise<void> {
+    await this.ensureMigrated()
+    const base = branch || (await this.defaultBranch())
+    await this.withGitLock(() => this.refreshBase(base))
+  }
+
   async renameBranch(worktreePath: string, current: string, requested: string): Promise<string> {
     await this.ensureMigrated()
     return this.withGitLock(() => this.renameBranchImpl(worktreePath, current, requested))
@@ -762,20 +769,14 @@ export class WorktreeManager {
             source: "remote",
           }
         }
+        WorktreeManager.fetchCache.delete(cacheKey)
       }
 
       // Either not cached or cache is stale - do the fetch.
       // Use non-interactive env to prevent SSH passphrase popups.
       onProgress?.("fetching", `Fetching ${remote}/${branch}...`)
       try {
-        // Only opt into simple-git's allowUnsafeSshCommand when the SSH command
-        // is the fixed value Kilo injects — never for an inherited one, which
-        // could be attacker-controlled.
-        const env = nonInteractiveEnv()
-        await simpleGit(this.root, { unsafe: { allowUnsafeSshCommand: isKiloOwnedSshCommand(env) } })
-          .env(env)
-          .fetch(remote, branch, { "--quiet": null, "--no-tags": null })
-        WorktreeManager.fetchCache.set(cacheKey, Date.now())
+        await this.refreshBase(branch, remote)
         if (await this.refExistsLocally(`${remote}/${branch}`)) {
           return {
             ref: `${remote}/${branch}`,
@@ -828,6 +829,23 @@ export class WorktreeManager {
     }
 
     throw new Error(`Could not resolve start point for branch "${branch}"`)
+  }
+
+  private async refreshBase(branch: string, requested?: string): Promise<void> {
+    const remote = requested ?? (await this.resolveRemote())
+    if (!remote) return
+    const key = `${this.root}:${remote}:${branch}`
+    const cached = WorktreeManager.fetchCache.get(key)
+    if (cached && Date.now() - cached < WorktreeManager.FETCH_CACHE_TTL) return
+
+    // Only opt into simple-git's allowUnsafeSshCommand when the SSH command
+    // is the fixed value Kilo injects — never for an inherited one, which
+    // could be attacker-controlled.
+    const env = nonInteractiveEnv()
+    await simpleGit(this.root, { unsafe: { allowUnsafeSshCommand: isKiloOwnedSshCommand(env) } })
+      .env(env)
+      .fetch(remote, branch, { "--quiet": null, "--no-tags": null })
+    WorktreeManager.fetchCache.set(key, Date.now())
   }
 
   /**

--- a/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
@@ -6,6 +6,9 @@ import { versionedName } from "./branch-name"
 import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
 import { ensureSandbox } from "./sandbox-bootstrap"
 import type { LifecycleHost } from "./provider-lifecycle"
+import { Semaphore } from "./semaphore"
+
+const PROVISION_CONCURRENCY = 2
 
 /**
  * Multi-version creation needs the lifecycle capabilities plus three provider
@@ -19,8 +22,8 @@ export interface MultiVersionHost extends LifecycleHost {
 }
 
 /**
- * Create N worktrees with one session each (optionally one model per version),
- * then fan the initial prompt out to every created session. State is reached
+ * Create N worktrees, provision their sessions with bounded concurrency, then
+ * send each initial prompt as soon as that session is ready. State is reached
  * through the project context; everything else goes through the host.
  */
 export async function createMultiVersion(
@@ -57,26 +60,49 @@ export async function createMultiVersion(
     groupId,
   })
 
-  // Phase 1: Create all worktrees + sessions first
+  // Phase 1: finish every shared-repository Git mutation before setup scripts
+  // or agents can run their own Git commands in the new worktrees.
   const created: CreatedVersion[] = []
 
-  for (let i = 0; i < versions; i++) {
-    const version = await createVersion(ctx, host, {
-      index: i,
-      versions,
-      groupId,
-      baseBranch,
-      branchName,
-      worktreeName,
-      models,
-      providerID,
-      modelID,
-      sandbox: msg.sandbox,
-    })
-    if (!version) continue
-    created.push(version)
+  const specs = Array.from({ length: versions }, (_, index) => ({
+    index,
+    versions,
+    groupId,
+    baseBranch,
+    branchName,
+    worktreeName,
+    models,
+    providerID,
+    modelID,
+    sandbox: msg.sandbox,
+  }))
+  const prepared: PreparedVersion[] = []
+  for (const spec of specs) {
+    const version = await prepareVersion(host, spec)
+    if (version) prepared.push(version)
+  }
 
-    // Update progress
+  // Phase 2: Git creation is complete, so independent setup/session pipelines
+  // can overlap without racing the shared worktree metadata mutation.
+  const provision = async (version: PreparedVersion) => {
+    const ready = await provisionVersion(ctx, host, version)
+    if (!ready) return
+    created.push(ready)
+
+    sendInitialPrompt(
+      host,
+      ctx.id,
+      ready,
+      models,
+      { providerID, modelID },
+      {
+        text,
+        agent,
+        variant: msg.variant,
+        files,
+      },
+    )
+
     host.post({
       type: "agentManager.multiVersionProgress",
       projectId: ctx.id,
@@ -87,15 +113,8 @@ export async function createMultiVersion(
     })
   }
 
-  // Phase 2: Send the initial prompt to all sessions, or clear busy state if no text.
-  await sendInitialPrompts(
-    host,
-    ctx.id,
-    created,
-    models,
-    { providerID, modelID },
-    { text, agent, variant: msg.variant, files },
-  )
+  const gate = new Semaphore(PROVISION_CONCURRENCY)
+  await Promise.all(prepared.map((version) => gate.run(() => provision(version))))
 
   // Notify completion
   host.post({
@@ -128,12 +147,13 @@ interface VersionSpec {
   sandbox: boolean | undefined
 }
 
-/** Create one version's worktree + session and wire it into state and the webview. */
-async function createVersion(
-  ctx: ProjectContext,
-  host: MultiVersionHost,
-  spec: VersionSpec,
-): Promise<CreatedVersion | null> {
+interface PreparedVersion {
+  spec: VersionSpec
+  wt: NonNullable<Awaited<ReturnType<MultiVersionHost["createOnDisk"]>>>
+}
+
+/** Create one version's worktree while the shared-repository Git barrier is active. */
+async function prepareVersion(host: MultiVersionHost, spec: VersionSpec): Promise<PreparedVersion | null> {
   host.log(`Creating worktree ${spec.index + 1}/${spec.versions}`)
 
   const version = versionedName(spec.branchName || spec.worktreeName, spec.index, spec.versions)
@@ -148,6 +168,16 @@ async function createVersion(
     host.log(`Failed to create worktree for version ${spec.index + 1}`)
     return null
   }
+  return { spec, wt }
+}
+
+/** Set up one prepared worktree, create its session, and expose it to the UI. */
+async function provisionVersion(
+  ctx: ProjectContext,
+  host: MultiVersionHost,
+  prepared: PreparedVersion,
+): Promise<CreatedVersion | null> {
+  const { spec, wt } = prepared
 
   await host.runSetup(wt.result.path, wt.result.branch, wt.worktree.id)
 
@@ -240,11 +270,11 @@ async function reconcileSandbox(
   }
 }
 
-/** Fan the initial prompt out to every created session, throttled between sends. */
-async function sendInitialPrompts(
+/** Send one version's initial prompt as soon as its session is ready. */
+function sendInitialPrompt(
   host: MultiVersionHost,
   projectId: string,
-  created: CreatedVersion[],
+  created: CreatedVersion,
   models: VersionSpec["models"],
   resolved: { providerID: string | undefined; modelID: string | undefined },
   input: {
@@ -253,22 +283,16 @@ async function sendInitialPrompts(
     variant: string | undefined
     files: Extract<AgentManagerInMessage, { type: "agentManager.createMultiVersion" }>["files"]
   },
-): Promise<void> {
-  const messages = buildInitialMessages(created, models, resolved, input.text, input.agent, input.variant, input.files)
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i]!
-    if (input.text) {
-      host.log(`Sending initial message to version ${i + 1} (session=${msg.sessionId})`)
-      host.promptName({
-        sessionID: msg.sessionId,
-        text: input.text,
-        providerID: msg.providerID,
-        modelID: msg.modelID,
-      })
-    }
-    host.post({ type: "agentManager.sendInitialMessage", projectId, ...msg })
-    if (input.text && i < messages.length - 1) {
-      await new Promise((resolve) => setTimeout(resolve, 300))
-    }
+): void {
+  const msg = buildInitialMessages([created], models, resolved, input.text, input.agent, input.variant, input.files)[0]!
+  if (input.text) {
+    host.log(`Sending initial message to version ${created.versionIndex + 1} (session=${msg.sessionId})`)
+    host.promptName({
+      sessionID: msg.sessionId,
+      text: input.text,
+      providerID: msg.providerID,
+      modelID: msg.modelID,
+    })
   }
+  host.post({ type: "agentManager.sendInitialMessage", projectId, ...msg })
 }

--- a/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
@@ -34,9 +34,7 @@ export class WorktreeImporter {
       const configured = state?.getDefaultBaseBranch()
       const base =
         configured && result.branches.some((branch) => branch.name === configured) ? configured : result.defaultBranch
-      void manager
-        .prefetchBase(base)
-        .catch((err) => this.host.log("Failed to prefetch base branch:", err))
+      void manager.prefetchBase(base).catch((err) => this.host.log("Failed to prefetch base branch:", err))
       const checked = await manager.checkedOutBranches()
       const branches = result.branches.map((branch) => ({
         ...branch,

--- a/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
@@ -30,6 +30,9 @@ export class WorktreeImporter {
 
     try {
       const result = await manager.listBranches()
+      void manager
+        .prefetchBase(result.defaultBranch)
+        .catch((err) => this.host.log("Failed to prefetch base branch:", err))
       const checked = await manager.checkedOutBranches()
       const branches = result.branches.map((branch) => ({
         ...branch,

--- a/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
@@ -30,8 +30,11 @@ export class WorktreeImporter {
 
     try {
       const result = await manager.listBranches()
+      const state = this.host.state()
+      const configured = state?.getDefaultBaseBranch()
+      const base = configured && result.branches.some((branch) => branch.name === configured) ? configured : result.defaultBranch
       void manager
-        .prefetchBase(result.defaultBranch)
+        .prefetchBase(base)
         .catch((err) => this.host.log("Failed to prefetch base branch:", err))
       const checked = await manager.checkedOutBranches()
       const branches = result.branches.map((branch) => ({
@@ -39,8 +42,6 @@ export class WorktreeImporter {
         isCheckedOut: checked.has(branch.name),
       }))
 
-      const state = this.host.state()
-      const configured = state?.getDefaultBaseBranch()
       if (state && configured && !branches.some((branch) => branch.name === configured)) {
         this.host.log(`Default base branch "${configured}" no longer exists, clearing`)
         state.setDefaultBaseBranch(undefined)

--- a/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-importer.ts
@@ -32,7 +32,8 @@ export class WorktreeImporter {
       const result = await manager.listBranches()
       const state = this.host.state()
       const configured = state?.getDefaultBaseBranch()
-      const base = configured && result.branches.some((branch) => branch.name === configured) ? configured : result.defaultBranch
+      const base =
+        configured && result.branches.some((branch) => branch.name === configured) ? configured : result.defaultBranch
       void manager
         .prefetchBase(base)
         .catch((err) => this.host.log("Failed to prefetch base branch:", err))

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -461,7 +461,7 @@ describe("Agent Manager Provider — onMessage routing", () => {
     const lifecycle = source.getProject().addSourceFileAtPath(path.join(ROOT, "src/agent-manager", module))
     const fn = lifecycle.getFunction(delegated[1]!)
     expect(fn, `delegated function ${delegated[1]} not found in ${module}`).toBeTruthy()
-    // The multi-version flow spans phase helpers (createVersion, sendInitialPrompts),
+    // The multi-version flow spans prepare, provision, and initial-prompt helpers,
     // so ordering assertions need the whole module, not just the orchestrator.
     if (delegated[1] === "createMultiVersion") return lifecycle.getText()
     return fn!.getText()

--- a/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, mock } from "bun:test"
+import type { Session } from "@kilocode/sdk/v2/client"
+import { createMultiVersion, type MultiVersionHost } from "../../src/agent-manager/provider-multi-version"
+import type { ProjectContext } from "../../src/agent-manager/project/context"
+import type { CreateWorktreeOnDiskResult } from "../../src/agent-manager/worktree-create"
+
+describe("multi-version provisioning", () => {
+  it("finishes git creation before provisioning at bounded concurrency", async () => {
+    const flow: string[] = []
+    const gates = [Promise.withResolvers<void>(), Promise.withResolvers<void>()]
+    const entered = [Promise.withResolvers<void>(), Promise.withResolvers<void>()]
+    const state = { addSession: mock(() => {}), armAutoName: mock(() => {}) }
+    const ctx = {
+      id: "project-1",
+      stateManager: () => state,
+      peekState: () => state,
+      worktreeManager: () => ({ removeWorktree: mock(async () => {}) }),
+    } as unknown as ProjectContext
+    const host = {
+      log: mock(() => {}),
+      post: mock((msg: { type: string; sessionId?: string }) => {
+        if (msg.type === "agentManager.sendInitialMessage") flow.push(`prompt:${msg.sessionId}`)
+      }),
+      createOnDisk: mock(async (opts: { branchName?: string }) => {
+        const index = opts.branchName?.endsWith("_v2") ? 1 : opts.branchName?.endsWith("_v3") ? 2 : 0
+        flow.push(`git:${index}`)
+        return {
+          worktree: { id: `wt-${index}` },
+          result: { path: `/repo/wt-${index}`, branch: `branch-${index}`, parentBranch: "main" },
+        } as CreateWorktreeOnDiskResult
+      }),
+      runSetup: mock(async (dir: string) => {
+        const index = Number(dir.at(-1)!)
+        flow.push(`setup:${index}`)
+        if (index < 2) {
+          entered[index]?.resolve()
+          await gates[index]?.promise
+        }
+      }),
+      createSession: mock(async (dir: string) => ({ id: `session-${dir.at(-1)!}` }) as Session),
+      autoName: () => ({ enabled: false }),
+      register: mock(() => {}),
+      notifyReady: mock(() => {}),
+      sessions: { register: mock(() => {}) },
+      promptName: mock(() => {}),
+      capture: mock(() => {}),
+      error: mock(() => {}),
+    } as unknown as MultiVersionHost
+
+    const pending = createMultiVersion(ctx, host, {
+      type: "agentManager.createMultiVersion",
+      text: "Fix it",
+      branchName: "fix-it",
+      versions: 3,
+    })
+    await Promise.all(entered.map((entry) => entry.promise))
+
+    expect(flow.slice(0, 5)).toEqual(["git:0", "git:1", "git:2", "setup:0", "setup:1"])
+    expect(flow).not.toContain("setup:2")
+
+    gates.forEach((gate) => gate.resolve())
+    await pending
+
+    expect(flow).toContain("setup:2")
+    expect(flow.filter((event) => event.startsWith("prompt:"))).toHaveLength(3)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
+++ b/packages/kilo-vscode/tests/unit/sandbox-bootstrap.test.ts
@@ -98,8 +98,8 @@ describe("Agent Manager sandbox startup", () => {
   )
 
   test("reconciles before exposing or prompting the session", () => {
-    // In createVersion the sandbox gate runs before the session is exposed.
-    const start = flow.indexOf("async function createVersion")
+    // In provisionVersion the sandbox gate runs before the session is exposed.
+    const start = flow.indexOf("async function provisionVersion")
     const version = flow.slice(start, flow.indexOf("\n/**", start + 1))
     const gate = version.indexOf("await reconcileSandbox")
     const register = version.indexOf("host.register", gate)
@@ -122,8 +122,8 @@ describe("Agent Manager sandbox startup", () => {
     expect(abort).toBeGreaterThan(discard)
 
     // The created sessions feed the initial prompt phase.
-    const prompts = flow.slice(flow.indexOf("async function sendInitialPrompts"))
-    expect(prompts).toContain("buildInitialMessages(created")
+    const prompts = flow.slice(flow.indexOf("function sendInitialPrompt"))
+    expect(prompts).toContain("buildInitialMessages([created]")
     expect(prompts).toContain('type: "agentManager.sendInitialMessage"')
   })
 


### PR DESCRIPTION
## Problem

Agent Manager worktree creation keeps repository preparation and session startup on the critical path. In a Kilo-sized checkout, Git materialization is amplified by the parent VS Code workspace recursively watching the newly created worktree. Multi-version creation also waits for every version's setup and session before dispatching any prompt.

## What changes

- Prefetch the selected default base branch while Agent Manager loads branches, using the existing 60-second fetch cache and the existing Git mutex.
- Exclude `.kilo/worktrees/**` and `.kilocode/worktrees/**` from the parent VS Code workspace file watcher by default.
- Keep all shared-repository Git worktree mutations serialized.
- Split multi-version creation into a serialized Git phase and a bounded post-Git provisioning phase (two concurrent setup/session pipelines).
- Dispatch each version's initial prompt as soon as its session is ready instead of waiting for every version and inserting a fixed 300 ms delay between prompts.

## Measured impact

The end-to-end measurement used the real Agent Manager UI in the Kilo repository, the same model, and the same prompt (`Reply with exactly READY.`). The timer started at the Create action and ended at the corresponding UI event.

| Metric | Before | After | Difference | Relative change |
|---|---:|---:|---:|---:|
| Create click to session startup | 7.96 s | 5.02 s | -2.95 s | 37% faster |
| Create click to first streamed text | 10.10 s | 7.02 s | -3.08 s | 30% faster |
| Session startup to first streamed text | 2.14 s | 2.01 s | -0.13 s | 6% faster |

The repository contained 9,139 tracked files and 129.9 MiB of tracked checkout data. Individual measurements showed:

| Operation | Measured difference |
|---|---:|
| `git fetch origin main` | 1.55-1.72 s |
| Worktree checkout in a temporary directory | 1.83-2.23 s |
| Worktree checkout under an open VS Code workspace | up to 5.3-7.6 s |
| Same nested checkout with VS Code closed | 3.42 s |
| Four serialized normal worktree creations | 12.13 s |
| Four serialized registrations plus parallel population experiment | 4.33 s |

The open-workspace slowdown correlated with FSEvents overflow and recursive-rescan messages. After the watcher exclusion, the same end-to-end flow had no watcher overflow messages.

## Why this is safe

Git worktree creation remains protected by the existing repository mutex. Concurrent `git worktree add -b` processes were tested and raced on shared `.git/config` updates, producing config-lock failures. This PR does not weaken that boundary.

The multi-version flow now has an explicit barrier: all `git worktree add` operations finish before any setup script, sandbox reconciliation, session creation, or model prompt can run. Only after shared Git metadata mutation is complete do independent worktree directories use bounded concurrency. This prevents setup scripts or agents that run Git commands from racing worktree registration.

The watcher exclusion applies to the parent workspace's recursive observation only. A worktree opened explicitly as its own VS Code workspace remains usable and can be watched normally. The base-branch prefetch uses the same mutex and verifies the cached remote ref before creation, so a failed or stale prefetch falls back to the existing fetch path.

The faster `--no-checkout` plus parallel population experiment was not adopted. Although it reduced four checkout populations from 12.13 s to 4.33 s, it changes checkout and hook semantics and complicates failure cleanup, LFS, custom hooks, and partially materialized worktrees. The implementation therefore optimizes the safe portions of the current lifecycle without changing normal Git checkout semantics.
