### PR TITLE
fix(vscode): keep session errors visible

### DIFF
--- a/.changeset/show-vscode-session-errors.md
+++ b/.changeset/show-vscode-session-errors.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep model and provider errors visible in VS Code when chat history refreshes.

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -450,7 +450,7 @@ export type WebviewMessage =
   | { type: "sessionUpdated"; session: ReturnType<typeof sessionToWebview> }
   | { type: "sessionDeleted"; sessionID: string }
   | { type: "messageRemoved"; sessionID: string; messageID: string }
-  | { type: "sessionError"; sessionID?: string; error?: unknown }
+  | { type: "sessionError"; eventID: string; sessionID?: string; error?: unknown }
   | {
       type: "sandboxStatus"
       sessionID: string
@@ -620,6 +620,7 @@ export function mapSSEEventToWebviewMessage(event: StreamEvent, sessionID: strin
     case "session.error": {
       return {
         type: "sessionError",
+        eventID: event.id,
         sessionID: event.properties.sessionID,
         error: event.properties.error,
       }

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -21,6 +21,7 @@ import type {
   Event,
   EventSessionStatus,
   EventSessionTurnClose,
+  EventSessionError,
   EventSandboxStatusChanged,
   EventPermissionAsked,
   EventPermissionReplied,
@@ -373,6 +374,30 @@ describe("mapSSEEventToWebviewMessage", () => {
     }
     const msg = mapSSEEventToWebviewMessage(event, "sess-1")
     expect(msg).toEqual({ type: "sessionTurnClosed", sessionID: "sess-1", reason: "interrupted" })
+  })
+
+  it("maps session errors with their event identity and message", () => {
+    const event: EventSessionError = {
+      id: "evt-error",
+      type: "session.error",
+      properties: {
+        sessionID: "sess-1",
+        error: {
+          name: "APIError",
+          data: {
+            message: "prompt_cache_breakpoint is not supported on this model",
+            isRetryable: false,
+          },
+        },
+      },
+    }
+
+    expect(mapSSEEventToWebviewMessage(event, "sess-1")).toEqual({
+      type: "sessionError",
+      eventID: "evt-error",
+      sessionID: "sess-1",
+      error: event.properties.error,
+    })
   })
 
   it("maps permission.asked to permissionRequest", () => {

--- a/packages/kilo-vscode/tests/unit/session-errors.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-errors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test"
-import { errorIDs, visibleError } from "../../webview-ui/src/context/session-errors"
+import {
+  errorIDs,
+  preserveSessionErrors,
+  visibleError,
+  withoutResolvedSessionErrors,
+} from "../../webview-ui/src/context/session-errors"
 import type { Message } from "../../webview-ui/src/types/messages"
 
 const base = {
@@ -43,5 +48,34 @@ describe("visibleError", () => {
     const messages = [assistant("message_1", { name: "MessageAbortedError" })]
 
     expect(visibleError(messages, () => false)).toBeUndefined()
+  })
+})
+
+describe("session error reconciliation", () => {
+  const error = {
+    name: "APIError",
+    data: { message: "prompt_cache_breakpoint is not supported on this model", isRetryable: false },
+  }
+
+  it("preserves transient errors across stale history replacements", () => {
+    const user = { ...base, id: "message_1", role: "user" as const }
+    const transient = { ...assistant("message_2", error), parentID: user.id, sessionErrorID: "event_1" }
+
+    expect(preserveSessionErrors([user, transient], [user])).toEqual([user, transient])
+  })
+
+  it("replaces a transient error with its persisted assistant message", () => {
+    const transient = { ...assistant("message_2", error), parentID: "message_1", sessionErrorID: "event_1" }
+    const persisted = { ...assistant("message_3", error), parentID: "message_1" }
+
+    expect(preserveSessionErrors([transient], [persisted])).toEqual([persisted])
+    expect(withoutResolvedSessionErrors([transient], [persisted])).toEqual([])
+  })
+
+  it("deduplicates repeated delivery of the same session error event", () => {
+    const first = { ...assistant("message_2", error), parentID: "message_1", sessionErrorID: "event_1" }
+    const repeat = { ...assistant("message_3", error), parentID: "message_1", sessionErrorID: "event_1" }
+
+    expect(withoutResolvedSessionErrors([first], [repeat])).toEqual([])
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/context/session-errors.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-errors.ts
@@ -3,6 +3,27 @@ import type { Message } from "../types/messages"
 type Entry = { id: string; error?: Message["error"] }
 type Error = NonNullable<Message["error"]>
 
+function sameError(a: Message, b: Message) {
+  if (!a.error || !b.error || a.error.name !== b.error.name) return false
+  if (a.parentID !== b.parentID) return false
+  return JSON.stringify(a.error.data) === JSON.stringify(b.error.data)
+}
+
+export function withoutResolvedSessionErrors(current: Message[], incoming: Message[]) {
+  const events = new Set(incoming.map((msg) => msg.sessionErrorID).filter((id): id is string => !!id))
+  return current.filter((msg) => {
+    if (!msg.sessionErrorID) return true
+    if (events.has(msg.sessionErrorID)) return false
+    return !incoming.some((next) => !next.sessionErrorID && sameError(msg, next))
+  })
+}
+
+export function preserveSessionErrors(current: Message[], incoming: Message[]) {
+  const ids = new Set(incoming.map((msg) => msg.id))
+  const errors = withoutResolvedSessionErrors(current, incoming).filter((msg) => msg.sessionErrorID && !ids.has(msg.id))
+  return [...incoming, ...errors]
+}
+
 export function errorIDs(messages: Entry[]) {
   return messages.filter((msg) => !!msg.error).map((msg) => msg.id)
 }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -70,7 +70,7 @@ import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { getAgentModel } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
-import { errorIDs } from "./session-errors"
+import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
 import { mergeParts, sameParts } from "./session-parts"
 import { state as todoState } from "./todo-revert"
@@ -1175,7 +1175,7 @@ export const SessionProvider: ParentComponent = (props) => {
         break
 
       case "sessionError": {
-        if (message.error?.name === "MessageAbortedError") break
+        if (!message.error || message.error.name === "MessageAbortedError") break
         const sid = message.sessionID ?? currentSessionID()
         if (!sid) break
         // Find the last user message in this session to use as parentID
@@ -1188,6 +1188,7 @@ export const SessionProvider: ParentComponent = (props) => {
           createdAt: new Date().toISOString(),
           parentID: parent?.id,
           error: message.error,
+          sessionErrorID: message.eventID,
         }
         handleMessageCreated(errorMsg)
         break
@@ -1381,20 +1382,17 @@ export const SessionProvider: ParentComponent = (props) => {
   }
 
   function mergeMessages(current: Message[], incoming: Message[], mode: Exclude<MessageLoadMode, "focus">) {
+    const kept = withoutResolvedSessionErrors(current, incoming)
     if (mode === "reconcile") {
-      // Tail reconcile: incoming is the authoritative newest-N snapshot.
-      // Local state may already hold some of those IDs and may also hold
-      // newer optimistic entries created after the fetch was taken. Merge
-      // by id (server wins on collision) then sort by createdAt so new
-      // server messages land in the right position and optimistic tail
-      // entries stay at the end.
+      // Merge the authoritative newest-N snapshot by ID, then sort so newer
+      // optimistic entries stay at the end.
       const byId = new Map<string, Message>()
-      for (const msg of current) byId.set(msg.id, msg)
+      for (const msg of kept) byId.set(msg.id, msg)
       for (const msg of incoming) byId.set(msg.id, msg)
       return [...byId.values()].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
     }
     const seen = new Set<string>()
-    const source = mode === "prepend" ? [...incoming, ...current] : incoming
+    const source = mode === "prepend" ? [...incoming, ...kept] : incoming
     return source.filter((msg) => {
       if (seen.has(msg.id)) return false
       seen.add(msg.id)
@@ -1418,12 +1416,13 @@ export const SessionProvider: ParentComponent = (props) => {
   }
 
   function withPending(sessionID: string, messages: Message[]) {
-    const pending = pendingOptimistic.get(sessionID)
-    if (!pending || pending.size === 0) return messages
-    const ids = new Set(messages.map((msg) => msg.id))
     const current = store.messages[sessionID] ?? []
+    const merged = preserveSessionErrors(current, messages)
+    const pending = pendingOptimistic.get(sessionID)
+    if (!pending || pending.size === 0) return merged
+    const ids = new Set(merged.map((msg) => msg.id))
     const orphans = current.filter((msg) => pending.has(msg.id) && !ids.has(msg.id))
-    return [...messages, ...orphans]
+    return [...merged, ...orphans]
   }
 
   // Cheap tail check: same ids in the same order and no visible streamed-part
@@ -1601,16 +1600,18 @@ export const SessionProvider: ParentComponent = (props) => {
 
     const exists = (store.messages[message.sessionID] ?? []).some((msg) => msg.id === message.id)
     setStore("messages", message.sessionID, (msgs = []) => {
+      const current = withoutResolvedSessionErrors(msgs, [message])
+      if (message.sessionErrorID && current.some((msg) => msg.sessionErrorID === message.sessionErrorID)) return current
       // Check if message already exists (optimistic or update case).
       // Since we now use the same messageID for optimistic and server messages,
       // this naturally handles the optimistic→real transition.
-      const idx = msgs.findIndex((m) => m.id === message.id)
+      const idx = current.findIndex((m) => m.id === message.id)
       if (idx >= 0) {
-        const updated = [...msgs]
-        updated[idx] = { ...msgs[idx], ...message }
+        const updated = [...current]
+        updated[idx] = { ...current[idx], ...message }
         return updated
       }
-      return [...msgs, message]
+      return [...current, message]
     })
     patchPage(message.sessionID, { lastMutation: exists ? "update" : "append" })
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1600,8 +1600,8 @@ export const SessionProvider: ParentComponent = (props) => {
 
     const exists = (store.messages[message.sessionID] ?? []).some((msg) => msg.id === message.id)
     setStore("messages", message.sessionID, (msgs = []) => {
+      if (message.sessionErrorID && msgs.some((msg) => msg.sessionErrorID === message.sessionErrorID)) return msgs
       const current = withoutResolvedSessionErrors(msgs, [message])
-      if (message.sessionErrorID && current.some((msg) => msg.sessionErrorID === message.sessionErrorID)) return current
       // Check if message already exists (optimistic or update case).
       // Since we now use the same messageID for optimistic and server messages,
       // this naturally handles the optimistic→real transition.

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -148,6 +148,7 @@ export interface SessionTurnClosedMessage {
 
 export interface SessionErrorMessage {
   type: "sessionError"
+  eventID: string
   sessionID?: string
   error?: { name: string; data?: Record<string, unknown> }
 }

--- a/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
@@ -22,6 +22,7 @@ export interface Message {
   parentID?: string
   path?: { cwd: string; root: string }
   error?: { name: string; data?: Record<string, unknown> }
+  sessionErrorID?: string
   summary?: { title?: string; body?: string; diffs?: unknown[] } | boolean
   cost?: number
   tokens?: TokenUsage


### PR DESCRIPTION
## What changed

Preserve transient model and provider errors in the VS Code chat when a history response replaces local transcript state. Once the backend persists the same assistant error, the transient entry is removed so only one error card remains.

## Why

`session.error` is a live, non-durable event. The VS Code webview converted it into a synthetic assistant message, but late history loads could overwrite that message before users saw it, unlike the TUI which renders the event immediately.