### PR TITLE
fix(agent-manager): handle spawn failures in git-transfer stdin path

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/git-transfer.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-transfer.ts
@@ -38,7 +38,13 @@ function git(args: string[], cwd: string, stdin?: string): Promise<{ code: numbe
       let stderr = ""
       child.stdout.on("data", (d: Buffer) => (stdout += d.toString()))
       child.stderr.on("data", (d: Buffer) => (stderr += d.toString()))
+      // Without an "error" listener a failed spawn (ENOENT/EAGAIN/EMFILE) throws
+      // an uncaught exception in the extension host and leaves this promise pending.
+      child.on("error", (err) => resolve({ code: 1, stdout, stderr: err.message }))
       child.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }))
+      // Ignore EPIPE on stdin when the process failed to spawn or exited early;
+      // the failure is already reported through the "error"/"close" handlers.
+      child.stdin.on("error", () => {})
       child.stdin.end(stdin)
     } else {
       cp.execFile(

--- a/packages/kilo-vscode/tests/unit/git-transfer.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-transfer.test.ts
@@ -103,6 +103,26 @@ describe("git-transfer", () => {
       await fs.rm(target, { recursive: true, force: true }).catch(() => {})
     })
 
+    it("resolves with an error instead of throwing when git cannot be spawned", async () => {
+      // The stdin path of apply() uses cp.spawn; point PATH at an empty
+      // directory so the spawn fails with ENOENT.
+      const originalPath = process.env.PATH
+      const emptyBin = await fs.mkdtemp(path.join(os.tmpdir(), "git-transfer-empty-bin-"))
+      process.env.PATH = emptyBin
+      try {
+        const result = await apply(
+          { branch: "main", head: "deadbeef", unstaged: null, staged: "diff --git a/x b/x\n", untracked: [] },
+          target,
+          noop,
+        )
+        expect(result.ok).toBe(false)
+        expect(result.error).toContain("Staged patch failed")
+      } finally {
+        process.env.PATH = originalPath
+        await fs.rm(emptyBin, { recursive: true, force: true })
+      }
+    })
+
     it("applies unstaged changes", async () => {
       await fs.writeFile(path.join(dir, "init.txt"), "modified\n")
       const snapshot = await capture(dir, noop)


### PR DESCRIPTION
## Issue

N/A — found by code inspection (no tracking issue).

## Context

`git-transfer.ts` powers the Agent Manager's "Continue in Worktree" flow: it captures uncommitted git state as patches and applies them in a fresh worktree. Applying a patch pipes it to `git apply` via `cp.spawn` (the stdin path of the internal `git()` helper).

That spawn branch had no `error` listener on the child process. When `spawn` fails — `git` missing from `PATH`, or `EAGAIN`/`EMFILE` resource exhaustion — Node emits an `error` event on the `ChildProcess`, and with no listener attached the error is **thrown as an uncaught exception in the extension host**. At the same time the returned promise never settles, so the worktree transfer would hang in the "transferring" state even if the exception were swallowed.

Note that the sibling `execFile` branch in the same function already handles spawn failure via its callback, and `services/git/context.ts` registers an `error` listener for the same reason — this branch was simply missed.

## Implementation

- Register `child.on("error", ...)` and resolve with `{ code: 1, stderr: err.message }`, matching the `execFile` branch's error semantics so callers surface a normal "patch failed" error.
- Swallow the resulting `EPIPE` on `child.stdin` (writing to stdin of a process that failed to spawn would otherwise raise a second unhandled error); the actual failure is already reported through the `error`/`close` handlers.
- Added a regression test that applies a staged patch with `PATH` pointed at an empty directory, forcing `spawn` to fail with `ENOENT`. Against the old code the test process dies with the uncaught `ENOENT`; with the fix `apply()` resolves to `{ ok: false, error: "Staged patch failed: ..." }`.

## How to Test

### Manual/local verification

- `bun test tests/unit/git-transfer.test.ts` from `packages/kilo-vscode/` — 16 pass, 0 fail, including the new spawn-failure test.
- Verified the new test crashes against the pre-fix implementation (uncaught `ENOENT` from the spawn path).

### Reviewer test steps

- Temporarily hide `git` from `PATH` (or otherwise make `spawn` fail) and run "Continue in Worktree" on a session with uncommitted changes: the transfer should report a normal failure instead of throwing in the extension host.
