### PR TITLE
fix(cli): dispatch theme.switch command from the openThemes endpoint

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
@@ -49,7 +49,7 @@ export const tuiHandlers = HttpApiBuilder.group(InstanceHttpApi, "tui", (handler
     })
 
     const openThemes = Effect.fn("TuiHttpApi.openThemes")(function* () {
-      yield* publishCommand("session.list")
+      yield* publishCommand("theme.switch")
       return true
     })
 

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -1042,6 +1042,49 @@ describe("HttpApi SDK", () => {
     ),
   )
 
+  serverPathParity("dispatches the theme switch command for SDK openThemes", (serverPath) =>
+    withStandardProject(serverPath, ({ sdk }) =>
+      Effect.gen(function* () {
+        const controller = new AbortController()
+        yield* Effect.addFinalizer(() => Effect.sync(() => controller.abort()))
+        const events = yield* call(() => sdk.event.subscribe(undefined, { signal: controller.signal }))
+        yield* Effect.addFinalizer(() =>
+          call(async () => void (await events.stream.return?.(undefined))).pipe(Effect.ignore),
+        )
+
+        const ready = yield* Deferred.make<void>()
+        const received = yield* Deferred.make<unknown>()
+
+        yield* call(async () => {
+          for await (const event of events.stream) {
+            const payload = record(event).payload ?? event
+            const type = record(payload).type
+            if (type === "server.connected") {
+              Deferred.doneUnsafe(ready, Effect.void)
+              continue
+            }
+            if (type === "tui.command.execute") {
+              Deferred.doneUnsafe(received, Effect.succeed(payload))
+              return
+            }
+          }
+        }).pipe(Effect.forkScoped)
+
+        yield* awaitWithTimeout(Deferred.await(ready), "timed out waiting for /event server.connected", "2 seconds")
+
+        const opened = yield* capture(() => sdk.tui.openThemes())
+        expect(opened.status).toBe(200)
+
+        const event = yield* awaitWithTimeout(
+          Deferred.await(received),
+          "timed out waiting for tui.command.execute over /event",
+          "2 seconds",
+        )
+        expect(record(record(event).properties).command).toBe("theme.switch")
+      }),
+    ),
+  )
+
   serverPathParity("matches generated SDK project git initialization", (serverPath) =>
     withProject(serverPath, {}, ({ sdk, directory }) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Issue

N/A — found by code inspection (no tracking issue).

## Context

`POST /tui/open-themes` (SDK: `tui.openThemes()`) is meant to open the theme picker dialog in an attached TUI. The handler currently publishes the `session.list` command — copy-pasted from the `openSessions` handler directly above it — so any SDK client calling `tui.openThemes()` opens the **session list** instead of the theme picker.

The TUI registers the theme list dialog under the `theme.switch` command (`packages/tui/src/config/keybind.ts`, `packages/tui/src/app.tsx`) and dispatches incoming `tui.command.execute` events verbatim via `keymap.dispatchCommand(evt.properties.command)`, so the endpoint must publish `theme.switch`.

## Implementation

One-line fix: publish `theme.switch` instead of `session.list` in the `openThemes` handler.

Also added a regression test that subscribes to the instance event stream, calls `sdk.tui.openThemes()`, and asserts the dispatched `tui.command.execute` command is `theme.switch`. It fails against the old handler and passes with the fix. The existing SDK parity test only asserted the `true` response body, which is why the wrong command went unnoticed.

## How to Test

### Manual/local verification

- `bun test ./test/server/httpapi-sdk.test.ts` from `packages/opencode/` — 22 pass, 0 fail, including the new regression test.
- Verified the regression test goes red when the handler is reverted to `session.list`.

### Reviewer test steps

- Call `POST /tui/open-themes` (or `sdk.tui.openThemes()`) against a `kilo serve` instance with an attached TUI and confirm the theme picker opens instead of the session list.
