### PR TITLE
fix(gateway): omit Authorization on public /api/defaults

### DIFF
--- a/.changeset/public-defaults-no-auth.md
+++ b/.changeset/public-defaults-no-auth.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/kilo-gateway": patch
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Omit Authorization on public `/api/defaults` requests unless an organization id is present.

--- a/packages/kilo-gateway/src/api/profile.ts
+++ b/packages/kilo-gateway/src/api/profile.ts
@@ -95,9 +95,8 @@ export async function fetchBalance(token: string, organizationId?: string): Prom
 export const getKiloBalance = fetchBalance
 
 /**
- * Fetch default model for a given organization context
- * When token is provided, returns the authenticated user's default model
- * When no token is provided, returns the default free model for anonymous usage
+ * Fetch default model for a given organization context.
+ * `/api/defaults` is public — send Authorization only when an organization id is present.
  */
 export async function fetchDefaultModel(token?: string, organizationId?: string): Promise<string> {
   const path = organizationId ? `/api/organizations/${organizationId}/defaults` : `/api/defaults`
@@ -107,7 +106,7 @@ export async function fetchDefaultModel(token?: string, organizationId?: string)
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     }
-    if (token) {
+    if (token && organizationId) {
       headers.Authorization = `Bearer ${token}`
     }
 

--- a/packages/kilo-gateway/test/api/profile.test.ts
+++ b/packages/kilo-gateway/test/api/profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { defaultOrganizationId } from "../../src/api/profile.js"
+import { defaultOrganizationId, fetchDefaultModel } from "../../src/api/profile.js"
+import { DEFAULT_FREE_MODEL, DEFAULT_MODEL } from "../../src/api/constants.js"
 import type { KilocodeProfile } from "../../src/types.js"
 
 const profile = (input: Partial<KilocodeProfile> = {}): KilocodeProfile => ({
@@ -48,5 +49,74 @@ describe("defaultOrganizationId", () => {
         }),
       ),
     ).toBe("org_2")
+  })
+})
+
+describe("fetchDefaultModel", () => {
+  function stub(fn: (input: string | URL | Request, init?: RequestInit) => Promise<Response>) {
+    const orig = globalThis.fetch
+    globalThis.fetch = fn as typeof fetch
+    return () => {
+      globalThis.fetch = orig
+    }
+  }
+
+  test("omits Authorization on /api/defaults even when a token is present", async () => {
+    let path = ""
+    let auth: string | null = null
+    const restore = stub(async (input, init) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      path = new URL(req.url).pathname
+      auth = req.headers.get("authorization")
+      return Response.json({ defaultModel: "kilo/paid", defaultFreeModel: "kilo/free" })
+    })
+
+    try {
+      const model = await fetchDefaultModel("stored-token")
+      expect(path).toBe("/api/defaults")
+      expect(auth).toBeNull()
+      expect(model).toBe("kilo/paid")
+    } finally {
+      restore()
+    }
+  })
+
+  test("sends Authorization only for organization defaults", async () => {
+    let path = ""
+    let auth: string | null = null
+    const restore = stub(async (input, init) => {
+      const req = input instanceof Request ? input : new Request(input, init)
+      path = new URL(req.url).pathname
+      auth = req.headers.get("authorization")
+      return Response.json({ defaultModel: "kilo/org" })
+    })
+
+    try {
+      const model = await fetchDefaultModel("stored-token", "org_1")
+      expect(path).toBe("/api/organizations/org_1/defaults")
+      expect(auth).toBe("Bearer stored-token")
+      expect(model).toBe("kilo/org")
+    } finally {
+      restore()
+    }
+  })
+
+  test("uses the public free model when no token is provided", async () => {
+    const restore = stub(async () => Response.json({ defaultModel: "kilo/paid", defaultFreeModel: "kilo/free" }))
+    try {
+      expect(await fetchDefaultModel()).toBe("kilo/free")
+    } finally {
+      restore()
+    }
+  })
+
+  test("falls back to bundled defaults when the request fails", async () => {
+    const restore = stub(async () => new Response(null, { status: 500 }))
+    try {
+      expect(await fetchDefaultModel("stored-token")).toBe(DEFAULT_MODEL)
+      expect(await fetchDefaultModel()).toBe(DEFAULT_FREE_MODEL)
+    } finally {
+      restore()
+    }
   })
 })

--- a/packages/opencode/src/kilocode/cloud/catalog.ts
+++ b/packages/opencode/src/kilocode/cloud/catalog.ts
@@ -58,7 +58,12 @@ export namespace CloudCatalog {
     const fetcher = options.fetch ?? ((request: Request) => globalThis.fetch(request))
     const env = options.env ?? process.env
 
-    const request = Effect.fn("CloudCatalog.request")(function* <A>(url: string, input: Input, schema: z.ZodType<A>) {
+    const request = Effect.fn("CloudCatalog.request")(function* <A>(
+      url: string,
+      input: Input,
+      schema: z.ZodType<A>,
+      auth = true,
+    ) {
       const req = yield* Effect.try({
         try: () =>
           new Request(url, {
@@ -69,7 +74,7 @@ export namespace CloudCatalog {
                 input.organizationID ? { kilocodeOrganizationId: input.organizationID } : undefined,
               ),
               "X-KILOCODE-FEATURE": "kilo-cli",
-              Authorization: `Bearer ${Redacted.value(input.token)}`,
+              ...(auth ? { Authorization: `Bearer ${Redacted.value(input.token)}` } : {}),
             },
             redirect: "error",
             signal: AbortSignal.timeout(TIMEOUT),
@@ -165,7 +170,7 @@ export namespace CloudCatalog {
       const path = input.organizationID
         ? `../organizations/${encodeURIComponent(input.organizationID)}/defaults`
         : "../defaults"
-      return (yield* request(new URL(path, root).toString(), input, Defaults)).defaultModel
+      return (yield* request(new URL(path, root).toString(), input, Defaults, !!input.organizationID)).defaultModel
     })
 
     return Layer.succeed(Service, Service.of({ models, defaultModel }))

--- a/packages/opencode/test/kilocode/cloud/defaults.test.ts
+++ b/packages/opencode/test/kilocode/cloud/defaults.test.ts
@@ -303,7 +303,20 @@ it.instance(
         Effect.tap((resolved) =>
           Effect.sync(() => {
             expect(resolved.model).toBe("anthropic/default")
-            expect(requests.map((request) => request.path)).toEqual(["/api/openrouter/models", "/api/defaults"])
+            expect(requests).toEqual([
+              {
+                authorization: "Bearer stored-api-token",
+                feature: "kilo-cli",
+                organization: null,
+                path: "/api/openrouter/models",
+              },
+              {
+                authorization: null,
+                feature: "kilo-cli",
+                organization: null,
+                path: "/api/defaults",
+              },
+            ])
           }),
         ),
         Effect.provide(
@@ -314,6 +327,47 @@ it.instance(
           ),
         ),
       ),
+    ),
+  {
+    config: { agent: { code: { model: null } } },
+  },
+)
+
+it.instance(
+  "authorizes organization defaults but not the public defaults endpoint",
+  () =>
+    withCatalog(["anthropic/default"], "anthropic/default", (url, requests) =>
+      Effect.gen(function* () {
+        const organizationID = "11111111-1111-4111-8111-111111111111"
+        const resolved = yield* CloudDefaults.resolve().pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              authLayer(oauth("stored-token", organizationID)),
+              stateLayer(state()),
+              CloudCatalog.layer({ env: { KILO_API_URL: url.origin } }),
+            ),
+          ),
+        )
+        expect(resolved).toMatchObject({
+          mode: "code",
+          model: "anthropic/default",
+          organizationID,
+        })
+        expect(requests).toEqual([
+          {
+            authorization: "Bearer stored-token",
+            feature: "kilo-cli",
+            organization: organizationID,
+            path: `/api/organizations/${organizationID}/models`,
+          },
+          {
+            authorization: "Bearer stored-token",
+            feature: "kilo-cli",
+            organization: organizationID,
+            path: `/api/organizations/${organizationID}/defaults`,
+          },
+        ])
+      }),
     ),
   {
     config: { agent: { code: { model: null } } },


### PR DESCRIPTION
## What

Stop sending `Authorization` on public `/api/defaults` requests unless an organization id is also present. Organization-scoped `/api/organizations/:id/defaults` still authenticates as before.

## Why

`/api/defaults` is a public, cacheable endpoint. An `Authorization` header prevents server-side caching, so personal-account and anonymous clients would each miss the shared cache and hit origin. Only send the token when an organization id is present and the request is org-scoped.

## Notes

Covers both `fetchDefaultModel` in kilo-gateway and Cloud Catalog default-model fetches.