### PR TITLE
fix(cli): exclude gpt-5.6-terra models from explicit prompt cache breakpoints

### DIFF
--- a/.changeset/exclude-terra-from-prompt-cache-breakpoint.md
+++ b/.changeset/exclude-terra-from-prompt-cache-breakpoint.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Exclude GPT-5.6-Terra models from explicit prompt cache breakpoints.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -328,13 +328,14 @@ function normalizeMessages(
   return msgs
 }
 
-// kilocode_change start - explicit prompt cache breakpoints for GPT-5.6+ (excluding ChatGPT subscriptions)
+// kilocode_change start - explicit prompt cache breakpoints for GPT-5.6+ (excluding ChatGPT subscriptions and unsupported variants)
 function isLikelyChatGPTSubscription(model: Provider.Model): boolean {
   return model.providerID === "openai" && model.cost?.input === 0 && model.cost?.output === 0
 }
 
 function supportsPromptCacheBreakpoint(model: Provider.Model): boolean {
   if (isLikelyChatGPTSubscription(model)) return false
+  if (model.api.id.includes("terra")) return false
   const match = model.api.id.match(/gpt-(\d+)\.(\d+)/)
   if (match) {
     const major = Number(match[1])

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3194,6 +3194,38 @@ describe("ProviderTransform.message - cache control on gateway", () => {
     expect(result[0].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
     expect(result[1].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
   })
+
+  test("openai gpt-5.6-terra does not apply promptCacheBreakpoint", () => {
+    const model = createModel({
+      providerID: "openai",
+      api: {
+        id: "gpt-5.6-terra",
+        url: "https://api.openai.com/v1",
+        npm: "@ai-sdk/openai",
+      },
+      id: "gpt-5.6-terra",
+      cost: {
+        input: 0.002,
+        output: 0.008,
+        cache: { read: 0.0005, write: 0.002 },
+      },
+    })
+    const msgs = [
+      {
+        role: "system",
+        content: "You are a helpful assistant",
+      },
+      {
+        role: "user",
+        content: "Hello",
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+
+    expect(result[0].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+    expect(result[1].providerOptions?.openai?.promptCacheBreakpoint).toBeUndefined()
+  })
   // kilocode_change end
 })
 


### PR DESCRIPTION
### Summary

- Fixes the error reported in #13022 (`prompt_cache_breakpoint is not supported on this model` on `GPT-5.6 Terra`).
- Exclude `-terra` model variants from manual `promptCacheBreakpoint: { mode: 'explicit' }` treatment on the OpenAI provider, falling back to standard automatic caching.
- Retain explicit breakpoints for base GPT-5.6, Azure OpenAI, and Kilo Gateway.