### PR TITLE
fix(vscode): apply the selected agent instead of the stale session agent

### DIFF
--- a/.changeset/selected-agent-over-stale-session.md
+++ b/.changeset/selected-agent-over-stale-session.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix agent mode switch getting stuck on draft/cloud-import sessions: apply the explicitly selected agent instead of reverting to the stale session agent.

--- a/packages/kilo-vscode/tests/unit/session-agent.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-agent.test.ts
@@ -146,6 +146,14 @@ describe("resolvePromptAgent", () => {
     expect(resolvePromptAgent({ selections: {}, pending: "code" })).toBe("code")
   })
 
+  it("honors an explicit pending selection for a draft scope with no per-session entry", () => {
+    expect(resolvePromptAgent({ sessionID: "draft-1", selections: {}, pending: "ask" })).toBe("ask")
+  })
+
+  it("does not fall back to pending for a real server session with no per-session entry", () => {
+    expect(resolvePromptAgent({ sessionID: "ses_1", selections: {}, pending: "ask" })).toBeUndefined()
+  })
+
   it("omits the agent when there is no explicit selection", () => {
     expect(resolvePromptAgent({ sessionID: "ses_1", selections: {}, pending: null })).toBeUndefined()
     expect(resolvePromptAgent({ selections: {}, pending: null })).toBeUndefined()

--- a/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-agent.ts
@@ -31,7 +31,17 @@ export function resolvePromptAgent(input: {
   selections: Record<string, string>
   pending: string | null
 }) {
-  if (input.sessionID) return input.selections[input.sessionID]
+  if (input.sessionID) {
+    const sel = input.selections[input.sessionID]
+    if (sel) return sel
+    // Only fall back to the pending selection for draft scopes, not real server
+    // sessions. A server session with no stored selection must keep its own agent
+    // rather than be flipped to the stale/default pending agent.
+    if (!input.sessionID.startsWith("ses_")) {
+      return input.pending ?? undefined
+    }
+    return undefined
+  }
   return input.pending ?? undefined
 }
 


### PR DESCRIPTION
## Issue

<!-- Reference an existing issue with `Fixes #123`, `Closes #123`, or equivalent linked issue wording. -->

After switching Ask→Code, new draft/cloud-import sessions could get stuck in the old mode (#13102, partially fixed by #13121). Now the explicit mode selection is honored for them too.

## Implementation

`resolvePromptAgent` now falls back to the pending selection only for draft/cloud-import scopes (IDs that are not real server sessions). For a real server session with no stored selection it returns undefined, so the backend keeps that session's own agent instead of flipping it to the stale/default pending agent. Covered by unit tests for both the draft-scope-with-no-entry case and the server-session-must-not-flip case.

## Screenshots / Video

### Bug
https://github.com/user-attachments/assets/55515fe8-8b83-4008-95a0-2f935de6ca11

### Fix
https://github.com/user-attachments/assets/e30cc8e5-6e0a-4281-9f59-604cade21c60

## How to Test

### Manual/local verification

- In the development extension, start a new draft/cloud-import session, select an agent (e.g. Ask), then switch and send in another mode; confirm the turn runs in the explicitly selected agent rather than the previously persisted one.


## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
