### PR TITLE
fix(core): serialize concurrent database migrations

### DIFF
--- a/.changeset/steady-migration-journal.md
+++ b/.changeset/steady-migration-journal.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop startup from crashing on a database migration that another Kilo process already applied

--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -68,14 +68,19 @@ export function applyOnly(db: Database, input: Migration[]) {
 
     for (const migration of input) {
       if (completed.has(migration.id)) continue
-      yield* db.transaction((tx) =>
-        Effect.gen(function* () {
-          yield* migration.up(tx)
-          yield* tx.run(
-            sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
-          )
-        }),
+      // kilocode_change start - another kilo process may have recorded this migration since the snapshot above; take the write lock and re-check before replaying, or the journal insert dies on the primary key
+      yield* db.transaction(
+        (tx) =>
+          Effect.gen(function* () {
+            if (yield* tx.get(sql`SELECT id FROM ${sql.identifier("migration")} WHERE id = ${migration.id}`)) return
+            yield* migration.up(tx)
+            yield* tx.run(
+              sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
+            )
+          }),
+        { behavior: "immediate" },
       )
+      // kilocode_change end
     }
   })
 }

--- a/packages/core/test/kilocode/database-migration-compat.test.ts
+++ b/packages/core/test/kilocode/database-migration-compat.test.ts
@@ -244,4 +244,74 @@ describe("database migration compatibility", () => {
       }).pipe(Effect.provide(SqliteClient.layer({ filename })), Effect.scoped),
     )
   })
+
+  test("skips a migration another writer recorded after the completed snapshot", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* make
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+        // stands in for a second kilo process committing the later migration's journal row
+        // while this process is already partway through applyOnly
+        const first = {
+          id: "20260622170816_first",
+          up: (tx) =>
+            tx.run(
+              sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES ('20260622202450_second', 1)`,
+            ),
+        } satisfies DatabaseMigration.Migration
+        const second = {
+          id: "20260622202450_second",
+          up: (tx) => tx.run(sql`CREATE TABLE replayed (id text)`),
+        } satisfies DatabaseMigration.Migration
+
+        yield* DatabaseMigration.applyOnly(db, [first, second])
+
+        // the already-recorded migration must be skipped, not replayed
+        expect(
+          yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'replayed'`),
+        ).toBeUndefined()
+        expect(
+          (yield* db.all<{ id: string }>(sql`SELECT id FROM migration ORDER BY id`)).map((row) => row.id),
+        ).toEqual(["20260622170816_first", "20260622202450_second"])
+      }),
+    )
+  })
+
+  test("holds the write lock before re-checking the migration journal", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "kilo.db")
+    let error: unknown
+    // opens a second, independent connection to the same file from inside the
+    // migration's own transaction: if the write reservation isn't already held
+    // (BEGIN IMMEDIATE), this insert succeeds instead of being rejected as busy
+    const migration = {
+      id: "20260622210000_lock_pin",
+      up: () =>
+        Effect.sync(() => {
+          const writer = new SQLite(filename)
+          writer.run("PRAGMA busy_timeout = 50")
+          try {
+            writer.run("INSERT INTO migration (id, time_completed) VALUES ('20260622210000_other_writer', 1)")
+          } catch (err) {
+            error = err
+          } finally {
+            writer.close()
+          }
+        }),
+    } satisfies DatabaseMigration.Migration
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* make
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY)`)
+        yield* DatabaseMigration.applyOnly(db, [migration])
+        expect(yield* db.get(sql`SELECT id FROM migration WHERE id = ${migration.id}`)).toEqual({ id: migration.id })
+      }).pipe(Effect.provide(SqliteClient.layer({ filename })), Effect.scoped),
+    )
+
+    // bun:sqlite reports lock contention as a SQLiteError with code SQLITE_BUSY;
+    // asserting on that structured field (rather than any thrown error) ensures
+    // an unrelated failure can't masquerade as the lock being held
+    expect((error as { code?: string } | undefined)?.code).toBe("SQLITE_BUSY")
+  })
 })


### PR DESCRIPTION
## Issue

Fixes #13060

## Context

Kilo 7.4.21 can crash during startup when two processes share the same SQLite database and attempt the same pending migration. `applyOnly()` previously took one completed-migration snapshot, so a second process could record an ID after that snapshot; the first process would replay the migration and then fail its journal insert with `UNIQUE constraint failed: migration.id`.

## Implementation

Run each pending migration in a `BEGIN IMMEDIATE` transaction and re-check that migration's journal ID after acquiring the SQLite write reservation. If another process already recorded it, skip `up()`; otherwise apply the migration and journal it atomically.

The regression coverage verifies both the stale-snapshot skip and that the write reservation is held before migration work begins. A patch changeset documents the user-facing startup fix.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Agent reproduced the original two-process race against the pre-fix implementation: the losing process failed on the migration journal `INSERT` with `SQLITE_CONSTRAINT_PRIMARYKEY` / `UNIQUE constraint failed: migration.id`.
- Agent repeated the same schedule with this fix: both processes completed, the journal contained one row for the migration, and the migration state was correct.
- Agent ran `cd packages/core && bun test test/kilocode/database-migration-compat.test.ts test/database-migration.test.ts` (21 passed, 0 failed).
- Agent ran `cd packages/core && bun run typecheck`.
- Agent ran `bun run script/check-opencode-annotations.ts --worktree`.
- Agent ran `git diff --check`.
- The repository pre-push hook ran `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains` successfully.

### Reviewer test steps

1. Run `cd packages/core`.
2. Run `bun test test/kilocode/database-migration-compat.test.ts test/database-migration.test.ts`.
3. Confirm the compatibility tests verify that an ID recorded after the initial snapshot skips replay and that a second SQLite writer receives `SQLITE_BUSY` while the migration transaction holds its immediate write reservation.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
