### PR TITLE
feat(vscode): improve custom provider dialog and model fetching

### DIFF
--- a/.changeset/custom-provider-edit-improvements.md
+++ b/.changeset/custom-provider-edit-improvements.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+---
+
+Improve custom provider edit dialog sizing, add clickable advanced settings button, support toggling reasoning and images for all models, and support models fetching for Anthropic API.

--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -30,6 +30,7 @@ exclude = [
   '^https?://(cloud|console)\.google\.ai',
   # API endpoint prefixes are valid but return 4xx to plain GET link checks.
   '^https?://ai-gateway\.vercel\.sh/v1/?$',
+  '^https?://api\.anthropic\.com(/v1/models)?/?$',
   '^https?://api\.voyageai\.com/v1/embeddings/?$',
   '^https?://inference\.do-ai\.run/v1/?$',
   '^https?://generativelanguage\.googleapis\.com/v1beta/openai/?$',

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -4,6 +4,10 @@
 
 - <https://accounts.x.ai>
   <!-- packages/opencode/src/plugin/xai.ts -->
+- <https://api.anthropic.com>
+  <!-- packages/kilo-vscode/src/shared/fetch-models.ts -->
+- <https://api.anthropic.com/v1/models>
+  <!-- packages/kilo-vscode/src/shared/fetch-models.ts -->
 - <https://api.apertis.ai/v1>
   <!-- packages/opencode/src/provider/model-cache.ts -->
   <!-- packages/opencode/src/provider/models.ts -->

--- a/packages/kilo-ui/src/components/dialog.css
+++ b/packages/kilo-ui/src/components/dialog.css
@@ -20,18 +20,8 @@
     font-weight: 600;
   }
 
-  &[data-size="large"] [data-slot="dialog-container"] {
-    width: min(calc(100vw - 32px), 800px);
-    height: min(calc(100vh - 32px), 800px);
-  }
-
   &[data-size="large"] [data-slot="dialog-content"] {
     max-width: 800px;
-  }
-
-  &[data-size="x-large"] [data-slot="dialog-container"] {
-    width: min(calc(100vw - 32px), 980px);
-    height: min(calc(100vh - 32px), 850px);
   }
 
   &[data-size="x-large"] [data-slot="dialog-content"] {

--- a/packages/kilo-ui/src/components/dialog.css
+++ b/packages/kilo-ui/src/components/dialog.css
@@ -19,6 +19,24 @@
   [data-slot="dialog-title"] {
     font-weight: 600;
   }
+
+  &[data-size="large"] [data-slot="dialog-container"] {
+    width: min(calc(100vw - 32px), 800px);
+    height: min(calc(100vh - 32px), 800px);
+  }
+
+  &[data-size="large"] [data-slot="dialog-content"] {
+    max-width: 800px;
+  }
+
+  &[data-size="x-large"] [data-slot="dialog-container"] {
+    width: min(calc(100vw - 32px), 980px);
+    height: min(calc(100vh - 32px), 850px);
+  }
+
+  &[data-size="x-large"] [data-slot="dialog-content"] {
+    max-width: 980px;
+  }
 }
 
 [data-component="dialog"][data-fit] [data-slot="dialog-container"] {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -158,7 +158,7 @@ import {
 } from "./provider-actions"
 import type { StoredProviderKey } from "./provider-actions"
 import { AnacondaDesktopBridge } from "./anaconda-desktop/bridge"
-import { fetchOpenAIModels, FetchModelsError } from "./shared/fetch-models"
+import { fetchCustomModels, FetchModelsError } from "./shared/fetch-models"
 import type { Agent } from "@kilocode/sdk/v2/client"
 import { configFeatures } from "./features"
 import { fetchSnapshot } from "./kilo-provider/config-snapshot"
@@ -2457,12 +2457,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private async handleFetchCustomProviderModels(msg: Record<string, unknown>): Promise<void> {
     const rid = typeof msg.requestId === "string" ? msg.requestId : ""
     const url = typeof msg.baseURL === "string" ? msg.baseURL : ""
+    const npm = typeof msg.npm === "string" ? msg.npm : undefined
     if (!rid || !url) return
     const key =
       typeof msg.apiKey === "string" ? msg.apiKey : resolveStoredKey(this.storedProviderKeys, msg.providerID, url)
     const headers = msg.headers && typeof msg.headers === "object" ? (msg.headers as Record<string, string>) : undefined
     try {
-      const models = await fetchOpenAIModels({ baseURL: url, apiKey: key, headers })
+      const models = await fetchCustomModels({ npm, baseURL: url, apiKey: key, headers })
       this.postMessage({ type: "customProviderModelsFetched", requestId: rid, models })
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to fetch models"

--- a/packages/kilo-vscode/src/shared/fetch-models.ts
+++ b/packages/kilo-vscode/src/shared/fetch-models.ts
@@ -1,15 +1,15 @@
 /**
- * Fetch available models from an OpenAI-compatible /models endpoint.
+ * Fetch available models from an OpenAI-compatible or Anthropic /models endpoint.
  * Runs in the extension host — no CLI backend dependency.
  */
 
-type Options = {
+export type Options = {
   baseURL: string
   apiKey?: string
   headers?: Record<string, string>
 }
 
-type ModelEntry = {
+export type ModelEntry = {
   id: string
   name: string
 }
@@ -63,4 +63,126 @@ export async function fetchOpenAIModels(opts: Options): Promise<ModelEntry[]> {
   }
   result.sort((a, b) => a.id.localeCompare(b.id))
   return result
+}
+
+function resolveAnthropicURL(baseURL: string) {
+  const base = baseURL.replace(/\/+$/, "")
+  let path = base
+  if (path.endsWith("/messages")) {
+    path = path.slice(0, -9).replace(/\/+$/, "")
+  }
+  if (path.endsWith("/models")) {
+    // already ends with /models
+  } else if (path.endsWith("/v1")) {
+    path = `${path}/models`
+  } else if (path === "https://api.anthropic.com") {
+    path = "https://api.anthropic.com/v1/models"
+  } else {
+    path = `${path}/models`
+  }
+
+  const urlObj = new URL(path)
+  if (!urlObj.searchParams.has("limit")) {
+    urlObj.searchParams.set("limit", "1000")
+  }
+  return { base, url: urlObj.toString() }
+}
+
+function parseAnthropicError(text: string, status: number) {
+  try {
+    const parsed = JSON.parse(text)
+    if (typeof parsed?.error?.message === "string") {
+      return parsed.error.message
+    }
+  } catch {
+    // ignore non-json error responses
+  }
+  return `HTTP ${status}: ${text.slice(0, 200)}`
+}
+
+function parseAnthropicItems(items: unknown) {
+  if (!Array.isArray(items)) return []
+  const seen = new Set<string>()
+  const result: ModelEntry[] = []
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue
+    const obj = item as { id?: string; name?: string; display_name?: string }
+    const id = typeof obj.id === "string" ? obj.id.trim() : ""
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const name =
+      typeof obj.display_name === "string" && obj.display_name.trim()
+        ? obj.display_name.trim()
+        : typeof obj.name === "string" && obj.name.trim()
+          ? obj.name.trim()
+          : id
+    result.push({ id, name })
+  }
+  result.sort((a, b) => a.id.localeCompare(b.id))
+  return result
+}
+
+/**
+ * Fetch available models from an Anthropic /models endpoint.
+ * Supports api.anthropic.com as well as Anthropic-compatible proxies and gateways.
+ */
+export async function fetchAnthropicModels(opts: Options): Promise<ModelEntry[]> {
+  const { base, url } = resolveAnthropicURL(opts.baseURL)
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "anthropic-version": "2023-06-01",
+    ...opts.headers,
+  }
+  if (opts.apiKey) {
+    headers["x-api-key"] = opts.apiKey
+  }
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(15_000),
+    })
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : "Network request failed"
+    throw new FetchModelsError(msg)
+  }
+
+  if (response.status === 404 && !base.includes("/v1")) {
+    const fallbackUrl = new URL(`${base}/v1/models`)
+    fallbackUrl.searchParams.set("limit", "1000")
+    const fallbackRes = await fetch(fallbackUrl.toString(), {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(15_000),
+    }).catch(() => null)
+    if (fallbackRes?.ok) {
+      response = fallbackRes
+    }
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "")
+    throw new FetchModelsError(parseAnthropicError(text, response.status), response.status)
+  }
+
+  const body = (await response.json()) as {
+    data?: unknown
+    models?: unknown
+  }
+  const items = Array.isArray(body?.data) ? body.data : Array.isArray(body?.models) ? body.models : []
+  return parseAnthropicItems(items)
+}
+
+export type CustomModelsOptions = Options & {
+  npm?: string
+}
+
+export async function fetchCustomModels(opts: CustomModelsOptions): Promise<ModelEntry[]> {
+  if (opts.npm === "@ai-sdk/anthropic") {
+    return fetchAnthropicModels(opts)
+  }
+  return fetchOpenAIModels(opts)
 }

--- a/packages/kilo-vscode/src/shared/fetch-models.ts
+++ b/packages/kilo-vscode/src/shared/fetch-models.ts
@@ -153,13 +153,15 @@ export async function fetchAnthropicModels(opts: Options): Promise<ModelEntry[]>
   if (response.status === 404 && !base.includes("/v1")) {
     const fallbackUrl = new URL(`${base}/v1/models`)
     fallbackUrl.searchParams.set("limit", "1000")
-    const fallbackRes = await fetch(fallbackUrl.toString(), {
-      method: "GET",
-      headers,
-      signal: AbortSignal.timeout(15_000),
-    }).catch(() => null)
-    if (fallbackRes?.ok) {
-      response = fallbackRes
+    if (fallbackUrl.toString() !== url) {
+      const fallbackRes = await fetch(fallbackUrl.toString(), {
+        method: "GET",
+        headers,
+        signal: AbortSignal.timeout(15_000),
+      }).catch(() => null)
+      if (fallbackRes?.ok) {
+        response = fallbackRes
+      }
     }
   }
 

--- a/packages/kilo-vscode/tests/unit/custom-provider.test.ts
+++ b/packages/kilo-vscode/tests/unit/custom-provider.test.ts
@@ -118,7 +118,7 @@ describe("sanitizeCustomProviderConfig", () => {
       models: { "model-1": { name: "Model One" } },
     })
 
-    expect("error" in result ? result.error : "").toContain("Invalid enum value")
+    expect("error" in result ? result.error : "").toMatch(/Invalid (enum value|option)/)
   })
 
   it("accepts supported thinking variant options", () => {

--- a/packages/kilo-vscode/tests/unit/fetch-models.test.ts
+++ b/packages/kilo-vscode/tests/unit/fetch-models.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import {
+  FetchModelsError,
+  fetchAnthropicModels,
+  fetchCustomModels,
+  fetchOpenAIModels,
+} from "../../src/shared/fetch-models"
+
+describe("fetch-models", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  describe("fetchOpenAIModels", () => {
+    it("fetches and parses models from OpenAI compatible endpoint", async () => {
+      let requestedURL = ""
+      let requestedHeaders: Record<string, string> = {}
+
+      globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+        requestedURL = url.toString()
+        requestedHeaders = (init?.headers ?? {}) as Record<string, string>
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: "gpt-4o-mini", name: "GPT-4o Mini" },
+              { id: "gpt-4o", name: "GPT-4o" },
+              { id: "gpt-4o" }, // duplicate
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      }) as typeof fetch
+
+      const result = await fetchOpenAIModels({
+        baseURL: "https://api.openai.com/v1/",
+        apiKey: "sk-test-key",
+        headers: { "X-Custom": "custom-val" },
+      })
+
+      expect(requestedURL).toBe("https://api.openai.com/v1/models")
+      expect(requestedHeaders["Authorization"]).toBe("Bearer sk-test-key")
+      expect(requestedHeaders["X-Custom"]).toBe("custom-val")
+      expect(result).toEqual([
+        { id: "gpt-4o", name: "GPT-4o" },
+        { id: "gpt-4o-mini", name: "GPT-4o Mini" },
+      ])
+    })
+
+    it("throws FetchModelsError on HTTP error with auth detection", async () => {
+      globalThis.fetch = (async () => {
+        return new Response("Unauthorized", { status: 401 })
+      }) as typeof fetch
+
+      let caught: unknown
+      try {
+        await fetchOpenAIModels({ baseURL: "https://api.example.com/v1", apiKey: "bad-key" })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught instanceof FetchModelsError).toBe(true)
+      expect((caught as FetchModelsError).auth).toBe(true)
+      expect((caught as FetchModelsError).status).toBe(401)
+    })
+  })
+
+  describe("fetchAnthropicModels", () => {
+    it("fetches and parses models from Anthropic API with display_name", async () => {
+      let requestedURL = ""
+      let requestedHeaders: Record<string, string> = {}
+
+      globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+        requestedURL = url.toString()
+        requestedHeaders = (init?.headers ?? {}) as Record<string, string>
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: "claude-3-7-sonnet-20250219", display_name: "Claude 3.7 Sonnet" },
+              { id: "claude-3-5-haiku-20241022", display_name: "Claude 3.5 Haiku" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      }) as typeof fetch
+
+      const result = await fetchAnthropicModels({
+        baseURL: "https://api.anthropic.com",
+        apiKey: "sk-ant-test",
+        headers: { "anthropic-beta": "output-128k-2025-02-19" },
+      })
+
+      expect(requestedURL).toBe("https://api.anthropic.com/v1/models?limit=1000")
+      expect(requestedHeaders["x-api-key"]).toBe("sk-ant-test")
+      expect(requestedHeaders["anthropic-version"]).toBe("2023-06-01")
+      expect(requestedHeaders["anthropic-beta"]).toBe("output-128k-2025-02-19")
+      expect(result).toEqual([
+        { id: "claude-3-5-haiku-20241022", name: "Claude 3.5 Haiku" },
+        { id: "claude-3-7-sonnet-20250219", name: "Claude 3.7 Sonnet" },
+      ])
+    })
+
+    it("normalizes /v1 and /messages in base URLs", async () => {
+      let requestedURL = ""
+
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        requestedURL = url.toString()
+        return new Response(JSON.stringify({ data: [{ id: "claude-3-haiku" }] }), { status: 200 })
+      }) as typeof fetch
+
+      await fetchAnthropicModels({ baseURL: "https://custom-proxy.com/v1/messages" })
+      expect(requestedURL).toBe("https://custom-proxy.com/v1/models?limit=1000")
+    })
+
+    it("extracts error message from Anthropic error response", async () => {
+      globalThis.fetch = (async () => {
+        return new Response(
+          JSON.stringify({
+            type: "error",
+            error: {
+              type: "authentication_error",
+              message: "invalid x-api-key",
+            },
+          }),
+          { status: 401 },
+        )
+      }) as typeof fetch
+
+      let caught: unknown
+      try {
+        await fetchAnthropicModels({ baseURL: "https://api.anthropic.com", apiKey: "bad" })
+      } catch (err) {
+        caught = err
+      }
+
+      expect(caught instanceof FetchModelsError).toBe(true)
+      expect((caught as FetchModelsError).message).toBe("invalid x-api-key")
+      expect((caught as FetchModelsError).auth).toBe(true)
+    })
+  })
+
+  describe("fetchCustomModels", () => {
+    it("routes @ai-sdk/anthropic to fetchAnthropicModels", async () => {
+      let requestedHeaders: Record<string, string> = {}
+
+      globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+        requestedHeaders = (init?.headers ?? {}) as Record<string, string>
+        return new Response(JSON.stringify({ data: [{ id: "claude-3-5-sonnet" }] }), { status: 200 })
+      }) as typeof fetch
+
+      await fetchCustomModels({
+        npm: "@ai-sdk/anthropic",
+        baseURL: "https://api.anthropic.com",
+        apiKey: "ant-key",
+      })
+
+      expect(requestedHeaders["x-api-key"]).toBe("ant-key")
+      expect(requestedHeaders["anthropic-version"]).toBe("2023-06-01")
+    })
+
+    it("routes other packages to fetchOpenAIModels", async () => {
+      let requestedHeaders: Record<string, string> = {}
+
+      globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+        requestedHeaders = (init?.headers ?? {}) as Record<string, string>
+        return new Response(JSON.stringify({ data: [{ id: "gpt-4o" }] }), { status: 200 })
+      }) as typeof fetch
+
+      await fetchCustomModels({
+        npm: "@ai-sdk/openai-compatible",
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "oai-key",
+      })
+
+      expect(requestedHeaders["Authorization"]).toBe("Bearer oai-key")
+    })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
@@ -232,6 +232,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     const npm = fetchPackage()
     const url = fetchURL()
     const key = fetchKey()
+    void npm // subscribe to package changes
     void key // subscribe to key changes without using the value here
 
     // Clear previous results whenever URL or key changes
@@ -240,7 +241,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     setFetchStatus(undefined)
     setSearch("")
 
-    if (npm === "@ai-sdk/anthropic" || !/^https?:\/\//.test(url.trim())) return
+    if (!/^https?:\/\//.test(url.trim())) return
 
     fetchVersion++
     const version = fetchVersion
@@ -322,6 +323,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     vscode.postMessage({
       type: "fetchCustomProviderModels",
       requestId: rid,
+      npm: fetchPackage(),
       baseURL: url,
       apiKey,
       providerID,
@@ -451,6 +453,18 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
     setErrors("models", (v) => v.filter((_, i) => i !== index))
   }
 
+  function toggleAllReasoning() {
+    const all = form.models.every((m) => m.reasoning)
+    const next = !all
+    form.models.forEach((_, i) => setForm("models", i, "reasoning", next))
+  }
+
+  function toggleAllSupportsImages() {
+    const all = form.models.every((m) => m.supportsImages)
+    const next = !all
+    form.models.forEach((_, i) => setForm("models", i, "supportsImages", next))
+  }
+
   function addHeader() {
     setForm("headers", (v) => [...v, { key: "", value: "" }])
     setErrors("headers", (v) => [...v, {}])
@@ -524,6 +538,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
           aria-label={language.t("common.goBack")}
         />
       }
+      size="large"
       transition
     >
       <div
@@ -533,7 +548,7 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
           gap: "24px",
           padding: "0 10px 12px 10px",
           "overflow-y": "auto",
-          "max-height": "60vh",
+          "max-height": "calc(85vh - 70px)",
         }}
       >
         <div style={{ padding: "0 10px", display: "flex", gap: "16px", "align-items": "center" }}>
@@ -560,21 +575,26 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
                   url: "https://kilo.ai/docs/ai-providers#custom-provider",
                 })
               }}
+              style={{
+                color: "var(--vscode-textLink-foreground)",
+                "text-decoration": "underline",
+                cursor: "pointer",
+              }}
             >
               {language.t("provider.custom.description.link")}
             </a>
             {language.t("provider.custom.description.suffix")}
             <Show when={editing()}>
-              <div style={{ "margin-top": "8px" }}>
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    vscode.postMessage(configMessage("global", language.t))
-                  }}
+              <div style={{ "margin-top": "12px" }}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="small"
+                  icon="edit"
+                  onClick={() => vscode.postMessage(configMessage("global", language.t))}
                 >
                   {language.t("provider.custom.edit.advanced")}
-                </a>
+                </Button>
               </div>
             </Show>
           </div>
@@ -651,18 +671,38 @@ const CustomProviderDialog = (props: CustomProviderDialogProps) => {
 
           {/* Models */}
           <div style={{ display: "flex", "flex-direction": "column", gap: "12px" }}>
-            <div style={{ display: "flex", "align-items": "center", gap: "8px" }}>
-              <label
-                style={{
-                  "font-size": "var(--kilo-font-size-12)",
-                  "font-weight": "500",
-                  color: "var(--text-weak-base)",
-                }}
-              >
-                {language.t("provider.custom.models.label")}
-              </label>
-              <Show when={fetching()}>
-                <Spinner style={{ width: "12px", height: "12px" }} />
+            <div
+              style={{
+                display: "flex",
+                "align-items": "center",
+                "justify-content": "space-between",
+                "flex-wrap": "wrap",
+                gap: "8px",
+              }}
+            >
+              <div style={{ display: "flex", "align-items": "center", gap: "8px" }}>
+                <label
+                  style={{
+                    "font-size": "var(--kilo-font-size-12)",
+                    "font-weight": "500",
+                    color: "var(--text-weak-base)",
+                  }}
+                >
+                  {language.t("provider.custom.models.label")}
+                </label>
+                <Show when={fetching()}>
+                  <Spinner style={{ width: "12px", height: "12px" }} />
+                </Show>
+              </div>
+              <Show when={form.models.length > 0}>
+                <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap" }}>
+                  <Button type="button" size="small" variant="secondary" icon="brain" onClick={toggleAllReasoning}>
+                    {language.t("provider.custom.models.toggleReasoning")}
+                  </Button>
+                  <Button type="button" size="small" variant="secondary" icon="photo" onClick={toggleAllSupportsImages}>
+                    {language.t("provider.custom.models.toggleImages")}
+                  </Button>
+                </div>
               </Show>
             </div>
             <For each={form.models}>

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -445,6 +445,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "صورة",
   "provider.custom.models.remove": "إزالة النموذج",
   "provider.custom.models.add": "إضافة نموذج",
+  "provider.custom.models.toggleReasoning": "تبديل التفكير للجميع",
+  "provider.custom.models.toggleImages": "تبديل الصور للجميع",
   "provider.custom.models.fetch.authError": "فشلت المصادقة. تحقق من مفتاح API أعلاه وحاول مرة أخرى.",
   "provider.custom.models.fetch.empty": "لم يتم العثور على نماذج على هذا الخادم.",
   "provider.custom.models.fetch.added": "تمت إضافة {{count}} نموذج(نماذج).",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -456,6 +456,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Imagem",
   "provider.custom.models.remove": "Remover modelo",
   "provider.custom.models.add": "Adicionar modelo",
+  "provider.custom.models.toggleReasoning": "Alternar raciocínio para todos",
+  "provider.custom.models.toggleImages": "Alternar imagens para todos",
   "provider.custom.models.fetch.authError": "Falha na autenticação. Verifique a chave de API acima e tente novamente.",
   "provider.custom.models.fetch.empty": "Nenhum modelo encontrado neste servidor.",
   "provider.custom.models.fetch.added": "{{count}} modelo(s) adicionado(s).",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -498,6 +498,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Slika",
   "provider.custom.models.remove": "Ukloni model",
   "provider.custom.models.add": "Dodaj model",
+  "provider.custom.models.toggleReasoning": "Prebaci rezonovanje za sve",
+  "provider.custom.models.toggleImages": "Prebaci slike za sve",
   "provider.custom.models.fetch.authError":
     "Autentifikacija nije uspjela. Provjerite API ključ iznad i pokušajte ponovo.",
   "provider.custom.models.fetch.empty": "Nisu pronađeni modeli na ovom serveru.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -496,6 +496,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Billede",
   "provider.custom.models.remove": "Fjern model",
   "provider.custom.models.add": "Tilføj model",
+  "provider.custom.models.toggleReasoning": "Slå ræsonnering til/fra for alle",
+  "provider.custom.models.toggleImages": "Slå billeder til/fra for alle",
   "provider.custom.models.fetch.authError": "Godkendelse mislykkedes. Kontrollér API-nøglen ovenfor, og prøv igen.",
   "provider.custom.models.fetch.empty": "Ingen modeller fundet på denne server.",
   "provider.custom.models.fetch.added": "{{count}} model(ler) tilføjet.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -506,6 +506,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Bild",
   "provider.custom.models.remove": "Modell entfernen",
   "provider.custom.models.add": "Modell hinzufügen",
+  "provider.custom.models.toggleReasoning": "Reasoning für alle umschalten",
+  "provider.custom.models.toggleImages": "Bilder für alle umschalten",
   "provider.custom.models.fetch.authError":
     "Authentifizierung fehlgeschlagen. Überprüfen Sie den API-Schlüssel oben und versuchen Sie es erneut.",
   "provider.custom.models.fetch.empty": "Keine Modelle auf diesem Server gefunden.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -410,6 +410,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Image",
   "provider.custom.models.remove": "Remove model",
   "provider.custom.models.add": "Add model",
+  "provider.custom.models.toggleReasoning": "Toggle reasoning for all",
+  "provider.custom.models.toggleImages": "Toggle images for all",
   "provider.custom.models.fetch.authError": "Authentication failed. Check the API key above and try again.",
   "provider.custom.models.fetch.empty": "No models found on this server.",
   "provider.custom.models.fetch.added": "Added {{count}} model(s).",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -499,6 +499,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Imagen",
   "provider.custom.models.remove": "Eliminar modelo",
   "provider.custom.models.add": "Añadir modelo",
+  "provider.custom.models.toggleReasoning": "Alternar razonamiento para todos",
+  "provider.custom.models.toggleImages": "Alternar imágenes para todos",
   "provider.custom.models.fetch.authError":
     "Autenticación fallida. Verifica la clave de API arriba e intenta de nuevo.",
   "provider.custom.models.fetch.empty": "No se encontraron modelos en este servidor.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -411,6 +411,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "تصویر",
   "provider.custom.models.remove": "حذف مدل",
   "provider.custom.models.add": "افزودن مدل",
+  "provider.custom.models.toggleReasoning": "تغییر وضعیت استدلال برای همه",
+  "provider.custom.models.toggleImages": "تغییر وضعیت تصویر برای همه",
   "provider.custom.models.fetch.authError": "احراز هویت ناموفق بود. کلید API بالا را بررسی کرده و دوباره امتحان کنید.",
   "provider.custom.models.fetch.empty": "هیچ مدلی در این سرور یافت نشد.",
   "provider.custom.models.fetch.added": "{{count}} مدل اضافه شد.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -500,6 +500,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Image",
   "provider.custom.models.remove": "Supprimer le modèle",
   "provider.custom.models.add": "Ajouter un modèle",
+  "provider.custom.models.toggleReasoning": "Basculer le raisonnement pour tous",
+  "provider.custom.models.toggleImages": "Basculer les images pour tous",
   "provider.custom.models.fetch.authError": "Échec de l'authentification. Vérifiez la clé API ci-dessus et réessayez.",
   "provider.custom.models.fetch.empty": "Aucun modèle trouvé sur ce serveur.",
   "provider.custom.models.fetch.added": "{{count}} modèle(s) ajouté(s).",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -320,6 +320,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Immagine",
   "provider.custom.models.remove": "Rimuovi modello",
   "provider.custom.models.add": "Aggiungi modello",
+  "provider.custom.models.toggleReasoning": "Attiva/disattiva ragionamento per tutti",
+  "provider.custom.models.toggleImages": "Attiva/disattiva immagini per tutti",
   "provider.custom.models.fetch.authError": "Autenticazione non riuscita. Controlla l'API key sopra e riprova.",
   "provider.custom.models.fetch.empty": "Nessun modello trovato su questo server.",
   "provider.custom.models.fetch.added": "Aggiunti {{count}} modelli.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -492,6 +492,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "画像",
   "provider.custom.models.remove": "モデルを削除",
   "provider.custom.models.add": "モデルを追加",
+  "provider.custom.models.toggleReasoning": "すべての推論を切り替え",
+  "provider.custom.models.toggleImages": "すべての画像を切り替え",
   "provider.custom.models.fetch.authError": "認証に失敗しました。上記のAPIキーを確認して再試行してください。",
   "provider.custom.models.fetch.empty": "このサーバーにモデルが見つかりません。",
   "provider.custom.models.fetch.added": "{{count}}個のモデルを追加しました。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -453,6 +453,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "이미지",
   "provider.custom.models.remove": "모델 제거",
   "provider.custom.models.add": "모델 추가",
+  "provider.custom.models.toggleReasoning": "모든 모델 추론 토글",
+  "provider.custom.models.toggleImages": "모든 모델 이미지 토글",
   "provider.custom.models.fetch.authError": "인증에 실패했습니다. 위의 API 키를 확인하고 다시 시도하세요.",
   "provider.custom.models.fetch.empty": "이 서버에서 모델을 찾을 수 없습니다.",
   "provider.custom.models.fetch.added": "{{count}}개 모델이 추가되었습니다.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -449,6 +449,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Afbeelding",
   "provider.custom.models.remove": "Model verwijderen",
   "provider.custom.models.add": "Model toevoegen",
+  "provider.custom.models.toggleReasoning": "Redeneren voor alle modellen wisselen",
+  "provider.custom.models.toggleImages": "Afbeeldingen voor alle modellen wisselen",
   "provider.custom.models.fetch.authError":
     "Authenticatie mislukt. Controleer de API-sleutel hierboven en probeer het opnieuw.",
   "provider.custom.models.fetch.empty": "Geen modellen gevonden op deze server.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -459,6 +459,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Bilde",
   "provider.custom.models.remove": "Fjern modell",
   "provider.custom.models.add": "Legg til modell",
+  "provider.custom.models.toggleReasoning": "Slå resonnering av/på for alle",
+  "provider.custom.models.toggleImages": "Slå bilder av/på for alle",
   "provider.custom.models.fetch.authError": "Autentisering mislyktes. Sjekk API-nøkkelen ovenfor og prøv igjen.",
   "provider.custom.models.fetch.empty": "Ingen modeller funnet på denne serveren.",
   "provider.custom.models.fetch.added": "{{count}} modell(er) lagt til.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -454,6 +454,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Obraz",
   "provider.custom.models.remove": "Usuń model",
   "provider.custom.models.add": "Dodaj model",
+  "provider.custom.models.toggleReasoning": "Przełącz rozumowanie dla wszystkich",
+  "provider.custom.models.toggleImages": "Przełącz obrazy dla wszystkich",
   "provider.custom.models.fetch.authError":
     "Uwierzytelnianie nie powiodło się. Sprawdź klucz API powyżej i spróbuj ponownie.",
   "provider.custom.models.fetch.empty": "Nie znaleziono modeli na tym serwerze.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -493,6 +493,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Изображение",
   "provider.custom.models.remove": "Удалить модель",
   "provider.custom.models.add": "Добавить модель",
+  "provider.custom.models.toggleReasoning": "Переключить рассуждения для всех",
+  "provider.custom.models.toggleImages": "Переключить изображения для всех",
   "provider.custom.models.fetch.authError": "Ошибка аутентификации. Проверьте API-ключ выше и попробуйте снова.",
   "provider.custom.models.fetch.empty": "На этом сервере модели не найдены.",
   "provider.custom.models.fetch.added": "Добавлено {{count}} модель(ей).",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -490,6 +490,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "รูปภาพ",
   "provider.custom.models.remove": "ลบโมเดล",
   "provider.custom.models.add": "เพิ่มโมเดล",
+  "provider.custom.models.toggleReasoning": "สลับการให้เหตุผลสำหรับทุกโมเดล",
+  "provider.custom.models.toggleImages": "สลับรูปภาพสำหรับทุกโมเดล",
   "provider.custom.models.fetch.authError": "การยืนยันตัวตนล้มเหลว ตรวจสอบคีย์ API ด้านบนแล้วลองอีกครั้ง",
   "provider.custom.models.fetch.empty": "ไม่พบโมเดลบนเซิร์ฟเวอร์นี้",
   "provider.custom.models.fetch.added": "เพิ่มแล้ว {{count}} โมเดล",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -444,6 +444,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Görüntü",
   "provider.custom.models.remove": "Modeli kaldır",
   "provider.custom.models.add": "Model ekle",
+  "provider.custom.models.toggleReasoning": "Tüm modeller için akıl yürütmeyi aç/kapat",
+  "provider.custom.models.toggleImages": "Tüm modeller için görselleri aç/kapat",
   "provider.custom.models.fetch.authError":
     "Kimlik doğrulama başarısız oldu. Yukarıdaki API anahtarını kontrol edin ve tekrar deneyin.",
   "provider.custom.models.fetch.empty": "Bu sunucuda model bulunamadı.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -448,6 +448,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "Зображення",
   "provider.custom.models.remove": "Видалити модель",
   "provider.custom.models.add": "Додати модель",
+  "provider.custom.models.toggleReasoning": "Перемкнути міркування для всіх",
+  "provider.custom.models.toggleImages": "Перемкнути зображення для всіх",
   "provider.custom.models.fetch.authError": "Автентифікація не вдалася. Перевірте API-ключ вище і спробуйте ще раз.",
   "provider.custom.models.fetch.empty": "На цьому сервері моделей не знайдено.",
   "provider.custom.models.fetch.added": "Додано {{count}} моделей.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -475,6 +475,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "图片",
   "provider.custom.models.remove": "移除模型",
   "provider.custom.models.add": "添加模型",
+  "provider.custom.models.toggleReasoning": "切换所有模型的推理",
+  "provider.custom.models.toggleImages": "切换所有模型的图像支持",
   "provider.custom.models.fetch.authError": "认证失败。请检查上方的 API 密钥后重试。",
   "provider.custom.models.fetch.empty": "此服务器上未找到模型。",
   "provider.custom.models.fetch.added": "已添加 {{count}} 个模型。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -435,6 +435,8 @@ export const dict = {
   "provider.custom.models.modalities.image": "圖片",
   "provider.custom.models.remove": "移除模型",
   "provider.custom.models.add": "新增模型",
+  "provider.custom.models.toggleReasoning": "切換所有模型的推理",
+  "provider.custom.models.toggleImages": "切換所有模型的圖像支援",
   "provider.custom.models.fetch.authError": "驗證失敗。請檢查上方的 API 金鑰後重試。",
   "provider.custom.models.fetch.empty": "此伺服器上未找到模型。",
   "provider.custom.models.fetch.added": "已新增 {{count}} 個模型。",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -1,3 +1,4 @@
+import type { CustomProviderPackage } from "../../../../src/shared/provider-model"
 import type { InstallMarketplaceItemOptions, MarketplaceFilters, MarketplaceItem } from "../marketplace"
 import type { FileAttachment } from "./parts"
 import type { MessageLoadMode } from "./sessions"
@@ -1231,6 +1232,7 @@ export interface SaveCustomProviderMessage {
 export interface FetchCustomProviderModelsMessage {
   type: "fetchCustomProviderModels"
   requestId: string
+  npm?: CustomProviderPackage
   baseURL: string
   apiKey?: string
   /**


### PR DESCRIPTION
## Summary
- Expand custom provider edit dialog sizing to `large` (up to 800px width and comfortable vertical height) so it uses available space around the dialog.
- Make the advanced settings entry in the custom provider dialog an explicitly styled secondary button with an edit icon for clear clickability.
- Add "Toggle reasoning for all" and "Toggle images for all" buttons in the custom provider models section.
- Add support for fetching models from Anthropic-compatible endpoints (`@ai-sdk/anthropic`), including URL normalization and proper `anthropic-version` and `x-api-key` headers.

## Verification
- `bun test tests/unit/fetch-models.test.ts` passes.
- `bun test tests/unit/custom-provider.test.ts` passes.
- `bun test tests/unit/custom-provider-dialog-validate.test.ts` passes.
- `bun turbo typecheck` and extension lint checks pass.