### PR TITLE
fix(cli): make terminal input an explicit takeover

### DIFF
--- a/.changeset/interactive-terminal-takeover.md
+++ b/.changeset/interactive-terminal-takeover.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Make interactive terminal input an explicit takeover flow with a visible active state, mounted-panel handshake, actionable controls, and surfaced connection errors.

--- a/packages/opencode/src/kilocode/cli/cmd/run-terminal.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/run-terminal.ts
@@ -33,21 +33,27 @@ export namespace KiloRunTerminal {
 
     return {
       write: async (input: { terminalID: string; data: string }) => {
-        await client.terminal.write({
+        const result = await client.terminal.write({
           terminalID: input.terminalID,
           workspace: await workspace(),
           interactiveTerminalWriteInput: { data: input.data },
         })
+        if (result.error) throw result.error
+        if (result.data !== true) throw new Error("Interactive terminal rejected input")
       },
       resize: async (input: { terminalID: string; cols: number; rows: number }) => {
-        await client.terminal.resize({
+        const result = await client.terminal.resize({
           terminalID: input.terminalID,
           workspace: await workspace(),
           interactiveTerminalResizeInput: { cols: input.cols, rows: input.rows },
         })
+        if (result.error) throw result.error
+        if (result.data !== true) throw new Error("Interactive terminal is no longer connected")
       },
       close: async (terminalID: string) => {
-        await client.terminal.close({ terminalID, workspace: await workspace() })
+        const result = await client.terminal.close({ terminalID, workspace: await workspace() })
+        if (result.error) throw result.error
+        if (result.data !== true) throw new Error("Interactive terminal is already closed")
       },
     }
   }

--- a/packages/opencode/src/kilocode/cli/cmd/run/interactive-terminal.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/run/interactive-terminal.tsx
@@ -28,12 +28,18 @@ export function RunInteractiveTerminalBody(props: Props) {
   const [version, refresh] = createSignal(0)
   const [offset, setOffset] = createSignal(0)
   const [closing, setClosing] = createSignal(false)
+  const [error, setError] = createSignal("")
 
   function send(data: string) {
     if (!data || closing()) return
     state.input = state.input
       .then(() => props.onWrite({ terminalID: props.terminal().info.id, data }))
-      .catch(() => undefined)
+      .then(() => {
+        setError("")
+      })
+      .catch((err) => {
+        setError(`input failed: ${err instanceof Error ? err.message : String(err)}`)
+      })
   }
 
   function scroll(delta: number) {
@@ -43,7 +49,11 @@ export function RunInteractiveTerminalBody(props: Props) {
   function close() {
     if (closing()) return
     setClosing(true)
-    void props.onClose(props.terminal().info.id).catch(() => setClosing(false))
+    setError("")
+    void props.onClose(props.terminal().info.id).catch((err) => {
+      setClosing(false)
+      setError(`close failed: ${err instanceof Error ? err.message : String(err)}`)
+    })
   }
 
   useKeyboard((event) => {
@@ -94,7 +104,10 @@ export function RunInteractiveTerminalBody(props: Props) {
       state.vt.resize(width, VIEW_ROWS)
       setOffset((value) => Math.min(state.vt.scrollbackSize(), value))
       refresh((value) => value + 1)
-      void props.onResize({ terminalID: props.terminal().info.id, cols: width, rows: VIEW_ROWS }).catch(() => undefined)
+      void props
+        .onResize({ terminalID: props.terminal().info.id, cols: width, rows: VIEW_ROWS })
+        .then(() => setError(""))
+        .catch((err) => setError(`connection failed: ${err instanceof Error ? err.message : String(err)}`))
     }),
   )
 
@@ -107,7 +120,7 @@ export function RunInteractiveTerminalBody(props: Props) {
     <box width="100%" height={RUN_INTERACTIVE_TERMINAL_ROWS} flexDirection="column" paddingLeft={2} paddingRight={2}>
       <box height={1} flexDirection="row" justifyContent="space-between" flexShrink={0}>
         <text fg={props.theme.text} attributes={TextAttributes.BOLD} wrapMode="none" truncate>
-          {props.terminal().info.description ?? props.terminal().info.command}
+          TERMINAL INPUT ACTIVE · {props.terminal().info.description ?? props.terminal().info.command}
         </text>
         <box onMouseUp={close}>
           <text fg={closing() ? props.theme.muted : props.theme.error} wrapMode="none">
@@ -132,11 +145,16 @@ export function RunInteractiveTerminalBody(props: Props) {
         </text>
       </box>
       <box height={1} flexDirection="row" gap={2} flexShrink={0}>
+        <box onMouseUp={() => send("\x03")}>
+          <text fg={props.theme.text} wrapMode="none">
+            ctrl+c <span style={{ fg: props.theme.muted }}>interrupt</span>
+          </text>
+        </box>
         <text fg={props.theme.text} wrapMode="none">
-          ctrl+c <span style={{ fg: props.theme.muted }}>interrupt</span>
+          esc <span style={{ fg: props.theme.muted }}>close</span>
         </text>
-        <text fg={props.theme.text} wrapMode="none">
-          pgup/pgdn <span style={{ fg: props.theme.muted }}>scroll{offset() > 0 ? ` (${offset()} up)` : ""}</span>
+        <text fg={error() ? props.theme.error : props.theme.text} wrapMode="none" truncate>
+          {error() || `pgup/pgdn scroll${offset() > 0 ? ` (${offset()} up)` : ""}`}
         </text>
       </box>
     </box>

--- a/packages/opencode/src/kilocode/interactive-terminal/index.ts
+++ b/packages/opencode/src/kilocode/interactive-terminal/index.ts
@@ -121,6 +121,7 @@ export namespace InteractiveTerminal {
     cursor: number
     resolve: (result: Result) => void
     ready?: Promise<void>
+    mounted?: PromiseWithResolvers<void>
     timer?: ReturnType<typeof setTimeout>
     data?: Disp
     exit?: Disp
@@ -244,6 +245,7 @@ export namespace InteractiveTerminal {
     active.timer = undefined
     active.abort?.()
     active.abort = undefined
+    active.mounted?.resolve()
 
     if (input.kill) {
       try {
@@ -331,6 +333,7 @@ export namespace InteractiveTerminal {
     }
     state.terminals.set(id, active)
     const announced = Promise.withResolvers<void>()
+    active.mounted = Promise.withResolvers<void>()
     active.ready = announced.promise
     active.data = proc.onData((data) => append(active, data))
     active.exit = proc.onExit((event) => {
@@ -351,9 +354,10 @@ export namespace InteractiveTerminal {
       else input.abort.addEventListener("abort", abort, { once: true })
     }
 
-    if (!active.done) active.proc.write(release(input.shell))
     await publish(active, Event.Updated, { info: clone(active.info) })
     announced.resolve()
+    await active.mounted.promise
+    if (!active.done) active.proc.write(release(input.shell))
     return waiter.promise
   }
 
@@ -420,6 +424,7 @@ export namespace InteractiveTerminal {
     const width = Math.max(1, cols)
     const height = Math.max(1, rows)
     active.proc.resize(width, height)
+    active.mounted?.resolve()
     active.info.cols = width
     active.info.rows = height
     active.info.time.updated = Date.now()

--- a/packages/opencode/src/kilocode/interactive-terminal/index.ts
+++ b/packages/opencode/src/kilocode/interactive-terminal/index.ts
@@ -20,6 +20,7 @@ import z from "zod"
 export namespace InteractiveTerminal {
   const log = Log.create({ service: "interactive-terminal" })
   const FLUSH_MS = 25
+  const MOUNT_TIMEOUT_MS = 5_000
   const DEFAULT_COLS = 100
   const DEFAULT_ROWS = 18
 
@@ -101,6 +102,7 @@ export namespace InteractiveTerminal {
     env: NodeJS.ProcessEnv
     cols?: number
     rows?: number
+    mountTimeout?: number
     abort?: AbortSignal
   }
 
@@ -356,7 +358,18 @@ export namespace InteractiveTerminal {
 
     await publish(active, Event.Updated, { info: clone(active.info) })
     announced.resolve()
-    await active.mounted.promise
+    const timeout = setTimeout(
+      () => active.mounted?.reject(new Error("Interactive terminal panel did not mount")),
+      input.mountTimeout ?? MOUNT_TIMEOUT_MS,
+    )
+    try {
+      await active.mounted.promise
+    } catch (err) {
+      await finish(state, active, { closedBy: "abort", kill: true })
+      throw err
+    } finally {
+      clearTimeout(timeout)
+    }
     if (!active.done) active.proc.write(release(input.shell))
     return waiter.promise
   }

--- a/packages/opencode/test/kilocode/cli/cmd/run/interactive-terminal-view.test.tsx
+++ b/packages/opencode/test/kilocode/cli/cmd/run/interactive-terminal-view.test.tsx
@@ -1,0 +1,102 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { RunInteractiveTerminalBody } from "@/kilocode/cli/cmd/run/interactive-terminal"
+import { RUN_THEME_FALLBACK } from "@/cli/cmd/run/theme"
+
+test("mounted terminal takes keyboard input and exposes takeover controls", async () => {
+  const writes: string[] = []
+  const resizes: Array<{ terminalID: string; cols: number; rows: number }> = []
+  const app = await testRender(
+    () => (
+      <box width={100} height={18}>
+        <RunInteractiveTerminalBody
+          terminal={() => ({
+            info: {
+              id: "itx_terminal",
+              sessionID: "ses_terminal",
+              pid: 123,
+              command: "node prompt.mjs",
+              cwd: "/tmp",
+              description: "Enter authentication code",
+              status: "running",
+              cols: 80,
+              rows: 14,
+              time: { started: 1, updated: 1 },
+            },
+            output: "Code: ",
+            cursor: 6,
+          })}
+          theme={RUN_THEME_FALLBACK.footer}
+          onWrite={async (input) => {
+            writes.push(input.data)
+          }}
+          onResize={async (input) => {
+            resizes.push(input)
+          }}
+          onClose={async () => {}}
+        />
+      </box>
+    ),
+    { width: 100, height: 18 },
+  )
+
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("TERMINAL INPUT ACTIVE")
+    expect(app.captureCharFrame()).toContain("ctrl+c interrupt")
+    expect(app.captureCharFrame()).toContain("esc close")
+    expect(resizes).toEqual([expect.objectContaining({ terminalID: "itx_terminal", rows: 14 })])
+
+    app.mockInput.pressKey("4")
+    app.mockInput.pressEnter()
+    await app.renderOnce()
+    await Promise.resolve()
+    expect(writes.join("")).toContain("4")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("terminal surfaces write failures instead of swallowing them", async () => {
+  const app = await testRender(
+    () => (
+      <box width={100} height={18}>
+        <RunInteractiveTerminalBody
+          terminal={() => ({
+            info: {
+              id: "itx_terminal",
+              sessionID: "ses_terminal",
+              pid: 123,
+              command: "node prompt.mjs",
+              cwd: "/tmp",
+              status: "running",
+              cols: 80,
+              rows: 14,
+              time: { started: 1, updated: 1 },
+            },
+            output: "Code: ",
+            cursor: 6,
+          })}
+          theme={RUN_THEME_FALLBACK.footer}
+          onWrite={async () => {
+            throw new Error("socket disconnected")
+          }}
+          onResize={async () => {}}
+          onClose={async () => {}}
+        />
+      </box>
+    ),
+    { width: 100, height: 18 },
+  )
+
+  try {
+    await app.renderOnce()
+    app.mockInput.pressKey("x")
+    await Bun.sleep(10)
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("input failed: socket disconnected")
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/opencode/test/kilocode/interactive-terminal.test.ts
+++ b/packages/opencode/test/kilocode/interactive-terminal.test.ts
@@ -114,11 +114,12 @@ function run(input: { sessionID: SessionID; command: string; cwd: string; abort?
   })
   void ready.promise
     .then((info) => Instance.restore(ctx, () => InteractiveTerminal.resize(info.id, 100, 18)))
+    .catch(() => undefined)
     .finally(() => ready.dispose())
   return pending
 }
 
-function gated(input: { sessionID: SessionID; command: string; cwd: string }) {
+function gated(input: { sessionID: SessionID; command: string; cwd: string; mountTimeout?: number }) {
   return InteractiveTerminal.run({
     ...input,
     shell: Shell.acceptable(),
@@ -273,6 +274,32 @@ process.stdin.once("data", (data) => {
         expect(yield* Effect.promise(() => InteractiveTerminal.resize(info.id, 80, 14))).toBe(true)
         const result = yield* Effect.promise(() => pending)
         expect(result.output).toContain("COMMAND_STARTED")
+      } finally {
+        ready.dispose()
+        yield* Effect.promise(() => InteractiveTerminal.stopSession(sessionID))
+      }
+    }),
+  )
+
+  it.instance("fails cleanly when no terminal panel mounts", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const sessionID = SessionID.descending()
+      const command = yield* Effect.promise(() =>
+        script(test.directory, "unmounted.mjs", `console.log("SHOULD_NOT_START")\n`),
+      )
+      const ready = started(sessionID)
+      try {
+        const pending = gated({ sessionID, command, cwd: test.directory, mountTimeout: 25 })
+        yield* Effect.promise(() => ready.promise)
+        const err = yield* Effect.promise(() =>
+          pending.then(
+            () => undefined,
+            (cause) => cause,
+          ),
+        )
+        expect(err).toMatchObject({ message: "Interactive terminal panel did not mount" })
+        expect(yield* Effect.promise(() => InteractiveTerminal.list({ sessionID }))).toEqual([])
       } finally {
         ready.dispose()
         yield* Effect.promise(() => InteractiveTerminal.stopSession(sessionID))

--- a/packages/opencode/test/kilocode/interactive-terminal.test.ts
+++ b/packages/opencode/test/kilocode/interactive-terminal.test.ts
@@ -105,6 +105,20 @@ async function snapshot(ctx: InstanceContext, id: InteractiveTerminal.ID, expect
 }
 
 function run(input: { sessionID: SessionID; command: string; cwd: string; abort?: AbortSignal }) {
+  const ctx = capture()!
+  const ready = started(input.sessionID)
+  const pending = InteractiveTerminal.run({
+    ...input,
+    shell: Shell.acceptable(),
+    env: { ...process.env },
+  })
+  void ready.promise
+    .then((info) => Instance.restore(ctx, () => InteractiveTerminal.resize(info.id, 100, 18)))
+    .finally(() => ready.dispose())
+  return pending
+}
+
+function gated(input: { sessionID: SessionID; command: string; cwd: string }) {
   return InteractiveTerminal.run({
     ...input,
     shell: Shell.acceptable(),
@@ -226,12 +240,39 @@ process.stdin.once("data", (data) => {
       try {
         const pending = run({ sessionID, command, cwd: test.directory })
         const info = yield* Effect.promise(() => ready.promise)
+        const ctx = capture()!
+        yield* Effect.promise(() => snapshot(ctx, info.id, "READY"))
         const wrote = yield* Effect.promise(() => InteractiveTerminal.write(info.id, "hello\r"))
         expect(wrote).toBe(true)
         const result = yield* Effect.promise(() => pending)
         expect(result.closedBy).toBe("exit")
         expect(result.output).toContain("READY")
         expect(result.output).toContain("INPUT:hello")
+      } finally {
+        ready.dispose()
+        yield* Effect.promise(() => InteractiveTerminal.stopSession(sessionID))
+      }
+    }),
+  )
+
+  it.instance("waits for the terminal panel to mount before starting the command", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const sessionID = SessionID.descending()
+      const command = yield* Effect.promise(() =>
+        script(test.directory, "mounted.mjs", `console.log("COMMAND_STARTED")\n`),
+      )
+      const ready = started(sessionID)
+      try {
+        const pending = gated({ sessionID, command, cwd: test.directory })
+        const info = yield* Effect.promise(() => ready.promise)
+        yield* Effect.promise(() => Bun.sleep(100))
+        const before = yield* Effect.promise(() => InteractiveTerminal.get(info.id))
+        expect(before?.output).not.toContain("COMMAND_STARTED")
+
+        expect(yield* Effect.promise(() => InteractiveTerminal.resize(info.id, 80, 14))).toBe(true)
+        const result = yield* Effect.promise(() => pending)
+        expect(result.output).toContain("COMMAND_STARTED")
       } finally {
         ready.dispose()
         yield* Effect.promise(() => InteractiveTerminal.stopSession(sessionID))


### PR DESCRIPTION
## Summary

Make interactive terminal sessions an explicit human-takeover flow so commands do not begin until the terminal panel is mounted and users can clearly see that keyboard control belongs to the PTY.

## Changes

- Gate interactive commands until the rendered terminal confirms its initial resize, while still allowing abort and close to unblock the pending run.
- Show a prominent `TERMINAL INPUT ACTIVE` state with interrupt, close, and scroll controls.
- Keep keyboard and paste input captured by the terminal and surface input, connection, and close failures in the panel.
- Validate terminal transport responses instead of silently accepting failed writes, resizes, or closes.
- Add real-PTY regression coverage for the mount handshake and rendered-terminal coverage for keyboard routing, controls, and errors.
- Add a patch changeset for `@kilocode/cli`.

## Testing

- `bun run script/test-runner.ts test/kilocode/interactive-terminal.test.ts test/kilocode/cli/cmd/run-terminal.test.ts test/kilocode/cli/cmd/run/interactive-terminal.test.ts test/kilocode/cli/cmd/run/interactive-terminal-view.test.tsx` — 4 files passed, 0 failed, 0 flaky.
- `bun run typecheck` in `packages/opencode` — passed.
- Pre-push non-JetBrains monorepo typecheck — 29/29 packages passed.
- `bun run lint` — completed with 0 errors; existing repository warnings remain.
- `bun run ../../script/check-opencode-annotations.ts --worktree` — passed; no shared upstream source files changed.

Fixes #12933