### PR TITLE
fix(cli): preserve session agent for headless prompts

### DIFF
--- a/.changeset/calm-agents-wait.md
+++ b/.changeset/calm-agents-wait.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Preserve the selected session agent when sending headless prompts without an explicit agent.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -816,7 +816,7 @@ export const layer = Layer.effect(
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-      const agentName = input.agent
+      const agentName = input.agent ?? (yield* sessions.get(input.sessionID).pipe(Effect.orDie)).agent // kilocode_change
       const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!ag) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)

--- a/packages/opencode/test/kilocode/headless-session-agent.test.ts
+++ b/packages/opencode/test/kilocode/headless-session-agent.test.ts
@@ -49,7 +49,7 @@ test("headless prompts preserve the agent selected when the session was created"
       const session = (await created.json()) as { id: string; agent?: string }
       expect(session.agent).toBe("test-engineer")
 
-      const prompted = await app.request(`/session/${session.id}/prompt`, {
+      const prompted = await app.request(`/session/${session.id}/message`, {
         method: "POST",
         headers,
         body: JSON.stringify({

--- a/packages/opencode/test/kilocode/headless-session-agent.test.ts
+++ b/packages/opencode/test/kilocode/headless-session-agent.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+import { disposeAllInstances, provideTestInstance, tmpdir } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+test("headless prompts preserve the agent selected when the session was created", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      formatter: false,
+      lsp: false,
+      agent: {
+        "test-engineer": {
+          mode: "primary",
+          model: "mock/custom-model",
+        },
+      },
+      provider: {
+        mock: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Mock",
+          options: { baseURL: "http://127.0.0.1:1/v1", apiKey: "test" },
+          models: {
+            "custom-model": {
+              name: "Custom Model",
+              limit: { context: 128000, output: 8192 },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      const app = Server.Default().app
+      const headers = { "content-type": "application/json", "x-kilo-directory": tmp.path }
+      const created = await app.request("/session", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ agent: "test-engineer" }),
+      })
+      expect(created.status).toBe(200)
+      const session = (await created.json()) as { id: string; agent?: string }
+      expect(session.agent).toBe("test-engineer")
+
+      const prompted = await app.request(`/session/${session.id}/prompt`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        }),
+      })
+      expect(prompted.status).toBe(200)
+      const message = (await prompted.json()) as {
+        info: { agent: string; model: { providerID: string; modelID: string } }
+      }
+      expect(message.info.agent).toBe("test-engineer")
+      expect(message.info.model).toEqual({ providerID: "mock", modelID: "custom-model" })
+
+      const loaded = await app.request(`/session/${session.id}`, { headers })
+      expect(loaded.status).toBe(200)
+      const current = (await loaded.json()) as { agent?: string }
+      expect(current.agent).toBe("test-engineer")
+    },
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #13027

## Context

Headless sessions created with an explicit agent lost that selection when the first prompt omitted the `agent` field. The prompt fell back to the default `code` agent, so the custom agent's model and permissions were not applied.

This change preserves the agent selected during session creation when a later headless prompt does not explicitly override it.

## Implementation

Agent resolution for user messages now falls back to the agent stored on the session when `input.agent` is absent. Explicit prompt-level agent selections continue to take precedence, and sessions without a selected agent continue to use the configured default agent.

The regression test exercises the public headless HTTP flow by creating a session with a custom `test-engineer` agent, sending a prompt without an agent, and verifying that both the custom agent and its configured model remain selected.

## Screenshots / Video

N/A — this change has no visual impact.

## How to Test

### Manual/local verification

- Agent: ran `git diff --check`; it completed successfully.
- Agent: ran `bun run script/check-opencode-annotations.ts --worktree`; all shared OpenCode changes were correctly annotated.
- Agent: reviewed the HTTP regression test against the session create and prompt route schemas.

### Reviewer test steps

1. From `packages/opencode/`, run `bun test ./test/kilocode/headless-session-agent.test.ts`.
2. Confirm the test creates a session with `agent: "test-engineer"` and sends the first prompt without an `agent` field.
3. Confirm the returned user message uses `test-engineer` and `mock/custom-model` rather than the default `code` agent.
4. Run `bun run typecheck` from `packages/opencode/`.

### Blocked checks and substitute verification

- Agent: `bun test ./test/kilocode/headless-session-agent.test.ts` could not start because the current workspace dependencies are incomplete (`@opentui/solid/preload` is missing). Substitute verification consisted of reviewing the test setup and HTTP route schemas, running `git diff --check`, and running the OpenCode annotation guard.
- Agent: `bun run typecheck` from `packages/opencode/` could not start because `tsgo` is missing from the current workspace dependencies. The diff and annotation checks above completed successfully, but the target test and typecheck should be rerun after installing dependencies.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes

