### PR TITLE
fix(ci): reduce Windows CLI test contention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,10 @@ jobs:
             exit 0
           fi
           echo 'general=true' >> "$GITHUB_OUTPUT"
-          echo 'settings=[{"os":"linux","index":1,"total":2,"host":"blacksmith-4vcpu-ubuntu-2404","run":true,"packages":true},{"os":"linux","index":2,"total":2,"host":"blacksmith-4vcpu-ubuntu-2404","run":true,"packages":false},{"os":"macos","index":1,"total":1,"host":"macos-15","run":true,"packages":true},{"os":"windows","index":1,"total":4,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":true},{"os":"windows","index":2,"total":4,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":3,"total":4,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":4,"total":4,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false}]' >> "$GITHUB_OUTPUT"
+          # kilocode_change - Windows is 6 shards (was 4): CLI tests now run at KILO_TEST_CONCURRENCY=2
+          # instead of the default 4 to cut CPU contention on the 4-vCPU runner; more shards keep
+          # per-shard wall-clock within the job timeout despite the lower per-shard parallelism.
+          echo 'settings=[{"os":"linux","index":1,"total":2,"host":"blacksmith-4vcpu-ubuntu-2404","run":true,"packages":true},{"os":"linux","index":2,"total":2,"host":"blacksmith-4vcpu-ubuntu-2404","run":true,"packages":false},{"os":"macos","index":1,"total":1,"host":"macos-15","run":true,"packages":true},{"os":"windows","index":1,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":true},{"os":"windows","index":2,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":3,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":4,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":5,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false},{"os":"windows","index":6,"total":6,"host":"blacksmith-4vcpu-windows-2025","run":true,"packages":false}]' >> "$GITHUB_OUTPUT"
   # kilocode_change end
   unit:
     # kilocode_change start
@@ -172,6 +175,17 @@ jobs:
           KILO_EXPERIMENTAL_DISABLE_FILEWATCHER: "true" # kilocode_change - was Windows-only; the CLI now starts a watcher per instance, too heavy/racy for unit tests. Watcher tests opt back in.
           KILO_TEST_PROFILE: ${{ matrix.settings.os == 'macos' && 'darwin' || '' }}
           KILO_TEST_SHARD: ${{ format('{0}/{1}', matrix.settings.index, matrix.settings.total) }}
+          # kilocode_change - cap parallelism on the 4-vCPU Windows runner. At the default
+          # min(4, cpus)=4, four heavy real-server test files share 4 vCPUs (~1 each) and blow
+          # their per-test timeouts; 2 gives each process real CPU headroom. Windows grows to
+          # 6 shards to absorb the lower per-shard parallelism. Linux/macOS (not timeout
+          # offenders; macOS is a single unsharded job) keep the default.
+          KILO_TEST_CONCURRENCY: ${{ matrix.settings.os == 'windows' && '2' || '' }}
+          # kilocode_change - raise the per-file kill deadline on Windows only. Heavy real-server
+          # files run ~230-270s serially there (vs ~40s on macOS/Linux), leaving only ~30s under
+          # the 300s default; 600s gives healthy-but-slow files real margin without masking hangs
+          # elsewhere (Linux/macOS keep the 300s default).
+          KILO_TEST_FILE_TIMEOUT: ${{ matrix.settings.os == 'windows' && '600000' || '' }}
       # kilocode_change end
 
       # kilocode_change start

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -29,9 +29,9 @@ if (argv.includes("--help") || argv.includes("-h")) {
       "",
       "Options:",
       "  --ci                 Enable JUnit XML output to .artifacts/unit/junit.xml",
-      "  --concurrency <N>    Max parallel processes (default: min(4, CPU count))",
+      "  --concurrency <N>    Max parallel processes (default: min(4, CPU count), env: KILO_TEST_CONCURRENCY)",
       "  --timeout <ms>       Per-test timeout passed to bun test (default: 60000)",
-      "  --file-timeout <ms>  Per-file process timeout (default: 300000)",
+      "  --file-timeout <ms>  Per-file process timeout (default: 300000, env: KILO_TEST_FILE_TIMEOUT)",
       "  --retries <N>        Extra attempts for failing files (default: 1)",
       "  --profile <name>     Run a curated test profile (env: KILO_TEST_PROFILE)",
       "  --shard <N/M>        Run one balanced file shard (env: KILO_TEST_SHARD)",
@@ -73,9 +73,39 @@ const dots = !verbose && (ci || argv.includes("--dots"))
 // Cap concurrency at 4 even on bigger runners: the bottleneck is shared
 // resources (ports, global filesystem like ~/.local/share/kilo), not CPU.
 // Eight parallel processes was triggering port/FS races, not going faster.
-const concurrency = opt("concurrency", Math.min(4, os.cpus().length))
+// kilocode_change start - allow CI to lower concurrency via env. On the 4-vCPU
+// Windows runner, the default (min(4, cpus)=4) oversubscribes: 4 heavy real-server
+// test files share 4 vCPUs (~1 each) and blow their per-test timeouts.
+// `KILO_TEST_CONCURRENCY` lets the workflow throttle Windows without affecting the
+// local default. An explicit `--concurrency` flag wins.
+const concurrencyEnv = (() => {
+  const raw = process.env.KILO_TEST_CONCURRENCY?.trim()
+  if (!raw) return undefined
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < 1) {
+    console.error(`Invalid KILO_TEST_CONCURRENCY "${raw}"; expected a positive integer`)
+    process.exit(2)
+  }
+  return value
+})()
+const concurrency = opt("concurrency", concurrencyEnv ?? Math.min(4, os.cpus().length))
+// kilocode_change end
 const timeout = opt("timeout", 60000)
-const deadline = opt("file-timeout", 300000)
+// kilocode_change start - allow CI to raise the per-file kill deadline via env. On Windows,
+// heavy real-server files (e.g. config-overlay) legitimately run ~270s serially, only ~30s
+// under the 300s default; raising it there prevents a slow-but-healthy run from being killed.
+const fileTimeoutEnv = (() => {
+  const raw = process.env.KILO_TEST_FILE_TIMEOUT?.trim()
+  if (!raw) return undefined
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < 1) {
+    console.error(`Invalid KILO_TEST_FILE_TIMEOUT "${raw}"; expected a positive integer (ms)`)
+    process.exit(2)
+  }
+  return value
+})()
+const deadline = opt("file-timeout", fileTimeoutEnv ?? 300000)
+// kilocode_change end
 const retries = opt("retries", 1)
 const flag = text("profile")
 const env = process.env.KILO_TEST_PROFILE?.trim() || undefined
@@ -156,7 +186,28 @@ if (shard && shard.total > candidates.length) {
   console.error(`Test shard count ${shard.total} exceeds selected file count ${candidates.length}`)
   process.exit(2)
 }
-const weight = (file: string) => Bun.file(path.join(root, "test", file)).size
+// kilocode_change start - shard by estimated DURATION, not file size. File size is a poor
+// proxy: run-process.test.ts is ~7 KB but ~230s, while config-overlay is the single slowest
+// file — under size-weighting both landed in the same shard, stacking the two heaviest files.
+// DURATION_HINTS are max observed per-file durations (ms) from real Windows CI runs; the LPT
+// splitter places the highest-weight files first, so hinted heavy files get spread across
+// distinct shards. Unhinted files fall back to size (a fine proxy among the fast majority);
+// hint values (tens of thousands of ms) dominate byte sizes, so heavy files always sort first.
+// Refresh these from observed CI durations when the suite changes materially.
+const DURATION_HINTS: Record<string, number> = {
+  "kilocode/server/config-overlay.test.ts": 270_000,
+  "cli/run/run-process.test.ts": 233_000,
+  "snapshot/snapshot.test.ts": 165_000,
+  "session/prompt.test.ts": 128_000,
+  "tool/shell.test.ts": 95_000,
+  "kilocode/background-process.test.ts": 94_000,
+  "provider/provider.test.ts": 90_000,
+  "kilocode/indexing-startup.test.ts": 88_000,
+  "kilocode/daemon.test.ts": 65_000,
+  "tool/task.test.ts": 64_000,
+}
+const weight = (file: string) => DURATION_HINTS[file] ?? Bun.file(path.join(root, "test", file)).size
+// kilocode_change end
 const files = shard ? TestShard.split(candidates, weight, shard.total)[shard.index - 1] : candidates
 
 if (files.length === 0) {
@@ -189,9 +240,7 @@ const xmldir = ci ? path.join(os.tmpdir(), `opencode-junit-${process.pid}`) : ""
 if (ci) await fs.mkdir(xmldir, { recursive: true })
 // kilocode_change start
 const supplied = process.env[TestCli.ENV]
-const built = supplied
-  ? { binary: supplied, dir: undefined }
-  : { binary: await TestCli.build(root), dir: undefined }
+const built = supplied ? { binary: supplied, dir: undefined } : { binary: await TestCli.build(root), dir: undefined }
 
 async function cleanBinary() {
   if (!built.dir) return


### PR DESCRIPTION
## fix(ci): reduce Windows CLI test contention

### Problem
Windows unit jobs are the biggest CI flakiness source (~62% of test-job failures). The `@kilocode/cli` tests run through our custom `test-runner.ts` at `min(4, cpus)` = **4 files at once on the 4-vCPU Windows runner**; heavy real-server files get ~1 vCPU each and blow their per-test timeouts.

### In scope (Windows, `@kilocode/cli` runner only)
- **Concurrency capped to 2** (`KILO_TEST_CONCURRENCY=2`) — each file gets ~2 vCPU.
- **6 shards** (was 4) to keep per-shard wall-clock under the job cap.
- **Duration-based sharding** (was file size) so the two heaviest files don't stack.
- **Per-file deadline raised to 600s** (`KILO_TEST_FILE_TIMEOUT`) — the heaviest file runs ~270s, only ~30s under the old 300s default.

Linux/macOS unchanged.

### Out of scope
- **Non-CLI / `@opencode-ai/core` suite** — runs via plain `bun test`, so these knobs don't reach it; throttling it is a separate lever (per @marius-kilocode's note).
- **HttpApi permission race** (Linux) and **opentui/scrollback hang** (Windows) — real code/dependency bugs, separate follow-ups.

### Evidence — 6 runs, all green
This PR's own CI run — a real `pull_request` (cache-miss = genuine execution, real PR conditions): **[31545193495](https://github.com/Kilo-Org/kilocode/actions/runs/31545193495)** — all 6 Windows shards pass.

Plus 5 prior `workflow_dispatch` runs: [31536957068](https://github.com/Kilo-Org/kilocode/actions/runs/31536957068) · [31539345090](https://github.com/Kilo-Org/kilocode/actions/runs/31539345090) · [31539347494](https://github.com/Kilo-Org/kilocode/actions/runs/31539347494) · [31541429209](https://github.com/Kilo-Org/kilocode/actions/runs/31541429209) · [31541432642](https://github.com/Kilo-Org/kilocode/actions/runs/31541432642)

Across the 4 instrumented runs: **24 Windows shard-jobs / 2,640 file-runs → 0 failures, 0 timeouts, 0 flaky.** Per-file timeout headroom went from ~30s to ~340s.

### Cost / tradeoff
This buys stability with a bit more time — **only on real (cache-miss) runs**:
- **Wall-clock:** Windows finishes **~2.7 min later** (~11 min vs ~8–9 min).
- **Billed:** **~+22 Windows VM-minutes/run** (2 extra VMs + concurrency 2).

When no relevant code changed, the turbo cache replays in ~1s, so it's **almost free** (~+3 VM-min, negligible wall-clock). Still far under the 45-min job cap.

### Validation
`workflow_dispatch` runs mostly hit the turbo cache; the real proof is **on-main PR traffic**. Plan: merge, then watch the Windows failure rate over the following week.
