### PR TITLE
fix(cli): stop memory auto-save from parsing SSE as JSON

### DIFF
--- a/.changeset/memory-sse-json.md
+++ b/.changeset/memory-sse-json.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop memory auto-save from failing on OpenAI-compatible providers that stream by default.

--- a/packages/opencode/src/kilocode/memory/ports.ts
+++ b/packages/opencode/src/kilocode/memory/ports.ts
@@ -153,6 +153,7 @@ function recalledMemory(turn: Turn) {
 // --- Model resolution + invocation (host provider/`ai` -> port ModelHandle) --------------------
 
 function consolidationOptions(model: Provider.Model) {
+  if (model.api.npm === "@ai-sdk/openai-compatible") return { ...ProviderTransform.smallOptions(model), stream: false }
   if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai") return { store: false }
   return ProviderTransform.smallOptions(model)
 }

--- a/packages/opencode/test/kilocode/memory/memory-ports.test.ts
+++ b/packages/opencode/test/kilocode/memory/memory-ports.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { APICallError } from "ai"
 import { Effect } from "effect"
@@ -15,11 +16,11 @@ import { MemoryModel, MemorySession } from "../../../src/kilocode/memory/ports"
 const pid = ProviderV2.ID.make("test")
 const mid = ModelV2.ID.make("fake-memory-model")
 
-function mdl(id = mid): Provider.Model {
+function mdl(id = mid, npm = "test-provider", providerID = pid): Provider.Model {
   return {
     id,
-    providerID: pid,
-    api: { id, npm: "test-provider", url: "" },
+    providerID,
+    api: { id, npm, url: "" },
     limit: { context: 100_000, output: 4_000 },
     capabilities: {
       toolcall: true,
@@ -66,12 +67,20 @@ function lang(outputs: (string | Error)[] = ["{}"], calls?: unknown[], hang?: bo
 }
 
 function provider(
-  input: { outputs?: (string | Error)[]; seen?: string[]; calls?: unknown[]; hang?: boolean } = {},
+  input: {
+    outputs?: (string | Error)[]
+    seen?: string[]
+    calls?: unknown[]
+    hang?: boolean
+    npm?: string
+    providerID?: ProviderV2.ID
+  } = {},
 ): Provider.Interface {
-  const base = mdl()
-  const mem = mdl(ModelV2.ID.make("memory-config-model"))
+  const providerID = input.providerID ?? pid
+  const base = mdl(mid, input.npm, providerID)
+  const mem = mdl(ModelV2.ID.make("memory-config-model"), input.npm, providerID)
   const info = {
-    id: pid,
+    id: providerID,
     name: "Test",
     source: "config",
     env: [],
@@ -79,7 +88,7 @@ function provider(
     models: { [base.id]: base, [mem.id]: mem },
   } satisfies Provider.Info
   return {
-    list: () => Effect.succeed({ [pid]: info }),
+    list: () => Effect.succeed({ [providerID]: info }),
     getProvider: () => Effect.succeed(info),
     getModel: (providerID, modelID) => {
       const found = info.models[modelID]
@@ -290,6 +299,93 @@ describe("memory ports", () => {
     expect(seen).toEqual(["memory-config-model", "fake-memory-model"])
   })
 
+  test("model port asks OpenAI-compatible providers for a non-streaming JSON response", async () => {
+    const calls: unknown[] = []
+    const port = MemoryModel.port({ provider: provider({ npm: "@ai-sdk/openai-compatible", calls }) })
+    const resolved = await Effect.runPromise(port.resolve({ session: ref }))
+
+    await port.run({ handle: resolved.handle, system: "system", prompt: "prompt", timeoutMs: 30_000 })
+
+    const opts = calls[0] as { providerOptions?: Record<string, { stream?: boolean }> }
+    expect(opts.providerOptions?.test?.stream).toBe(false)
+  })
+
+  test("model port still disables streaming when a compatible model is registered as openai", async () => {
+    const calls: unknown[] = []
+    const port = MemoryModel.port({
+      provider: provider({
+        npm: "@ai-sdk/openai-compatible",
+        providerID: ProviderV2.ID.make("openai"),
+        calls,
+      }),
+    })
+    const resolved = await Effect.runPromise(port.resolve({ session: ref }))
+
+    await port.run({ handle: resolved.handle, system: "system", prompt: "prompt", timeoutMs: 30_000 })
+
+    const opts = calls[0] as { providerOptions?: Record<string, { stream?: boolean }> }
+    expect(opts.providerOptions?.openai?.stream).toBe(false)
+  })
+
+  test("model port puts stream:false on the OpenAI-compatible request body", async () => {
+    const seen: unknown[] = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const body = await request.json()
+        seen.push(body)
+        if ((body as { stream?: boolean }).stream !== false) {
+          return new Response(`data: ${JSON.stringify({ choices: [{ delta: { reasoning_content: "The" } }] })}\n\n`, {
+            headers: { "content-type": "text/event-stream" },
+          })
+        }
+        return Response.json({
+          id: "mem",
+          object: "chat.completion",
+          created: 0,
+          model: "fake-memory-model",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: '{"topic":"t","summary":"s"}',
+                reasoning_content: "The user just",
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        })
+      },
+    })
+    try {
+      const sdk = createOpenAICompatible({
+        name: "test",
+        baseURL: `http://127.0.0.1:${server.port}/v1`,
+        apiKey: "unused",
+      })
+      const port = MemoryModel.port({
+        provider: {
+          ...provider({ npm: "@ai-sdk/openai-compatible" }),
+          getLanguage: () => Effect.succeed(sdk.languageModel("fake-memory-model")),
+        },
+      })
+      const resolved = await Effect.runPromise(port.resolve({ session: ref }))
+      const result = await port.run({
+        handle: resolved.handle,
+        system: "system",
+        prompt: "prompt",
+        timeoutMs: 30_000,
+      })
+
+      expect((seen[0] as { stream?: boolean }).stream).toBe(false)
+      expect(result.text).toBe('{"topic":"t","summary":"s"}')
+    } finally {
+      server.stop(true)
+    }
+  })
+
   test("model port retries a transient provider failure once", async () => {
     const calls: unknown[] = []
     const err = new APICallError({
@@ -307,6 +403,8 @@ describe("memory ports", () => {
     await port.run({ handle: resolved.handle, system: "system", prompt: "prompt", timeoutMs: 30_000 })
 
     expect(calls).toHaveLength(2)
+    const opts = calls[0] as { providerOptions?: Record<string, { stream?: boolean }> }
+    expect(opts.providerOptions?.test?.stream).toBeUndefined()
   })
 
   test("model port emits a structured timeout error", async () => {


### PR DESCRIPTION
## What

Memory auto-save fails on OpenAI-compatible providers that default to streaming. `generateText` omits `stream`, the relay returns SSE, and the SDK `JSON.parse`s the whole body as one document.

## Why

Those background consolidation requests need a single JSON completion, not a token stream. The main chat already has an SSE parser; memory does not.

## How

Send `stream: false` through `providerOptions` for `@ai-sdk/openai-compatible` models. Unknown compatible options are already spread onto the chat-completions body.

Fixes #13120