### PR TITLE
fix(cli): stop env-var skill docs from triggering shell prompts

### DIFF
--- a/.changeset/skill-shell-env-var-docs.md
+++ b/.changeset/skill-shell-env-var-docs.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop env-var documentation placeholders in skill markdown from triggering shell permission prompts.

--- a/packages/opencode/src/kilocode/skills/inject.ts
+++ b/packages/opencode/src/kilocode/skills/inject.ts
@@ -41,7 +41,7 @@ export namespace SkillInject {
   export const render = Effect.fn("SkillInject.render")(function* (opts: Options) {
     // Fenced blocks and inline code spans (`` !`cmd` ``) are documentation, not live commands.
     const inert = ranges(opts.content)
-    const live = ConfigMarkdown.shell(opts.content).filter((m) => !inert(m.index))
+    const live = ConfigMarkdown.shell(opts.content).filter((m) => !isInert(m.index, m[1], inert))
     if (live.length === 0) return opts.content
 
     // Policy checks before the approval gate; `replace` only touches live placeholders.
@@ -135,8 +135,17 @@ export namespace SkillInject {
   // containing `!`cmd`` stays inert, and documentation examples stay literal text.
   function rewrite(content: string, inert: (index: number) => boolean, value: (command: string) => string) {
     return content.replace(ConfigMarkdown.SHELL_REGEX, (match, command: string, index: number) =>
-      inert(index) ? match : value(command),
+      isInert(index, command, inert) ? match : value(command),
     )
+  }
+
+  // `!`RUST_LOG`` in prose documents an env var name, not a shell command to run.
+  function documentationShell(command: string) {
+    return /^[A-Z][A-Z0-9_]*$/.test(command.trim())
+  }
+
+  function isInert(index: number, command: string, inert: (index: number) => boolean) {
+    return inert(index) || documentationShell(command)
   }
 
   // Fenced code block spans (``` or ~~~), sorted and non-overlapping by construction.

--- a/packages/opencode/test/kilocode/skills/inject.test.ts
+++ b/packages/opencode/test/kilocode/skills/inject.test.ts
@@ -339,6 +339,28 @@ describe("skill shell injection", () => {
     }),
   )
 
+  unix("does not treat env-var documentation placeholders as shell commands", () =>
+    Effect.gen(function* () {
+      // Regression for #12868: prose like `!`RUST_LOG`` documents an env var name and must
+      // not request bash permission or try to execute it.
+      yield* writeGlobalSkill(
+        "env-var-doc-shell",
+        "- Make log level configurable via env (!`RUST_LOG` or `EnvFilter`).",
+      )
+
+      const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+      const result = yield* loadSkill("env-var-doc-shell", (req) =>
+        Effect.sync(() => {
+          requests.push(req)
+        }),
+      )
+
+      expect(result.output).toContain("!`RUST_LOG`")
+      expect(result.output).not.toContain("[skill shell")
+      expect(requests.some((r) => r.permission === "bash")).toBe(false)
+    }),
+  )
+
   unix("does not let distant unrelated inline code spans merge into one inert range", () =>
     Effect.gen(function* () {
       // Code spans cannot cross a blank line. Stray double-backticks in an earlier paragraph
@@ -516,6 +538,20 @@ describe("SkillInject.render gating", () => {
     Effect.gen(function* () {
       const out = yield* Effect.promise(() => run({ trusted: true, disabled: false, content: "no commands here" }))
       expect(out).toBe("no commands here")
+    }),
+  )
+
+  it.effect("env-var documentation placeholders stay literal without asking", () =>
+    Effect.gen(function* () {
+      const out = yield* Effect.promise(() =>
+        run({
+          trusted: true,
+          disabled: false,
+          content: "- Make log level configurable via env (!`RUST_LOG` or `EnvFilter`).",
+        }),
+      )
+      expect(out).toContain("!`RUST_LOG`")
+      expect(out).not.toContain("[skill shell")
     }),
   )
 })


### PR DESCRIPTION
## Issue

Fixes #12868

## Context

Trusted skill markdown that documents environment variable names using the `!`VAR`` placeholder syntax (e.g. `!`RUST_LOG``) was incorrectly treated as a live shell command. Loading such a skill requested bash permission on every load even though no command should run.

## Implementation

`SkillInject.render` already skips placeholders inside fenced code blocks and inline code spans. This adds a narrow documentation heuristic: placeholder bodies that are SCREAMING_SNAKE_CASE identifiers (typical env var names) are treated as inert documentation, not executable commands.

Real shell placeholders like `!`printf one`` continue to prompt and execute as before.

## Screenshots / Video

N/A — behavior change is permission-prompt suppression for documentation text; no UI layout change.

| before | after |
|---|---|
| N/A | N/A |

## How to Test

### Manual/local verification

- Not run manually; covered by automated tests below.

### Reviewer test steps

1. Check out this branch.
2. From `packages/opencode`, run:
   `bun test test/kilocode/skills/inject.test.ts --test-name-pattern "env-var"`
3. Confirm both env-var regression tests pass and no bash permission is requested for `!`RUST_LOG`` documentation text.

### Blocked checks and substitute verification

- Full `inject.test.ts` suite: one unrelated pre-existing test (`runs the batch after a single forced approval`) timed out once on a loaded runner; env-var regression tests and the rest of the suite passed on re-run. Targeted env-var tests passed cleanly (2/2).

**Agent-executed verification:**
- `bun test test/kilocode/skills/inject.test.ts --test-name-pattern "env-var"` — 2 pass, 0 fail
- Pre-push hook `bun turbo typecheck` — passed (cached)

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (`@kilocode/cli` patch changeset included)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A