### PR TITLE
fix(vscode): toggle Agent Manager terminal from toolbar button

### DIFF
--- a/.changeset/fix-agent-manager-terminal-toggle.md
+++ b/.changeset/fix-agent-manager-terminal-toggle.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the Agent Manager terminal toolbar button to toggle panel visibility directly.

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-side.test.ts
@@ -83,6 +83,23 @@ describe("Agent Manager side terminal controller", () => {
     expect(hidden.calls.hide).toBe(0)
   })
 
+  it("toggles panel visibility from toolbar button without requiring focus", () => {
+    const visibleUnfocused = scene({ destination: "agentManager", visible: true })
+    visibleUnfocused.ctl.openPreferred("tab_toolbar")
+    expect(visibleUnfocused.calls.hide).toBe(1)
+    expect(visibleUnfocused.calls.requestSide).toBe(0)
+
+    const visibleFocused = scene({ destination: "agentManager", visible: true, focusedId: "terminal:side" })
+    visibleFocused.ctl.openPreferred("tab_toolbar")
+    expect(visibleFocused.calls.hide).toBe(1)
+    expect(visibleFocused.calls.requestSide).toBe(0)
+
+    const hidden = scene({ destination: "agentManager", visible: false })
+    hidden.ctl.openPreferred("tab_toolbar")
+    expect(hidden.calls.requestSide).toBe(1)
+    expect(hidden.calls.hide).toBe(0)
+  })
+
   it("ensures an open terminal panel has a terminal after switching contexts", async () => {
     const visible = scene({ visible: true })
     visible.ctl.syncContext("wt-2", "wt-1")

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2401,9 +2401,6 @@ const AgentManagerContent: Component = () => {
           onToggleReview={metrics.click("fullscreen_review", "tab_toolbar", toggleReviewTab)}
           terminalDestination={sideCtl.destination}
           terminalDestinationActive={() => sidePanel() === "terminal"}
-          terminalDestinationFocused={() =>
-            sideCtl.destination() === "agentManager" && terms.sideFocusedId() !== undefined
-          }
           terminalKeybind={() => kb().showTerminal ?? ""}
           onTerminalDestinationOpen={() => {
             cancelAmbientSetup()

--- a/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
@@ -57,7 +57,6 @@ export interface TabBarProps {
   onToggleReview: () => void
   terminalDestination: () => TerminalDestination
   terminalDestinationActive: () => boolean
-  terminalDestinationFocused: () => boolean
   terminalKeybind: () => string
   onTerminalDestinationOpen: () => void
   onTerminalDestinationChoose: (destination: TerminalDestination) => void
@@ -260,7 +259,6 @@ export const TabBar: Component<TabBarProps> = (props) => (
           <TerminalDestinationButton
             destination={props.terminalDestination}
             active={props.terminalDestinationActive}
-            focused={props.terminalDestinationFocused}
             keybind={props.terminalKeybind}
             onOpen={props.onTerminalDestinationOpen}
             onChoose={props.onTerminalDestinationChoose}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalDestinationButton.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalDestinationButton.tsx
@@ -20,8 +20,6 @@ interface Props {
   destination: Accessor<TerminalDestination>
   /** True while the embedded terminal panel is showing. */
   active: Accessor<boolean>
-  /** True while the embedded terminal owns DOM focus. */
-  focused: Accessor<boolean>
   keybind: Accessor<string>
   onOpen: () => void
   onChoose: (destination: TerminalDestination) => void
@@ -29,10 +27,6 @@ interface Props {
 
 export const TerminalDestinationButton: Component<Props> = (props) => {
   const { t } = useLanguage()
-  const title = () =>
-    props.destination() === "agentManager" && props.focused()
-      ? t("agentManager.shortcuts.toggleTerminal")
-      : t("agentManager.tab.openTerminal")
   const item = (destination: TerminalDestination, label: string) => (
     <DropdownMenu.Item onSelect={() => props.onChoose(destination)}>
       <span class="am-menu-check">
@@ -45,7 +39,7 @@ export const TerminalDestinationButton: Component<Props> = (props) => {
   )
   return (
     <div class="am-split-button">
-      <TooltipKeybind title={title()} keybind={props.keybind()} placement="bottom">
+      <TooltipKeybind title={t("agentManager.tab.terminal")} keybind={props.keybind()} placement="bottom">
         <IconButton
           icon="console"
           size="small"

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/side.ts
@@ -3,11 +3,9 @@
  *
  * Extracted from AgentManagerApp.tsx to keep that file under the
  * `max-lines` lint cap. Owns the destination preference plus the toggle
- * semantics of the toolbar button / `Cmd/Ctrl+/` shortcut, so the
- * embedded terminal behaves like the diff panel: press once to reveal,
- * press again while focused to hide, and press while visible but unfocused
- * to return focus to the shell. Hiding never kills the terminal — only the
- * explicit close action does.
+ * semantics: the toolbar button toggles visibility, while `Cmd/Ctrl+/`
+ * reveals, focuses when unfocused, and hides when focused.
+ * Hiding never kills the terminal — only the explicit close action does.
  *
  * ## Destination state ownership
  *
@@ -109,14 +107,15 @@ export function createSideTerminal(deps: SideTerminalDeps) {
     if (wasFocused) deps.refocus()
   }
 
-  const toggle = () => {
+  const toggle = (trigger: "keyboard_shortcut" | "tab_toolbar" = "keyboard_shortcut") => {
     if (deps.visible()) {
-      if (!deps.focusedId()) {
+      if (trigger === "keyboard_shortcut" && !deps.focusedId()) {
         deps.handlers.requestSide()
         return
       }
+      const was = deps.focusedId() !== undefined
       deps.hide()
-      handoff(true)
+      handoff(was)
       return
     }
     deps.handlers.requestSide()
@@ -149,7 +148,7 @@ export function createSideTerminal(deps: SideTerminalDeps) {
     const target = destination()
     deps.track("terminal", trigger, { destination: target })
     if (target === "agentManager") {
-      toggle()
+      toggle(trigger)
       return
     }
     deps.openVscode()


### PR DESCRIPTION
### Summary

Clicking the Agent Manager terminal toolbar button previously failed to hide an open terminal panel because the toggle handler required the terminal host to hold DOM focus before allowing a hide transition. Since clicking toolbar buttons moves DOM focus to the toolbar, the panel was never recognized as focused on click and instead continually requested focus.

### Changes

- Distinguish toolbar button invocations from keyboard shortcut invocations in `side.ts` so clicking the toolbar button directly toggles panel visibility without requiring prior terminal focus.
- Preserve two-step `Cmd/Ctrl+/` shortcut behavior to focus when visible and unfocused, and hide when focused.
- Remove redundant `focused` prop plumbing from `TerminalDestinationButton` and `TabBar`.
- Add unit tests verifying toolbar button visibility toggling.