### PR TITLE
fix(cli): use managed ripgrep in packaged builds

### DIFF
--- a/.changeset/fix-packaged-codebase-search.md
+++ b/.changeset/fix-packaged-codebase-search.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Keep codebase search working in packaged builds by using Kilo's managed ripgrep binary.

--- a/packages/core/src/kilocode/ripgrep-binary.ts
+++ b/packages/core/src/kilocode/ripgrep-binary.ts
@@ -1,0 +1,4 @@
+import path from "path"
+import { Global } from "../global"
+
+export const target = path.join(Global.Path.bin, process.platform === "win32" ? "rg.exe" : "rg")

--- a/packages/core/src/ripgrep/binary.ts
+++ b/packages/core/src/ripgrep/binary.ts
@@ -8,6 +8,7 @@ import { makeGlobalNode } from "../effect/app-node"
 import { httpClient } from "../effect/app-node-platform"
 import { FSUtil } from "../fs-util"
 import { Global } from "../global"
+import * as Managed from "../kilocode/ripgrep-binary" // kilocode_change
 import { which } from "../util/which"
 
 export namespace RipgrepBinary {
@@ -95,7 +96,7 @@ export namespace RipgrepBinary {
             const system = yield* Effect.sync(() => (process.platform === "win32" ? undefined : which("rg")))
             if (system && (yield* fs.isFile(system).pipe(Effect.orDie))) return system
 
-            const target = path.join(Global.Path.bin, `rg${process.platform === "win32" ? ".exe" : ""}`)
+            const target = Managed.target // kilocode_change
             if (yield* fs.isFile(target).pipe(Effect.orDie)) return target
 
             const platformKey = `${process.arch}-${process.platform}` as keyof typeof PLATFORM

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -24,6 +24,7 @@ import { stageBubblewrap } from "./kilocode/bubblewrap"
 import { LanceDBRuntime } from "../src/kilocode/lancedb"
 import { KiloSandboxWorker } from "./kilocode/kilo-sandbox-worker"
 import { KiloSandboxNetwork } from "./kilocode/kilo-sandbox-network"
+import { plugin as rg } from "./kilocode/morph-ripgrep"
 // kilocode_change end
 
 const singleFlag = process.argv.includes("--single")
@@ -307,7 +308,7 @@ for (const item of targets) {
   await Bun.build({
     conditions: ["bun", "node"], // kilocode_change - port anomalyco/opencode#30873; current form from #31566
     tsconfig: "./tsconfig.json",
-    plugins: [plugin],
+    plugins: [plugin, rg(dir)], // kilocode_change - avoid Morph's optional ripgrep package in packaged builds
     // kilocode_change start - skip sourcemaps for release builds (each .js.map adds ~50 MB per target → ~600 MB total)
     sourcemap: Script.release ? "none" : "external",
     external: ["node-gyp", ...LanceDBRuntime.external],
@@ -351,6 +352,7 @@ for (const item of targets) {
       KILO_SANDBOX_MUTATION_WORKER_PATH: JSON.stringify(KiloSandboxWorker.filename),
       KILO_SANDBOX_NETWORK_RELAY_PATH: item.os === "linux" ? JSON.stringify(KiloSandboxNetwork.relay) : "undefined",
       KILO_SANDBOX_SECCOMP_PATH: item.os === "linux" ? JSON.stringify(KiloSandboxNetwork.seccomp) : "undefined",
+      KILO_MORPH_RIPGREP_MANAGED: "true",
       // kilocode_change end
       KILO_CHANNEL: `'${Script.channel}'`,
       KILO_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",

--- a/packages/opencode/script/kilocode/morph-ripgrep.ts
+++ b/packages/opencode/script/kilocode/morph-ripgrep.ts
@@ -1,0 +1,12 @@
+import path from "path"
+
+export function plugin(root: string): Bun.BunPlugin {
+  return {
+    name: "kilo-morph-ripgrep",
+    setup(build) {
+      build.onResolve({ filter: /^@vscode\/ripgrep$/ }, () => ({
+        path: path.resolve(root, "src/kilocode/morph-ripgrep.ts"),
+      }))
+    },
+  }
+}

--- a/packages/opencode/src/kilocode/morph-ripgrep.ts
+++ b/packages/opencode/src/kilocode/morph-ripgrep.ts
@@ -1,0 +1,4 @@
+import { target } from "@opencode-ai/core/kilocode/ripgrep-binary"
+import { which } from "@opencode-ai/core/util/which"
+
+export const rgPath = process.platform === "win32" ? target : (which("rg") ?? target)

--- a/packages/opencode/src/kilocode/tool/warpgrep.ts
+++ b/packages/opencode/src/kilocode/tool/warpgrep.ts
@@ -1,0 +1,30 @@
+import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+import { Cause, Effect, Exit } from "effect"
+
+declare global {
+  const KILO_MORPH_RIPGREP_MANAGED: boolean
+}
+
+const active = typeof KILO_MORPH_RIPGREP_MANAGED === "boolean" && KILO_MORPH_RIPGREP_MANAGED
+
+export const prepare = Effect.gen(function* () {
+  const binary = yield* RipgrepBinary.Service
+  return (query: string) =>
+    Effect.gen(function* () {
+      const ready = yield* binary.filepath.pipe(Effect.asVoid, Effect.exit)
+      if (Exit.isSuccess(ready)) return
+
+      const error = Cause.squash(ready.cause)
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        title: `Codebase Search: ${query}`,
+        output: `Codebase search unavailable: ${message}`,
+        metadata: { count: 0 },
+      }
+    })
+})
+
+export const load = (enabled: boolean) =>
+  enabled ? prepare : Effect.succeed((_query: string) => Effect.succeed(undefined))
+
+export const provision = load(active)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -503,6 +503,7 @@ export const node = LayerNode.suspend(() =>
       RuntimeFlags.node,
       Database.node,
       Ripgrep.node,
+      RipgrepBinary.node,
       Command.node,
       Git.node,
       Bus.node,

--- a/packages/opencode/src/tool/warpgrep.ts
+++ b/packages/opencode/src/tool/warpgrep.ts
@@ -3,6 +3,7 @@ import * as Tool from "./tool"
 import { WarpGrepClient } from "@morphllm/morphsdk/tools/warp-grep/client" // kilocode_change
 import { Telemetry } from "@kilocode/kilo-telemetry" // kilocode_change
 import { Instance } from "../kilocode/instance" // kilocode_change
+import * as Provision from "../kilocode/tool/warpgrep" // kilocode_change
 import { EventV2Bridge } from "@/event-v2-bridge" // kilocode_change
 import { TuiEvent } from "@/server/tui-event" // kilocode_change
 import DESCRIPTION from "./warpgrep.txt"
@@ -22,6 +23,7 @@ export const CodebaseSearchTool = Tool.define(
   "codebase_search",
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service // kilocode_change
+    const provision = yield* Provision.provision // kilocode_change
     return {
       description: DESCRIPTION,
       parameters: Parameters,
@@ -44,6 +46,11 @@ export const CodebaseSearchTool = Tool.define(
             ...(apiKey ? {} : { morphApiUrl: KILO_WARPGREP_PROXY_URL }),
             timeout: 60_000,
           })
+
+          // kilocode_change start - provision only when the packaged Morph shim is active
+          const unavailable = yield* provision(params.query)
+          if (unavailable) return unavailable
+          // kilocode_change end
 
           const result = yield* Effect.promise(() =>
             client.execute({

--- a/packages/opencode/test/kilocode/tool/warpgrep-ripgrep-provisioning.test.ts
+++ b/packages/opencode/test/kilocode/tool/warpgrep-ripgrep-provisioning.test.ts
@@ -1,0 +1,67 @@
+import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "node:path"
+import * as Provision from "../../../src/kilocode/tool/warpgrep"
+import { tmpdir } from "../../fixture/fixture"
+import { it } from "../../lib/effect"
+import { plugin } from "../../../script/kilocode/morph-ripgrep"
+
+describe("codebase_search ripgrep provisioning", () => {
+  it.effect("skips managed provisioning in source mode", () =>
+    Effect.gen(function* () {
+      const calls: string[] = []
+      const binary = Layer.mock(RipgrepBinary.Service, {
+        filepath: Effect.sync(() => calls.push("filepath")).pipe(Effect.andThen(Effect.succeed("rg"))),
+      })
+
+      const provision = yield* Provision.provision.pipe(Effect.provide(binary))
+      const result = yield* provision("find the entry point")
+
+      expect(result).toBeUndefined()
+      expect(calls).toEqual([])
+    }),
+  )
+
+  it.effect("returns a normal failure when packaged provisioning dies", () =>
+    Effect.gen(function* () {
+      const failure = new Error("ripgrep provisioning failed")
+      const binary = Layer.mock(RipgrepBinary.Service, {
+        filepath: Effect.die(failure),
+      })
+
+      const provision = yield* Provision.prepare.pipe(Effect.provide(binary))
+      const result = yield* provision("find the entry point")
+
+      expect(result).not.toBeUndefined()
+      if (!result) return
+      expect(result).toEqual({
+        title: "Codebase Search: find the entry point",
+        output: `Codebase search unavailable: ${failure.message}`,
+        metadata: { count: 0 },
+      })
+    }),
+  )
+})
+
+test("bundles the Morph ripgrep import through the Kilo plugin", async () => {
+  await using tmp = await tmpdir()
+  const entry = path.join(tmp.path, "entry.ts")
+  const out = path.join(tmp.path, "out")
+  const root = path.resolve(import.meta.dir, "../../../")
+
+  await Bun.write(entry, 'import { rgPath } from "@vscode/ripgrep"\nconsole.log(rgPath)\n')
+  const result = await Bun.build({
+    entrypoints: [entry],
+    outdir: out,
+    plugins: [plugin(root)],
+    target: "bun",
+  })
+
+  expect(result.success).toBe(true)
+  if (!result.success) return
+  const output = await result.outputs[0].text()
+  expect(output).not.toContain("@vscode/ripgrep")
+  expect(output).not.toContain("ripgrep-darwin-arm64")
+  expect(output).not.toContain("Ensure optionalDependencies are installed")
+})


### PR DESCRIPTION
## Issue

Fixes #12787

## Context

Packaged Kilo binaries do not ship a `node_modules` tree, but Morph's WarpGrep client imports `@vscode/ripgrep`, which resolves a platform-specific optional package at module load. On macOS ARM64 this crashes codebase search before Morph or Kilo can fall back to another ripgrep binary.

## Implementation

The packaged CLI build aliases only `@vscode/ripgrep` to a Kilo-owned shim that selects a compatible system `rg` or Kilo's managed cache path. Before invoking Morph, `codebase_search` provisions that path through `RipgrepBinary.Service`.

The tool registry declares the binary service directly because transitive Effect layer dependencies are not exposed to consumers. Provisioning failures and defects are returned as normal zero-result tool output instead of crashing the tool.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Agent: compiled the original loader as a standalone binary and reproduced the exact `@vscode/ripgrep-darwin-arm64` failure with exit code 1.
- Agent: compiled the same import through the Kilo build plugin under the same no-system-`rg`, no-runtime-`node_modules` conditions; it exited 0 and resolved Kilo's managed cache path.
- Agent: built the native macOS ARM64 standalone CLI with `bun run script/build.ts --single --skip-install` and initialized its real tool registry through the compiled server.
- Agent: ran `bun test ./test/kilocode/tool/warpgrep-ripgrep-provisioning.test.ts` — 2 passed.
- Agent: the pre-push repository typecheck passed for all packages, including JetBrains with Java 21.
- Agent: annotation, Promise-facade, formatting, diff, and lint guards passed.

### Reviewer test steps

1. From `packages/opencode`, run `bun test ./test/kilocode/tool/warpgrep-ripgrep-provisioning.test.ts`.
2. Build the current platform binary with `bun run script/build.ts --single --skip-install`.
3. On macOS ARM64, launch the packaged CLI or extension without a system `rg` on `PATH` and with an empty Kilo binary cache.
4. Invoke `codebase_search` and confirm it provisions ripgrep instead of reporting a missing `@vscode/ripgrep-darwin-arm64` package.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
