### PR TITLE
fix(cli): surface commit-message generation errors

### DIFF
--- a/.changeset/commit-message-surface-errors.md
+++ b/.changeset/commit-message-surface-errors.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show the real commit-message generation error instead of a generic "check server logs" toast.

--- a/packages/opencode/src/kilocode/server/httpapi/groups/commit-message.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/commit-message.ts
@@ -29,7 +29,9 @@ const CommitMessageResponse = Schema.Struct({
 
 export class CommitMessageNoChangesError extends Schema.ErrorClass<CommitMessageNoChangesError>(
   "CommitMessageNoChangesError",
-)(
+)({ message: Schema.String }, { httpApiStatus: 422 }) {}
+
+export class CommitMessageFailedError extends Schema.ErrorClass<CommitMessageFailedError>("CommitMessageFailedError")(
   { message: Schema.String },
   { httpApiStatus: 422 },
 ) {}
@@ -42,7 +44,7 @@ export const CommitMessageApi = HttpApi.make("commit-message")
           query: WorkspaceRoutingQuery,
           payload: CommitMessagePayload,
           success: described(CommitMessageResponse, "Generated commit message"),
-          error: [HttpApiError.BadRequest, CommitMessageNoChangesError],
+          error: [HttpApiError.BadRequest, CommitMessageNoChangesError, CommitMessageFailedError],
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "commitMessage.generate",

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/commit-message.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/commit-message.ts
@@ -4,7 +4,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { InstanceHttpApi } from "@/server/routes/instance/httpapi/api"
 import { Config } from "@/config/config"
 import { generateCommitMessage, NoChangesError } from "@/kilocode/commit-message"
-import { CommitMessageNoChangesError, CommitMessagePayload } from "../groups/commit-message"
+import { CommitMessageFailedError, CommitMessageNoChangesError, CommitMessagePayload } from "../groups/commit-message"
 
 export const commitMessageHandlers = HttpApiBuilder.group(InstanceHttpApi, "commit-message", (handlers) =>
   Effect.gen(function* () {
@@ -27,6 +27,9 @@ export const commitMessageHandlers = HttpApiBuilder.group(InstanceHttpApi, "comm
         Effect.catchDefect((defect) => {
           if (defect instanceof NoChangesError) {
             return Effect.fail(new CommitMessageNoChangesError({ message: defect.message }))
+          }
+          if (defect instanceof Error) {
+            return Effect.fail(new CommitMessageFailedError({ message: defect.message }))
           }
           return Effect.die(defect)
         }),

--- a/packages/opencode/test/kilocode/server/commit-message-no-changes.test.ts
+++ b/packages/opencode/test/kilocode/server/commit-message-no-changes.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import path from "path"
 import { Server } from "../../../src/server/server"
+import { CommitMessageRuntime } from "../../../src/kilocode/commit-message/generate"
 import { resetDatabase } from "../../fixture/db"
 import { disposeAllInstances, tmpdir } from "../../fixture/fixture"
 
@@ -20,5 +22,29 @@ describe("commit-message httpapi", () => {
 
     expect(res.status).toBe(422)
     expect(await res.json()).toEqual({ message: "No changes found to generate a commit message for" })
+  })
+
+  test("returns 422 with the real message when generation fails", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Bun.write(path.join(tmp.path, "note.txt"), "hello")
+
+    const model = spyOn(CommitMessageRuntime, "model").mockResolvedValue({
+      providerID: "test",
+      id: "test-small-model",
+    } as never)
+    const generate = spyOn(CommitMessageRuntime, "generate").mockRejectedValue(new Error("provider rate limited"))
+    try {
+      const res = await Server.Default().app.request("/commit-message", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-kilo-directory": tmp.path },
+        body: JSON.stringify({ path: tmp.path }),
+      })
+
+      expect(res.status).toBe(422)
+      expect(await res.json()).toEqual({ message: "Failed to generate commit message: provider rate limited" })
+    } finally {
+      generate.mockRestore()
+      model.mockRestore()
+    }
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -91,6 +91,7 @@ export type Event =
   | EventWorkspaceStatus1
   | EventWorktreeReady1
   | EventWorktreeFailed1
+  | EventWorktreeSetupReady1
   | EventServerConnected1
   | EventGlobalDisposed1
   | EventGlobalConfigUpdated1
@@ -209,6 +210,7 @@ export type Event =
   | EventWorkspaceStatus
   | EventWorktreeReady
   | EventWorktreeFailed
+  | EventWorktreeSetupReady
   | EventServerConnected
   | EventGlobalDisposed
   | EventGlobalConfigUpdated
@@ -1254,6 +1256,7 @@ export type GlobalEvent = {
     | EventWorkspaceStatus
     | EventWorktreeReady
     | EventWorktreeFailed
+    | EventWorktreeSetupReady
     | EventServerConnected
     | EventGlobalDisposed
     | EventGlobalConfigUpdated
@@ -2111,6 +2114,14 @@ export type GlobalEvent = {
         type: "worktree.failed"
         properties: {
           message: string
+        }
+      }
+    | {
+        id: string
+        type: "worktree.setup.ready"
+        properties: {
+          name: string
+          branch?: string
         }
       }
     | {
@@ -3917,6 +3928,10 @@ export type CommitMessageNoChangesError = {
   message: string
 }
 
+export type CommitMessageFailedError = {
+  message: string
+}
+
 export type ConfigOverlayResponse = {
   scope: "global" | "project"
   effective: Config
@@ -4729,6 +4744,7 @@ export type V2Event =
   | WorkspaceStatus
   | WorktreeReady
   | WorktreeFailed
+  | WorktreeSetupReady
   | ServerConnected
   | GlobalDisposed
   | GlobalConfigUpdated
@@ -6186,6 +6202,15 @@ export type EventWorktreeFailed = {
   type: "worktree.failed"
   properties: {
     message: string
+  }
+}
+
+export type EventWorktreeSetupReady = {
+  id: string
+  type: "worktree.setup.ready"
+  properties: {
+    name: string
+    branch?: string
   }
 }
 
@@ -9118,6 +9143,24 @@ export type WorktreeFailed = {
   }
 }
 
+export type WorktreeSetupReady = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  type: "worktree.setup.ready"
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  data: {
+    name: string
+    branch?: string
+  }
+}
+
 export type ServerConnected = {
   id: string
   metadata?: {
@@ -10154,6 +10197,15 @@ export type EventWorktreeFailed1 = {
   type: "worktree.failed"
   properties: {
     message: string
+  }
+}
+
+export type EventWorktreeSetupReady1 = {
+  id: string
+  type: "worktree.setup.ready"
+  properties: {
+    name: string
+    branch?: string
   }
 }
 
@@ -15093,9 +15145,9 @@ export type CommitMessageGenerateErrors = {
    */
   400: EffectHttpApiErrorBadRequest | InvalidRequestError
   /**
-   * CommitMessageNoChangesError
+   * CommitMessageNoChangesError | CommitMessageFailedError
    */
-  422: CommitMessageNoChangesError
+  422: CommitMessageNoChangesError | CommitMessageFailedError
 }
 
 export type CommitMessageGenerateError = CommitMessageGenerateErrors[keyof CommitMessageGenerateErrors]

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11421,11 +11421,18 @@
             }
           },
           "422": {
-            "description": "CommitMessageNoChangesError",
+            "description": "CommitMessageNoChangesError | CommitMessageFailedError",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommitMessageNoChangesError"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/CommitMessageNoChangesError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CommitMessageFailedError"
+                    }
+                  ]
                 }
               }
             }
@@ -25905,6 +25912,9 @@
             "$ref": "#/components/schemas/EventWorktreeFailed1"
           },
           {
+            "$ref": "#/components/schemas/EventWorktreeSetupReady1"
+          },
+          {
             "$ref": "#/components/schemas/EventServerConnected1"
           },
           {
@@ -26257,6 +26267,9 @@
           },
           {
             "$ref": "#/components/schemas/EventWorktreeFailed"
+          },
+          {
+            "$ref": "#/components/schemas/EventWorktreeSetupReady"
           },
           {
             "$ref": "#/components/schemas/EventServerConnected"
@@ -29406,6 +29419,9 @@
                 "$ref": "#/components/schemas/EventWorktreeFailed"
               },
               {
+                "$ref": "#/components/schemas/EventWorktreeSetupReady"
+              },
+              {
                 "$ref": "#/components/schemas/EventServerConnected"
               },
               {
@@ -32378,6 +32394,34 @@
                       }
                     },
                     "required": ["message"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["worktree.setup.ready"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "branch": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["name"],
                     "additionalProperties": false
                   }
                 },
@@ -37769,6 +37813,16 @@
         "required": ["message"],
         "additionalProperties": false
       },
+      "CommitMessageFailedError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+      },
       "ConfigOverlayResponse": {
         "type": "object",
         "properties": {
@@ -40283,6 +40337,9 @@
           },
           {
             "$ref": "#/components/schemas/WorktreeFailed"
+          },
+          {
+            "$ref": "#/components/schemas/WorktreeSetupReady"
           },
           {
             "$ref": "#/components/schemas/ServerConnected"
@@ -45397,6 +45454,33 @@
               }
             },
             "required": ["message"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventWorktreeSetupReady": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["worktree.setup.ready"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
             "additionalProperties": false
           }
         },
@@ -54239,6 +54323,56 @@
         "required": ["id", "type", "data"],
         "additionalProperties": false
       },
+      "WorktreeSetupReady": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["worktree.setup.ready"]
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
       "ServerConnected": {
         "type": "object",
         "properties": {
@@ -57442,6 +57576,34 @@
               }
             },
             "required": ["message"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventWorktreeSetupReady1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["worktree.setup.ready"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "branch": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
             "additionalProperties": false
           }
         },


### PR DESCRIPTION
## Issue

N/A — surfaces real commit-message generation errors instead of masking them behind generic 500s.

## Context

The SCM generate-commit-message button often fails with `Unexpected server error. Check server logs for details.` Timeouts, provider errors, and auth failures all die as untyped defects and get masked as HTTP 500. The backend already knows the real reason; the toast does not.

This change maps those generation `Error`s to a typed 422 so the existing VS Code client shows the real message. It does not raise the 30s timeout or make slow small models finish.

## Implementation

Follows the same pattern as the no-changes 422 from #12033. `POST /commit-message` now declares `CommitMessageFailedError` and the handler translates any remaining `Error` defect (after `NoChangesError`) into that typed failure.

The extension already displays `getErrorMessage(error)`, so no VS Code package change is required. JetBrains and TUI do not call this endpoint.

## Screenshots / Video

N/A — toast copy only, no visual layout change.

## How to Test

### Manual/local verification

- Isolated HTTP test: `bun run test commit-message-no-changes.test.ts` from `packages/opencode` (2 pass)
- Typecheck: `bun turbo typecheck` (30 packages passed)
- SDK generation: `./script/generate.ts` executed cleanly from repository root
- Reproduced before/after against `POST /commit-message`:
  - before: HTTP 500 `UnknownError` / `Check server logs for details`
  - after: HTTP 422 `{ "message": "Commit message generation timed out after 30 seconds" }` or `{ "message": "Failed to generate commit message: provider rate limited" }`

### Reviewer test steps

1. Stage some files in a git repo and click the Kilo SCM generate-commit-message button.
2. On a timeout or provider failure, the toast should show the real reason, not `Check server logs for details.`
3. With no staged or unstaged changes, the toast should still say `No changes found to generate a commit message for`.

### Blocked checks and substitute verification

- The VS Code vitest spec was not run; no extension source changed.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch