### PR TITLE
fix(cli): honor explicit env read allows without nested deny leak

### DIFF
--- a/.changeset/subagent-env-permissions.md
+++ b/.changeset/subagent-env-permissions.md
@@ -3,4 +3,4 @@
 "kilo-code": patch
 ---
 
-Include the spawned subagent's own permission rules in the child session permission ruleset. This lets user-configured subagents explicitly allow reading `.env` files, while still inheriting parent denials and keeping `.env` hardening for broad `read: "*": "allow"`.
+Honor explicit `read: "*.env": "allow"` (and `*.env.*`) when resolving env reads, even if a later broad `read: "*"` rule would otherwise be hardened back to ask. Do not copy a subagent's full agent ruleset into `session.permission`, which made nested subagents inherit the delegator's deny catch-all.

--- a/.changeset/subagent-env-permissions.md
+++ b/.changeset/subagent-env-permissions.md
@@ -3,4 +3,4 @@
 "kilo-code": patch
 ---
 
-Honor explicit `read: "*.env": "allow"` (and `*.env.*`) when resolving env reads, even if a later broad `read: "*"` rule would otherwise be hardened back to ask. Do not copy a subagent's full agent ruleset into `session.permission`, which made nested subagents inherit the delegator's deny catch-all.
+Honor explicit `read: "*.env": "allow"` (and `*.env.*`) when resolving env reads, even if a later broad `read: "*"` rule would otherwise be hardened back to ask. Stop nested subagents from inheriting parent-session deny rules: only the immediate child receives the parent session's deny and `external_directory` ceilings; deeper descendants are governed by their own agent ruleset and default subagent restrictions.

--- a/.changeset/subagent-env-permissions.md
+++ b/.changeset/subagent-env-permissions.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Include the spawned subagent's own permission rules in the child session permission ruleset. This lets user-configured subagents explicitly allow reading `.env` files, while still inheriting parent denials and keeping `.env` hardening for broad `read: "*": "allow"`.

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -1,27 +1,38 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import type { Agent } from "./agent"
 
+// kilocode_change start - depth-aware parent-session inheritance; nested subagents
+// must not accumulate session-local denies (#EST-1825).
 /**
- * Build the `permission` ruleset for a subagent's session when it's spawned
- * via the task tool. Combines:
+ * Build the `permission` ruleset for a subagent's session when it is spawned
+ * via the task tool.
  *
- * 1. The parent session's deny rules and external_directory rules.
- *    Parent agent restrictions only govern that agent; the subagent's own
- *    permissions determine its capabilities.
- * 2. Default `todowrite` and `task` denies if the subagent's own ruleset
- *    doesn't already permit them.
+ * For the immediate child of a primary/delegating agent (`depth === 0`), the
+ * parent session's deny rules and `external_directory` rules are copied as
+ * hard ceilings. Deeper descendants (`depth > 0`) only inherit
+ * `external_directory` rules; other parent session denies are session-local
+ * and must not leak across the subagent boundary.
+ *
+ * Default `todowrite` and `task` denies are added if the subagent's own
+ * ruleset doesn't already permit them.
  */
 export function deriveSubagentSessionPermission(input: {
   parentSessionPermission: PermissionV1.Ruleset
   subagent: Agent.Info
+  depth?: number
 }): PermissionV1.Ruleset {
   const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
+  const inherited =
+    input.depth && input.depth > 0
+      ? input.parentSessionPermission.filter((rule) => rule.permission === "external_directory")
+      : input.parentSessionPermission.filter(
+          (rule) => rule.permission === "external_directory" || rule.action === "deny",
+        )
   return [
-    ...input.parentSessionPermission.filter(
-      (rule) => rule.permission === "external_directory" || rule.action === "deny",
-    ),
+    ...inherited,
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
   ]
 }
+// kilocode_change end

--- a/packages/opencode/src/kilocode/permission/read.ts
+++ b/packages/opencode/src/kilocode/permission/read.ts
@@ -1,5 +1,5 @@
 import { Wildcard } from "@/util/wildcard"
-import { PermissionRule, type Rule } from "@/kilocode/permission/rule"
+import { PermissionRule, type Rule, type Ruleset } from "@/kilocode/permission/rule"
 
 function guard(pattern: string) {
   if (Wildcard.match(pattern, "*.env.example")) return
@@ -8,11 +8,21 @@ function guard(pattern: string) {
 }
 
 export namespace ReadPermission {
-  export function harden(permission: string, pattern: string, rule: Rule): Rule {
+  /** Last explicit non-broad read-allow that matches this file, if any. */
+  export function explicitAllow(pattern: string, ruleset?: Ruleset): Rule | undefined {
+    return ruleset
+      ?.filter((rule) => rule.permission === "read" && rule.action === "allow" && !PermissionRule.broad(rule))
+      .findLast((rule) => Wildcard.match(pattern, rule.pattern))
+  }
+
+  export function harden(permission: string, pattern: string, rule: Rule, ruleset?: Ruleset): Rule {
     if (permission !== "read") return rule
-    if (rule.action !== "allow") return rule
+    if (rule.action === "deny") return rule
     const match = guard(pattern)
     if (!match) return rule
+    const explicit = explicitAllow(pattern, ruleset)
+    if (explicit) return { permission: "read", pattern: explicit.pattern, action: "allow" }
+    if (rule.action !== "allow") return rule
     if (!PermissionRule.broad(rule)) return rule
     return { permission, pattern: match, action: "ask" }
   }

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -39,25 +39,21 @@ export namespace KiloTask {
 
   /**
    * Build inherited permission ceilings from the calling agent.
-   * Merges the static agent definition with the session's accumulated permissions
-   * so denials survive multi-hop chains (plan → general → explore) without
-   * overriding the selected subagent's own allowlist with parent ask/allow rules.
+   * For the immediate child of a primary/delegating agent (`depth === 0`) this
+   * merges the caller's static agent definition with the parent session's
+   * accumulated permissions so Plan Mode edit/notebook/MCP denials and session
+   * tool-toggles can act as hard ceilings.
    *
-   * OpenCode removed parent-agent inheritance entirely in anomalyco/opencode#31696.
-   * Kilo intentionally differs: parent edit/notebook/MCP denials remain hard ceilings
-   * for Plan Mode and MCP restrictions, while parent ask/allow rules must not replace
-   * the selected subagent's policy. Preserve this distinction during upstream merges.
+   * Deeper descendants (`depth > 0`) do **not** inherit these ceilings; each
+   * subagent is governed by its own agent ruleset plus the default subagent
+   * restrictions. This prevents nested subagents from accumulating a delegator's
+   * deny rules (#EST-1825).
    *
-   * Broad bash denies are deliberately NOT inherited from the calling agent. A read-only/delegating
-   * agent (plan, ask, orchestrator) carries a `readOnlyBash` allowlist whose deny rules
-   * (`*`, `git *`, shell-operator guards) exist only to shape that allowlist. Projecting
-   * those denies onto a writable subagent capped commands the subagent's own config
-   * explicitly allows (e.g. `git status`), surfacing phantom deny rules the user never
-   * wrote (#11523). The subagent's own bash policy governs its bash capabilities; an
-   * explicit session-scoped bash lockdown (sandbox / session deny) still reaches the
-   * child via `deriveSubagentSessionPermission`, which inherits session deny rules. Built-in
-   * Explore has its own enforcement-level read-only bash policy, so every caller retains that
-   * boundary without projecting a delegator's bash rules onto custom writable subagents.
+   * Broad bash denies are deliberately NOT inherited. A read-only/delegating
+   * agent (plan, ask, orchestrator) carries a `readOnlyBash` allowlist whose deny
+   * rules exist only to shape that allowlist. Projecting those denies onto a
+   * writable subagent would surface phantom deny rules the user never wrote
+   * (#11523). The subagent's own bash policy governs its bash capabilities.
    *
    * The caller must resolve `caller` (Agent.Info) and `session` (Session.Info)
    * before calling. This function is pure/synchronous.
@@ -66,7 +62,9 @@ export namespace KiloTask {
     caller: Agent.Info
     session: Session.Info
     mcp: Config.Info["mcp"]
+    depth?: number
   }): Permission.Ruleset {
+    if (input.depth && input.depth > 0) return []
     const rules = Permission.merge(input.caller.permission ?? [], input.session.permission ?? [])
     const prefixes = Object.keys(input.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
     const isMcp = (p: string) => prefixes.some((prefix) => p.startsWith(prefix))

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -121,9 +121,13 @@ export function resolve(permission: string, pattern: string, ruleset: Ruleset, .
   const base = AgentManagerPermission.harden(
     permission,
     pattern,
-    ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ruleset)),
+    ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ruleset), ruleset),
   ) // kilocode_change
-  const saved = AgentManagerPermission.harden(permission, pattern, evalFn(permission, pattern, ...overrides)) // kilocode_change
+  const saved = AgentManagerPermission.harden(
+    permission,
+    pattern,
+    ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ...overrides), overrides.flat()),
+  ) // kilocode_change
   if (base.action === "deny") return base
   if (saved.action === "deny") return saved
   if (base.action === "ask") {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -169,6 +169,7 @@ export const TaskTool = Tool.define(
       const caller = yield* agent.get(ctx.agent)
       const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp })
       const childPermission = KiloTask.merge(
+        next.permission ?? [],
         deriveSubagentSessionPermission({
           parentSessionPermission: parent.permission ?? [],
           subagent: next,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -169,7 +169,6 @@ export const TaskTool = Tool.define(
       const caller = yield* agent.get(ctx.agent)
       const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp })
       const childPermission = KiloTask.merge(
-        next.permission ?? [],
         deriveSubagentSessionPermission({
           parentSessionPermission: parent.permission ?? [],
           subagent: next,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -167,11 +167,12 @@ export const TaskTool = Tool.define(
       }
       // kilocode_change start — inherit edit/bash/MCP restrictions from calling agent
       const caller = yield* agent.get(ctx.agent)
-      const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp })
+      const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp, depth })
       const childPermission = KiloTask.merge(
         deriveSubagentSessionPermission({
           parentSessionPermission: parent.permission ?? [],
           subagent: next,
+          depth,
         }),
         cfg.experimental?.primary_tools?.map((permission) => ({
           permission,

--- a/packages/opencode/test/kilocode/permission/env-read.test.ts
+++ b/packages/opencode/test/kilocode/permission/env-read.test.ts
@@ -96,6 +96,35 @@ describe("env read permissions", () => {
     }),
   )
 
+  it.live("explicit *.env allow wins over a later broad read allow", () =>
+    Effect.sync(() => {
+      const set = Permission.merge(
+        rules(),
+        Permission.fromConfig({
+          read: {
+            "*.env": "allow",
+            "*.env.*": "allow",
+            "*": "allow",
+          },
+        }),
+      )
+      expect(Permission.resolve("read", "project/.env", set).action).toBe("allow")
+      expect(Permission.resolve("read", "project/.env.local", set).action).toBe("allow")
+      expect(Permission.resolve("read", "src/.env", set).action).toBe("allow")
+      expect(Permission.resolve("read", "README.md", set).action).toBe("allow")
+    }),
+  )
+
+  it.live("explicit env allow does not override a deny", () =>
+    Effect.sync(() => {
+      const set = Permission.merge(
+        Permission.fromConfig({ read: { "*.env": "allow" } }),
+        Permission.fromConfig({ read: { "*.env": "deny" } }),
+      )
+      expect(Permission.resolve("read", "project/.env", set).action).toBe("deny")
+    }),
+  )
+
   it.live("saved wildcard read approval does not bypass env ask", () =>
     withDir(() =>
       Effect.gen(function* () {

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -667,16 +667,16 @@ describe("tool.task", () => {
     },
   )
 
-  // kilocode_change start - test that subagent own read permissions are carried into child session permission
+  // kilocode_change start - #12387: explicit env allow on the subagent must survive Permission.resolve
   it.instance(
-    "execute preserves subagent read allow rules for env files",
+    "execute keeps explicit subagent env allow on the production resolve path",
     () =>
       Effect.gen(function* () {
         const sessions = yield* Session.Service
+        const agents = yield* Agent.Service
         const { chat, assistant } = yield* seed()
         const tool = yield* TaskTool
         const def = yield* tool.init()
-        const promptOps = stubOps()
 
         const result = yield* def.execute(
           {
@@ -689,7 +689,7 @@ describe("tool.task", () => {
             messageID: assistant.id,
             agent: "build",
             abort: new AbortController().signal,
-            extra: { promptOps },
+            extra: { promptOps: stubOps() },
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
@@ -697,15 +697,14 @@ describe("tool.task", () => {
         )
 
         const child = yield* sessions.get(result.metadata.sessionId)
+        const agent = (yield* agents.get("envreader"))!
         expect(child.parentID).toBe(chat.id)
         expect(child.agent).toBe("envreader")
-        expect(child.permission).toEqual(
-          expect.arrayContaining([{ permission: "read", pattern: "*.env", action: "allow" }]),
-        )
 
-        const effective = child.permission ?? []
-        expect(Permission.evaluate("read", "project/.env", effective).action).toBe("allow")
-        expect(Permission.evaluate("read", "project/.env.local", effective).action).toBe("ask")
+        const effective = Permission.merge(agent.permission, child.permission ?? [])
+        expect(Permission.resolve("read", "project/.env", effective).action).toBe("allow")
+        expect(Permission.resolve("read", "project/.env.local", effective).action).toBe("ask")
+        expect(Permission.resolve("read", "README.md", effective).action).toBe("allow")
       }),
     {
       config: {
@@ -724,6 +723,73 @@ describe("tool.task", () => {
         },
       },
     },
+  )
+
+  it.instance(
+    "nested subagent does not inherit the delegator's catch-all deny",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const agents = yield* Agent.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+
+        const first = yield* def.execute(
+          {
+            description: "explore",
+            prompt: "look around",
+            subagent_type: "explore",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps() },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const explorer = yield* sessions.get(first.metadata.sessionId)
+        const nestedAssistant = yield* sessions.updateMessage({
+          ...assistant,
+          id: MessageID.ascending(),
+          parentID: MessageID.ascending(),
+          sessionID: explorer.id,
+        })
+
+        const second = yield* def.execute(
+          {
+            description: "write work",
+            prompt: "continue in general",
+            subagent_type: "general",
+          },
+          {
+            sessionID: explorer.id,
+            messageID: nestedAssistant.id,
+            agent: "explore",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps() },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const grandchild = yield* sessions.get(second.metadata.sessionId)
+        const general = (yield* agents.get("general"))!
+        const effective = Permission.merge(general.permission, grandchild.permission ?? [])
+        expect(grandchild.parentID).toBe(explorer.id)
+        // Explore's catch-all deny must not land in session.permission and then
+        // last-match-deny the nested general agent's reads. Edit denials from
+        // KiloTask.inherited() are a separate Plan/Explore mutation ceiling.
+        expect(Permission.resolve("read", "README.md", effective).action).not.toBe("deny")
+        expect(Permission.resolve("read", "project/.env", effective).action).not.toBe("deny")
+      }),
+    { config: { subagent_depth: 2 } },
   )
   // kilocode_change end
 

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -791,6 +791,85 @@ describe("tool.task", () => {
       }),
     { config: { subagent_depth: 2 } },
   )
+
+  it.instance(
+    "nested subagent does not inherit the parent session edit deny",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const agents = yield* Agent.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+
+        const first = yield* def.execute(
+          {
+            description: "edit lock",
+            prompt: "do some editing",
+            subagent_type: "lockeditor",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps() },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const child = yield* sessions.get(first.metadata.sessionId)
+        const childAssistant = yield* sessions.updateMessage({
+          ...assistant,
+          id: MessageID.ascending(),
+          parentID: MessageID.ascending(),
+          sessionID: child.id,
+        })
+
+        const second = yield* def.execute(
+          {
+            description: "general work",
+            prompt: "continue in general",
+            subagent_type: "general",
+          },
+          {
+            sessionID: child.id,
+            messageID: childAssistant.id,
+            agent: "lockeditor",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps() },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const grandchild = yield* sessions.get(second.metadata.sessionId)
+        const general = (yield* agents.get("general"))!
+        const effective = Permission.merge(general.permission, grandchild.permission ?? [])
+        expect(grandchild.parentID).toBe(child.id)
+        // The lockeditor's edit deny is a ceiling for the child it spawns, but it
+        // must not be written into session.permission in a way that the grandchild
+        // inherits it via deriveSubagentSessionPermission.
+        expect(Permission.resolve("edit", "README.md", effective).action).not.toBe("deny")
+      }),
+    {
+      config: {
+        subagent_depth: 2,
+        agent: {
+          lockeditor: {
+            mode: "subagent",
+            permission: {
+              edit: "deny",
+              task: "allow",
+            },
+          },
+        },
+      },
+    },
+  )
   // kilocode_change end
 
   // kilocode_change start - terminal child assistant errors fail the task tool boundary

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -26,6 +26,7 @@ import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { Permission } from "../../src/permission" // kilocode_change
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -665,6 +666,66 @@ describe("tool.task", () => {
       },
     },
   )
+
+  // kilocode_change start - test that subagent own read permissions are carried into child session permission
+  it.instance(
+    "execute preserves subagent read allow rules for env files",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const result = yield* def.execute(
+          {
+            description: "read env",
+            prompt: "read the .env file",
+            subagent_type: "envreader",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const child = yield* sessions.get(result.metadata.sessionId)
+        expect(child.parentID).toBe(chat.id)
+        expect(child.agent).toBe("envreader")
+        expect(child.permission).toEqual(
+          expect.arrayContaining([{ permission: "read", pattern: "*.env", action: "allow" }]),
+        )
+
+        const effective = child.permission ?? []
+        expect(Permission.evaluate("read", "project/.env", effective).action).toBe("allow")
+        expect(Permission.evaluate("read", "project/.env.local", effective).action).toBe("ask")
+      }),
+    {
+      config: {
+        agent: {
+          envreader: {
+            mode: "subagent",
+            permission: {
+              read: {
+                "*": "allow",
+                "*.env": "allow",
+                "*.env.*": "ask",
+                "*.env.example": "allow",
+              },
+            },
+          },
+        },
+      },
+    },
+  )
+  // kilocode_change end
 
   // kilocode_change start - terminal child assistant errors fail the task tool boundary
   it.instance("execute fails when child prompt returns assistant error", () =>


### PR DESCRIPTION
## Problem

Subagents still prompt on `.env` reads when the user sets an explicit `read: "*.env": "allow"` rule. The previous revision copied the subagent's full `agent.permission` into `session.permission`; that did not fix the reporter's `.env` case and introduced a nested-deny regression where children inherited the delegator's catch-all and session-local denies.

## Root cause

1. **Env read hardening only looked at the final matched rule.** `Permission.resolve` -> `ReadPermission.harden` turns a broad `read: "*": "allow"` into `ask` for `.env` / `.env.*`. If a later catch-all `*` was the last match, an earlier explicit `*.env` allow was ignored.
2. **Wrong merge order.** Putting `next.permission` first in `KiloTask.merge` wrote the whole subagent ruleset into `session.permission`. `deriveSubagentSessionPermission` then forwarded those deny rules to nested children, so `explore`/`plan` `*: deny` (and edit denials inherited as ceilings) leaked to grandchildren.

## Fix

- Honor an explicit non-broad `read` allow that matches the env file, even when a later broad `read: "*"` would otherwise be hardened to `ask`.
- Keep `session.permission` as inherited ceilings only; do not dump `next.permission` into it.
- Make `KiloTask.inherited` and `deriveSubagentSessionPermission` depth-aware:
  - The immediate child of a primary/delegating agent (`depth === 0`) inherits parent session deny and `external_directory` ceilings plus the default subagent restrictions.
  - Deeper descendants (`depth > 0`) are governed by their own agent ruleset and default subagent restrictions; parent-session denies (including edit/MCP ceilings inherited by the immediate child) are not forwarded again.
- Explicit `deny` still wins.

## Verification

```bash
cd packages/opencode
bun run typecheck
bun test test/kilocode/permission/env-read.test.ts test/tool/task.test.ts
```

Result on this branch:
- `env read permissions > explicit *.env allow wins over a later broad read allow` - pass
- `tool.task > execute keeps explicit subagent env allow on the production resolve path` - pass
- `tool.task > nested subagent does not inherit the delegator's catch-all deny` - pass
- `tool.task > nested subagent does not inherit the parent session edit deny` - pass

Sabotage checks (fail on pre-fix, pass here):

| Command | Pre-fix (b817d08) | Pre-fix (8c9870d) | This branch |
|---|---|---|---|
| `bun test test/kilocode/permission/env-read.test.ts -t "explicit *.env allow"` | `Expected: "allow", received: "ask"` | pass | pass |
| `bun test test/tool/task.test.ts -t "nested subagent does not inherit the parent session edit deny"` | N/A | `Expected: not "deny"` | pass |

## Risks

- Session-scoped denials still last-match-win over agent allows.
- Immediate child edit/MCP ceilings from `KiloTask.inherited` remain active; only deeper descendants are released from session-local deny inheritance.
