### PR TITLE
fix(cli): revalidate, deprioritize and allow removal of skills.url skills

### DIFF
--- a/.changeset/revalidate-url-skills.md
+++ b/.changeset/revalidate-url-skills.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Revalidate skills downloaded from `skills.urls`, prevent cached URL skills from shadowing local skills, and allow removing URL-backed skill caches.

--- a/packages/opencode/src/kilocode/skill-remove.ts
+++ b/packages/opencode/src/kilocode/skill-remove.ts
@@ -1,4 +1,4 @@
-import { unlink } from "node:fs/promises"
+import { rm } from "node:fs/promises"
 import path from "node:path"
 import { Global } from "@opencode-ai/core/global"
 import { Skill } from "@/skill"
@@ -24,14 +24,23 @@ export function target(location: string, skills: readonly Info[]) {
 
   const cache = path.join(Global.Path.cache, "skills")
   const relative = path.relative(cache, file)
-  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
-    throw new Error("remove URL-backed skills from configuration")
+  if (relative === "") throw new Error("remove URL-backed skills from configuration")
+
+  if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+    const dir = path.dirname(file)
+    const parent = path.relative(cache, dir)
+    if (parent === "" || parent.startsWith("..") || path.isAbsolute(parent)) {
+      throw new Error("remove URL-backed skills from configuration")
+    }
+    return dir
   }
+
   return file
 }
 
 export async function remove(location: string, skills: readonly Info[]) {
-  const file = target(location, skills)
+  const targetPath = target(location, skills)
   // Removing only the manifest disables discovery without recursively deleting user files.
-  await unlink(file)
+  // URL-backed skills live entirely inside the cache, so the whole skill directory is removed.
+  await rm(targetPath, { recursive: true, force: true })
 }

--- a/packages/opencode/src/skill/discovery.ts
+++ b/packages/opencode/src/skill/discovery.ts
@@ -1,8 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient, path } from "@opencode-ai/core/effect/app-node-platform"
-import { NodePath } from "@effect/platform-node"
 import { Effect, Layer, Path, Schema, Context } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
@@ -32,20 +31,55 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Path.Path | HttpClient
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const path = yield* Path.Path
-    const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
+    const client = yield* HttpClient.HttpClient
+    const httpRaw = withTransientReadRetry(client)
+    const http = HttpClient.filterStatusOk(httpRaw)
     const cache = path.join(Global.Path.cache, "skills")
 
-    const download = Effect.fn("Discovery.download")(function* (url: string, dest: string) {
-      if (yield* fs.exists(dest).pipe(Effect.orDie)) return true
+    // kilocode_change start - revalidate cached URL skill files using ETag/Last-Modified
+    // sidecars so stale copies are not returned forever.
+    const etagFile = (dest: string) => `${dest}.etag`
+    const lastmodFile = (dest: string) => `${dest}.lastmod`
 
-      return yield* HttpClientRequest.get(url).pipe(
-        http.execute,
-        Effect.flatMap((res) => res.arrayBuffer),
-        Effect.flatMap((body) => fs.writeWithDirs(dest, new Uint8Array(body))),
-        Effect.as(true),
-        Effect.catch((err) => Effect.logError("failed to download", { url: url, error: err }).pipe(Effect.as(false))),
-      )
+    const readTag = (tag: string) =>
+      Effect.gen(function* () {
+        if (!(yield* fs.exists(tag).pipe(Effect.orDie))) return undefined
+        return yield* fs.readFileStringSafe(tag).pipe(Effect.catch(() => Effect.succeed(undefined)))
+      })
+
+    const writeTag = (tag: string, value: string | null) =>
+      value ? fs.writeWithDirs(tag, value) : fs.remove(tag, { force: true }).pipe(Effect.ignore)
+
+    const download = Effect.fn("Discovery.download")(function* (url: string, dest: string, revalidate: boolean) {
+      const exists = yield* fs.exists(dest).pipe(Effect.orDie)
+      if (exists && !revalidate) return true
+
+      const headers: Record<string, string> = {}
+      if (revalidate) {
+        const etag = yield* readTag(etagFile(dest))
+        if (etag) headers["If-None-Match"] = etag
+        const lastmod = yield* readTag(lastmodFile(dest))
+        if (lastmod) headers["If-Modified-Since"] = lastmod
+      }
+
+      return yield* Effect.gen(function* () {
+        const res = yield* HttpClientRequest.get(url).pipe(
+          HttpClientRequest.setHeaders(headers),
+          httpRaw.execute,
+        )
+        if (res.status === 304) return true
+        if (res.status !== 200) {
+          yield* Effect.logError("failed to download", { url, status: res.status })
+          return false
+        }
+        const body = yield* res.arrayBuffer
+        yield* fs.writeWithDirs(dest, new Uint8Array(body))
+        yield* writeTag(etagFile(dest), res.headers["etag"] ?? null)
+        yield* writeTag(lastmodFile(dest), res.headers["last-modified"] ?? null)
+        return true
+      }).pipe(Effect.catch((err) => Effect.logError("failed to download", { url, error: err }).pipe(Effect.as(false))))
     })
+    // kilocode_change end
 
     const pull = Effect.fn("Discovery.pull")(function* (url: string) {
       const base = url.endsWith("/") ? url : `${url}/`
@@ -110,23 +144,26 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Path.Path | HttpClient
           Effect.gen(function* () {
             const { root, version } = skill
             const versionFile = path.join(root, ".opencode-version")
-            const fetchInto = (target: string) =>
-              Effect.forEach(skill.files, (file) => download(file.url, path.join(target, file.rel)), {
+            // kilocode_change start - pass revalidate so unversioned files are revalidated and
+            // versioned files short-circuit on existing copies.
+            const fetchInto = (target: string, revalidate: boolean) =>
+              Effect.forEach(skill.files, (file) => download(file.url, path.join(target, file.rel), revalidate), {
                 concurrency: fileConcurrency,
               })
+            // kilocode_change end
             const current =
               version === undefined
                 ? undefined
                 : yield* fs.readFileStringSafe(versionFile).pipe(Effect.catch(() => Effect.succeed(undefined)))
 
             if (version === undefined || current === version) {
-              yield* fetchInto(root)
+              yield* fetchInto(root, version === undefined)
             } else {
               const token = crypto.randomUUID()
               const staging = `${root}.tmp-${token}`
               const backup = `${root}.old-${token}`
               yield* Effect.gen(function* () {
-                const downloaded = yield* fetchInto(staging)
+                const downloaded = yield* fetchInto(staging, false)
                 if (!downloaded.every(Boolean)) return
                 if (!(yield* fs.exists(path.join(staging, "SKILL.md")).pipe(Effect.orDie))) return
                 yield* fs.writeFileString(path.join(staging, ".opencode-version"), version)

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -210,6 +210,18 @@ const discoverSkills = Effect.fnUntraced(function* (
   const state: ScanState = { matches: new Map(), dirs: new Set() } // kilocode_change
   const projectRoot = worktree === "/" ? directory : worktree // kilocode_change - project substitution boundary
 
+  const cfg = yield* config.get()
+
+  // kilocode_change start - discover URL skills first so locally-installed skills discovered later take
+  // precedence and cannot be silently shadowed by a stale cached copy.
+  for (const url of cfg.skills?.urls ?? []) {
+    const pulledDirs = yield* discovery.pull(url)
+    for (const dir of pulledDirs) {
+      yield* scan(state, dir, SKILL_PATTERN, { root: dir }) // kilocode_change - downloaded markdown is untrusted
+    }
+  }
+  // kilocode_change end
+
   const externalDirs: string[] = []
   if (!disableExternalSkills) {
     if (!disableClaudeCodeSkills) externalDirs.push(CLAUDE_EXTERNAL_DIR)
@@ -260,7 +272,6 @@ const discoverSkills = Effect.fnUntraced(function* (
     // kilocode_change end
   }
 
-  const cfg = yield* config.get()
   for (const item of cfg.skills?.paths ?? []) {
     const expanded = item.startsWith("~/") ? path.join(global.home, item.slice(2)) : item
     const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)
@@ -278,13 +289,6 @@ const discoverSkills = Effect.fnUntraced(function* (
       projectRoot,
     })
     // kilocode_change end
-  }
-
-  for (const url of cfg.skills?.urls ?? []) {
-    const pulledDirs = yield* discovery.pull(url)
-    for (const dir of pulledDirs) {
-      yield* scan(state, dir, SKILL_PATTERN, { root: dir }) // kilocode_change - downloaded markdown is untrusted
-    }
   }
 
   return {

--- a/packages/opencode/test/kilocode/skill-remove.test.ts
+++ b/packages/opencode/test/kilocode/skill-remove.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "node:path"
 import { Global } from "@opencode-ai/core/global"
-import { target } from "../../src/kilocode/skill-remove"
+import { target, remove } from "../../src/kilocode/skill-remove"
 
 const info = (location: string) => ({
   name: "synthetic",
@@ -34,9 +34,16 @@ describe("skill removal target", () => {
     expect(() => target(location, [info(location)])).toThrow("skill location must reference SKILL.md")
   })
 
-  test("rejects URL-backed cache entries", () => {
+  test("returns the cache directory for a URL-backed skill", () => {
     const location = path.join(Global.Path.cache, "skills", "synthetic", "SKILL.md")
-    expect(() => target(location, [info(location)])).toThrow("remove URL-backed skills from configuration")
+    expect(target(location, [info(location)])).toBe(path.dirname(location))
+  })
+
+  test("removes a URL-backed skill cache directory", async () => {
+    const location = path.join(Global.Path.cache, "skills", "synthetic-remove", "SKILL.md")
+    await Bun.write(location, "---\nname: synthetic\n---\n")
+    await remove(location, [info(location)])
+    expect(await Bun.file(location).exists()).toBe(false)
   })
 
   test("returns only the registered skill manifest", () => {

--- a/packages/opencode/test/skill/discovery.test.ts
+++ b/packages/opencode/test/skill/discovery.test.ts
@@ -16,6 +16,7 @@ let mutableVersion = "1"
 let mutableContent = "# Old"
 let mutableDownloadCount = 0
 let mutableFiles = ["SKILL.md"]
+let unversionedContent = "# Initial"
 
 const fixturePath = path.join(import.meta.dir, "../fixture/skills")
 const cacheDir = path.join(Global.Path.cache, "skills")
@@ -28,15 +29,41 @@ beforeAll(async () => {
     port: 0,
     async fetch(req) {
       const url = new URL(req.url)
+      const ifNoneMatch = req.headers.get("If-None-Match")
+
+      const etag = (body: string | ArrayBuffer | Uint8Array) => {
+        const input = typeof body === "string" ? body : new Uint8Array(body)
+        return `"${Bun.hash(input)}"`
+      }
+      const send = (body: string, counter: (() => void) | null = null) => {
+        const tag = etag(body)
+        if (ifNoneMatch === tag) return new Response(null, { status: 304, headers: { ETag: tag } })
+        counter?.()
+        return new Response(body, { headers: { ETag: tag } })
+      }
+      const sendFile = async (fullPath: string, counter: () => void) => {
+        const body = await Bun.file(fullPath).arrayBuffer()
+        const tag = etag(body)
+        if (ifNoneMatch === tag) return new Response(null, { status: 304, headers: { ETag: tag } })
+        counter()
+        return new Response(Bun.file(fullPath), { headers: { ETag: tag } })
+      }
 
       if (url.pathname === "/mutable/index.json") {
         return Response.json({ skills: [{ name: "mutable", version: mutableVersion, files: mutableFiles }] })
       }
       if (url.pathname === "/mutable/mutable/SKILL.md") {
-        mutableDownloadCount++
-        return new Response(mutableContent)
+        return send(mutableContent, () => mutableDownloadCount++)
       }
-      if (url.pathname === "/mutable/mutable/old.md") return new Response("old reference")
+      if (url.pathname === "/mutable/mutable/old.md") return send("old reference")
+
+      if (url.pathname === "/unversioned/index.json") {
+        return Response.json({ skills: [{ name: "unversioned", files: ["SKILL.md"] }] })
+      }
+      if (url.pathname === "/unversioned/unversioned/SKILL.md") {
+        return send(unversionedContent)
+      }
+
       // kilocode_change start - serve a crafted index whose skill name escapes the cache via `../`
       if (url.pathname === "/evil/index.json") {
         return Response.json({ skills: [{ name: "../../../.agents/skills/evil", files: ["SKILL.md"] }] })
@@ -56,10 +83,10 @@ beforeAll(async () => {
         const fullPath = path.join(fixturePath, filePath)
 
         if (await Filesystem.exists(fullPath)) {
-          if (!fullPath.endsWith("index.json")) {
-            downloadCount++
+          if (fullPath.endsWith("index.json")) {
+            return new Response(Bun.file(fullPath))
           }
-          return new Response(Bun.file(fullPath))
+          return sendFile(fullPath, () => downloadCount++)
         }
       }
 
@@ -216,6 +243,22 @@ describe("Discovery.pull", () => {
 
       yield* discovery.pull(url)
       expect(mutableDownloadCount).toBe(3)
+    }),
+  )
+
+  it.live("revalidates unversioned URL skills when the remote content changes", () =>
+    Effect.gen(function* () {
+      yield* Effect.promise(() => rm(cacheDir, { recursive: true, force: true }))
+      unversionedContent = "# Initial"
+      const discovery = yield* Discovery.Service
+      const url = `http://localhost:${server.port}/unversioned/`
+
+      const first = yield* discovery.pull(url)
+      expect(yield* Effect.promise(() => Bun.file(path.join(first[0], "SKILL.md")).text())).toBe("# Initial")
+
+      unversionedContent = "# Updated"
+      const second = yield* discovery.pull(url)
+      expect(yield* Effect.promise(() => Bun.file(path.join(second[0], "SKILL.md")).text())).toBe("# Updated")
     }),
   )
 })


### PR DESCRIPTION
## Issue

Fixes #12907

## Context

`skills.urls` skills were cached under `~/.cache/kilo/skills/<name>/` and never revalidated after the first download. Because `skills.urls` was discovered *after* local/global skill directories, a stale cached copy could silently win name collisions and shadow a correctly-installed skill. The removal path also refused to delete these cache entries, leaving stale files on disk indefinitely.

## Implementation

- `packages/opencode/src/skill/discovery.ts`
  - `Discovery.download` now stores `ETag` and `Last-Modified` sidecars and sends conditional `If-None-Match` / `If-Modified-Since` requests for unversioned URLs, so unchanged remote files return `304` and avoid unnecessary re-downloads.
  - Versioned skills still short-circuit when the cached version matches.
- `packages/opencode/src/skill/index.ts`
  - Discovery now scans `cfg.skills.urls` *first*, so local and project-specific skills discovered later take precedence in name collisions instead of being shadowed by cached URL skills.
- `packages/opencode/src/kilocode/skill-remove.ts`
  - `target()` returns the skill's cache directory for URL-backed skills.
  - `remove()` recursively deletes that directory (including sidecars and downloaded files).
- Added a `.changeset` for the user-facing fix and updated/added tests.

## Screenshots / Video

N/A — no UI changes.

## How to Test

### Manual/local verification

Ran the affected CLI tests and monorepo typecheck:

```bash
cd packages/opencode
bun test test/skill/discovery.test.ts
bun test test/kilocode/skill-remove.test.ts
bun test test/skill/skill.test.ts
bun run typecheck
```

All targeted tests pass:
- `test/skill/discovery.test.ts`: 10/10 pass, including the new unversioned URL revalidation test.
- `test/kilocode/skill-remove.test.ts`: 8/8 pass, including removal of a URL-backed cache directory.
- `test/skill/skill.test.ts`: 17/17 pass.

Root typecheck (excluding JetBrains) also passes:

```bash
bun turbo typecheck --filter='!@kilocode/kilo-jetbrains'
```

> 28 successful, 28 total

The local push also ran the repo's pre-push `turbo typecheck` hook (including `@kilocode/kilo-jetbrains`) and completed successfully.

### Reviewer test steps

1. Configure a `skills.urls` entry pointing at a local `index.json` and SKILL file.
2. Run `kilo` and confirm the skill loads.
3. Modify the remote SKILL content and `/reload`.
4. Confirm the updated skill content is now loaded.
5. Install a skill with the same declared `name` in `~/.kilo/skills/<name>/` with different content.
6. Confirm the local skill takes precedence over the cached URL skill.
7. Trigger the skill removal flow for the URL-backed skill and confirm its cache directory is deleted.

### Blocked checks and substitute verification

No blocked checks. The full pre-push typecheck (including JetBrains) completed, confirming Java 21 / Gradle were already available in this environment.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
