### PR TITLE
fix(vscode): remove invalid $esbuild-watch problem matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
       "command": "bun",
       "args": ["run", "watch:esbuild"],
       "group": "build",
-      "problemMatcher": "$esbuild-watch",
+      "problemMatcher": [],
       "isBackground": true,
       "presentation": {
         "group": "watch",


### PR DESCRIPTION
$esbuild-watch is not a built-in VS Code problem matcher. Causes 'Error: Invalid problemMatcher reference' on folderOpen when workspace is trusted. Use empty array like CLI Watch task.

## Issue

Fixes #N/A (no existing issue — trivial config fix)

## Context

The VS Code extension's "VSCode - ESBuild" watch task referenced `$esbuild-watch` as a problemMatcher. This is not a built-in VS Code problem matcher, causing an error on folder open when the workspace is trusted:

```
Error: Invalid problemMatcher reference: $esbuild-watch
```

The fix removes the invalid matcher, matching the approach used by the "VSCode - CLI Watch" task which also uses an empty array.

## Implementation

Single-line change in `.vscode/tasks.json`: replaced `"problemMatcher": "$esbuild-watch"` with `"problemMatcher": []` for the ESBuild watch task.

No functional change beyond removing the error — esbuild watch errors were not being parsed by VS Code's Problems panel anyway since the custom esbuild output format doesn't match any built-in matcher.

## Screenshots / Video

N/A (config-only change, no visual impact)

## How to Test

### Manual/local verification

- Open the repo in VS Code with workspace trusted
- No "Invalid problemMatcher reference" error appears in the Extension Host output
- Run `bun run watch:esbuild` from packages/kilo-vscode — task starts without matcher error

### Reviewer test steps

1. Clone repo, open in VS Code
2. Trust workspace if prompted
3. Verify no matcher error in Extension Host logs
4. Run "VSCode - ESBuild" task via Command Palette → Tasks: Run Task
5. Confirm task runs as background watch task

### Blocked checks and substitute verification

All CI checks pass (typecheck, lint, tests).

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (not needed — internal config fix)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.