### PR TITLE
docs: add HAI AI provider guide

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/hai.md
+++ b/packages/kilo-docs/pages/ai-providers/hai.md
@@ -1,0 +1,98 @@
+---
+title: "Using HAI with Kilo Code"
+description: "Connect HAI, a Japan-based OpenAI-compatible LLM Inference API with JPY billing, to Kilo Code."
+sidebar_label: HAI
+---
+
+# Using HAI With Kilo Code
+
+HAI is a Japan-based OpenAI-compatible LLM Inference API with fixed JPY pricing. It exposes standard OpenAI Chat Completions and Responses endpoints, so you can use it from Kilo Code via the catalog (after [models.dev](https://models.dev) includes HAI) or as a custom OpenAI-compatible provider.
+
+**Website:** [https://hai.hcloud.ltd](https://hai.hcloud.ltd)  
+**Docs:** [https://hai.hcloud.ltd/docs](https://hai.hcloud.ltd/docs)  
+**API Base:** `https://hai-api.hcloud.ltd/v1`
+
+## Getting an API Key
+
+1. Open the [HAI Console](https://hai.hcloud.ltd/console/).
+2. Sign in and create an API key (`hai_...`).
+3. Copy the key. Store it as `HAI_API_KEY` if you prefer environment variables.
+
+## Supported Models
+
+Examples (see the [HAI docs](https://hai.hcloud.ltd/docs) for the full catalog):
+
+| Model ID | Notes |
+|---|---|
+| `kimi-k2.6` | General purpose (recommended default) |
+| `kimi-k3` | Long context (1M) |
+| `deepseek-v4-flash` | Fast / low cost |
+| `qwen3.6-35b-a3b` | Lightweight MoE |
+| `qwen3.6-35b-a3b-uncensored` | Uncensored MoE |
+| `gemma-4-31b-it` | Multimodal (includes video) |
+
+## Configuration in Kilo Code
+
+{% tabs %}
+{% tab label="VSCode" %}
+
+### Option A — Provider from catalog (after models.dev lists HAI)
+
+1. Open **Settings** → **Providers**.
+2. Select **HAI**.
+3. Paste your API key.
+
+### Option B — Custom OpenAI Compatible provider
+
+1. Open **Settings** → **Providers**.
+2. Click **Custom provider**.
+3. Set:
+   - **Provider API:** OpenAI Compatible
+   - **Base URL:** `https://hai-api.hcloud.ltd/v1`
+   - **API Key:** your `hai_...` key
+   - **Model:** e.g. `kimi-k2.6`
+
+{% /tab %}
+{% tab label="CLI" %}
+
+```bash
+export HAI_API_KEY="hai_..."
+```
+
+```jsonc
+{
+  "provider": {
+    "hai": {
+      "env": ["HAI_API_KEY"],
+      "options": {
+        "baseURL": "https://hai-api.hcloud.ltd/v1"
+      }
+    }
+  }
+}
+```
+
+Or as a custom OpenAI-compatible endpoint:
+
+```jsonc
+{
+  "provider": {
+    "hai-custom": {
+      "npm": "@ai-sdk/openai-compatible",
+      "api": "https://hai-api.hcloud.ltd/v1",
+      "env": ["HAI_API_KEY"]
+    }
+  }
+}
+```
+
+Select `hai/kimi-k2.6` (or your custom provider ID + model) in the model picker.
+
+{% /tab %}
+{% /tabs %}
+
+## Tips
+
+- Pricing is JPY per million tokens; see the [pricing table](https://hai.hcloud.ltd).
+- Auth header is `Authorization: Bearer hai_...`.
+- Base URL must end at `/v1` (do not append `/chat/completions`).

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -37,6 +37,7 @@ Run models on your own hardware for privacy and offline use:
 - **[Anaconda Desktop](/docs/ai-providers/anaconda-desktop)** - Discover and connect to a local text-generation model server
 - **[Ollama](/docs/ai-providers/ollama)** - Easy local model management
 - **[LM Studio](/docs/ai-providers/lmstudio)** - Desktop app for local models
+- **[HAI](/docs/ai-providers/hai)** - Japan-based OpenAI-compatible API (JPY)
 - **[OpenAI Compatible](/docs/ai-providers/openai-compatible)** - Any OpenAI-compatible endpoint
 
 ### AI Gateways


### PR DESCRIPTION
## Summary

Add documentation for **HAI** (https://hai.hcloud.ltd), a Japan-based OpenAI-compatible LLM Inference API with JPY billing.

### Changes

- New page: `packages/kilo-docs/pages/ai-providers/hai.md`
- Linked from the AI providers index

### Connection details

| Field | Value |
|---|---|
| API Base | `https://hai-api.hcloud.ltd/v1` |
| API Key | `hai_...` from https://hai.hcloud.ltd/console/ |
| Env | `HAI_API_KEY` |
| Default model | `kimi-k2.6` |

### Related

- [models.dev PR](https://github.com/anomalyco/models.dev/pull/4411) — native catalog entry so HAI can appear as a first-class provider once merged and generated

Until models.dev lists HAI, users can connect via **Custom provider → OpenAI Compatible** as documented.

## Test plan

- [ ] Docs build includes `/docs/ai-providers/hai`
- [ ] Index link resolves