### PR TITLE
test(cli): optimize httpapi exerciser by removing redundant git fixtures and isolating scenario passes

### DIFF
--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -209,14 +209,17 @@ export const kiloScenarios: Scenario[] = [
     .json(200, object),
   http.protected
     .get("/experimental/worktree/diff", "worktree.diff")
+    .inProject({ git: true })
     .at((ctx) => ({ path: "/experimental/worktree/diff?base=HEAD", headers: ctx.headers() }))
     .json(200, array),
   http.protected
     .get("/experimental/worktree/diff/summary", "worktree.diffSummary")
+    .inProject({ git: true })
     .at((ctx) => ({ path: "/experimental/worktree/diff/summary?base=HEAD", headers: ctx.headers() }))
     .json(200, array),
   http.protected
     .get("/experimental/worktree/diff/file", "worktree.diffFile")
+    .inProject({ git: true })
     .at((ctx) => ({
       path: `/experimental/worktree/diff/file?${new URLSearchParams({ base: "HEAD", file: "missing.txt" })}`,
       headers: ctx.headers(),

--- a/packages/opencode/test/server/httpapi-exercise/dsl.ts
+++ b/packages/opencode/test/server/httpapi-exercise/dsl.ts
@@ -23,7 +23,7 @@ class ScenarioBuilder<S = undefined> {
       path,
       name,
       // kilocode_change start - default to an in-memory project dir; opt into git init only for routes
-      // that exercise VCS primitives or HEAD-baseed diffs to avoid ~70 redundant `git init` calls per run.
+      // that exercise VCS primitives or HEAD-based diffs to avoid ~70 redundant `git init` calls per run.
       project: { git: false },
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- The unseeded builder state is intentionally undefined until `.seeded(...)` narrows it.
       seed: () => Effect.succeed(undefined as S),

--- a/packages/opencode/test/server/httpapi-exercise/dsl.ts
+++ b/packages/opencode/test/server/httpapi-exercise/dsl.ts
@@ -22,7 +22,9 @@ class ScenarioBuilder<S = undefined> {
       method,
       path,
       name,
-      project: { git: true },
+      // kilocode_change start - default to an in-memory project dir; opt into git init only for routes
+      // that exercise VCS primitives or HEAD-baseed diffs to avoid ~70 redundant `git init` calls per run.
+      project: { git: false },
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- The unseeded builder state is intentionally undefined until `.seeded(...)` narrows it.
       seed: () => Effect.succeed(undefined as S),
       request: (ctx) => ({ path, headers: ctx.headers() }),
@@ -39,12 +41,12 @@ class ScenarioBuilder<S = undefined> {
     return this.clone({ project: undefined, request: () => ({ path: this.state.path }) })
   }
 
-  inProject(project: ProjectOptions = { git: true }) {
+  inProject(project: ProjectOptions = { git: false }) {
     return this.clone({ project })
   }
 
   withLlm() {
-    return this.clone({ project: { ...(this.state.project ?? { git: true }), llm: true } })
+    return this.clone({ project: { ...(this.state.project ?? { git: false }), llm: true } })
   }
 
   at(request: BuilderState<S>["request"]) {

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -116,11 +116,13 @@ const scenarios: Scenario[] = [
       },
       "status",
     ),
-  http.protected.get("/path", "path.get").json(200, (body, ctx) => {
+  // kilocode_change start - opt into git init; the worktree assertion requires a git-backed project
+  http.protected.get("/path", "path.get").inProject({ git: true }).json(200, (body, ctx) => {
     object(body)
     check(body.directory === ctx.directory, "directory should resolve from x-kilo-directory")
     check(body.worktree === ctx.directory, "worktree should resolve from x-kilo-directory")
   }),
+  // kilocode_change end
   http.protected.get("/vcs", "vcs.get").inProject({ git: true }).json(),
   http.protected.get("/vcs/status", "vcs.status").inProject({ git: true }).json(200, array),
   http.protected
@@ -165,14 +167,19 @@ const scenarios: Scenario[] = [
     .status(400),
   http.protected.get("/config/providers", "config.providers").json(),
   http.protected.get("/project", "project.list").json(200, array, "status"),
-  http.protected.get("/project/current", "project.current").json(
-    200,
-    (body, ctx) => {
-      object(body)
-      check(body.worktree === ctx.directory, "current project should resolve from scenario directory")
-    },
-    "status",
-  ),
+  // kilocode_change start - opt into git init; the worktree assertion requires a git-backed project
+  http.protected
+    .get("/project/current", "project.current")
+    .inProject({ git: true })
+    .json(
+      200,
+      (body, ctx) => {
+        object(body)
+        check(body.worktree === ctx.directory, "current project should resolve from scenario directory")
+      },
+      "status",
+    ),
+  // kilocode_change end
   http.protected
     .patch("/project/{projectID}", "project.update")
     .mutating()
@@ -871,6 +878,9 @@ const scenarios: Scenario[] = [
       headers: ctx.headers(),
       body: { action: "read", resources: [".env"] },
     }))
+    // kilocode_change start - opt into git init; the permission resolver consults VCS state for unknown resources
+    .inProject({ git: true })
+    // kilocode_change end
     .json(200, (body) => {
       object(body)
       object(body.data)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -31,11 +31,11 @@ import {
   exerciseGlobalRoot,
 } from "./environment"
 import { color, printHeader, printResults } from "./report"
-import { coverageResult, parseOptions, routeKey, routeKeys, selectedScenarios } from "./routing"
+import { coverageResult, parseOptions, routeKey, routeKeys, selectedScenarios, shardScenarios } from "./routing" // kilocode_change
 import { runScenario } from "./runner"
 import { disposeApps } from "./backend"
-import { runtime } from "./runtime"
-import { type Scenario } from "./types"
+import { publicApi, runtime } from "./runtime" // kilocode_change
+import { type Scenario, type Result } from "./types"
 import { kiloScenarios } from "../../kilocode/server/httpapi-exercise-scenarios" // kilocode_change
 
 function cursor(input: Record<string, unknown>) {
@@ -121,13 +121,14 @@ const scenarios: Scenario[] = [
     check(body.directory === ctx.directory, "directory should resolve from x-kilo-directory")
     check(body.worktree === ctx.directory, "worktree should resolve from x-kilo-directory")
   }),
-  http.protected.get("/vcs", "vcs.get").json(),
-  http.protected.get("/vcs/status", "vcs.status").json(200, array),
+  http.protected.get("/vcs", "vcs.get").inProject({ git: true }).json(),
+  http.protected.get("/vcs/status", "vcs.status").inProject({ git: true }).json(200, array),
   http.protected
     .get("/vcs/diff", "vcs.diff")
+    .inProject({ git: true })
     .at((ctx) => ({ path: "/vcs/diff?mode=git", headers: ctx.headers() }))
     .json(200, array),
-  http.protected.get("/vcs/diff/raw", "vcs.diff.raw").status(
+  http.protected.get("/vcs/diff/raw", "vcs.diff.raw").inProject({ git: true }).status(
     200,
     (_ctx, result) =>
       Effect.sync(() => {
@@ -581,6 +582,7 @@ const scenarios: Scenario[] = [
   http.protected
     .post("/experimental/worktree", "worktree.create")
     .mutating()
+    .inProject({ git: true })
     .at((ctx) => ({ path: "/experimental/worktree", headers: ctx.headers(), body: { name: "api-dsl" } }))
     .jsonEffect(
       200,
@@ -599,6 +601,7 @@ const scenarios: Scenario[] = [
   http.protected
     .delete("/experimental/worktree", "worktree.remove")
     .mutating()
+    .inProject({ git: true })
     .seeded((ctx) => ctx.worktree({ name: "api-remove" }))
     .at((ctx) => ({ path: "/experimental/worktree", headers: ctx.headers(), body: { directory: ctx.state.directory } }))
     .json(200, (body) => {
@@ -607,6 +610,7 @@ const scenarios: Scenario[] = [
   http.protected
     .post("/experimental/worktree/reset", "worktree.reset")
     .mutating()
+    .inProject({ git: true })
     .seeded((ctx) => ctx.worktree({ name: "api-reset" }))
     .at((ctx) => ({
       path: "/experimental/worktree/reset",
@@ -1314,6 +1318,7 @@ const scenarios: Scenario[] = [
     }),
   http.protected
     .get("/session/{sessionID}/diff", "session.diff")
+    .inProject({ git: true })
     .seeded((ctx) => ctx.session({ title: "Diff session" }))
     .at((ctx) => ({ path: route("/session/{sessionID}/diff", { sessionID: ctx.state.id }), headers: ctx.headers() }))
     .json(200, array),
@@ -1795,9 +1800,31 @@ const main = Effect.gen(function* () {
   )
   // kilocode_change end
   const options = parseOptions(Bun.argv.slice(2))
+  // kilocode_change start - coverage only needs the OpenAPI group; bypass runtime + LLM + DB allocation
+  if (options.mode === "coverage") {
+    const selected = selectedScenarios(options, scenarios)
+    const effectRoutes = routeKeys(OpenApi.fromApi(yield* Effect.promise(() => publicApi())))
+    const missing = effectRoutes.filter((route) => !scenarios.some((scenario) => route === routeKey(scenario)))
+    const extra = scenarios.filter((scenario) => !effectRoutes.includes(routeKey(scenario)))
+    printHeader(options, effectRoutes, selected, missing, extra, {
+      database: exerciseDatabasePath,
+      global: exerciseGlobalRoot,
+    })
+    const results = selected.map(coverageResult)
+    printResults(results, missing, extra)
+    if (results.some((result) => result.status === "fail"))
+      return yield* Effect.fail(new Error("one or more scenarios failed"))
+    if (options.failOnSkip && results.some((result) => result.status === "skip"))
+      return yield* Effect.fail(new Error("one or more scenarios are skipped"))
+    if (options.failOnMissing && missing.length > 0)
+      return yield* Effect.fail(new Error("one or more routes have no scenario"))
+    return undefined
+  }
+  // kilocode_change end
   const modules = yield* Effect.promise(() => runtime())
   const effectRoutes = routeKeys(OpenApi.fromApi(modules.PublicApi))
   const selected = selectedScenarios(options, scenarios)
+  const sharded = shardScenarios(selected, options.shard)
   const missing = effectRoutes.filter((route) => !scenarios.some((scenario) => route === routeKey(scenario)))
   const extra = scenarios.filter((scenario) => !effectRoutes.includes(routeKey(scenario)))
 
@@ -1807,23 +1834,20 @@ const main = Effect.gen(function* () {
     }
   }
 
-  printHeader(options, effectRoutes, selected, missing, extra, {
+  printHeader(options, effectRoutes, sharded, missing, extra, {
     database: exerciseDatabasePath,
     global: exerciseGlobalRoot,
   })
 
-  const results =
-    options.mode === "coverage"
-      ? selected.map(coverageResult)
-      : yield* Effect.forEach(
-          selected,
-          (scenario) =>
-            Effect.gen(function* () {
-              if (options.progress) console.log(`${color.dim}RUN ${routeKey(scenario)} ${scenario.name}${color.reset}`)
-              return yield* runScenario(options)(scenario)
-            }),
-          { concurrency: 1 },
-        )
+  const results: Result[] = yield* Effect.forEach(
+    sharded,
+    (scenario) =>
+      Effect.gen(function* () {
+        if (options.progress) console.log(`${color.dim}RUN ${routeKey(scenario)} ${scenario.name}${color.reset}`)
+        return yield* runScenario(options)(scenario)
+      }),
+    { concurrency: 1 },
+  )
   printResults(results, missing, extra)
 
   if (results.some((result) => result.status === "fail"))
@@ -1835,11 +1859,10 @@ const main = Effect.gen(function* () {
   return undefined
 })
 
-// kilocode_change start - route-only coverage must not acquire a listening fake LLM server
+// kilocode_change start - route-only coverage must not acquire a listening fake LLM server; effect/auth runs alone
+const initialOptions = parseOptions(Bun.argv.slice(2))
 const llm =
-  parseOptions(Bun.argv.slice(2)).mode === "coverage"
-    ? Layer.mock(TestLLMServer)({ url: "http://coverage.invalid" })
-    : TestLLMServer.layer
+  initialOptions.mode === "coverage" ? Layer.mock(TestLLMServer)({ url: "http://coverage.invalid" }) : TestLLMServer.layer
 
 Effect.runPromise(main.pipe(Effect.provide(llm), Effect.scoped)).then(
   () => process.exit(0),

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1789,17 +1789,12 @@ const llmScenarios = new Set([
 ])
 
 const main = Effect.gen(function* () {
-  // kilocode_change start - dispose final non-mutating instances so shared test scopes can close
-  yield* Effect.addFinalizer(() =>
-    Effect.gen(function* () {
-      const modules = yield* Effect.promise(() => runtime())
-      yield* Effect.promise(() => modules.disposeAllInstances())
-      yield* Effect.promise(() => disposeApps())
-      yield* cleanupExercisePaths
-    }),
-  )
-  // kilocode_change end
   const options = parseOptions(Bun.argv.slice(2))
+  for (const scenario of scenarios) {
+    if (scenario.kind === "active" && llmScenarios.has(scenario.name) && !scenario.project?.llm) {
+      return yield* Effect.fail(new Error(`${scenario.name} must use TestLLMServer via .withLlm()`))
+    }
+  }
   // kilocode_change start - coverage only needs the OpenAPI group; bypass runtime + LLM + DB allocation
   if (options.mode === "coverage") {
     const selected = selectedScenarios(options, scenarios)
@@ -1818,8 +1813,19 @@ const main = Effect.gen(function* () {
       return yield* Effect.fail(new Error("one or more scenarios are skipped"))
     if (options.failOnMissing && missing.length > 0)
       return yield* Effect.fail(new Error("one or more routes have no scenario"))
+    yield* cleanupExercisePaths
     return undefined
   }
+  // kilocode_change end
+  // kilocode_change start - dispose final non-mutating instances so shared test scopes can close; skip when coverage returned early so runtime() is never imported in static mode
+  yield* Effect.addFinalizer(() =>
+    Effect.gen(function* () {
+      const modules = yield* Effect.promise(() => runtime())
+      yield* Effect.promise(() => modules.disposeAllInstances())
+      yield* Effect.promise(() => disposeApps())
+      yield* cleanupExercisePaths
+    }),
+  )
   // kilocode_change end
   const modules = yield* Effect.promise(() => runtime())
   const effectRoutes = routeKeys(OpenApi.fromApi(modules.PublicApi))
@@ -1827,12 +1833,6 @@ const main = Effect.gen(function* () {
   const sharded = shardScenarios(selected, options.shard)
   const missing = effectRoutes.filter((route) => !scenarios.some((scenario) => route === routeKey(scenario)))
   const extra = scenarios.filter((scenario) => !effectRoutes.includes(routeKey(scenario)))
-
-  for (const scenario of scenarios) {
-    if (scenario.kind === "active" && llmScenarios.has(scenario.name) && !scenario.project?.llm) {
-      return yield* Effect.fail(new Error(`${scenario.name} must use TestLLMServer via .withLlm()`))
-    }
-  }
 
   printHeader(options, effectRoutes, sharded, missing, extra, {
     database: exerciseDatabasePath,

--- a/packages/opencode/test/server/httpapi-exercise/routing.ts
+++ b/packages/opencode/test/server/httpapi-exercise/routing.ts
@@ -52,8 +52,30 @@ export function parseOptions(args: string[]): Options {
     scenarioTimeout: parseScenarioTimeout(option(args, "--scenario-timeout") ?? "30 seconds"),
     progress: args.includes("--progress"),
     trace: args.includes("--trace"),
+    // kilocode_change start - each shard owns an isolated DB already; --shard <index>/<total> lets the runner
+    // distribute the work across processes/cores. The PID-keyed DB means shards are safe to run in parallel.
+    shard: parseShard(option(args, "--shard")),
+    // kilocode_change end
   }
 }
+
+// kilocode_change start - allow external (CI) callers to fan the exerciser out across N processes by index
+export function shardScenarios<T>(items: T[], shard: { index: number; total: number }): T[] {
+  if (shard.total <= 1) return items
+  return items.filter((_item, i) => i % shard.total === shard.index)
+}
+
+function parseShard(input: string | undefined): { index: number; total: number } {
+  if (!input) return { index: 0, total: 1 }
+  const match = input.match(/^(\d+)\/(\d+)$/)
+  if (!match) throw new Error(`invalid --shard ${input}, expected <index>/<total>`)
+  const index = Number(match[1])
+  const total = Number(match[2])
+  if (total < 1) throw new Error(`--shard total must be >= 1, got ${total}`)
+  if (index < 0 || index >= total) throw new Error(`--shard index must be in 0..${total - 1}, got ${index}`)
+  return { index, total }
+}
+// kilocode_change end
 
 export function matches(options: Options, scenario: Scenario) {
   if (!options.include) return true

--- a/packages/opencode/test/server/httpapi-exercise/runtime.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runtime.ts
@@ -14,6 +14,14 @@ export type Runtime = {
   tmpdir: (typeof import("../../fixture/fixture"))["tmpdir"]
 }
 
+// kilocode_change start - coverage only needs the OpenAPI group; bypass the full runtime import to keep
+// static route-coverage checks sub-second on CI
+export async function publicApi() {
+  const publicApiModule = await import("../../../src/server/routes/instance/httpapi/public")
+  return publicApiModule.PublicApi
+}
+// kilocode_change end
+
 let runtimePromise: Promise<Runtime> | undefined
 
 export function runtime() {

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -35,6 +35,7 @@ export type Options = {
   scenarioTimeout: Duration.Duration
   progress: boolean
   trace: boolean
+  shard: { index: number; total: number } // kilocode_change - opt-in sharding so CI runners can fan out across processes
 }
 
 export type RequestSpec = {


### PR DESCRIPTION
The HttpApi exerciser was the largest CI bottleneck at ~6m30s on the 8-vCPU runner. Profiling identified three contributors; this PR addresses all three.

## Changes

- **Default scenario project fixture is now in-memory.** `ScenarioBuilder` and `inProject()` default to `{ git: false }`; only the ~10 routes that actually exercise VCS primitives or HEAD-based diffs opt into git init via `.inProject({ git: true })`. Eliminates ~70 redundant `git init` calls per run.
- **`mode coverage` is now a standalone fast static check.** It early-returns after comparing scenario names against `routeKeys(OpenApi.fromApi(publicApi()))` via a new `publicApi()` helper in `runtime.ts`, skipping the full runtime/LLM/DB allocation entirely.
- **`--shard <index>/<total>` flag** added so CI runners can fan the exerciser out across processes. `shardScenarios()` partitions the scenario list before `Effect.forEach`. Each shard already owns an isolated PID-keyed DB (`opencode-httpapi-exercise-${process.pid}.db`), so shards are safe to run in parallel.

## Verification

- `bun run typecheck` passes in `packages/opencode/`.
- `bun run script/check-opencode-annotations.ts --worktree` passes (all Kilo-specific changes in shared upstream files are annotated).
- `bun run script/check-workflows.ts` passes.
- `bun run knip` in `packages/kilo-vscode/` passes.

CI timing measurements will be collected by the next exerciser run on the upstream runner.

## Markers

All shared-file changes use `kilocode_change` markers per AGENTS.md fork-isolation rules.