### PR TITLE
fix(tui): stop one bad event from dropping the rest of a flush batch

### DIFF
--- a/.changeset/tui-turn-end-batch-drop.md
+++ b/.changeset/tui-turn-end-batch-drop.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep TUI session output updating after a turn ends instead of leaving a finished duration next to a spinning prompt.

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -35,7 +35,15 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     const handlers = new Set<(event: GlobalEvent) => void>()
     const emitter = {
       emit(_type: "event", event: GlobalEvent) {
-        for (const handler of handlers) handler(event)
+        // kilocode_change start
+        for (const handler of handlers) {
+          try {
+            handler(event)
+          } catch (err) {
+            console.error("tui event handler failed", { type: event.payload.type, err })
+          }
+        }
+        // kilocode_change end
       },
       on(_type: "event", handler: (event: GlobalEvent) => void) {
         handlers.add(handler)

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -35,7 +35,15 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     const handlers = new Set<(event: GlobalEvent) => void>()
     const emitter = {
       emit(_type: "event", event: GlobalEvent) {
-        for (const handler of handlers) handler(event)
+        // kilocode_change start
+        for (const handler of handlers) {
+          try {
+            handler(event)
+          } catch (err) {
+            console.error("tui event handler failed", { type: event.payload.type, err })
+          }
+        }
+        // kilocode_change end
       },
       on(_type: "event", handler: (event: GlobalEvent) => void) {
         handlers.add(handler)
@@ -60,7 +68,13 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       // Batch all event emissions so all store updates result in a single render
       batch(() => {
         for (const event of events) {
-          emitter.emit("event", event)
+          // kilocode_change start
+          try {
+            emitter.emit("event", event)
+          } catch (err) {
+            console.error("tui event handler failed", { type: event.payload.type, err })
+          }
+          // kilocode_change end
         }
       })
     }

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -415,6 +415,13 @@ export const {
         }
 
         // kilocode_change start
+        case "session.idle": {
+          setStore("session_status", event.properties.sessionID, { type: "idle" })
+          break
+        }
+        // kilocode_change end
+
+        // kilocode_change start
         case "background_process.updated": {
           const info = event.properties.info
           deleted.delete(info.id)
@@ -538,6 +545,7 @@ export const {
         case "message.removed": {
           touchMessage(event.properties.sessionID, event.properties.messageID)
           const messages = store.message[event.properties.sessionID]
+          if (!messages) break // kilocode_change
           const result = at(messages, event.properties.messageID) // kilocode_change - list is time-ordered, not id-sorted
           if (result.found) {
             setStore(
@@ -594,6 +602,7 @@ export const {
         case "message.part.removed": {
           touchPart(event.properties.sessionID, event.properties.partID)
           const parts = store.part[event.properties.messageID]
+          if (!parts) break // kilocode_change
           const result = search(parts, event.properties.partID, (p) => p.id)
           if (result.found) {
             setStore(

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -414,6 +414,13 @@ export const {
         }
 
         // kilocode_change start
+        case "session.idle": {
+          setStore("session_status", event.properties.sessionID, { type: "idle" })
+          break
+        }
+        // kilocode_change end
+
+        // kilocode_change start
         case "background_process.updated": {
           const info = event.properties.info
           deleted.delete(info.id)
@@ -537,6 +544,7 @@ export const {
         case "message.removed": {
           touchMessage(event.properties.sessionID, event.properties.messageID)
           const messages = store.message[event.properties.sessionID]
+          if (!messages) break // kilocode_change
           const result = search(messages, event.properties.messageID, (m) => m.id)
           if (result.found) {
             setStore(
@@ -593,6 +601,7 @@ export const {
         case "message.part.removed": {
           touchPart(event.properties.sessionID, event.properties.partID)
           const parts = store.part[event.properties.messageID]
+          if (!parts) break // kilocode_change
           const result = search(parts, event.properties.partID, (p) => p.id)
           if (result.found) {
             setStore(

--- a/packages/tui/test/cli/cmd/tui/sync-batch-drop.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-batch-drop.test.tsx
@@ -1,0 +1,84 @@
+// kilocode_change - new file
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import type { GlobalEvent } from "@kilocode/sdk/v2"
+import { tmpdir } from "../../../fixture/fixture"
+import { directory, mount, wait } from "./sync-fixture"
+
+const view = "ses_view"
+const bg = "ses_bg"
+const message = "msg_view"
+
+function wrap(payload: unknown): GlobalEvent {
+  return { directory, project: "proj_test", payload } as GlobalEvent
+}
+
+const busy = wrap({
+  id: "evt_busy",
+  type: "session.status",
+  properties: { sessionID: view, status: { type: "busy" } },
+})
+
+const idle = wrap({
+  id: "evt_idle",
+  type: "session.idle",
+  properties: { sessionID: view },
+})
+
+const removed = wrap({
+  id: "evt_removed",
+  type: "message.part.removed",
+  properties: { sessionID: bg, messageID: "msg_bg", partID: "prt_bg" },
+})
+
+const good = wrap({
+  id: "evt_good",
+  type: "message.updated",
+  properties: {
+    sessionID: view,
+    info: {
+      id: message,
+      sessionID: view,
+      role: "user",
+      time: { created: 1 },
+      path: { cwd: directory, root: directory },
+    },
+  },
+})
+
+describe("tui sync batch drop", () => {
+  test("part.removed for an unhydrated session does not drop later events in the batch", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(busy)
+      emit(removed)
+      emit(good)
+      await wait(() => sync.data.message[view]?.some((item) => item.id === message) ?? false)
+
+      expect(sync.data.message[view]?.map((item) => item.id)).toEqual([message])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("session.idle returns the status to idle after busy", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(busy)
+      await wait(() => sync.data.session_status[view]?.type === "busy")
+
+      emit(idle)
+      await wait(() => sync.data.session_status[view]?.type === "idle")
+
+      expect(sync.data.session_status[view]).toEqual({ type: "idle" })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/tui/test/kilocode/sync-batch-drop.test.tsx
+++ b/packages/tui/test/kilocode/sync-batch-drop.test.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import type { GlobalEvent } from "@kilocode/sdk/v2"
+import { tmpdir } from "../fixture/fixture"
+import { directory, mount, wait } from "../cli/cmd/tui/sync-fixture"
+
+const view = "ses_view"
+const bg = "ses_bg"
+const message = "msg_view"
+
+function wrap(payload: unknown): GlobalEvent {
+  return { directory, project: "proj_test", payload } as GlobalEvent
+}
+
+const busy = wrap({
+  id: "evt_busy",
+  type: "session.status",
+  properties: { sessionID: view, status: { type: "busy" } },
+})
+
+const idle = wrap({
+  id: "evt_idle",
+  type: "session.idle",
+  properties: { sessionID: view },
+})
+
+const removed = wrap({
+  id: "evt_removed",
+  type: "message.part.removed",
+  properties: { sessionID: bg, messageID: "msg_bg", partID: "prt_bg" },
+})
+
+const good = wrap({
+  id: "evt_good",
+  type: "message.updated",
+  properties: {
+    sessionID: view,
+    info: {
+      id: message,
+      sessionID: view,
+      role: "user",
+      time: { created: 1 },
+      path: { cwd: directory, root: directory },
+    },
+  },
+})
+
+describe("tui sync batch drop", () => {
+  test("part.removed for an unhydrated session does not drop later events in the batch", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(busy)
+      emit(removed)
+      emit(good)
+      await wait(() => sync.data.message[view]?.some((item) => item.id === message) ?? false)
+
+      expect(sync.data.message[view]?.map((item) => item.id)).toEqual([message])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("session.idle returns the status to idle after busy", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(busy)
+      await wait(() => sync.data.session_status[view]?.type === "busy")
+
+      emit(idle)
+      await wait(() => sync.data.session_status[view]?.type === "idle")
+
+      expect(sync.data.session_status[view]).toEqual({ type: "idle" })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## What

Fixes the TUI stall where a turn visibly finishes (footer shows the completed duration) but the prompt keeps spinning and the transcript stops updating.

## Why

The SSE client batches events and `flush()` clears the queue before iterating, emitting each event unguarded inside a single Solid `batch()`. The legacy `message.removed` / `message.part.removed` handlers in `sync.tsx` called `search(...)` on `store.message[...]` / `store.part[...]` without checking they exist — for a session this TUI never hydrated (background-session cleanup, revert, another window), that is `undefined` and `search` throws reading `items.length`. One such event mid-batch permanently dropped every later event in that flush, including the idle status the spinner depends on.

Changes:

- `sync.tsx`: guard the legacy `message.removed` / `message.part.removed` handlers with the same missing-collection checks the `.1` handlers already have, and handle `session.idle` by resetting `session_status` to idle.
- `sdk.tsx`: isolate event dispatch per handler and per event so one throwing handler logs (`tui event handler failed`) instead of dropping the rest of the batch or killing the SSE loop.
- Tests reproduce both symptoms on the existing sync fixture; both fail without the fix.