### PR TITLE
test(cli): unflake permission.create after isolated fixtures

### DIFF
--- a/packages/opencode/test/kilocode/server/httpapi-exercise-ready.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-ready.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import { AgentV2 } from "@opencode-ai/core/agent"
+import { isRecord } from "../../server/httpapi-exercise/assertions"
+import { request } from "../../server/httpapi-exercise/backend"
+import { pollWithTimeout } from "../../lib/effect"
+import type { ScenarioContext } from "../../server/httpapi-exercise/types"
+
+export function sessionAfterDefaultAgent(ctx: ScenarioContext, title: string) {
+  return Effect.gen(function* () {
+    const session = yield* ctx.session({ title })
+    // GET /api/agent and POST /permission share this directory today; a workspace/worktree
+    // session would boot a different AgentV2 and this wait would not cover it.
+    yield* pollWithTimeout(
+      request("GET", { path: "/api/agent", headers: ctx.headers() }).pipe(
+        Effect.map((result) => {
+          const body = result.body
+          if (!isRecord(body) || !Array.isArray(body.data)) return undefined
+          return body.data.some((item) => isRecord(item) && item.id === AgentV2.defaultID) ? (true as const) : undefined
+        }),
+      ),
+      "default agent never loaded before permission create",
+    )
+    return session
+  }).pipe(Effect.orDie)
+}

--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -3,6 +3,7 @@ import { HttpRouter } from "effect/unstable/http"
 import { parse } from "./assertions"
 import { runtime, type Runtime } from "./runtime"
 import type { ActiveScenario, BackendApp, CallResult, CaptureMode, SeededContext } from "./types"
+import type { Method, RequestSpec } from "./types" // kilocode_change
 
 type CallOptions = {
   auth?: {
@@ -16,6 +17,23 @@ export function call(scenario: ActiveScenario, ctx: SeededContext<unknown>, opti
     capture(await app(await runtime(), options).request(toRequest(scenario, ctx)), scenario.capture),
   )
 }
+
+// kilocode_change start
+export function request(method: Method, spec: RequestSpec) {
+  return Effect.promise(async () =>
+    capture(
+      await app(await runtime(), {}).request(
+        new Request(new URL(spec.path, "http://localhost"), {
+          method,
+          headers: spec.body === undefined ? spec.headers : { "content-type": "application/json", ...spec.headers },
+          body: spec.body === undefined ? undefined : JSON.stringify(spec.body),
+        }),
+      ),
+      "full",
+    ),
+  )
+}
+// kilocode_change end
 
 export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" | "valid" = "missing") {
   return Effect.promise(async () => {

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -37,6 +37,7 @@ import { disposeApps } from "./backend"
 import { publicApi, runtime } from "./runtime" // kilocode_change
 import { type Scenario, type Result } from "./types"
 import { kiloScenarios } from "../../kilocode/server/httpapi-exercise-scenarios" // kilocode_change
+import { sessionAfterDefaultAgent } from "../../kilocode/server/httpapi-exercise-ready" // kilocode_change
 
 function cursor(input: Record<string, unknown>) {
   return Buffer.from(JSON.stringify(input)).toString("base64url")
@@ -872,7 +873,7 @@ const scenarios: Scenario[] = [
   }),
   http.protected
     .post("/api/session/{sessionID}/permission", "v2.session.permission.create")
-    .seeded((ctx) => ctx.session({ title: "Permission create owner" }))
+    .seeded((ctx) => sessionAfterDefaultAgent(ctx, "Permission create owner")) // kilocode_change
     .at((ctx) => ({
       path: route("/api/session/{sessionID}/permission", { sessionID: ctx.state.id }),
       headers: ctx.headers(),
@@ -885,7 +886,7 @@ const scenarios: Scenario[] = [
       object(body)
       object(body.data)
       check(typeof body.data.id === "string", "permission create should return an ID")
-      check(body.data.effect === "ask", "permission create should create a pending request")
+      check(body.data.effect === "ask", `permission create should create a pending request, got ${JSON.stringify(body.data.effect)}`) // kilocode_change
     }),
   http.protected
     .get("/api/session/{sessionID}/permission", "v2.session.permission.list")


### PR DESCRIPTION
## Issue

No existing issue. This is a test-only flake that started after #13091 isolated `v2.session.permission.create` on a fresh project.

## Context

#13091 made this scenario cheap enough to run before the default `build` agent finishes loading. `PermissionV2.configured` then falls back to deny-all, so the assertion `effect === "ask"` flakes.

Wait for that agent over `GET /api/agent` before asserting. The failure message now includes the observed effect so a recurrence is diagnosable. No production change.

## Implementation

`sessionAfterDefaultAgent` polls `GET /api/agent` until `AgentV2.defaultID` appears, then the scenario posts the permission request. That list and the `.env` ask rule are written in the same `AgentPlugin` transform, so the gate is causally correct for this assertion.

The probe uses the same `x-kilo-directory` the later POST uses. A workspace/worktree session would boot a different `AgentV2` and this wait would not cover it. The wait stays on this scenario rather than the shared runner so the other 300+ scenarios do not pay an extra HTTP poll.

## Screenshots / Video

N/A — test-only, no UI change.

## How to Test

### Manual/local verification

- Agent: `bun run typecheck` in `packages/opencode/` — pass
- Agent: `bun run script/check-opencode-annotations.ts --worktree` — pass
- Agent: `bun run script/httpapi-exercise.ts --mode effect --include v2.session.permission.create --fail-on-skip` — `PASS`

### Reviewer test steps

1. From `packages/opencode/`, run `bun run script/httpapi-exercise.ts --mode effect --include v2.session.permission.create`
2. Confirm the scenario passes with `effect === "ask"`

### Blocked checks and substitute verification

- Full `bun run test:httpapi` was not re-run after the assertion message change; the isolated `v2.session.permission.create` scenario was.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch