### PR TITLE
fix(cli): key kilo model cache by token and organization

### DIFF
--- a/.changeset/model-cache-kilo-identity.md
+++ b/.changeset/model-cache-kilo-identity.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Key the Kilo model cache by token and organization so a catalog fetched before login is no longer served to a later authenticated request.

--- a/packages/opencode/src/provider/model-cache.ts
+++ b/packages/opencode/src/provider/model-cache.ts
@@ -31,6 +31,7 @@ export const kiloModelsLayer = Layer.succeed(
   KiloModelsService.of({ fetch: (options) => Effect.tryPromise(() => fetchKiloModels(options)) }),
 )
 type Cell = {
+  readonly id: string
   readonly providerID: string
   readonly options: Options
   readonly view: View
@@ -41,7 +42,8 @@ type Cell = {
 export interface Interface {
   readonly getFailure: (providerID: string) => Effect.Effect<Failure | undefined>
   readonly failedProviders: () => Effect.Effect<string[]>
-  readonly get: (providerID: string) => Effect.Effect<Models | undefined>
+  /** Reads the cached models for an identity: the resolved credentials merged with `options`. */
+  readonly get: (providerID: string, options?: Options) => Effect.Effect<Models | undefined>
   readonly fetch: (providerID: string, options?: Options) => Effect.Effect<Models, unknown>
   readonly refresh: (providerID: string, options?: Options) => Effect.Effect<Models, unknown>
   readonly clear: (providerID: string) => Effect.Effect<void>
@@ -170,16 +172,18 @@ export const layer: Layer.Layer<
       return Effect.succeed({ models: {} })
     }
 
-    const load = Effect.fn("ModelCache.load")(function* (providerID: string, options: Options) {
+    // Credentials are part of a request's identity, so they must be resolved before anything is keyed:
+    // a public/unauthenticated catalog must never satisfy a later authenticated request for the same provider.
+    const resolve = Effect.fn("ModelCache.resolve")(function* (providerID: string, options?: Options) {
       const resolved = yield* authOptions(providerID).pipe(
         Effect.catchCause((cause) =>
           Effect.sync(() => {
             log.warn("auth options failed", { providerID, cause })
-            return {}
+            return {} as Options
           }),
         ),
       )
-      return yield* fetchModels(providerID, { ...resolved, ...options })
+      return { ...resolved, ...options } satisfies Options
     })
 
     const key = (providerID: string, options?: Options) => {
@@ -195,7 +199,7 @@ export const layer: Layer.Layer<
       const existing = cells.get(id)
       if (existing) return existing
       const view: View = {}
-      const next: Cell = { providerID, options, view }
+      const next: Cell = { id, providerID, options, view }
       cells.set(id, next)
       return next
     })
@@ -214,8 +218,9 @@ export const layer: Layer.Layer<
         ),
       )
 
-    const commit = (providerID: string, version: number, entry: Cell, result: Result) =>
+    const commit = (version: number, entry: Cell, result: Result) =>
       Effect.sync(() => {
+        const providerID = entry.providerID
         if ((versions.get(providerID) ?? 0) !== version) return result.models
         if (result.error) {
           failures.set(providerID, result.error)
@@ -225,7 +230,7 @@ export const layer: Layer.Layer<
         }
         entry.view.models = result.models
         entry.view.timestamp = Date.now()
-        active.set(providerID, entry)
+        active.set(entry.id, entry)
         log.info("models fetched and cached", { providerID, count: Object.keys(result.models).length })
         return result.models
       })
@@ -236,7 +241,7 @@ export const layer: Layer.Layer<
         Effect.gen(function* () {
           const cached = entry.cached
           if (cached && cached.expires > Date.now()) {
-            yield* commit(entry.providerID, version, entry, cached.result)
+            yield* commit(version, entry, cached.result)
             return cached.result
           }
 
@@ -251,12 +256,12 @@ export const layer: Layer.Layer<
           entry.flight = flight
           yield* Effect.uninterruptibleMask((restore) =>
             Effect.gen(function* () {
-              const exit = yield* restore(load(entry.providerID, entry.options)).pipe(Effect.exit)
+              const exit = yield* restore(fetchModels(entry.providerID, entry.options)).pipe(Effect.exit)
               if (entry.flight === flight) {
                 entry.flight = undefined
                 if (Exit.isSuccess(exit)) {
                   entry.cached = { result: exit.value, expires: Date.now() + Duration.toMillis(ttl) }
-                  yield* commit(entry.providerID, flight.version, entry, exit.value)
+                  yield* commit(flight.version, entry, exit.value)
                 }
               }
               yield* Deferred.done(done, exit)
@@ -266,8 +271,8 @@ export const layer: Layer.Layer<
         }),
       )
 
-    const get = Effect.fn("ModelCache.get")(function* (providerID: string) {
-      const entry = active.get(providerID)
+    const peek = Effect.fn("ModelCache.peek")(function* (providerID: string, id: string) {
+      const entry = active.get(id)
       if (!entry?.view.models || entry.view.timestamp === undefined) {
         log.debug("cache miss", { providerID })
         return
@@ -286,21 +291,28 @@ export const layer: Layer.Layer<
       return entry.view.models
     })
 
+    const get = Effect.fn("ModelCache.get")(function* (providerID: string, options?: Options) {
+      const resolved = yield* resolve(providerID, options)
+      return yield* peek(providerID, key(providerID, resolved))
+    })
+
     const fetch = Effect.fn("ModelCache.fetch")(function* (providerID: string, options?: Options) {
-      const cached = yield* get(providerID)
+      const resolved = yield* resolve(providerID, options)
+      const cached = yield* peek(providerID, key(providerID, resolved))
       if (cached) return cached
       const version = (versions.get(providerID) ?? 0) + 1
       versions.set(providerID, version)
-      const entry = yield* cell(providerID, options)
+      const entry = yield* cell(providerID, resolved)
       log.info("fetching models", { providerID })
       const result = yield* evaluate(entry, version)
       return result.models
     })
 
     const refresh = Effect.fn("ModelCache.refresh")(function* (providerID: string, options?: Options) {
+      const resolved = yield* resolve(providerID, options)
       const version = (versions.get(providerID) ?? 0) + 1
       versions.set(providerID, version)
-      const entry = yield* cell(providerID, options)
+      const entry = yield* cell(providerID, resolved)
       log.info("refreshing models", { providerID })
       yield* invalidate(entry)
       const result = yield* evaluate(entry, version)
@@ -314,7 +326,9 @@ export const layer: Layer.Layer<
         entries.map(([id, entry]) => detach(entry).pipe(Effect.tap(() => Effect.sync(() => cells.delete(id))))),
         { discard: true },
       )
-      active.delete(providerID)
+      for (const [id, entry] of active) {
+        if (entry.providerID === providerID) active.delete(id)
+      }
       failures.delete(providerID)
       if (entries.some(([, entry]) => entry.view.models)) {
         log.info("cache cleared", { providerID })

--- a/packages/opencode/test/kilocode/model-cache-effect.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-effect.test.ts
@@ -109,7 +109,7 @@ it.live("keeps a shared refresh alive when one waiter times out", () =>
         expect(Option.isNone(yield* Fiber.join(first))).toBe(true)
         yield* Deferred.succeed(wait, undefined)
         const models = yield* Fiber.join(second)
-        return { models, cached: yield* cache.get("apertis") }
+        return { models, cached: yield* cache.get("apertis", { apiKey: "test-key" }) }
       }),
     ).pipe(Effect.provide(layer(hits, TestConfig.layer(), auth, { started, wait })))
 
@@ -133,7 +133,7 @@ it.live("commits a refresh after its only waiter times out", () =>
         expect(Option.isNone(yield* Fiber.join(caller))).toBe(true)
         yield* Deferred.succeed(wait, undefined)
         return yield* pollWithTimeout(
-          cache.get("apertis"),
+          cache.get("apertis", { apiKey: "test-key" }),
           "service-owned refresh did not commit after its waiter timed out",
         )
       }),
@@ -185,7 +185,11 @@ it.live("keeps concurrent request options isolated", () =>
         yield* Deferred.succeed(wait, undefined)
         const firstModels = yield* Fiber.join(first)
         const secondModels = yield* Fiber.join(second)
-        return { first: firstModels, second: secondModels, current: yield* cache.get("apertis") }
+        return {
+          first: firstModels,
+          second: secondModels,
+          current: yield* cache.get("apertis", { apiKey: "second", baseURL: "https://second.test/v1" }),
+        }
       }),
     ).pipe(Effect.provide(layer(hits, TestConfig.layer(), auth, { started, wait })))
 
@@ -213,12 +217,19 @@ it.live("does not let an older fetch override a newer refresh", () =>
         const fresh = yield* cache.refresh("apertis", { apiKey: "second", baseURL: "https://second.test/v1" })
         yield* Deferred.succeed(wait, undefined)
         yield* Fiber.join(stale)
-        return { fresh, current: yield* cache.get("apertis") }
+        return {
+          fresh,
+          current: yield* cache.get("apertis", { apiKey: "second", baseURL: "https://second.test/v1" }),
+          // The superseded fetch must not surface under its own identity either — that is the only
+          // thing keeping the version guard in commit() honest now that identities have separate slots.
+          superseded: yield* cache.get("apertis", { apiKey: "first", baseURL: "https://first.test/v1" }),
+        }
       }),
     ).pipe(Effect.provide(layer(hits, TestConfig.layer(), auth, { started, wait })))
 
     expect(models.current).toEqual(models.fresh)
     expect(Object.keys(models.current ?? {})).toEqual(["apertis-2"])
+    expect(models.superseded).toBeUndefined()
   }),
 )
 
@@ -239,13 +250,19 @@ it.live("promotes a cached result after a newer option load fails", () =>
         yield* Deferred.succeed(wait, undefined)
         yield* Fiber.join(first)
         const models = yield* cache.fetch("apertis", { apiKey: "first", baseURL: "https://first.test/v1" })
-        return { failed, models, current: yield* cache.get("apertis") }
+        return {
+          failed,
+          models,
+          current: yield* cache.get("apertis", { apiKey: "first", baseURL: "https://first.test/v1" }),
+          rejected: yield* cache.get("apertis", { apiKey: "second", baseURL: "https://second.test/v1" }),
+        }
       }),
     ).pipe(Effect.provide(layer(hits, TestConfig.layer(), auth, { started, wait }, 2)))
 
     expect(Exit.isFailure(out.failed)).toBe(true)
     expect(Object.keys(out.models)).toEqual(["apertis-1"])
     expect(out.current).toEqual(out.models)
+    expect(out.rejected).toBeUndefined()
     expect((yield* Ref.get(hits)).length).toBe(2)
   }),
 )
@@ -264,7 +281,7 @@ it.live("does not restore a fetch that was cleared while pending", () =>
         yield* cache.clear("apertis")
         yield* Deferred.succeed(wait, undefined)
         yield* Fiber.join(pending)
-        return yield* cache.get("apertis")
+        return yield* cache.get("apertis", { apiKey: "first", baseURL: "https://first.test/v1" })
       }),
     ).pipe(Effect.provide(layer(hits, TestConfig.layer(), auth, { started, wait })))
 
@@ -279,7 +296,7 @@ it.live("exposes the most recently refreshed provider value", () =>
       Effect.gen(function* () {
         yield* cache.fetch("apertis", { apiKey: "first", baseURL: "https://first.test/v1" })
         const refreshed = yield* cache.refresh("apertis", { apiKey: "second", baseURL: "https://second.test/v1" })
-        const current = yield* cache.get("apertis")
+        const current = yield* cache.get("apertis", { apiKey: "second", baseURL: "https://second.test/v1" })
         return { refreshed, current }
       }),
     ).pipe(Effect.provide(layer(hits)))

--- a/packages/opencode/test/kilocode/model-cache-identity.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-identity.test.ts
@@ -1,0 +1,159 @@
+// kilocode_change - new file
+// Regression tests: the kilo model cache must be keyed by the identity of the request
+// (token + organization + baseURL), not by the provider id alone. A public/unauthenticated
+// catalog fetched before login must never be served to a later authenticated request, and two
+// organizations must not share the same cached catalog.
+
+import { expect } from "bun:test"
+import { Effect, Layer, Ref } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import * as Log from "@opencode-ai/core/util/log"
+
+Log.init({ print: false })
+
+import { Auth } from "../../src/auth"
+import { ModelCache } from "../../src/provider/model-cache"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+type Options = Parameters<ModelCache.KiloModels["fetch"]>[0]
+
+const label = (options: Options) =>
+  options.kilocodeToken
+    ? `kilo-${options.kilocodeOrganizationId ?? "personal"}-${options.kilocodeToken}`
+    : "kilo-public"
+
+function layer(info: Ref.Ref<Auth.Info | undefined>, calls: Ref.Ref<Options[]>) {
+  const auth = Layer.mock(Auth.Service)({
+    get: (id) => (id === "kilo" ? Ref.get(info) : Effect.succeed(undefined)),
+  })
+  const models = Layer.succeed(
+    ModelCache.KiloModelsService,
+    ModelCache.KiloModelsService.of({
+      fetch: (options) =>
+        Ref.update(calls, (list) => [...list, options]).pipe(
+          Effect.as({ models: { [label(options)]: { id: label(options), name: label(options) } } }),
+        ),
+    }),
+  )
+  return Layer.fresh(ModelCache.layer).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(TestConfig.layer()),
+    Layer.provide(auth),
+    Layer.provide(models),
+  )
+}
+
+const oauth = (access: string, accountId?: string) =>
+  new Auth.Oauth({
+    type: "oauth",
+    access,
+    refresh: `refresh-${access}`,
+    expires: Date.now() + 3600000,
+    ...(accountId ? { accountId } : {}),
+  })
+
+const it = testEffect(Layer.empty)
+
+it.live("an unauthenticated catalog is not reused for a later authenticated fetch", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(undefined)
+    const calls = yield* Ref.make<Options[]>([])
+    yield* ModelCache.Service.use((cache) =>
+      Effect.gen(function* () {
+        expect(Object.keys(yield* cache.fetch("kilo"))).toEqual(["kilo-public"])
+        expect((yield* Ref.get(calls)).length).toBe(1)
+
+        // The user logs in while the public catalog is still inside its TTL.
+        yield* Ref.set(info, oauth("token-a", "org-a"))
+        expect(Object.keys(yield* cache.fetch("kilo"))).toEqual(["kilo-org-a-token-a"])
+        expect((yield* Ref.get(calls)).length).toBe(2)
+        expect((yield* Ref.get(calls))[1]).toMatchObject({
+          kilocodeToken: "token-a",
+          kilocodeOrganizationId: "org-a",
+        })
+
+        // Both identities keep their own entry; neither leaks into the other.
+        expect(Object.keys((yield* cache.get("kilo")) ?? {})).toEqual(["kilo-org-a-token-a"])
+        yield* Ref.set(info, undefined)
+        expect(Object.keys((yield* cache.get("kilo")) ?? {})).toEqual(["kilo-public"])
+        expect((yield* Ref.get(calls)).length).toBe(2)
+      }),
+    ).pipe(Effect.provide(layer(info, calls)))
+  }),
+)
+
+it.live("a token change alone invalidates the cached catalog", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(oauth("token-old"))
+    const calls = yield* Ref.make<Options[]>([])
+    yield* ModelCache.Service.use((cache) =>
+      Effect.gen(function* () {
+        expect(Object.keys(yield* cache.fetch("kilo"))).toEqual(["kilo-personal-token-old"])
+        yield* Ref.set(info, oauth("token-new"))
+        expect(Object.keys(yield* cache.fetch("kilo"))).toEqual(["kilo-personal-token-new"])
+        expect((yield* Ref.get(calls)).length).toBe(2)
+      }),
+    ).pipe(Effect.provide(layer(info, calls)))
+  }),
+)
+
+it.live("different organizations do not share the active entry", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(oauth("token-shared", "org-a"))
+    const calls = yield* Ref.make<Options[]>([])
+    yield* ModelCache.Service.use((cache) =>
+      Effect.gen(function* () {
+        const a = yield* cache.fetch("kilo", { kilocodeOrganizationId: "org-a" })
+        const b = yield* cache.fetch("kilo", { kilocodeOrganizationId: "org-b" })
+        expect(Object.keys(a)).toEqual(["kilo-org-a-token-shared"])
+        expect(Object.keys(b)).toEqual(["kilo-org-b-token-shared"])
+        expect((yield* Ref.get(calls)).length).toBe(2)
+
+        expect(yield* cache.get("kilo", { kilocodeOrganizationId: "org-a" })).toEqual(a)
+        expect(yield* cache.get("kilo", { kilocodeOrganizationId: "org-b" })).toEqual(b)
+      }),
+    ).pipe(Effect.provide(layer(info, calls)))
+  }),
+)
+
+it.live("clear drops every cached identity for the provider", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(oauth("token-shared", "org-a"))
+    const calls = yield* Ref.make<Options[]>([])
+    yield* ModelCache.Service.use((cache) =>
+      Effect.gen(function* () {
+        yield* cache.fetch("kilo", { kilocodeOrganizationId: "org-a" })
+        yield* cache.fetch("kilo", { kilocodeOrganizationId: "org-b" })
+        expect((yield* Ref.get(calls)).length).toBe(2)
+
+        yield* cache.clear("kilo")
+        expect(yield* cache.get("kilo", { kilocodeOrganizationId: "org-a" })).toBeUndefined()
+        expect(yield* cache.get("kilo", { kilocodeOrganizationId: "org-b" })).toBeUndefined()
+
+        yield* cache.fetch("kilo", { kilocodeOrganizationId: "org-a" })
+        expect((yield* Ref.get(calls)).length).toBe(3)
+      }),
+    ).pipe(Effect.provide(layer(info, calls)))
+  }),
+)
+
+it.live("in-flight requests coalesce per identity, not per provider", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(oauth("token-shared", "org-a"))
+    const calls = yield* Ref.make<Options[]>([])
+    yield* ModelCache.Service.use((cache) =>
+      Effect.gen(function* () {
+        const same = yield* Effect.all(
+          [
+            cache.fetch("kilo", { kilocodeOrganizationId: "org-a" }),
+            cache.fetch("kilo", { kilocodeOrganizationId: "org-a" }),
+          ],
+          { concurrency: "unbounded" },
+        )
+        expect(same[0]).toEqual(same[1])
+        expect((yield* Ref.get(calls)).length).toBe(1)
+      }),
+    ).pipe(Effect.provide(layer(info, calls)))
+  }),
+)

--- a/packages/opencode/test/kilocode/model-cache-stale-catalog.test.ts
+++ b/packages/opencode/test/kilocode/model-cache-stale-catalog.test.ts
@@ -1,0 +1,121 @@
+// kilocode_change - new file
+// Reproduces the reported symptom end to end through ModelsDev.get(), the caller that actually
+// builds the kilo fetch options: a client started before login (TUI) fetched the public catalog,
+// and for the rest of the 5 minute TTL every later authenticated fetch was served that same public
+// catalog — so the TUI kept a short model list while a VS Code window started with a token saw the
+// full one. Covers both a personal login and an organization login.
+
+import { expect } from "bun:test"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import * as CoreModels from "@opencode-ai/core/models-dev"
+import { Effect, Layer, Ref } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import * as Log from "@opencode-ai/core/util/log"
+
+Log.init({ print: false })
+
+import { Auth } from "../../src/auth"
+import { ModelCache } from "../../src/provider/model-cache"
+import { ModelsDev } from "../../src/provider/models"
+import { TestConfig } from "../fixture/config"
+import { provideInstance, testInstanceStoreLayer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const model = (id: string) => ({
+  id,
+  name: id,
+  cost: { input: 1, output: 2 },
+  limit: { context: 200000, output: 8192 },
+})
+
+const PUBLIC_CATALOG = { "anthropic/claude-sonnet-4": model("anthropic/claude-sonnet-4") }
+const FULL_CATALOG = {
+  ...PUBLIC_CATALOG,
+  "anthropic/claude-sonnet-4.5": model("anthropic/claude-sonnet-4.5"),
+}
+
+const seed: Record<string, ModelsDev.Provider> = {
+  apertis: { id: "apertis", name: "Apertis", env: ["APERTIS_API_KEY"], models: {} },
+}
+
+const files = Layer.effect(
+  FSUtil.Service,
+  Effect.gen(function* () {
+    const fs = yield* FSUtil.Service
+    return FSUtil.Service.of({ ...fs, readJson: () => Effect.succeed(seed), stat: () => fs.stat(import.meta.path) })
+  }),
+).pipe(Layer.provide(FSUtil.defaultLayer))
+
+// The gateway serves the public catalog to an anonymous request and the full one to an authenticated
+// request — the same shape as the 401 fallback in @kilocode/kilo-gateway.
+function layer(info: Ref.Ref<Auth.Info | undefined>) {
+  const cfg = TestConfig.layer()
+  const auth = Layer.mock(Auth.Service)({ get: (id) => (id === "kilo" ? Ref.get(info) : Effect.succeed(undefined)) })
+  const models = Layer.succeed(
+    ModelCache.KiloModelsService,
+    ModelCache.KiloModelsService.of({
+      fetch: (options) => Effect.succeed({ models: options.kilocodeToken ? FULL_CATALOG : PUBLIC_CATALOG }),
+    }),
+  )
+  const cache = Layer.fresh(ModelCache.layer).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(cfg),
+    Layer.provide(auth),
+    Layer.provide(models),
+  )
+  const core = Layer.succeed(
+    CoreModels.Service,
+    CoreModels.Service.of({ get: () => Effect.succeed(seed), refresh: () => Effect.void }),
+  )
+  return Layer.fresh(ModelsDev.layer).pipe(
+    Layer.provide(core),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(files),
+    Layer.provide(cfg),
+    Layer.provide(auth),
+    Layer.provide(cache),
+  )
+}
+
+const login = (accountId?: string) =>
+  new Auth.Oauth({
+    type: "oauth",
+    access: "kilo-access-token",
+    refresh: "kilo-refresh-token",
+    expires: Date.now() + 3600000,
+    ...(accountId ? { accountId } : {}),
+  })
+
+// Both catalog reads go through one long-lived ModelsDev/ModelCache pair, the way a single
+// running client does — the stale entry lives in the cache service closure.
+const session = (info: Ref.Ref<Auth.Info | undefined>, accountId?: string) =>
+  Effect.gen(function* () {
+    const models = yield* ModelsDev.Service
+    const catalog = () => models.get().pipe(Effect.map((providers) => Object.keys(providers.kilo?.models ?? {}).sort()))
+
+    const before = yield* catalog()
+    yield* Ref.set(info, login(accountId))
+    return { before, after: yield* catalog() }
+  }).pipe(Effect.provide(layer(info)), provideInstance(process.cwd()))
+
+const it = testEffect(testInstanceStoreLayer)
+
+it.live("a personal login inside the TTL is not served the pre-login public catalog", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(undefined)
+    const out = yield* session(info)
+
+    expect(out.before).toEqual(["anthropic/claude-sonnet-4"])
+    expect(out.after).toEqual(["anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5"])
+  }),
+)
+
+it.live("an organization login inside the TTL is not served the pre-login public catalog", () =>
+  Effect.gen(function* () {
+    const info = yield* Ref.make<Auth.Info | undefined>(undefined)
+    const out = yield* session(info, "org-enterprise-123")
+
+    expect(out.before).toEqual(["anthropic/claude-sonnet-4"])
+    expect(out.after).toEqual(["anthropic/claude-sonnet-4", "anthropic/claude-sonnet-4.5"])
+  }),
+)


### PR DESCRIPTION
## Issue

No public issue. Internal report of mismatched Kilo Gateway model lists across clients.

## Context

The Kilo model cache was keyed by provider ID only. The first fetch in a process (logged out, or a public fallback) could occupy the slot for 5 minutes, so a later authenticated fetch reused that stale catalog.

## Implementation

Resolve token / org / base URL before keying, so cache entries, TTL, and in-flight coalescing are scoped to those credentials. `clear()` still drops every entry for the provider.

This only covers a credential change that does not already clear the cache (another process logging in, or a mid-run global config edit). In-process login already cleared. The provider-layer catalog snapshot is unchanged.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Agent: `bun test` on the model-cache suites — pass
- Agent: `bun run typecheck` — clean
- Agent: same tests fail against the pre-fix cache

### Reviewer test steps

1. `cd packages/opencode && bun test test/kilocode/model-cache-identity.test.ts test/kilocode/model-cache-stale-catalog.test.ts test/kilocode/model-cache-effect.test.ts test/kilocode/model-cache-org.test.ts`

### Blocked checks and substitute verification

- Agent: no live TUI / VS Code / Gateway run (no credentials here). Substituted with a `ModelsDev.get()` test that flips login mid-session.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch