### PR TITLE
fix(ui): copy Mermaid PNG/SVG as clipboard images in webviews

### DIFF
--- a/packages/ui/src/kilocode/markdown-mermaid-actions.tsx
+++ b/packages/ui/src/kilocode/markdown-mermaid-actions.tsx
@@ -49,9 +49,18 @@ function Item(props: { label: string; onSelect: () => void }) {
 export function MermaidActions(props: Props) {
   const [copied, setCopied] = createSignal(false)
   const copy = (run: () => Promise<void>) => {
-    void run().then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
+    void run()
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1500)
+      })
+      .catch((err) => {
+        console.warn("Mermaid copy failed", err)
+      })
+  }
+  const download = (run: () => Promise<void>) => {
+    void run().catch((err) => {
+      console.warn("Mermaid download failed", err)
     })
   }
 
@@ -72,7 +81,7 @@ export function MermaidActions(props: Props) {
         <DropdownMenu.Portal>
           <DropdownMenu.Content>
             <Item label={props.labels.downloadSvg} onSelect={props.onDownloadSvg} />
-            <Item label={props.labels.downloadPng} onSelect={() => void props.onDownloadPng()} />
+            <Item label={props.labels.downloadPng} onSelect={() => download(props.onDownloadPng)} />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu>

--- a/packages/ui/src/kilocode/markdown-mermaid.ts
+++ b/packages/ui/src/kilocode/markdown-mermaid.ts
@@ -303,9 +303,38 @@ async function copyText(text: string) {
   await navigator.clipboard.writeText(text)
 }
 
+// VS Code webview CSP blocks fetch(data:...); decode the data URL locally instead.
+function dataUrlToBlob(dataUrl: string): Blob {
+  const comma = dataUrl.indexOf(",")
+  if (comma < 0) throw new Error("Unable to export Mermaid diagram.")
+  const header = dataUrl.slice(0, comma)
+  const data = dataUrl.slice(comma + 1)
+  const mime = /^data:([^;,]*)/.exec(header)?.[1] || "application/octet-stream"
+  const binary = atob(data)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new Blob([bytes], { type: mime })
+}
+
+function supportsSvgClipboardImage() {
+  return typeof ClipboardItem !== "undefined" && "supports" in ClipboardItem && ClipboardItem.supports("image/svg+xml")
+}
+
+async function copySvg(svg: SVGSVGElement) {
+  const markup = serialize(svg)
+  // Prefer image/svg+xml so paste targets receive a diagram, not SVG source text.
+  // Fall back to text on hosts that do not support SVG clipboard images yet.
+  if (supportsSvgClipboardImage()) {
+    const blob = new Blob([markup], { type: "image/svg+xml" })
+    await navigator.clipboard.write([new ClipboardItem({ "image/svg+xml": blob })])
+    return
+  }
+  await navigator.clipboard.writeText(markup)
+}
+
 async function copyPng(svg: SVGSVGElement) {
   const url = await png(svg)
-  const blob = await (await fetch(url)).blob()
+  const blob = dataUrlToBlob(url)
   if (typeof ClipboardItem === "undefined") {
     await navigator.clipboard.writeText(serialize(svg))
     return
@@ -329,7 +358,7 @@ function renderActions(el: HTMLDivElement, pre: HTMLPreElement, source: string, 
     mountMermaidActions(el, {
       labels,
       onCopySource: () => copyText(sourceText),
-      onCopySvg: () => copyText(sourceSvg()),
+      onCopySvg: () => copySvg(svg),
       onCopyPng: () => copyPng(svg),
       onDownloadSvg: () => save(sourceSvgUrl(), "mermaid-diagram.svg"),
       onDownloadPng: async () => save(await png(svg), "mermaid-diagram.png"),


### PR DESCRIPTION
## Summary
- Fix **Copy PNG** in VS Code webviews: CSP blocks `fetch(data:...)`, which failed the copy and could crash the webview via an unhandled rejection. Decode the PNG data URL locally with `dataUrlToBlob` instead.
- Fix **Copy SVG** so it writes `image/svg+xml` to the clipboard when supported (Chromium clipboard SVG), instead of always copying SVG markup as plain text. Falls back to text on unsupported hosts.
- Catch copy/download promise rejections so failures do not surface as webview fatal errors.

## Test plan
- [ ] In the VS Code extension webview, render a Mermaid diagram
- [ ] **Copy PNG** → paste into an image-capable app (Notes/Word/Slack); expect a bitmap, no webview crash / "Failed to fetch"
- [ ] **Copy SVG** → on Chromium ≥124 / recent Electron, paste as an SVG image where the target supports it; on older hosts, text fallback is OK
- [ ] **Download SVG/PNG** still works via the existing `kilo:save-image` bridge
- [ ] Failed clipboard operations only log a warning (no unhandledrejection)