### PR TITLE
docs: remove no-more-than-three-PRs rule from contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,7 @@ Maintainers may close PRs that appear to be submitted without credible contribut
 
 Do not submit batches of agent-generated, untested, or weakly reviewed PRs.
 
-Please keep concurrent PRs focused and limited. As a rule, open no more than three PRs at a time, especially if you are a new contributor. Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
+Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
 
 For issues, do not mass-create tickets through automation or agents. Search existing issues first, open issues only when you have enough context for someone to act, and prioritize the most important reports instead of filing every possible finding. Maintainers may close duplicate, low-signal, automated, or weakly reviewed issues without action.
 

--- a/packages/kilo-docs/pages/contributing/development-environment.md
+++ b/packages/kilo-docs/pages/contributing/development-environment.md
@@ -57,7 +57,7 @@ The full list of recommended extensions is in `.vscode/extensions.json`
 
 AI and coding agents are allowed in this repo. If you use one, start it from the repository root so the root `AGENTS.md` is available, then check package-specific guidance when your change touches a package with its own `AGENTS.md` or contributor docs.
 
-You remain responsible for the submitted work. Before opening a PR, personally review the diff, test the change, make sure you can explain it, and understand how it interacts with the affected package and the rest of the repo. Do not use agents to submit batches of agent-generated, untested, or weakly reviewed PRs. Keep concurrent PRs limited, generally no more than three at a time, and prioritize high-impact issues first. Do not use automation or agents to mass-create issues without human review and prioritization.
+You remain responsible for the submitted work. Before opening a PR, personally review the diff, test the change, make sure you can explain it, and understand how it interacts with the affected package and the rest of the repo. Do not use agents to submit batches of agent-generated, untested, or weakly reviewed PRs. Prioritize high-impact issues first. Do not use automation or agents to mass-create issues without human review and prioritization.
 
 Kilo has bug bounties. To be eligible, make sure your GitHub account is connected in your Kilo account.
 

--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -151,7 +151,7 @@ When a PR is close to this bar, addresses important work, or would benefit from 
 
 Please keep the issue and PR trackers useful for maintainers and contributors. Do not submit batches of agent-generated, untested, or weakly reviewed PRs.
 
-Keep concurrent PRs focused and limited. As a rule, open no more than three PRs at a time, especially if you are a new contributor. Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
+Prioritize high-impact or high-priority issues first instead of opening many speculative fixes. If a contributor opens a large batch of low-value or duplicative PRs, maintainers may close the batch and ask the contributor to choose one PR to reopen, focus, and bring up to the documented review bar before submitting more.
 
 For issues, do not mass-create tickets through automation or agents. Search existing issues first, open issues only when you have enough context for someone to act, and prioritize the most important reports instead of filing every possible finding. Maintainers may close duplicate, low-signal, automated, or weakly reviewed issues without action.
 


### PR DESCRIPTION
## Issue

Closes #13072

## Context

Removes the explicit "no more than three PRs at a time" cap introduced in #10574 across `CONTRIBUTING.md` and the contributing docs pages, while keeping the surrounding advice to prioritize high-impact work and avoid batches of low-value or weakly reviewed PRs.

Kilo is an open source project where PRs regularly take 2 weeks to a month to be reviewed and merged. Maintainer @emilieschario acknowledged this directly in https://github.com/Kilo-Org/kilocode/discussions/12239#discussioncomment-17650896:

> "We have limited engineering bandwidth and are always prioritizing across many priorities"

A hard cap on concurrent PRs might harm the project under those conditions. Contributor @shssoichiro agreed that PRs take a while to get merged in https://github.com/Kilo-Org/kilocode/issues/12447#issuecomment-5184160488:

> "Unfortunately I am done contributing. The team doesn't care enough to review contributions in a timely manner. I'm tired of spending more time fixing merge conflicts on PRs that stay open for months than actually making meaningful improvements."

A rule that only counts PRs against a contributor while the project's review backlog grows does not deter low-value work, it deters contributors. Removing the numeric limit lets contributors build at "Kilo Speed" (https://kilo.ai/manifesto) instead of throttling themselves to match the maintainers' review cadence. The remaining text in each section still preserves the substantive guidance against low-signal batch PRs and weakly reviewed agent-generated work, which is the actual underlying concern.

## Implementation

Three single-line edits that delete the numeric cap sentence. No restructuring, no other wording changes — the surrounding paragraphs already convey the desired behavior. Affected sections:

- `CONTRIBUTING.md` — `### Tracker Use and Automation`
- `packages/kilo-docs/pages/contributing/development-environment.md` — `### Using AI and Coding Agents`
- `packages/kilo-docs/pages/contributing/index.md` — `## Tracker Use and Automation`

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Ran `git diff main` on this branch and confirmed the only changes are deletion of the "no more than three PRs at a time" wording in each of the three files above.
- Verified the remaining surrounding guidance (prioritize high-impact work, maintainers may close batches of low-value or duplicative PRs) is intact in all three locations.

### Reviewer test steps

1. Open `CONTRIBUTING.md` around the `### Tracker Use and Automation` section and confirm the sentence "As a rule, open no more than three PRs at a time..." is gone, and the "Prioritize high-impact or high-priority issues first..." sentence remains.
2. Open `packages/kilo-docs/pages/contributing/development-environment.md` under `### Using AI and Coding Agents` and confirm "Keep concurrent PRs limited, generally no more than three at a time..." is gone.
3. Open `packages/kilo-docs/pages/contributing/index.md` under `## Tracker Use and Automation` and confirm "As a rule, open no more than three PRs at a time..." is gone.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — N/A (internal contributor docs; no user-facing behavior change)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18
