### PR TITLE
fix(ci): make HttpApi exerciser and Bun setup resilient to flakes

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -29,9 +29,10 @@ runs:
           echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
-    # kilocode_change start - the Bun release download intermittently fails with a transient
-    # network error (e.g. "socket hang up"), which fails the whole check. Allow one retry,
-    # mirroring the Setup Node retry pattern used elsewhere in CI.
+    # kilocode_change start - the Bun release download from GitHub intermittently fails with a
+    # transient network error ("socket hang up", HTTP 503), which fails the whole check. GitHub's
+    # CDN blips can last tens of seconds, so an immediate retry is not enough: attempt up to three
+    # times with a backoff between tries. Only the final attempt (no continue-on-error) fails the job.
     - name: Setup Bun
       id: setup-bun
       continue-on-error: true
@@ -40,8 +41,27 @@ runs:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
 
-    - name: Retry Setup Bun
+    - name: Back off before Bun retry
       if: steps.setup-bun.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - name: Retry Setup Bun
+      id: setup-bun-retry
+      if: steps.setup-bun.outcome == 'failure'
+      continue-on-error: true
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Back off before final Bun attempt
+      if: steps.setup-bun.outcome == 'failure' && steps.setup-bun-retry.outcome == 'failure'
+      shell: bash
+      run: sleep 30
+
+    - name: Setup Bun (final attempt)
+      if: steps.setup-bun.outcome == 'failure' && steps.setup-bun-retry.outcome == 'failure'
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -29,11 +29,24 @@ runs:
           echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
+    # kilocode_change start - the Bun release download intermittently fails with a transient
+    # network error (e.g. "socket hang up"), which fails the whole check. Allow one retry,
+    # mirroring the Setup Node retry pattern used elsewhere in CI.
     - name: Setup Bun
+      id: setup-bun
+      continue-on-error: true
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Retry Setup Bun
+      if: steps.setup-bun.outcome == 'failure'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
+    # kilocode_change end
 
     - name: Get cache directory
       id: cache

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDownloader.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDownloader.kt
@@ -17,6 +17,7 @@ import okhttp3.Response
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import java.io.File
+import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
 import java.nio.channels.OverlappingFileLockException
@@ -41,6 +42,11 @@ class KiloCliDownloader(
     companion object {
         private const val LOCK_TIMEOUT_MS = 30_000L
         private const val LOCK_POLL_MS = 100L
+        // GitHub release downloads intermittently drop the connection mid-transfer
+        // (e.g. "Unexpected end of file from server"). Retry transient network errors
+        // with a short backoff so a single flake does not fail the whole build/connect.
+        private const val NETWORK_ATTEMPTS = 3
+        private const val NETWORK_BACKOFF_MS = 500L
         private val DIGEST = Regex("^sha256:[a-f0-9]{64}$")
         private val JSON = Json { ignoreUnknownKeys = true }
         private val LOCKS = ConcurrentHashMap<String, Any>()
@@ -218,6 +224,7 @@ class KiloCliDownloader(
             .url(url)
             .header("Accept", "application/vnd.github+json")
             .build()
+        return retryNetwork("Fetching Kilo CLI $version metadata") {
         http.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 val info = rate(response)
@@ -250,7 +257,8 @@ class KiloCliDownloader(
             if (!digest.matches(DIGEST)) {
                 fail("Kilo CLI release $version asset $name has a malformed digest '$digest'; expected sha256:<64 hex chars>")
             }
-            return digest
+            digest
+        }
         }
     }
 
@@ -269,6 +277,7 @@ class KiloCliDownloader(
         val url = url(version, platform, ext)
         log.info("Downloading Kilo CLI $version for $platform from $url")
         val request = Request.Builder().url(url).build()
+        retryNetwork("Downloading Kilo CLI $version for $platform") {
         http.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 throw IllegalStateException("Failed to download Kilo CLI $version for $platform: HTTP ${response.code}")
@@ -294,6 +303,25 @@ class KiloCliDownloader(
                         }
                     }
                 }
+            }
+        }
+        }
+    }
+
+    // Retry transient network failures (dropped connections, read timeouts) with a short
+    // linear backoff. HTTP status errors surface as IllegalStateException and are not retried.
+    private fun <T> retryNetwork(what: String, block: () -> T): T {
+        var attempt = 1
+        while (true) {
+            try {
+                return block()
+            } catch (e: IOException) {
+                if (attempt >= NETWORK_ATTEMPTS) {
+                    throw IllegalStateException("$what failed after $attempt attempts: ${e.message}", e)
+                }
+                log.warn("$what failed on attempt $attempt/$NETWORK_ATTEMPTS, retrying: ${e.message}")
+                Thread.sleep(NETWORK_BACKOFF_MS * attempt)
+                attempt += 1
             }
         }
     }

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/cli/KiloCliDownloaderTest.kt
@@ -4,6 +4,7 @@ import ai.kilocode.backend.testing.TestLog
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import okio.Buffer
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
@@ -224,6 +225,35 @@ class KiloCliDownloaderTest {
             assertTrue(cli.isFile)
             assertEquals("#!/bin/old\n", cli.readText())
             assertTrue(File(cli.parentFile.parentFile, ".complete").isFile)
+        }
+    }
+
+    @Test
+    fun `retries a dropped download and succeeds`() = runBlocking {
+        MockWebServer().use { server ->
+            val bytes = archive()
+            // First attempt drops the connection mid-transfer (the observed CI flake:
+            // "Unexpected end of file from server"); the retry then completes normally.
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(Buffer().write(bytes))
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY)
+            )
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(bytes)))
+            val log = TestLog()
+
+            val cli = KiloCliDownloader(
+                log = log,
+                root = dir,
+                baseUrl = server.url("/release").toString(),
+                api = server.url("/api").toString(),
+                digests = digests(bytes),
+            ).resolve("1.2.3")
+
+            assertTrue(cli.isFile)
+            assertEquals(2, server.requestCount)
+            assertTrue(log.messages.any { it.contains("Downloading Kilo CLI 1.2.3") && it.contains("retrying") })
         }
     }
 

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
@@ -17,6 +17,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URI
 import java.security.MessageDigest
@@ -32,7 +33,14 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
         private val DIGEST = Regex("^sha256:[a-f0-9]{64}$")
         private val JSON = Json { ignoreUnknownKeys = true }
         private const val API = "https://api.github.com/repos/Kilo-Org/kilocode/releases/tags"
+        // GitHub release/API downloads intermittently drop connections or return transient 5xx
+        // (observed in CI: "socket hang up", HTTP 503). Retry those with a backoff so a brief
+        // CDN blip does not fail the whole build. Permanent errors (404, digest, rate limit) do not retry.
+        private const val NETWORK_ATTEMPTS = 4
+        private const val NETWORK_BACKOFF_MS = 5_000L
     }
+
+    private class RetryableHttp(val code: Int, message: String) : RuntimeException(message)
 
     @get:Input
     abstract val cliVersion: Property<String>
@@ -151,6 +159,7 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
     private fun asset(version: String, name: String): String {
         val url = "$API/v$version"
         logger.lifecycle("Fetching pinned Kilo CLI release metadata from $url")
+        return withRetry("Fetching pinned Kilo CLI release metadata") {
         val conn = URI(url).toURL().openConnection() as HttpURLConnection
         conn.connectTimeout = 30_000
         conn.readTimeout = 120_000
@@ -173,7 +182,9 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
                         "GitHub API rate limit exceeded while fetching pinned Kilo CLI release metadata ($info)$detail"
                     )
                 }
-                throw GradleException("Failed to fetch pinned Kilo CLI release metadata: HTTP $code from $url ($info)$detail")
+                val message = "Failed to fetch pinned Kilo CLI release metadata: HTTP $code from $url ($info)$detail"
+                if (transient(code)) throw RetryableHttp(code, message)
+                throw GradleException(message)
             }
             val body = conn.inputStream.bufferedReader().use { it.readText() }
             val digest = JSON.parseToJsonElement(body).jsonObject["assets"]?.jsonArray
@@ -181,11 +192,35 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
                 ?.jsonObject?.get("digest")?.jsonPrimitive?.contentOrNull
                 ?: throw GradleException("Pinned Kilo CLI release $version did not include $name")
             if (!digest.matches(DIGEST)) throw GradleException("Pinned Kilo CLI release $version asset $name has invalid digest")
-            return digest
+            digest
         } finally {
             conn.disconnect()
         }
+        }
     }
+
+    // Retry transient network failures (dropped connections and 5xx) with a linear backoff.
+    // Permanent errors (4xx, rate limit, digest mismatch) surface immediately as GradleException.
+    private fun <T> withRetry(what: String, block: () -> T): T {
+        var attempt = 1
+        while (true) {
+            try {
+                return block()
+            } catch (e: RetryableHttp) {
+                if (attempt >= NETWORK_ATTEMPTS) throw GradleException(e.message ?: "$what failed after $attempt attempts")
+                logger.warn("$what failed on attempt $attempt/$NETWORK_ATTEMPTS (HTTP ${e.code}), retrying")
+                Thread.sleep(NETWORK_BACKOFF_MS * attempt)
+                attempt += 1
+            } catch (e: IOException) {
+                if (attempt >= NETWORK_ATTEMPTS) throw GradleException("$what failed after $attempt attempts: ${e.message}", e)
+                logger.warn("$what failed on attempt $attempt/$NETWORK_ATTEMPTS, retrying: ${e.message}")
+                Thread.sleep(NETWORK_BACKOFF_MS * attempt)
+                attempt += 1
+            }
+        }
+    }
+
+    private fun transient(code: Int) = code in 500..599
 
     private fun rate(conn: HttpURLConnection): String {
         val reset = conn.getHeaderField("X-RateLimit-Reset")
@@ -200,18 +235,24 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
 
     private fun download(url: String, file: File) {
         logger.lifecycle("Downloading pinned Kilo CLI from $url")
-        val conn = URI(url).toURL().openConnection() as HttpURLConnection
-        conn.connectTimeout = 30_000
-        conn.readTimeout = 120_000
-        conn.instanceFollowRedirects = true
-        try {
-            val code = conn.responseCode
-            if (code !in 200..299) throw GradleException("Failed to download pinned Kilo CLI: HTTP $code from $url")
-            conn.inputStream.use { input ->
-                file.outputStream().use { output -> input.copyTo(output) }
+        withRetry("Downloading pinned Kilo CLI") {
+            val conn = URI(url).toURL().openConnection() as HttpURLConnection
+            conn.connectTimeout = 30_000
+            conn.readTimeout = 120_000
+            conn.instanceFollowRedirects = true
+            try {
+                val code = conn.responseCode
+                if (code !in 200..299) {
+                    val message = "Failed to download pinned Kilo CLI: HTTP $code from $url"
+                    if (transient(code)) throw RetryableHttp(code, message)
+                    throw GradleException(message)
+                }
+                conn.inputStream.use { input ->
+                    file.outputStream().use { output -> input.copyTo(output) }
+                }
+            } finally {
+                conn.disconnect()
             }
-        } finally {
-            conn.disconnect()
         }
     }
 

--- a/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
+++ b/packages/kilo-jetbrains/build-tasks/src/main/kotlin/GenerateOpenApiSpecTask.kt
@@ -34,9 +34,10 @@ abstract class GenerateOpenApiSpecTask : DefaultTask() {
         private val JSON = Json { ignoreUnknownKeys = true }
         private const val API = "https://api.github.com/repos/Kilo-Org/kilocode/releases/tags"
         // GitHub release/API downloads intermittently drop connections or return transient 5xx
-        // (observed in CI: "socket hang up", HTTP 503). Retry those with a backoff so a brief
-        // CDN blip does not fail the whole build. Permanent errors (404, digest, rate limit) do not retry.
-        private const val NETWORK_ATTEMPTS = 4
+        // (observed in CI: "socket hang up", HTTP 503) for tens of seconds at a time. This build
+        // task has no cached fallback, so retry generously (linear backoff 5s/10s/15s/20s ~= 50s)
+        // to ride out CDN blips. Permanent errors (404, digest, rate limit) still fail immediately.
+        private const val NETWORK_ATTEMPTS = 5
         private const val NETWORK_BACKOFF_MS = 5_000L
     }
 

--- a/packages/opencode/test/server/httpapi-exercise-retry.test.ts
+++ b/packages/opencode/test/server/httpapi-exercise-retry.test.ts
@@ -1,0 +1,59 @@
+// kilocode_change - new file
+//
+// Unit tests for the HttpApi exerciser scenario retry. A single transient scenario
+// flake must not fail the whole gate, while a genuine regression must fail every attempt.
+
+import { describe, expect, test } from "bun:test"
+import { Effect, Ref } from "effect"
+import { attemptWithRetry } from "./httpapi-exercise/runner"
+import type { ActiveScenario, Result } from "./httpapi-exercise/types"
+
+const scenario = { kind: "active", name: "probe", method: "GET", path: "/x" } as unknown as ActiveScenario
+
+// An attempt that fails its first `failures` runs, then passes. Re-running the same
+// Effect increments the shared counter, mirroring how `attemptWithRetry` re-runs it.
+const flaky = (counter: Ref.Ref<number>, failures: number) =>
+  Ref.updateAndGet(counter, (n) => n + 1).pipe(
+    Effect.map(
+      (tries): Result =>
+        tries <= failures ? { status: "fail", scenario, message: "boom" } : { status: "pass", scenario },
+    ),
+  )
+
+describe("attemptWithRetry", () => {
+  test("passes on the first try without tagging attempts", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const counter = yield* Ref.make(0)
+        return yield* attemptWithRetry(flaky(counter, 0), 3, 1)
+      }),
+    )
+    if (result.status === "skip") throw new Error("unexpected skip result")
+    expect(result.status).toBe("pass")
+    expect(result.attempts).toBeUndefined()
+  })
+
+  test("recovers from a transient failure and records the attempt count", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const counter = yield* Ref.make(0)
+        return yield* attemptWithRetry(flaky(counter, 1), 3, 1)
+      }),
+    )
+    if (result.status === "skip") throw new Error("unexpected skip result")
+    expect(result.status).toBe("pass")
+    expect(result.attempts).toBe(2)
+  })
+
+  test("fails after exhausting every attempt", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const counter = yield* Ref.make(0)
+        return yield* attemptWithRetry(flaky(counter, 99), 3, 1)
+      }),
+    )
+    if (result.status === "skip") throw new Error("unexpected skip result")
+    expect(result.status).toBe("fail")
+    expect(result.attempts).toBe(3)
+  })
+})

--- a/packages/opencode/test/server/httpapi-exercise/report.ts
+++ b/packages/opencode/test/server/httpapi-exercise/report.ts
@@ -31,9 +31,13 @@ export function printHeader(
 export function printResults(results: Result[], missing: string[], extra: Scenario[]) {
   for (const result of results) {
     if (result.status === "pass") {
+      // kilocode_change start - flag scenarios that only passed after a retry so flakes stay visible
+      const retried =
+        result.attempts && result.attempts > 1 ? ` ${color.yellow}[attempt ${result.attempts}]${color.reset}` : ""
       console.log(
-        `${color.green}PASS${color.reset} ${pad(result.scenario.method, 6)} ${pad(result.scenario.path, 48)} ${result.scenario.name}`,
+        `${color.green}PASS${color.reset} ${pad(result.scenario.method, 6)} ${pad(result.scenario.path, 48)} ${result.scenario.name}${retried}`,
       )
+      // kilocode_change end
       continue
     }
     if (result.status === "skip") {
@@ -56,9 +60,12 @@ export function printResults(results: Result[], missing: string[], extra: Scenar
     for (const scenario of extra)
       console.log(`${color.yellow}EXTRA${color.reset} ${routeKey(scenario)} ${scenario.name}`)
   }
+  // kilocode_change start - surface the flaky count (passed only after a retry) alongside the totals
+  const flaky = results.filter((result) => result.status === "pass" && (result.attempts ?? 1) > 1).length
   console.log(
-    `\n${color.dim}summary pass=${results.filter((result) => result.status === "pass").length} fail=${results.filter((result) => result.status === "fail").length} skip=${results.filter((result) => result.status === "skip").length} missing=${missing.length} extra=${extra.length}${color.reset}`,
+    `\n${color.dim}summary pass=${results.filter((result) => result.status === "pass").length} fail=${results.filter((result) => result.status === "fail").length} skip=${results.filter((result) => result.status === "skip").length} flaky=${flaky} missing=${missing.length} extra=${extra.length}${color.reset}`,
   )
+  // kilocode_change end
 }
 
 function routeKey(scenario: Scenario) {

--- a/packages/opencode/test/server/httpapi-exercise/routing.ts
+++ b/packages/opencode/test/server/httpapi-exercise/routing.ts
@@ -50,6 +50,7 @@ export function parseOptions(args: string[]): Options {
     failOnMissing: args.includes("--fail-on-missing"),
     failOnSkip: args.includes("--fail-on-skip"),
     scenarioTimeout: parseScenarioTimeout(option(args, "--scenario-timeout") ?? "30 seconds"),
+    retries: parseRetries(option(args, "--retries")), // kilocode_change
     progress: args.includes("--progress"),
     trace: args.includes("--trace"),
   }
@@ -84,6 +85,17 @@ function option(args: string[], name: string) {
   if (index === -1) return undefined
   return args[index + 1]
 }
+
+// kilocode_change start - default to 2 extra attempts so a single transient scenario flake
+// (for example cross-scenario state that outlives an async reset) does not fail the whole gate.
+// Retries only cost time on failure; a real regression still fails every attempt.
+function parseRetries(input: string | undefined) {
+  if (input === undefined) return 2
+  const value = Number(input)
+  if (!Number.isInteger(value) || value < 0) throw new Error(`invalid --retries ${input}`)
+  return value
+}
+// kilocode_change end
 
 function parseScenarioTimeout(input: string) {
   if (!isScenarioTimeout(input)) throw new Error(`invalid --scenario-timeout ${input}`)

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -17,17 +17,41 @@ import { ModelV2 } from "@opencode-ai/core/model"
 export function runScenario(options: Options) {
   return (scenario: Scenario) => {
     if (scenario.kind === "todo") return Effect.succeed({ status: "skip", scenario } as Result)
-    return runActive(options, scenario).pipe(
-      Effect.timeoutOrElse({
-        duration: options.scenarioTimeout,
-        orElse: () => Effect.die(new Error(`scenario timed out after ${Duration.format(options.scenarioTimeout)}`)),
-      }),
-      Effect.as({ status: "pass", scenario } as Result),
-      Effect.catchCause((cause) => Effect.succeed({ status: "fail" as const, scenario, message: Cause.pretty(cause) })),
-      Effect.scoped,
-    )
+    // kilocode_change start - retry a failing scenario before it counts as a failure so a single transient
+    // flake does not turn the whole HttpApi gate (and main) red. A genuine regression fails every attempt.
+    return attemptWithRetry(runOnce(options, scenario), options.retries + 1, 1)
+    // kilocode_change end
   }
 }
+
+// kilocode_change start
+function runOnce(options: Options, scenario: ActiveScenario) {
+  return runActive(options, scenario).pipe(
+    Effect.timeoutOrElse({
+      duration: options.scenarioTimeout,
+      orElse: () => Effect.die(new Error(`scenario timed out after ${Duration.format(options.scenarioTimeout)}`)),
+    }),
+    Effect.as({ status: "pass", scenario } as Result),
+    Effect.catchCause((cause) => Effect.succeed({ status: "fail" as const, scenario, message: Cause.pretty(cause) })),
+    Effect.scoped,
+  )
+}
+
+export function attemptWithRetry<R>(
+  attempt: Effect.Effect<Result, never, R>,
+  total: number,
+  index: number,
+): Effect.Effect<Result, never, R> {
+  return attempt.pipe(
+    Effect.flatMap((result) => {
+      if (result.status === "fail" && index < total) return attemptWithRetry(attempt, total, index + 1)
+      // Only tag `attempts` once a retry happened so single-try passes stay noise-free in the report.
+      if (result.status === "skip" || index === 1) return Effect.succeed(result)
+      return Effect.succeed({ ...result, attempts: index })
+    }),
+  )
+}
+// kilocode_change end
 
 function runActive(options: Options, scenario: ActiveScenario) {
   if (options.mode === "auth") return runAuth(scenario)

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -33,6 +33,7 @@ export type Options = {
   failOnMissing: boolean
   failOnSkip: boolean
   scenarioTimeout: Duration.Duration
+  retries: number // kilocode_change - extra attempts for a failing scenario before it counts as a failure
   progress: boolean
   trace: boolean
 }
@@ -121,8 +122,10 @@ export type TodoScenario = {
 }
 
 export type Result =
-  | { status: "pass"; scenario: ActiveScenario }
-  | { status: "fail"; scenario: ActiveScenario; message: string }
+  // kilocode_change start - `attempts` records how many tries a scenario took; >1 means it passed only after a retry (flaky)
+  | { status: "pass"; scenario: ActiveScenario; attempts?: number }
+  | { status: "fail"; scenario: ActiveScenario; message: string; attempts?: number }
+  // kilocode_change end
   | { status: "skip"; scenario: TodoScenario }
 
 export type SessionInfo = { id: SessionID; title: string; parentID?: SessionID }


### PR DESCRIPTION
## What

Resilience fixes that eliminate the most frequent transient CI failures on `main`. All three are the same root pattern — **a network download or a single flaky scenario with no retry fails the whole gate**:

1. **HttpApi exerciser scenario retry** — the exerciser had no retry, so one flaky scenario failed the whole required `test (linux)` gate. Added `--retries` (default **2** extra attempts) in `test/server/httpapi-exercise/`. Retried passes are reported as `flaky=N` in the summary and tagged `[attempt N]` per line so flakes stay visible. A genuine regression still fails every attempt.
2. **Bun download retry** — `.github/actions/setup-bun` now retries the `oven-sh/setup-bun` download once (`continue-on-error` + a gated retry step), mirroring the existing Setup Node retry.
3. **Kilo CLI download retry (JetBrains)** — `KiloCliDownloader` fetched release metadata and the archive with single OkHttp calls; a dropped connection failed the whole jetbrains typecheck/build. Now retries transient network errors (up to 3 attempts, short backoff). HTTP status errors (404, rate limit) still fail immediately.

## Why

Investigation of recent push runs on `main` showed the `test` workflow failing ~32% of the time, from transient classes:

- **HttpApi exerciser** (4/8 `test` failures): always the identical scenario `v2.session.permission.create` (`pass=314 fail=1`). Cross-scenario state occasionally outlives the async reset between scenarios, flipping the created permission's `effect` away from `"ask"`.
- **`typecheck`**: `socket hang up` while downloading the Bun release.
- **`typecheck-jetbrains`** (seen on this PR's own CI): `java.net.SocketException: Unexpected end of file` downloading the pinned Kilo CLI release. Confirmed transient — passed on re-run.

Retry is the contained, correct fix for all three: transient flakes recover on a second attempt, real breakage keeps failing.

## Tests

- New `test/server/httpapi-exercise-retry.test.ts` covers the exerciser retry decision logic (first-try pass, recover-after-one-failure with `attempts=2`, exhaust-all-attempts fail).
- New `KiloCliDownloaderTest."retries a dropped download and succeeds"` uses `MockWebServer` with `DISCONNECT_DURING_RESPONSE_BODY` to prove the download recovers after a mid-transfer drop (13/13 downloader tests pass).
- `bun run typecheck`, prettier, `check-opencode-annotations.ts --worktree`, and `./gradlew :backend:test --tests KiloCliDownloaderTest` all pass. Ran the exerciser locally: permission scenarios green, `flaky=0`.

## Not in scope (follow-up)

The remaining `test` failures are Windows unit-test flakes on the 4-vCPU runners — timeouts on a *different* test each run (`KiloSnapshotTrack`, `config overlay routes`, `HttpApi Server.listen`) plus a `grep-signal-controls` layer-init `fetch()` socket drop. These are real-time / harness-network races that need careful, individual rewrites (per the repo's "wait on a readiness signal, not wall-clock" guidance) and are intentionally left out of this PR to keep it low-risk. The unit runner already retries failed files once.
