### PR TITLE
fix(cli): keep models.dev refresh errors off the TUI

### DIFF
--- a/.changeset/models-dev-tui-logging.md
+++ b/.changeset/models-dev-tui-logging.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop models.dev catalog refresh errors from overwriting the TUI prompt.

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Context, Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
+import { Context, Duration, Effect, Layer, Logger, Option, Schedule, Schema } from "effect" // kilocode_change
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ModelsDev } from "@opencode-ai/schema/models-dev"
 import { Global } from "./global"
@@ -12,6 +12,7 @@ import * as ModelsRefresh from "./kilocode/models-refresh" // kilocode_change
 import { EventV2 } from "./event"
 import { makeGlobalNode } from "./effect/app-node"
 import { httpClient } from "./effect/app-node-platform"
+import { Observability } from "./observability" // kilocode_change
 
 export const CatalogModelStatus = Schema.Literals(["alpha", "beta", "deprecated"])
 export type CatalogModelStatus = typeof CatalogModelStatus.Type
@@ -156,6 +157,7 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const events = yield* EventV2.Service
+    const loggers = yield* Effect.service(Logger.CurrentLoggers) // kilocode_change
     const http = HttpClient.filterStatusOk(
       (yield* HttpClient.HttpClient).pipe(
         HttpClient.retryTransient({
@@ -259,6 +261,7 @@ const layer = Layer.effect(
       ).pipe(
         Effect.tapCause((cause) => Effect.logError("Failed to fetch models.dev", { cause: cause })),
         Effect.ignore,
+        Effect.provideService(Logger.CurrentLoggers, loggers), // kilocode_change
       )
     })
 
@@ -271,6 +274,12 @@ const layer = Layer.effect(
   }),
 )
 
-export const node = makeGlobalNode({ service: Service, layer: layer, deps: [FSUtil.node, EventV2.node, httpClient] })
+// kilocode_change start - capture file/OTLP loggers before the refresh fork
+export const node = makeGlobalNode({
+  service: Service,
+  layer: layer,
+  deps: [FSUtil.node, EventV2.node, httpClient, Observability.node],
+})
+// kilocode_change end
 
 export * as ModelsDev from "./models-dev"

--- a/packages/core/test/kilocode/models-dev-logger.test.ts
+++ b/packages/core/test/kilocode/models-dev-logger.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNodePlatform } from "@opencode-ai/core/effect/app-node-platform"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Global } from "@opencode-ai/core/global"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { mkdir, readFile, rm, writeFile } from "fs/promises"
+import path from "path"
+import * as TestConsole from "effect/testing/TestConsole"
+import { it } from "../lib/effect"
+
+const ORIGINAL_MODELS_PATH = Flag.KILO_MODELS_PATH
+const ORIGINAL_DISABLE_FETCH = Flag.KILO_DISABLE_MODELS_FETCH
+const cache = Global.Path.cache
+const log = Global.Path.log
+const root = path.join(Global.Path.tmp, `models-logger-${process.pid}-${Math.random().toString(36).slice(2)}`)
+const logs = path.join(root, "log")
+
+beforeAll(async () => {
+  Flag.KILO_MODELS_PATH = undefined
+  Flag.KILO_DISABLE_MODELS_FETCH = true
+  Global.Path.cache = root
+  Global.Path.log = logs
+  await mkdir(logs, { recursive: true })
+  await writeFile(path.join(root, "models.json"), "{}")
+})
+
+afterAll(async () => {
+  Flag.KILO_MODELS_PATH = ORIGINAL_MODELS_PATH
+  Flag.KILO_DISABLE_MODELS_FETCH = ORIGINAL_DISABLE_FETCH
+  Global.Path.cache = cache
+  Global.Path.log = log
+  await rm(root, { recursive: true, force: true })
+})
+
+const client = HttpClient.make((request) =>
+  Effect.succeed(HttpClientResponse.fromWeb(request, new Response("boom", { status: 500 }))),
+)
+
+const layer = Layer.fresh(
+  AppNodeBuilder.build(ModelsDev.node, [[LayerNodePlatform.httpClient, Layer.succeed(HttpClient.HttpClient, client)]]),
+)
+
+async function logged() {
+  const file = path.join(logs, "opencode.log")
+  for (let i = 0; i < 50; i++) {
+    const text = await readFile(file, "utf8").catch(() => "")
+    if (text.includes("Failed to fetch models.dev")) return text
+    await Bun.sleep(10)
+  }
+  return await readFile(file, "utf8").catch(() => "")
+}
+
+describe("ModelsDev catalog refresh logging", () => {
+  it.live("failed refresh logs to file without Effect defaultLogger", () =>
+    Effect.gen(function* () {
+      yield* ModelsDev.Service.use((s) => s.refresh(true)).pipe(Effect.provide(layer))
+      const lines = yield* TestConsole.logLines
+      expect(lines.join("\n")).not.toContain("Failed to fetch models.dev")
+      expect(yield* Effect.promise(logged)).toContain("Failed to fetch models.dev")
+    }),
+  )
+})


### PR DESCRIPTION
## Issue

No existing gh issue. A live TUI session when `models.dev` was unreachable: Effect's default logger dumped `[HH:MM:SS.mmm] ERROR (#N): Failed to fetch models.dev { cause: { _id: "Cause", ... } }` onto the tty and overwrote the prompt footer (`Claude Opus 5 Kilo Gateway · high` became `_id: "Cause",de Opus 5 Kilo Gateway · high`).

## Context

The TUI listener builds a fresh ModelsDev graph and only `Layer.provide`s `AppLayer`. That does **not** install Observability into the ModelsDev construction fiber, so a failed catalog refresh uses Effect's default pretty logger and writes to the tty. `AppLayer` / `createRoutes` already `provideMerge(Observability.layer)` last and do not leak.

## Implementation

`ModelsDev.node` now depends on `Observability.node`. Construction captures `Logger.CurrentLoggers` once and `refresh()` reuses that set. Failed fetches still log at Error to the file/OTLP loggers; they no longer rebuild Observability or dump to the TUI.

## Screenshots / Video

N/A — the leaked line is the Effect defaultLogger dump above. No layout or styling change.

## How to Test

### Manual/local verification

- Agent: `bun test ./test/kilocode/models-dev-logger.test.ts` in `packages/core` — 1 pass.
- Agent A/B: same test on HEAD fails with `Received: "... ERROR (#2):\nFailed to fetch models.dev\n[object Object]"`; with the fix it passes.
- Agent: `bun test ./test/models.test.ts ./test/plugin/models-dev.test.ts ./test/kilocode/models-dev-logger.test.ts` in `packages/core` — 12/12.
- Agent: `bun test ./test/provider/provider-model-refresh.test.ts ./test/provider/provider.test.ts` in `packages/opencode` — 100/100 (from the independent review).
- Agent: `bun run script/check-opencode-annotations.ts --worktree` passed.

### Reviewer test steps

Reproduce the leak on `main` / this branch's parent (`8013e5f504`):

1. From `packages/core`, force a failed `ModelsDev.refresh(true)` against a 500 `https://models.dev/api.json` response **without** `Layer.provideMerge(Observability.layer)` — the TUI listener shape is `Layer.fresh(listener).pipe(Layer.provide(AppLayer))`.
2. Confirm Effect prints `[HH:MM:SS.mmm] ERROR (#N): Failed to fetch models.dev { cause: { _id: "Cause", failures: [[Object ...]] } }` to the console.
3. On this branch, repeat the same failed refresh. The dump must not appear; the error still lands in the file logger (`opencode.log`).
4. Optional live TUI: start `kilo` with outbound `models.dev` blocked (sandbox / offline). The prompt footer must stay intact instead of being overwritten by `_id: "Cause",`.

Minimal unit check:

```sh
cd packages/core
bun test ./test/kilocode/models-dev-logger.test.ts
```

That test fails on HEAD and passes here.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.