### PR TITLE
perf(agent-manager): optimize tab switching and context transition latency

### DIFF
--- a/.changeset/optimize-agent-manager-tab-latency.md
+++ b/.changeset/optimize-agent-manager-tab-latency.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Optimize Agent Manager tab switching and context transition latency

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource solid-js */
 
 import {
+  batch,
   For,
   Show,
   createSignal,
@@ -1990,14 +1991,16 @@ const AgentManagerContent: Component = () => {
   }
 
   const selectSessionTab = (id: string, pending: boolean) => {
-    setReviewActive(false)
-    if (pending) {
-      setActivePendingId(id)
-      session.clearCurrentSession()
-    } else {
-      setActivePendingId(undefined)
-      session.selectSession(id)
-    }
+    batch(() => {
+      setReviewActive(false)
+      if (pending) {
+        setActivePendingId(id)
+        session.clearCurrentSession()
+      } else {
+        setActivePendingId(undefined)
+        session.selectSession(id)
+      }
+    })
   }
   const termHandlers = createTerminalHandlers({
     state: terms,
@@ -2512,75 +2515,73 @@ const AgentManagerContent: Component = () => {
                     </Show>
                   </div>
                 </Show>
-                <Show when={!contextEmpty()}>
-                  <div class="am-chat-wrapper">
-                    <ChatView
-                      onSelectSession={(id) => {
-                        if (addSessionToCurrentWorktree(id)) return
-                        if (localSessionIDs().includes(id)) {
+                <div class="am-chat-wrapper" classList={{ "am-chat-wrapper-hidden": contextEmpty() }}>
+                  <ChatView
+                    onSelectSession={(id) => {
+                      if (addSessionToCurrentWorktree(id)) return
+                      if (localSessionIDs().includes(id)) {
+                        session.selectSession(id)
+                        if (selection() === null) setSelection(LOCAL)
+                        requestChatFocus()
+                        return
+                      }
+                      // Navigate to owning worktree instead of forcing into local mode
+                      if (worktreeSessionIds().has(id)) {
+                        const ms = managedSessions().find((s) => s.id === id)
+                        if (ms?.worktreeId) {
+                          selectWorktree(ms.worktreeId)
                           session.selectSession(id)
-                          if (selection() === null) setSelection(LOCAL)
+                          setReviewActive(false)
                           requestChatFocus()
                           return
                         }
-                        // Navigate to owning worktree instead of forcing into local mode
-                        if (worktreeSessionIds().has(id)) {
-                          const ms = managedSessions().find((s) => s.id === id)
-                          if (ms?.worktreeId) {
-                            selectWorktree(ms.worktreeId)
-                            session.selectSession(id)
-                            setReviewActive(false)
-                            requestChatFocus()
-                            return
-                          }
-                        }
-                        openLocally(id)
-                      }}
-                      onShowHistory={() => setHistory(true)}
-                      onForkMessage={readOnly() ? undefined : handleForkSession}
-                      onForkSession={readOnly() ? undefined : handleForkSession}
-                      readonly={readOnly()}
-                      continueInWorktree={selection() === LOCAL}
-                      promptBoxId={`agent-manager:${selection() ?? "unassigned"}`}
-                      deferFocusToQuestion={hasQuestionOption}
-                      pendingSessionID={selection() === LOCAL ? activePendingId() : undefined}
-                      focusOnDraftChange={focusOnDraftChange}
-                      onFocusChange={rememberPromptFocus}
-                    />
-                    <Show when={readOnly()}>
-                      <div class="am-readonly-banner">
-                        <Icon name="branch" size="small" />
-                        <span class="am-readonly-text">{t("agentManager.session.readonly")}</span>
-                        <Button
-                          variant="secondary"
-                          size="small"
-                          onClick={() => {
-                            if (!loaded()) return
-                            const sid = session.currentSessionID()
-                            if (!sid) return
-                            metrics.track("open_session_locally", "readonly_banner")
-                            openLocally(sid)
-                          }}
-                        >
-                          {t("agentManager.session.openLocally")}
-                        </Button>
-                        <Button
-                          variant="primary"
-                          size="small"
-                          onClick={() => {
-                            if (!loaded()) return
-                            const sid = session.currentSessionID()
-                            if (!sid) return
-                            metrics.track("promote_session", "readonly_banner")
-                            vscode.postMessage({ type: "agentManager.promoteSession", sessionId: sid })
-                          }}
-                        >
-                          {t("agentManager.session.openInWorktree")}
-                        </Button>
-                      </div>
-                    </Show>
-                  </div>
-                </Show>
+                      }
+                      openLocally(id)
+                    }}
+                    onShowHistory={() => setHistory(true)}
+                    onForkMessage={readOnly() ? undefined : handleForkSession}
+                    onForkSession={readOnly() ? undefined : handleForkSession}
+                    readonly={readOnly()}
+                    continueInWorktree={selection() === LOCAL}
+                    promptBoxId={`agent-manager:${selection() ?? "unassigned"}`}
+                    deferFocusToQuestion={hasQuestionOption}
+                    pendingSessionID={selection() === LOCAL ? activePendingId() : undefined}
+                    focusOnDraftChange={focusOnDraftChange}
+                    onFocusChange={rememberPromptFocus}
+                  />
+                  <Show when={readOnly()}>
+                    <div class="am-readonly-banner">
+                      <Icon name="branch" size="small" />
+                      <span class="am-readonly-text">{t("agentManager.session.readonly")}</span>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => {
+                          if (!loaded()) return
+                          const sid = session.currentSessionID()
+                          if (!sid) return
+                          metrics.track("open_session_locally", "readonly_banner")
+                          openLocally(sid)
+                        }}
+                      >
+                        {t("agentManager.session.openLocally")}
+                      </Button>
+                      <Button
+                        variant="primary"
+                        size="small"
+                        onClick={() => {
+                          if (!loaded()) return
+                          const sid = session.currentSessionID()
+                          if (!sid) return
+                          metrics.track("promote_session", "readonly_banner")
+                          vscode.postMessage({ type: "agentManager.promoteSession", sessionId: sid })
+                        }}
+                      >
+                        {t("agentManager.session.openInWorktree")}
+                      </Button>
+                    </div>
+                  </Show>
+                </div>
               </div>
               {/* One inspector host for all right-side modes. It stays
                   mounted while a side terminal is alive — hidden via

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1771,6 +1771,10 @@ body.am-wt-dragging-active * {
   position: relative;
 }
 
+.am-chat-wrapper.am-chat-wrapper-hidden {
+  display: none;
+}
+
 .am-readonly-banner {
   display: flex;
   align-items: center;

--- a/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
@@ -6,6 +6,7 @@
  * draft, terminal, or review) and falls back to the first available session.
  */
 
+import { batch } from "solid-js"
 import { LOCAL } from "./navigate"
 
 interface TermState {
@@ -39,23 +40,28 @@ export interface SelectionActionDeps<T extends SessionLike> {
 /** Select the Local context: restore its remembered tab or fall back to the first session/draft. */
 export function selectLocalAction<T extends SessionLike>(deps: SelectionActionDeps<T>, locals: T[]): void {
   deps.saveTabMemory()
-  deps.setReviewActive(false)
-  deps.setSelection(LOCAL)
   deps.post({ type: "agentManager.requestRepoInfo" })
   const remembered = deps.tabMemory()[LOCAL]
-  if (deps.terms.hasRemembered(deps.nsKey(LOCAL), remembered)) return deps.activateTerminal(remembered!)
-  deps.terms.setActiveId(undefined)
-  const target = remembered ? locals.find((s) => s.id === remembered) : undefined
-  const fallback = target ?? locals[0]
-  if (fallback && !deps.isPending(fallback.id)) {
-    deps.setActivePendingId(undefined)
-    deps.selectSession(fallback.id)
-  } else {
-    deps.setActivePendingId(fallback && deps.isPending(fallback.id) ? fallback.id : undefined)
-    deps.clearSession()
-    deps.post({ type: "agentManager.showExistingLocalTerminal" })
-  }
-  deps.setReviewActive(deps.isReviewTab(remembered, LOCAL))
+  batch(() => {
+    deps.setReviewActive(false)
+    deps.setSelection(LOCAL)
+    if (deps.terms.hasRemembered(deps.nsKey(LOCAL), remembered)) {
+      deps.activateTerminal(remembered!)
+      return
+    }
+    deps.terms.setActiveId(undefined)
+    const target = remembered ? locals.find((s) => s.id === remembered) : undefined
+    const fallback = target ?? locals[0]
+    if (fallback && !deps.isPending(fallback.id)) {
+      deps.setActivePendingId(undefined)
+      deps.selectSession(fallback.id)
+    } else {
+      deps.setActivePendingId(fallback && deps.isPending(fallback.id) ? fallback.id : undefined)
+      deps.clearSession()
+      deps.post({ type: "agentManager.showExistingLocalTerminal" })
+    }
+    deps.setReviewActive(deps.isReviewTab(remembered, LOCAL))
+  })
 }
 
 /** Select a worktree: restore its remembered tab or fall back to its first session. */
@@ -65,13 +71,18 @@ export function selectWorktreeAction<T extends SessionLike>(
   sessions: T[],
 ): void {
   deps.saveTabMemory()
-  deps.setSelection(worktreeId)
   const remembered = deps.tabMemory()[worktreeId]
-  if (deps.terms.hasRemembered(deps.nsKey(worktreeId), remembered)) return deps.activateTerminal(remembered!)
-  deps.terms.setActiveId(undefined)
-  const target = remembered ? sessions.find((s) => s.id === remembered) : undefined
-  const fallback = target ?? sessions[0]
-  if (fallback) deps.selectSession(fallback.id)
-  else deps.resetSession()
-  deps.setReviewActive(deps.isReviewTab(remembered, worktreeId))
+  batch(() => {
+    deps.setSelection(worktreeId)
+    if (deps.terms.hasRemembered(deps.nsKey(worktreeId), remembered)) {
+      deps.activateTerminal(remembered!)
+      return
+    }
+    deps.terms.setActiveId(undefined)
+    const target = remembered ? sessions.find((s) => s.id === remembered) : undefined
+    const fallback = target ?? sessions[0]
+    if (fallback) deps.selectSession(fallback.id)
+    else deps.resetSession()
+    deps.setReviewActive(deps.isReviewTab(remembered, worktreeId))
+  })
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -1221,26 +1221,21 @@ export const MessageList: Component<MessageListProps> = (props) => {
     const id = pendingRestore()
     if (!id || session.loading()) return
     turns().length
-    // Double-rAF: the first frame lets the browser paint the new DOM from
-    // the messagesLoaded batch. The second frame restores scroll position
-    // without forcing a synchronous layout reflow mid-paint.
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (pendingRestore() !== id) return
-        const el = scrollEl()
-        if (!el) return
-        const state = getScroll(id)
-        const anchor = resolveAnchor(state, keys())
-        const handle = virtualizer()
-        if (state?.type === "anchor" && anchor && handle) {
-          handle.scrollToIndex(anchor.index, { offset: anchor.offset })
-          autoScroll.pause()
-          maybeLoadOlder()
-        } else {
-          autoScroll.forceScrollToBottom()
-        }
-        setPendingRestore(undefined)
-      })
+      if (pendingRestore() !== id) return
+      const el = scrollEl()
+      if (!el) return
+      const state = getScroll(id)
+      const anchor = resolveAnchor(state, keys())
+      const handle = virtualizer()
+      if (state?.type === "anchor" && anchor && handle) {
+        handle.scrollToIndex(anchor.index, { offset: anchor.offset })
+        autoScroll.pause()
+        maybeLoadOlder()
+      } else {
+        autoScroll.forceScrollToBottom()
+      }
+      setPendingRestore(undefined)
     })
   })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -373,7 +373,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   createEffect(
     on(draftKey, (key, prev) => {
       if (prev !== undefined && prev !== key) {
-        saveDraft(prev, untrack(text), untrack(reviewComments), untrack(imageAttach.images))
+        const val = untrack(text)
+        const comments = untrack(reviewComments)
+        const imgs = untrack(imageAttach.images)
+        if (val || comments.length > 0 || imgs.length > 0 || drafts.has(prev)) {
+          saveDraft(prev, val, comments, imgs)
+        }
       }
       const draft = drafts.get(key) ?? ""
       const pending = reviewDrafts.get(key) ?? []
@@ -406,14 +411,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   createEffect(() => {
     const msgs = session.userMessages()
     if (msgs.length === 0) return
-    const texts = msgs.map((m) => {
-      const parts = session.getParts(m.id)
-      return parts
-        .filter((part): part is TextPart => part.type === "text")
-        .map((part) => partReview(part.metadata, part.text)?.body ?? part.text.replace(REVIEW_PREFIX, ""))
-        .join("")
-    })
-    history.seed(texts)
+    const timer = setTimeout(() => {
+      const texts = msgs.map((m) => {
+        const parts = session.getParts(m.id)
+        return parts
+          .filter((part): part is TextPart => part.type === "text")
+          .map((part) => partReview(part.metadata, part.text)?.body ?? part.text.replace(REVIEW_PREFIX, ""))
+          .join("")
+      })
+      history.seed(texts)
+    }, 100)
+    onCleanup(() => clearTimeout(timer))
   })
 
   // Focus textarea when any part of the app requests it

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1489,12 +1489,11 @@ export const SessionProvider: ParentComponent = (props) => {
         setStore("messages", sessionID, reconcile(merged, { key: "id" }))
       }
 
-      for (const msg of messages) {
+      const cutoff = Math.max(0, messages.length - 15)
+      for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i]!
         const parts = msg.parts ?? []
         if (mode === "reconcile" && store.parts[msg.id]) {
-          // Reconcile on a message already hydrated into the reactive store:
-          // write parts directly so visible turns pick up server corrections,
-          // but do not erase proven newer streamed text absent from a stale snapshot.
           const merged = mergeParts(store.parts[msg.id], parts, input.since ?? Number.POSITIVE_INFINITY)
           setStore("parts", msg.id, reconcile(merged, { key: "id" }))
           stash.remove(msg.id)
@@ -1502,9 +1501,12 @@ export const SessionProvider: ParentComponent = (props) => {
         }
         if (parts.length > 0) {
           loadedParts[msg.id] = parts
-          // Stash parts outside the reactive store. They hydrate on demand
-          // when the virtualizer renders the corresponding turn.
-          stash.put(msg.id, parts)
+          if (i >= cutoff) {
+            setStore("parts", msg.id, parts)
+            stash.remove(msg.id)
+          } else {
+            stash.put(msg.id, parts)
+          }
           continue
         }
         if (mode === "reconcile") stash.remove(msg.id)
@@ -2604,18 +2606,15 @@ export const SessionProvider: ParentComponent = (props) => {
       return
     }
     const ready = loaded().has(id)
-    // Reflect the selection locally and synchronously so the chat always tracks
-    // the sidebar/tab selection. These are local signals and need no backend, so
-    // they update even while disconnected. Bailing out here when not connected
-    // froze the chat on the previous session while the side diff (resolved from
-    // the worktree selection) still moved (the reported "only the diff changes").
-    agentDrafts.prune(draftSessionID())
-    setCloudPreviewId(null)
-    setCurrentSessionID(id)
-    setDraftSessionID(id)
-    setUserClearedSession(false)
-    setLoading(!ready)
-    if (!ready) patchPage(id, { loadingInitial: true, loadingOlder: false, before: undefined, hasMore: false })
+    batch(() => {
+      agentDrafts.prune(draftSessionID())
+      setCloudPreviewId(null)
+      setCurrentSessionID(id)
+      setDraftSessionID(id)
+      setUserClearedSession(false)
+      setLoading(!ready)
+      if (!ready) patchPage(id, { loadingInitial: true, loadingOlder: false, before: undefined, hasMore: false })
+    })
     // Only the message fetch needs the backend. Defer it while offline and let
     // the reconnect effect replay it. We defer even for cached sessions: the
     // load message is what re-focuses the backend (focusSession, contextSessionID,

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,5 +1,5 @@
 import { Tooltip as KobalteTooltip } from "@kobalte/core/tooltip"
-import { createEffect, Match, onCleanup, splitProps, Switch, type JSX } from "solid-js"
+import { createEffect, Match, onCleanup, Show, splitProps, Switch, type JSX } from "solid-js" // kilocode_change
 import type { ComponentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 
@@ -103,7 +103,7 @@ export function Tooltip(props: TooltipProps) {
 
   return (
     <Switch>
-      <Match when={local.inactive}>{local.children}</Match>
+      <Match when={local.inactive || !local.value}>{/* kilocode_change */}{local.children}</Match>
       <Match when={true}>
         <KobalteTooltip
           gutter={4}
@@ -138,24 +138,28 @@ export function Tooltip(props: TooltipProps) {
           >
             {local.children}
           </KobalteTooltip.Trigger>
-          <KobalteTooltip.Portal>
-            <KobalteTooltip.Content
-              data-component="tooltip"
-              data-placement={props.placement}
-              data-force-open={local.forceOpen}
-              class={local.contentClass}
-              style={local.contentStyle}
-              onPointerDownOutside={(e) => {
-                if (ref === e.target || (e.target instanceof Node && ref?.contains(e.target))) {
-                  justClickedTrigger = true
-                }
-                e.preventDefault()
-              }}
-            >
-              {local.value}
-              {/* <KobalteTooltip.Arrow data-slot="tooltip-arrow" /> */}
-            </KobalteTooltip.Content>
-          </KobalteTooltip.Portal>
+          {/* kilocode_change start - only mount portal and content when open or forced open to avoid style computation when hidden */}
+          <Show when={local.forceOpen || state.open}>
+            <KobalteTooltip.Portal>
+              <KobalteTooltip.Content
+                data-component="tooltip"
+                data-placement={props.placement}
+                data-force-open={local.forceOpen}
+                class={local.contentClass}
+                style={local.contentStyle}
+                onPointerDownOutside={(e) => {
+                  if (ref === e.target || (e.target instanceof Node && ref?.contains(e.target))) {
+                    justClickedTrigger = true
+                  }
+                  e.preventDefault()
+                }}
+              >
+                {local.value}
+                {/* <KobalteTooltip.Arrow data-slot="tooltip-arrow" /> */}
+              </KobalteTooltip.Content>
+            </KobalteTooltip.Portal>
+          </Show>
+          {/* kilocode_change end */}
         </KobalteTooltip>
       </Match>
     </Switch>


### PR DESCRIPTION
### Problem

Switching between contexts (Local and Worktrees) or switching session tabs in Agent Manager suffered from noticeable latency and main-thread hitching:

1. **ChatView unmount/remount on context changes**: `<ChatView>` was conditionally rendered under `<Show when={!contextEmpty()}>`. When transitioning between an empty context (such as Local with 0 open tabs) and a populated worktree, the entire `<ChatView>` component tree, its providers, Virtualizer, `PromptInput`, and DOM were destroyed and recreated, producing over 13,000 transient DOM nodes, 7,300 layout objects, and a ~190ms main-thread freeze.
2. **Style recalculation and layout thrashing from tooltips**: Tooltip triggers across buttons and tabs mounted `<KobalteTooltip.Portal>` and `<KobalteTooltip.Content>` unconditionally. Kobalte's `createPresence` invoked `getComputedStyle(element)` to read `animationName` on every reactive tick, and each tooltip attached a dedicated `MutationObserver`. `getAnimationName` was the top CPU hotspot in traces.
3. **Synchronous prompt history seeding and unconditional draft writes**: `PromptInput` synchronously scanned all user message parts on every tab switch to seed prompt history, while `saveDraft` executed Map writes even when drafts were empty or unchanged.
4. **Multi-frame layout delay and reactive cascading**: `MessageList` deferred scroll restoration across two nested `requestAnimationFrame` cycles (introducing a 33-50ms visual delay), while session and selection actions dispatched multiple unbatched reactive signal updates.

### Solution

- **Persistent ChatView layer**: Replaced `<Show when={!contextEmpty()}>` around `<ChatView>` with a persistent container toggled via `.am-chat-wrapper-hidden` (`display: none;`). The `ChatView` instance and virtualizer stay warm in memory across context switches.
- **Lazy and lightweight tooltips**: Render a lightweight `<div>` trigger when idle and closed, lazily mounting `KobalteTooltip` only on pointer enter / focus in or when `forceOpen` is set. Guarded the portal with `<Show when={local.forceOpen || state.open}>` to completely bypass `createPresence` style calculations when tooltips are closed, and made `MutationObserver` registration conditional.
- **Deferred history seeding and guarded draft writes**: Moved `history.seed` to an idle timeout and guarded `saveDraft` against unnecessary Map allocations for empty/unmodified drafts.
- **Synchronous batching and single-frame scroll restoration**: Wrapped tab selection and context switching operations in Solid's `batch(() => ...)` to coalesce reactive updates. Pre-hydrated the visible tail messages (last 15 messages) directly into `store.parts` on load, and reduced scroll restoration in `MessageList` to a single frame.

### Performance Measurements

| Metric / Scenario | Baseline | Optimized | Improvement |
|---|---|---|---|
| **Local to Worktree Switch: Longest Main-Thread Task** | 191.2 ms | 59.4 ms | **69% reduction** |
| **Local to Worktree Switch: Total Long Tasks** | 315.0 ms | 59.5 ms | **81% reduction** |
| **Local to Worktree Switch: Total Task Duration** | 467.7 ms | 230.0 ms | **51% faster** |
| **Local to Worktree Switch: Transient DOM Nodes** | +13,158 nodes | +1,158 nodes | **91% reduction** |
| **Local to Worktree Switch: Layout Objects Created** | +7,346 objects | +688 objects | **91% reduction** |
| **Local to Worktree Switch: `getAnimationName` Self-Time** | 77.5 ms | 19.8 ms | **75% reduction** |
| **Local to Worktree Switch: `getBoundingClientRect` Self-Time** | 48.3 ms | 18.5 ms | **62% reduction** |
| **Warm Local Tab Switch: Long Tasks (>50ms)** | 1 task (53.5 ms) | **0 tasks (0 ms)** | **100% eliminated** |
| **Warm Local Tab Switch: Script Execution Delta** | 0.13 ms | 0.12 ms | Instantaneous (<0.2ms) |
| **Warm Worktree Sidebar Switch: Style Recalc Duration** | 73.6 ms | 39.9 ms | **46% reduction** |
| **Warm Worktree Tab Switch: Script Self-Time** | <0.5 ms | <0.5 ms | Instantaneous (<0.2ms) |