### PR TITLE
fix(vscode, cli): surface frontmatter parse errors in VS Code diagnostics

### DIFF
--- a/.changeset/four-snakes-itch.md
+++ b/.changeset/four-snakes-itch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Surface frontmatter parse errors as VS Code diagnostics with line and column positions.

--- a/packages/core/src/v1/config/error.ts
+++ b/packages/core/src/v1/config/error.ts
@@ -25,6 +25,10 @@ export const InvalidError = NamedError.create("ConfigInvalidError", {
 export const FrontmatterError = NamedError.create("ConfigFrontmatterError", {
   path: Schema.String,
   message: Schema.String,
+  // kilocode_change start - carry parse position to editor diagnostics
+  line: Schema.optional(Schema.Number),
+  column: Schema.optional(Schema.Number),
+  // kilocode_change end
 })
 
 export const DirectoryTypoError = NamedError.create("ConfigDirectoryTypoError", {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -317,6 +317,9 @@ type ContextRequestMessage =
   | { type: "requestFilePicker"; requestId: string }
   | { type: "requestTerminalContext"; requestId: string; sessionID?: string }
 
+// Shared per-directory so multiple providers in the same workspace do not duplicate Problems entries.
+const configDiagnosticsByDirectory = new Map<string, vscode.DiagnosticCollection>()
+
 export class KiloProvider implements vscode.WebviewViewProvider, TelemetryPropertiesProvider {
   public static readonly viewType = "kilo-code.SidebarProvider"
   private readonly instanceId = crypto.randomUUID()
@@ -364,7 +367,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Ref-count of in-flight handleUpdateConfig calls; prevents fetchAndSendConfig from sending stale data */
   private pending = 0
   private configWarningsShown = false
-  private configDiagnostics: vscode.DiagnosticCollection | undefined
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: NotificationsMessage | null = null
   private pendingKiloModel: { modelID?: string; agent?: string } | null = null
@@ -2786,8 +2788,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       }>
       console.log("[Kilo New] KiloProvider: config warnings fetched", { from, count: list.length })
 
-      this.configDiagnostics ??= vscode.languages.createDiagnosticCollection("kilo-config")
-      this.configDiagnostics.clear()
+      const dirKey = dir ?? this.getWorkspaceDirectory()
+      const configDiagnostics =
+        configDiagnosticsByDirectory.get(dirKey) ?? vscode.languages.createDiagnosticCollection("kilo-config")
+      configDiagnosticsByDirectory.set(dirKey, configDiagnostics)
+      configDiagnostics.clear()
 
       const byUri = new Map<string, vscode.Diagnostic[]>()
       for (const w of list) {
@@ -2807,7 +2812,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         byUri.set(key, existing)
       }
       for (const [key, diagnostics] of byUri) {
-        this.configDiagnostics.set(vscode.Uri.parse(key), diagnostics)
+        configDiagnostics.set(vscode.Uri.parse(key), diagnostics)
       }
 
       if (list.length === 0) return
@@ -5064,7 +5069,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.requirements.dispose()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
-    this.configDiagnostics?.dispose()
     disposeGitChangesTarget()
   }
 }

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -364,6 +364,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   /** Ref-count of in-flight handleUpdateConfig calls; prevents fetchAndSendConfig from sending stale data */
   private pending = 0
   private configWarningsShown = false
+  private configDiagnostics: vscode.DiagnosticCollection | undefined
   /** Cached notificationsLoaded payload */
   private cachedNotificationsMessage: NotificationsMessage | null = null
   private pendingKiloModel: { modelID?: string; agent?: string } | null = null
@@ -2762,15 +2763,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /**
-   * Fetch config warnings from the server and display a single consolidated
-   * VS Code warning with a "Show Details" action button.
-   * Only shown once per provider lifecycle (flag resets on dispose/re-create, not on SSE reconnect).
+   * Fetch config warnings from the server, publish them as VS Code diagnostics,
+   * and display a single consolidated VS Code warning with a "Show Details" action.
+   * The notification is shown once per provider lifecycle; diagnostics refresh on
+   * every call so stale errors disappear after the user fixes the file.
    */
   private async checkConfigWarnings(from: string): Promise<void> {
-    if (this.configWarningsShown) {
-      console.log("[Kilo New] KiloProvider: config warnings already shown", { from })
-      return
-    }
     if (!this.client) {
       console.log("[Kilo New] KiloProvider: config warnings skipped (no client)", { from })
       return
@@ -2779,12 +2777,47 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       const dir = this.getWorkspaceDirectory()
       console.log("[Kilo New] KiloProvider: checking config warnings", { from, dir })
       const result = await this.client.config.warnings({ directory: dir })
-      const list = result?.data ?? []
+      const list = (result?.data ?? []) as Array<{
+        path: string
+        message: string
+        detail?: string
+        line?: number
+        column?: number
+      }>
       console.log("[Kilo New] KiloProvider: config warnings fetched", { from, count: list.length })
+
+      this.configDiagnostics ??= vscode.languages.createDiagnosticCollection("kilo-config")
+      this.configDiagnostics.clear()
+
+      const byUri = new Map<string, vscode.Diagnostic[]>()
+      for (const w of list) {
+        if (!w.path) continue
+        const uri = vscode.Uri.file(w.path)
+        const key = uri.toString()
+        const pos =
+          w.line !== undefined && w.column !== undefined
+            ? new vscode.Range(w.line, w.column, w.line, Number.MAX_SAFE_INTEGER)
+            : new vscode.Range(0, 0, 0, 0)
+        const severity = w.line !== undefined ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning
+        const message = w.detail ? `${w.message}\n${w.detail}` : w.message
+        const diagnostic = new vscode.Diagnostic(pos, message, severity)
+        diagnostic.source = "kilo"
+        const existing = byUri.get(key) ?? []
+        existing.push(diagnostic)
+        byUri.set(key, existing)
+      }
+      for (const [key, diagnostics] of byUri) {
+        this.configDiagnostics.set(vscode.Uri.parse(key), diagnostics)
+      }
+
       if (list.length === 0) return
+      if (this.configWarningsShown) {
+        console.log("[Kilo New] KiloProvider: config warning notification already shown", { from })
+        return
+      }
       this.configWarningsShown = true
 
-      const first = list[0]!
+      const first = list[0]
       const summary = list.length === 1 ? first.message : `${first.message} (and ${list.length - 1} more)`
       console.warn("[Kilo New] KiloProvider: showing config warnings", { from, count: list.length, path: first.path })
 
@@ -5031,6 +5064,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.requirements.dispose()
     this.ignoreController?.dispose()
     this.chatAutocomplete?.dispose()
+    this.configDiagnostics?.dispose()
     disposeGitChangesTarget()
   }
 }

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -2,7 +2,6 @@ export * as ConfigAgent from "./agent"
 
 import path from "path"
 import * as Log from "@opencode-ai/core/util/log"
-import { Exit, Schema } from "effect"
 import { Glob } from "@opencode-ai/core/util/glob"
 import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
 import { configEntryNameFromPath } from "./entry-name"
@@ -41,7 +40,12 @@ export async function load(
         ? err.data.message
         : `Failed to parse agent ${item}`
       // kilocode_change start
-      if (warnings) warnings.push({ path: item, message })
+      const warn: Warning = { path: item, message }
+      if (FrontmatterError.isInstance(err)) {
+        warn.line = err.data.line
+        warn.column = err.data.column
+      }
+      if (warnings) warnings.push(warn)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()
@@ -122,7 +126,12 @@ export async function loadMode(
         ? err.data.message
         : `Failed to parse mode ${item}`
       // kilocode_change start
-      if (warnings) warnings.push({ path: item, message })
+      const warn: Warning = { path: item, message }
+      if (FrontmatterError.isInstance(err)) {
+        warn.line = err.data.line
+        warn.column = err.data.column
+      }
+      if (warnings) warnings.push(warn)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()

--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -36,22 +36,13 @@ export async function load(
     // kilocode_change start
     const md = await ConfigMarkdown.parse(item, { trusted, fileScope, sourceScope }).catch(async (err) => {
       // kilocode_change end
-      const message = FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse agent ${item}`
-      // kilocode_change start
-      const warn: Warning = { path: item, message }
-      if (FrontmatterError.isInstance(err)) {
-        warn.line = err.data.line
-        warn.column = err.data.column
-      }
-      if (warnings) warnings.push(warn)
+      const warn = KilocodeConfig.frontmatterWarning(err, item, "agent", warnings)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()
-        if (ctx) await report(ctx, message)
+        if (ctx) await report(ctx, warn.message)
       } catch (error) {
-        log.warn("could not publish session error", { message, err: error })
+        log.warn("could not publish session error", { message: warn.message, err: error })
       }
       // kilocode_change end
       log.error("failed to load agent", { agent: item, err })
@@ -122,22 +113,13 @@ export async function loadMode(
     // kilocode_change start
     const md = await ConfigMarkdown.parse(item, { trusted, fileScope, sourceScope }).catch(async (err) => {
       // kilocode_change end
-      const message = FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse mode ${item}`
-      // kilocode_change start
-      const warn: Warning = { path: item, message }
-      if (FrontmatterError.isInstance(err)) {
-        warn.line = err.data.line
-        warn.column = err.data.column
-      }
-      if (warnings) warnings.push(warn)
+      const warn = KilocodeConfig.frontmatterWarning(err, item, "mode", warnings)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()
-        if (ctx) await report(ctx, message)
+        if (ctx) await report(ctx, warn.message)
       } catch (error) {
-        log.warn("could not publish session error", { message, err: error })
+        log.warn("could not publish session error", { message: warn.message, err: error })
       }
       // kilocode_change end
       log.error("failed to load mode", { mode: item, err })

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -38,22 +38,13 @@ export async function load(
     // kilocode_change start
     const md = await ConfigMarkdown.parse(item, { trusted, fileScope, sourceScope }).catch(async (err) => {
       // kilocode_change end
-      const message = FrontmatterError.isInstance(err)
-        ? err.data.message
-        : `Failed to parse command ${item}`
-      // kilocode_change start
-      const warn: Warning = { path: item, message }
-      if (FrontmatterError.isInstance(err)) {
-        warn.line = err.data.line
-        warn.column = err.data.column
-      }
-      if (warnings) warnings.push(warn)
+      const warn = KilocodeConfig.frontmatterWarning(err, item, "command", warnings)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()
-        if (ctx) await report(ctx, message)
+        if (ctx) await report(ctx, warn.message)
       } catch (error) {
-        log.warn("could not publish session error", { message, err: error })
+        log.warn("could not publish session error", { message: warn.message, err: error })
       }
       // kilocode_change end
       log.error("failed to load command", { command: item, err })

--- a/packages/opencode/src/config/command.ts
+++ b/packages/opencode/src/config/command.ts
@@ -42,7 +42,12 @@ export async function load(
         ? err.data.message
         : `Failed to parse command ${item}`
       // kilocode_change start
-      if (warnings) warnings.push({ path: item, message })
+      const warn: Warning = { path: item, message }
+      if (FrontmatterError.isInstance(err)) {
+        warn.line = err.data.line
+        warn.column = err.data.column
+      }
+      if (warnings) warnings.push(warn)
       try {
         const { capture } = await import("@/kilocode/instance")
         const ctx = capture()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -91,6 +91,10 @@ export const Warning = z.object({
   path: z.string(),
   message: z.string(),
   detail: z.string().optional(),
+  // kilocode_change start - carry parse position to editor diagnostics
+  line: z.number().optional(),
+  column: z.number().optional(),
+  // kilocode_change end
 })
 export type Warning = z.infer<typeof Warning>
 

--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -67,6 +67,40 @@ export function fallbackSanitization(content: string): string {
   return content.replace(frontmatter, () => processed)
 }
 
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/
+
+function yamlMark(err: unknown): { line: number; column: number } | undefined {
+  if (!err || typeof err !== "object") return undefined
+  const raw = (err as Record<string, unknown>).mark
+  if (!raw || typeof raw !== "object") return undefined
+  const m = raw as Record<string, unknown>
+  if (typeof m.line !== "number" || typeof m.column !== "number") return undefined
+  return { line: m.line, column: m.column }
+}
+
+// kilocode_change start - extract a usable editor position from a YAML parse error
+function frontmatterErrorPosition(text: string, err: unknown): { line?: number; column?: number } {
+  const mark = yamlMark(err)
+  if (!mark) return {}
+
+  const match = text.match(FRONTMATTER)
+  if (!match) return { line: mark.line, column: mark.column }
+
+  const lines = match[1].split(/\r?\n/)
+  const end = Math.min(mark.line, lines.length - 1)
+  for (const [i, line] of lines.entries()) {
+    if (i > end) break
+    if (!line) continue
+    // Point at keys where the colon is immediately followed by a value,
+    // which is the common "missing space after colon" mistake.
+    const kv = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\S/)
+    if (kv) return { line: i, column: kv[1].length }
+  }
+
+  return { line: mark.line, column: mark.column }
+}
+// kilocode_change end
+
 // kilocode_change start - accept source trust and confine untrusted markdown source reads
 export async function parse(filePath: string, options: KilocodeMarkdown.Options) {
   const template = options.trusted
@@ -75,25 +109,39 @@ export async function parse(filePath: string, options: KilocodeMarkdown.Options)
   // kilocode_change end
 
   // kilocode_change start - substitute content and retry invalid frontmatter with permissive sanitization
+  let firstError: unknown
+
   try {
-    const md = matter(template)
+    const md = matter(template, {})
+    md.content = await KilocodeMarkdown.substitute(md.content, filePath, options) // kilocode_change
+    return md
+  } catch (err) {
+    firstError = err
+  }
+
+  try {
+    const md = matter(fallbackSanitization(template), {})
     md.content = await KilocodeMarkdown.substitute(md.content, filePath, options) // kilocode_change
     return md
   } catch {
-    try {
-      const md = matter(fallbackSanitization(template))
-      md.content = await KilocodeMarkdown.substitute(md.content, filePath, options) // kilocode_change
-      return md
-    } catch (err) {
-      throw new FrontmatterError(
-        {
-          path: filePath,
-          message: `${filePath}: Failed to parse YAML frontmatter: ${err instanceof Error ? err.message : String(err)}`,
-        },
-        { cause: err },
-      )
-    }
+    // Ignore the fallback error; the original YAML parse error is what the user needs to fix.
   }
+
+  const pos = frontmatterErrorPosition(template, firstError)
+  const detail = firstError instanceof Error
+    ? firstError.message
+    : typeof firstError === "string"
+      ? firstError
+      : "unknown error"
+  throw new FrontmatterError(
+    {
+      path: filePath,
+      message: `${filePath}: Failed to parse YAML frontmatter: ${detail}`,
+      line: pos.line,
+      column: pos.column,
+    },
+    { cause: firstError },
+  )
   // kilocode_change end
 }
 

--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -1,7 +1,10 @@
 import matter from "gray-matter"
 import { Filesystem } from "@/util/filesystem"
 import { FrontmatterError } from "@opencode-ai/core/v1/config/error"
+import * as Log from "@opencode-ai/core/util/log" // kilocode_change
 import { KilocodeMarkdown } from "../kilocode/config/markdown" // kilocode_change
+
+const log = Log.create({ service: "config-markdown" }) // kilocode_change
 
 export const FILE_REGEX = /(?<![\w`])@(\.?[^\s`,.]*(?:\.[^\s`,.]+)*)/g
 export const SHELL_REGEX = /!`([^`]+)`/g
@@ -86,6 +89,7 @@ function frontmatterErrorPosition(text: string, err: unknown): { line?: number; 
   const match = text.match(FRONTMATTER)
   if (!match) return { line: mark.line, column: mark.column }
 
+  const startLine = text.slice(0, match.index).split(/\r?\n/).length - 1
   const lines = match[1].split(/\r?\n/)
   const end = Math.min(mark.line, lines.length - 1)
   for (const [i, line] of lines.entries()) {
@@ -94,10 +98,10 @@ function frontmatterErrorPosition(text: string, err: unknown): { line?: number; 
     // Point at keys where the colon is immediately followed by a value,
     // which is the common "missing space after colon" mistake.
     const kv = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\S/)
-    if (kv) return { line: i, column: kv[1].length }
+    if (kv) return { line: startLine + 1 + i, column: kv[1].length }
   }
 
-  return { line: mark.line, column: mark.column }
+  return { line: startLine + 1 + mark.line, column: mark.column }
 }
 // kilocode_change end
 
@@ -123,8 +127,8 @@ export async function parse(filePath: string, options: KilocodeMarkdown.Options)
     const md = matter(fallbackSanitization(template), {})
     md.content = await KilocodeMarkdown.substitute(md.content, filePath, options) // kilocode_change
     return md
-  } catch {
-    // Ignore the fallback error; the original YAML parse error is what the user needs to fix.
+  } catch (fallbackErr) {
+    log.debug("fallback frontmatter parse failed", { path: filePath, err: fallbackErr })
   }
 
   const pos = frontmatterErrorPosition(template, firstError)

--- a/packages/opencode/src/kilocode/config-validation.ts
+++ b/packages/opencode/src/kilocode/config-validation.ts
@@ -82,9 +82,12 @@ export namespace ConfigValidation {
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
-      const msg = FrontmatterError.isInstance(e)
+      let msg = FrontmatterError.isInstance(e)
         ? e.data.message
         : `Failed to parse frontmatter: ${e instanceof Error ? e.message : String(e)}`
+      if (FrontmatterError.isInstance(e) && e.data.line !== undefined) {
+        msg = `${msg} (line ${e.data.line + 1}, column ${(e.data.column ?? 0) + 1})`
+      }
       return `\n\n<config_validation>\nERROR: ${label(filepath)}\n  ${msg}\n</config_validation>`
     }
 

--- a/packages/opencode/src/kilocode/config/config.ts
+++ b/packages/opencode/src/kilocode/config/config.ts
@@ -263,6 +263,27 @@ export namespace KilocodeConfig {
       .join("\n")
   }
 
+  /** Build a Warning from a frontmatter parse error and optionally append it to a list. */
+  export function frontmatterWarning(
+    err: unknown,
+    item: string,
+    kind: string,
+    warnings?: Config.Warning[],
+  ): Config.Warning {
+    const warn: Config.Warning = {
+      path: item,
+      message: ConfigError.FrontmatterError.isInstance(err)
+        ? err.data.message
+        : `Failed to parse ${kind} ${item}`,
+    }
+    if (ConfigError.FrontmatterError.isInstance(err)) {
+      warn.line = err.data.line
+      warn.column = err.data.column
+    }
+    if (warnings) warnings.push(warn)
+    return warn
+  }
+
   /** Handle an invalid agent/command config: log, publish session error, collect warning. */
   export async function handleInvalid(
     kind: "agent" | "command",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -15,6 +15,10 @@ const Warning = Schema.Struct({
   path: Schema.String,
   message: Schema.String,
   detail: Schema.optional(Schema.String),
+  // kilocode_change start - carry parse position to editor diagnostics
+  line: Schema.optional(Schema.Number),
+  column: Schema.optional(Schema.Number),
+  // kilocode_change end
 })
 // kilocode_change end
 

--- a/packages/opencode/test/kilocode/config/markdown.test.ts
+++ b/packages/opencode/test/kilocode/config/markdown.test.ts
@@ -73,7 +73,7 @@ describe("ConfigMarkdown frontmatter diagnostics", () => {
     )
 
     expect(FrontmatterError.isInstance(err)).toBeTrue()
-    expect(err.data.line).toBe(1)
+    expect(err.data.line).toBe(2)
     expect(err.data.column).toBe(5)
     expect(err.data.path).toBe(file)
   })

--- a/packages/opencode/test/kilocode/config/markdown.test.ts
+++ b/packages/opencode/test/kilocode/config/markdown.test.ts
@@ -1,5 +1,7 @@
 import path from "node:path"
-import { expect, test } from "bun:test"
+import { expect, test, describe } from "bun:test"
+import { ConfigMarkdown } from "@/config/markdown"
+import { FrontmatterError } from "@opencode-ai/core/v1/config/error"
 import { KilocodeMarkdown } from "@/kilocode/config/markdown"
 import { tmpdir } from "../../fixture/fixture"
 
@@ -56,4 +58,23 @@ test("confines project markdown substitutions while preserving trusted substitut
     if (prior === undefined) delete process.env[name]
     else process.env[name] = prior
   }
+})
+
+describe("ConfigMarkdown frontmatter diagnostics", () => {
+  test("reports the line and column of a missing space after a colon", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "agent.md")
+    const text = "---\nmode: subagent\nmodel:codedesign/KAT-Coder-V2.5-Dev\ndescription: Workspace Discovery Agent.\n---\n"
+    await Bun.write(file, text)
+
+    const err = await ConfigMarkdown.parse(file, { trusted: true }).then(
+      () => new Error("expected frontmatter parse to fail"),
+      (e) => e,
+    )
+
+    expect(FrontmatterError.isInstance(err)).toBeTrue()
+    expect(err.data.line).toBe(1)
+    expect(err.data.column).toBe(5)
+    expect(err.data.path).toBe(file)
+  })
 })


### PR DESCRIPTION
## Issue

Fixes #13005

## Context

A missing space after a colon in a `.md` config frontmatter currently breaks agent/command loading without showing an editor diagnostic. The VS Code extension only shows a one-time warning notification, so the user has no in-editor pointer to the exact error.

## Implementation

- Extended `ConfigFrontmatterError` (`packages/core/src/v1/config/error.ts`) and `Config.Warning` (`packages/opencode/src/config/config.ts`) to carry optional `line`/`column` positions.
- In `ConfigMarkdown.parse` (`packages/opencode/src/config/markdown.ts`), when `gray-matter` fails, extract the YAML `mark`, scan the frontmatter for the common `key:value` (missing space) pattern, and attach a 0-based line/column to the thrown `FrontmatterError`. Also pass `{}` to `matter(..., {})` so gray-matter's internal cache doesn't swallow the original parse error on the fallback retry.
- `ConfigAgent`/`ConfigCommand` (`packages/opencode/src/config/agent.ts`, `command.ts`) now copy the error position into warnings.
- `ConfigApi` warnings schema and `ConfigValidation.check` propagate the position.
- `KiloProvider.checkConfigWarnings` (`packages/kilo-vscode/src/KiloProvider.ts`) creates a `vscode.DiagnosticCollection`, publishes `Error`-severity diagnostics at the reported line/column, and still shows the consolidated warning notification.

## Screenshots / Video

N/A — this is a diagnostics/Problems panel change; verification is via unit tests and type checks.

## How to Test

### Manual/local verification

- `cd packages/opencode && bun test --timeout 30000 test/kilocode/config/markdown.test.ts` — passes.
- `cd packages/opencode && bun test --timeout 60000 test/config` — 195 passes.
- `cd packages/opencode && bun run typecheck` — passes.
- `cd packages/kilo-vscode && bun run typecheck` — passes.
- `cd packages/kilo-vscode && bun run lint` — passes.
- `bun run lint` from root — 0 errors, warnings are pre-existing.
- `bun run check-kilocode-change` and `bun run script/check-opencode-annotations.ts --worktree` — pass.
- `cd packages/kilo-vscode && bun run test:unit` — 3795 passes; the one failure (`transcript parts > keeps timeline candidates aligned with visible transcript parts`) is a pre-existing timeout that passes when rerun with `--timeout 30000` and is unrelated to this change.

### Reviewer test steps

1. Create `.kilo/agent/test.md` with a frontmatter line like `model:codedesign/KAT-Coder-V2.5-Dev` (no space after the colon).
2. Reload the VS Code window / extension.
3. Open the file and open the Problems panel (`Ctrl+Shift+M`).
4. Confirm a `kilo` diagnostic appears on the offending line with a message about the YAML frontmatter parse error.

### Blocked checks and substitute verification

- `scripts/preflight_ship.py` does not exist in this repo; the substitute verification listed above was run instead.

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.