### PR TITLE
fix(vscode): sync mode selector after agent handoff

### DIFF
--- a/.changeset/fix-vscode-agent-mode-sync.md
+++ b/.changeset/fix-vscode-agent-mode-sync.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the VS Code mode selector synced with the backend after agent handoffs.

--- a/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
@@ -328,6 +328,13 @@ describe("PromptInput restoreFailed fallback contract", () => {
     expect(created).toContain("clearSessionDraftDiscarded(message.sessionID)")
     expect(status).not.toContain("clearSessionDraftDiscarded")
   })
+
+  it("reconciles confirmed backend user agents into the mode selector", () => {
+    const session = readFile(SESSION_FILE)
+    const created = extractFunctionBody(session, "handleMessageCreated")
+    expect(created).toContain("reconcileAgent(message, agentNames(), reconciledUser.get(message.sessionID))")
+    expect(created).toContain('setStore("agentSelections", message.sessionID, agent)')
+  })
 })
 
 describe("PromptInput send origin contract", () => {

--- a/packages/kilo-vscode/tests/unit/session-preferences.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-preferences.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { resolveMessagePrefs } from "../../webview-ui/src/context/session-preferences"
+import { reconcileAgent, resolveMessagePrefs } from "../../webview-ui/src/context/session-preferences"
 import type { Message } from "../../webview-ui/src/types/messages"
 
 function msg(input: Partial<Message>): Message {
@@ -68,5 +68,27 @@ describe("session preference recovery", () => {
       model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
       variant: undefined,
     })
+  })
+})
+
+describe("session agent reconciliation", () => {
+  it("reconciles a valid user message agent", () => {
+    expect(reconcileAgent(msg({ id: "new", agent: "code" }), agents, undefined)).toBe("code")
+  })
+
+  it("ignores a user message id that was already reconciled", () => {
+    expect(reconcileAgent(msg({ id: "same", agent: "code" }), agents, "same")).toBeUndefined()
+  })
+
+  it("ignores assistant messages", () => {
+    expect(reconcileAgent(msg({ role: "assistant", agent: "code" }), agents, undefined)).toBeUndefined()
+  })
+
+  it("ignores invalid agents", () => {
+    expect(reconcileAgent(msg({ agent: "task" }), agents, undefined)).toBeUndefined()
+  })
+
+  it("ignores messages without an agent", () => {
+    expect(reconcileAgent(msg({}), agents, undefined)).toBeUndefined()
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/context/session-preferences.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-preferences.ts
@@ -23,3 +23,11 @@ export function resolveMessagePrefs(messages: Message[], names: Set<string>): Me
   }
   return prefs
 }
+
+export function reconcileAgent(message: Message, names: Set<string>, last: string | undefined) {
+  if (message.role !== "user") return undefined
+  if (last === message.id) return undefined
+  const agent = message.agent?.trim()
+  if (!agent || !names.has(agent)) return undefined
+  return agent
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -70,7 +70,7 @@ import {
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
 import { getAgentModel } from "./session-model-store"
-import { resolveMessagePrefs } from "./session-preferences"
+import { reconcileAgent, resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
 import { mergeParts } from "./session-parts"
@@ -469,6 +469,7 @@ export const SessionProvider: ParentComponent = (props) => {
   // Tracks optimistic messageIDs that haven't been confirmed by the server yet.
   // Prevents handleMessagesLoaded from wiping them when it replaces the array.
   const pendingOptimistic = new Map<string, Set<string>>()
+  const reconciledUser = new Map<string, string>()
   // Sessions can be created/imported while an older list request is still in flight.
   // Keep them until a later list payload confirms them or deletion arrives.
   const freshSessions = new Set<string>()
@@ -1581,6 +1582,11 @@ export const SessionProvider: ParentComponent = (props) => {
     patchPage(message.sessionID, { lastMutation: exists ? "update" : "append" })
 
     recoverPrefs(message.sessionID, [message])
+    const agent = reconcileAgent(message, agentNames(), reconciledUser.get(message.sessionID))
+    if (agent) {
+      reconciledUser.set(message.sessionID, message.id)
+      setStore("agentSelections", message.sessionID, agent)
+    }
 
     if (message.parts && message.parts.length > 0) {
       stash.remove(message.id)
@@ -1978,6 +1984,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function handleSessionDeleted(sessionID: string) {
     pendingOptimistic.delete(sessionID)
+    reconciledUser.delete(sessionID)
     freshSessions.delete(sessionID)
     aborts.clear(sessionID)
     confirmSubmissions(sessionID)


### PR DESCRIPTION
## Issue

No linked issue; reported directly during dogfooding.

## Context

The VS Code mode selector could drift from the backend's active agent after backend-driven agent handoffs, leaving the UI showing one mode while the session behaved as another until the window was reloaded.

## Implementation

Backend-confirmed user messages now reconcile the webview's per-session agent selection when they carry a valid agent. A per-session message id guard prevents re-fired message updates from overwriting an unsent manual mode selection. The existing history recovery path remains guarded so normal session focus behavior is unchanged.

Added unit coverage for the reconciliation helper and a source contract test to keep the `handleMessageCreated` wiring in place.

## Screenshots / Video

N/A — state-sync fix with no visual changes.

## How to Test

### Manual/local verification

- Agent ran `bun test tests/unit/session-preferences.test.ts tests/unit/prompt-send-contract.test.ts` from `packages/kilo-vscode/`.
- Agent ran `bun run check-types:webview` from `packages/kilo-vscode/`.
- Agent ran `bun run lint` from `packages/kilo-vscode/`.
- Agent ran `bun run format` from `packages/kilo-vscode/`.
- Pre-push hook ran `bun turbo typecheck "--filter=!@kilocode/kilo-jetbrains"` successfully.

### Reviewer test steps

1. Launch the development extension with `bun run extension:isolated:clean -- ../sample-project`.
2. Set the chat mode to Architect and ask it to create a short implementation plan.
3. When the plan follow-up appears, submit a custom refinement answer.
4. Confirm the mode selector updates to the backend-confirmed agent without reloading the VS Code window.
5. Reload the VS Code window and confirm the selector value does not change.

### Blocked checks and substitute verification

- `bun run test -- --grep ...` could not complete in this local environment because `vscode-test` downloaded VS Code but failed to spawn Electron with `ENOENT`; substitute verification was running the two affected unit files directly with Bun plus webview typecheck, lint, format, and the pre-push turborepo typecheck.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A
