### PR TITLE
fix(cli): prevent VS Code server connection failure on unwritable state paths

### DIFF
--- a/.changeset/fallback-state-directory.md
+++ b/.changeset/fallback-state-directory.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Start Kilo with a persistent fallback when the default runtime state directory is not writable.

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -5,7 +5,7 @@ import os from "os"
 import { Context, Effect, Layer } from "effect"
 import { Flock } from "./util/flock"
 import { markNoIndex } from "./kilocode/spotlight" // kilocode_change
-import { ensureRealDir } from "./kilocode/global" // kilocode_change
+import { ensureRealDir, resolveState } from "./kilocode/global" // kilocode_change
 import { Flag } from "./flag/flag"
 import { makeGlobalNode } from "./effect/app-node"
 
@@ -22,7 +22,8 @@ const clean = (p: string | undefined) => p?.replace(/[\r\n]+/g, "")
 const data = path.join(clean(xdgData)!, app)
 const cache = path.join(clean(xdgCache)!, app)
 const config = path.join(clean(xdgConfig)!, app)
-const state = path.join(clean(xdgState)!, app)
+const preferred = path.join(clean(xdgState)!, app)
+const state = await resolveState(preferred, process.env.XDG_STATE_HOME ? undefined : path.join(data, "state"))
 // kilocode_change end
 const tmp = path.join(os.tmpdir(), app)
 
@@ -47,7 +48,6 @@ Flock.setGlobal({ state })
 await Promise.all([
   ensureRealDir(Path.data), // kilocode_change
   ensureRealDir(Path.config), // kilocode_change
-  ensureRealDir(Path.state), // kilocode_change
   ensureRealDir(Path.tmp), // kilocode_change
   ensureRealDir(Path.log), // kilocode_change
   ensureRealDir(Path.bin), // kilocode_change

--- a/packages/core/src/kilocode/global.ts
+++ b/packages/core/src/kilocode/global.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises"
-import { constants } from "fs"
+import path from "path"
+import { randomUUID } from "crypto"
 
 /**
  * Like `fs.mkdir({ recursive: true })` but also repairs broken symlinks and
@@ -23,9 +24,15 @@ export async function ensureRealDir(p: string) {
   }
 }
 
+async function writable(p: string) {
+  const probe = path.join(p, `.kilo-write-${process.pid}-${randomUUID()}`)
+  await fs.writeFile(probe, "", { flag: "wx", mode: 0o600 })
+  await fs.unlink(probe)
+}
+
 async function ready(p: string) {
   await ensureRealDir(p)
-  await fs.access(p, constants.W_OK | constants.X_OK)
+  await writable(p)
 }
 
 export async function resolveState(p: string, fallback?: string) {
@@ -35,7 +42,7 @@ export async function resolveState(p: string, fallback?: string) {
       : await fs.stat(fallback).then(
           (stat) =>
             stat.isDirectory() &&
-            fs.access(fallback, constants.W_OK | constants.X_OK).then(
+            writable(fallback).then(
               () => true,
               () => false,
             ),

--- a/packages/core/src/kilocode/global.ts
+++ b/packages/core/src/kilocode/global.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises"
+import { constants } from "fs"
 
 /**
  * Like `fs.mkdir({ recursive: true })` but also repairs broken symlinks and
@@ -20,4 +21,45 @@ export async function ensureRealDir(p: string) {
     await fs.rm(p, { force: true })
     await fs.mkdir(p, { recursive: true })
   }
+}
+
+async function ready(p: string) {
+  await ensureRealDir(p)
+  await fs.access(p, constants.W_OK | constants.X_OK)
+}
+
+export async function resolveState(p: string, fallback?: string) {
+  const sticky =
+    fallback === undefined
+      ? false
+      : await fs.stat(fallback).then(
+          (stat) =>
+            stat.isDirectory() &&
+            fs.access(fallback, constants.W_OK | constants.X_OK).then(
+              () => true,
+              () => false,
+            ),
+          () => false,
+        )
+  if (sticky && fallback !== undefined) return fallback
+
+  const err = await ready(p).then(
+    () => undefined,
+    (err: unknown) => err,
+  )
+  if (err === undefined) return p
+  if (fallback === undefined) throw err
+
+  const failed = await ready(fallback).then(
+    () => undefined,
+    (err: unknown) => err,
+  )
+  if (failed !== undefined) {
+    throw new AggregateError([err, failed], `Cannot use state directory "${p}" or fallback "${fallback}"`)
+  }
+
+  const msg = err instanceof Error ? err.message : "Unknown error"
+  // Logging is not initialized until Global.Path.log exists.
+  console.warn(`[kilo] Cannot use state directory "${p}"; using "${fallback}" instead: ${msg}`)
+  return fallback
 }

--- a/packages/core/test/kilocode/global.test.ts
+++ b/packages/core/test/kilocode/global.test.ts
@@ -1,0 +1,108 @@
+import fs from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { resolveState } from "@opencode-ai/core/kilocode/global"
+import { tmpdir } from "../fixture/tmpdir"
+
+const skip = process.platform === "win32" || process.getuid?.() === 0
+
+describe("global state directory", () => {
+  test("uses the preferred state directory when available", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+
+    expect(await resolveState(preferred, path.join(tmp.path, "fallback"))).toBe(preferred)
+    expect((await fs.stat(preferred)).isDirectory()).toBe(true)
+  })
+
+  test("falls back when the default state directory is unusable", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    const fallback = path.join(tmp.path, "data", "state")
+    await fs.writeFile(preferred, "not a directory")
+
+    expect(await resolveState(preferred, fallback)).toBe(fallback)
+    expect((await fs.stat(fallback)).isDirectory()).toBe(true)
+  })
+
+  test("keeps using an existing fallback", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    const fallback = path.join(tmp.path, "fallback")
+    await fs.mkdir(fallback)
+
+    expect(await resolveState(preferred, fallback)).toBe(fallback)
+    expect(
+      await fs.stat(preferred).then(
+        () => true,
+        () => false,
+      ),
+    ).toBe(false)
+  })
+
+  test.skipIf(skip)("uses the preferred directory when an existing fallback is not writable", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    const fallback = path.join(tmp.path, "fallback")
+    await fs.mkdir(fallback)
+    await fs.chmod(fallback, 0o500)
+
+    try {
+      expect(await resolveState(preferred, fallback)).toBe(preferred)
+    } finally {
+      await fs.chmod(fallback, 0o700)
+    }
+  })
+
+  test.skipIf(skip)("falls back when the preferred directory cannot be created", async () => {
+    await using tmp = await tmpdir()
+    const parent = path.join(tmp.path, "preferred")
+    const preferred = path.join(parent, "kilo")
+    const fallback = path.join(tmp.path, "data", "state")
+    await fs.mkdir(parent)
+    await fs.chmod(parent, 0o500)
+
+    try {
+      expect(await resolveState(preferred, fallback)).toBe(fallback)
+    } finally {
+      await fs.chmod(parent, 0o700)
+    }
+  })
+
+  test.skipIf(skip)("falls back when the preferred directory exists but is not writable", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    const fallback = path.join(tmp.path, "data", "state")
+    await fs.mkdir(preferred)
+    await fs.chmod(preferred, 0o500)
+
+    try {
+      expect(await resolveState(preferred, fallback)).toBe(fallback)
+    } finally {
+      await fs.chmod(preferred, 0o700)
+    }
+  })
+
+  test("preserves errors for explicitly configured state directories", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    await fs.writeFile(preferred, "not a directory")
+
+    const err = await resolveState(preferred).catch((err: unknown) => err)
+    expect(err).toBeDefined()
+  })
+
+  test("reports both paths when the fallback also fails", async () => {
+    await using tmp = await tmpdir()
+    const preferred = path.join(tmp.path, "preferred")
+    const fallback = path.join(tmp.path, "fallback")
+    await Promise.all([fs.writeFile(preferred, "not a directory"), fs.writeFile(fallback, "not a directory")])
+
+    const err = await resolveState(preferred, fallback).catch((err: unknown) => err)
+    expect(err).toBeInstanceOf(AggregateError)
+    if (!(err instanceof AggregateError)) throw err
+    expect(err.message).toContain(preferred)
+    expect(err.message).toContain(fallback)
+    expect(err.errors).toHaveLength(2)
+  })
+})

--- a/packages/core/test/kilocode/global.test.ts
+++ b/packages/core/test/kilocode/global.test.ts
@@ -13,6 +13,7 @@ describe("global state directory", () => {
 
     expect(await resolveState(preferred, path.join(tmp.path, "fallback"))).toBe(preferred)
     expect((await fs.stat(preferred)).isDirectory()).toBe(true)
+    expect(await fs.readdir(preferred)).toEqual([])
   })
 
   test("falls back when the default state directory is unusable", async () => {
@@ -89,7 +90,7 @@ describe("global state directory", () => {
     await fs.writeFile(preferred, "not a directory")
 
     const err = await resolveState(preferred).catch((err: unknown) => err)
-    expect(err).toBeDefined()
+    expect(err).toBeInstanceOf(Error)
   })
 
   test("reports both paths when the fallback also fails", async () => {


### PR DESCRIPTION
## Issue

Fixes #12939

## Context

The bundled CLI exits before the VS Code server starts when the default Kilo state directory cannot be created or written. This leaves the extension unable to connect even though Kilo has another persistent, writable application directory available.

## Implementation

When `XDG_STATE_HOME` is unset, probe the default state directory and fall back to a state directory under Kilo's data root when necessary. Once used, a writable fallback remains sticky so concurrent or later processes do not split locks and runtime state across roots. Explicit `XDG_STATE_HOME` values remain authoritative, and failures from both candidate paths are preserved.

## Screenshots / Video

N/A — this is a backend startup fix with no visual changes.

## How to Test

### Manual/local verification

- Agent: exercised real permission-denied cases for an uncreatable directory and an existing non-writable directory; both selected the fallback.
- Agent: verified a writable existing fallback remains sticky, while an inaccessible fallback falls through to a recovered preferred directory.
- Agent: ran `bun test ./test/kilocode/global.test.ts` from `packages/core` (8 passed).
- Agent: ran `bun run typecheck` from `packages/core` successfully.
- Agent: ran formatting, targeted lint, annotation, Promise-facade, and diff checks successfully. Targeted lint reports one pre-existing unused import warning in `packages/core/src/global.ts` and no errors.

### Reviewer test steps

1. Run `cd packages/core && bun test ./test/kilocode/global.test.ts`.
2. Confirm all eight state-directory tests pass.
3. Start Kilo without `XDG_STATE_HOME` while `~/.local/state/kilo` cannot be created, and confirm startup continues using the data-root fallback.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
