### PR TITLE
feat(agent-manager): lifecycle-bound non-blocking worktree creation and live card status

### DIFF
--- a/.changeset/optimistic-worktree-creation.md
+++ b/.changeset/optimistic-worktree-creation.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Make Agent Manager worktree creation optimistic and non-blocking, allowing immediate multi-tasking while background provisioning runs with live sidebar progress indicators.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -159,6 +159,11 @@ export class WorktreeManager {
     await this.withGitLock(() => this.refreshBase(base))
   }
 
+  /** Compute the filesystem path for a worktree branch. */
+  worktreePath(branch: string): string {
+    return path.join(this.dir, branch.replace(/\//g, "-"))
+  }
+
   async renameBranch(worktreePath: string, current: string, requested: string): Promise<string> {
     await this.ensureMigrated()
     return this.withGitLock(() => this.renameBranchImpl(worktreePath, current, requested))
@@ -349,11 +354,7 @@ export class WorktreeManager {
     await this.removeWorktreeImpl(worktreePath)
   }
 
-  private async resolveBranch(params: {
-    prompt?: string
-    existingBranch?: string
-    branchName?: string
-  }): Promise<string> {
+  async resolveBranch(params: { prompt?: string; existingBranch?: string; branchName?: string }): Promise<string> {
     if (params.existingBranch) {
       const exists = await this.branchExists(params.existingBranch)
       if (!exists) throw new Error(`Branch "${params.existingBranch}" does not exist`)

--- a/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeStateManager.ts
@@ -56,6 +56,10 @@ export interface Worktree {
   autoNameSessionId?: string
   /** Number of prompts observed for the armed session; bounds rename attempts. */
   autoNamePromptCount?: number
+  /** Display state during creation lifecycle. */
+  status?: "creating" | "setting-up" | "ready" | "error"
+  /** Progress or error message during creation lifecycle. */
+  statusMessage?: string
   /** Section this worktree belongs to, or undefined for ungrouped. */
   sectionId?: string
 }
@@ -200,6 +204,9 @@ export class WorktreeStateManager {
     groupId?: string
     label?: string
     branchOwned?: boolean
+    sectionId?: string
+    status?: "creating" | "setting-up" | "ready" | "error"
+    statusMessage?: string
   }): Worktree {
     const id = generateId("wt")
     const wt: Worktree = {
@@ -213,6 +220,9 @@ export class WorktreeStateManager {
     if (params.groupId) wt.groupId = params.groupId
     if (params.label) wt.label = params.label
     if (params.branchOwned !== undefined) wt.branchOwned = params.branchOwned
+    if (params.sectionId) wt.sectionId = params.sectionId
+    if (params.status) wt.status = params.status
+    if (params.statusMessage) wt.statusMessage = params.statusMessage
     this.worktrees.set(id, wt)
     this.setNormalizedWorktreeOrder(this.worktreeOrder)
     this.log(
@@ -220,6 +230,23 @@ export class WorktreeStateManager {
     )
     void this.save()
     return wt
+  }
+
+  updateWorktreePath(id: string, path: string): boolean {
+    const wt = this.worktrees.get(id)
+    if (!wt || wt.path === path) return false
+    wt.path = path
+    void this.save()
+    return true
+  }
+
+  updateWorktreeStatus(id: string, status: "creating" | "setting-up" | "ready" | "error", message?: string): boolean {
+    const wt = this.worktrees.get(id)
+    if (!wt) return false
+    wt.status = status
+    wt.statusMessage = message
+    void this.save()
+    return true
   }
 
   restoreWorktree(params: {
@@ -770,6 +797,10 @@ export class WorktreeStateManager {
       if (!fs.existsSync(resolved)) {
         this.log(`Worktree ${wt.id} directory missing (${resolved}), removing`)
         this.removeWorktree(wt.id)
+        changed = true
+      } else if (wt.status === "creating" || wt.status === "setting-up") {
+        wt.status = "ready"
+        wt.statusMessage = undefined
         changed = true
       }
     }

--- a/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
+++ b/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
@@ -121,7 +121,10 @@ export function registerSession(
   sourceId: string,
 ): void {
   const state = ctx.getStateManager()
-  if (state) state.addSession(session.id, worktreeId)
+  if (state) {
+    state.addSession(session.id, worktreeId)
+    state.updateWorktreeStatus?.(worktreeId, "ready")
+  }
   ctx.registerWorktreeSession(session.id, result.path)
   // Push state before registerSession so the webview knows this is a worktree
   // session before receiving the sessionCreated message. Without this ordering,

--- a/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
@@ -69,7 +69,16 @@ export async function createLifecycleWorktree(
     return null
   }
 
-  const state = ctx.peekState()!
+  const state = ctx.peekState()
+  if (!state?.getWorktree(created.worktree.id)) {
+    ctx
+      .worktreeManager()
+      .removeWorktree(created.result.path)
+      .catch(() => {})
+    return null
+  }
+
+  state.updateWorktreeStatus?.(created.worktree.id, "ready")
   state.addSession(session.id, created.worktree.id)
   if (!opts.branchName && host.autoName().enabled) state.armAutoName(created.worktree.id, session.id)
   host.register(session.id, created.result.path)

--- a/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
@@ -200,6 +200,7 @@ async function provisionVersion(
   if (spec.sandbox !== undefined && !(await reconcileSandbox(host, spec, wt, session.id))) return null
 
   host.register(session.id, wt.result.path)
+  state.updateWorktreeStatus?.(wt.worktree.id, "ready")
   host.notifyReady(session.id, wt.result, wt.worktree.id)
   host.sessions.register(session)
 

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -205,6 +205,7 @@ async function worktree(
     return false
   }
   state.addSession(session.id, created.worktree.id)
+  state.updateWorktreeStatus?.(created.worktree.id, "ready")
   deps.registerWorktreeSession(session.id, created.result.path)
   deps.notifyReady(session.id, created.result, created.worktree.id)
   deps.getPanel()?.sessions.registerSession(session)

--- a/packages/kilo-vscode/src/agent-manager/worktree-create.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-create.ts
@@ -50,12 +50,14 @@ export async function createWorktreeOnDisk(
     return null
   }
 
-  ctx.postToWebview({ type: "agentManager.worktreeSetup", status: "creating", message: "Creating git worktree..." })
-
-  // Resolve effective base branch using configured default
   const effectiveBase = opts?.existingBranch
     ? undefined
     : await resolveBaseBranch(ctx, manager, state, opts?.baseBranch)
+
+  const branch = await resolveTargetBranch(ctx, manager, opts)
+  if (!branch) return null
+
+  const worktree = registerPendingWorktree(ctx, state, manager, branch, effectiveBase, opts)
 
   let result: CreateWorktreeResult
   try {
@@ -63,8 +65,84 @@ export async function createWorktreeOnDisk(
       prompt: opts?.name || "kilo",
       baseBranch: effectiveBase ?? opts?.baseBranch,
       baseRef: opts?.baseRef,
-      branchName: opts?.branchName,
+      branchName: branch,
       existingBranch: opts?.existingBranch,
+    })
+  } catch (error) {
+    handleDiskError(ctx, state, worktree.id, branch, error)
+    return null
+  }
+
+  if (!state.getWorktree(worktree.id)) {
+    ctx.log(`Worktree ${worktree.id} was deleted during creation, cleaning up on disk: ${result.path}`)
+    await manager.removeWorktree(result.path, result.branch).catch(() => {})
+    return null
+  }
+
+  finalizeDiskWorktree(ctx, state, worktree.id, result)
+  return { worktree, result }
+}
+
+function registerPendingWorktree(
+  ctx: CreateWorktreeOnDiskContext,
+  state: WorktreeStateManager,
+  manager: WorktreeManager,
+  branch: string,
+  effectiveBase?: string,
+  opts?: CreateWorktreeOnDiskOptions,
+): Worktree {
+  const worktree = state.addWorktree({
+    branch,
+    path: manager.worktreePath(branch),
+    parentBranch: effectiveBase ?? opts?.baseBranch ?? "main",
+    groupId: opts?.groupId,
+    label: opts?.label,
+    branchOwned: !opts?.existingBranch,
+    status: "creating",
+    statusMessage: "Creating git worktree...",
+  })
+
+  ctx.pushState()
+  ctx.postToWebview({
+    type: "agentManager.worktreeSetup",
+    status: "creating",
+    message: "Creating git worktree...",
+    branch,
+    worktreeId: worktree.id,
+  })
+  return worktree
+}
+
+function finalizeDiskWorktree(
+  ctx: CreateWorktreeOnDiskContext,
+  state: WorktreeStateManager,
+  worktreeId: string,
+  result: CreateWorktreeResult,
+): void {
+  const wt = state.getWorktree(worktreeId)
+  if (wt && wt.branch !== result.branch) state.updateWorktreeBranch(worktreeId, result.branch)
+  state.updateWorktreePath(worktreeId, result.path)
+  state.updateWorktreeStatus(worktreeId, "setting-up", "Setting up worktree...")
+  ctx.pushState()
+  ctx.postToWebview({
+    type: "agentManager.worktreeSetup",
+    status: "creating",
+    message: "Setting up worktree...",
+    branch: result.branch,
+    worktreeId,
+  })
+}
+
+async function resolveTargetBranch(
+  ctx: CreateWorktreeOnDiskContext,
+  manager: WorktreeManager,
+  opts?: CreateWorktreeOnDiskOptions,
+): Promise<string | null> {
+  try {
+    return await manager.resolveBranch({
+      prompt: opts?.name || "kilo",
+      existingBranch: opts?.existingBranch,
+      branchName: opts?.branchName,
     })
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
@@ -74,35 +152,33 @@ export async function createWorktreeOnDisk(
       message: msg,
       errorCode: classifyWorktreeError(msg),
     })
-    ctx.capture("Agent Manager Session Error", {
-      source: PLATFORM,
-      error: msg,
-      context: "createWorktree",
-    })
     return null
   }
+}
 
-  const worktree = state.addWorktree({
-    branch: result.branch,
-    path: result.path,
-    parentBranch: result.parentBranch,
-    remote: result.remote,
-    groupId: opts?.groupId,
-    label: opts?.label,
-    branchOwned: !opts?.existingBranch,
-  })
-
-  // Push state immediately so the sidebar shows the new worktree with a loading indicator
+function handleDiskError(
+  ctx: CreateWorktreeOnDiskContext,
+  state: WorktreeStateManager,
+  worktreeId: string,
+  branch: string,
+  error: unknown,
+): void {
+  state.removeWorktree(worktreeId)
   ctx.pushState()
+  const msg = error instanceof Error ? error.message : String(error)
   ctx.postToWebview({
     type: "agentManager.worktreeSetup",
-    status: "creating",
-    message: "Setting up worktree...",
-    branch: result.branch,
-    worktreeId: worktree.id,
+    status: "error",
+    message: msg,
+    errorCode: classifyWorktreeError(msg),
+    worktreeId,
+    branch,
   })
-
-  return { worktree, result }
+  ctx.capture("Agent Manager Session Error", {
+    source: PLATFORM,
+    error: msg,
+    context: "createWorktree",
+  })
 }
 
 /** Resolve the effective base branch using the configured default, explicit override, and existence check. */

--- a/packages/kilo-vscode/tests/unit/agent-manager-remote-sessions.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-remote-sessions.test.ts
@@ -22,7 +22,7 @@ test("does not report synthetic pending or cloud preview IDs", () => {
 test("blocks visible presence while setup or an empty pane covers chat", () => {
   const source = flat(fs.readFileSync(APP, "utf-8"))
   expect(source).toContain(
-    "visible( session.currentSessionID(), !!terms.activeId() || reviewActive() || history() || !!overlay() || contextEmpty(), )",
+    "visible(session.currentSessionID(), !!terms.activeId() || reviewActive() || history() || contextEmpty())",
   )
-  expect(source).toContain("<Show when={overlay()}>")
+  expect(source).toContain("<Show when={contextEmpty()}>")
 })

--- a/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
@@ -9,7 +9,11 @@ describe("multi-version provisioning", () => {
     const flow: string[] = []
     const gates = [Promise.withResolvers<void>(), Promise.withResolvers<void>()]
     const entered = [Promise.withResolvers<void>(), Promise.withResolvers<void>()]
-    const state = { addSession: mock(() => {}), armAutoName: mock(() => {}) }
+    const state = {
+      addSession: mock(() => {}),
+      armAutoName: mock(() => {}),
+      updateWorktreeStatus: mock(() => true),
+    }
     const ctx = {
       id: "project-1",
       stateManager: () => state,

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -184,15 +184,6 @@ import "./agent-manager-review.css"
 import { cycleAgent as cycle } from "../src/context/session-agent"
 const REVIEW_TAB_ID = "review"
 
-interface SetupState {
-  active: boolean
-  message: string
-  branch?: string
-  error?: boolean
-  worktreeId?: string
-  errorCode?: string
-}
-
 /** Sidebar selection: LOCAL for local repo, worktree ID for a worktree, or null for an unassigned session. */
 type SidebarSelection = typeof LOCAL | string | null
 type SidePanel = "diff" | "pr" | "terminal" | null
@@ -212,7 +203,19 @@ const AgentManagerContent: Component = () => {
 
   const [kb, setKb] = createSignal<Record<string, string>>(defaultBindings)
 
-  const [setup, setSetup] = createSignal<SetupState>({ active: false, message: "" })
+  const [projectList, setProjectList] = createSignal<AgentProjectSnapshot[]>([])
+  const [multiProject, setMultiProject] = createSignal(false)
+  const [currentProjectId, setCurrentProjectId] = createSignal<string | undefined>()
+  const [projectStates, setProjectStates] = createSignal<Record<string, AgentManagerStateMessage>>({})
+  const activeProjectId = () => projectList().find((p) => p.active)?.id ?? currentProjectId()
+
+  // Recover persisted local session IDs from webview state
+  const persisted = vscode.getState<PersistedProjectTabs & { sidebarWidth?: number; sidePanelWidth?: number }>()
+  const registry = createProjectRegistry({
+    persisted: persisted ?? {},
+    activeId: () => currentProjectId() ?? "single",
+  })
+
   const worktrees = () => registry.active().worktrees()
   const setWorktrees = (v: Parameters<Setter<WorktreeState[]>>[0]) => registry.active().setWorktrees(v)
   const managedSessions = () => registry.active().managedSessions()
@@ -234,11 +237,6 @@ const AgentManagerContent: Component = () => {
   const defaultBaseBranch = () => registry.active().defaultBaseBranch()
   const setDefaultBaseBranch = (v: Parameters<Setter<string | undefined>>[0]) =>
     registry.active().setDefaultBaseBranch(v)
-  const [projectList, setProjectList] = createSignal<AgentProjectSnapshot[]>([])
-  const [multiProject, setMultiProject] = createSignal(false)
-  const [currentProjectId, setCurrentProjectId] = createSignal<string | undefined>()
-  const [projectStates, setProjectStates] = createSignal<Record<string, AgentManagerStateMessage>>({})
-  const activeProjectId = () => projectList().find((p) => p.active)?.id ?? currentProjectId()
   const creation = usePendingCreate(activeProjectId, (projectId, worktreeId) =>
     vscode.postMessage({
       type: "agentManager.activateSelection",
@@ -253,13 +251,6 @@ const AgentManagerContent: Component = () => {
   const DEFAULT_SIDEBAR_WIDTH = 260
   const MIN_SIDEBAR_WIDTH = 200
   const MAX_SIDEBAR_WIDTH_RATIO = 0.4
-
-  // Recover persisted local session IDs from webview state
-  const persisted = vscode.getState<PersistedProjectTabs & { sidebarWidth?: number; sidePanelWidth?: number }>()
-  const registry = createProjectRegistry({
-    persisted: persisted ?? {},
-    activeId: () => currentProjectId() ?? "single",
-  })
   const defaultBase = (id: string) => {
     const store = registry.ensure(id)
     return (
@@ -765,28 +756,18 @@ const AgentManagerContent: Component = () => {
 
   const showDetailStack = createMemo(() => showTerminalStack(history(), selection(), contextEmpty()))
 
-  const overlay = createMemo((): SetupState | null => {
-    const state = setup()
-    const sel = selection()
-    // A live Setup script terminal shows progress and failures on its own
-    // tab; never cover it with the blocking overlay.
-    if (typeof sel === "string" && sel !== LOCAL && hasSetupTerminal(nsKey(sel), terms.sides())) return null
-    if (state.active && (!state.worktreeId || sel === state.worktreeId)) return state
-    if (typeof sel !== "string" || sel === LOCAL) return null
-    const busy = busyWorktrees().get(sel)
-    if (busy?.reason !== "setting-up") return null
-    const tree = worktrees().find((item) => item.id === sel)
-    return {
-      active: true,
-      message: busy.message ?? "",
-      branch: busy.branch ?? tree?.branch,
-    }
-  })
-
   /** The selected worktree is provisioning: block session CTAs, keep selection put. */
   const settingUpSelection = createMemo(() => {
     const sel = selection()
     if (typeof sel !== "string" || sel === LOCAL) return undefined
+    const wt = worktrees().find((w) => w.id === sel)
+    if (wt?.status === "creating" || wt?.status === "setting-up") {
+      return {
+        reason: "setting-up" as const,
+        message: wt.statusMessage || busyWorktrees().get(sel)?.message || t("agentManager.setup.settingUp"),
+        branch: wt.branch,
+      }
+    }
     const busy = busyWorktrees().get(sel)
     if (busy?.reason !== "setting-up") return undefined
     return busy
@@ -821,10 +802,7 @@ const AgentManagerContent: Component = () => {
     return session.currentSessionID() ?? activePendingId()
   })
   const visibleSession = createMemo(() =>
-    visible(
-      session.currentSessionID(),
-      !!terms.activeId() || reviewActive() || history() || !!overlay() || contextEmpty(),
-    ),
+    visible(session.currentSessionID(), !!terms.activeId() || reviewActive() || history() || contextEmpty()),
   )
   reportVisibleSession(vscode, visibleSession)
   const worktreeLabel = (wt: WorktreeState): string => {
@@ -833,6 +811,11 @@ const AgentManagerContent: Component = () => {
   }
 
   const worktreeSubtitle = (wt: WorktreeState): string | undefined => {
+    if (wt.status === "creating" || wt.status === "setting-up") {
+      return wt.statusMessage || busyWorktrees().get(wt.id)?.message || t("agentManager.setup.settingUp")
+    }
+    const busy = busyWorktrees().get(wt.id)
+    if (busy?.reason === "setting-up" && busy.message) return busy.message
     const label = worktreeLabel(wt)
     return label !== wt.branch ? wt.branch : undefined
   }
@@ -1382,39 +1365,37 @@ const AgentManagerContent: Component = () => {
         if (ev.status === "ready" || ev.status === "error") {
           const error = ev.status === "error"
           if (ev.worktreeId) updateBusy((prev) => new Map([...prev].filter(([k]) => k !== ev.worktreeId)))
+          if (error) {
+            showToast({
+              variant: "error",
+              title: t("agentManager.setup.failed"),
+              description: ev.message || t("agentManager.setup.failed"),
+            })
+            if (ev.worktreeId && selection() === ev.worktreeId) setSelection(LOCAL)
+          }
           if (!isActivePayload(ev.projectId)) return
-          setSetup({
-            active: true,
-            message: ev.message,
-            branch: ev.branch,
-            error,
-            worktreeId: ev.worktreeId,
-            errorCode: ev.errorCode,
-          })
-          globalThis.setTimeout(() => setSetup({ active: false, message: "" }), error ? 3000 : 500)
           if (!error && ev.sessionId) {
-            session.selectSession(ev.sessionId)
-            const ms = managedSessions().find((s) => s.id === ev.sessionId)
-            if (ms?.worktreeId) setSelection(ms.worktreeId)
             evictLocal(ev.sessionId)
-            requestChatFocus(true)
+            const ms = managedSessions().find((s) => s.id === ev.sessionId)
+            const targetWorktreeId = ms?.worktreeId ?? ev.worktreeId
+            const isCurrent = selection() === targetWorktreeId
+            if (isCurrent) {
+              session.selectSession(ev.sessionId)
+              if (targetWorktreeId) setSelection(targetWorktreeId)
+              requestChatFocus(true)
+            }
           }
         } else {
-          // Track this worktree as setting up and auto-select it in the sidebar
+          // Track this worktree as setting up
           if (ev.worktreeId) {
             updateBusy(
               (prev) =>
                 new Map([...prev, [ev.worktreeId!, { reason: "setting-up", message: ev.message, branch: ev.branch }]]),
             )
-            if (!isActivePayload(ev.projectId)) return
-            setSelection(ev.worktreeId)
           }
           if (!isActivePayload(ev.projectId)) return
-          // Close diff/review panels — nothing to show during setup.
-          // Terminal panels keep live setup output, so they stay open.
           if (sidePanel() === "diff") setSidePanel(null)
           setReviewActive(false)
-          setSetup({ active: true, message: ev.message, branch: ev.branch, worktreeId: ev.worktreeId })
         }
       }
 
@@ -2410,29 +2391,6 @@ const AgentManagerContent: Component = () => {
           track={metrics.click}
         />
 
-        <Show when={overlay()}>
-          {(state) => (
-            <div class="am-setup-overlay">
-              <div class="am-setup-card">
-                <Icon name="branch" size="large" />
-                <div class="am-setup-title">
-                  {state().error ? t("agentManager.setup.failed") : t("agentManager.setup.settingUp")}
-                </div>
-                <Show when={state().branch}>
-                  <div class="am-setup-branch">{state().branch}</div>
-                </Show>
-                <div class="am-setup-status">
-                  <Show when={!state().error} fallback={<Icon name="circle-x" size="small" />}>
-                    <Spinner class="am-setup-spinner" />
-                  </Show>
-                  <span>
-                    {state().errorCode ? t(`agentManager.setup.error.${state().errorCode}`) : state().message}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-        </Show>
         <Show when={history()}>
           <HistoryView
             onSelectSession={(id) => {
@@ -2478,12 +2436,17 @@ const AgentManagerContent: Component = () => {
                     <Show
                       when={!settingUpSelection()}
                       fallback={
-                        <>
-                          <Spinner class="am-setup-spinner" />
-                          <div class="am-empty-state-text">
-                            {settingUpSelection()?.message ?? t("agentManager.setup.settingUp")}
+                        <div class="am-setup-card">
+                          <Icon name="branch" size="large" />
+                          <div class="am-setup-title">{t("agentManager.setup.settingUp")}</div>
+                          <Show when={settingUpSelection()?.branch}>
+                            <div class="am-setup-branch">{settingUpSelection()?.branch}</div>
+                          </Show>
+                          <div class="am-setup-status">
+                            <Spinner class="am-setup-spinner" />
+                            <span>{settingUpSelection()?.message || t("agentManager.setup.settingUp")}</span>
                           </div>
-                        </>
+                        </div>
                       }
                     >
                       <div class="am-empty-state-icon">

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -207,7 +207,15 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                 onClick={() => props.onClick()}
               >
                 <div class="am-wt-icon">
-                  <Show when={!props.busy && !props.working} fallback={<Spinner class="am-worktree-spinner" />}>
+                  <Show
+                    when={
+                      !props.busy &&
+                      !props.working &&
+                      props.worktree.status !== "creating" &&
+                      props.worktree.status !== "setting-up"
+                    }
+                    fallback={<Spinner class="am-worktree-spinner" />}
+                  >
                     <Icon name="branch" size="small" />
                   </Show>
                 </div>
@@ -268,7 +276,14 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                     </Show>
                     {/* Grid cell: stats visible by default, hover actions on top */}
                     <div class="am-wt-actions-cell">
-                      <Show when={props.stats === undefined}>
+                      <Show
+                        when={
+                          !props.busy &&
+                          props.worktree.status !== "creating" &&
+                          props.worktree.status !== "setting-up" &&
+                          props.stats === undefined
+                        }
+                      >
                         <div class="am-worktree-stats-skeleton">
                           <div class="am-worktree-stats-skeleton-row" />
                         </div>
@@ -298,7 +313,7 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                           </Show>
                         </div>
                       </Show>
-                      <Show when={props.pendingDelete && !props.busy}>
+                      <Show when={props.pendingDelete}>
                         <span class="am-worktree-delete-hint">{t("agentManager.worktree.confirmDelete")}</span>
                       </Show>
                       <div class="am-wt-hover-actions">
@@ -310,7 +325,7 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                             {props.shortcut}
                           </span>
                         </Show>
-                        <Show when={!props.busy && !props.pendingDelete}>
+                        <Show when={!props.pendingDelete}>
                           <div
                             class="am-worktree-close"
                             onMouseEnter={() => setOverClose(true)}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2588,27 +2588,7 @@ body.am-wt-dragging-active * {
   color: var(--text-weak);
 }
 
-/* Setup overlay */
-
-.am-setup-overlay {
-  position: absolute;
-  inset: 0;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--surface-base);
-  animation: am-fade-in 0.15s ease;
-}
-
-@keyframes am-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
+/* Setup card */
 
 .am-setup-card {
   display: flex;

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -31,6 +31,10 @@ export interface WorktreeState {
   prUrl?: string
   /** Cached PR state for correct badge color on reload (open/merged/closed/draft). */
   prState?: string
+  /** Status during creation lifecycle: creating, setting-up, ready, or error. */
+  status?: "creating" | "setting-up" | "ready" | "error"
+  /** Progress or error message during creation lifecycle. */
+  statusMessage?: string
   /** Section this worktree belongs to, or undefined for ungrouped. */
   sectionId?: string
 }


### PR DESCRIPTION
## Problem

Agent Manager worktree creation previously displayed a full-screen blocking overlay (`am-setup-overlay`) across the entire webview during Git creation and workspace setup. This locked users out of interacting with other sessions, reading diffs, or running terminals until the new worktree completed. Furthermore, if a user attempted to navigate or delete during in-flight creation, the previous lifecycle lacked an explicit state model, risking focus-stealing upon completion or orphaned state.

## What changes

- **Lifecycle-Bound Worktree State**: Worktree objects are allocated and registered in `WorktreeStateManager` with an explicit `status` (`creating` -> `setting-up` -> `ready`) from the start of creation, making the backend the single source of truth without client-side dummy cards.
- **Immediate Feedback without Blocking Overlay**: The creation dialog closes instantly (<16 ms) and the new worktree card appears in the sidebar with an animated spinner and live progress subtitle (`Creating git worktree...` -> `Setting up worktree...`).
- **Scoped Inline Setup State**: Removed the full-screen `am-setup-overlay`. Setup progress is rendered inline inside the main pane's empty state (`am-empty-state`) only when the creating worktree is selected.
- **Multi-Tasking with No Focus Stealing**: Users can freely switch to `Local` or other worktrees while creation runs in the background. If the user navigates away, completion updates the sidebar card in the background without stealing focus or interrupting the active view.
- **Safe In-Flight Cancellation & Deletion**: Users can delete or cancel a worktree at any point during creation. `deleteLifecycleWorktree` removes the worktree from state immediately, updates the UI, and prunes disk directories and branches cleanly.
- **Multi-Project Support**: Fully compatible with multi-project workspaces; creation, deletion, and status updates route to the target project's context without affecting adjacent projects.
