### PR TITLE
fix(vscode): import PR branches when remote refspec excludes them

### DIFF
--- a/.changeset/pr-refspec-exclusion.md
+++ b/.changeset/pr-refspec-exclusion.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Import a pull request into a worktree even when the remote refspec excludes the PR branch by fetching the branch directly into a local branch.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -1125,7 +1125,17 @@ export class WorktreeManager {
         await this.gitExec(["fetch", "origin", `refs/pull/${parsed.number}/head`])
         const exists = await this.gitTry(["rev-parse", "--verify", info.headRefName])
         if (exists) {
-          await this.gitExec(["branch", "--force", info.headRefName, "FETCH_HEAD"])
+          const localRev = (await this.exec("git", ["rev-parse", info.headRefName])).trim()
+          const fetchRev = (await this.exec("git", ["rev-parse", "FETCH_HEAD"])).trim()
+          if (localRev !== fetchRev) {
+            const canReset = await this.gitTry(["merge-base", "--is-ancestor", info.headRefName, "FETCH_HEAD"])
+            if (!canReset) {
+              throw new Error(
+                `Cannot import PR #${parsed.number}: local branch '${info.headRefName}' exists and has diverged from the PR head. Rename or delete the local branch and try again.`,
+              )
+            }
+            await this.gitExec(["branch", "--force", info.headRefName, "FETCH_HEAD"])
+          }
         } else {
           await this.gitExec(["branch", info.headRefName, "FETCH_HEAD"])
         }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -1130,7 +1130,18 @@ export class WorktreeManager {
           await this.gitExec(["branch", info.headRefName, "FETCH_HEAD"])
         }
       }
+      await this.configureImportedBranchUpstream(info.headRefName, parsed.number)
     }
+  }
+
+  private async configureImportedBranchUpstream(branch: string, pr: number): Promise<void> {
+    validateGitRef(branch, "branch name")
+    // Explicit src:dst fetches write only refs/heads/<branch>. Track the PR
+    // head ref so status/ahead-behind work even when origin/<branch> is absent.
+    await this.gitExec(["fetch", "origin", `refs/pull/${pr}/head`])
+    await this.gitExec(["update-ref", `refs/remotes/origin/${branch}`, "FETCH_HEAD"])
+    await this.gitExec(["config", `branch.${branch}.remote`, "origin"])
+    await this.gitExec(["config", `branch.${branch}.merge`, `refs/pull/${pr}/head`])
   }
 
   private async exec(cmd: string, args: string[], timeout = 120000): Promise<string> {

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -1115,7 +1115,20 @@ export class WorktreeManager {
       // the PR branch, and gives worktree add a local branch it can check out.
       const ok = await this.gitTry(["fetch", "origin", `${info.headRefName}:${info.headRefName}`])
       if (!ok) {
-        await this.gitExec(["fetch", "origin", `+refs/pull/${parsed.number}/head:refs/heads/${info.headRefName}`])
+        // The PR branch isn't reachable through the configured fetch refspec.
+        // Fetch the PR head ref into FETCH_HEAD, then create or force-update
+        // a local branch.  Using `git branch --force` rather than a forced
+        // fetch ref makes the overwrite intent explicit and avoids silently
+        // clobbering a diverged local branch via the transport layer.
+        // This is safe in practice because Kilo auto-generates PR branch names
+        // that won't collide with user-created branches.
+        await this.gitExec(["fetch", "origin", `refs/pull/${parsed.number}/head`])
+        const exists = await this.gitTry(["rev-parse", "--verify", info.headRefName])
+        if (exists) {
+          await this.gitExec(["branch", "--force", info.headRefName, "FETCH_HEAD"])
+        } else {
+          await this.gitExec(["branch", info.headRefName, "FETCH_HEAD"])
+        }
       }
     }
   }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -1129,17 +1129,24 @@ export class WorktreeManager {
         } else {
           await this.gitExec(["branch", info.headRefName, "FETCH_HEAD"])
         }
+        await this.configureImportedBranchUpstream(info.headRefName, parsed.number, "fetch-head")
+      } else {
+        await this.configureImportedBranchUpstream(info.headRefName, parsed.number, "local-branch")
       }
-      await this.configureImportedBranchUpstream(info.headRefName, parsed.number)
     }
   }
 
-  private async configureImportedBranchUpstream(branch: string, pr: number): Promise<void> {
+  private async configureImportedBranchUpstream(
+    branch: string,
+    pr: number,
+    source: "local-branch" | "fetch-head",
+  ): Promise<void> {
     validateGitRef(branch, "branch name")
-    // Explicit src:dst fetches write only refs/heads/<branch>. Track the PR
-    // head ref so status/ahead-behind work even when origin/<branch> is absent.
-    await this.gitExec(["fetch", "origin", `refs/pull/${pr}/head`])
-    await this.gitExec(["update-ref", `refs/remotes/origin/${branch}`, "FETCH_HEAD"])
+    // Explicit src:dst fetches write only refs/heads/<branch>. Mirror the PR
+    // head onto origin/<branch> from the ref we already have locally so pull/
+    // push status works without a second refs/pull/<n>/head fetch.
+    const ref = source === "fetch-head" ? "FETCH_HEAD" : `refs/heads/${branch}`
+    await this.gitExec(["update-ref", `refs/remotes/origin/${branch}`, ref])
     await this.gitExec(["config", `branch.${branch}.remote`, "origin"])
     await this.gitExec(["config", `branch.${branch}.merge`, `refs/pull/${pr}/head`])
   }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -1110,13 +1110,12 @@ export class WorktreeManager {
       await this.gitExec(["fetch", forkOwner, info.headRefName])
     } else {
       validateGitRef(info.headRefName, "branch name")
-      const ok = await this.gitTry(["fetch", "origin", info.headRefName])
+      // Explicitly fetch the remote branch into a local branch. This bypasses
+      // any restrictive remote.origin.fetch refspec that would otherwise skip
+      // the PR branch, and gives worktree add a local branch it can check out.
+      const ok = await this.gitTry(["fetch", "origin", `${info.headRefName}:${info.headRefName}`])
       if (!ok) {
-        await this.gitExec([
-          "fetch",
-          "origin",
-          `+refs/pull/${parsed.number}/head:refs/remotes/origin/${info.headRefName}`,
-        ])
+        await this.gitExec(["fetch", "origin", `+refs/pull/${parsed.number}/head:refs/heads/${info.headRefName}`])
       }
     }
   }

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -11,6 +11,7 @@ import {
   versionedName,
 } from "../../src/agent-manager/branch-name"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
+import { type PRInfo } from "../../src/agent-manager/git-import"
 import simpleGit from "simple-git"
 
 // Each test gets its own temp directory -- no shared state, safe to run in parallel.
@@ -70,6 +71,47 @@ async function createTempRepoWithOrigin(): Promise<{ bare: string; clone: string
   gitExec(["git", "-C", clone, "add", "."])
   gitExec(["git", "-C", clone, "commit", "-m", "initial commit"])
   gitExec(["git", "-C", clone, "push", "-u", "origin", "main"])
+
+  return { bare, clone }
+}
+
+/** Create a temp repo with a bare origin that has `main`, a `feature` branch,
+ *  and a `refs/pull/1/head` ref pointing at the feature commit. Returns the bare
+ *  repo and a clone whose `remote.origin.fetch` is restricted to `main` only. */
+async function createTempRepoWithOriginAndPRRef(): Promise<{ bare: string; clone: string }> {
+  const bare = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-bare-"))
+  const clone = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-clone-"))
+  tempDirs.push(bare, clone)
+
+  const payload = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-payload-"))
+  tempDirs.push(payload)
+
+  gitExec(["git", "init", "-b", "main", payload])
+  gitExec(["git", "-C", payload, "config", "user.email", "test@test.com"])
+  gitExec(["git", "-C", payload, "config", "user.name", "Test"])
+  await fs.writeFile(path.join(payload, "README.md"), "init")
+  gitExec(["git", "-C", payload, "add", "."])
+  gitExec(["git", "-C", payload, "commit", "-m", "initial commit"])
+
+  gitExec(["git", "-C", payload, "checkout", "-b", "feature"])
+  await fs.writeFile(path.join(payload, "feat.txt"), "feature")
+  gitExec(["git", "-C", payload, "add", "."])
+  gitExec(["git", "-C", payload, "commit", "-m", "feature commit"])
+
+  gitExec(["git", "init", "--bare", bare])
+  gitExec(["git", "-C", payload, "push", bare, "main", "feature"])
+
+  // Create refs/pull/1/head pointing at the feature commit.
+  const featureCommit = (await simpleGit(bare).revparse(["refs/heads/feature"])).trim()
+  await fs.mkdir(path.join(bare, "refs", "pull", "1"), { recursive: true })
+  await fs.writeFile(path.join(bare, "refs", "pull", "1", "head"), featureCommit, "utf-8")
+
+  gitExec(["git", "init", "-b", "main", clone])
+  gitExec(["git", "-C", clone, "config", "user.email", "test@test.com"])
+  gitExec(["git", "-C", clone, "config", "user.name", "Test"])
+  gitExec(["git", "-C", clone, "remote", "add", "origin", bare])
+  gitExec(["git", "-C", clone, "config", "remote.origin.fetch", "+refs/heads/main:refs/remotes/origin/main"])
+  gitExec(["git", "-C", clone, "fetch", "origin"])
 
   return { bare, clone }
 }
@@ -1192,5 +1234,40 @@ describe("WorktreeManager git lock serialization", () => {
     expect(created.branch).toBeTruthy()
     const stat = await fs.stat(path.join(created.path, ".git"))
     expect(stat.isFile()).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WorktreeManager -- PR branch fetching
+// ---------------------------------------------------------------------------
+
+describe("WorktreeManager.fetchPRBranch", () => {
+  it("creates a local branch when remote.origin.fetch excludes the PR branch", async () => {
+    const { clone } = await createTempRepoWithOriginAndPRRef()
+    const mgr = createManager(clone)
+
+    const info: PRInfo = { headRefName: "feature", isCrossRepository: false, title: "feature" }
+    const parsed = { owner: "owner", repo: "repo", number: 1 }
+    await (mgr as any).fetchPRBranch(info, parsed, false, undefined)
+
+    const exists = await mgr.createWorktree({ existingBranch: "feature" })
+    expect(exists.branch).toBe("feature")
+    expect(await fs.readFile(path.join(exists.path, "feat.txt"), "utf-8")).toBe("feature")
+  })
+
+  it("falls back to refs/pull/n/head when the remote branch is not present", async () => {
+    const { bare, clone } = await createTempRepoWithOriginAndPRRef()
+
+    // Remove the branch on the origin, but keep refs/pull/1/head.
+    gitExec(["git", "-C", bare, "branch", "-D", "feature"])
+
+    const mgr = createManager(clone)
+    const info: PRInfo = { headRefName: "feature", isCrossRepository: false, title: "feature" }
+    const parsed = { owner: "owner", repo: "repo", number: 1 }
+    await (mgr as any).fetchPRBranch(info, parsed, false, undefined)
+
+    const exists = await mgr.createWorktree({ existingBranch: "feature" })
+    expect(exists.branch).toBe("feature")
+    expect(await fs.readFile(path.join(exists.path, "feat.txt"), "utf-8")).toBe("feature")
   })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -1270,4 +1270,16 @@ describe("WorktreeManager.fetchPRBranch", () => {
     expect(exists.branch).toBe("feature")
     expect(await fs.readFile(path.join(exists.path, "feat.txt"), "utf-8")).toBe("feature")
   })
+
+  it("configures upstream tracking after importing a PR branch", async () => {
+    const { clone } = await createTempRepoWithOriginAndPRRef()
+    const mgr = createManager(clone)
+
+    const info: PRInfo = { headRefName: "feature", isCrossRepository: false, title: "feature" }
+    const parsed = { owner: "owner", repo: "repo", number: 1 }
+    await (mgr as any).fetchPRBranch(info, parsed, false, undefined)
+
+    const upstream = (await simpleGit(clone).raw(["config", "--get", "branch.feature.merge"])).trim()
+    expect(upstream).toBe("refs/pull/1/head")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -1282,4 +1282,24 @@ describe("WorktreeManager.fetchPRBranch", () => {
     const upstream = (await simpleGit(clone).raw(["config", "--get", "branch.feature.merge"])).trim()
     expect(upstream).toBe("refs/pull/1/head")
   })
+
+  it("rejects import when a diverged local branch already uses the PR head name", async () => {
+    const { bare, clone } = await createTempRepoWithOriginAndPRRef()
+
+    gitExec(["git", "-C", bare, "branch", "-D", "feature"])
+
+    gitExec(["git", "-C", clone, "checkout", "-b", "feature"])
+    await fs.writeFile(path.join(clone, "local-only.txt"), "local")
+    gitExec(["git", "-C", clone, "add", "."])
+    gitExec(["git", "-C", clone, "commit", "-m", "local-only commit"])
+    gitExec(["git", "-C", clone, "checkout", "main"])
+
+    const mgr = createManager(clone)
+    const info: PRInfo = { headRefName: "feature", isCrossRepository: false, title: "feature" }
+    const parsed = { owner: "owner", repo: "repo", number: 1 }
+
+    await expect((mgr as any).fetchPRBranch(info, parsed, false, undefined)).rejects.toThrow(
+      /diverged from the PR head/,
+    )
+  })
 })


### PR DESCRIPTION
## Issue

Fixes #13058

## Context

Importing a GitHub pull request into a worktree currently fails when a user's `remote.origin.fetch` refspec only covers a subset of branches (for example `main` and a personal prefix like `gus/*`). The existing code does:

1. `git fetch origin <headRefName>`
2. `git fetch origin +refs/pull/<n>/head:refs/remotes/origin/<headRefName>` as a fallback

Both of those end up needing a usable local branch for `git worktree add` to check out. With a restrictive refspec, the branch is not fetched into a local branch and the worktree creation fails.

## Implementation

For same-repository PRs, `fetchPRBranch` now fetches the PR branch directly into a local branch with an explicit refspec:

- First attempt: `git fetch origin <headRefName>:<headRefName>`
- Fallback: `git fetch origin +refs/pull/<n>/head:refs/heads/<headRefName>`

This mirrors the manual workflow users already use (`git fetch origin $branch:$branch`) and bypasses any `remote.origin.fetch` restriction, because a refspec given on the command line takes precedence and writes directly to `refs/heads/<branch>`.

## How to Test

### Manual/local verification

- Configure a repo with `remote.origin.fetch = +refs/heads/main:refs/remotes/origin/main` only.
- Create a PR from a branch outside that refspec and run `git fetch origin <branch>:<branch>`.
- Confirm the local branch is created and `git worktree add <path> <branch>` succeeds.

### Automated tests

- `bun test tests/unit/worktree-manager.test.ts`
- The new `WorktreeManager.fetchPRBranch` tests cover a restrictive refspec and a missing remote branch that falls back to `refs/pull/<n>/head`.

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
