### PR TITLE
fix(vscode): show full session cost on load

### DIFF
--- a/.changeset/show-full-session-cost.md
+++ b/.changeset/show-full-session-cost.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show the full session cost immediately when opening long conversations

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -194,11 +194,14 @@ export async function runWithMessageConfirmation<T>(
   }
 }
 
-export function sessionToWebview(session: Pick<Session, "id" | "parentID" | "title" | "time" | "summary" | "revert">) {
+export function sessionToWebview(
+  session: Pick<Session, "id" | "parentID" | "title" | "time" | "summary" | "revert" | "cost">,
+) {
   return {
     id: session.id,
     parentID: session.parentID ?? null,
     title: session.title,
+    cost: session.cost,
     createdAt: new Date(session.time.created).toISOString(),
     updatedAt: new Date(session.time.updated).toISOString(),
     // Use null (not undefined) so the value survives postMessage JSON serialization.

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -150,9 +150,10 @@ describe("sessionToWebview", () => {
   })
 
   it("preserves id and title", () => {
-    const result = sessionToWebview(makeSession({ id: "abc", title: "My Session" }))
+    const result = sessionToWebview(makeSession({ id: "abc", title: "My Session", cost: 1.25 }))
     expect(result.id).toBe("abc")
     expect(result.title).toBe("My Session")
+    expect(result.cost).toBe(1.25)
   })
 
   it("produces valid ISO format", () => {

--- a/packages/kilo-vscode/tests/unit/session-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-utils.test.ts
@@ -285,6 +285,26 @@ describe("buildFamilyCosts", () => {
     expect(costs.get("s3")).toBeCloseTo(0.1)
   })
 
+  it("uses the session total when only a page of messages is loaded", () => {
+    const family = new Set(["s1"])
+    const messages = { s1: [msg("recent", "assistant", 0.25)] }
+    const sessions = { s1: { cost: 1 } }
+
+    const costs = buildFamilyCosts(family, messages, sessions)
+
+    expect(costs.get("s1")).toBe(1)
+  })
+
+  it("keeps a newer loaded-message total above a stale session total", () => {
+    const family = new Set(["s1"])
+    const messages = { s1: [msg("old", "assistant", 0.75), msg("live", "assistant", 0.5)] }
+    const sessions = { s1: { cost: 1 } }
+
+    const costs = buildFamilyCosts(family, messages, sessions)
+
+    expect(costs.get("s1")).toBe(1.25)
+  })
+
   it("subtracts each subagent's propagated total from its parent (single child)", () => {
     // Backend contract: parent's message.info.cost already includes the
     // child's total. Parent total $0.15 = parent own $0.05 + child $0.10.

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -333,11 +333,14 @@ export function formatTG(value: number | undefined, locale: string) {
 export function buildFamilyCosts(
   family: Set<string>,
   messages: Record<string, Array<{ role: string; cost?: number }>>,
-  sessions: Record<string, { parentID?: string | null } | undefined>,
+  sessions: Record<string, { parentID?: string | null; cost?: number } | undefined>,
   parents: Map<string, string> = new Map(),
 ): Map<string, number> {
   const totals = new Map<string, number>()
-  for (const sid of family) totals.set(sid, calcTotalCost(messages[sid] ?? []))
+  for (const sid of family) {
+    const loaded = calcTotalCost(messages[sid] ?? [])
+    totals.set(sid, Math.max(loaded, sessions[sid]?.cost ?? 0))
+  }
 
   const own = new Map<string, number>(totals)
   for (const sid of family) {

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -2848,10 +2848,10 @@ export const SessionProvider: ParentComponent = (props) => {
   )
 
   /**
-   * Per-session **own cost** — reads `store.messages` for per-session
-   * propagated totals and task metadata as a fallback for parent links so each
-   * session's entry excludes the cost already propagated up from its
-   * descendants by the CLI backend.
+   * Per-session **own cost** — uses the authoritative session total as a floor
+   * for the paginated messages currently loaded, then excludes the cost already
+   * propagated up from descendants by the CLI backend. Task metadata provides
+   * fallback parent links for child sessions not yet present in the session list.
    */
   const familyCosts = createMemo<Map<string, number>>(() => {
     const id = currentSessionID()

--- a/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/sessions.ts
@@ -44,6 +44,7 @@ export interface SessionInfo {
   id: string
   parentID?: string | null
   title?: string
+  cost?: number
   createdAt: string
   updatedAt: string
   revert?: {


### PR DESCRIPTION
## What changed

Long conversations now show their complete session cost immediately, including portions of the session were not loaded. For really long sessions, earlier turns cost was only included when you scrolled back far enough to cause them to be loaded.

The VS Code webview uses the authoritative cost already present on session metadata as a floor for its loaded-message calculation. This preserves live cost updates and subagent breakdowns without adding API requests or scanning the full transcript.

## Why

The task header previously calculated cost only from messages loaded into the paginated webview. On long sessions, the initial page could display only a fraction of the actual cost and increase as older pages loaded.