### PR TITLE
feat(vs-code): GraphQL gh schema validation on pull request (non-blocking)

### DIFF
--- a/.github/workflows/test-vscode.yml
+++ b/.github/workflows/test-vscode.yml
@@ -53,3 +53,24 @@ jobs:
       - name: Check for kilocode_change markers
         working-directory: packages/kilo-vscode
         run: bun run check-kilocode-change
+
+  graphql-schema:
+    name: Validate GraphQL schema (non-blocking)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Non-blocking - PR can merge even if this fails
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Validate GitQL fields against GitHub schema
+        working-directory: packages/kilo-vscode
+        run: |
+          echo "Checking GraphQL fields..."
+          bun run validate:github-graphql || {
+            echo "::warning::GraphQL validation failed - check logs above"
+            exit 1
+          }

--- a/packages/kilo-vscode/.gitignore
+++ b/packages/kilo-vscode/.gitignore
@@ -4,3 +4,4 @@ out/
 storybook-static/
 test-results/
 playwright-report/
+.github-schema-cache.graphql

--- a/packages/kilo-vscode/.prettierignore
+++ b/packages/kilo-vscode/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 out
 *.md
+.github-schema-cache.graphql

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1287,6 +1287,7 @@
     "esbuild-plugin-solid": "^0.6.0",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
+    "graphql": "17.0.2",
     "happy-dom": "20.8.9",
     "knip": "5.85.0",
     "prettier": "3.6.2",

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1254,6 +1254,7 @@
     "lint": "eslint --cache --cache-strategy content --cache-location node_modules/.cache/eslint src webview-ui",
     "test": "vscode-test",
     "test:unit": "bun test tests/unit/ --dots",
+    "validate:github-graphql": "bun script/validate-github-graphql.ts",
     "rebuild-sdk": "bun run --cwd ../sdk/js build",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build -o storybook-static",

--- a/packages/kilo-vscode/script/validate-github-graphql.ts
+++ b/packages/kilo-vscode/script/validate-github-graphql.ts
@@ -1,92 +1,75 @@
 #!/usr/bin/env bun
 /**
- * Validates GraphQL queries against GitHub's public schema.
- * Automatically extracts all identifiers from GraphQL queries in
- * src/agent-manager/pr/graphql.ts and validates them.
+ * Validates GraphQL queries against GitHub's public schema using AST type checking.
+ * Parses all queries in src/agent-manager/pr/graphql.ts and validates them against
+ * the schema using the `graphql` package — catching wrong fields, type mismatches,
+ * and missing required arguments, not just substring matches.
  *
- * Note: Schema from GitHub docs may differ from api.github.com/graphql
- * especially for Enterprise Server or preview features.
+ * Note: Schema fetched from GitHub Docs (FPT) — may lag slightly behind
+ * api.github.com/graphql after GitHub deploys schema changes. For exact parity,
+ * run introspection locally via `gh api graphql` (requires authenticated gh CLI).
  *
  * Run with: bun run validate:github-graphql
  */
 
-// Schema from GitHub docs - version may differ from api.github.com/graphql
-// especially for Enterprise Server or preview features
+import { buildASTSchema, parse, validate } from "graphql"
+import * as queries from "../src/agent-manager/pr/graphql"
+
 const SCHEMA_URL = "https://docs.github.com/public/fpt/schema.docs.graphql"
-// NOTE: This script assumes it's run from packages/kilo-vscode/ directory
-// (CI sets working-directory: packages/kilo-vscode before running)
-const FIELDS_FILE = "src/agent-manager/pr/graphql.ts"
 
 async function fetchSchema(): Promise<string> {
-  console.log("Fetching GitHub GraphQL schema...")
-  const response = await fetch(SCHEMA_URL)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch schema: ${response.status}`)
-  }
-  return await response.text()
+	console.log("Fetching GitHub GraphQL schema...")
+	const response = await fetch(SCHEMA_URL)
+	if (!response.ok) throw new Error(`Failed to fetch schema: ${response.status}`)
+	return response.text()
 }
 
-function extractFields(source: string): string[] {
-  const fields: string[] = []
-
-  // Find all template literals (GraphQL queries) - matches content between backticks
-  const templateRegex = /`([\s\S]*?)`/g
-  let match
-
-  while ((match = templateRegex.exec(source)) !== null) {
-    const content = match[1]
-    // Only process template literals that contain GraphQL
-    if (!content.match(/^(query|mutation|subscription)/)) continue
-
-    // Extract all identifiers
-    const fieldRegex = /\b([a-zA-Z_][a-zA-Z0-9_]*)\b/g
-    let fieldMatch
-
-    while ((fieldMatch = fieldRegex.exec(content)) !== null) {
-      fields.push(fieldMatch[1])
-    }
-  }
-
-  // Remove duplicates: fields appearing in multiple queries (like 'id') only need to be validated once
-  // Convert to Set (automatically unique), spread back to array, then sort alphabetically for consistent output
-  return [...new Set(fields)].sort()
+function extractQueries(): { name: string; query: string }[] {
+	return Object.entries(queries)
+		.filter(([ , val]) => typeof val === "string" && /^(query|mutation|subscription)/.test(val.trim()))
+		.map(([name, val]) => ({ name, query: (val as string).trim() }))
 }
 
 async function main() {
-  console.log("Validating GitHub GraphQL schema...\n")
+	console.log("Validating GitHub GraphQL queries...\n")
 
-  const schema = await fetchSchema()
-  const sourceCode = await Bun.file(FIELDS_FILE).text()
-  const fields = extractFields(sourceCode)
+	const sdl = await fetchSchema()
+	// buildASTSchema with assumeValid: skip internal schema consistency checks —
+	// the GitHub Docs SDL has deprecated-field interface mismatches that would
+	// otherwise throw before we get to validate our queries
+	const schema = buildASTSchema(parse(sdl), { assumeValid: true })
+	const found = extractQueries()
 
-  if (fields.length === 0) {
-    console.error(`ERROR: Could not extract fields from ${FIELDS_FILE}`)
-    process.exit(1)
-  }
+	if (found.length === 0) {
+		console.error("ERROR: No GraphQL queries found in src/agent-manager/pr/graphql.ts")
+		process.exit(1)
+	}
 
-  let missing = 0
+	let failed = 0
 
-  for (const field of fields) {
-    if (schema.includes(field)) {
-      console.log(`  ✓ ${field}`)
-    } else {
-      console.log(`  ✗ ${field} NOT FOUND`)
-      missing++
-    }
-  }
+	for (const { name, query } of found) {
+		const doc = parse(query)
+		const errors = validate(schema, doc)
+		if (errors.length === 0) {
+			console.log(`  ✓ ${name}`)
+		} else {
+			console.log(`  ✗ ${name}`)
+			for (const err of errors) console.log(`      ${err.message}`)
+			failed++
+		}
+	}
 
-  if (missing === 0) {
-    console.log(`All ${fields.length} required fields present in schema`)
-    process.exit(0)
-  } else {
-    console.error(`ERROR: ${missing}/${fields.length} field(s) not found in schema`)
-    console.error("Schema may have changed or fields may be deprecated")
-    console.error("Update GraphQL queries in src/agent-manager/pr/graphql.ts if needed")
-    process.exit(1) // Fail so it's visible in CI logs, but continue-on-error allows merge
-  }
+	if (failed === 0) {
+		console.log(`\nAll ${found.length} queries valid`)
+		process.exit(0)
+	} else {
+		console.error(`\n${failed}/${found.length} queries failed validation`)
+		console.error("Update GraphQL queries in src/agent-manager/pr/graphql.ts")
+		process.exit(1)
+	}
 }
 
 main().catch((err) => {
-  console.error("Validation failed:", err)
-  process.exit(1)
+	console.error("Validation failed:", err)
+	process.exit(1)
 })

--- a/packages/kilo-vscode/script/validate-github-graphql.ts
+++ b/packages/kilo-vscode/script/validate-github-graphql.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * Validates GraphQL queries against GitHub's public schema.
+ * Automatically extracts all identifiers from GraphQL queries in
+ * src/agent-manager/pr/graphql.ts and validates them.
+ *
+ * Note: Schema from GitHub docs may differ from api.github.com/graphql
+ * especially for Enterprise Server or preview features.
+ *
+ * Run with: bun run validate:github-graphql
+ */
+
+// Schema from GitHub docs - version may differ from api.github.com/graphql
+// especially for Enterprise Server or preview features
+const SCHEMA_URL = "https://docs.github.com/public/fpt/schema.docs.graphql"
+// NOTE: This script assumes it's run from packages/kilo-vscode/ directory
+// (CI sets working-directory: packages/kilo-vscode before running)
+const FIELDS_FILE = "src/agent-manager/pr/graphql.ts"
+
+async function fetchSchema(): Promise<string> {
+  console.log("Fetching GitHub GraphQL schema...")
+  const response = await fetch(SCHEMA_URL)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch schema: ${response.status}`)
+  }
+  return await response.text()
+}
+
+function extractFields(source: string): string[] {
+  const fields: string[] = []
+
+  // Find all template literals (GraphQL queries) - matches content between backticks
+  const templateRegex = /`([\s\S]*?)`/g
+  let match
+
+  while ((match = templateRegex.exec(source)) !== null) {
+    const content = match[1]
+    // Only process template literals that contain GraphQL
+    if (!content.match(/^(query|mutation|subscription)/)) continue
+
+    // Extract all identifiers
+    const fieldRegex = /\b([a-zA-Z_][a-zA-Z0-9_]*)\b/g
+    let fieldMatch
+
+    while ((fieldMatch = fieldRegex.exec(content)) !== null) {
+      fields.push(fieldMatch[1])
+    }
+  }
+
+  // Remove duplicates: fields appearing in multiple queries (like 'id') only need to be validated once
+  // Convert to Set (automatically unique), spread back to array, then sort alphabetically for consistent output
+  return [...new Set(fields)].sort()
+}
+
+async function main() {
+  console.log("Validating GitHub GraphQL schema...\n")
+
+  const schema = await fetchSchema()
+  const sourceCode = await Bun.file(FIELDS_FILE).text()
+  const fields = extractFields(sourceCode)
+
+  if (fields.length === 0) {
+    console.error(`ERROR: Could not extract fields from ${FIELDS_FILE}`)
+    process.exit(1)
+  }
+
+  let missing = 0
+
+  for (const field of fields) {
+    if (schema.includes(field)) {
+      console.log(`  ✓ ${field}`)
+    } else {
+      console.log(`  ✗ ${field} NOT FOUND`)
+      missing++
+    }
+  }
+
+  if (missing === 0) {
+    console.log(`All ${fields.length} required fields present in schema`)
+    process.exit(0)
+  } else {
+    console.error(`ERROR: ${missing}/${fields.length} field(s) not found in schema`)
+    console.error("Schema may have changed or fields may be deprecated")
+    console.error("Update GraphQL queries in src/agent-manager/pr/graphql.ts if needed")
+    process.exit(1) // Fail so it's visible in CI logs, but continue-on-error allows merge
+  }
+}
+
+main().catch((err) => {
+  console.error("Validation failed:", err)
+  process.exit(1)
+})

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -6,6 +6,7 @@ import { execGhRead } from "./gh"
 import { classifyPRError } from "./git-import"
 import type { Semaphore } from "./semaphore"
 import { parsePRResult, checkStatus, formatCheckDuration, parseComments, parseReviewers } from "./pr/am-pr-utils"
+import { PR_REVIEWERS_QUERY, PR_COMMENTS_QUERY } from "./pr/graphql"
 import type { PRResult, GhThread, GhReviewRequest, GhReview } from "./pr/am-pr-types"
 
 interface PRStatusPollerOptions {
@@ -437,24 +438,12 @@ export class PRStatusPoller {
   private async fetchReviewers(prNumber: number, cwd: string): Promise<PRReviewer[]> {
     try {
       const repo = await this.getRepoInfo(cwd)
-      const query = `query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewRequests(first: 20) {
-              nodes { requestedReviewer { ... on User { login avatarUrl } } }
-            }
-            reviews(last: 20, states: [APPROVED, CHANGES_REQUESTED, COMMENTED]) {
-              nodes { author { login avatarUrl } state }
-            }
-          }
-        }
-      }`
       const { stdout } = await this.gh(
         [
           "api",
           "graphql",
           "-f",
-          `query=${query}`,
+          `query=${PR_REVIEWERS_QUERY}`,
           "-F",
           `owner=${repo.owner}`,
           "-F",
@@ -481,38 +470,12 @@ export class PRStatusPoller {
   ): Promise<{ total: number; unresolved: number; comments: PRComment[] }> {
     try {
       const repo = await this.getRepoInfo(cwd)
-      const query = `query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewThreads(first: 100) {
-              totalCount
-              nodes {
-                id
-                isResolved
-                comments(first: 1) {
-                  nodes {
-                    id
-                    author { login avatarUrl }
-                    body
-                    path
-                    line
-                    url
-                    createdAt
-                    diffHunk
-                  }
-                }
-              }
-            }
-          }
-        }
-      }`
-
       const { stdout } = await this.gh(
         [
           "api",
           "graphql",
           "-f",
-          `query=${query}`,
+          `query=${PR_COMMENTS_QUERY}`,
           "-F",
           `owner=${repo.owner}`,
           "-F",

--- a/packages/kilo-vscode/src/agent-manager/pr/PRActions.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr/PRActions.ts
@@ -1,10 +1,10 @@
 import { execGhRead } from "../gh"
 import { GH_MUTATION_TIMEOUT } from "./pr-constants"
+import { RESOLVE_THREAD_MUTATION, UNRESOLVE_THREAD_MUTATION } from "./graphql"
 
 export async function resolveComment(threadId: string, cwd: string): Promise<void> {
-  const mutation = `mutation($id: ID!) { resolveReviewThread(input: { threadId: $id }) { thread { isResolved } } }`
   try {
-    await execGhRead(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${threadId}`], {
+    await execGhRead(["api", "graphql", "-f", `query=${RESOLVE_THREAD_MUTATION}`, "-F", `id=${threadId}`], {
       cwd,
       timeout: GH_MUTATION_TIMEOUT,
     })
@@ -16,9 +16,8 @@ export async function resolveComment(threadId: string, cwd: string): Promise<voi
 }
 
 export async function unresolveComment(threadId: string, cwd: string): Promise<void> {
-  const mutation = `mutation($id: ID!) { unresolveReviewThread(input: { threadId: $id }) { thread { isResolved } } }`
   try {
-    await execGhRead(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${threadId}`], {
+    await execGhRead(["api", "graphql", "-f", `query=${UNRESOLVE_THREAD_MUTATION}`, "-F", `id=${threadId}`], {
       cwd,
       timeout: GH_MUTATION_TIMEOUT,
     })

--- a/packages/kilo-vscode/src/agent-manager/pr/graphql.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr/graphql.ts
@@ -1,0 +1,62 @@
+/**
+ * GitHub GraphQL queries and mutations for PR-related operations.
+ *
+ * All GraphQL in one place for easy maintenance and validation.
+ */
+
+// Query to fetch PR reviewers
+export const PR_REVIEWERS_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewRequests(first: 20) {
+        nodes { requestedReviewer { ... on User { login avatarUrl } } }
+      }
+      reviews(last: 20, states: [APPROVED, CHANGES_REQUESTED, COMMENTED]) {
+        nodes { author { login avatarUrl } state }
+      }
+    }
+  }
+}`
+
+// Query to fetch PR review threads and comments
+export const PR_COMMENTS_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        totalCount
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              id
+              author { login avatarUrl }
+              body
+              path
+              line
+              url
+              createdAt
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+// Mutation to resolve a review thread
+export const RESOLVE_THREAD_MUTATION = `mutation($id: ID!) {
+  resolveReviewThread(input: { threadId: $id }) {
+    thread { isResolved }
+  }
+}`
+
+// Mutation to unresolve a review thread
+export const UNRESOLVE_THREAD_MUTATION = `mutation($id: ID!) {
+  unresolveReviewThread(input: { threadId: $id }) {
+    thread { isResolved }
+  }
+}`
+
+// Fields are automatically extracted from queries by script/validate-github-graphql.ts


### PR DESCRIPTION
## Issue

Refactor the graphql queries and improve the validation for gh integration in VS code with non-blocking CI GraphQL schema checks. Please review the "why this approach" section, and feel free to comment if you disagree with this approach - weighing pros/cons of different approaches versus immediate benefit. 

## Context

Unit tests require mocking, many aspects of the gh api integration, which limits the benefits of the tests.

*Why this approach:* alternatives like `@graphql-eslint`, `graphql-codegen`, or `graphql-config` would require multiple devDependencies, additional config files, and gql tagged template literals throughout the codebase. Since the queries are passed as CLI string arguments to `gh api graphql` at runtime (not used as parsed documents), tagging them adds no runtime value with the current implementation. The graphql package alone is sufficient — it provides the same AST parse and type-aware validation that the heavier toolchains build on, without the setup overhead. Schema introspection via `gh api graphql` would give exact API parity but requires authenticated gh in CI, which is too heavy a dependency for a validation job. Instead the schema is fetched as a plain HTTPS request from GitHub's public docs URL — no auth, no credentials, no gh CLI required in the CI environment. The GitHub Docs SDL is close enough for catching real errors in practice.

The CI job is non-blocking for now (continue-on-error: true) to allow a burn-in period. The graphql package is devDependency only and is never included in the extension bundle.

*Important note:* The documentation schema reference does not have a version to pin, so this validation is meant to be more of a non-blocking sanity check, as the version cannot be confirmed.

## Implementation

### GraphQL query validation

- Moves all gh api graphql query strings out of PRStatusPoller.ts and PRActions.ts into a single module (src/agent-manager/pr/graphql.ts) and adds a validation script that catches schema errors before they hit runtime.

- The validator fetches GitHub's public GraphQL SDL and uses the graphql package to do full AST type checking — validating each query against the correct parent type in the schema graph rather than just checking if field names appear somewhere in the schema as text. A bad field like diffHunk on PullRequest (instead of PullRequestReviewComment) will now be caught at CI time with a clear error message.

- Can be run locally via bun run validate:github-graphql or directly as a TypeScript file with bun script/validate-github-graphql.ts.

- The CI job is non-blocking for now (continue-on-error: true) to allow a burn-in period. The graphql package is devDependency only and is never included in the extension bundle.

## How to Test with Sample Output

> bun run validate:github-graphql
```
$ bun script/validate-github-graphql.ts
Validating GitHub GraphQL queries...

Fetching GitHub GraphQL schema...
  ✓ PR_COMMENTS_QUERY
  ✓ PR_REVIEWERS_QUERY
  ✓ RESOLVE_THREAD_MUTATION
  ✓ UNRESOLVE_THREAD_MUTATION

All 4 queries valid
```

Sample of faked negative case (diffHunk field is actually on PullRequestReviewComment):
```
$ bun script/validate-github-graphql.ts
Validating GitHub GraphQL queries...

Fetching GitHub GraphQL schema...
  ✗ PR_COMMENTS_QUERY
      Cannot query field "diffHunk" on type "PullRequest".
  ✓ PR_REVIEWERS_QUERY
  ✓ RESOLVE_THREAD_MUTATION
  ✓ UNRESOLVE_THREAD_MUTATION
```

### Reviewer test steps

Reviewer test steps
1. Check out the branch and run bun install from packages/kilo-vscode/
2. Run bun run validate:github-graphql — all 4 queries should pass with ✓ based on the above sample output
3. To verify it catches real errors, temporarily add a bad field to one of the queries in src/agent-manager/pr/graphql.ts (e.g. add diffHunk directly under pullRequest) and re-run — it should fail with Cannot query field "diffHunk" on type "PullRequest" and exit 1
4. Revert the bad field and confirm it passes again
5. Check that graphql appears only in devDependencies in package.json and is not imported anywhere under src/ or webview-ui/

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [ ] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
