### PR TITLE
fix(cli): include Kilo version in agent environment context

### DIFF
--- a/.changeset/spotty-pillows-stick.md
+++ b/.changeset/spotty-pillows-stick.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Include the Kilo Code version in the agent's environment context so it can avoid advising outdated features and slash commands.

--- a/packages/opencode/src/kilocode/system-prompt.ts
+++ b/packages/opencode/src/kilocode/system-prompt.ts
@@ -1,6 +1,7 @@
 // kilocode_change - new file
 
 import { Global } from "@opencode-ai/core/global"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Effect } from "effect"
 import { staticEnvLines, type EditorContext } from "@/kilocode/editor-context"
 import { KiloMemory } from "@kilocode/kilo-memory/effect"
@@ -25,6 +26,7 @@ export namespace KilocodeSystemPrompt {
         `<env>`,
         `  Is directory a git repo: ${input.ctx.project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
+        `  Kilo Code version: ${InstallationVersion}`,
         `  Today's date: ${new Date().toDateString()}`,
         `  Project config: .kilo/command/*.md, .kilo/agent/*.md, kilo.json, AGENTS.md. Put new commands and agents in .kilo/. Do not use .kilocode/ or .opencode/.`,
         `  Global config: ${Global.Path.config}/ (same structure)`,

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { SystemPrompt } from "../../src/session/system"
+import { KilocodeSystemPrompt } from "../../src/kilocode/system-prompt"
 import { environmentDetails } from "../../src/kilocode/editor-context"
 import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -9,6 +10,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderTest } from "../fake/provider"
 import { patchAgents } from "../../src/kilocode/agent"
 import PROMPT_ASK from "../../src/agent/prompt/ask.txt"
+import { ProjectV2 } from "@opencode-ai/core/project"
 
 import PROMPT_ANTHROPIC from "../../src/session/prompt/anthropic.txt"
 import PROMPT_DEFAULT from "../../src/session/prompt/default.txt"
@@ -248,5 +250,26 @@ describe("KiloSessionPrompt.injectEditorContext", () => {
     expect(env.synthetic).toBe(true)
     expect(env.text.startsWith("\n\n<environment_details>")).toBe(true)
     expect(env.text).toContain("Active file: src/app.ts")
+  })
+})
+
+describe("KilocodeSystemPrompt.environment", () => {
+  test("includes Kilo Code version", () => {
+    const result = KilocodeSystemPrompt.environment({
+      ctx: {
+        directory: "/project",
+        worktree: "/project",
+        project: {
+          id: ProjectV2.ID.make("test-project"),
+          worktree: "/project",
+          vcs: "git",
+          time: { created: 0, updated: 0 },
+          sandboxes: [],
+        },
+      },
+      model: ProviderTest.model(),
+    })
+
+    expect(result[0]).toContain("Kilo Code version:")
   })
 })


### PR DESCRIPTION
Closes #12891

## What changed
The agent's environment context now reports the Kilo Code version it is running under, so the model can stop advising outdated slash commands and features.

## Why
When the model does not know the version, it recommends features or commands that may not exist in the installed release (e.g. `/open`). Adding the version to the `<env>` block gives it the grounding needed to avoid that.

## Notes
- The pre-push typecheck hook fails on a pre-existing, unrelated error in `packages/opencode/src/session/llm.ts` (`allowSystemInMessages` not in the installed `@ai-sdk` types). Confirmed pre-existing on the base branch; not touched by this PR.