### PR TITLE
docs(kilo-docs): correct session paths and scope

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
@@ -31,7 +31,7 @@ Selecting a suggestion inserts the mention and highlights it in the input. File 
 
 ### Referencing Past Chats
 
-Choosing **Past chats** from the `@` menu opens a searchable picker of sessions in the current workspace, ordered by recency. Search matches session titles and workspace names. Selecting a session inserts a highlighted mention token; when you send the message, that session's current chat history is added as context so the agent can build on the earlier conversation. Clicking the mention token opens the referenced session.
+Choosing **Past chats** from the `@` menu opens a searchable picker of sessions in the current workspace and related Git worktrees, including Agent Manager worktrees, ordered by recency. Search matches session titles and worktree names. Selecting a session inserts a highlighted mention token; when you send the message, that session's current chat history is added as context so the agent can build on the earlier conversation. Clicking the mention token opens the referenced session.
 
 Very long chat histories are truncated, keeping the beginning and end, so a single mention cannot fill the context window.
 
@@ -77,7 +77,7 @@ This means the agent can explore your entire project as needed, rather than bein
 | **Mention files when helpful** | If you know the exact file, mention its path to save the agent a search step |
 | **Keep editor tabs relevant** | Open tabs are passed as context, so keep relevant files open |
 | **Trust the agent's tools** | The agent can search, read, and explore your codebase — let it do the discovery work |
-| **Reference a past chat** | Type `@` and choose **Past chats** to search sessions in the current workspace. Selecting a session adds its current chat history as context when you send the message. |
+| **Reference a past chat** | Type `@` and choose **Past chats** to search the current workspace and related Git worktrees, including Agent Manager worktrees. Selecting a session adds its current chat history as context when you send the message. |
 
 {% /tab %}
 {% tab label="CLI" %}

--- a/packages/kilo-docs/pages/code-with-ai/agents/session-history.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/session-history.md
@@ -21,9 +21,9 @@ Different search surfaces cover different content and scopes:
 | [JetBrains History](#search-session-history-in-jetbrains) | Session titles | Sessions loaded in the selected Local or Cloud history view |
 | [CLI Past chats](#reference-a-past-chat-in-the-cli-tui) | Session titles | Current workspace |
 | [`kilo session list --search`](#filter-session-titles) | Session titles | Current workspace, or every local workspace with `--all` |
-| [Ask Kilo to recall past chats](#ask-kilo-to-search-past-chats) | Titles and high-signal chat content | Current workspace |
+| [Ask Kilo to recall past chats](#ask-kilo-to-search-past-chats) | Titles and high-signal chat content | Current workspace and related Git worktrees |
 | [VS Code chat search](#search-the-open-chat-session) | Rendered content in the open session | Current chat session |
-| [VS Code Past chats](#add-a-past-chat-to-the-current-session) | Session titles and workspace names | Current workspace |
+| [VS Code Past chats](#add-a-past-chat-to-the-current-session) | Session titles and worktree names | Current workspace and related Git worktrees, including Agent Manager worktrees |
 | [SQLite query](#query-sqlite-directly) | Any stored field you select | Entire selected local database |
 
 History and CLI list searches do **not** search message content. To find a string inside prompts or replies, ask Kilo to search past chats or use a direct SQLite query.
@@ -58,7 +58,7 @@ Kilo loads older messages while the search is active so the search covers the fu
 
 ### Add a past chat to the current session
 
-Type `@` in the chat input, select **Past chats**, and search by session title or workspace name. Selecting a result adds that past chat's content as context when you send the message from your current session. It does not switch or reopen sessions. Past chats includes sessions in the current workspace.
+Type `@` in the chat input, select **Past chats**, and search by session title or worktree name. Selecting a result adds that past chat's content as context when you send the message from your current session. It does not switch or reopen sessions. Past chats includes sessions in the current workspace and related Git worktrees, including Agent Manager worktrees.
 
 {% /tab %}
 {% tab label="JetBrains" %}
@@ -98,7 +98,7 @@ The simplest way to search message content across past local sessions is to ask 
 Search my local sessions for "database disk image is malformed" and summarize the matching conversations.
 ```
 
-Kilo's local recall search covers session titles, user and assistant text, file references, and failed tool errors in the current workspace. Every query term must occur somewhere in a matching session; exact phrases and user-authored matches rank higher.
+Kilo's local recall search covers session titles, user and assistant text, file references, and failed tool errors in the current workspace and related Git worktrees. Every query term must occur somewhere in a matching session; exact phrases and user-authored matches rank higher.
 
 The search includes archived and child sessions. It excludes reasoning, synthetic or ignored text, successful tool output, file contents, and other metadata. Kilo can then read the full chat history for a selected result.
 
@@ -144,8 +144,8 @@ Stable installations normally use these paths:
 
 | Environment | Default path |
 |---|---|
-| Windows | `%LOCALAPPDATA%\kilo\kilo.db` |
-| macOS | `~/Library/Application Support/kilo/kilo.db` |
+| Windows | `%USERPROFILE%\.local\share\kilo\kilo.db` |
+| macOS | `~/.local/share/kilo/kilo.db` |
 | Linux | `~/.local/share/kilo/kilo.db` |
 | VS Code Remote SSH | `~/.local/share/kilo/kilo.db` on the remote machine |
 

--- a/packages/kilo-docs/pages/getting-started/troubleshooting/troubleshooting-extension.md
+++ b/packages/kilo-docs/pages/getting-started/troubleshooting/troubleshooting-extension.md
@@ -33,8 +33,8 @@ The default database location depends on where Kilo Code is running:
 
 | Environment | Database path |
 |---|---|
-| Windows | `%LOCALAPPDATA%\kilo\kilo.db` |
-| macOS | `~/Library/Application Support/kilo/kilo.db` |
+| Windows | `%USERPROFILE%\.local\share\kilo\kilo.db` |
+| macOS | `~/.local/share/kilo/kilo.db` |
 | Linux | `~/.local/share/kilo/kilo.db` |
 | VS Code Remote SSH | `~/.local/share/kilo/kilo.db` on the remote machine |
 


### PR DESCRIPTION
## What

Correct the documented local database paths to match the CLI's XDG-based resolver on Windows and macOS. Clarify that VS Code Past chats and local recall include related Git worktrees, while preserving workspace terminology and the narrower CLI Past chats scope.

## Why

The original session-search guide listed platform-native data directories that the CLI does not use and understated the VS Code picker's worktree-family scope.