### PR TITLE
docs: document --worktree flag in CLI reference

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli-reference.md
@@ -139,6 +139,7 @@ Options:
   -s, --session       session id to continue  [string]
       --fork          fork the session when continuing (use with --continue or --session)  [boolean]
       --cloud-fork    fetch session from cloud and continue locally (use with --session)  [boolean]
+      --worktree      create (or reuse) a git worktree with this name and start kilo there  [string]
       --prompt        prompt to use  [string]
       --agent         agent to use  [string]
       --auto          auto-approve permissions that are not explicitly denied (dangerous!)  [boolean] [default: false]


### PR DESCRIPTION
## What

Regenerates the auto-generated CLI reference so `kilo --worktree` is documented.

## Why

#12809 added `--worktree` to the TUI (`kilo [project]`) so you can create or reuse a git worktree and start kilo there. The CLI reference was not regenerated, so the flag was missing from the docs.

## Notes

- Generated by `bun ./script/generate-cli-docs.ts` from repo root. Do not hand-edit `cli-reference.md`.
- `kilo run` does not take `--worktree`; the flag lives on the default TUI command.