### PR TITLE
fix(vscode): resolve chat file links from session directory

### DIFF
--- a/.changeset/fix-vscode-session-file-links.md
+++ b/.changeset/fix-vscode-session-file-links.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open relative chat file links from the session's working directory in multi-repository workspaces.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1560,7 +1560,19 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private handleEditorOpenMessage(message: Parameters<typeof handleEditorAction>[0]): boolean {
     return handleEditorAction(message, {
-      dir: () => this.getWorkspaceDirectory(this.currentSession?.id),
+      dir: () => {
+        const sid = message.sessionID ?? this.contextSessionID ?? this.currentSession?.id
+        if (!sid) return this.getRootDirectory()
+        const routed = this.routeSessionDirectory(sid)
+        if (routed === null) {
+          console.warn(`[Kilo New] KiloProvider: session ${sid} is ambiguous across projects; refusing file action`)
+          return
+        }
+        const session = this.currentSession?.id === sid ? this.currentSession : undefined
+        const dir = routed ?? this.getSessionDirectory(sid, session)
+        const root = this.getRootDirectory()
+        return !existsSync(dir) && existsSync(root) ? root : dir
+      },
       diff: this.diffVirtualProvider,
       storage: this.extensionContext?.globalStorageUri,
       post: (msg) => this.postMessage(msg),

--- a/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
+++ b/packages/kilo-vscode/src/kilo-provider/editor-actions.ts
@@ -6,6 +6,7 @@ import type { DiffVirtualFile, DiffVirtualProvider } from "../DiffVirtualProvide
 
 type EditorOpenMessage = {
   type?: string
+  sessionID?: string
   filePath?: string
   line?: number
   column?: number
@@ -73,14 +74,16 @@ export function handleEditorAction(
     paths?: string[]
   },
   opts: {
-    dir: () => string
+    dir: () => string | undefined
     diff?: DiffVirtualProvider
     storage?: vscode.Uri
     post?: (msg: unknown) => void
   },
 ): boolean {
   if (message.type === "openFile") {
-    if (message.filePath) openFile(opts.dir(), message.filePath, message.line, message.column)
+    const dir = opts.dir()
+    if (message.filePath && dir) openFile(dir, message.filePath, message.line, message.column)
+    if (message.filePath && !dir) vscode.window.showWarningMessage("Unable to resolve file for this session")
     return true
   }
   if (message.type === "openContent") {
@@ -92,7 +95,12 @@ export function handleEditorAction(
     const paths = message.paths
     if (id && paths && opts.post) {
       const post = opts.post
-      validateFiles(opts.dir(), paths).then(
+      const dir = opts.dir()
+      if (!dir) {
+        post({ type: "validateFilesResult", id, existing: [] })
+        return true
+      }
+      validateFiles(dir, paths).then(
         (existing) => post({ type: "validateFilesResult", id, existing }),
         (err) => console.error("[Kilo New] KiloProvider: validateFiles failed:", err),
       )

--- a/packages/kilo-vscode/tests/unit/kilo-provider-file-links.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-file-links.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as vscode from "vscode"
+import type { Session } from "@kilocode/sdk/v2/client"
+import { ProjectRouteService } from "../../src/agent-manager/project/route"
+
+// vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
+const { KiloProvider } = await import("../../src/KiloProvider")
+
+type Internals = {
+  contextSessionID?: string
+  webview: { postMessage: (message: unknown) => Promise<unknown> } | null
+  handleEditorOpenMessage: (
+    message:
+      | { type: "openFile"; sessionID?: string; filePath: string; line?: number; column?: number }
+      | { type: "validateFiles"; sessionID?: string; id: string; paths: string[] },
+  ) => boolean
+}
+
+function session(directory: string): Session {
+  return {
+    id: "ses_frontend",
+    slug: "frontend",
+    projectID: "prj_frontend",
+    directory,
+    title: "Frontend",
+    version: "1",
+    time: { created: 1, updated: 1 },
+  }
+}
+
+function create(root: string, routes?: ProjectRouteService) {
+  const provider = new KiloProvider({} as never, {} as never, undefined, {
+    rootDirectory: () => root,
+    routeService: routes,
+  })
+  const internal = provider as unknown as Internals
+  internal.webview = { postMessage: async () => true }
+  return { provider, internal }
+}
+
+const stat = spyOn(vscode.workspace.fs, "stat")
+const roots = new Set<string>()
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-file-links-"))
+  const frontend = path.join(root, "frontend")
+  const backend = path.join(root, "backend")
+  const worktree = path.join(frontend, ".kilo", "worktrees", "feature")
+  await Promise.all([fs.mkdir(backend, { recursive: true }), fs.mkdir(worktree, { recursive: true })])
+  roots.add(root)
+  return { root, frontend, backend, worktree }
+}
+
+beforeEach(() => {
+  stat.mockClear()
+  stat.mockImplementation(async () => ({ type: vscode.FileType.File, ctime: 0, mtime: 0, size: 0 }))
+})
+
+afterAll(async () => {
+  await Promise.all([...roots].map((root) => fs.rm(root, { recursive: true, force: true })))
+  stat.mockRestore()
+})
+
+describe("KiloProvider chat file links", () => {
+  it("validates a relative link from the session directory instead of the workspace parent", async () => {
+    const { root, frontend: dir } = await fixture()
+    const file = path.join(dir, "spec", "foo_spec.rb")
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, "describe 'example'\n")
+
+    const state = create(root)
+    const result = new Promise<unknown>((resolve) => {
+      state.internal.webview = {
+        postMessage: async (message) => {
+          if ((message as { type?: unknown }).type === "validateFilesResult") resolve(message)
+          return true
+        },
+      }
+    })
+    state.provider.registerSession(session(dir))
+
+    state.internal.handleEditorOpenMessage({
+      type: "validateFiles",
+      sessionID: "ses_frontend",
+      id: "check",
+      paths: ["spec/foo_spec.rb"],
+    })
+
+    expect(await result).toEqual({
+      type: "validateFilesResult",
+      id: "check",
+      existing: ["spec/foo_spec.rb"],
+    })
+    stat.mockClear()
+
+    state.internal.handleEditorOpenMessage({
+      type: "openFile",
+      sessionID: "ses_frontend",
+      filePath: "spec/foo_spec.rb",
+    })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: file }))
+  })
+
+  it("resolves a relative link from the active session directory in a multi-repo workspace", async () => {
+    const { root, frontend } = await fixture()
+    const state = create(root)
+    state.provider.registerSession(session(frontend))
+
+    state.internal.handleEditorOpenMessage({
+      type: "openFile",
+      sessionID: "ses_frontend",
+      filePath: "spec/foo_spec.rb",
+      line: 12,
+    })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: path.join(frontend, "spec", "foo_spec.rb") }))
+  })
+
+  it("falls back to the workspace when the session directory no longer exists", async () => {
+    const { root } = await fixture()
+    const file = path.join(root, "spec", "foo_spec.rb")
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await fs.writeFile(file, "describe 'example'\n")
+
+    const state = create(root)
+    const result = new Promise<unknown>((resolve) => {
+      state.internal.webview = {
+        postMessage: async (message) => {
+          if ((message as { type?: unknown }).type === "validateFilesResult") resolve(message)
+          return true
+        },
+      }
+    })
+    state.provider.registerSession(session(path.join(root, "removed")))
+
+    state.internal.handleEditorOpenMessage({ type: "validateFiles", id: "check", paths: ["spec/foo_spec.rb"] })
+
+    expect(await result).toEqual({
+      type: "validateFilesResult",
+      id: "check",
+      existing: ["spec/foo_spec.rb"],
+    })
+    stat.mockClear()
+
+    state.internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb" })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: file }))
+  })
+
+  it("does not use the previous session directory while switching sessions", async () => {
+    const { root, backend } = await fixture()
+    const state = create(root)
+    state.provider.registerSession({
+      ...session(backend),
+      id: "ses_backend",
+      slug: "backend",
+      projectID: "prj_backend",
+      title: "Backend",
+    })
+    state.internal.contextSessionID = "ses_frontend"
+
+    state.internal.handleEditorOpenMessage({ type: "openFile", filePath: "spec/foo_spec.rb", line: 12 })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: path.join(root, "spec", "foo_spec.rb") }))
+  })
+
+  it("uses the displayed session while the extension focus is stale offline", async () => {
+    const { root, frontend, backend } = await fixture()
+    const state = create(root)
+    state.provider.registerSession({
+      ...session(backend),
+      id: "ses_backend",
+      slug: "backend",
+      projectID: "prj_backend",
+      title: "Backend",
+    })
+    state.provider.setSessionDirectory("ses_frontend", frontend)
+    state.internal.contextSessionID = "ses_backend"
+
+    state.internal.handleEditorOpenMessage({
+      type: "openFile",
+      sessionID: "ses_frontend",
+      filePath: "spec/foo_spec.rb",
+      line: 12,
+    })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: path.join(frontend, "spec", "foo_spec.rb") }))
+  })
+
+  it("prefers an explicit directory override for the active session", async () => {
+    const { root, frontend, worktree } = await fixture()
+    const state = create(root)
+    state.provider.registerSession(session(frontend))
+    state.provider.setSessionDirectory("ses_frontend", worktree)
+
+    state.internal.handleEditorOpenMessage({
+      type: "openFile",
+      sessionID: "ses_frontend",
+      filePath: "spec/foo_spec.rb",
+      line: 12,
+    })
+
+    expect(stat).toHaveBeenCalledWith(expect.objectContaining({ fsPath: path.join(worktree, "spec", "foo_spec.rb") }))
+  })
+
+  it("refuses file actions for an ambiguous session route", async () => {
+    const { root, frontend, backend } = await fixture()
+    const routes = new ProjectRouteService()
+    routes.registerProject("frontend", frontend, 1)
+    routes.registerProject("backend", backend, 1)
+    routes.registerSession({ projectId: "frontend", sessionId: "same" }, frontend, 1)
+    routes.registerSession({ projectId: "backend", sessionId: "same" }, backend, 1)
+    const state = create(root, routes)
+    const result = new Promise<unknown>((resolve) => {
+      state.internal.webview = {
+        postMessage: async (message) => {
+          if ((message as { type?: unknown }).type === "validateFilesResult") resolve(message)
+          return true
+        },
+      }
+    })
+
+    state.internal.handleEditorOpenMessage({
+      type: "validateFiles",
+      sessionID: "same",
+      id: "check",
+      paths: ["spec/foo_spec.rb"],
+    })
+
+    expect(await result).toEqual({ type: "validateFilesResult", id: "check", existing: [] })
+
+    state.internal.handleEditorOpenMessage({ type: "openFile", sessionID: "same", filePath: "spec/foo_spec.rb" })
+
+    expect(stat).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -121,7 +121,7 @@ export const DataBridge: Component<{ children: any }> = (props) => {
   }
 
   const open = (filePath: string, line?: number, column?: number) => {
-    vscode.postMessage({ type: "openFile", filePath, line, column })
+    vscode.postMessage({ type: "openFile", sessionID: session.currentSessionID(), filePath, line, column })
   }
 
   const openDiff = (diff: { file: string; patch?: string; additions: number; deletions: number }) => {
@@ -143,7 +143,7 @@ export const DataBridge: Component<{ children: any }> = (props) => {
     const id = `vf-${++counter.n}`
     return new Promise((resolve) => {
       pending.set(id, resolve)
-      vscode.postMessage({ type: "validateFiles", id, paths })
+      vscode.postMessage({ type: "validateFiles", sessionID: session.currentSessionID(), id, paths })
       setTimeout(() => {
         if (pending.has(id)) {
           pending.delete(id)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1428,7 +1428,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       if (mention.mentionedSessions().has(seg().text.replace(/^@/, ""))) return
                       e.preventDefault()
                       e.stopPropagation()
-                      vscode.postMessage({ type: "openFile", filePath: seg().text.replace(/^@/, "") })
+                      vscode.postMessage({
+                        type: "openFile",
+                        sessionID: session.currentSessionID(),
+                        filePath: seg().text.replace(/^@/, ""),
+                      })
                     }}
                   >
                     {seg().text}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ReviewComments.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ReviewComments.tsx
@@ -38,7 +38,13 @@ export const ReviewComments: Component<ReviewCommentsProps> = (props) => {
       dialog.close()
       return
     }
-    vscode.postMessage({ type: "openFile", filePath: item.file, line: item.line, column: 1 })
+    vscode.postMessage({
+      type: "openFile",
+      sessionID: props.sessionID,
+      filePath: item.file,
+      line: item.line,
+      column: 1,
+    })
     dialog.close()
   }
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/AgentBehaviourTab.tsx
@@ -1065,7 +1065,9 @@ const AgentBehaviourTab: Component = () => {
                   size="small"
                   variant="ghost"
                   icon="pencil-line"
-                  onClick={() => vscode.postMessage({ type: "openFile", filePath: path })}
+                  onClick={() =>
+                    vscode.postMessage({ type: "openFile", sessionID: session.currentSessionID(), filePath: path })
+                  }
                 />
                 <IconButton size="small" variant="ghost" icon="close" onClick={() => removeInstruction(index())} />
               </div>

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -146,6 +146,7 @@ export interface OpenExternalRequest {
 
 export interface OpenFileRequest {
   type: "openFile"
+  sessionID?: string
   filePath: string
   line?: number
   column?: number
@@ -159,6 +160,7 @@ export interface OpenContentRequest {
 
 export interface ValidateFilesRequest {
   type: "validateFiles"
+  sessionID?: string
   id: string
   paths: string[]
 }


### PR DESCRIPTION
## Issue

Fixes #12833

## Context

Relative file links in chat were resolved from the VS Code workspace root. In a workspace containing multiple child repositories, that made links depend on a filename fallback search instead of the repository associated with the selected session. Unique filenames could mask the problem, while missing or duplicated filenames produced failed or ambiguous navigation.

## Implementation

Resolve editor actions from the synchronously selected session ID and preserve existing Agent Manager route and worktree-directory precedence. Session metadata is used only when it belongs to the selected session, preventing rapid tab switches from opening a file in the previous repository. If the recorded session directory no longer exists, navigation falls back to the existing workspace root.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Agent: reproduced the workspace-root failure with a temporary multi-repository filesystem fixture, then verified validation and opening use the session repository after the fix.
- Agent: ran `bun test tests/unit/kilo-provider-file-links.test.ts tests/unit/kilo-provider-route-integration.test.ts tests/unit/kilo-provider-load-messages.test.ts` from `packages/kilo-vscode` (66 passed, 137 assertions).
- Agent: ran `bun run typecheck`, focused ESLint and Prettier checks, `bun run check-kilocode-change`, and `git diff --check`.

### Reviewer test steps

1. Open a VS Code workspace whose root contains two child repositories.
2. Open a chat session associated with one child repository.
3. Click a relative file link in that chat and confirm it opens from the session repository.
4. Switch rapidly between sessions in different repositories and confirm a link never opens from the previously selected repository.
5. Remove or rename a recorded session directory and confirm links can still fall back to the workspace root.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
