### PR TITLE
fix: keep Code agent after switching from Ask

### DIFF
--- a/.changeset/ask-to-code-agent-switch.md
+++ b/.changeset/ask-to-code-agent-switch.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Keep the selected agent after switching from Ask to Code, and remind the model that previous Ask-mode restrictions no longer apply.

--- a/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
@@ -276,13 +276,10 @@ describe("sendMessage / sendCommand draft id contract", () => {
     )
   })
 
-  it("promptAgent sends an explicit selection instead of omitting the default agent", () => {
-    const match = source.match(/function promptAgent\(sessionID\?: string\) \{([\s\S]*?)\n  \}/)
-    expect(match).not.toBeNull()
-    expect(match![1]).toContain("store.agentSelections[sessionID]")
-    expect(match![1]).toContain("pendingAgentSelection()")
-    expect(match![1]).not.toContain("defaultAgent()")
-    expect(match![1]).not.toMatch(/name !== defaultAgent\(\) \? name : undefined/)
+  it("sendMessage and sendCommand post the agent returned by promptAgent", () => {
+    expect(extractFunctionBody(source, "sendMessage")).toContain("const agent = promptAgent(scope)")
+    expect(extractFunctionBody(source, "sendCommand")).toContain("const agent = promptAgent(scope)")
+    expect(extractFunctionBody(source, "promptAgent")).toContain("return resolvePromptAgent({")
   })
 
   it("createSession and clearCurrentSession do not pin the provisional default agent", () => {

--- a/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-send-contract.test.ts
@@ -276,6 +276,22 @@ describe("sendMessage / sendCommand draft id contract", () => {
     )
   })
 
+  it("promptAgent sends an explicit selection instead of omitting the default agent", () => {
+    const match = source.match(/function promptAgent\(sessionID\?: string\) \{([\s\S]*?)\n  \}/)
+    expect(match).not.toBeNull()
+    expect(match![1]).toContain("store.agentSelections[sessionID]")
+    expect(match![1]).toContain("pendingAgentSelection()")
+    expect(match![1]).not.toContain("defaultAgent()")
+    expect(match![1]).not.toMatch(/name !== defaultAgent\(\) \? name : undefined/)
+  })
+
+  it("createSession and clearCurrentSession do not pin the provisional default agent", () => {
+    expect(extractFunctionBody(source, "createSession")).toContain("setPendingAgentSelection(null)")
+    expect(extractFunctionBody(source, "createSession")).not.toContain("setPendingAgentSelection(defaultAgent())")
+    expect(extractFunctionBody(source, "clearCurrentSession")).toContain("setPendingAgentSelection(null)")
+    expect(extractFunctionBody(source, "clearCurrentSession")).not.toContain("setPendingAgentSelection(defaultAgent())")
+  })
+
   it("does not clear a newer pending agent when a seeded draft is promoted", () => {
     const body = extractFunctionBody(source, "handleSessionCreated")
     const draftBlock = body.match(/if \(draftID\) \{([\s\S]*?)\} else if/)

--- a/packages/kilo-vscode/tests/unit/session-agent.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-agent.test.ts
@@ -3,6 +3,7 @@ import {
   cycleAgent,
   createDraftAgentSeed,
   draftAgentSelection,
+  resolvePromptAgent,
   resolveSessionAgent,
 } from "../../webview-ui/src/context/session-agent"
 import type { Message } from "../../webview-ui/src/types/messages"
@@ -127,6 +128,27 @@ describe("cycleAgent", () => {
       }),
     ).toBeUndefined()
     expect(selected).toEqual([])
+  })
+})
+
+describe("resolvePromptAgent", () => {
+  it("sends Code after an explicit Ask to Code selection", () => {
+    expect(
+      resolvePromptAgent({
+        sessionID: "ses_1",
+        selections: { ses_1: "code" },
+        pending: "ask",
+      }),
+    ).toBe("code")
+  })
+
+  it("sends an explicit pending Code selection on a new draft", () => {
+    expect(resolvePromptAgent({ selections: {}, pending: "code" })).toBe("code")
+  })
+
+  it("omits the agent when there is no explicit selection", () => {
+    expect(resolvePromptAgent({ sessionID: "ses_1", selections: {}, pending: null })).toBeUndefined()
+    expect(resolvePromptAgent({ selections: {}, pending: null })).toBeUndefined()
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
@@ -26,6 +26,15 @@ export function resolveSessionAgent(messages: Message[], names: Set<string>): st
   }
 }
 
+export function resolvePromptAgent(input: {
+  sessionID?: string
+  selections: Record<string, string>
+  pending: string | null
+}) {
+  if (input.sessionID) return input.selections[input.sessionID]
+  return input.pending ?? undefined
+}
+
 export function draftAgentSelection(selections: Record<string, string>, draft: string, pending: string | null) {
   if (selections[draft]) return undefined
   return pending ?? undefined

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -717,8 +717,8 @@ export const SessionProvider: ParentComponent = (props) => {
   })
 
   function promptAgent(sessionID?: string) {
-    const name = agentForScope(sessionID)
-    return name !== defaultAgent() ? name : undefined
+    if (sessionID) return store.agentSelections[sessionID]
+    return pendingAgentSelection() ?? undefined
   }
 
   function hideErrors(sid: string) {
@@ -2549,9 +2549,9 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
 
-    // Reset agent selection to default for the new session (model overrides persist)
+    // Clear the pending agent so the picker shows the default and send omits it
     agentDrafts.prune(draftSessionID())
-    setPendingAgentSelection(defaultAgent())
+    setPendingAgentSelection(null)
     vscode.postMessage({ type: "createSession" })
   }
 
@@ -2562,7 +2562,7 @@ export const SessionProvider: ParentComponent = (props) => {
     setDraftSessionID(undefined)
     setCloudPreviewId(null)
     setLoading(false)
-    setPendingAgentSelection(defaultAgent())
+    setPendingAgentSelection(null)
     vscode.postMessage({ type: "clearSession" })
   }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -85,7 +85,7 @@ import { clearSessionDraftDiscarded, deleteDraftsForSession } from "../utils/dra
 import { createAbortState } from "./abort-state"
 import { clearIfOn, createCloudPrune } from "./session-cloud-prune"
 import { isSameSessionTree } from "./model-usage"
-import { createDraftAgentSeed } from "./session-agent"
+import { createDraftAgentSeed, resolvePromptAgent } from "./session-agent"
 import { createModelSelector } from "./session-model-selector"
 
 const RECENT_LIMIT = 5
@@ -717,8 +717,11 @@ export const SessionProvider: ParentComponent = (props) => {
   })
 
   function promptAgent(sessionID?: string) {
-    if (sessionID) return store.agentSelections[sessionID]
-    return pendingAgentSelection() ?? undefined
+    return resolvePromptAgent({
+      sessionID,
+      selections: store.agentSelections,
+      pending: pendingAgentSelection(),
+    })
   }
 
   function hideErrors(sid: string) {

--- a/packages/opencode/src/kilocode/session/ask-code-switch.txt
+++ b/packages/opencode/src/kilocode/session/ask-code-switch.txt
@@ -1,0 +1,6 @@
+<system-reminder>
+The active agent has changed from Ask to Code.
+Previous Ask-mode behavioral restrictions no longer apply.
+Follow the current Code agent instructions and the permissions configured for this agent.
+Ignore earlier conversation text that says you are in Ask mode or must not make changes.
+</system-reminder>

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -26,7 +26,7 @@ import { MemoryPaths } from "@kilocode/kilo-memory/effect/paths"
 import { MemoryMarker } from "@/kilocode/memory/marker"
 import { KilocodeSystemPrompt } from "@/kilocode/system-prompt"
 import { KiloToolRegistry } from "@/kilocode/tool/registry"
-import CODE_SWITCH from "@/session/prompt/code-switch.txt"
+import ASK_CODE_SWITCH from "./ask-code-switch.txt"
 import { consumeAutoTitle, markAutoTitle } from "@/kilo-sessions/rename-adoptions"
 
 export namespace KiloSessionPrompt {
@@ -456,6 +456,25 @@ export namespace KiloSessionPrompt {
         : 'Before creating or updating the plan file, or calling plan_exit, ask the user to choose exactly one of: "Finalize and save the plan" or "Continue refining". If the user chooses to finalize, write the main plan file, then call plan_exit.',
     ].join("\n")
     add(`<system-reminder>\n${body}\n</system-reminder>`)
+  }
+
+  export function insertAgentSwitchReminder(input: {
+    agent: { name: string }
+    userMessage: MessageV2.WithParts
+    messages: MessageV2.WithParts[]
+  }) {
+    if (mode(input.agent.name) !== "code") return
+    const prior = input.messages.findLast((msg) => msg.info.id !== input.userMessage.info.id)
+    if (!prior || mode(prior.info.agent) !== "ask") return
+    if (input.userMessage.parts.some((part) => part.type === "text" && part.text === ASK_CODE_SWITCH)) return
+    return {
+      id: PartID.ascending(),
+      messageID: input.userMessage.info.id,
+      sessionID: input.userMessage.info.sessionID,
+      type: "text" as const,
+      text: ASK_CODE_SWITCH,
+      synthetic: true,
+    }
   }
 
   /**

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -10,6 +10,7 @@ import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import CODE_SWITCH from "./prompt/code-switch.txt" // kilocode_change
+import ASK_CODE_SWITCH from "@/kilocode/session/ask-code-switch.txt" // kilocode_change
 
 export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   messages: SessionV1.WithParts[]
@@ -22,8 +23,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
 
-  // kilocode_change start - shared planning reminder path
-  // No-op unless the active agent is plan-like.
+  // kilocode_change start - shared planning / agent-switch reminder path
   yield* Effect.promise(() =>
     KiloSessionPrompt.insertPlanReminders({
       agent: input.agent,
@@ -32,11 +32,21 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
       messages: input.messages,
     }),
   )
+  const switched = KiloSessionPrompt.insertAgentSwitchReminder({
+    agent: input.agent,
+    userMessage,
+    messages: input.messages,
+  })
+  if (switched) userMessage.parts.push(yield* sessions.updatePart(switched))
   // kilocode_change end
 
   if (!flags.experimentalPlanMode) {
     const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-    if (wasPlan && input.agent.name === "code") {
+    if (
+      wasPlan &&
+      input.agent.name === "code" &&
+      !userMessage.parts.some((part) => part.type === "text" && part.text === ASK_CODE_SWITCH)
+    ) {
       // kilocode_change - renamed from "build" to "code"
       userMessage.parts.push({
         id: PartID.ascending(),

--- a/packages/opencode/test/kilocode/ask-switch-reminder.test.ts
+++ b/packages/opencode/test/kilocode/ask-switch-reminder.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from "bun:test"
+import ASK_CODE_SWITCH from "../../src/kilocode/session/ask-code-switch.txt"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { MessageV2 } from "../../src/session/message-v2"
+import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
+
+const model = {
+  providerID: ProviderV2.ID.make("openai"),
+  modelID: ModelV2.ID.make("gpt-4"),
+}
+
+function user(input: { agent: string; text: string }) {
+  const id = MessageID.ascending()
+  const sessionID = SessionID.make("ses_test")
+  return {
+    info: {
+      id,
+      role: "user" as const,
+      sessionID,
+      time: { created: Date.now() },
+      agent: input.agent,
+      model,
+    },
+    parts: [
+      {
+        id: PartID.ascending(),
+        messageID: id,
+        sessionID,
+        type: "text" as const,
+        text: input.text,
+      },
+    ],
+  } satisfies MessageV2.WithParts
+}
+
+function assistant(input: { sessionID: SessionID; parentID: MessageID; agent: string; text: string }) {
+  const id = MessageID.ascending()
+  return {
+    info: {
+      id,
+      role: "assistant" as const,
+      sessionID: input.sessionID,
+      time: { created: Date.now() },
+      parentID: input.parentID,
+      modelID: model.modelID,
+      providerID: model.providerID,
+      mode: input.agent,
+      agent: input.agent,
+      path: { cwd: "/tmp", root: "/tmp" },
+      cost: 0,
+      tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      {
+        id: PartID.ascending(),
+        messageID: id,
+        sessionID: input.sessionID,
+        type: "text" as const,
+        text: input.text,
+      },
+    ],
+  } satisfies MessageV2.WithParts
+}
+
+function reminder(message: MessageV2.WithParts) {
+  return message.parts
+    .filter((part): part is MessageV2.TextPart => part.type === "text")
+    .map((part) => part.text)
+    .find((text) => text === ASK_CODE_SWITCH)
+}
+
+describe("insertAgentSwitchReminder", () => {
+  test("injects Ask to Code reminder when the previous turn was Ask", () => {
+    const ask = user({ agent: "ask", text: "How does this work?" })
+    const reply = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: ask.info.id,
+      agent: "ask",
+      text: "I cannot modify files in Ask mode.",
+    })
+    const next = user({ agent: "code", text: "Please implement the change." })
+    next.info.sessionID = ask.info.sessionID
+    for (const part of next.parts) part.sessionID = ask.info.sessionID
+
+    const added = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: next,
+      messages: [ask, reply, next],
+    })
+
+    expect(added?.text).toBe(ASK_CODE_SWITCH)
+    expect(reminder(next)).toBeUndefined()
+    next.parts.push(added!)
+    expect(reminder(next)).toBe(ASK_CODE_SWITCH)
+    expect(ASK_CODE_SWITCH).toContain("from Ask to Code")
+    expect(ASK_CODE_SWITCH).toContain("permissions configured for this agent")
+    expect(ASK_CODE_SWITCH).not.toContain("full toolset")
+    expect(ASK_CODE_SWITCH).not.toContain("You may modify files")
+  })
+
+  test("does not inject after an intermediate non-Ask agent", () => {
+    const ask = user({ agent: "ask", text: "How does this work?" })
+    const asked = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: ask.info.id,
+      agent: "ask",
+      text: "I cannot modify files in Ask mode.",
+    })
+    const review = user({ agent: "review", text: "Review that plan." })
+    review.info.sessionID = ask.info.sessionID
+    const reviewed = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: review.info.id,
+      agent: "review",
+      text: "Looks good.",
+    })
+    const next = user({ agent: "code", text: "Implement it." })
+    next.info.sessionID = ask.info.sessionID
+
+    KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: next,
+      messages: [ask, asked, review, reviewed, next],
+    })
+
+    expect(reminder(next)).toBeUndefined()
+  })
+
+  test("does not inject when staying in Ask", () => {
+    const ask = user({ agent: "ask", text: "Explain this." })
+    const reply = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: ask.info.id,
+      agent: "ask",
+      text: "Here is the explanation.",
+    })
+    const next = user({ agent: "ask", text: "And this file?" })
+    next.info.sessionID = ask.info.sessionID
+
+    KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: next,
+      messages: [ask, reply, next],
+    })
+
+    expect(reminder(next)).toBeUndefined()
+  })
+
+  test("does not inject on later Code turns after the switch", () => {
+    const ask = user({ agent: "ask", text: "How does this work?" })
+    const reply = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: ask.info.id,
+      agent: "ask",
+      text: "I cannot modify files in Ask mode.",
+    })
+    const first = user({ agent: "code", text: "Implement it." })
+    first.info.sessionID = ask.info.sessionID
+    const coded = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: first.info.id,
+      agent: "code",
+      text: "Done.",
+    })
+    const later = user({ agent: "code", text: "Also add tests." })
+    later.info.sessionID = ask.info.sessionID
+
+    KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: later,
+      messages: [ask, reply, first, coded, later],
+    })
+
+    expect(reminder(later)).toBeUndefined()
+  })
+
+  test("does not inject twice on the same user message", () => {
+    const ask = user({ agent: "ask", text: "How does this work?" })
+    const reply = assistant({
+      sessionID: ask.info.sessionID,
+      parentID: ask.info.id,
+      agent: "ask",
+      text: "I cannot modify files in Ask mode.",
+    })
+    const next = user({ agent: "code", text: "Please implement the change." })
+    next.info.sessionID = ask.info.sessionID
+
+    const first = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: next,
+      messages: [ask, reply, next],
+    })
+    next.parts.push(first!)
+    const second = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: next,
+      messages: [ask, reply, next],
+    })
+
+    expect(second).toBeUndefined()
+    expect(next.parts.filter((part) => part.type === "text" && part.text === ASK_CODE_SWITCH)).toHaveLength(1)
+  })
+
+  test("does not inject on Plan to Code", () => {
+    const plan = user({ agent: "plan", text: "Make a plan." })
+    const reply = assistant({
+      sessionID: plan.info.sessionID,
+      parentID: plan.info.id,
+      agent: "plan",
+      text: "Here is the plan.",
+    })
+    const next = user({ agent: "code", text: "Implement the plan." })
+    next.info.sessionID = plan.info.sessionID
+
+    const added = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "code" },
+      userMessage: next,
+      messages: [plan, reply, next],
+    })
+
+    expect(added).toBeUndefined()
+    expect(reminder(next)).toBeUndefined()
+  })
+
+  test("does not inject when staying in Plan", () => {
+    const plan = user({ agent: "plan", text: "Make a plan." })
+    const reply = assistant({
+      sessionID: plan.info.sessionID,
+      parentID: plan.info.id,
+      agent: "plan",
+      text: "Here is the plan.",
+    })
+    const next = user({ agent: "plan", text: "Refine it." })
+    next.info.sessionID = plan.info.sessionID
+
+    const added = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "plan" },
+      userMessage: next,
+      messages: [plan, reply, next],
+    })
+
+    expect(added).toBeUndefined()
+    expect(reminder(next)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #13118

## Context

Switching a live conversation from Ask to Code still ran the next turn as Ask, or sent Code while the model kept following prior Ask replies.

After #13102, an omitted agent falls back to `session.agent` instead of the default Code agent. The webview omitted `agent` whenever it equaled the frontend default, so a Code selection after Ask turns never reached the server. Even after the request is `agent=code`, DeepSeek and similar models still follow earlier Ask refusals in history.

## Implementation

`promptAgent` now sends the explicit picker/session selection, including Code. New Session / Clear no longer pin the provisional `"code"` default before agents load.

The first Code turn after an immediate Ask turn persists a permission-neutral `ASK_CODE_SWITCH` reminder. Plan→Code still uses the existing `CODE_SWITCH` path.

## Screenshots / Video

## Before
<img width="428" height="990" alt="Screenshot 2026-08-14 at 17 16 24" src="https://github.com/user-attachments/assets/116b38f3-5a77-4991-8642-233a5b35bdd9" />

## After
<img width="486" height="898" alt="Screenshot 2026-08-14 at 18 48 04" src="https://github.com/user-attachments/assets/ba6cf164-d64c-4b4e-97fa-5a9ac13486a0" />

## How to Test

### Manual/local verification

- Start a conversation in Ask, switch the picker to Code, and send an implementation request. The outgoing turn should use Code.
- With DeepSeek or a similar model, confirm the first Code turn after Ask no longer says it is still in Ask mode.
- Plan → Code should still receive the existing plan-to-code reminder.

### Reviewer test steps

1. Open a project in the VS Code extension.
2. Start a conversation with the Ask agent and send a couple of questions.
3. Switch the agent selector to Code.
4. Ask Kilo to modify a file.
5. Confirm the model proceeds as Code instead of refusing as Ask.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
