### PR TITLE
fix(tui): stop leftover toast titles during update install

### DIFF
--- a/.changeset/tui-toast-title-leak.md
+++ b/.changeset/tui-toast-title-leak.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop leftover toast titles from appearing when installing a TUI update.

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, type ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
+import { reconcile } from "solid-js/store" // kilocode_change
 import { useTheme } from "../context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "./border"
@@ -60,7 +61,7 @@ function init() {
   const toast = {
     show(options: ToastInput) {
       const toastOptions = { ...options, duration: options.duration ?? 5000 }
-      setStore("currentToast", toastOptions)
+      setStore("currentToast", reconcile(toastOptions)) // kilocode_change
       if (timeoutHandle) clearTimeout(timeoutHandle)
       // kilocode_change start
       timeoutHandle = null

--- a/packages/tui/test/kilocode/toast.test.tsx
+++ b/packages/tui/test/kilocode/toast.test.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { ToastProvider, useToast } from "../../src/ui/toast"
+
+test("replacing a toast does not keep the previous title", async () => {
+  let toast: ReturnType<typeof useToast>
+  function Probe() {
+    toast = useToast()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <ToastProvider>
+      <Probe />
+    </ToastProvider>
+  ))
+
+  try {
+    toast!.show({
+      title: "MCP Authentication Required",
+      message: `Server "foo" requires authentication.`,
+      variant: "warning",
+      duration: 0,
+    })
+    toast!.show({
+      variant: "info",
+      message: "Updating to v7.4.21...",
+      duration: 0,
+    })
+    expect(toast!.currentToast?.title).toBeUndefined()
+    expect(toast!.currentToast?.message).toBe("Updating to v7.4.21...")
+    expect(toast!.currentToast?.variant).toBe("info")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What

When accepting the TUI update prompt, the installing notification reused the previous toast title (`MCP Authentication Required`) instead of an update title.

## Why

SolidJS `createStore` merges objects, so `currentToast.title` leaked from the last toast when the update toast omitted `title`.

## Change

- Replace the toast with `reconcile` so omitted fields do not persist
- Set an explicit `Updating` title on the install toast
- Add a regression test for title replacement

## How to Test

1. Trigger an MCP auth toast
2. Accept an available TUI update
3. Confirm the installing toast title is `Updating`, not the MCP title