### PR TITLE
fix(tui): broaden live-output resilience for stalled sessions

### DIFF
--- a/.changeset/tui-live-output-extras.md
+++ b/.changeset/tui-live-output-extras.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep TUI reasoning output painting while a turn is still running, recover live text deltas that arrive before their part, resync a busy session after a few seconds without new output, and keep the event stream reconnecting after transient errors.

--- a/packages/tui/src/context/event.ts
+++ b/packages/tui/src/context/event.ts
@@ -70,7 +70,10 @@ export function useEvent() {
         return
       }
 
-      if (event.directory !== "global" && event.project !== project.project()) return // kilocode_change
+      // kilocode_change start - fail open while the current project id is unknown
+      const current = project.project()
+      if (event.directory !== "global" && current && event.project !== current) return
+      // kilocode_change end
       handler(event.payload, { directory: event.directory, workspace: event.workspace })
     })
   }
@@ -79,7 +82,8 @@ export function useEvent() {
     return sdk.event.on("event", (event) => {
       const payload = normalizeSyncEvent(event.payload)
       if (!payload) return
-      if (event.directory === "global" || event.project === project.project()) {
+      const current = project.project() // kilocode_change
+      if (event.directory === "global" || !current || event.project === current) { // kilocode_change
         handler(payload, { directory: event.directory, workspace: event.workspace })
       }
     })

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -88,21 +88,31 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         while (true) {
           if (abort.signal.aborted || ctrl.signal.aborted) break
 
-          const events = await sdk.global.event({
-            signal: ctrl.signal,
-            sseMaxRetryAttempts: 0,
-          })
+          // kilocode_change start - keep reconnecting when the SSE iterator throws
+          try {
+            const events = await sdk.global.event({
+              signal: ctrl.signal,
+              sseMaxRetryAttempts: 0,
+            })
 
-          if (Flag.KILO_EXPERIMENTAL_WORKSPACES) {
-            // Start syncing workspaces, it's important to do this after
-            // we've started listening to events
-            await sdk.sync.start().catch(() => {})
-          }
+            if (Flag.KILO_EXPERIMENTAL_WORKSPACES) {
+              // Start syncing workspaces, it's important to do this after
+              // we've started listening to events
+              await sdk.sync.start().catch(() => {})
+            }
 
-          for await (const event of events.stream) {
-            if (ctrl.signal.aborted) break
-            handleEvent(event)
+            let delivered = 0
+            for await (const event of events.stream) {
+              if (ctrl.signal.aborted) break
+              handleEvent(event)
+              delivered += 1
+            }
+            if (delivered > 0) attempt = 0
+          } catch (err) {
+            if (abort.signal.aborted || ctrl.signal.aborted) break
+            console.error("tui event stream failed", { err })
           }
+          // kilocode_change end
 
           if (timer) clearTimeout(timer)
           if (queue.length > 0) flush()

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -38,6 +38,7 @@ import path from "path"
 import { useKV } from "./kv"
 import { handleSuggestionEvent } from "@/kilocode/suggestion/tui/sync" // kilocode_change
 import { appendTerminalOutput } from "@/kilocode/interactive-terminal/output" // kilocode_change
+import { apply, drop, queue, take, type Delta } from "../kilocode/live-output" // kilocode_change
 import { useToast } from "../ui/toast" // kilocode_change
 import { usePermission } from "./permission"
 
@@ -166,6 +167,7 @@ export const {
     const project = useProject()
     const sdk = useSDK()
     const toast = useToast() // kilocode_change
+    const pending = new Map<string, Delta[]>() // kilocode_change
 
     // kilocode_change start
     function evict(sessionID: string) {
@@ -188,6 +190,7 @@ export const {
         }),
       )
       fullSyncedSessions.delete(sessionID)
+      drop(pending, sessionID)
       for (const child of children) evict(child)
     }
 
@@ -210,6 +213,15 @@ export const {
     const touchPart = (sessionID: string, partID: string) => {
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
+
+    // kilocode_change start - replay orphan text deltas once the part exists
+    function seed(part: Part) {
+      const items = take(pending, part.id)
+      if (items.length === 0) return part
+      if (part.type !== "text" && part.type !== "reasoning") return part
+      return { ...part, text: apply(part.text, items) }
+    }
+    // kilocode_change end
 
     function sessionListQuery(): { scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
@@ -551,31 +563,38 @@ export const {
         }
         case "message.part.updated": {
           touchPart(event.properties.part.sessionID, event.properties.part.id)
-          const parts = store.part[event.properties.part.messageID]
+          // kilocode_change start - seed parts with any deltas that arrived first
+          const next = seed(event.properties.part)
+          const parts = store.part[next.messageID]
           if (!parts) {
-            setStore("part", event.properties.part.messageID, [event.properties.part])
+            setStore("part", next.messageID, [next])
             break
           }
-          const result = search(parts, event.properties.part.id, (p) => p.id)
+          const result = search(parts, next.id, (p) => p.id)
           if (result.found) {
-            setStore("part", event.properties.part.messageID, result.index, reconcile(event.properties.part))
+            setStore("part", next.messageID, result.index, reconcile(next))
             break
           }
           setStore(
             "part",
-            event.properties.part.messageID,
+            next.messageID,
             produce((draft) => {
-              draft.splice(result.index, 0, event.properties.part)
+              draft.splice(result.index, 0, next)
             }),
           )
+          // kilocode_change end
           break
         }
 
         case "message.part.delta": {
           const parts = store.part[event.properties.messageID]
-          if (!parts) break
-          const result = search(parts, event.properties.partID, (p) => p.id)
-          if (!result.found) break
+          // kilocode_change start - hold deltas that arrive before their part
+          const result = parts ? search(parts, event.properties.partID, (p) => p.id) : { found: false, index: 0 }
+          if (!parts || !result.found) {
+            queue(pending, event.properties)
+            break
+          }
+          // kilocode_change end
           touchPart(event.properties.sessionID, event.properties.partID)
           setStore(
             "part",
@@ -721,7 +740,7 @@ export const {
         }
         case "message.part.updated.1": {
           touchPart(event.data.sessionID, event.data.part.id)
-          const part = event.data.part
+          const part = seed(event.data.part) // kilocode_change
           const parts = store.part[part.messageID]
           if (!parts) {
             setStore("part", part.messageID, [part])
@@ -978,8 +997,8 @@ export const {
           if (last.role === "user") return "working"
           return last.time.completed ? "idle" : "working"
         },
-        async sync(sessionID: string) {
-          if (fullSyncedSessions.has(sessionID)) return
+        async sync(sessionID: string, opts?: { force?: boolean }) { // kilocode_change
+          if (!opts?.force && fullSyncedSessions.has(sessionID)) return // kilocode_change
           const syncing = syncingSessions.get(sessionID)
           if (syncing) return syncing
           const tracker = { messages: new Set<string>(), parts: new Set<string>() }
@@ -1039,11 +1058,11 @@ export const {
                   draft.part[message.info.id] = parts
                 }
                 for (const message of removed) delete draft.part[message.id]
-                draft.message[sessionID] = visible
+                if (messages.data) draft.message[sessionID] = visible // kilocode_change
                 draft.session_diff[sessionID] = diff.data ?? []
               }),
             )
-            fullSyncedSessions.add(sessionID)
+            if (messages.data) fullSyncedSessions.add(sessionID) // kilocode_change
           })().finally(() => {
             syncingSessions.delete(sessionID)
             hydratingSessions.delete(sessionID)

--- a/packages/tui/src/kilocode/live-output.ts
+++ b/packages/tui/src/kilocode/live-output.ts
@@ -1,0 +1,75 @@
+export const STALL_GRACE_MS = 3000
+const STALL_MAX_MS = 30_000
+
+export function liveReasoningCode(done: boolean) {
+  return {
+    drawUnstyledText: true,
+    streaming: !done,
+  }
+}
+
+export function liveAssistantMarkdown(done: boolean) {
+  return {
+    streaming: !done,
+  }
+}
+
+export type Delta = {
+  sessionID: string
+  messageID: string
+  partID: string
+  field: string
+  delta: string
+}
+
+export function queue(pending: Map<string, Delta[]>, item: Delta) {
+  const list = pending.get(item.partID)
+  if (list) {
+    list.push(item)
+    return
+  }
+  pending.set(item.partID, [item])
+}
+
+export function take(pending: Map<string, Delta[]>, partID: string) {
+  const list = pending.get(partID) ?? []
+  pending.delete(partID)
+  return list
+}
+
+export function drop(pending: Map<string, Delta[]>, sessionID: string) {
+  for (const [id, items] of pending) {
+    if (items[0]?.sessionID === sessionID) pending.delete(id)
+  }
+}
+
+export function apply(text: string, items: Delta[]) {
+  if (text.length > 0) return text
+  let next = text
+  for (const item of items) next += item.delta
+  return next
+}
+
+export function live(status?: { type: string }) {
+  return status?.type === "busy" || status?.type === "retry"
+}
+
+export function wait(attempt: number, grace = STALL_GRACE_MS) {
+  return Math.min(grace * 2 ** attempt, STALL_MAX_MS)
+}
+
+export function mark(input: {
+  status?: { type: string }
+  last?: { id: string; role: string; time?: object }
+  parts: Array<{ id: string; type: string; text?: string; state?: { status?: string } }>
+}) {
+  const time = input.last?.time
+  const done = time && "completed" in time ? time.completed : undefined
+  const parts = input.parts.map((part) => {
+    if ("text" in part && (part.type === "text" || part.type === "reasoning"))
+      return `${part.id}:${part.text?.length ?? 0}`
+    if (part.state?.status) return `${part.id}:${part.state.status}`
+    return part.id
+  })
+  return [input.status?.type, input.last?.id, input.last?.role, done, ...parts].join("|")
+}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -96,6 +96,7 @@ import { RoutedModelMeta } from "@/kilocode/cli/cmd/tui/routes/session/routed-mo
 import { submitFeedback } from "@/kilocode/cli/cmd/tui/feedback"
 import { MemorySessionTui } from "@/kilocode/cli/cmd/tui/routes/session/memory"
 import { formatMarkdownTables } from "../../util/markdown"
+import { live, liveAssistantMarkdown, liveReasoningCode, mark, wait } from "../../kilocode/live-output"
 // kilocode_change end
 import { LocationProvider } from "../../context/location"
 
@@ -420,6 +421,53 @@ export function Session() {
       navigate({ type: "home" })
     })
   })
+
+  // kilocode_change start - resync a busy session when the store stops changing
+  const seen = new Map<string, string>()
+  const attempt = new Map<string, number>()
+  const watch = new Map<string, ReturnType<typeof setTimeout>>()
+  const clear = (sessionID: string) => {
+    const timer = watch.get(sessionID)
+    if (timer) clearTimeout(timer)
+    watch.delete(sessionID)
+  }
+  const arm = (sessionID: string) => {
+    clear(sessionID)
+    const n = attempt.get(sessionID) ?? 0
+    watch.set(
+      sessionID,
+      setTimeout(() => {
+        watch.delete(sessionID)
+        if (!live(sync.data.session_status[sessionID])) return
+        attempt.set(sessionID, n + 1)
+        void sync.session.sync(sessionID, { force: true }).finally(() => {
+          if (live(sync.data.session_status[sessionID])) arm(sessionID)
+        })
+      }, wait(n)),
+    )
+  }
+  createEffect(() => {
+    const sessionID = route.sessionID
+    const list = sync.data.message[sessionID] ?? []
+    const tail = list.at(-1)
+    const parts = tail ? (sync.data.part[tail.id] ?? []) : []
+    const status = sync.data.session_status[sessionID]
+    const sig = mark({ status, last: tail, parts })
+    if (!live(status)) {
+      seen.delete(sessionID)
+      attempt.delete(sessionID)
+      clear(sessionID)
+      return
+    }
+    if (seen.get(sessionID) === sig) return
+    seen.set(sessionID, sig)
+    attempt.set(sessionID, 0)
+    arm(sessionID)
+  })
+  onCleanup(() => {
+    for (const sessionID of [...watch.keys()]) clear(sessionID)
+  })
+  // kilocode_change end
 
   let lastSwitch: string | undefined = undefined
   event.onSync("message.part.updated.1", (evt) => {
@@ -1827,8 +1875,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
           <box paddingLeft={inMinimal() ? 2 : 0} marginTop={1}>
             <code
               filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
+              {...liveReasoningCode(isDone())} // kilocode_change
               syntaxStyle={syntax()}
               content={summary().body}
               conceal={ctx.conceal()}
@@ -1900,7 +1947,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
       <box ref={(el: BoxRenderable) => alwaysSeparate.add(el)} paddingLeft={3} marginTop={1} flexShrink={0}>
         <markdown
           syntaxStyle={syntax()}
-          streaming={true}
+          {...liveAssistantMarkdown(props.part.time?.end !== undefined || !!props.message.time.completed)} // kilocode_change
           internalBlockMode="top-level"
           content={content()} // kilocode_change
           tableOptions={{ style: "grid" }}

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -146,6 +146,49 @@ test("orphan live deltas do not suppress hydrated parts", async () => {
   }
 })
 
+// kilocode_change start - orphan deltas replay into the part once it exists
+test("orphan live deltas fill a later empty part", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) return json([])
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    emit(
+      global({
+        id: "evt_delta",
+        type: "message.part.delta",
+        properties: { sessionID, messageID, partID, field: "text", delta: "visible live content" },
+      }),
+    )
+    emit(global({ id: "evt_message", type: "message.updated", properties: { sessionID, info: assistant } }))
+    emit(
+      global({
+        id: "evt_part",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 2,
+          part: { id: partID, sessionID, messageID, type: "text", text: "" },
+        },
+      }),
+    )
+    await wait(() => {
+      const part = sync.data.part[messageID]?.[0]
+      return part?.type === "text" && part.text === "visible live content"
+    })
+    expect(sync.data.part[messageID][0]).toMatchObject({ text: "visible live content" })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+// kilocode_change end
+
 test("hydration does not clear text streamed before it starts", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")

--- a/packages/tui/test/cli/cmd/tui/sync-undefined-messages.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-undefined-messages.test.tsx
@@ -40,4 +40,60 @@ describe("tui sync (#26560)", () => {
       app.renderer.destroy()
     }
   })
+
+  // kilocode_change start - a failed fetch must not latch fullSyncedSessions
+  test("a failed messages fetch does not latch an empty transcript", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+    const sessionPayload = {
+      id: sessionID,
+      title: "broken",
+      time: { created: 0, updated: 0 },
+      version: "1.14.42",
+      directory,
+      project_id: "proj_test",
+    }
+    let calls = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json(sessionPayload)
+      if (url.pathname === `/session/${sessionID}/message` || url.pathname === `/session/${sessionID}/messages`) {
+        calls += 1
+        if (calls === 1) return json({}, { status: 500 })
+        return json([
+          {
+            info: {
+              id: "msg_recovered",
+              sessionID,
+              role: "assistant",
+              agent: "build",
+              modelID: "model",
+              providerID: "test",
+              mode: "build",
+              parentID: "msg_user",
+              path: { cwd: directory, root: directory },
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              time: { created: 1, completed: 2 },
+            },
+            parts: [{ id: "prt_recovered", sessionID, messageID: "msg_recovered", type: "text", text: "recovered" }],
+          },
+        ])
+      }
+      if (url.pathname === `/session/${sessionID}/todo`) return json([])
+      if (url.pathname === `/session/${sessionID}/diff`) return json([])
+      if (url.pathname === "/session") return json([sessionPayload])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      expect(sync.data.message[sessionID] ?? []).toEqual([])
+      await sync.session.sync(sessionID)
+      expect(sync.data.message[sessionID]?.[0]?.id).toBe("msg_recovered")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+  // kilocode_change end
 })

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -6,7 +6,7 @@ import { onMount } from "solid-js"
 import { ProjectProvider, useProject } from "../../../src/context/project"
 import { SDKProvider } from "../../../src/context/sdk"
 import { useEvent } from "../../../src/context/event"
-import { createEventSource, createFetch, directory } from "../../fixture/tui-sdk"
+import { createEventSource, createFetch, directory, json } from "../../fixture/tui-sdk" // kilocode_change
 import { TestTuiContexts } from "../../fixture/tui-environment"
 
 const projectID = "proj_test"
@@ -162,4 +162,47 @@ describe("useEvent", () => {
       app.renderer.destroy()
     }
   })
+
+  // kilocode_change start - the filter fails open until the project id loads
+  test("fails open when the current project id is missing", async () => {
+    const events = createEventSource()
+    const calls = createFetch((url) => {
+      if (url.pathname === "/project/current") return json({})
+    })
+    const seen: Event[] = []
+    const workspaces: Array<string | undefined> = []
+    let project!: ReturnType<typeof useProject>
+    let done!: () => void
+    const ready = new Promise<void>((resolve) => {
+      done = resolve
+    })
+    const app = await testRender(() => (
+      <TestTuiContexts>
+        <SDKProvider url="http://test" directory={directory} events={events.source} fetch={calls.fetch}>
+          <ProjectProvider>
+            <Probe
+              onReady={async (ctx) => {
+                project = ctx.project
+                await project.sync()
+                done()
+              }}
+              seen={seen}
+              workspaces={workspaces}
+            />
+          </ProjectProvider>
+        </SDKProvider>
+      </TestTuiContexts>
+    ))
+    await ready
+
+    try {
+      expect(project.project()).toBeUndefined()
+      events.emit(event(vcs("kept"), { directory: "/tmp/other", project: "proj_foreign" }))
+      await wait(() => seen.length === 1)
+      expect(seen).toEqual([vcs("kept")])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+  // kilocode_change end
 })

--- a/packages/tui/test/kilocode/live-output-render.test.ts
+++ b/packages/tui/test/kilocode/live-output-render.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { CodeRenderable, SyntaxStyle } from "@opentui/core"
+import { createTestRenderer } from "@opentui/core/testing"
+import { liveAssistantMarkdown, liveReasoningCode } from "../../src/kilocode/live-output"
+
+test("OpenTUI streaming with hidden unstyled text freezes later content", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  try {
+    const code = new CodeRenderable(setup.renderer, {
+      content: "first",
+      filetype: "markdown",
+      syntaxStyle: SyntaxStyle.fromStyles({ default: { fg: "#ffffff" } }),
+      drawUnstyledText: false,
+      streaming: true,
+    })
+    setup.renderOnce()
+    expect(code.plainText).toContain("first")
+    code.content = "first\nsecond"
+    setup.renderOnce()
+    expect(code.plainText).not.toContain("second")
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
+test("live reasoning props keep later content visible", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  try {
+    const code = new CodeRenderable(setup.renderer, {
+      content: "first",
+      filetype: "markdown",
+      syntaxStyle: SyntaxStyle.fromStyles({ default: { fg: "#ffffff" } }),
+      ...liveReasoningCode(false),
+    })
+    setup.renderOnce()
+    code.content = "first\nsecond"
+    setup.renderOnce()
+    expect(code.plainText).toContain("second")
+  } finally {
+    setup.renderer.destroy()
+  }
+})
+
+test("live assistant markdown streams until done", () => {
+  expect(liveAssistantMarkdown(false)).toEqual({ streaming: true })
+  expect(liveAssistantMarkdown(true)).toEqual({ streaming: false })
+})

--- a/packages/tui/test/kilocode/live-output.test.ts
+++ b/packages/tui/test/kilocode/live-output.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import {
+  STALL_GRACE_MS,
+  apply,
+  drop,
+  live,
+  liveAssistantMarkdown,
+  liveReasoningCode,
+  mark,
+  queue,
+  take,
+  wait,
+} from "../../src/kilocode/live-output"
+
+test("live reasoning always paints unstyled text and stops streaming when done", () => {
+  expect(liveReasoningCode(false)).toEqual({ drawUnstyledText: true, streaming: true })
+  expect(liveReasoningCode(true)).toEqual({ drawUnstyledText: true, streaming: false })
+})
+
+test("live assistant markdown streams until the part or message is done", () => {
+  expect(liveAssistantMarkdown(false)).toEqual({ streaming: true })
+  expect(liveAssistantMarkdown(true)).toEqual({ streaming: false })
+})
+
+test("queued deltas fill an empty part and do not clobber existing text", () => {
+  const pending = new Map()
+  queue(pending, { sessionID: "s", messageID: "m", partID: "p", field: "text", delta: "hel" })
+  queue(pending, { sessionID: "s", messageID: "m", partID: "p", field: "text", delta: "lo" })
+  expect(apply("", take(pending, "p"))).toBe("hello")
+  expect(apply("hydrated", take(pending, "p"))).toBe("hydrated")
+})
+
+test("drop removes only deltas for the evicted session", () => {
+  const pending = new Map()
+  queue(pending, { sessionID: "keep", messageID: "m", partID: "a", field: "text", delta: "a" })
+  queue(pending, { sessionID: "gone", messageID: "m", partID: "b", field: "text", delta: "b" })
+  drop(pending, "gone")
+  expect(take(pending, "a")[0]?.delta).toBe("a")
+  expect(take(pending, "b")).toEqual([])
+})
+
+test("busy and retry count as live", () => {
+  expect(live({ type: "idle" })).toBe(false)
+  expect(live({ type: "busy" })).toBe(true)
+  expect(live({ type: "retry" })).toBe(true)
+})
+
+test("watchdog backoff doubles until the ceiling", () => {
+  expect(wait(0)).toBe(STALL_GRACE_MS)
+  expect(wait(1)).toBe(6000)
+  expect(wait(4)).toBe(30_000)
+  expect(wait(8)).toBe(30_000)
+})
+
+test("mark changes when live text or tool state changes and stays put otherwise", () => {
+  const last = { id: "a", role: "assistant", time: {} }
+  const first = mark({
+    status: { type: "busy" },
+    last,
+    parts: [{ id: "p", type: "text", text: "hi" }],
+  })
+  expect(
+    mark({
+      status: { type: "busy" },
+      last,
+      parts: [{ id: "p", type: "text", text: "hi" }],
+    }),
+  ).toBe(first)
+  expect(
+    mark({
+      status: { type: "busy" },
+      last,
+      parts: [{ id: "p", type: "text", text: "hi!" }],
+    }),
+  ).not.toBe(first)
+  expect(
+    mark({
+      status: { type: "busy" },
+      last,
+      parts: [{ id: "t", type: "tool", state: { status: "running" } }],
+    }),
+  ).not.toBe(
+    mark({
+      status: { type: "busy" },
+      last,
+      parts: [{ id: "t", type: "tool", state: { status: "completed" } }],
+    }),
+  )
+})


### PR DESCRIPTION
## What

Broader TUI live-output mitigations observed while investigating Remon's stalled-session report. This is PR 2 of 2 — the proven turn-end batch-drop fix (handler/flush isolation and the `session.idle` consumer) ships separately in PR 1; none of those hunks are included here.

- **Live reasoning rendering**: OpenTUI 0.4.5's `CodeRenderable` skips its text buffer when `streaming=true && filetype && !drawUnstyledText`, freezing later reasoning content. New `liveReasoningCode`/`liveAssistantMarkdown` helpers always draw unstyled text and stop streaming once the part/message completes. A render test pins the upstream freeze behavior.
- **Orphan delta replay**: `message.part.delta` arriving before its part exists was dropped, leaving a later empty part empty forever. Deltas are now queued per part and replayed when the part shows up (never clobbering non-empty text), and evicted with the session.
- **Busy-session watchdog**: while a session is `busy`/`retry` and the store signature (status, last message, live part text/tool state) stops changing for 3s, the session route forces `sync.session.sync(id, { force: true })` with exponential backoff capped at 30s.
- **Fail-open project filter**: `useEvent` dropped every project-scoped event while `project.project()` was still undefined; it now fails open until the id loads.
- **No latching a failed hydration**: a failed messages fetch no longer overwrites the transcript with `[]` or marks the session fully synced, so the next sync can recover.
- **SSE reconnect**: the reconnect loop survives a throwing stream iterator (log + retry instead of dying), and resets the backoff attempt counter after a stream that delivered events.

## Why

These failure modes all silently freeze live output in the TUI with no error surfaced. Each one is individually plausible in the stall reports but not proven by the reproduction GIF (that specific stall is PR 1's batch-drop fix); they are shipped separately so the proven fix can be evaluated on its own.

## Notes for review

- Kilo logic lives in `packages/tui/src/kilocode/live-output.ts`; shared-file changes are annotated with `kilocode_change` and `bun run script/check-opencode-annotations.ts --worktree` passes.
- `bun run typecheck` and the full `bun test` suite pass in `packages/tui/` (231 pass / 1 pre-existing skip).