### PR TITLE
fix(cli): synchronize live organization selection

### DIFF
--- a/.changeset/calm-org-switches.md
+++ b/.changeset/calm-org-switches.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep Kilo organization selection synchronized across live model and provider usage requests

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilo-gateway.ts
@@ -29,13 +29,15 @@ import { DIRECT_FIM_ENV, requestMistralFim, resolveFimTarget } from "@kilocode/k
 import { DIRECT_EDIT_ENV, extractFencedBody, resolveEditTarget } from "@kilocode/kilo-gateway/edit"
 import { buildMercuryEditPrompt } from "@kilocode/kilo-gateway/edit-prompt"
 import { buildKiloHeaders } from "@kilocode/kilo-gateway"
-import { Cause, Effect, Result, Schema } from "effect"
+import { Cause, Effect, Result, Schema, Semaphore } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import * as Log from "@opencode-ai/core/util/log"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Database } from "@opencode-ai/core/database/database"
+import { Credential } from "@opencode-ai/core/credential"
+import { Integration } from "@opencode-ai/core/integration"
 import type { DeepMutable } from "@opencode-ai/core/schema"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { KilocodeConfig } from "@/kilocode/config/config"
@@ -72,7 +74,9 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     const cache = yield* ModelCache.Service
     const events = yield* EventV2Bridge.Service
     const database = yield* Database.Service
+    const credentials = yield* Credential.Service
     const storage = yield* Storage.Service
+    const lock = yield* Semaphore.make(1)
 
     const profile = Effect.fn("KiloGatewayHttpApi.profile")(function* () {
       const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
@@ -346,22 +350,51 @@ export const kiloGatewayHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilo",
     })
 
     const organization = Effect.fn("KiloGatewayHttpApi.organization")(function* (ctx) {
-      const info = yield* auth.get("kilo").pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-      if (!info || info.type !== "oauth") return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+      yield* lock
+        .withPermit(
+          Effect.gen(function* () {
+            const info = yield* auth.get("kilo")
+            if (!info || info.type !== "oauth") return yield* Effect.fail(new HttpApiError.Unauthorized({}))
 
-      yield* auth
-        .set("kilo", {
-          type: "oauth",
-          refresh: info.refresh,
-          access: info.access,
-          expires: info.expires,
-          ...(ctx.payload.organizationId && { accountId: ctx.payload.organizationId }),
-        })
+            const existing = yield* credentials.list(Integration.ID.make("kilo"))
+            const active = existing.at(-1)
+            if (!active || active.value.type !== "oauth") return yield* Effect.fail(new HttpApiError.Unauthorized({}))
+
+            const rollback = <E>(cause: Cause.Cause<E>) =>
+              Effect.gen(function* () {
+                yield* credentials.update(active.id, { value: active.value })
+                yield* auth.set("kilo", info)
+              }).pipe(
+                Effect.matchCauseEffect({
+                  onFailure: (next) => Effect.failCause(Cause.combine(cause, next)),
+                  onSuccess: () => Effect.failCause(cause),
+                }),
+              )
+
+            const metadata = { ...active.value.metadata }
+            if (ctx.payload.organizationId) metadata.accountID = ctx.payload.organizationId
+            else delete metadata.accountID
+            yield* credentials
+              .update(active.id, { value: { ...active.value, metadata } })
+              .pipe(Effect.catchCause(rollback))
+
+            yield* auth
+              .set("kilo", {
+                type: "oauth",
+                refresh: info.refresh,
+                access: info.access,
+                expires: info.expires,
+                ...(info.enterpriseUrl !== undefined && { enterpriseUrl: info.enterpriseUrl }),
+                ...(ctx.payload.organizationId && { accountId: ctx.payload.organizationId }),
+              })
+              .pipe(Effect.catchCause(rollback))
+
+            yield* cache.clear("kilo")
+            clearModesCache()
+            yield* store.disposeAll()
+          }).pipe(Effect.uninterruptible),
+        )
         .pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
-
-      yield* cache.clear("kilo")
-      clearModesCache()
-      yield* store.disposeAll().pipe(Effect.mapError(() => new HttpApiError.Unauthorized({})))
       return true
     })
 

--- a/packages/opencode/test/kilocode/server/httpapi-kilo-organization.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-kilo-organization.test.ts
@@ -1,0 +1,273 @@
+import { NodeHttpServer } from "@effect/platform-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Credential } from "@opencode-ai/core/credential"
+import { Database } from "@opencode-ai/core/database/database"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Integration } from "@opencode-ai/core/integration"
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi"
+import { Auth } from "../../../src/auth"
+import { EventV2Bridge } from "../../../src/event-v2-bridge"
+import { KiloGatewayApi, KiloGatewayPaths } from "../../../src/kilocode/server/httpapi/groups/kilo-gateway"
+import { kiloGatewayHandlers } from "../../../src/kilocode/server/httpapi/handlers/kilo-gateway"
+import { InstanceStore } from "../../../src/project/instance-store"
+import { ModelCache } from "../../../src/provider/model-cache"
+import { Authorization } from "../../../src/server/routes/instance/httpapi/middleware/authorization"
+import { InstanceContextMiddleware } from "../../../src/server/routes/instance/httpapi/middleware/instance-context"
+import { schemaErrorLayer } from "../../../src/server/routes/instance/httpapi/middleware/schema-error"
+import {
+  WorkspaceRouteContext,
+  WorkspaceRoutingMiddleware,
+} from "../../../src/server/routes/instance/httpapi/middleware/workspace-routing"
+import { Session } from "../../../src/session/session"
+import { Storage } from "../../../src/storage/storage"
+import { testEffect } from "../../lib/effect"
+
+const TestHttpApi = HttpApi.make("opencode-instance").addHttpApi(KiloGatewayApi)
+const AuthFile = Schema.Record(Schema.String, Auth.Info)
+const state: { file: Record<string, Auth.Info>; cleared: boolean; disposed: boolean; fail: boolean } = {
+  file: {},
+  cleared: false,
+  disposed: false,
+  fail: false,
+}
+const auth = Layer.mock(Auth.Service)({
+  get: (key) => Effect.sync(() => state.file[key]),
+  set: (key, info) =>
+    Effect.sync(() => {
+      state.file = { ...state.file, [key]: info }
+    }),
+})
+const store = Layer.mock(InstanceStore.Service)({
+  disposeAll: () => Effect.sync(() => void (state.disposed = true)),
+})
+const cache = Layer.mock(ModelCache.Service)({
+  clear: () => Effect.sync(() => void (state.cleared = true)),
+})
+const session = Layer.mock(Session.Service)({})
+const storage = Layer.mock(Storage.Service)({})
+const fs = Layer.effect(
+  FSUtil.Service,
+  Effect.gen(function* () {
+    const service = yield* FSUtil.Service
+    return FSUtil.Service.of({
+      ...service,
+      readJson: () => Effect.sync(() => state.file),
+      writeJson: (_path, data) =>
+        Effect.suspend(() => {
+          if (state.fail) {
+            state.fail = false
+            return Effect.fail(new FSUtil.FileSystemError({ method: "writeJson" }))
+          }
+          state.file = Schema.decodeUnknownSync(AuthFile)(data)
+          return Effect.void
+        }),
+    })
+  }),
+).pipe(Layer.provide(FSUtil.defaultLayer))
+const database = Database.layerFromPath(":memory:")
+const credentials = Credential.layer.pipe(
+  Layer.provide(database),
+  Layer.provide(fs),
+  Layer.provide(Global.layerWith({ data: "/test" })),
+)
+const authorization = Layer.succeed(
+  Authorization,
+  Authorization.of((effect) => effect),
+)
+const instance = Layer.succeed(
+  InstanceContextMiddleware,
+  InstanceContextMiddleware.of((effect) => effect),
+)
+const workspace = Layer.succeed(
+  WorkspaceRoutingMiddleware,
+  WorkspaceRoutingMiddleware.of((effect) =>
+    effect.pipe(Effect.provideService(WorkspaceRouteContext, WorkspaceRouteContext.of({ directory: process.cwd() }))),
+  ),
+)
+const server = HttpRouter.serve(
+  HttpApiBuilder.layer(TestHttpApi).pipe(
+    Layer.provide(kiloGatewayHandlers),
+    Layer.provide(schemaErrorLayer),
+    Layer.provide([
+      authorization,
+      instance,
+      workspace,
+      auth,
+      store,
+      cache,
+      session,
+      AppNodeBuilder.build(EventV2Bridge.node),
+    ]),
+    Layer.provide(database),
+    Layer.provide(storage),
+    Layer.provide(credentials),
+  ),
+  { disableListenLog: true, disableLogger: true },
+).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
+const it = testEffect(Layer.mergeAll(server, credentials))
+
+function select(organizationId: string | null) {
+  return HttpClientRequest.post(KiloGatewayPaths.organization).pipe(
+    HttpClientRequest.bodyJson({ organizationId }),
+    Effect.flatMap(HttpClient.execute),
+  )
+}
+
+function oauth(metadata: Record<string, unknown>) {
+  return Credential.OAuth.make({
+    type: "oauth",
+    methodID: Integration.MethodID.make("oauth"),
+    refresh: "core-refresh",
+    access: "core-access",
+    expires: 456,
+    metadata,
+  })
+}
+
+describe("Kilo organization selection", () => {
+  it.live("synchronizes Personal to organization without restarting the backend", () =>
+    Effect.gen(function* () {
+      state.file = {}
+      state.cleared = false
+      state.disposed = false
+      state.fail = false
+      const service = yield* Credential.Service
+      const created = yield* service.create({
+        integrationID: Integration.ID.make("kilo"),
+        label: "Kilo",
+        value: oauth({ enterpriseURL: "https://enterprise.example.com" }),
+      })
+      state.file = {
+        kilo: new Auth.Oauth({
+          type: "oauth",
+          refresh: "legacy-refresh",
+          access: "legacy-access",
+          expires: 123,
+          enterpriseUrl: "https://legacy.example.com",
+        }),
+      }
+
+      const response = yield* select("org-new")
+
+      expect(response.status).toBe(200)
+      expect(state.file.kilo).toEqual(
+        new Auth.Oauth({
+          type: "oauth",
+          refresh: "legacy-refresh",
+          access: "legacy-access",
+          expires: 123,
+          enterpriseUrl: "https://legacy.example.com",
+          accountId: "org-new",
+        }),
+      )
+      expect((yield* service.get(created.id))?.value).toEqual(
+        oauth({ enterpriseURL: "https://enterprise.example.com", accountID: "org-new" }),
+      )
+      expect(state.cleared).toBe(true)
+      expect(state.disposed).toBe(true)
+    }),
+  )
+
+  it.live("synchronizes organization to Personal without restarting the backend", () =>
+    Effect.gen(function* () {
+      state.file = {}
+      state.cleared = false
+      state.disposed = false
+      state.fail = false
+      const service = yield* Credential.Service
+      const created = yield* service.create({
+        integrationID: Integration.ID.make("kilo"),
+        label: "Kilo",
+        value: oauth({ enterpriseURL: "https://enterprise.example.com", accountID: "org-old" }),
+      })
+      state.file = {
+        kilo: new Auth.Oauth({
+          type: "oauth",
+          refresh: "legacy-refresh",
+          access: "legacy-access",
+          expires: 123,
+          enterpriseUrl: "https://legacy.example.com",
+          accountId: "org-old",
+        }),
+      }
+
+      const response = yield* select(null)
+      const value = (yield* service.get(created.id))?.value
+
+      expect(response.status).toBe(200)
+      expect(state.file.kilo).toEqual(
+        new Auth.Oauth({
+          type: "oauth",
+          refresh: "legacy-refresh",
+          access: "legacy-access",
+          expires: 123,
+          enterpriseUrl: "https://legacy.example.com",
+        }),
+      )
+      expect(value).toEqual(oauth({ enterpriseURL: "https://enterprise.example.com" }))
+      expect(value?.metadata).not.toHaveProperty("accountID")
+      expect(state.cleared).toBe(true)
+      expect(state.disposed).toBe(true)
+    }),
+  )
+
+  it.live("does not update Auth or dispose locations without an active Core OAuth credential", () =>
+    Effect.gen(function* () {
+      const initial = new Auth.Oauth({
+        type: "oauth",
+        refresh: "legacy-refresh",
+        access: "legacy-access",
+        expires: 123,
+      })
+      state.file = { kilo: initial }
+      state.cleared = false
+      state.disposed = false
+      state.fail = false
+
+      const response = yield* select("org-new")
+
+      expect(response.status).toBe(401)
+      expect(state.file.kilo).toEqual(initial)
+      expect(state.cleared).toBe(false)
+      expect(state.disposed).toBe(false)
+    }),
+  )
+
+  it.live("rolls back Core when its legacy Auth write fails", () =>
+    Effect.gen(function* () {
+      state.file = {}
+      state.cleared = false
+      state.disposed = false
+      state.fail = false
+      const service = yield* Credential.Service
+      const created = yield* service.create({
+        integrationID: Integration.ID.make("kilo"),
+        label: "Kilo",
+        value: oauth({ enterpriseURL: "https://enterprise.example.com" }),
+      })
+      const initial = new Auth.Oauth({
+        type: "oauth",
+        refresh: "legacy-refresh",
+        access: "legacy-access",
+        expires: 123,
+        enterpriseUrl: "https://legacy.example.com",
+      })
+      state.file = { kilo: initial }
+      state.fail = true
+
+      const response = yield* select("org-new")
+
+      expect(response.status).toBe(500)
+      expect(state.file.kilo).toEqual(initial)
+      expect((yield* service.get(created.id))?.value).toEqual(
+        oauth({ enterpriseURL: "https://enterprise.example.com" }),
+      )
+      expect(state.cleared).toBe(false)
+      expect(state.disposed).toBe(false)
+    }),
+  )
+})

--- a/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
+++ b/packages/opencode/test/kilocode/server/kilo-gateway-statuses.test.ts
@@ -1,6 +1,7 @@
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { NodeHttpServer } from "@effect/platform-node"
 import { Database } from "@opencode-ai/core/database/database"
+import { Credential } from "@opencode-ai/core/credential"
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
@@ -30,6 +31,7 @@ const store = Layer.mock(InstanceStore.Service)({})
 const cache = Layer.mock(ModelCache.Service)({})
 const session = Layer.mock(Session.Service)({})
 const storage = Layer.mock(Storage.Service)({})
+const credentials = Layer.mock(Credential.Service)({})
 const passthroughAuthorization = Layer.succeed(
   Authorization,
   Authorization.of((effect) => effect),
@@ -55,6 +57,7 @@ const layer = HttpRouter.serve(
       auth,
       store,
       cache,
+      credentials,
       session,
       AppNodeBuilder.build(EventV2Bridge.node),
     ]),


### PR DESCRIPTION
## What changed

Synchronize organization selection across the legacy Kilo Auth record and the active Core Kilo OAuth credential in the live backend. Organization switches now update Core `metadata.accountID` (or remove it for Personal), preserve unrelated OAuth fields and metadata, serialize concurrent switches, and roll both stores back if persistence fails before cache and instance invalidation.

## Why

Core imports `auth.json` only when the process-global Credential layer starts, while `kilo.organization.set` previously updated only legacy Auth. Disposing an instance does not rerun that import, so Core consumers could continue using the previous organization until the backend restarted.

This fixes that dual-store synchronization boundary directly. It is independent of #11611: Provider Usage exposed the stale credential state, but session model routing and any other Core credential consumer share the same underlying issue.