### PR TITLE
fix: omit Authorization header on /api/defaults without organization ID

### DIFF
--- a/.changeset/omit-auth-on-defaults-without-org.md
+++ b/.changeset/omit-auth-on-defaults-without-org.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-gateway": patch
+"@kilocode/cli": patch
+---
+
+Omit Authorization header on requests to /api/defaults when organization ID is not present.

--- a/packages/kilo-gateway/src/api/profile.ts
+++ b/packages/kilo-gateway/src/api/profile.ts
@@ -107,7 +107,7 @@ export async function fetchDefaultModel(token?: string, organizationId?: string)
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     }
-    if (token) {
+    if (token && organizationId) {
       headers.Authorization = `Bearer ${token}`
     }
 

--- a/packages/kilo-gateway/test/api/profile.test.ts
+++ b/packages/kilo-gateway/test/api/profile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { defaultOrganizationId } from "../../src/api/profile.js"
+import { defaultOrganizationId, fetchDefaultModel } from "../../src/api/profile.js"
 import type { KilocodeProfile } from "../../src/types.js"
 
 const profile = (input: Partial<KilocodeProfile> = {}): KilocodeProfile => ({
@@ -48,5 +48,47 @@ describe("defaultOrganizationId", () => {
         }),
       ),
     ).toBe("org_2")
+  })
+})
+
+describe("fetchDefaultModel", () => {
+  test("does not specify Authorization header for /api/defaults without organization id", async () => {
+    const original = globalThis.fetch
+    const headers: (string | null)[] = []
+    const paths: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      paths.push(String(input))
+      headers.push(new Headers(init?.headers).get("Authorization"))
+      return new Response(JSON.stringify({ defaultModel: "test-model" }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      const model = await fetchDefaultModel("secret-token")
+      expect(model).toBe("test-model")
+      expect(paths[0]).toContain("/api/defaults")
+      expect(headers[0]).toBeNull()
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
+  test("specifies Authorization header when organization id is present", async () => {
+    const original = globalThis.fetch
+    const headers: (string | null)[] = []
+    const paths: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      paths.push(String(input))
+      headers.push(new Headers(init?.headers).get("Authorization"))
+      return new Response(JSON.stringify({ defaultModel: "org-model" }), { status: 200 })
+    }) as typeof fetch
+
+    try {
+      const model = await fetchDefaultModel("secret-token", "org_123")
+      expect(model).toBe("org-model")
+      expect(paths[0]).toContain("/api/organizations/org_123/defaults")
+      expect(headers[0]).toBe("Bearer secret-token")
+    } finally {
+      globalThis.fetch = original
+    }
   })
 })

--- a/packages/opencode/src/kilocode/cloud/catalog.ts
+++ b/packages/opencode/src/kilocode/cloud/catalog.ts
@@ -59,6 +59,8 @@ export namespace CloudCatalog {
     const env = options.env ?? process.env
 
     const request = Effect.fn("CloudCatalog.request")(function* <A>(url: string, input: Input, schema: z.ZodType<A>) {
+      const defaults = url.endsWith("/defaults") || url.includes("/defaults?")
+      const auth = !defaults || input.organizationID ? { Authorization: `Bearer ${Redacted.value(input.token)}` } : {}
       const req = yield* Effect.try({
         try: () =>
           new Request(url, {
@@ -69,7 +71,7 @@ export namespace CloudCatalog {
                 input.organizationID ? { kilocodeOrganizationId: input.organizationID } : undefined,
               ),
               "X-KILOCODE-FEATURE": "kilo-cli",
-              Authorization: `Bearer ${Redacted.value(input.token)}`,
+              ...auth,
             },
             redirect: "error",
             signal: AbortSignal.timeout(TIMEOUT),

--- a/packages/opencode/test/kilocode/cloud/defaults.test.ts
+++ b/packages/opencode/test/kilocode/cloud/defaults.test.ts
@@ -304,6 +304,7 @@ it.instance(
           Effect.sync(() => {
             expect(resolved.model).toBe("anthropic/default")
             expect(requests.map((request) => request.path)).toEqual(["/api/openrouter/models", "/api/defaults"])
+            expect(requests[1].authorization).toBeNull()
           }),
         ),
         Effect.provide(


### PR DESCRIPTION
Omit the Authorization header when requesting /api/defaults unless an organization ID is present.