### PR TITLE
docs: update Bedrock and Vertex setup

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/bedrock.md
+++ b/packages/kilo-docs/pages/ai-providers/bedrock.md
@@ -15,9 +15,9 @@ Kilo Code supports accessing models through Amazon Bedrock, a fully managed serv
 - **AWS Account:** You need an active AWS account.
 - **Bedrock Access:** You must request and be granted access to Amazon Bedrock. See the [AWS Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html) for details on requesting access.
 - **Model Access:** Within Bedrock, you need to request access to the specific models you want to use (e.g., Anthropic Claude).
-- **Install AWS CLI:** Use AWS CLI to configure your account for authentication
+- **AWS CLI (profile authentication only):** If you plan to use an AWS profile, install AWS CLI and configure your credentials:
   ```bash
-   aws configure
+  aws configure
   ```
 
 ## Getting Credentials
@@ -27,7 +27,7 @@ You have three options for configuring AWS credentials:
 1.  **Bedrock API Key:**
     - Create a Bedrock-specific API key in the AWS Console. This is a simple service-specific authentication method.
     - See the [AWS documentation on Bedrock credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_bedrock.html) for instructions on creating an API key.
-2.  **AWS Access Keys (Recommended for Development):**
+2.  **AWS Access Keys:**
     - Create an IAM user with the necessary permissions (at least `bedrock:InvokeModel`).
     - Generate an access key ID and secret access key for that user.
     - _(Optional)_ Create a session token if required by your IAM configuration.
@@ -39,20 +39,32 @@ You have three options for configuring AWS credentials:
 {% tabs %}
 {% tab label="VSCode" %}
 
-Open **Settings** (gear icon) and go to the **Providers** tab to add AWS Bedrock. The extension uses the AWS credentials chain for authentication — configure your AWS credentials using the AWS CLI or environment variables before adding the provider.
+1. Open **Settings** and select **Providers**.
+2. Find **Amazon Bedrock** and select **Connect**.
+3. Choose an authentication method:
+   - **AWS access keys:** Enter the AWS access key ID, AWS secret access key, optional AWS session token, and AWS region.
+   - **Bedrock API key:** Enter a Bedrock API key.
+4. Select **Connect**.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+The extension stores these credentials in Kilo's credential store, not in `kilo.json`.
 
 {% /tab %}
 {% tab label="CLI" %}
 
-Bedrock uses the AWS credentials chain for authentication. Configure your AWS credentials using the AWS CLI or environment variables:
+Bedrock supports a Bedrock API key or the AWS credentials chain.
 
-**Environment variables:**
+**Bedrock API key:**
+
+```bash
+export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
+```
+
+**AWS access key environment variables:**
 
 ```bash
 export AWS_ACCESS_KEY_ID="your-access-key"
 export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_SESSION_TOKEN="your-session-token" # Optional
 export AWS_REGION="us-east-1"
 ```
 
@@ -60,6 +72,7 @@ Or use an AWS profile:
 
 ```bash
 aws configure --profile bedrock
+export AWS_PROFILE="bedrock"
 ```
 
 **Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):

--- a/packages/kilo-docs/pages/ai-providers/bedrock.md
+++ b/packages/kilo-docs/pages/ai-providers/bedrock.md
@@ -44,7 +44,7 @@ You have three options for configuring AWS credentials:
 3. Choose an authentication method:
    - **AWS access keys:** Enter the AWS access key ID, AWS secret access key, optional AWS session token, and AWS region.
    - **Bedrock API key:** Enter a Bedrock API key.
-4. Select **Connect**.
+4. Select **Submit**.
 
 The extension stores these credentials in Kilo's credential store, not in `kilo.json`.
 

--- a/packages/kilo-docs/pages/ai-providers/vertex.md
+++ b/packages/kilo-docs/pages/ai-providers/vertex.md
@@ -28,7 +28,7 @@ Kilo Code supports accessing models through Google Cloud Platform's Vertex AI, a
 3. Paste the complete service account JSON into **Service-account JSON**.
 4. Enter a **Google Cloud project ID** only if you want to override the `project_id` in the JSON.
 5. Enter the **Vertex AI location**, such as `us-central1` or `global`.
-6. Select **Connect**.
+6. Select **Submit**.
 
 The extension stores the service account JSON in Kilo's credential store, not in `kilo.json`. The JSON is visible while you edit it so you can verify the value before connecting.
 

--- a/packages/kilo-docs/pages/ai-providers/vertex.md
+++ b/packages/kilo-docs/pages/ai-providers/vertex.md
@@ -15,30 +15,37 @@ Kilo Code supports accessing models through Google Cloud Platform's Vertex AI, a
 - **Google Cloud Account:** You need an active Google Cloud Platform (GCP) account.
 - **Project:** You need a GCP project with the Vertex AI API enabled.
 - **Model Access:** You must request and be granted access to the specific Claude models on Vertex AI you want to use. See the [Google Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#before_you_begin) for instructions.
-- **Application Default Credentials (ADC):** Kilo Code uses Application Default Credentials to authenticate with Vertex AI. The easiest way to set this up is to:
-  1.  Install the Google Cloud CLI: [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install)
-  2.  Authenticate using: `gcloud auth application-default login`
-- **Service Account Key (Alternative):** Alternatively, you can authenticate using a Google Cloud Service Account key file. You'll need to generate this key in your GCP project. See the [Google Cloud documentation on creating service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+- **Service Account Key:** To connect the VS Code extension, generate a JSON key for a service account that can access Vertex AI. See the [Google Cloud documentation on creating service account keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+- **Application Default Credentials (CLI option):** To use ADC with the CLI, [install the Google Cloud CLI](https://cloud.google.com/sdk/docs/install) and run `gcloud auth application-default login`.
 
 ## Configuration in Kilo Code
 
 {% tabs %}
 {% tab label="VSCode" %}
 
-Open **Settings** (gear icon) and go to the **Providers** tab to add GCP Vertex AI. The extension uses Google Application Default Credentials (ADC) for authentication — run `gcloud auth application-default login` before adding the provider. Set your project ID and region in the provider settings.
+1. Open **Settings** and select **Providers**.
+2. Find **Google Vertex AI** and select **Connect**.
+3. Paste the complete service account JSON into **Service-account JSON**.
+4. Enter a **Google Cloud project ID** only if you want to override the `project_id` in the JSON.
+5. Enter the **Vertex AI location**, such as `us-central1` or `global`.
+6. Select **Connect**.
 
-The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+The extension stores the service account JSON in Kilo's credential store, not in `kilo.json`. The JSON is visible while you edit it so you can verify the value before connecting.
+
+{% callout type="warning" %}
+Treat service account JSON like a password. Do not share it or commit it to source control.
+{% /callout %}
 
 {% /tab %}
 {% tab label="CLI" %}
 
-Vertex AI uses Google Application Default Credentials (ADC) for authentication. Set up ADC using the Google Cloud CLI:
+The following CLI setup uses Google Application Default Credentials (ADC). Authenticate with the Google Cloud CLI:
 
 ```bash
 gcloud auth application-default login
 ```
 
-Set your project and region as environment variables:
+Set your project and location as environment variables:
 
 ```bash
 export GOOGLE_CLOUD_PROJECT="your-project-id"


### PR DESCRIPTION
## What changed

Update the Bedrock and Vertex provider pages to match the VS Code credential setup introduced in #13100. The docs now list the exact access-key and service-account fields, explain credential storage, and distinguish the VS Code flows from CLI authentication.

Also document Bedrock bearer-token and named-profile CLI setup, which were missing from the existing page.

## Why

The Vertex page still directed VS Code users to Application Default Credentials, and the Bedrock page still described only the AWS credential chain. Those instructions no longer matched the provider dialogs.