### PR TITLE
fix(cli): prefix environment_details block with a textual separator

### DIFF
--- a/.changeset/environment-details-separator.md
+++ b/.changeset/environment-details-separator.md
@@ -1,5 +1,5 @@
 ---
-"kilo-code": patch
+"@kilocode/cli": patch
 ---
 
 Prefix the per-message `<environment_details>` block with an explicit textual separator so it is not interpreted as a continuation of a preceding tool argument or user prompt on OpenAI-compatible providers.

--- a/.changeset/environment-details-separator.md
+++ b/.changeset/environment-details-separator.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prefix the per-message `<environment_details>` block with an explicit textual separator so it is not interpreted as a continuation of a preceding tool argument or user prompt on OpenAI-compatible providers.

--- a/packages/opencode/src/kilocode/editor-context.ts
+++ b/packages/opencode/src/kilocode/editor-context.ts
@@ -64,5 +64,5 @@ export function environmentDetails(ctx?: EditorContext): string {
       lines.push(`  ${f}`)
     }
   }
-  return ["<environment_details>", ...lines, "</environment_details>"].join("\n")
+  return "\n\n" + ["<environment_details>", ...lines, "</environment_details>"].join("\n")
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -436,7 +436,7 @@ function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage
           typeof part === "object" &&
           part.type !== "tool-approval-request" &&
           part.type !== "tool-approval-response" &&
-          !(part.type === "text" && part.text.startsWith("<environment_details>"))
+          !(part.type === "text" && part.text.trimStart().startsWith("<environment_details>"))
         ) {
           targetIndex = i
           break

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -141,4 +141,13 @@ describe("environmentDetails", () => {
     expect(result).toContain("Workspace root folder: /repo/.kilo/worktrees/feature")
     expect(result).toContain("Active file: src/app.ts")
   })
+
+  test("prefixes the block with an explicit textual separator", () => {
+    const result = environmentDetails({
+      directory: "/repo/.kilo/worktrees/feature",
+      activeFile: "src/app.ts",
+    })
+
+    expect(result.startsWith("\n\n<environment_details>")).toBe(true)
+  })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3375,7 +3375,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
       id: "gpt-5.6",
     })
-    const envBlock = "<environment_details>\nCurrent time: 2026-08-08T18:00:00+00:00\n</environment_details>"
+    const envBlock = "\n\n<environment_details>\nCurrent time: 2026-08-08T18:00:00+00:00\n</environment_details>"
     const msgs = [
       {
         role: "system",


### PR DESCRIPTION
## Issue

Fixes #13110

## Context

The user prompt and the auto-generated `<environment_details>` block are sent as two separate text content parts in the same user message. When the second part immediately follows a write-tool argument, some OpenAI-compatible providers can interpret the `<environment_details>` block as a continuation of that argument, leaking it into tool arguments.

The issue already reproduced this leak 6/6 times; prefixing the block with `\n\n` reduced it to 0/6.

This is a core CLI/provider prompt-construction change, not a visible UI change.

## Implementation

- `packages/opencode/src/kilocode/editor-context.ts`: prefix the generated `<environment_details>` block with `\n\n` so it is clearly separated from the preceding text.
- `packages/opencode/src/provider/transform.ts`: use `trimStart().startsWith(...)` when skipping the trailing block for prompt-cache breakpoint placement, so the detection still matches the new leading whitespace.
- Added regression tests in `packages/opencode/test/kilocode/system-prompt.test.ts` and `packages/opencode/test/provider/transform.test.ts`.

## Screenshots / Video

N/A — this is a non-visual CLI/provider change.

## How to Test

- `cd packages/opencode && bun run typecheck`
- `cd packages/opencode && bun test ./test/kilocode/system-prompt.test.ts`
- `cd packages/opencode && bun test ./test/provider/transform.test.ts`
- `bun run script/check-opencode-annotations.ts --worktree`

All passed locally on this branch. Targeted `oxlint` on the four changed files reported 0 errors (only pre-existing warnings).

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.